### PR TITLE
feat: `WorldChainBlockRegistry`

### DIFF
--- a/contracts/scripts/DeployBlockRegistry.s.sol
+++ b/contracts/scripts/DeployBlockRegistry.s.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Script, console} from "forge-std/Script.sol";
+import {WorldChainBlockRegistry} from "../src/WorldChainBlockRegistry.sol";
+
+contract Deploy is Script {
+    WorldChainBlockRegistry public worldChainBlockRegistry;
+    address public constant BUILDER = address(0);
+
+    function run() public {
+        uint256 deployer = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(deployer);
+        worldChainBlockRegistry = new WorldChainBlockRegistry(BUILDER);
+        vm.stopBroadcast();
+    }
+}

--- a/contracts/scripts/DeployDevnet.s.sol
+++ b/contracts/scripts/DeployDevnet.s.sol
@@ -18,11 +18,13 @@ import {SafeModuleSetup} from "@4337/SafeModuleSetup.sol";
 import {PBHSafe4337Module} from "../src/PBH4337Module.sol";
 import {Mock4337Module} from "../test/mocks/Mock4337Module.sol";
 import {Safe4337Module} from "@4337/Safe4337Module.sol";
+import {WorldChainBlockRegistry} from "../src/WorldChainBlockRegistry.sol";
 
 contract DeployDevnet is Script {
     address public pbhEntryPoint;
     address public pbhEntryPointImpl;
     address public pbhSignatureAggregator;
+    address public worldChainBlockRegistry;
 
     Safe public singleton;
     SafeProxyFactory public factory;
@@ -32,6 +34,7 @@ contract DeployDevnet is Script {
         0x0000000071727De22E5E9d8BAf0edAc6f37da032;
     address public constant WORLD_ID =
         0x5FbDB2315678afecb367f032d93F642f64180aa3;
+    address public constant BUILDER = address(0); // TODO: Update
     /// @dev The root of the Test tree.
     uint256 constant INITIAL_ROOT =
         0x5276AD6D825269EB0B67A2E1589123DED27C8B8EABFA898FF7E878AD61071AD;
@@ -40,7 +43,7 @@ contract DeployDevnet is Script {
 
     function run() public {
         console.log(
-            "Deploying: EntryPoint, PBHEntryPoint, PBHEntryPointImplV1, PBHSignatureAggregator, PBHSafe4337Module"
+            "Deploying: EntryPoint, PBHEntryPoint, PBHEntryPointImplV1, PBHSignatureAggregator, PBHSafe4337Module, WorldChainBlockRegistry"
         );
 
         uint256 privateKey = vm.envUint("PRIVATE_KEY");
@@ -48,6 +51,7 @@ contract DeployDevnet is Script {
         deployPBHEntryPoint();
         deployPBHSignatureAggregator();
         deploySafeAndModules();
+        deployWorldChainBlockRegistry();
         updateWorldID();
         vm.stopBroadcast();
     }
@@ -78,6 +82,16 @@ contract DeployDevnet is Script {
         console.log(
             "PBHSignatureAggregator Deployed at: ",
             pbhSignatureAggregator
+        );
+    }
+
+    function deployWorldChainBlockRegistry() public {
+        worldChainBlockRegistry = new WorldChainBlockRegistry(
+            BUILDER
+        );
+        console.log(
+            "WorldChainBlockRegistry Deployed at: ",
+            worldChainBlockRegistry
         );
     }
 

--- a/contracts/src/WorldChainBlockRegistry.sol
+++ b/contracts/src/WorldChainBlockRegistry.sol
@@ -2,12 +2,13 @@
 pragma solidity ^0.8.28;
 
 import "@openzeppelin/contracts/access/Ownable2Step.sol";
+import "./interfaces/IWorldChainBlockRegistry.sol";
 
 /// @title World Chain Block Registry
 /// @notice This contract records which blocks were built by the World Chain Builder.
 /// @dev Each block, the builder will insert a transaction calling stampBlock() to indiciate which
 /// blocks should enforce PBH priority ordering.
-contract WorldChainBlockRegistry is Ownable2Step {
+contract WorldChainBlockRegistry is IWorldChainBlockRegistry, Ownable2Step {
     ///////////////////////////////////////////////////////////////////////////////
     ///                             STATE VARIABLES                             ///
     //////////////////////////////////////////////////////////////////////////////

--- a/contracts/src/WorldChainBlockRegistry.sol
+++ b/contracts/src/WorldChainBlockRegistry.sol
@@ -46,7 +46,7 @@ contract WorldChainBlockRegistry is Ownable2Step {
     ///////////////////////////////////////////////////////////////////////////////
     ///                               FUNCTIONS                                 ///
     ///////////////////////////////////////////////////////////////////////////////
-    constructor(address builder) Ownable2Step(msg.sender) {
+    constructor(address builder) Ownable(msg.sender) {
         require(builder != address(0), AddressZero());
         worldChainBuilder = builder;
     }

--- a/contracts/src/WorldChainBlockRegistry.sol
+++ b/contracts/src/WorldChainBlockRegistry.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "@openzeppelin/contracts/access/Ownable2Step.sol";
+
+/// @title World Chain Block Registry
+/// @notice This contract records which blocks were built by the World Chain Builder.
+/// @dev Each block, the builder will insert a transaction calling stampBlock() to indiciate which
+/// blocks should enforce PBH priority ordering.
+contract WorldChainBlockRegistry is Ownable2Step {
+    ///////////////////////////////////////////////////////////////////////////////
+    ///                             STATE VARIABLES                             ///
+    //////////////////////////////////////////////////////////////////////////////
+
+    /// @notice Address of the World Chain Builder
+    address worldChainBuilder;
+
+    /// @notice Mapping to record which blocks were built by the World Chain Builder
+    mapping(uint256 blockNumber => address builder) public builtBlocks;
+
+    ///////////////////////////////////////////////////////////////////////////////
+    ///                                  Events                                ///
+    //////////////////////////////////////////////////////////////////////////////
+
+    /// @notice Event emitted whenever the builder calls stampBlock()
+    event BuiltBlock(address indexed builder, uint256 indexed blockNumber);
+
+    /// @notice Event emitted whenever the owner updates the builder
+    event WorldChainBuilderUpdated(address indexed builder);
+
+    ///////////////////////////////////////////////////////////////////////////////
+    ///                                  ERRORS                                ///
+    //////////////////////////////////////////////////////////////////////////////
+    error AddressZero();
+    error BlockAlreadyRegistered();
+    error Unauthorized();
+
+    ///////////////////////////////////////////////////////////////////////////////
+    ///                               MODIFIERS                                 ///
+    ///////////////////////////////////////////////////////////////////////////////
+    modifier onlyBuilder() {
+        require(msg.sender == worldChainBuilder, Unauthorized());
+        _;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    ///                               FUNCTIONS                                 ///
+    ///////////////////////////////////////////////////////////////////////////////
+    constructor(address builder) {
+        require(builder != address(0), AddressZero());
+        worldChainBuilder = builder;
+    }
+
+    /// @notice Record the current block as being built by the World Chain Builder
+    function stampBlock() public onlyBuilder {
+        require(builtBlocks[block.number] == address(0), BlockAlreadyRegistered());
+        builtBlocks[block.number] = msg.sender;
+        emit BuiltBlock(msg.sender, block.number);
+    }
+
+    /// @notice Update the World Chain Builder address
+    function updateBuilder(address builder) public onlyOwner {
+        require(builder != address(0), AddressZero());
+        worldChainBuilder = builder;
+        emit WorldChainBuilderUpdated(builder);
+    }
+}

--- a/contracts/src/WorldChainBlockRegistry.sol
+++ b/contracts/src/WorldChainBlockRegistry.sol
@@ -46,7 +46,7 @@ contract WorldChainBlockRegistry is Ownable2Step {
     ///////////////////////////////////////////////////////////////////////////////
     ///                               FUNCTIONS                                 ///
     ///////////////////////////////////////////////////////////////////////////////
-    constructor(address builder) {
+    constructor(address builder) Ownable2Step(msg.sender) {
         require(builder != address(0), AddressZero());
         worldChainBuilder = builder;
     }

--- a/contracts/src/interfaces/IWorldChainBlockRegistry.sol
+++ b/contracts/src/interfaces/IWorldChainBlockRegistry.sol
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.12 <0.9.0;
+pragma solidity ^0.8.28;
 
-interface IWorldChainBlockRegistry {}
+interface IWorldChainBlockRegistry {
+    function stampBlock() external;
+    function updateBuilder(address builder) external;
+}

--- a/contracts/src/interfaces/IWorldChainBlockRegistry.sol
+++ b/contracts/src/interfaces/IWorldChainBlockRegistry.sol
@@ -4,4 +4,5 @@ pragma solidity ^0.8.28;
 interface IWorldChainBlockRegistry {
     function stampBlock() external;
     function updateBuilder(address builder) external;
+    function builtBlocks(uint256 blockNumber) external view returns (address);
 }

--- a/contracts/src/interfaces/IWorldChainBlockRegistry.sol
+++ b/contracts/src/interfaces/IWorldChainBlockRegistry.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.12 <0.9.0;
+
+interface IWorldChainBlockRegistry {}

--- a/contracts/test/WorldChainBlockRegistry.t.sol
+++ b/contracts/test/WorldChainBlockRegistry.t.sol
@@ -2,7 +2,8 @@
 pragma solidity ^0.8.28;
 
 import "forge-std/Test.sol";
-import "src/WorldChainBlockRegistry.sol";
+import "../src/WorldChainBlockRegistry.sol";
+import "@openzeppelin/contracts/access/Ownable2Step.sol";
 
 contract WorldChainBlockRegistryTest is Test {
     WorldChainBlockRegistry blockRegistry;
@@ -51,7 +52,7 @@ contract WorldChainBlockRegistryTest is Test {
     function test_updateBuilder_RevertIf_Unauthorized() public {
         address newBuilder = address(0xCAFE);
         vm.prank(address(0xDEAD));
-        vm.expectRevert(WorldChainBlockRegistry.Unauthorized.selector);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, address(0xDEAD)));
         blockRegistry.updateBuilder(newBuilder);
     }
 }

--- a/contracts/test/WorldChainBlockRegistry.t.sol
+++ b/contracts/test/WorldChainBlockRegistry.t.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import "src/WorldChainBlockRegistry.sol";
+
+contract WorldChainBlockRegistryTest is Test {
+    WorldChainBlockRegistry blockRegistry;
+    address builder = address(0xC0FFEE);
+    address owner = address(0xB0B);
+
+    function setUp() public {
+        vm.prank(owner);
+        blockRegistry = new WorldChainBlockRegistry(builder);
+    }
+
+    function test_stampBlock() public {
+        vm.prank(builder);
+        vm.expectEmit(true, true, true, true);
+        emit WorldChainBlockRegistry.BuiltBlock(builder, block.number);
+        blockRegistry.stampBlock();
+        assertEq(registry.builtBlocks(block.number), builder);
+    }
+
+    function test_stampBlock_RevertIf_Unauthorized() public {
+        vm.expectRevert(WorldChainBlockRegistry.Unauthorized.selector);
+        blockRegistry.stampBlock();
+    }
+
+    function test_stampBlock_RevertIf_AlreadyRegistered() public {
+        vm.prank(builder);
+        blockRegistry.stampBlock();
+
+        vm.prank(builder);
+        vm.expectRevert(WorldChainBlockRegistry.BlockAlreadyRegistered.selector);
+        blockRegistry.stampBlock();
+    }
+
+    function test_updateBuilder() public {
+        address newBuilder = address(0xCAFE);
+        vm.prank(owner);
+        vm.expectEmit(true, true, true, true);
+        emit WorldChainBlockRegistry.WorldChainBuilderUpdated(newBuilder);
+        blockRegistry.updateBuilder(newBuilder);
+
+        vm.prank(newBuilder);
+        blockRegistry.stampBlock();
+        assertEq(registry.builtBlocks(block.number), newBuilder);
+    }
+
+    function test_updateBuilder_RevertIf_Unauthorized() public {
+        address newBuilder = address(0xCAFE);
+        vm.prank(address(0xDEAD));
+        vm.expectRevert(WorldChainBlockRegistry.Unauthorized.selector);
+        blockRegistry.updateBuilder(newBuilder);
+    }
+}

--- a/contracts/test/WorldChainBlockRegistry.t.sol
+++ b/contracts/test/WorldChainBlockRegistry.t.sol
@@ -19,7 +19,7 @@ contract WorldChainBlockRegistryTest is Test {
         vm.expectEmit(true, true, true, true);
         emit WorldChainBlockRegistry.BuiltBlock(builder, block.number);
         blockRegistry.stampBlock();
-        assertEq(registry.builtBlocks(block.number), builder);
+        assertEq(blockRegistry.builtBlocks(block.number), builder);
     }
 
     function test_stampBlock_RevertIf_Unauthorized() public {
@@ -45,7 +45,7 @@ contract WorldChainBlockRegistryTest is Test {
 
         vm.prank(newBuilder);
         blockRegistry.stampBlock();
-        assertEq(registry.builtBlocks(block.number), newBuilder);
+        assertEq(blockRegistry.builtBlocks(block.number), newBuilder);
     }
 
     function test_updateBuilder_RevertIf_Unauthorized() public {


### PR DESCRIPTION
This PR introduces the WorldChainBlockRegistry which enables the World Chain builder to record which blocks were produced by the builder. This allows third parties to have visibility into which blocks should be constructed with the PBH ordering policy.

```solidity
contract WorldChainBlockRegistry is Ownable2Step {
   // --snip--

    /// @notice Record the current block as being built by the World Chain Builder
    function stampBlock() public onlyBuilder {
        require(builtBlocks[block.number] == address(0), BlockAlreadyRegistered());
        builtBlocks[block.number] = msg.sender;
        emit BuiltBlock(msg.sender, block.number);
    }
```