### PR TITLE
feat: workflow to sync 10k blocks

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -9,7 +9,8 @@ on:
   push:
     tags:
         - v*
-
+  pull_request:
+    
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,62 @@
+# Runs sync tests.
+name: sync test
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 1'
+  push:
+    tags:
+        - v*
+
+env:
+  CARGO_TERM_COLOR: always
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    name: sync (${{ matrix.chain.bin }})
+    runs-on: ubuntu-22.04-32core
+    env:
+      RUST_LOG: info,sync=error
+      RUST_BACKTRACE: 1
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        chain:
+          - build: install
+            bin: world-chain-builder
+            features: jemalloc
+            chain: base
+            tip: "0xbb9b85352c7ebca6ba8efc63bd66cecd038c92ec8ebd02e153a3e0b197e672b7"
+            block: 10000
+            unwind-target: "0x118a6e922a8c6cab221fc5adfe5056d2b72d58c6580e9c5629de55299e2cf8de"
+        # TODO: Add World Chain Mainnet
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - name: Build ${{ matrix.chain.bin }}
+        run: just ${{ matrix.chain.build }} --features ${{ matrix.chain.features }}
+      - name: Run sync
+        run: |
+          ${{ matrix.chain.bin }} node \
+            --chain ${{ matrix.chain.chain }} \
+            --debug.tip ${{ matrix.chain.tip }} \
+            --debug.max-block ${{ matrix.chain.block }} \
+            --debug.terminate
+      - name: Verify the target block hash
+        run: |
+          ${{ matrix.chain.bin }} db --chain ${{ matrix.chain.chain }} get static-file headers ${{ matrix.chain.block }} \
+            | grep ${{ matrix.chain.tip }}
+      - name: Run stage unwind for 100 blocks
+        run: |
+          ${{ matrix.chain.bin }} stage --chain ${{ matrix.chain.chain }} unwind num-blocks 100
+      - name: Run stage unwind to block hash
+        run: |
+          ${{ matrix.chain.bin }} stage --chain ${{ matrix.chain.chain }} unwind to-block ${{ matrix.chain.unwind-target }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -10,7 +10,7 @@ on:
     tags:
         - v*
   pull_request:
-    
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -40,6 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@just
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,4 +1,5 @@
 # Runs sync tests.
+# This workflow is modified from Reth: https://github.com/paradigmxyz/reth/blob/main/.github/workflows/sync.yml
 name: sync test
 
 on:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -9,8 +9,7 @@ on:
   push:
     tags:
         - v*
-  pull_request:
-
+        
 env:
   CARGO_TERM_COLOR: always
 
@@ -55,7 +54,7 @@ jobs:
             --debug.terminate \
             --builder.pbh_entrypoint 0x7a2088a1bFc9d81c55368AE168C2C02570cB814F \
             --builder.signature_aggregator 0x09635F643e140090A9A8Dcd712eD6285858ceBef
-            
+
       - name: Verify the target block hash
         run: |
           ${{ matrix.chain.bin }} db --chain ${{ matrix.chain.chain }} get static-file headers ${{ matrix.chain.block }} \

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -52,7 +52,10 @@ jobs:
             --chain ${{ matrix.chain.chain }} \
             --debug.tip ${{ matrix.chain.tip }} \
             --debug.max-block ${{ matrix.chain.block }} \
-            --debug.terminate
+            --debug.terminate \
+            --builder.pbh_entrypoint 0x7a2088a1bFc9d81c55368AE168C2C02570cB814F \
+            --builder.signature_aggregator 0x09635F643e140090A9A8Dcd712eD6285858ceBef
+            
       - name: Verify the target block hash
         run: |
           ${{ matrix.chain.bin }} db --chain ${{ matrix.chain.chain }} get static-file headers ${{ matrix.chain.block }} \

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -48,7 +48,7 @@ jobs:
         run: just ${{ matrix.chain.build }} --features ${{ matrix.chain.features }}
       - name: Run sync
         run: |
-          ${{ matrix.chain.bin }} node \
+          ~/.cargo/bin/${{ matrix.chain.bin }} node \
             --chain ${{ matrix.chain.chain }} \
             --debug.tip ${{ matrix.chain.tip }} \
             --debug.max-block ${{ matrix.chain.block }} \

--- a/Justfile
+++ b/Justfile
@@ -27,3 +27,7 @@ test:
 # Formats the world-chain-builder
 fmt: 
     @just ./world-chain-builder/fmt
+
+# Installs the world-chain-builder
+install *args='':
+    @just ./world-chain-builder/install $@

--- a/devnet/src/el/world-chain/world_chain_launcher.star
+++ b/devnet/src/el/world-chain/world_chain_launcher.star
@@ -167,7 +167,7 @@ def get_config(
         "--metrics=0.0.0.0:{0}".format(METRICS_PORT_NUM),
         "--discovery.port={0}".format(discovery_port),
         "--port={0}".format(discovery_port),
-        "--builder.pbh_validator=0x7a2088a1bFc9d81c55368AE168C2C02570cB814F", # Deterministic Deployment Address on re-runs
+        "--builder.pbh_entrypoint=0x7a2088a1bFc9d81c55368AE168C2C02570cB814F", # Deterministic Deployment Address on re-runs
         "--builder.signature_aggregator=0x09635F643e140090A9A8Dcd712eD6285858ceBef" # Deterministic Deployment Address on re-runs
     ]
 

--- a/world-chain-builder/Justfile
+++ b/world-chain-builder/Justfile
@@ -16,3 +16,5 @@ fmt-check:
 e2e-test:
     RUST_LOG=info cargo run -p tests --release 
 
+install *args='':
+  cargo install --path crates/world/bin --locked $@


### PR DESCRIPTION
This PR introduces a workflow that syncs 10k blocks of base chain. Verifying the integrity of syncing `world-chain-builder` prior to cutting a new release. 

Job: https://github.com/worldcoin/world-chain/actions/runs/12756214550/job/35553889239