### PR TITLE
fix: foundry config

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -1,11 +1,14 @@
 [profile.default]
+solc = "0.8.28"
 evm_version = 'cancun'
-fs_permissions = [{access = "read-write", path = "./"}]
 libs = ["lib"]
-optimizer = true
-optimizer_runs = 200
 out = "out"
 src = "src"
+optimizer = true
+optimizer_runs = 200
+bytecode_hash = "none"
+cbor_metadata = false
+fs_permissions = [{access = "read-write", path = "./"}]
 
 remappings = [
   "@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/",


### PR DESCRIPTION
This configuration guarantees the init code of the contracts do not change across recompilation. 

Ref: https://book.getfoundry.sh/guides/deterministic-deployments-using-create2