### PR TITLE
fix(contracts): Update `PBHSignatureAggregatorTest` to fix stack overflow during `forge coverage`

### DIFF
--- a/contracts/test/PBHSignatureAggregator.t.sol
+++ b/contracts/test/PBHSignatureAggregator.t.sol
@@ -12,24 +12,37 @@ import "../src/helpers/PBHExternalNullifier.sol";
 import {PBHSignatureAggregator} from "../src/PBHSignatureAggregator.sol";
 
 contract PBHSignatureAggregatorTest is TestSetup {
+    struct ProofData {
+        uint256 p0;
+        uint256 p1;
+        uint256 p2;
+        uint256 p3;
+        uint256 p4;
+        uint256 p5;
+        uint256 p6;
+        uint256 p7;
+    }
+
     function testFuzz_AggregateSignatures(
         uint256 root,
         uint256 pbhExternalNullifier,
         uint256 nullifierHash,
-        uint256 p0,
-        uint256 p1,
-        uint256 p2,
-        uint256 p3,
-        uint256 p4,
-        uint256 p5,
-        uint256 p6,
-        uint256 p7
+        ProofData calldata proofData
     ) public {
         IPBHEntryPoint.PBHPayload memory proof = IPBHEntryPoint.PBHPayload({
             root: root,
             pbhExternalNullifier: pbhExternalNullifier,
             nullifierHash: nullifierHash,
-            proof: [p0, p1, p2, p3, p4, p5, p6, p7]
+            proof: [
+                proofData.p0,
+                proofData.p1,
+                proofData.p2,
+                proofData.p3,
+                proofData.p4,
+                proofData.p5,
+                proofData.p6,
+                proofData.p7
+            ]
         });
 
         bytes[] memory proofs = new bytes[](2);
@@ -75,14 +88,7 @@ contract PBHSignatureAggregatorTest is TestSetup {
         uint256 pbhExternalNullifier,
         uint256 nullifierHash,
         uint8 signatureThreshold,
-        uint256 p0,
-        uint256 p1,
-        uint256 p2,
-        uint256 p3,
-        uint256 p4,
-        uint256 p5,
-        uint256 p6,
-        uint256 p7
+        ProofData calldata proofData
     ) public {
         vm.assume(signatureThreshold >= 1);
         deployMockSafe(address(pbhAggregator), signatureThreshold);
@@ -90,7 +96,16 @@ contract PBHSignatureAggregatorTest is TestSetup {
             root: root,
             pbhExternalNullifier: pbhExternalNullifier,
             nullifierHash: nullifierHash,
-            proof: [p0, p1, p2, p3, p4, p5, p6, p7]
+            proof: [
+                proofData.p0,
+                proofData.p1,
+                proofData.p2,
+                proofData.p3,
+                proofData.p4,
+                proofData.p5,
+                proofData.p6,
+                proofData.p7
+            ]
         });
 
         bytes memory proofData = abi.encode(proof);
@@ -159,20 +174,22 @@ contract PBHSignatureAggregatorTest is TestSetup {
         uint256 root,
         uint256 pbhExternalNullifier,
         uint256 nullifierHash,
-        uint256 p0,
-        uint256 p1,
-        uint256 p2,
-        uint256 p3,
-        uint256 p4,
-        uint256 p5,
-        uint256 p6,
-        uint256 p7
+        ProofData calldata proofData
     ) public {
         IPBHEntryPoint.PBHPayload memory proof = IPBHEntryPoint.PBHPayload({
             root: root,
             pbhExternalNullifier: pbhExternalNullifier,
             nullifierHash: nullifierHash,
-            proof: [p0, p1, p2, p3, p4, p5, p6, p7]
+            proof: [
+                proofData.p0,
+                proofData.p1,
+                proofData.p2,
+                proofData.p3,
+                proofData.p4,
+                proofData.p5,
+                proofData.p6,
+                proofData.p7
+            ]
         });
 
         bytes[] memory proofs = new bytes[](2);


### PR DESCRIPTION
Previously, `forge coverage` could not run due to stack overflow. This PR updates `PBHSignatureAggregatorTest` to use `ProofData` in order to reduce the amount of variables on the stack. Below is the current output from `forge coverage`.


```bash
╭----------------------------------------------+------------------+------------------+-----------------+----------------╮
| File                                         | % Lines          | % Statements     | % Branches      | % Funcs        |
+=======================================================================================================================+
| src/PBH4337Module.sol                        | 96.30% (26/27)   | 93.75% (30/32)   | 50.00% (5/10)   | 100.00% (2/2)  |
|----------------------------------------------+------------------+------------------+-----------------+----------------|
| src/PBHEntryPointImplV1.sol                  | 87.50% (56/64)   | 86.96% (60/69)   | 70.00% (7/10)   | 88.89% (8/9)   |
|----------------------------------------------+------------------+------------------+-----------------+----------------|
| src/PBHSignatureAggregator.sol               | 84.21% (16/19)   | 81.82% (18/22)   | 66.67% (4/6)    | 75.00% (3/4)   |
|----------------------------------------------+------------------+------------------+-----------------+----------------|
| src/helpers/ByteHasher.sol                   | 100.00% (2/2)    | 100.00% (2/2)    | 100.00% (0/0)   | 100.00% (1/1)  |
|----------------------------------------------+------------------+------------------+-----------------+----------------|
| src/helpers/PBHExternalNullifier.sol         | 100.00% (15/15)  | 100.00% (16/16)  | 100.00% (12/12) | 100.00% (3/3)  |
|----------------------------------------------+------------------+------------------+-----------------+----------------|
| src/helpers/SafeModuleSignatures.sol         | 90.91% (10/11)   | 92.31% (12/13)   | 50.00% (1/2)    | 100.00% (1/1)  |
|----------------------------------------------+------------------+------------------+-----------------+----------------|
| test/TestSetup.sol                           | 66.22% (49/74)   | 75.68% (56/74)   | 100.00% (0/0)   | 7.69% (1/13)   |
|----------------------------------------------+------------------+------------------+-----------------+----------------|
| test/TestUtils.sol                           | 100.00% (33/33)  | 100.00% (38/38)  | 100.00% (0/0)   | 100.00% (7/7)  |
|----------------------------------------------+------------------+------------------+-----------------+----------------|
| test/mocks/Mock4337Module.sol                | 100.00% (2/2)    | 100.00% (2/2)    | 100.00% (0/0)   | 100.00% (1/1)  |
|----------------------------------------------+------------------+------------------+-----------------+----------------|
| test/mocks/MockAccount.sol                   | 62.50% (5/8)     | 75.00% (3/4)     | 100.00% (0/0)   | 50.00% (2/4)   |
|----------------------------------------------+------------------+------------------+-----------------+----------------|
| test/mocks/MockEIP1271SignatureValidator.sol | 100.00% (2/2)    | 100.00% (1/1)    | 100.00% (0/0)   | 100.00% (1/1)  |
|----------------------------------------------+------------------+------------------+-----------------+----------------|
| test/mocks/MockWorldIDGroups.sol             | 80.00% (4/5)     | 66.67% (2/3)     | 0.00% (0/1)     | 100.00% (2/2)  |
|----------------------------------------------+------------------+------------------+-----------------+----------------|
| Total                                        | 83.97% (220/262) | 86.96% (240/276) | 70.73% (29/41)  | 66.67% (32/48) |
╰----------------------------------------------+------------------+------------------+-----------------+----------------╯
```