### PR TITLE
Osiris/better validation

### DIFF
--- a/world-chain-builder/Cargo.lock
+++ b/world-chain-builder/Cargo.lock
@@ -13707,6 +13707,7 @@ dependencies = [
  "reth-db",
  "reth-e2e-test-utils",
  "reth-eth-wire-types",
+ "reth-evm",
  "reth-optimism-chainspec",
  "reth-optimism-node",
  "reth-optimism-primitives",

--- a/world-chain-builder/crates/world/node/Cargo.toml
+++ b/world-chain-builder/crates/world/node/Cargo.toml
@@ -26,10 +26,12 @@ reth-optimism-payload-builder.workspace = true
 reth-primitives = { workspace = true, optional = true }
 reth-primitives-traits = { workspace = true, optional = true }
 reth-provider.workspace = true
+reth-optimism-evm = { workspace = true, optional = true }
 reth-prune-types = { workspace = true, optional = true }
 reth-trie = { workspace = true, optional = true }
 reth-trie-db.workspace = true
 reth-e2e-test-utils = { workspace = true, optional = true }
+reth-evm = { workspace = true, optional = true}
 
 alloy-eips = { workspace = true, optional = true }
 alloy-primitives.workspace = true
@@ -74,8 +76,10 @@ test = [
     "dep:reth-e2e-test-utils",
     "dep:reth-chain-state",
     "dep:reth-primitives",
+    "dep:reth-evm",
     "dep:reth-primitives-traits",
     "dep:reth-prune-types",
+    "dep:reth-optimism-evm",
     "dep:reth-trie",
     "dep:reth-db",
     "dep:revm-primitives",

--- a/world-chain-builder/crates/world/node/src/test_utils.rs
+++ b/world-chain-builder/crates/world/node/src/test_utils.rs
@@ -17,7 +17,10 @@ use reth_chain_state::{
 };
 use reth_db::models::{AccountBeforeTx, StoredBlockBodyIndices};
 use reth_e2e_test_utils::transaction::TransactionTestContext;
+use reth_evm::ConfigureEvm;
 use reth_optimism_chainspec::OpChainSpec;
+use reth_optimism_evm::OpEvmConfig;
+use reth_optimism_primitives::OpTransactionSigned;
 use reth_primitives::{
     Account, Block, Bytecode, EthPrimitives, Header, Receipt, RecoveredBlock, SealedBlock,
     SealedHeader, TransactionMeta, TransactionSigned,
@@ -619,25 +622,30 @@ impl ForkChoiceSubscriptions for WorldChainNoopProvider {
     }
 }
 
-pub struct WorldChainNoopValidator<Client, Tx>
+pub struct WorldChainNoopValidator<Client, Tx, EvmConfig>
 where
     Client: StateProviderFactory + BlockReaderIdExt,
 {
-    _inner: WorldChainTransactionValidator<Client, Tx>,
+    _inner: WorldChainTransactionValidator<Client, Tx, EvmConfig>,
 }
 
-impl WorldChainNoopValidator<WorldChainNoopProvider, WorldChainPooledTransaction> {
+impl WorldChainNoopValidator<WorldChainNoopProvider, WorldChainPooledTransaction, OpEvmConfig> {
     pub fn new(
-        inner: WorldChainTransactionValidator<WorldChainNoopProvider, WorldChainPooledTransaction>,
+        inner: WorldChainTransactionValidator<
+            WorldChainNoopProvider,
+            WorldChainPooledTransaction,
+            OpEvmConfig,
+        >,
     ) -> Self {
         Self { _inner: inner }
     }
 }
 
-impl<Client, Tx> TransactionValidator for WorldChainNoopValidator<Client, Tx>
+impl<Client, Tx, EvmConfig> TransactionValidator for WorldChainNoopValidator<Client, Tx, EvmConfig>
 where
     Client: StateProviderFactory + BlockReaderIdExt,
     Tx: WorldChainPoolTransaction,
+    EvmConfig: ConfigureEvm<Header = Header, Transaction = OpTransactionSigned>,
 {
     type Transaction = Tx;
 

--- a/world-chain-builder/crates/world/node/tests/mod.rs
+++ b/world-chain-builder/crates/world/node/tests/mod.rs
@@ -59,6 +59,7 @@ type NodeHelperType = NodeAdapter<
                         NodeTypesWithDBAdapter<WorldChainBuilder, Arc<TempDatabase<DatabaseEnv>>>,
                     >,
                     WorldChainPooledTransaction,
+                    OpEvmConfig,
                 >,
             >,
             WorldChainOrdering<WorldChainPooledTransaction>,

--- a/world-chain-builder/crates/world/pool/Cargo.toml
+++ b/world-chain-builder/crates/world/pool/Cargo.toml
@@ -24,6 +24,7 @@ reth-optimism-primitives.workspace = true
 reth-optimism-chainspec.workspace = true
 revm-primitives.workspace = true
 reth-primitives-traits.workspace = true
+reth-evm.workspace = true
 
 alloy-consensus.workspace = true
 alloy-primitives.workspace = true

--- a/world-chain-builder/crates/world/pool/src/builder.rs
+++ b/world-chain-builder/crates/world/pool/src/builder.rs
@@ -7,6 +7,7 @@ use reth::transaction_pool::blobstore::DiskFileBlobStore;
 use reth::transaction_pool::TransactionValidationTaskExecutor;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_node::txpool::OpTransactionValidator;
+use reth_optimism_node::OpEvmConfig;
 use reth_optimism_primitives::OpPrimitives;
 use reth_provider::CanonStateSubscriptions;
 use tracing::{debug, info};
@@ -74,6 +75,7 @@ where
                     .expect("failed to initialize root validator");
             WorldChainTransactionValidator::new(
                 op_tx_validator,
+                OpEvmConfig::new(ctx.chain_spec()),
                 root_validator,
                 self.num_pbh_txs,
                 self.pbh_entrypoint,

--- a/world-chain-builder/crates/world/pool/src/error.rs
+++ b/world-chain-builder/crates/world/pool/src/error.rs
@@ -25,5 +25,5 @@ pub enum WorldChainTransactionPoolError {
     #[error(transparent)]
     Database(#[from] DatabaseError),
     #[error(transparent)]
-    RootProvider(#[from] ProviderError),
+    Provider(#[from] ProviderError),
 }

--- a/world-chain-builder/crates/world/pool/src/inspector.rs
+++ b/world-chain-builder/crates/world/pool/src/inspector.rs
@@ -1,0 +1,34 @@
+use reth::revm::{Database, Inspector};
+use revm_primitives::Address;
+
+/// Simple inspector that keeps track of the call stack
+pub struct CallTracer {
+    /// A vector of addresses across the call stack.
+    pub stack: Vec<Address>,
+}
+
+impl CallTracer {
+    /// Creates a new instance [`CallTracer`]
+    pub fn new() -> Self {
+        Self { stack: Vec::new() }
+    }
+
+    /// Checks whether the `pbh_entrypoint` exists within the call stack.
+    /// 
+    /// Note: This is excluding the target of the transaction from an EOA as the first external call interpreted will be
+    ///       within the call context of a contract. 
+    pub fn is_valid(&self, pbh_entrypoint: Address) -> bool {
+        self.stack.iter().all(|&addr| addr != pbh_entrypoint)
+    }
+}
+
+impl<DB: Database> Inspector<DB> for CallTracer {
+    fn call(
+        &mut self,
+        _context: &mut reth::revm::EvmContext<DB>,
+        inputs: &mut reth::revm::interpreter::CallInputs,
+    ) -> Option<reth::revm::interpreter::CallOutcome> {
+        self.stack.push(inputs.target_address);
+        None
+    }
+}

--- a/world-chain-builder/crates/world/pool/src/inspector.rs
+++ b/world-chain-builder/crates/world/pool/src/inspector.rs
@@ -14,9 +14,9 @@ impl CallTracer {
     }
 
     /// Checks whether the `pbh_entrypoint` exists within the call stack.
-    /// 
+    ///
     /// Note: This is excluding the target of the transaction from an EOA as the first external call interpreted will be
-    ///       within the call context of a contract. 
+    ///       within the call context of a contract.
     pub fn is_valid(&self, pbh_entrypoint: Address) -> bool {
         self.stack.iter().all(|&addr| addr != pbh_entrypoint)
     }

--- a/world-chain-builder/crates/world/pool/src/inspector.rs
+++ b/world-chain-builder/crates/world/pool/src/inspector.rs
@@ -5,22 +5,17 @@ use revm_primitives::Address;
 pub struct CallTracer {
     /// A vector of addresses across the call stack.
     pub stack: Vec<Address>,
-    /// Depth of the call stack
-    pub depth: u32,
 }
 
 impl CallTracer {
     /// Creates a new instance [`CallTracer`]
     pub fn new() -> Self {
-        Self {
-            stack: Vec::new(),
-            depth: 0,
-        }
+        Self { stack: Vec::new() }
     }
 
     /// Checks whether the `pbh_entrypoint` exists within the call stack.
     pub fn is_valid(&self, pbh_entrypoint: Address) -> bool {
-        self.stack.iter().all(|&addr| addr != pbh_entrypoint)
+        self.stack[1..].iter().all(|&addr| addr != pbh_entrypoint)
     }
 }
 
@@ -30,10 +25,8 @@ impl<DB: Database> Inspector<DB> for CallTracer {
         _context: &mut reth::revm::EvmContext<DB>,
         inputs: &mut reth::revm::interpreter::CallInputs,
     ) -> Option<reth::revm::interpreter::CallOutcome> {
-        if self.depth != 0 {
-            self.stack.push(inputs.target_address);
-        }
-        self.depth += 1;
+        self.stack.push(inputs.target_address);
+
         None
     }
 }

--- a/world-chain-builder/crates/world/pool/src/lib.rs
+++ b/world-chain-builder/crates/world/pool/src/lib.rs
@@ -9,6 +9,7 @@ pub mod ordering;
 pub mod root;
 pub mod tx;
 pub mod validator;
+pub mod inspector;
 
 #[cfg(any(feature = "test", test))]
 pub mod mock;

--- a/world-chain-builder/crates/world/pool/src/lib.rs
+++ b/world-chain-builder/crates/world/pool/src/lib.rs
@@ -4,12 +4,12 @@ pub mod bindings;
 pub mod builder;
 pub mod eip4337;
 pub mod error;
+pub mod inspector;
 pub mod noop;
 pub mod ordering;
 pub mod root;
 pub mod tx;
 pub mod validator;
-pub mod inspector;
 
 #[cfg(any(feature = "test", test))]
 pub mod mock;

--- a/world-chain-builder/crates/world/pool/src/root.rs
+++ b/world-chain-builder/crates/world/pool/src/root.rs
@@ -84,13 +84,8 @@ where
     where
         B: reth_primitives_traits::Block,
     {
-        let state = self
-            .client
-            .state_by_block_hash(block.hash())
-            .map_err(WorldChainTransactionPoolError::RootProvider)?;
-        let root = state
-            .storage(self.world_id, LATEST_ROOT_SLOT.into())
-            .map_err(WorldChainTransactionPoolError::RootProvider)?;
+        let state = self.client.state_by_block_hash(block.hash())?;
+        let root = state.storage(self.world_id, LATEST_ROOT_SLOT.into())?;
         self.latest_valid_timestamp = block.timestamp();
         if let Some(root) = root {
             self.valid_roots.insert(block.timestamp(), root);

--- a/world-chain-builder/crates/world/pool/src/test_utils.rs
+++ b/world-chain-builder/crates/world/pool/src/test_utils.rs
@@ -14,6 +14,7 @@ use reth::transaction_pool::validate::EthTransactionValidatorBuilder;
 use reth_optimism_node::txpool::{OpPooledTransaction, OpTransactionValidator};
 use reth_optimism_primitives::OpTransactionSigned;
 use reth_primitives::transaction::SignedTransactionIntoRecoveredExt;
+use reth_primitives::Block;
 use revm_primitives::TxKind;
 use semaphore::identity::Identity;
 use semaphore::poseidon_tree::LazyPoseidonTree;
@@ -254,6 +255,8 @@ pub const TEST_WORLD_ID: Address = address!("047eE5313F98E26Cc8177fA38877cB36292
 pub fn world_chain_validator(
 ) -> WorldChainTransactionValidator<MockEthProvider, WorldChainPooledTransaction> {
     let client = MockEthProvider::default();
+    let block = Block::<OpTransactionSigned>::default();
+    client.add_block(block.hash_slow(), block);
     let validator = EthTransactionValidatorBuilder::new(MAINNET.clone())
         .no_shanghai()
         .no_cancun()

--- a/world-chain-builder/crates/world/pool/src/tx.rs
+++ b/world-chain-builder/crates/world/pool/src/tx.rs
@@ -37,6 +37,8 @@ pub enum WorldChainPoolTransactionError {
     InvalidSignatureAggregator,
     #[error("Malformed Call Trace")]
     MalformedCallTrace,
+    #[error("Evm Error {0}")]
+    EvmError(String),
 }
 
 impl WorldChainPoolTransactionError {

--- a/world-chain-builder/crates/world/pool/src/tx.rs
+++ b/world-chain-builder/crates/world/pool/src/tx.rs
@@ -35,6 +35,8 @@ pub enum WorldChainPoolTransactionError {
     MissingPbhPayload,
     #[error("InvalidSignatureAggregator")]
     InvalidSignatureAggregator,
+    #[error("Malformed Call Trace")]
+    MalformedCallTrace,
 }
 
 impl WorldChainPoolTransactionError {


### PR DESCRIPTION
Related to `6.1 [Medium] Nullifier hashes may be consumed without a valid proof`
Introduces a Revm inspector to inspect the call trace of a transaction in the transaction validator. If any target address along the call stack is the `PBHEntryPoint` the transaction is considered "Invalid" and dropped from the Mempool. 

This protects the `PBHEntryPoint`s `nullifierHashes` mapping from ever being populated without proof verification. 