### PR TITLE
N-03

### DIFF
--- a/contracts/src/PBH4337Module.sol
+++ b/contracts/src/PBH4337Module.sol
@@ -106,7 +106,7 @@ contract PBHSafe4337Module is Safe4337Module {
         // A malicious bundler can pad the Safe operation `signatures` with additional bytes, causing the account to pay
         // more gas than needed for user operation validation (capped by `verificationGasLimit`).
         // `_checkSignaturesLength` ensures that there are no additional bytes in the `signature` than are required.
-        bool validSignature = _checkSignaturesLength(signatures, ISafe(payable(userOp.sender)).getThreshold());
+        bool validSignature = _checkSignaturesLength(signatures, threshold);
 
         try ISafe(payable(userOp.sender)).checkSignatures(keccak256(operationData), operationData, signatures) {}
         catch {

--- a/contracts/src/PBHEntryPointImplV1.sol
+++ b/contracts/src/PBHEntryPointImplV1.sol
@@ -167,6 +167,8 @@ contract PBHEntryPointImplV1 is IPBHEntryPoint, WorldIDImpl, ReentrancyGuardTran
         emit PBHEntryPointImplInitialized(_worldId, _entryPoint, _numPbhPerMonth, multicall3, _pbhGasLimit);
     }
 
+    /// @notice Verifies a PBH payload.
+    /// @param signalHash The signal hash associated with the PBH payload.
     /// @param pbhPayload The PBH payload containing the proof data.
     function verifyPbh(uint256 signalHash, PBHPayload memory pbhPayload)
         public
@@ -175,6 +177,13 @@ contract PBHEntryPointImplV1 is IPBHEntryPoint, WorldIDImpl, ReentrancyGuardTran
         onlyProxy
         onlyInitialized
     {
+        _verifyPbh(signalHash, pbhPayload);
+    }
+
+    /// @notice Verifies a PBH payload.
+    /// @param signalHash The signal hash associated with the PBH payload.
+    /// @param pbhPayload The PBH payload containing the proof data.
+    function _verifyPbh(uint256 signalHash, PBHPayload memory pbhPayload) internal view {
         // First, we make sure this nullifier has not been used before.
         if (nullifierHashes[pbhPayload.nullifierHash]) {
             revert InvalidNullifier();
@@ -219,7 +228,7 @@ contract PBHEntryPointImplV1 is IPBHEntryPoint, WorldIDImpl, ReentrancyGuardTran
                     sender, opsPerAggregator[i].userOps[j].nonce, opsPerAggregator[i].userOps[j].callData
                 ).hashToField();
 
-                verifyPbh(signalHash, pbhPayloads[j]);
+                _verifyPbh(signalHash, pbhPayloads[j]);
                 nullifierHashes[pbhPayloads[j].nullifierHash] = true;
                 emit PBH(sender, signalHash, pbhPayloads[j]);
             }
@@ -252,7 +261,7 @@ contract PBHEntryPointImplV1 is IPBHEntryPoint, WorldIDImpl, ReentrancyGuardTran
         returns (IMulticall3.Result[] memory returnData)
     {
         uint256 signalHash = abi.encode(msg.sender, calls).hashToField();
-        verifyPbh(signalHash, pbhPayload);
+        _verifyPbh(signalHash, pbhPayload);
         nullifierHashes[pbhPayload.nullifierHash] = true;
 
         returnData = IMulticall3(_multicall3).aggregate3{gas: pbhGasLimit}(calls);


### PR DESCRIPTION
N-03 Code Simplifications

ACK
> The handleAggregatedOps function [calls verifyPbh](https://github.com/worldcoin/world-chain/blob/cc112c40157eca93e998649459340f4c5f3580c0/contracts/src/PBHEntryPointImplV1.sol#L222) which redundantly invokes the [onlyProxy and onlyInitialized modifiers](https://github.com/worldcoin/world-chain/blob/cc112c40157eca93e998649459340f4c5f3580c0/contracts/src/PBHEntryPointImplV1.sol#L175-L176). The function body could be moved to its own internal function so that it can be invoked without the modifiers.

I believe we want this to be public for use by the bundler off chain. cc @0xKitsune 