### PR TITLE
test: e2e tests against mainnet entry point

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -44,5 +44,5 @@ jobs:
       - name: Run Forge tests
         working-directory: contracts
         run: |
-          forge test -vvv
+          forge test -f "${{ secrets.ETHEREUM_PROVIDER }}" -vvv
         id: test

--- a/contracts/remappings.txt
+++ b/contracts/remappings.txt
@@ -6,3 +6,4 @@
 @helpers/=src/helpers/
 openzeppelin-contracts/=lib/world-id-contracts/lib/openzeppelin-contracts/contracts/
 @forge-std/=lib/forge-std/src/
+forge-std/=lib/forge-std/src/

--- a/contracts/scripts/DeployDevnet.s.sol
+++ b/contracts/scripts/DeployDevnet.s.sol
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {Script} from "@forge-std/Script.sol";
+import {PBHEntryPoint} from "../src/PBHEntryPoint.sol";
+import {PBHEntryPointImplV1} from "../src/PBHEntryPointImplV1.sol";
+import {PBHSignatureAggregator} from "../src/PBHSignatureAggregator.sol";
+import {console} from "forge-std/console.sol";
+import {EntryPoint} from "@account-abstraction/contracts/core/EntryPoint.sol";
+import {WorldIDIdentityManager} from "@world-id-contracts/WorldIDIdentityManager.sol";
+import {WorldIDRouter} from "@world-id-contracts/WorldIDRouter.sol";
+import {IWorldID} from "@world-id-contracts/interfaces/IWorldID.sol";
+import {IPBHEntryPoint} from "../src/interfaces/IPBHEntryPoint.sol";
+import {IWorldIDGroups} from "@world-id-contracts/interfaces/IWorldIDGroups.sol";
+import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
+
+import "@world-id-contracts/WorldIDRouter.sol";
+import "@world-id-contracts/WorldIDRouterImplV1.sol";
+import "@world-id-contracts/WorldIDIdentityManager.sol";
+import "@world-id-contracts/WorldIDIdentityManagerImplV1.sol";
+import "@world-id-contracts/WorldIDIdentityManagerImplV2.sol";
+import "@world-id-contracts/SemaphoreVerifier.sol";
+
+import {Verifier as InsertionB10} from "@world-id-contracts/verifiers/insertion/b10.sol";
+import {Verifier as InsertionB100} from "@world-id-contracts/verifiers/insertion/b100.sol";
+import {Verifier as InsertionB600} from "@world-id-contracts/verifiers/insertion/b600.sol";
+import {Verifier as InsertionB1200} from "@world-id-contracts/verifiers/insertion/b1200.sol";
+
+import {Verifier as DeletionB10} from "@world-id-contracts/verifiers/deletion/b10.sol";
+import {Verifier as DeletionB100} from "@world-id-contracts/verifiers/deletion/b100.sol";
+
+contract DeployDevnet is Script {
+    address public entryPoint;
+    address public worldIdGroups;
+    address public pbhEntryPoint;
+    address public pbhEntryPointImpl;
+    address public pbhSignatureAggregator;
+
+    uint8 constant TREE_DEPTH = 30;
+    uint256 constant INITIAL_ROOT =
+        0x918D46BF52D98B034413F4A1A1C41594E7A7A3F6AE08CB43D1A2A230E1959EF;
+
+    address semaphoreVerifier = address(0);
+
+    address batchInsertionVerifiers = address(0);
+    address batchDeletionVerifiers = address(0);
+
+    function run() public {
+        console.log(
+            "Deploying: EntryPoint, PBHEntryPoint, PBHEntryPointImplV1, PBHSignatureAggregator, WorldIDRouter, WorldIDOrb"
+        );
+
+        WorldIDIdentityManager worldIDOrb = deployWorldID(INITIAL_ROOT);
+        console.log("WorldIDOrb Deployed at:", address(worldIDOrb));
+
+        WorldIDRouter router = deployWorldIDRouter(
+            IWorldID(address(worldIDOrb))
+        );
+        console.log("WorldIDRouter Deployed at: ", address(router));
+
+        // Add WorldIDOrb to the router again for backwards compatibility
+        // a lot of services assume it's at group id 1
+        updateGroup(address(router), 1, address(worldIDOrb));
+        worldIdGroups = address(router);
+
+        beginBroadcast();
+        deployEntryPoint();
+        deployPBHEntryPoint();
+        deployPBHSignatureAggregator();
+        vm.stopBroadcast();
+    }
+
+    function deployEntryPoint() public {
+        entryPoint = address(new EntryPoint());
+        console.log("EntryPoint Deployed at: ", entryPoint);
+    }
+
+    function deployPBHEntryPoint() public {
+        pbhEntryPointImpl = address(new PBHEntryPointImplV1());
+        console.log("PBHEntryPointImplV1 Deployed at: ", pbhEntryPointImpl);
+        bytes memory initCallData = abi.encodeCall(
+            PBHEntryPointImplV1.initialize,
+            (IWorldIDGroups(worldIdGroups), IEntryPoint(entryPoint), 30)
+        );
+        pbhEntryPoint = address(
+            new PBHEntryPoint(pbhEntryPointImpl, initCallData)
+        );
+        console.log("PBHEntryPoint Deployed at: ", pbhEntryPoint);
+    }
+
+    function deployPBHSignatureAggregator() public {
+        pbhSignatureAggregator = address(
+            new PBHSignatureAggregator(pbhEntryPoint)
+        );
+        console.log(
+            "PBHSignatureAggregator Deployed at: ",
+            pbhSignatureAggregator
+        );
+    }
+
+    function deployWorldID(
+        uint256 _initalRoot
+    ) public returns (WorldIDIdentityManager worldID) {
+        VerifierLookupTable batchInsertionVerifiers = deployInsertionVerifiers();
+        VerifierLookupTable batchUpdateVerifiers = deployVerifierLookupTable();
+        VerifierLookupTable batchDeletionVerifiers = deployDeletionVerifiers();
+
+        SemaphoreVerifier _semaphoreVerifier = deploySemaphoreVerifier();
+
+        beginBroadcast();
+        // Encode:
+        // 'initialize(
+        //    uint8 _treeDepth,
+        //    uint256 initialRoot,
+        //    address _batchInsertionVerifiers,
+        //    address _batchUpdateVerifiers,
+        //    address _semaphoreVerifier
+        //  )'
+        bytes memory initializeCall = abi.encodeWithSignature(
+            "initialize(uint8,uint256,address,address,address)",
+            TREE_DEPTH,
+            _initalRoot,
+            batchInsertionVerifiers,
+            batchUpdateVerifiers,
+            semaphoreVerifier
+        );
+
+        // Encode:
+        // 'initializeV2(VerifierLookupTable _batchDeletionVerifiers)'
+        bytes memory initializeV2Call = abi.encodeWithSignature(
+            "initializeV2(address)",
+            batchDeletionVerifiers
+        );
+
+        WorldIDIdentityManagerImplV1 impl1 = new WorldIDIdentityManagerImplV1();
+        WorldIDIdentityManagerImplV2 impl2 = new WorldIDIdentityManagerImplV2();
+
+        WorldIDIdentityManager worldID = new WorldIDIdentityManager(
+            address(impl1),
+            initializeCall
+        );
+
+        // Recast to access api
+        WorldIDIdentityManagerImplV1 worldIDImplV1 = WorldIDIdentityManagerImplV1(
+                address(worldID)
+            );
+        worldIDImplV1.upgradeToAndCall(address(impl2), initializeV2Call);
+
+        vm.stopBroadcast();
+
+        return worldID;
+    }
+
+    function deployWorldIDRouter(
+        IWorldID initialGroupIdentityManager
+    ) public returns (WorldIDRouter router) {
+        beginBroadcast();
+
+        // Encode:
+        // 'initialize(IWorldID initialGroupIdentityManager)'
+        bytes memory initializeCall = abi.encodeWithSignature(
+            "initialize(address)",
+            address(initialGroupIdentityManager)
+        );
+
+        WorldIDRouterImplV1 impl = new WorldIDRouterImplV1();
+        WorldIDRouter router = new WorldIDRouter(address(impl), initializeCall);
+
+        vm.stopBroadcast();
+
+        return router;
+    }
+
+    function deployVerifierLookupTable()
+        public
+        returns (VerifierLookupTable lut)
+    {
+        beginBroadcast();
+
+        VerifierLookupTable lut = new VerifierLookupTable();
+
+        vm.stopBroadcast();
+
+        return lut;
+    }
+
+    function deploySemaphoreVerifier() public returns (SemaphoreVerifier) {
+        if (semaphoreVerifier == address(0)) {
+            beginBroadcast();
+
+            SemaphoreVerifier verifier = new SemaphoreVerifier();
+            semaphoreVerifier = address(verifier);
+
+            vm.stopBroadcast();
+        }
+
+        return SemaphoreVerifier(semaphoreVerifier);
+    }
+
+    function deployInsertionVerifiers()
+        public
+        returns (VerifierLookupTable lut)
+    {
+        if (batchInsertionVerifiers == address(0)) {
+            VerifierLookupTable lut = deployVerifierLookupTable();
+            batchInsertionVerifiers = address(lut);
+
+            beginBroadcast();
+
+            lut.addVerifier(10, ITreeVerifier(address(new InsertionB10())));
+            lut.addVerifier(100, ITreeVerifier(address(new InsertionB100())));
+            lut.addVerifier(600, ITreeVerifier(address(new InsertionB600())));
+            lut.addVerifier(1200, ITreeVerifier(address(new InsertionB1200())));
+
+            vm.stopBroadcast();
+        }
+
+        return VerifierLookupTable(batchInsertionVerifiers);
+    }
+
+    function deployDeletionVerifiers()
+        public
+        returns (VerifierLookupTable lut)
+    {
+        if (batchDeletionVerifiers == address(0)) {
+            VerifierLookupTable lut = deployVerifierLookupTable();
+            batchDeletionVerifiers = address(lut);
+
+            beginBroadcast();
+
+            lut.addVerifier(10, ITreeVerifier(address(new DeletionB10())));
+            lut.addVerifier(100, ITreeVerifier(address(new DeletionB100())));
+
+            vm.stopBroadcast();
+        }
+
+        return VerifierLookupTable(batchDeletionVerifiers);
+    }
+
+    function updateGroup(
+        address router,
+        uint256 groupNumber,
+        address worldID
+    ) public {
+        WorldIDRouterImplV1 routerImpl = WorldIDRouterImplV1(router);
+
+        beginBroadcast();
+
+        uint256 groupCount = routerImpl.groupCount();
+        if (groupCount == groupNumber) {
+            routerImpl.addGroup(IWorldID(worldID));
+        } else if (groupCount < groupNumber) {
+            routerImpl.updateGroup(groupNumber, IWorldID(worldID));
+        } else {
+            revert("Cannot update group number - group must be added first");
+        }
+
+        vm.stopBroadcast();
+    }
+
+    function beginBroadcast() internal {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(deployerPrivateKey);
+    }
+}

--- a/contracts/scripts/deploy_anvil.sh
+++ b/contracts/scripts/deploy_anvil.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+LOCAL_HOST="127.0.0.1"
+PORT="8545"
+CHAIN_ID="31337"
+
+# start anvil in bg
+anvil --chain-id ${CHAIN_ID} --block-time 2 --host ${LOCAL_HOST} --port ${PORT} &
+
+ANVIL_PID=$!
+echo "Anvil PID: $ANVIL_PID"
+export PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+
+forge script scripts/DeployDevnet.s.sol:DeployDevnet --rpc-url http://127.0.0.1:8545 --broadcast
+
+# Wait for anvil to finish
+wait $ANVIL_PID

--- a/contracts/test/PBHSignatureAggregator.t.sol
+++ b/contracts/test/PBHSignatureAggregator.t.sol
@@ -39,7 +39,6 @@ contract PBHSignatureAggregatorTest is TestUtils, Setup {
         bytes[] memory proofs = new bytes[](2);
         proofs[0] = abi.encode(proof0);
         proofs[1] = abi.encode(proof1);
-        console.log(entryPoint.getNonce(address(safe), 0));
 
         PackedUserOperation[] memory uoTestFixture = createUOTestData(address(safe), proofs);
         bytes memory aggregatedSignature = pbhAggregator.aggregateSignatures(uoTestFixture);

--- a/contracts/test/PBHSignatureAggregator.t.sol
+++ b/contracts/test/PBHSignatureAggregator.t.sol
@@ -5,11 +5,53 @@ import {Setup} from "./Setup.sol";
 import {IPBHVerifier} from "../src/interfaces/IPBHVerifier.sol";
 import {console} from "@forge-std/console.sol";
 import {TestUtils} from "./TestUtils.sol";
+import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
 import "@account-abstraction/contracts/interfaces/PackedUserOperation.sol";
+import "@BokkyPooBahsDateTimeLibrary/BokkyPooBahsDateTimeLibrary.sol";
+import "../src/helpers/PBHExternalNullifier.sol";
 
 contract PBHSignatureAggregatorTest is TestUtils, Setup {
     function setUp() public override {
         super.setUp();
+    }
+
+    function testFullFlow() public {
+        uint256 timestamp = block.timestamp;
+        uint8 month = uint8(BokkyPooBahsDateTimeLibrary.getMonth(timestamp));
+        uint16 year = uint16(BokkyPooBahsDateTimeLibrary.getYear(timestamp));
+        uint256 encoded = PBHExternalNullifier.encode(PBHExternalNullifier.V1, 0, month, year);
+
+        worldIDGroups.setVerifyProofSuccess(true);
+        IPBHVerifier.PBHPayload memory proof0 = IPBHVerifier.PBHPayload({
+            root: 1,
+            pbhExternalNullifier: encoded,
+            nullifierHash: 0,
+            proof: [uint256(0), 0, 0, 0, 0, 0, 0, 0]
+        });
+
+        IPBHVerifier.PBHPayload memory proof1 = IPBHVerifier.PBHPayload({
+            root: 2,
+            pbhExternalNullifier: encoded,
+            nullifierHash: 1,
+            proof: [uint256(0), 0, 0, 0, 0, 0, 0, 0]
+        });
+
+        bytes[] memory proofs = new bytes[](2);
+        proofs[0] = abi.encode(proof0);
+        proofs[1] = abi.encode(proof1);
+        console.log(entryPoint.getNonce(address(safe), 0));
+
+        PackedUserOperation[] memory uoTestFixture = createUOTestData(address(safe), proofs);
+        bytes memory aggregatedSignature = pbhAggregator.aggregateSignatures(uoTestFixture);
+
+        IEntryPoint.UserOpsPerAggregator[] memory userOpsPerAggregator = new IEntryPoint.UserOpsPerAggregator[](1);
+        userOpsPerAggregator[0] = IEntryPoint.UserOpsPerAggregator({
+            aggregator: pbhAggregator,
+            userOps: uoTestFixture,
+            signature: aggregatedSignature
+        });
+
+        pbhEntryPoint.handleAggregatedOps(userOpsPerAggregator, payable(address(this)));
     }
 
     function testAggregateSignatures(uint256 root, uint256 pbhExternalNullifier, uint256 nullifierHash) public {
@@ -20,7 +62,10 @@ contract PBHSignatureAggregatorTest is TestUtils, Setup {
             proof: [uint256(0), 0, 0, 0, 0, 0, 0, 0]
         });
 
-        PackedUserOperation[] memory uoTestFixture = createUOTestData(address(safe), abi.encode(proof));
+        bytes[] memory proofs = new bytes[](2);
+        proofs[0] = abi.encode(proof);
+        proofs[1] = abi.encode(proof);
+        PackedUserOperation[] memory uoTestFixture = createUOTestData(address(safe), proofs);
         bytes memory aggregatedSignature = pbhAggregator.aggregateSignatures(uoTestFixture);
         IPBHVerifier.PBHPayload[] memory decodedProofs = abi.decode(aggregatedSignature, (IPBHVerifier.PBHPayload[]));
         assertEq(decodedProofs.length, 2, "Decoded proof length should be 1");
@@ -36,4 +81,6 @@ contract PBHSignatureAggregatorTest is TestUtils, Setup {
         );
         assertEq(decodedProofs[1].nullifierHash, proof.nullifierHash, "Nullifier Hash should match");
     }
+
+    receive() external payable {}
 }

--- a/contracts/test/Setup.sol
+++ b/contracts/test/Setup.sol
@@ -24,7 +24,7 @@ contract Setup is Test {
     ///////////////////////////////////////////////////////////////////////////////
 
     /// @notice The 4337 Entry Point on Ethereum Mainnet.
-    IEntryPoint internal entryPoint = IEntryPoint(address(0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789));
+    IEntryPoint internal entryPoint = IEntryPoint(address(0x0000000071727De22E5E9d8BAf0edAc6f37da032));
     /// @notice The PBHEntryPoint contract.
     IPBHEntryPoint public pbhEntryPoint;
     /// @notice The PBHSignatureAggregator contract.
@@ -32,7 +32,7 @@ contract Setup is Test {
     /// @notice No-op account.
     IAccount public safe;
     /// @notice The Mock World ID Groups contract.
-    IWorldIDGroups public worldIDGroups;
+    MockWorldIDGroups public worldIDGroups;
 
     address public pbhEntryPointImpl;
     address public immutable thisAddress = address(this);
@@ -58,7 +58,11 @@ contract Setup is Test {
         vm.label(pbhEntryPointImpl, "PBH Entry Point Impl V1");
 
         vm.deal(address(this), type(uint128).max);
-        vm.deal(address(safe), type(uint128).max);
+        vm.deal(address(safe), type(uint256).max);
+
+        // Deposit some funds into the Entry Point from the Mock Account.
+        vm.prank(address(safe));
+        entryPoint.depositTo{value: 10 ether}(address(safe));
     }
 
     ///////////////////////////////////////////////////////////////////////////////

--- a/contracts/test/TestUtils.sol
+++ b/contracts/test/TestUtils.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import "@account-abstraction/contracts/interfaces/PackedUserOperation.sol";
 import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
 import {IAggregator} from "@account-abstraction/contracts/interfaces/IAggregator.sol";
+import "@forge-std/console.sol";
 
 contract TestUtils {
     function encodeSignature(bytes memory proofData) public pure returns (bytes memory) {
@@ -26,27 +27,30 @@ contract TestUtils {
         return signature;
     }
 
-    function createUOTestData(address sender, bytes memory proofData)
+    /// @notice Create a test data for UserOperations.
+    function createUOTestData(address sender, bytes[] memory proofs)
         public
         pure
         returns (PackedUserOperation[] memory)
     {
-        bytes memory signature = encodeSignature(proofData);
-        PackedUserOperation[] memory uOps = new PackedUserOperation[](2);
-        PackedUserOperation memory baseUO = PackedUserOperation({
-            sender: sender,
-            nonce: 0,
-            initCode: abi.encodePacked("0x"),
-            callData: abi.encodePacked("0x"),
-            accountGasLimits: bytes32("10000"),
-            preVerificationGas: 10000,
-            gasFees: bytes32(0),
-            paymasterAndData: abi.encodePacked("0x"),
-            signature: signature
-        });
+        PackedUserOperation[] memory uOps = new PackedUserOperation[](proofs.length);
+        for (uint256 i = 0; i < proofs.length; ++i) {
+            bytes memory signature = encodeSignature(proofs[i]);
+            // uint256 preVerificationGas = uint256(100000) << 64 | 100000;
+            PackedUserOperation memory uo = PackedUserOperation({
+                sender: sender,
+                nonce: i,
+                initCode: new bytes(0),
+                callData: new bytes(0),
+                accountGasLimits: 0x00000000000000000000000000009fd300000000000000000000000000000000,
+                preVerificationGas: 21000,
+                gasFees: 0x0000000000000000000000000000000100000000000000000000000000000001,
+                paymasterAndData: new bytes(0),
+                signature: signature
+            });
+            uOps[i] = uo;
+        }
 
-        uOps[0] = baseUO;
-        uOps[1] = baseUO;
         return uOps;
     }
 }

--- a/contracts/test/TestUtils.sol
+++ b/contracts/test/TestUtils.sol
@@ -36,7 +36,6 @@ contract TestUtils {
         PackedUserOperation[] memory uOps = new PackedUserOperation[](proofs.length);
         for (uint256 i = 0; i < proofs.length; ++i) {
             bytes memory signature = encodeSignature(proofs[i]);
-            // uint256 preVerificationGas = uint256(100000) << 64 | 100000;
             PackedUserOperation memory uo = PackedUserOperation({
                 sender: sender,
                 nonce: i,


### PR DESCRIPTION
- Tests the e2e flow of the `handleAggregatedOps` through the Mainnet `EntryPoint` v0.7

- Patches UserOp hashing logic to hash all `PackedUserOperation[]` in `OpsPerAggregator[]` at the slot of the hash. Checking collision on storage prior to storing the hash.

- Adds a Devnet Deployment Script that we can use to start testing the block builder against fixtures through kurtosis