### PR TITLE
feat: add deterministic deployments & make implementation more efficient

### DIFF
--- a/contracts/scripts/Create2Deploy.sol
+++ b/contracts/scripts/Create2Deploy.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @title Create2Deploy
+/// @notice A contract to deploy a contract using the CREATE2 opcode
+contract Create2Factory {
+    function deploy(bytes32 salt, bytes memory initCode) public returns (address addr) {
+        assembly {
+            addr := create2(0, add(initCode, 0x20), mload(initCode), salt)
+            if iszero(extcodesize(addr)) {
+                mstore(0x00, 0x2f8f8019) 
+                revert(0x1c, 0x04)
+            }
+        }
+    }
+}

--- a/contracts/scripts/Deploy.s.sol
+++ b/contracts/scripts/Deploy.s.sol
@@ -9,33 +9,48 @@ import {console} from "forge-std/console.sol";
 import {IWorldID} from "@world-id-contracts/interfaces/IWorldID.sol";
 import {IPBHEntryPoint} from "../src/interfaces/IPBHEntryPoint.sol";
 import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
+import {Create2Factory} from "./Create2Deploy.sol";
 
-contract Deploy is Script {
+contract Deploy is Create2Factory, Script {
     address public pbhEntryPoint;
     address public pbhEntryPointImpl;
     address public pbhSignatureAggregator;
 
-    address internal constant WORLD_ID = 0xE177F37AF0A862A02edFEa4F59C02668E9d0aAA4;
-    address internal constant ENTRY_POINT = 0x0000000071727De22E5E9d8BAf0edAc6f37da032;
+    address internal constant WORLD_ID =
+        0xE177F37AF0A862A02edFEa4F59C02668E9d0aAA4;
+    address internal constant ENTRY_POINT =
+        0x0000000071727De22E5E9d8BAf0edAc6f37da032;
     uint256 internal constant MAX_PBH_GAS_LIMIT = 15000000; // 15M
     uint16 internal constant PBH_NONCE_LIMIT = type(uint16).max;
-    address[] internal authorizedBuilders = [address(0)]; // TODO:
+    address[] internal authorizedBuilders = [
+        0x0459B1592C4e1A2cFB2F0606fDe0F7D9E7995E9A
+    ]; 
+    address internal constant OWNER = 0x96d55BD9c8C4706FED243c1e15825FF7854920fA;
 
     function run() public {
         console.log(
             "Deploying: PBHEntryPoint, PBHEntryPointImplV1, PBHSignatureAggregator"
         );
-
+        bytes32 implSalt = vm.envBytes32("IMPL_SALT");
+        bytes32 proxySalt = vm.envBytes32("PROXY_SALT");
+        bytes32 signatureAggregatorSalt = vm.envBytes32("AGGREGATOR_SALT");
         uint256 privateKey = vm.envUint("PRIVATE_KEY");
+
         vm.startBroadcast(privateKey);
-        deployPBHEntryPoint();
-        deployPBHSignatureAggregator();
+        deployPBHEntryPoint(proxySalt, implSalt);
+        deployPBHSignatureAggregator(signatureAggregatorSalt);
         vm.stopBroadcast();
     }
 
-    function deployPBHEntryPoint() public {
-        pbhEntryPointImpl = address(new PBHEntryPointImplV1());
+    function deployPBHEntryPoint(bytes32 proxySalt, bytes32 implSalt) public {
+        pbhEntryPointImpl = deploy(
+            implSalt,
+            type(PBHEntryPointImplV1).creationCode
+        );
         console.log("PBHEntryPointImplV1 Deployed at: ", pbhEntryPointImpl);
+
+        /// @dev Do not modify this for deterministic deployments
+        ///     things can be toggled after deployment if needed.
         bytes memory initCallData = abi.encodeCall(
             PBHEntryPointImplV1.initialize,
             (
@@ -43,17 +58,31 @@ contract Deploy is Script {
                 IEntryPoint(ENTRY_POINT),
                 PBH_NONCE_LIMIT,
                 MAX_PBH_GAS_LIMIT,
-                authorizedBuilders
+                authorizedBuilders,
+                OWNER
             )
         );
-        pbhEntryPoint = address(
-            new PBHEntryPoint(pbhEntryPointImpl, initCallData)
+
+        bytes memory initCode = abi.encodePacked(
+            type(PBHEntryPoint).creationCode,
+            abi.encode(pbhEntryPointImpl, initCallData)
         );
+
+        // Note: Theoretically this tx could be front-run which would result in a revert on 
+        //       the deployment of the proxy. This is low-risk, and minimal impact as we can just redeploy.
+        pbhEntryPoint = deploy(proxySalt, initCode); 
         console.log("PBHEntryPoint Deployed at: ", pbhEntryPoint);
     }
 
-    function deployPBHSignatureAggregator() public {
-        pbhSignatureAggregator = address(new PBHSignatureAggregator(pbhEntryPoint, WORLD_ID));
-        console.log("PBHSignatureAggregator Deployed at: ", pbhSignatureAggregator);
+    function deployPBHSignatureAggregator(bytes32 salt) public {
+        bytes memory initCode = abi.encodePacked(
+            type(PBHSignatureAggregator).creationCode,
+            abi.encode(pbhEntryPoint, WORLD_ID)
+        );
+        pbhSignatureAggregator = deploy(salt, initCode);
+        console.log(
+            "PBHSignatureAggregator Deployed at: ",
+            pbhSignatureAggregator
+        );
     }
 }

--- a/contracts/scripts/DeployDevnet.s.sol
+++ b/contracts/scripts/DeployDevnet.s.sol
@@ -68,7 +68,8 @@ contract DeployDevnet is Script {
                 IEntryPoint(ENTRY_POINT),
                 255,
                 MAX_PBH_GAS_LIMIT,
-                authorizedBuilders
+                authorizedBuilders,
+                msg.sender
             )
         );
         pbhEntryPoint = address(

--- a/contracts/src/abstract/Base.sol
+++ b/contracts/src/abstract/Base.sol
@@ -1,0 +1,33 @@
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
+/// @title Base Delegated Implementation Contract
+/// @author Worldcoin
+/// @dev This is base class for implementations delegated to by a proxy.
+abstract contract Base is Ownable2StepUpgradeable, UUPSUpgradeable {
+    /// @notice Initializes the contract with the given owner.
+    ///
+    /// @param owner The address that will be set as the owner of the contract.
+    function __Base_init(address owner) internal virtual onlyInitializing {
+        __Ownable_init(owner);
+        __UUPSUpgradeable_init();
+    }
+
+    /// @notice Is called when upgrading the contract to check whether it should be performed.
+    ///
+    /// @param newImplementation The address of the implementation being upgraded to.
+    ///
+    /// @custom:reverts string If called by any account other than the proxy owner.
+    function _authorizeUpgrade(address newImplementation) internal virtual override onlyProxy onlyOwner {}
+
+     /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     */
+    uint256[49] private __gap;
+}

--- a/contracts/src/abstract/Base.sol
+++ b/contracts/src/abstract/Base.sol
@@ -1,4 +1,3 @@
-
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
@@ -7,7 +6,6 @@ import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/U
 
 /// @title Base Delegated Implementation Contract
 /// @author Worldcoin
-/// @dev This is base class for implementations delegated to by a proxy.
 abstract contract Base is Ownable2StepUpgradeable, UUPSUpgradeable {
     /// @notice Initializes the contract with the given owner.
     ///
@@ -24,7 +22,7 @@ abstract contract Base is Ownable2StepUpgradeable, UUPSUpgradeable {
     /// @custom:reverts string If called by any account other than the proxy owner.
     function _authorizeUpgrade(address newImplementation) internal virtual override onlyProxy onlyOwner {}
 
-     /**
+    /**
      * @dev This empty reserved space is put in place to allow future versions to add new
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps

--- a/contracts/src/interfaces/IPBHEntryPoint.sol
+++ b/contracts/src/interfaces/IPBHEntryPoint.sol
@@ -27,7 +27,8 @@ interface IPBHEntryPoint {
         IEntryPoint entryPoint,
         uint16 _numPbhPerMonth,
         uint256 _pbhGasLimit,
-        address[] calldata _authorizedBuilders
+        address[] calldata _authorizedBuilders,
+        address _owner
     ) external;
     function validateSignaturesCallback(bytes32 hashedOps) external view;
     function verifyPbh(uint256 signalHash, PBHPayload calldata pbhPayload) external view;

--- a/contracts/test/PBHEntryPointImplV1.t.sol
+++ b/contracts/test/PBHEntryPointImplV1.t.sol
@@ -15,6 +15,7 @@ import {TestSetup} from "./TestSetup.sol";
 import {TestUtils} from "./TestUtils.sol";
 import {Safe4337Module} from "@4337/Safe4337Module.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@account-abstraction/contracts/interfaces/PackedUserOperation.sol";
 import "@lib/PBHExternalNullifier.sol";
 
@@ -213,8 +214,10 @@ contract PBHEntryPointImplV1Test is TestSetup {
         pbhEntryPoint.setNumPbhPerMonth(numPbh);
     }
 
-    function test_setNumPbhPerMonth_RevertIf_NotOwner(uint8 numPbh) public {
-        vm.expectRevert("Ownable: caller is not the owner");
+    function test_setNumPbhPerMonth_RevertIf_NotOwner(uint8 numPbh, address addr) public {
+        vm.assume(addr != OWNER);
+        vm.prank(addr);
+        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, addr));
         pbhEntryPoint.setNumPbhPerMonth(numPbh);
     }
 
@@ -235,7 +238,8 @@ contract PBHEntryPointImplV1Test is TestSetup {
 
     function test_setWorldId_RevertIf_NotOwner(address addr) public {
         vm.assume(addr != OWNER);
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.prank(addr);
+        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, addr));
         pbhEntryPoint.setWorldId(addr);
     }
 
@@ -250,7 +254,7 @@ contract PBHEntryPointImplV1Test is TestSetup {
     function test_addBuilder_RevertIf_NotOwner(address addr) public {
         vm.assume(addr != OWNER);
         vm.prank(addr);
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, addr));
         pbhEntryPoint.addBuilder(addr);
     }
 
@@ -264,7 +268,8 @@ contract PBHEntryPointImplV1Test is TestSetup {
     function test_removeBuilder_RevertIf_NotOwner(address addr) public {
         vm.assume(addr != OWNER);
         vm.prank(addr);
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, addr));
+
         pbhEntryPoint.removeBuilder(addr);
     }
 

--- a/contracts/test/TestSetup.sol
+++ b/contracts/test/TestSetup.sol
@@ -131,11 +131,11 @@ contract TestSetup is Test {
 
         bytes memory initCallData = abi.encodeCall(
             PBHEntryPointImplV1.initialize,
-            (initialGroupAddress, initialEntryPoint, MAX_NUM_PBH_PER_MONTH, maxPbhGasLimit, authorizedBuilders)
+            (initialGroupAddress, initialEntryPoint, MAX_NUM_PBH_PER_MONTH, maxPbhGasLimit, authorizedBuilders, OWNER)
         );
         vm.expectEmit(true, true, true, true);
         emit PBHEntryPointImplV1.PBHEntryPointImplInitialized(
-            initialGroupAddress, initialEntryPoint, MAX_NUM_PBH_PER_MONTH, maxPbhGasLimit, authorizedBuilders
+            initialGroupAddress, initialEntryPoint, MAX_NUM_PBH_PER_MONTH, maxPbhGasLimit, authorizedBuilders, OWNER
         );
         pbhEntryPoint = IPBHEntryPoint(address(new PBHEntryPoint(pbhEntryPointImpl, initCallData)));
     }

--- a/devnet/src/el/op-reth/world_chain_builder_launcher.star
+++ b/devnet/src/el/op-reth/world_chain_builder_launcher.star
@@ -202,7 +202,6 @@ def get_config(
         "--builder.pbh_entrypoint={0}".format(PBH_ENTRY_POINT),
         "--builder.signature_aggregator={0}".format(PBH_SIGNATURE_AGGREGATOR),
         "--builder.world_id={0}".format(WORLD_ID),
-        "--builder.block_registry=0x4A679253410272dd5232B3Ff7cF5dbB88f295319"
     ]
     
     observability.expose_metrics_port(ports)

--- a/world-chain-builder/crates/world/node/src/args.rs
+++ b/world-chain-builder/crates/world/node/src/args.rs
@@ -35,8 +35,4 @@ pub struct WorldChainArgs {
     /// used for signing the stampBlock transaction
     #[arg(long = "builder.private_key", env = "BUILDER_PRIVATE_KEY")]
     pub builder_private_key: String,
-
-    /// Contract address for the world chain block registry contract
-    #[arg(long = "builder.block_registry")]
-    pub block_registry: Address,
 }

--- a/world-chain-builder/crates/world/node/src/node.rs
+++ b/world-chain-builder/crates/world/node/src/node.rs
@@ -92,7 +92,6 @@ impl WorldChainNode {
             signature_aggregator,
             world_id,
             builder_private_key,
-            block_registry,
         } = self.args.clone();
 
         let RollupArgs {
@@ -116,7 +115,6 @@ impl WorldChainNode {
                     pbh_entrypoint,
                     signature_aggregator,
                     builder_private_key,
-                    block_registry,
                 )
                 .with_da_config(self.da_config.clone()),
             ))
@@ -321,8 +319,6 @@ pub struct WorldChainPayloadBuilder<Txs = ()> {
     /// used for signing the stampBlock transaction
     pub builder_private_key: String,
 
-    /// Contract address for the world chain block registry contract
-    pub block_registry: Address,
 }
 
 impl WorldChainPayloadBuilder {
@@ -334,7 +330,6 @@ impl WorldChainPayloadBuilder {
         pbh_entry_point: Address,
         pbh_signature_aggregator: Address,
         builder_private_key: String,
-        block_registry: Address,
     ) -> Self {
         Self {
             compute_pending_block,
@@ -343,7 +338,6 @@ impl WorldChainPayloadBuilder {
             pbh_signature_aggregator,
             best_transactions: (),
             builder_private_key,
-            block_registry,
             da_config: OpDAConfig::default(),
         }
     }
@@ -366,7 +360,6 @@ impl<Txs> WorldChainPayloadBuilder<Txs> {
             pbh_entry_point,
             pbh_signature_aggregator,
             builder_private_key,
-            block_registry,
             ..
         } = self;
 
@@ -378,7 +371,6 @@ impl<Txs> WorldChainPayloadBuilder<Txs> {
             pbh_signature_aggregator,
             best_transactions,
             builder_private_key,
-            block_registry,
         }
     }
 
@@ -416,7 +408,6 @@ impl<Txs> WorldChainPayloadBuilder<Txs> {
                 self.pbh_entry_point,
                 self.pbh_signature_aggregator,
                 self.builder_private_key.clone(),
-                self.block_registry,
             )
             .with_transactions(self.best_transactions.clone());
 

--- a/world-chain-builder/crates/world/node/src/node.rs
+++ b/world-chain-builder/crates/world/node/src/node.rs
@@ -318,7 +318,6 @@ pub struct WorldChainPayloadBuilder<Txs = ()> {
     /// Sets the private key of the builder
     /// used for signing the stampBlock transaction
     pub builder_private_key: String,
-
 }
 
 impl WorldChainPayloadBuilder {

--- a/world-chain-builder/crates/world/payload/src/builder.rs
+++ b/world-chain-builder/crates/world/payload/src/builder.rs
@@ -66,7 +66,6 @@ where
     pub pbh_entry_point: Address,
     pub pbh_signature_aggregator: Address,
     pub builder_private_key: PrivateKeySigner,
-    pub block_registry: Address,
 }
 
 impl<Client, S> WorldChainPayloadBuilder<Client, S>
@@ -83,7 +82,6 @@ where
         pbh_entry_point: Address,
         pbh_signature_aggregator: Address,
         builder_private_key: String,
-        block_registry: Address,
     ) -> Self {
         Self::with_builder_config(
             pool,
@@ -95,7 +93,6 @@ where
             pbh_entry_point,
             pbh_signature_aggregator,
             builder_private_key,
-            block_registry,
         )
     }
 
@@ -110,7 +107,6 @@ where
         pbh_entry_point: Address,
         pbh_signature_aggregator: Address,
         builder_private_key: String,
-        block_registry: Address,
     ) -> Self {
         let inner = OpPayloadBuilder::with_builder_config(pool, client, evm_config, config)
             .set_compute_pending_block(compute_pending_block);
@@ -124,7 +120,6 @@ where
             pbh_entry_point,
             pbh_signature_aggregator,
             builder_private_key: private_key,
-            block_registry,
         }
     }
 }
@@ -149,7 +144,6 @@ where
             pbh_entry_point,
             pbh_signature_aggregator,
             builder_private_key,
-            block_registry,
         } = self;
 
         let OpPayloadBuilder {
@@ -174,7 +168,6 @@ where
             pbh_entry_point,
             pbh_signature_aggregator,
             builder_private_key,
-            block_registry,
         }
     }
 
@@ -238,7 +231,6 @@ where
             pbh_entry_point: self.pbh_entry_point,
             pbh_signature_aggregator: self.pbh_signature_aggregator,
             builder_private_key: self.builder_private_key.clone(),
-            block_registry: self.block_registry,
         };
 
         let op_ctx = &ctx.inner;
@@ -292,7 +284,6 @@ where
             pbh_entry_point: self.pbh_entry_point,
             pbh_signature_aggregator: self.pbh_signature_aggregator,
             builder_private_key: self.builder_private_key.clone(),
-            block_registry: self.block_registry,
         };
 
         let state_provider = self
@@ -555,7 +546,6 @@ pub struct WorldChainPayloadBuilderCtx<Client> {
     pub pbh_signature_aggregator: Address,
     pub client: Client,
     pub builder_private_key: PrivateKeySigner,
-    pub block_registry: Address,
 }
 
 impl<Client> WorldChainPayloadBuilderCtx<Client>

--- a/world-chain-builder/crates/world/pool/src/validator.rs
+++ b/world-chain-builder/crates/world/pool/src/validator.rs
@@ -26,10 +26,10 @@ use tracing::{info, warn};
 use world_chain_builder_pbh::payload::PBHPayload as PbhPayload;
 
 /// The slot of the `pbh_gas_limit` in the PBHEntryPoint contract.
-pub const PBH_GAS_LIMIT_SLOT: U256 = U256::from_limbs([305, 0, 0, 0]);
+pub const PBH_GAS_LIMIT_SLOT: U256 = U256::from_limbs([53, 0, 0, 0]);
 
 /// The slot of the `pbh_nonce_limit` in the PBHEntryPoint contract.
-pub const PBH_NONCE_LIMIT_SLOT: U256 = U256::from_limbs([302, 0, 0, 0]);
+pub const PBH_NONCE_LIMIT_SLOT: U256 = U256::from_limbs([50, 0, 0, 0]);
 
 /// The offset in bits of the `PBH_NONCE_LIMIT_SLOT` containing the u16 nonce limit.
 pub const PBH_NONCE_LIMIT_OFFSET: u32 = 160;


### PR DESCRIPTION
This PR makes 2 improvements:
- Allows for deterministic deployments of the `PBHEntryPoint` and `PBHSignatureAggregator` across Sepolia & Mainnet
- Simplifies (and makes Implementation more gas efficient)