### PR TITLE
feat(flashblocks): Initial `FlashblocksPayloadBuilder` implementation

### DIFF
--- a/world-chain-builder/crates/flashblocks/payload/Cargo.toml
+++ b/world-chain-builder/crates/flashblocks/payload/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 
 
 [dependencies]
-
 # reth
 reth.workspace = true
 reth-basic-payload-builder.workspace = true

--- a/world-chain-builder/crates/flashblocks/payload/src/builder.rs
+++ b/world-chain-builder/crates/flashblocks/payload/src/builder.rs
@@ -1,8 +1,3 @@
-use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex},
-};
-
 use alloy_consensus::{Header, EMPTY_OMMER_ROOT_HASH};
 use alloy_eips::merge::BEACON_NONCE;
 use alloy_primitives::{Address, B256, U256};
@@ -14,6 +9,8 @@ use reth::{
 };
 use reth_basic_payload_builder::{BuildArguments, BuildOutcome, BuildOutcomeKind};
 use reth_basic_payload_builder::{MissingPayloadBehaviour, PayloadBuilder, PayloadConfig};
+use reth_chain_state::{ExecutedBlock, ExecutedBlockWithTrieUpdates};
+use reth_evm::block::BlockExecutorFactory;
 use reth_evm::{
     execute::{BlockBuilder, BlockBuilderOutcome},
     ConfigureEvm, Evm,
@@ -31,15 +28,21 @@ use reth_optimism_payload_builder::{
     OpPayloadPrimitives,
 };
 use reth_optimism_primitives::OpTransactionSigned;
-use reth_payload_util::NoopPayloadTransactions;
+use reth_payload_util::{NoopPayloadTransactions, PayloadTransactions};
 use reth_primitives::{BlockBody, NodePrimitives, TxTy};
 use reth_primitives_traits::proofs;
 use reth_provider::{
     ChainSpecProvider, ExecutionOutcome, HashedPostStateProvider, ProviderError, StateProvider,
     StateProviderFactory, StateRootProvider, StorageRootProvider,
 };
-use reth_transaction_pool::{BestTransactionsAttributes, PoolTransaction, TransactionPool};
+use reth_transaction_pool::{
+    BestTransactionsAttributes, EthPoolTransaction, PoolTransaction, TransactionPool,
+};
 use revm::database::states::bundle_state::BundleRetention;
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 use tokio::{
     net::{TcpListener, TcpStream},
     sync::mpsc,
@@ -51,14 +54,6 @@ use crate::payload::{
     ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, FlashblocksMetadata,
     FlashblocksPayloadV1,
 };
-
-pub trait FlashblockBuilder: BlockBuilder {
-    fn build_flashblock<'a, Txs>(
-        db: impl Database<Error = ProviderError>,
-        state_provider: impl StateProvider,
-        best: impl FnOnce(BestTransactionsAttributes) -> Txs + Send + Sync + 'a,
-    );
-}
 
 /// Optimism's payload builder
 #[derive(Debug, Clone)]
@@ -142,6 +137,59 @@ impl<Pool, Client, Evm, Txs> FlashBlocksPayloadBuilder<Pool, Client, Evm, Txs> {
     }
 }
 
+impl<Pool, Client, Evm, N, T> FlashBlocksPayloadBuilder<Pool, Client, Evm, T>
+where
+    Pool: TransactionPool<Transaction: EthPoolTransaction<Consensus = N::SignedTx>>,
+    Client: StateProviderFactory + ChainSpecProvider<ChainSpec: EthChainSpec + OpHardforks>,
+    N: OpPayloadPrimitives,
+    Evm: ConfigureEvm<Primitives = N, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
+{
+    /// Constructs an Optimism payload from the transactions sent via the
+    /// Payload attributes by the sequencer. If the `no_tx_pool` argument is passed in
+    /// the payload attributes, the transaction pool will be ignored and the only transactions
+    /// included in the payload will be those sent through the attributes.
+    ///
+    /// Given build arguments including an Optimism client, transaction pool,
+    /// and configuration, this function creates a transaction payload. Returns
+    /// a result indicating success with the payload or an error in case of failure.
+    fn build_payload<'a, Txs>(
+        &self,
+        args: BuildArguments<OpPayloadBuilderAttributes<N::SignedTx>, OpBuiltPayload<N>>,
+        best: impl FnOnce(BestTransactionsAttributes) -> Txs + Send + Sync + 'a,
+    ) -> Result<BuildOutcome<OpBuiltPayload<N>>, PayloadBuilderError>
+    where
+        Txs: PayloadTransactions<Transaction: PoolTransaction<Consensus = N::SignedTx>>,
+    {
+        let BuildArguments {
+            mut cached_reads,
+            config,
+            cancel,
+            best_payload,
+        } = args;
+
+        let ctx = OpPayloadBuilderCtx {
+            evm_config: self.evm_config.clone(),
+            da_config: self.config.da_config.clone(),
+            chain_spec: self.client.chain_spec(),
+            config,
+            cancel,
+            best_payload,
+        };
+
+        let builder = FlashblockBuilder::new(best);
+        let state_provider = self.client.state_by_block_hash(ctx.parent().hash())?;
+        let state = StateProviderDatabase::new(&state_provider);
+
+        if ctx.attributes().no_tx_pool {
+            builder.build(state, &state_provider, ctx)
+        } else {
+            // sequencer mode we can reuse cachedreads from previous runs
+            builder.build(cached_reads.as_db_mut(state), &state_provider, ctx)
+        }
+        .map(|out| out.with_cached_reads(cached_reads))
+    }
+}
+
 impl<Pool, Client, Evm, N, Txs> PayloadBuilder for FlashBlocksPayloadBuilder<Pool, Client, Evm, Txs>
 where
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec: EthChainSpec + OpHardforks> + Clone,
@@ -157,84 +205,10 @@ where
         &self,
         args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
     ) -> Result<BuildOutcome<Self::BuiltPayload>, PayloadBuilderError> {
-        let BuildArguments {
-            mut cached_reads,
-            config,
-            cancel,
-            best_payload,
-        } = args;
-
-        let parent_hash = config.parent_header.hash();
-
-        // TODO: create generic payload builder ctx,
-        let ctx = OpPayloadBuilderCtx {
-            evm_config: self.evm_config.clone(),
-            da_config: self.config.da_config.clone(),
-            chain_spec: self.client.chain_spec(),
-            config,
-            cancel,
-            best_payload,
-        };
-
-        let state_provider = self.client.state_by_block_hash(parent_hash)?;
-        let state: StateProviderDatabase<&Box<dyn StateProvider>> =
-            StateProviderDatabase::new(&state_provider);
-
-        let mut db = State::builder()
-            .with_database(state)
-            .with_bundle_update()
-            .build();
-
-        let mut builder = ctx.block_builder(&mut db)?;
-
-        // apply pre-execution changes
-        builder.apply_pre_execution_changes().map_err(|err| {
-            warn!(target: "payload_builder", %err, "failed to apply pre-execution changes");
-            PayloadBuilderError::Internal(err.into())
-        })?;
-
-        // execute sequencer transactions
-        let mut info = ctx.execute_sequencer_transactions(&mut builder)?;
-
-        let mut next_block = None;
-        if !ctx.attributes().no_tx_pool {
-            let tx_attrs = ctx.best_transaction_attributes(builder.evm_mut().block());
-
-            // TODO: dynamically update amount of flashblocks
-            let num_flashblocks = 4;
-            for _ in 0..num_flashblocks {
-                // TODO: update to ensure the pool is being updated
-                let pool = self.pool.clone();
-                let best_txs = self.best_transactions.best_transactions(pool, tx_attrs);
-
-                if ctx
-                    .execute_best_transactions(&mut info, &mut builder, best_txs)?
-                    .is_some()
-                {
-                    return Ok(BuildOutcome::Cancelled);
-                }
-
-                // TODO:
-                // let BlockBuilderOutcome {
-                //     execution_result,
-                //     hashed_state,
-                //     trie_updates,
-                //     block,
-                // } = builder.finish(state_provider)?;
-
-                // TODO: separate building the block outcome from building flashblocks. Build and seal the final block after all flashblocks are built
-                let (payload, mut fb_payload, new_bundle_state) =
-                    build_flashblock(db, &ctx, &mut info)?;
-
-                let next_block = Some(payload);
-
-                // TODO: update the stream in a separate PR
-                let _ = self.send_message(serde_json::to_string(&fb_payload).unwrap_or_default());
-            }
-        }
-
-        // TODO: this is only temporary while this logic is wip
-        next_block.unwrap()
+        let pool = self.pool.clone();
+        self.build_payload(args, |attrs| {
+            self.best_transactions.best_transactions(pool, attrs)
+        })
     }
 
     fn on_missing_payload(
@@ -254,192 +228,325 @@ where
     }
 }
 
-/* TODO: currently this builds a flashblock and returns a built block to propose to the network.
-It looks like we only need to do some of thes calculations once when building the final block. This
-function should be updated and return all the necessary components needed to seal the block.
-*/
-pub fn build_flashblock<Evm, ChainSpec, N, DB, P>(
-    mut state: State<DB>,
-    ctx: &OpPayloadBuilderCtx<Evm, ChainSpec>,
-    info: &mut ExecutionInfo,
-) -> Result<(OpBuiltPayload<N>, FlashblocksPayloadV1, BundleState), PayloadBuilderError>
-where
-    Evm: ConfigureEvm<Primitives: OpPayloadPrimitives, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
-    ChainSpec: EthChainSpec + OpHardforks,
-    N: OpPayloadPrimitives<_TX = OpTransactionSigned>,
-    DB: Database<Error = ProviderError> + AsRef<P>,
-    P: StateRootProvider + HashedPostStateProvider + StorageRootProvider,
-{
-    // NOTE: ctx.withdrawals_root does not exist in latest reth
-    // let withdrawals_root = ctx.commit_withdrawals(&mut state)?;
+/// The type that builds the payload.
+///
+/// Payload building for optimism is composed of several steps.
+/// The first steps are mandatory and defined by the protocol.
+///
+/// 1. first all System calls are applied.
+/// 2. After canyon the forced deployed `create2deployer` must be loaded
+/// 3. all sequencer transactions are executed (part of the payload attributes)
+///
+/// Depending on whether the node acts as a sequencer and is allowed to include additional
+/// transactions (`no_tx_pool == false`):
+/// 4. include additional transactions
+///
+/// And finally
+/// 5. build the block: compute all roots (txs, state)
+pub struct FlashblockBuilder<'a, Txs> {
+    /// Yields the best transaction to include if transactions from the mempool are allowed.
+    best: Box<dyn FnOnce(BestTransactionsAttributes) -> Txs + 'a>,
+}
 
-    // TODO: We must run this only once per block, but we are running it on every flashblock
-    // merge all transitions into bundle state, this would apply the withdrawal balance changes
-    // and 4788 contract call
-    state.merge_transitions(BundleRetention::Reverts);
+impl<'a, Txs> FlashblockBuilder<'a, Txs> {
+    /// Creates a new [`OpBuilder`].
+    pub fn new(best: impl FnOnce(BestTransactionsAttributes) -> Txs + Send + Sync + 'a) -> Self {
+        Self {
+            best: Box::new(best),
+        }
+    }
+}
 
-    let new_bundle = state.take_bundle();
+impl<Txs> FlashblockBuilder<'_, Txs> {
+    /// Builds the payload on top of the state.
+    pub fn build<EvmConfig, ChainSpec, N>(
+        self,
+        db: impl Database<Error = ProviderError>,
+        state_provider: impl StateProvider,
+        // TODO: make ctx generic
+        ctx: OpPayloadBuilderCtx<EvmConfig, ChainSpec>,
+    ) -> Result<BuildOutcomeKind<OpBuiltPayload<N>>, PayloadBuilderError>
+    where
+        EvmConfig: ConfigureEvm<Primitives = N, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
+        ChainSpec: EthChainSpec + OpHardforks,
+        N: OpPayloadPrimitives,
+        Txs: PayloadTransactions<Transaction: PoolTransaction<Consensus = N::SignedTx>>,
+    {
+        let Self { best } = self;
+        debug!(target: "payload_builder", id=%ctx.payload_id(), parent_header = ?ctx.parent().hash(), parent_number = ctx.parent().number, "building new payload");
 
-    // NOTE: ctx.block_number does not exist in latest reth
-    // let block_number = ctx.block_number();
-    // assert_eq!(block_number, ctx.parent().number + 1);
+        // NOTE: we do not need to init this every time
+        let mut db = State::builder()
+            .with_database(db)
+            .with_bundle_update()
+            .build();
 
-    let block_number = ctx.parent().number + 1;
-    let execution_outcome = ExecutionOutcome::new(
-        new_bundle.clone(),
-        vec![info.receipts.clone()],
-        block_number,
-        vec![],
-    );
-    let receipts_root = execution_outcome
-        .generic_receipts_root_slow(block_number, |receipts| {
-            calculate_receipt_root_no_memo_optimism(
-                receipts,
-                &ctx.chain_spec,
-                ctx.attributes().timestamp(),
-            )
-        })
-        .expect("Number is in range");
-    let logs_bloom = execution_outcome
-        .block_logs_bloom(block_number)
-        .expect("Number is in range");
+        let mut builder = ctx.block_builder(&mut db)?;
 
-    // // calculate the state root
-    let state_provider = state.database.as_ref();
-    let hashed_state = state_provider.hashed_post_state(execution_outcome.state());
-    let (state_root, _trie_output) = {
-        state
-            .database
-            .as_ref()
-            .state_root_with_updates(hashed_state.clone())
-            .inspect_err(|err| {
-                warn!(target: "payload_builder",
-                parent_header=%ctx.parent().hash(),
-                    %err,
-                    "failed to calculate state root for payload"
-                );
-            })?
-    };
+        // NOTE: this can be calculated once
+        // 1. apply pre-execution changes
+        builder.apply_pre_execution_changes().map_err(|err| {
+            warn!(target: "payload_builder", %err, "failed to apply pre-execution changes");
+            PayloadBuilderError::Internal(err.into())
+        })?;
 
-    // create the block header
-    let transactions_root = proofs::calculate_transaction_root(&info.executed_transactions);
+        // NOTE: this can be calculated once
+        // 2. execute sequencer transactions
+        let mut info = ctx.execute_sequencer_transactions(&mut builder)?;
 
-    // OP doesn't support blobs/EIP-4844.
-    // https://specs.optimism.io/protocol/exec-engine.html#ecotone-disable-blob-transactions
-    // Need [Some] or [None] based on hardfork to match block hash.
-    let (excess_blob_gas, blob_gas_used) = ctx.blob_fields();
-    let extra_data = ctx.extra_data()?;
+        // 3. if mem pool transactions are requested we execute them
 
-    let header = Header {
-        parent_hash: ctx.parent().hash(),
-        ommers_hash: EMPTY_OMMER_ROOT_HASH,
-        beneficiary: ctx.evm_env.block_env.coinbase,
-        state_root,
-        transactions_root,
-        receipts_root,
-        withdrawals_root,
-        logs_bloom,
-        timestamp: ctx.attributes().payload_attributes.timestamp,
-        mix_hash: ctx.attributes().payload_attributes.prev_randao,
-        nonce: BEACON_NONCE.into(),
-        base_fee_per_gas: Some(ctx.base_fee()),
-        number: ctx.parent().number + 1,
-        gas_limit: ctx.block_gas_limit(),
-        difficulty: U256::ZERO,
-        gas_used: info.cumulative_gas_used,
-        extra_data,
-        parent_beacon_block_root: ctx.attributes().payload_attributes.parent_beacon_block_root,
-        blob_gas_used,
-        excess_blob_gas,
-        requests_hash: None,
-    };
+        // TODO: the gas limit for each flashblock should be enforced. We can add this by passing it into the `execute_best_transactions` function
+        if !ctx.attributes().no_tx_pool {
+            let best_txs = best(ctx.best_transaction_attributes(builder.evm_mut().block()));
+            if ctx
+                .execute_best_transactions(&mut info, &mut builder, best_txs)?
+                .is_some()
+            {
+                return Ok(BuildOutcomeKind::Cancelled);
+            }
 
-    // seal the block
-    let block = N::Block::new(
-        header,
-        BlockBody {
-            transactions: info.executed_transactions.clone(),
-            ommers: vec![],
-            withdrawals: ctx.withdrawals().cloned(),
-        },
-    );
+            // check if the new payload is even more valuable
+            if !ctx.is_better_payload(info.total_fees) {
+                // can skip building the block
+                return Ok(BuildOutcomeKind::Aborted {
+                    fees: info.total_fees,
+                });
+            }
+        }
 
-    let sealed_block = Arc::new(block.seal_slow());
-    debug!(target: "payload_builder", ?sealed_block, "sealed built block");
+        let BlockBuilderOutcome {
+            execution_result,
+            hashed_state,
+            trie_updates,
+            block,
+        } = builder.finish(state_provider)?;
 
-    let block_hash = sealed_block.hash();
+        let sealed_block = Arc::new(block.sealed_block().clone());
+        debug!(target: "payload_builder", id=%ctx.attributes().payload_id(), sealed_block_header = ?sealed_block.header(), "sealed built block");
 
-    // pick the new transactions from the info field and update the last flashblock index
-    let new_transactions = info.executed_transactions[info.last_flashblock_index..].to_vec();
+        let execution_outcome = ExecutionOutcome::new(
+            db.take_bundle(),
+            vec![execution_result.receipts],
+            block.number,
+            Vec::new(),
+        );
 
-    let new_transactions_encoded = new_transactions
-        .clone()
-        .into_iter()
-        .map(|tx| tx.encoded_2718().into())
-        .collect::<Vec<_>>();
+        // create the executed block data
+        let executed: ExecutedBlockWithTrieUpdates<N> = ExecutedBlockWithTrieUpdates {
+            block: ExecutedBlock {
+                recovered_block: Arc::new(block),
+                execution_output: Arc::new(execution_outcome),
+                hashed_state: Arc::new(hashed_state),
+            },
+            trie: Arc::new(trie_updates),
+        };
 
-    let new_receipts = info.receipts[info.last_flashblock_index..].to_vec();
-    info.last_flashblock_index = info.executed_transactions.len();
-    let receipts_with_hash = new_transactions
-        .iter()
-        .zip(new_receipts.iter())
-        .map(|(tx, receipt)| (*tx.tx_hash(), receipt.clone()))
-        .collect::<HashMap<B256, N::Receipt>>();
-    let new_account_balances = new_bundle
-        .state
-        .iter()
-        .filter_map(|(address, account)| account.info.as_ref().map(|info| (*address, info.balance)))
-        .collect::<HashMap<Address, U256>>();
+        let no_tx_pool = ctx.attributes().no_tx_pool;
 
-    let metadata = FlashblocksMetadata {
-        receipts: receipts_with_hash,
-        new_account_balances,
-        block_number: ctx.parent().number + 1,
-    };
-
-    // Prepare the flashblocks message
-    let fb_payload = FlashblocksPayloadV1 {
-        payload_id: ctx.payload_id(),
-        index: 0,
-        base: Some(ExecutionPayloadBaseV1 {
-            parent_beacon_block_root: ctx
-                .attributes()
-                .payload_attributes
-                .parent_beacon_block_root
-                .unwrap(),
-            parent_hash: ctx.parent().hash(),
-            fee_recipient: ctx.attributes().suggested_fee_recipient(),
-            prev_randao: ctx.attributes().payload_attributes.prev_randao,
-            block_number: ctx.parent().number + 1,
-            gas_limit: ctx.block_gas_limit(),
-            timestamp: ctx.attributes().payload_attributes.timestamp,
-            extra_data: ctx.extra_data()?,
-            base_fee_per_gas: ctx.base_fee().try_into().unwrap(),
-        }),
-        diff: ExecutionPayloadFlashblockDeltaV1 {
-            state_root,
-            receipts_root,
-            logs_bloom,
-            gas_used: info.cumulative_gas_used,
-            block_hash,
-            transactions: new_transactions_encoded,
-            withdrawals: ctx.withdrawals().cloned().unwrap_or_default().to_vec(),
-        },
-        metadata: serde_json::to_value(&metadata).unwrap_or_default(),
-    };
-
-    Ok((
-        OpBuiltPayload::new(
+        let payload = OpBuiltPayload::new(
             ctx.payload_id(),
             sealed_block,
             info.total_fees,
-            // This must be set to NONE for now because we are doing merge transitions on every flashblock
-            // when it should only happen once per block, thus, it returns a confusing state back to op-reth.
-            // We can live without this for now because Op syncs up the executed block using new_payload
-            // calls, but eventually we would want to return the executed block here.
-            None,
-        ),
-        fb_payload,
-        new_bundle,
-    ))
+            Some(executed),
+        );
+
+        if no_tx_pool {
+            // if `no_tx_pool` is set only transactions from the payload attributes will be included
+            // in the payload. In other words, the payload is deterministic and we can
+            // freeze it once we've successfully built it.
+            Ok(BuildOutcomeKind::Freeze(payload))
+        } else {
+            Ok(BuildOutcomeKind::Better { payload })
+        }
+    }
 }
+
+// /* TODO: currently this builds a flashblock and returns a built block to propose to the network.
+// It looks like we only need to do some of thes calculations once when building the final block. This
+// function should be updated and return all the necessary components needed to seal the block.
+// */
+// pub fn build_flashblock<Evm, ChainSpec, DB, P>(
+//     mut state: State<DB>,
+//     ctx: &OpPayloadBuilderCtx<Evm, ChainSpec>,
+//     info: &mut ExecutionInfo,
+// ) -> Result<(OpBuiltPayload, FlashblocksPayloadV1, BundleState), PayloadBuilderError>
+// where
+//     Evm: ConfigureEvm<Primitives: OpPayloadPrimitives, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
+//     ChainSpec: EthChainSpec + OpHardforks,
+//     DB: Database<Error = ProviderError> + AsRef<P>,
+//     P: StateRootProvider + HashedPostStateProvider + StorageRootProvider,
+// {
+//     // NOTE: ctx.withdrawals_root does not exist in latest reth
+//     // let withdrawals_root = ctx.commit_withdrawals(&mut state)?;
+
+//     // TODO: We must run this only once per block, but we are running it on every flashblock
+//     // merge all transitions into bundle state, this would apply the withdrawal balance changes
+//     // and 4788 contract call
+//     state.merge_transitions(BundleRetention::Reverts);
+
+//     let new_bundle = state.take_bundle();
+
+//     // NOTE: ctx.block_number does not exist in latest reth
+//     // let block_number = ctx.block_number();
+//     // assert_eq!(block_number, ctx.parent().number + 1);
+
+//     let block_number = ctx.parent().number + 1;
+//     let execution_outcome = ExecutionOutcome::new(
+//         new_bundle.clone(),
+//         vec![info.receipts.clone()],
+//         block_number,
+//         vec![],
+//     );
+//     let receipts_root = execution_outcome
+//         .generic_receipts_root_slow(block_number, |receipts| {
+//             calculate_receipt_root_no_memo_optimism(
+//                 receipts,
+//                 &ctx.chain_spec,
+//                 ctx.attributes().timestamp(),
+//             )
+//         })
+//         .expect("Number is in range");
+//     let logs_bloom = execution_outcome
+//         .block_logs_bloom(block_number)
+//         .expect("Number is in range");
+
+//     // // calculate the state root
+//     let state_provider = state.database.as_ref();
+//     let hashed_state = state_provider.hashed_post_state(execution_outcome.state());
+//     let (state_root, _trie_output) = {
+//         state
+//             .database
+//             .as_ref()
+//             .state_root_with_updates(hashed_state.clone())
+//             .inspect_err(|err| {
+//                 warn!(target: "payload_builder",
+//                 parent_header=%ctx.parent().hash(),
+//                     %err,
+//                     "failed to calculate state root for payload"
+//                 );
+//             })?
+//     };
+
+//     // create the block header
+//     let transactions_root = proofs::calculate_transaction_root(&info.executed_transactions);
+
+//     // OP doesn't support blobs/EIP-4844.
+//     // https://specs.optimism.io/protocol/exec-engine.html#ecotone-disable-blob-transactions
+//     // Need [Some] or [None] based on hardfork to match block hash.
+//     let (excess_blob_gas, blob_gas_used) = ctx.blob_fields();
+//     let extra_data = ctx.extra_data()?;
+
+//     let header = Header {
+//         parent_hash: ctx.parent().hash(),
+//         ommers_hash: EMPTY_OMMER_ROOT_HASH,
+//         beneficiary: ctx.evm_env.block_env.coinbase,
+//         state_root,
+//         transactions_root,
+//         receipts_root,
+//         withdrawals_root,
+//         logs_bloom,
+//         timestamp: ctx.attributes().payload_attributes.timestamp,
+//         mix_hash: ctx.attributes().payload_attributes.prev_randao,
+//         nonce: BEACON_NONCE.into(),
+//         base_fee_per_gas: Some(ctx.base_fee()),
+//         number: ctx.parent().number + 1,
+//         gas_limit: ctx.block_gas_limit(),
+//         difficulty: U256::ZERO,
+//         gas_used: info.cumulative_gas_used,
+//         extra_data,
+//         parent_beacon_block_root: ctx.attributes().payload_attributes.parent_beacon_block_root,
+//         blob_gas_used,
+//         excess_blob_gas,
+//         requests_hash: None,
+//     };
+
+//     // seal the block
+//     let block = N::Block::new(
+//         header,
+//         BlockBody {
+//             transactions: info.executed_transactions.clone(),
+//             ommers: vec![],
+//             withdrawals: ctx.withdrawals().cloned(),
+//         },
+//     );
+
+//     let sealed_block = Arc::new(block.seal_slow());
+//     debug!(target: "payload_builder", ?sealed_block, "sealed built block");
+
+//     let block_hash = sealed_block.hash();
+
+//     // pick the new transactions from the info field and update the last flashblock index
+//     let new_transactions = info.executed_transactions[info.last_flashblock_index..].to_vec();
+
+//     let new_transactions_encoded = new_transactions
+//         .clone()
+//         .into_iter()
+//         .map(|tx| tx.encoded_2718().into())
+//         .collect::<Vec<_>>();
+
+//     let new_receipts = info.receipts[info.last_flashblock_index..].to_vec();
+//     info.last_flashblock_index = info.executed_transactions.len();
+//     let receipts_with_hash = new_transactions
+//         .iter()
+//         .zip(new_receipts.iter())
+//         .map(|(tx, receipt)| (*tx.tx_hash(), receipt.clone()))
+//         .collect::<HashMap<B256, N::Receipt>>();
+//     let new_account_balances = new_bundle
+//         .state
+//         .iter()
+//         .filter_map(|(address, account)| account.info.as_ref().map(|info| (*address, info.balance)))
+//         .collect::<HashMap<Address, U256>>();
+
+//     let metadata = FlashblocksMetadata {
+//         receipts: receipts_with_hash,
+//         new_account_balances,
+//         block_number: ctx.parent().number + 1,
+//     };
+
+//     // Prepare the flashblocks message
+//     let fb_payload = FlashblocksPayloadV1 {
+//         payload_id: ctx.payload_id(),
+//         index: 0, // TODO: fix this
+//         base: Some(ExecutionPayloadBaseV1 {
+//             parent_beacon_block_root: ctx
+//                 .attributes()
+//                 .payload_attributes
+//                 .parent_beacon_block_root
+//                 .unwrap(),
+//             parent_hash: ctx.parent().hash(),
+//             fee_recipient: ctx.attributes().suggested_fee_recipient(),
+//             prev_randao: ctx.attributes().payload_attributes.prev_randao,
+//             block_number: ctx.parent().number + 1,
+//             gas_limit: ctx.block_gas_limit(),
+//             timestamp: ctx.attributes().payload_attributes.timestamp,
+//             extra_data: ctx.extra_data()?,
+//             base_fee_per_gas: ctx.base_fee().try_into().unwrap(),
+//         }),
+//         diff: ExecutionPayloadFlashblockDeltaV1 {
+//             state_root,
+//             receipts_root,
+//             logs_bloom,
+//             gas_used: info.cumulative_gas_used,
+//             block_hash,
+//             transactions: new_transactions_encoded,
+//             withdrawals: ctx.withdrawals().cloned().unwrap_or_default().to_vec(),
+//         },
+//         metadata: serde_json::to_value(&metadata).unwrap_or_default(),
+//     };
+
+//     Ok((
+//         OpBuiltPayload::new(
+//             ctx.payload_id(),
+//             sealed_block,
+//             info.total_fees,
+//             // This must be set to NONE for now because we are doing merge transitions on every flashblock
+//             // when it should only happen once per block, thus, it returns a confusing state back to op-reth.
+//             // We can live without this for now because Op syncs up the executed block using new_payload
+//             // calls, but eventually we would want to return the executed block here.
+//             None,
+//         ),
+//         fb_payload,
+//         new_bundle,
+//     ))
+// }

--- a/world-chain-builder/crates/flashblocks/payload/src/builder.rs
+++ b/world-chain-builder/crates/flashblocks/payload/src/builder.rs
@@ -25,7 +25,7 @@ use reth_optimism_payload_builder::{
     config::OpBuilderConfig,
     OpPayloadPrimitives,
 };
-use reth_payload_util::PayloadTransactions;
+use reth_payload_util::{NoopPayloadTransactions, PayloadTransactions};
 use reth_primitives::{NodePrimitives, SealedHeader, TxTy};
 use reth_provider::{
     ChainSpecProvider, ExecutionOutcome, ProviderError, StateProvider, StateProviderFactory,
@@ -217,7 +217,17 @@ where
         &self,
         config: PayloadConfig<Self::Attributes>,
     ) -> Result<Self::BuiltPayload, PayloadBuilderError> {
-        todo!()
+        let args = BuildArguments {
+            config,
+            cached_reads: Default::default(),
+            cancel: Default::default(),
+            best_payload: None,
+        };
+        self.build_payload(args, |_| {
+            NoopPayloadTransactions::<Pool::Transaction>::default()
+        })?
+        .into_payload()
+        .ok_or_else(|| PayloadBuilderError::MissingPayload)
     }
 }
 

--- a/world-chain-builder/crates/flashblocks/payload/src/builder.rs
+++ b/world-chain-builder/crates/flashblocks/payload/src/builder.rs
@@ -323,9 +323,7 @@ impl<Txs> FlashblockBuilder<'_, Txs> {
             let flashblock_gas_limit = ctx.attributes().gas_limit.unwrap_or(ctx.parent().gas_limit)
                 / (self.block_time / self.flashblock_interval);
 
-            // TODO: make this dynamic
-            let num_flashblocks = 4;
-
+            let num_flashblocks = self.block_time / self.flashblock_interval;
             for _ in 0..num_flashblocks {
                 let best_txs = best(ctx.best_transaction_attributes(builder.evm_mut().block()));
                 if ctx

--- a/world-chain-builder/crates/flashblocks/payload/src/builder.rs
+++ b/world-chain-builder/crates/flashblocks/payload/src/builder.rs
@@ -303,8 +303,8 @@ impl<Txs> FlashblockBuilder<'_, Txs> {
         let mut info = ctx.execute_sequencer_transactions(&mut builder)?;
 
         if !ctx.attributes().no_tx_pool {
-            let flashblock_gas_limit = ctx.attributes().gas_limit.unwrap_or(ctx.parent().gas_limit)
-                / (self.block_time / self.flashblock_interval);
+            let gas_limit = ctx.attributes().gas_limit.unwrap_or(ctx.parent().gas_limit);
+            let mut flashblock_gas_limit = gas_limit;
 
             let num_flashblocks = self.block_time / self.flashblock_interval;
             for _ in 0..num_flashblocks {
@@ -320,6 +320,8 @@ impl<Txs> FlashblockBuilder<'_, Txs> {
                 {
                     return Ok(BuildOutcomeKind::Cancelled);
                 }
+
+                flashblock_gas_limit = gas_limit - info.cumulative_gas_used;
             }
 
             // builder.finish_flashblock(&mut builder, &ctx, &mut info)?;


### PR DESCRIPTION
This PR introduces a `FlashBlocksPayloadBuilder` that extends Reth’s payload building logic to support streaming flashblocks during block construction. This PR also defines a new generic `PayloadBuilderCtx` trait, allowing generic payload building logic to be compatible with Flashblocks.

### Summary of Changes

- Adds `FlashBlocksPayloadBuilder`
- Introduces `PayloadBuilderCtx` trait for generic payload building within the `FlashblocksPayloadBuilder`.
- Introduces a `Flashblock` trait and `finish_flashblock()` method which is intended to be used to seal the flashblock before it is streamed. This logic is based on the existing `builder.finish()` implementation that seals the finalized block.

### Remaining Work
- Upstream the `PayloadBuilderCtx` trait to Reth
- Implement the `Flashblock` trait on `BasicBlockBuilder` to support `finish_flashblock()`.
  - The current `BasicBlockBuilder` from Reth is private. This should be updated to be made public which will enable us to implement the `Flashblock` trait.

This PR serves as the initial groundwork for flashblocks to support generic payload building logic. Further integration and testing will follow once the upstream dependencies are in place.