### PR TITLE
fix: only use 32 bits of the nonce key to differentiate PBH

### DIFF
--- a/contracts/src/PBH4337Module.sol
+++ b/contracts/src/PBH4337Module.sol
@@ -31,7 +31,7 @@ contract PBHSafe4337Module is Safe4337Module {
 
     /// @notice The PBH Nonce Key.
     /// @dev This key is used to identify a PBH user operation.
-    uint192 public immutable PBH_NONCE_KEY;
+    uint32 public immutable PBH_NONCE_KEY;
 
     ///////////////////////////////////////////////////////////////////////////////
     ///                                  ERRORS                                ///
@@ -50,7 +50,7 @@ contract PBHSafe4337Module is Safe4337Module {
     ///                               FUNCTIONS                                 ///
     ///////////////////////////////////////////////////////////////////////////////
 
-    constructor(address entryPoint, address _pbhSignatureAggregator, uint192 _pbhNonceKey) Safe4337Module(entryPoint) {
+    constructor(address entryPoint, address _pbhSignatureAggregator, uint32 _pbhNonceKey) Safe4337Module(entryPoint) {
         require(_pbhSignatureAggregator != address(0), AddressZero());
         require(entryPoint != address(0), AddressZero());
         require(_pbhNonceKey != 0, UninitializedNonceKey());
@@ -86,7 +86,7 @@ contract PBHSafe4337Module is Safe4337Module {
         // If it is a PBH transaction, we need to handle two cases with the signature:
         // 1. The bundler simulates the call with the proof appended
         // 2. UserOp execution without proof appended
-        bool isPBH = (key == PBH_NONCE_KEY);
+        bool isPBH = (key & 0xffffffff) == PBH_NONCE_KEY;
 
         uint256 threshold = ISafe(payable(userOp.sender)).getThreshold();
 

--- a/contracts/test/PBH4337Module.t.sol
+++ b/contracts/test/PBH4337Module.t.sol
@@ -29,7 +29,7 @@ contract PBHSafe4337ModuleTest is Test {
     uint256 public ownerKey;
 
     address public constant PBH_SIGNATURE_AGGREGATOR = address(0x123);
-    uint192 public constant PBH_NONCE_KEY = 1123123123;
+    uint32 public constant PBH_NONCE_KEY = 1123123123;
 
     function setUp() public {
         // Create single EOA owner

--- a/contracts/test/TestSetup.sol
+++ b/contracts/test/TestSetup.sol
@@ -63,7 +63,7 @@ contract TestSetup is Test {
     address public constant nullAddress = address(0);
     address public constant MULTICALL3 = 0xcA11bde05977b3631167028862bE2a173976CA11;
 
-    uint192 public constant PBH_NONCE_KEY = 1123123123;
+    uint32 public constant PBH_NONCE_KEY = 1123123123;
 
     uint8 public constant MAX_NUM_PBH_PER_MONTH = 30;
     uint256 public constant MAX_PBH_GAS_LIMIT = 10000000;

--- a/contracts/test/mocks/Mock4337Module.sol
+++ b/contracts/test/mocks/Mock4337Module.sol
@@ -10,7 +10,7 @@ import {ISafe} from "@4337/interfaces/Safe.sol";
 import "forge-std/console.sol";
 
 contract Mock4337Module is PBHSafe4337Module {
-    constructor(address entryPoint, address _pbhSignatureAggregator, uint192 _pbhNonceKey)
+    constructor(address entryPoint, address _pbhSignatureAggregator, uint32 _pbhNonceKey)
         PBHSafe4337Module(entryPoint, _pbhSignatureAggregator, _pbhNonceKey)
     {}
 


### PR DESCRIPTION
Fixes the `PBH4337Module` `PBH_NONCE_KEY` to only use 32 bits of the key to differentiate PBH. This allows the Safe Module to have multiple in flight PBH UserOperations in the bundler, as the nonce key can change while being able to differentiate PBH.