### PR TITLE
Osiris/fix nullifier db

### DIFF
--- a/world-chain-builder/bin/world-chain-builder.rs
+++ b/world-chain-builder/bin/world-chain-builder.rs
@@ -26,8 +26,12 @@ fn main() {
 
     if let Err(err) =
         Cli::<OpChainSpecParser, ExtArgs>::parse().run(|builder, builder_args| async move {
+            let data_dir = builder.config().datadir();
             let handle = builder
-                .node(WorldChainBuilder::new(builder_args.clone()))
+                .node(WorldChainBuilder::new(
+                    builder_args.clone(),
+                    data_dir.data_dir(),
+                )?)
                 .launch()
                 .await?;
 


### PR DESCRIPTION
**Overview**
When initializing the `WorldChainPoolBuilder`, and the `WorldChainPayloadBuilder` we acquired two RW locks on the database on separate threads which caused the binary to crash on startup.

This PR initializes the `DatabaseEnv` globally creating the tables once, and passes references to the environment to the services to resolve the issue.