### PR TITLE
feat(4337): Enforce `ConditionalOptions` check during payload building

### DIFF
--- a/world-chain-builder/src/pool/tx.rs
+++ b/world-chain-builder/src/pool/tx.rs
@@ -10,6 +10,7 @@ use crate::primitives::WorldChainPooledTransactionsElementEcRecovered;
 
 pub trait WorldChainPoolTransaction: EthPoolTransaction {
     fn pbh_payload(&self) -> Option<&PbhPayload>;
+    fn conditional_options(&self) -> Option<&ConditionalOptions>;
 }
 
 #[derive(Debug, Clone)]
@@ -44,6 +45,10 @@ impl EthPoolTransaction for WorldChainPooledTransaction {
 impl WorldChainPoolTransaction for WorldChainPooledTransaction {
     fn pbh_payload(&self) -> Option<&PbhPayload> {
         self.pbh_payload.as_ref()
+    }
+
+    fn conditional_options(&self) -> Option<&ConditionalOptions> {
+        self.conditional_options.as_ref()
     }
 }
 

--- a/world-chain-builder/src/pool/tx.rs
+++ b/world-chain-builder/src/pool/tx.rs
@@ -1,4 +1,5 @@
 use alloy_primitives::TxHash;
+use alloy_rpc_types::erc4337::ConditionalOptions;
 use reth::transaction_pool::{EthPoolTransaction, EthPooledTransaction, PoolTransaction};
 use reth_primitives::transaction::TryFromRecoveredTransactionError;
 use reth_primitives::{PooledTransactionsElementEcRecovered, TransactionSignedEcRecovered};
@@ -11,10 +12,11 @@ pub trait WorldChainPoolTransaction: EthPoolTransaction {
     fn pbh_payload(&self) -> Option<&PbhPayload>;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct WorldChainPooledTransaction {
     pub inner: EthPooledTransaction,
     pub pbh_payload: Option<PbhPayload>,
+    pub conditional_options: Option<ConditionalOptions>,
 }
 
 impl EthPoolTransaction for WorldChainPooledTransaction {
@@ -58,6 +60,7 @@ impl TryFrom<TransactionSignedEcRecovered> for WorldChainPooledTransaction {
         Ok(Self {
             inner: EthPooledTransaction::try_from(tx)?,
             pbh_payload: None,
+            conditional_options: None,
         })
     }
 }
@@ -67,6 +70,7 @@ impl From<WorldChainPooledTransactionsElementEcRecovered> for WorldChainPooledTr
         Self {
             inner: EthPooledTransaction::from_pooled(tx.inner),
             pbh_payload: tx.pbh_payload,
+            conditional_options: None,
         }
     }
 }
@@ -99,6 +103,7 @@ impl PoolTransaction for WorldChainPooledTransaction {
         EthPooledTransaction::try_from_consensus(tx).map(|inner| Self {
             inner,
             pbh_payload: None,
+            conditional_options: None,
         })
     }
 

--- a/world-chain-builder/src/rpc/bundle.rs
+++ b/world-chain-builder/src/rpc/bundle.rs
@@ -91,7 +91,7 @@ where
     Client: BlockReaderIdExt + StateProviderFactory,
 {
     let latest = provider
-        .block_by_id(BlockId::latest())
+        .block_by_id(BlockId::pending())
         .map_err(|e| ErrorObject::owned(ErrorCode::InternalError.code(), e.to_string(), Some("")))?
         .ok_or(ErrorObjectOwned::from(ErrorCode::InternalError))?;
 
@@ -108,7 +108,7 @@ where
     }
 
     if let Some(max_block) = options.block_number_max {
-        if max_block <= latest.number {
+        if max_block < latest.number {
             return Err(ErrorCode::from(-32003).into());
         }
     }
@@ -120,7 +120,7 @@ where
     }
 
     if let Some(max_timestamp) = options.timestamp_max {
-        if max_timestamp <= latest.timestamp {
+        if max_timestamp < latest.timestamp {
             return Err(ErrorCode::from(-32003).into());
         }
     }

--- a/world-chain-builder/src/rpc/bundle.rs
+++ b/world-chain-builder/src/rpc/bundle.rs
@@ -44,7 +44,8 @@ where
         tx: Bytes,
         options: ConditionalOptions,
     ) -> RpcResult<B256> {
-        self.validate_options(&options)?;
+        validate_conditional_options(&options, self.provider())?;
+
         let (recovered, _) = recover_raw_transaction(tx.clone())?;
         let mut pool_transaction = WorldChainPooledTransaction::from_pooled(recovered);
         pool_transaction.conditional_options = Some(options);
@@ -76,101 +77,106 @@ where
     pub fn pool(&self) -> &Pool {
         &self.pool
     }
+}
 
-    /// Validates the conditional inclusion options provided by the client.
-    ///
-    /// reference for the implementation <https://notes.ethereum.org/@yoav/SkaX2lS9j#>
-    /// See also <https://pkg.go.dev/github.com/aK0nshin/go-ethereum/arbitrum_types#ConditionalOptions>
-    pub fn validate_options(&self, options: &ConditionalOptions) -> RpcResult<()> {
-        let latest = self
-            .provider()
-            .block_by_id(BlockId::latest())
-            .map_err(|e| {
-                ErrorObject::owned(ErrorCode::InternalError.code(), e.to_string(), Some(""))
-            })?
-            .ok_or(ErrorObjectOwned::from(ErrorCode::InternalError))?;
+/// Validates the conditional inclusion options provided by the client.
+///
+/// reference for the implementation <https://notes.ethereum.org/@yoav/SkaX2lS9j#>
+/// See also <https://pkg.go.dev/github.com/aK0nshin/go-ethereum/arbitrum_types#ConditionalOptions>
+pub fn validate_conditional_options<Client>(
+    options: &ConditionalOptions,
+    provider: &Client,
+) -> RpcResult<()>
+where
+    Client: BlockReaderIdExt + StateProviderFactory,
+{
+    let latest = provider
+        .block_by_id(BlockId::latest())
+        .map_err(|e| ErrorObject::owned(ErrorCode::InternalError.code(), e.to_string(), Some("")))?
+        .ok_or(ErrorObjectOwned::from(ErrorCode::InternalError))?;
 
-        self.validate_known_accounts(&options.known_accounts, latest.header.number.into())?;
+    validate_known_accounts(
+        &options.known_accounts,
+        latest.header.number.into(),
+        provider,
+    )?;
 
-        if let Some(min_block) = options.block_number_min {
-            if min_block > latest.number {
-                return Err(ErrorCode::from(-32003).into());
-            }
+    if let Some(min_block) = options.block_number_min {
+        if min_block > latest.number {
+            return Err(ErrorCode::from(-32003).into());
         }
-
-        if let Some(max_block) = options.block_number_max {
-            if max_block <= latest.number {
-                return Err(ErrorCode::from(-32003).into());
-            }
-        }
-
-        if let Some(min_timestamp) = options.timestamp_min {
-            if min_timestamp > latest.timestamp {
-                return Err(ErrorCode::from(-32003).into());
-            }
-        }
-
-        if let Some(max_timestamp) = options.timestamp_max {
-            if max_timestamp <= latest.timestamp {
-                return Err(ErrorCode::from(-32003).into());
-            }
-        }
-
-        Ok(())
     }
 
-    /// Validates the account storage slots/storage root provided by the client
-    ///
-    /// Matches the current state of the account storage slots/storage root.
-    pub fn validate_known_accounts(
-        &self,
-        known_accounts: &HashMap<Address, AccountStorage, FbBuildHasher<20>>,
-        latest: BlockId,
-    ) -> RpcResult<()> {
-        let state = self.provider().state_by_block_id(latest).map_err(|e| {
-            ErrorObject::owned(ErrorCode::InternalError.code(), e.to_string(), Some(""))
-        })?;
+    if let Some(max_block) = options.block_number_max {
+        if max_block <= latest.number {
+            return Err(ErrorCode::from(-32003).into());
+        }
+    }
 
-        for (address, storage) in known_accounts.iter() {
-            match storage {
-                AccountStorage::Slots(slots) => {
-                    for (slot, value) in slots.iter() {
-                        let current =
-                            state
-                                .storage(*address, StorageKey::from(*slot))
-                                .map_err(|e| {
-                                    ErrorObject::owned(
-                                        ErrorCode::InternalError.code(),
-                                        e.to_string(),
-                                        Some(""),
-                                    )
-                                })?;
-                        if let Some(current) = current {
-                            if FixedBytes::<32>::from_slice(&current.to_be_bytes::<32>()) != *value
-                            {
-                                return Err(ErrorCode::from(-32003).into());
-                            }
-                        } else {
+    if let Some(min_timestamp) = options.timestamp_min {
+        if min_timestamp > latest.timestamp {
+            return Err(ErrorCode::from(-32003).into());
+        }
+    }
+
+    if let Some(max_timestamp) = options.timestamp_max {
+        if max_timestamp <= latest.timestamp {
+            return Err(ErrorCode::from(-32003).into());
+        }
+    }
+
+    Ok(())
+}
+
+/// Validates the account storage slots/storage root provided by the client
+///
+/// Matches the current state of the account storage slots/storage root.
+pub fn validate_known_accounts<Client>(
+    known_accounts: &HashMap<Address, AccountStorage, FbBuildHasher<20>>,
+    latest: BlockId,
+    provider: &Client,
+) -> RpcResult<()>
+where
+    Client: BlockReaderIdExt + StateProviderFactory,
+{
+    let state = provider.state_by_block_id(latest).map_err(|e| {
+        ErrorObject::owned(ErrorCode::InternalError.code(), e.to_string(), Some(""))
+    })?;
+
+    for (address, storage) in known_accounts.iter() {
+        match storage {
+            AccountStorage::Slots(slots) => {
+                for (slot, value) in slots.iter() {
+                    let current =
+                        state
+                            .storage(*address, StorageKey::from(*slot))
+                            .map_err(|e| {
+                                ErrorObject::owned(
+                                    ErrorCode::InternalError.code(),
+                                    e.to_string(),
+                                    Some(""),
+                                )
+                            })?;
+                    if let Some(current) = current {
+                        if FixedBytes::<32>::from_slice(&current.to_be_bytes::<32>()) != *value {
                             return Err(ErrorCode::from(-32003).into());
                         }
-                    }
-                }
-                AccountStorage::RootHash(expected) => {
-                    let root = state
-                        .storage_root(*address, Default::default())
-                        .map_err(|e| {
-                            ErrorObject::owned(
-                                ErrorCode::InternalError.code(),
-                                e.to_string(),
-                                Some(""),
-                            )
-                        })?;
-                    if *expected != root {
+                    } else {
                         return Err(ErrorCode::from(-32003).into());
                     }
                 }
             }
+            AccountStorage::RootHash(expected) => {
+                let root = state
+                    .storage_root(*address, Default::default())
+                    .map_err(|e| {
+                        ErrorObject::owned(ErrorCode::InternalError.code(), e.to_string(), Some(""))
+                    })?;
+                if *expected != root {
+                    return Err(ErrorCode::from(-32003).into());
+                }
+            }
         }
-        Ok(())
     }
+    Ok(())
 }

--- a/world-chain-builder/src/test/mod.rs
+++ b/world-chain-builder/src/test/mod.rs
@@ -39,6 +39,7 @@ pub fn get_non_pbh_transaction() -> WorldChainPooledTransaction {
     WorldChainPooledTransaction {
         inner: eth_tx,
         pbh_payload: None,
+        conditional_options: None,
     }
 }
 
@@ -53,6 +54,7 @@ pub fn get_pbh_transaction(nonce: u16) -> WorldChainPooledTransaction {
     WorldChainPooledTransaction {
         inner: eth_tx,
         pbh_payload: Some(pbh_payload),
+        conditional_options: None,
     }
 }
 


### PR DESCRIPTION
This PR updates the payload builder to enforce any pooled transaction with `ConditionalOptions` clear validation before including the tx into the payload. In the current implementation, all transactions that fail conditional options checks will be removed from the mempool.

```rust
// --snip--
  while let Some(pool_tx) = best_txs.next() {
        if let Some(conditional_options) = pool_tx.transaction.conditional_options() {
            if let Err(_) = validate_conditional_options(conditional_options, &client) {
                best_txs.mark_invalid(&pool_tx);
                invalid_txs.push(pool_tx.hash().clone());
                continue;
            }
        }

// --snip--
 if !invalid_txs.is_empty() {
   pool.remove_transactions(invalid_txs);
}
```