### PR TITLE
chore: upgrade rollup-boost:0.3rc4 + define World ID in node args

### DIFF
--- a/devnet/src/package_io/input_parser.star
+++ b/devnet/src/package_io/input_parser.star
@@ -15,7 +15,7 @@ DEFAULT_EL_IMAGES = {
 }
 
 DEFAULT_ENGINE_IMAGES = {
-    "rollup-boost": "flashbots/rollup-boost:0.2",
+    "rollup-boost": "flashbots/rollup-boost:0.3rc4",
 }
 
 DEFAULT_CL_IMAGES = {
@@ -24,7 +24,7 @@ DEFAULT_CL_IMAGES = {
 }
 
 DEFAULT_BATCHER_IMAGES = {
-    "op-batcher": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-batcher:develop",
+    "op-batcher": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-batcher:v1.9.4",
 }
 
 DEFAULT_PROPOSER_IMAGES = {

--- a/world-chain-builder/crates/world/node/src/args.rs
+++ b/world-chain-builder/crates/world/node/src/args.rs
@@ -29,8 +29,16 @@ pub struct WorldChainBuilderArgs {
 
     /// Sets the ERC-4337 EntryPoint Proxy contract address
     /// This contract is used to validate 4337 PBH bundles
-    #[arg(long = "builder.pbh_validator")]
-    pub pbh_validator: Address,
+    #[arg(long = "builder.pbh_entrypoint")]
+    pub pbh_entrypoint: Address,
+
+    /// Sets the WorldID contract address.
+    /// This contract is used to provide the latest merkle root on chain.
+    #[arg(
+        long = "builder.world_id",
+        default_value = "0x047eE5313F98E26Cc8177fA38877cB36292D2364"
+    )]
+    pub world_id: Address,
 
     /// Sets the ERC0-7766 Signature Aggregator contract address
     /// This contract signifies that a given bundle should receive priority inclusion if it passes validation

--- a/world-chain-builder/crates/world/node/src/node.rs
+++ b/world-chain-builder/crates/world/node/src/node.rs
@@ -75,8 +75,9 @@ impl WorldChainBuilder {
         let WorldChainBuilderArgs {
             num_pbh_txs,
             verified_blockspace_capacity,
-            pbh_validator,
+            pbh_entrypoint,
             signature_aggregator,
+            world_id,
         } = args.builder_args;
 
         let RollupArgs {
@@ -90,8 +91,9 @@ impl WorldChainBuilder {
             .node_types::<Node>()
             .pool(WorldChainPoolBuilder::new(
                 num_pbh_txs,
-                pbh_validator,
+                pbh_entrypoint,
                 signature_aggregator,
+                world_id,
             ))
             .payload(WorldChainPayloadBuilder::new(
                 compute_pending_block,

--- a/world-chain-builder/crates/world/node/src/test_utils.rs
+++ b/world-chain-builder/crates/world/node/src/test_utils.rs
@@ -50,7 +50,7 @@ use world_chain_builder_pbh::external_nullifier::ExternalNullifier;
 use alloy_eips::eip2718::Encodable2718;
 use chrono::Datelike;
 use world_chain_builder_pool::{
-    test_utils::{pbh_bundle, signer, user_op, PBH_TEST_VALIDATOR},
+    test_utils::{pbh_bundle, signer, user_op, PBH_TEST_ENTRYPOINT},
     tx::{WorldChainPoolTransaction, WorldChainPooledTransaction},
     validator::WorldChainTransactionValidator,
 };
@@ -86,7 +86,7 @@ impl PBHTransactionTestContext {
             chain_id,
             Some(Bytes::from(encoded)),
             tx_nonce,
-            PBH_TEST_VALIDATOR,
+            PBH_TEST_ENTRYPOINT,
         );
         let envelope = TransactionTestContext::sign_tx(signer(acc), tx).await;
         let raw_tx = envelope.encoded_2718();

--- a/world-chain-builder/crates/world/node/tests/mod.rs
+++ b/world-chain-builder/crates/world/node/tests/mod.rs
@@ -27,9 +27,9 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use world_chain_builder_pool::ordering::WorldChainOrdering;
-use world_chain_builder_pool::root::{LATEST_ROOT_SLOT, OP_WORLD_ID};
+use world_chain_builder_pool::root::LATEST_ROOT_SLOT;
 use world_chain_builder_pool::test_utils::{
-    signer, tree_root, PBH_TEST_SIGNATURE_AGGREGATOR, PBH_TEST_VALIDATOR,
+    signer, tree_root, PBH_TEST_ENTRYPOINT, PBH_TEST_SIGNATURE_AGGREGATOR, TEST_WORLD_ID,
 };
 use world_chain_builder_pool::tx::WorldChainPooledTransaction;
 use world_chain_builder_pool::validator::WorldChainTransactionValidator;
@@ -110,8 +110,9 @@ impl WorldChainBuilderTestContext {
                 builder_args: WorldChainBuilderArgs {
                     num_pbh_txs: 30,
                     verified_blockspace_capacity: 70,
-                    pbh_validator: PBH_TEST_VALIDATOR,
+                    pbh_entrypoint: PBH_TEST_ENTRYPOINT,
                     signature_aggregator: PBH_TEST_SIGNATURE_AGGREGATOR,
+                    world_id: TEST_WORLD_ID,
                 },
                 ..Default::default()
             })?)
@@ -299,7 +300,7 @@ fn get_chain_spec() -> OpChainSpec {
 
     OpChainSpecBuilder::base_mainnet()
         .genesis(genesis.extend_accounts(vec![(
-            OP_WORLD_ID,
+            TEST_WORLD_ID,
             GenesisAccount::default().with_storage(Some(BTreeMap::from_iter(vec![(
                 LATEST_ROOT_SLOT.into(),
                 tree_root().into(),

--- a/world-chain-builder/crates/world/pool/src/builder.rs
+++ b/world-chain-builder/crates/world/pool/src/builder.rs
@@ -23,16 +23,23 @@ use crate::validator::WorldChainTransactionValidator;
 #[derive(Debug, Clone)]
 pub struct WorldChainPoolBuilder {
     pub num_pbh_txs: u8,
-    pub pbh_validator: Address,
+    pub pbh_entrypoint: Address,
     pub pbh_signature_aggregator: Address,
+    pub world_id: Address,
 }
 
 impl WorldChainPoolBuilder {
-    pub fn new(num_pbh_txs: u8, pbh_validator: Address, pbh_signature_aggregator: Address) -> Self {
+    pub fn new(
+        num_pbh_txs: u8,
+        pbh_entrypoint: Address,
+        pbh_signature_aggregator: Address,
+        world_id: Address,
+    ) -> Self {
         Self {
             num_pbh_txs,
-            pbh_validator,
+            pbh_entrypoint,
             pbh_signature_aggregator,
+            world_id,
         }
     }
 }
@@ -62,13 +69,14 @@ where
                 // In --dev mode we can't require gas fees because we're unable to decode the L1
                 // block info
                 .require_l1_data_gas_fee(!ctx.config().dev.dev);
-            let root_validator = WorldChainRootValidator::new(validator.client().clone())
-                .expect("failed to initialize root validator");
+            let root_validator =
+                WorldChainRootValidator::new(validator.client().clone(), self.world_id)
+                    .expect("failed to initialize root validator");
             WorldChainTransactionValidator::new(
                 op_tx_validator,
                 root_validator,
                 self.num_pbh_txs,
-                self.pbh_validator,
+                self.pbh_entrypoint,
                 self.pbh_signature_aggregator,
             )
         });

--- a/world-chain-builder/crates/world/pool/src/root.rs
+++ b/world-chain-builder/crates/world/pool/src/root.rs
@@ -13,7 +13,7 @@ use super::error::WorldChainTransactionPoolError;
 /// The slot of the `_latestRoot` in the
 ///
 /// [WorldID contract](https://github.com/worldcoin/world-id-state-bridge/blob/729d2346a3bb6bac003284bdcefc0cf12ece3f7d/src/abstract/WorldIDBridge.sol#L30)
-pub const LATEST_ROOT_SLOT: U256 = U256::from_limbs([1, 0, 0, 0]);
+pub const LATEST_ROOT_SLOT: U256 = U256::from_limbs([2, 0, 0, 0]);
 /// Root Expiration Period
 pub const ROOT_EXPIRATION_WINDOW: u64 = 60 * 60; // 1 hour
 

--- a/world-chain-builder/crates/world/pool/src/root.rs
+++ b/world-chain-builder/crates/world/pool/src/root.rs
@@ -1,21 +1,19 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use alloy_consensus::{BlockHeader, Sealable};
+use alloy_primitives::{Address, U256};
 use parking_lot::RwLock;
 use reth::api::Block;
 use reth_primitives::SealedBlock;
 use reth_provider::{BlockReaderIdExt, StateProviderFactory};
-use revm_primitives::{address, Address, U256};
 use semaphore::Field;
 
 use super::error::WorldChainTransactionPoolError;
 
-/// The WorldID contract address.
-pub const OP_WORLD_ID: Address = address!("047eE5313F98E26Cc8177fA38877cB36292D2364");
 /// The slot of the `_latestRoot` in the
 ///
 /// [WorldID contract](https://github.com/worldcoin/world-id-state-bridge/blob/729d2346a3bb6bac003284bdcefc0cf12ece3f7d/src/abstract/WorldIDBridge.sol#L30)
-pub const LATEST_ROOT_SLOT: U256 = U256::from_limbs([2, 0, 0, 0]);
+pub const LATEST_ROOT_SLOT: U256 = U256::from_limbs([1, 0, 0, 0]);
 /// Root Expiration Period
 pub const ROOT_EXPIRATION_WINDOW: u64 = 60 * 60; // 1 hour
 
@@ -25,6 +23,8 @@ pub struct RootProvider<Client>
 where
     Client: StateProviderFactory + BlockReaderIdExt,
 {
+    /// Address of the WorldID contract
+    world_id: Address,
     /// The client used to aquire account state from the database.
     client: Client,
     /// A map of valid roots indexed by block timestamp.
@@ -45,9 +45,10 @@ where
     /// # Arguments
     ///
     /// * `client` - The client used to aquire account state from the database.
-    pub fn new(client: Client) -> Result<Self, WorldChainTransactionPoolError> {
+    pub fn new(client: Client, world_id: Address) -> Result<Self, WorldChainTransactionPoolError> {
         let mut this = Self {
             client,
+            world_id,
             valid_roots: BTreeMap::new(),
             latest_valid_timestamp: 0,
             latest_root: Field::ZERO,
@@ -60,7 +61,7 @@ where
                 let state = this
                     .client
                     .state_by_block_hash(block.header().hash_slow())?;
-                let latest_root = state.storage(OP_WORLD_ID, LATEST_ROOT_SLOT.into())?;
+                let latest_root = state.storage(this.world_id, LATEST_ROOT_SLOT.into())?;
                 if let Some(latest) = latest_root {
                     this.latest_root = latest;
                     this.valid_roots.insert(block.header().timestamp(), latest);
@@ -81,7 +82,7 @@ where
             .state_by_block_hash(block.hash())
             .map_err(WorldChainTransactionPoolError::RootProvider)?;
         let root = state
-            .storage(OP_WORLD_ID, LATEST_ROOT_SLOT.into())
+            .storage(self.world_id, LATEST_ROOT_SLOT.into())
             .map_err(WorldChainTransactionPoolError::RootProvider)?;
         self.latest_valid_timestamp = block.timestamp;
         if let Some(root) = root {
@@ -132,8 +133,8 @@ where
     /// # Arguments
     ///
     /// * `client` - The client used for state and block operations.
-    pub fn new(client: Client) -> Result<Self, WorldChainTransactionPoolError> {
-        let cache = RootProvider::new(client)?;
+    pub fn new(client: Client, world_id: Address) -> Result<Self, WorldChainTransactionPoolError> {
+        let cache = RootProvider::new(client, world_id)?;
 
         Ok(Self {
             cache: Arc::new(RwLock::new(cache)),
@@ -170,11 +171,13 @@ mod tests {
     use reth_primitives::{Header, SealedHeader};
     use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
 
+    use crate::test_utils::TEST_WORLD_ID;
+
     use super::*;
     use reth_primitives::Block;
     pub fn world_chain_root_validator() -> eyre::Result<WorldChainRootValidator<MockEthProvider>> {
         let client = MockEthProvider::default();
-        let root_validator = WorldChainRootValidator::new(client)?;
+        let root_validator = WorldChainRootValidator::new(client, TEST_WORLD_ID)?;
         Ok(root_validator)
     }
 
@@ -192,7 +195,7 @@ mod tests {
             ..Default::default()
         };
         validator.cache.read().client().add_account(
-            OP_WORLD_ID,
+            TEST_WORLD_ID,
             ExtendedAccount::new(0, U256::ZERO)
                 .extend_storage(vec![(LATEST_ROOT_SLOT.into(), root)]),
         );

--- a/world-chain-builder/crates/world/pool/src/test_utils.rs
+++ b/world-chain-builder/crates/world/pool/src/test_utils.rs
@@ -187,7 +187,7 @@ pub fn pbh_bundle(
             signature: signature_buff.into(),
             aggregator: PBH_TEST_SIGNATURE_AGGREGATOR,
         }],
-        _1: PBH_TEST_VALIDATOR,
+        _1: PBH_TEST_ENTRYPOINT,
     }
 }
 
@@ -245,7 +245,9 @@ pub fn pbh_multicall(
 pub const PBH_TEST_SIGNATURE_AGGREGATOR: Address =
     address!("09635F643e140090A9A8Dcd712eD6285858ceBef");
 
-pub const PBH_TEST_VALIDATOR: Address = address!("7a2088a1bFc9d81c55368AE168C2C02570cB814F");
+pub const PBH_TEST_ENTRYPOINT: Address = address!("7a2088a1bFc9d81c55368AE168C2C02570cB814F");
+
+pub const TEST_WORLD_ID: Address = address!("047eE5313F98E26Cc8177fA38877cB36292D2364");
 
 pub fn world_chain_validator(
 ) -> WorldChainTransactionValidator<MockEthProvider, WorldChainPooledTransaction> {
@@ -255,12 +257,12 @@ pub fn world_chain_validator(
         .no_cancun()
         .build(client.clone(), InMemoryBlobStore::default());
     let validator = OpTransactionValidator::new(validator).require_l1_data_gas_fee(false);
-    let root_validator = WorldChainRootValidator::new(client).unwrap();
+    let root_validator = WorldChainRootValidator::new(client, TEST_WORLD_ID).unwrap();
     WorldChainTransactionValidator::new(
         validator,
         root_validator,
         30,
-        PBH_TEST_VALIDATOR,
+        PBH_TEST_ENTRYPOINT,
         PBH_TEST_SIGNATURE_AGGREGATOR,
     )
 }

--- a/world-chain-builder/crates/world/pool/src/validator.rs
+++ b/world-chain-builder/crates/world/pool/src/validator.rs
@@ -336,8 +336,8 @@ pub mod tests {
 
     use super::WorldChainTransactionValidator;
     use crate::ordering::WorldChainOrdering;
-    use crate::root::{LATEST_ROOT_SLOT, OP_WORLD_ID};
-    use crate::test_utils::{self, world_chain_validator, PBH_TEST_VALIDATOR};
+    use crate::root::LATEST_ROOT_SLOT;
+    use crate::test_utils::{self, world_chain_validator, PBH_TEST_ENTRYPOINT, TEST_WORLD_ID};
     use crate::tx::WorldChainPooledTransaction;
 
     async fn setup() -> Pool<
@@ -363,7 +363,7 @@ pub mod tests {
 
         // Insert a world id root into the OpWorldId Account
         validator.inner.client().add_account(
-            OP_WORLD_ID,
+            TEST_WORLD_ID,
             ExtendedAccount::new(0, alloy_primitives::U256::ZERO)
                 .extend_storage(vec![(LATEST_ROOT_SLOT.into(), root)]),
         );
@@ -439,7 +439,7 @@ pub mod tests {
         let calldata = bundle.abi_encode();
 
         let tx = test_utils::eip1559()
-            .to(PBH_TEST_VALIDATOR)
+            .to(PBH_TEST_ENTRYPOINT)
             .input(calldata)
             .call();
 
@@ -507,7 +507,7 @@ pub mod tests {
         let calldata = bundle.abi_encode();
 
         let tx = test_utils::eip1559()
-            .to(PBH_TEST_VALIDATOR)
+            .to(PBH_TEST_ENTRYPOINT)
             .input(calldata)
             .call();
 
@@ -539,7 +539,7 @@ pub mod tests {
         let calldata = calldata.abi_encode();
 
         let tx = test_utils::eip1559()
-            .to(PBH_TEST_VALIDATOR)
+            .to(PBH_TEST_ENTRYPOINT)
             .input(calldata)
             .call();
 
@@ -574,7 +574,7 @@ pub mod tests {
         let calldata = bundle.abi_encode();
 
         let tx = test_utils::eip1559()
-            .to(PBH_TEST_VALIDATOR)
+            .to(PBH_TEST_ENTRYPOINT)
             .input(calldata)
             .call();
 
@@ -614,7 +614,7 @@ pub mod tests {
         let calldata = bundle.abi_encode();
 
         let tx = test_utils::eip1559()
-            .to(PBH_TEST_VALIDATOR)
+            .to(PBH_TEST_ENTRYPOINT)
             .input(calldata)
             .call();
 
@@ -650,7 +650,7 @@ pub mod tests {
         let calldata = bundle.abi_encode();
 
         let tx = test_utils::eip1559()
-            .to(PBH_TEST_VALIDATOR)
+            .to(PBH_TEST_ENTRYPOINT)
             .input(calldata)
             .call();
 
@@ -688,7 +688,7 @@ pub mod tests {
         let client = MockEthProvider::default();
         // Insert a world id root into the OpWorldId Account
         client.add_account(
-            OP_WORLD_ID,
+            TEST_WORLD_ID,
             ExtendedAccount::new(0, alloy_primitives::U256::ZERO)
                 .extend_storage(vec![(LATEST_ROOT_SLOT.into(), Field::from(1u64))]),
         );
@@ -722,7 +722,7 @@ pub mod tests {
         let client = MockEthProvider::default();
         // Insert a world id root into the OpWorldId Account
         client.add_account(
-            OP_WORLD_ID,
+            TEST_WORLD_ID,
             ExtendedAccount::new(0, alloy_primitives::U256::ZERO)
                 .extend_storage(vec![(LATEST_ROOT_SLOT.into(), Field::from(1u64))]),
         );


### PR DESCRIPTION
This PR:
- Upgrades `rollup-boost` to latest version
- Allows `world_id` address to be defined over CLI args
- Patches `op-batcher` version in devnet to pre DA throttle 