### PR TITLE
Fix typos: correct spelling 

### DIFF
--- a/contracts/test/TestSetup.sol
+++ b/contracts/test/TestSetup.sol
@@ -218,7 +218,7 @@ contract TestSetup is Test {
     }
 
     /// @notice Constructs a new pbhEntryPoint without initializing.
-    /// @dev Note that the owner will not be set without initilizing.
+    /// @dev Note that the owner will not be set without initializing.
     function makeUninitPBHEntryPoint() public {
         pbhEntryPointImpl = address(new PBHEntryPointImplV1());
         pbhEntryPoint = IPBHEntryPoint(address(new ERC1967Proxy(pbhEntryPointImpl, new bytes(0x0))));

--- a/crates/toolkit/README.md
+++ b/crates/toolkit/README.md
@@ -14,7 +14,7 @@ For the wallet we'll use the default test mnemonic used by both Anvil and Reth `
 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 ```
 
-The identity secret is a little weird since we never actually access it directly. Instead we use a seed to deterministicly generate an identity. For the purpose of testing we can use `11ff11` as our testing seed (the associated identity commitment is included in the staging sequencer).
+The identity secret is a little weird since we never actually access it directly. Instead we use a seed to deterministically generate an identity. For the purpose of testing we can use `11ff11` as our testing seed (the associated identity commitment is included in the staging sequencer).
 
 ## 1. Craft a transaction with `cast mktx`
 

--- a/specs/pbh/architecture.md
+++ b/specs/pbh/architecture.md
@@ -76,7 +76,7 @@ sequenceDiagram
     rollup-boost->>sequencer-el: engine_newPayloadV3(ExecutionPayload)
     sequencer-el->>rollup-boost: {status: VALID, ...}
 
-    Note over rollup-boost: Propose exectuion payload
+    Note over rollup-boost: Propose execution payload
     rollup-boost->>sequencer-cl: {executionPayload, blockValue}
     
     Note over sequencer-cl: Propagate new block


### PR DESCRIPTION
This PR fixes several typos across the codebase:

- contracts/test/TestSetup.sol: Fixed typo "initilizing" -> "initializing" in comment
- crates/toolkit/README.md: Fixed typo "deterministicly" -> "deterministically" 
- specs/pbh/architecture.md: Fixed typo "exectuion" -> "execution" in sequence diagram note

No functional changes, only documentation and comment fixes.