### PR TITLE
Add helper function to return index of unused nullifierHash

### DIFF
--- a/contracts/src/PBHEntryPointImplV1.sol
+++ b/contracts/src/PBHEntryPointImplV1.sol
@@ -367,15 +367,39 @@ contract PBHEntryPointImplV1 is IPBHEntryPoint, Base, ReentrancyGuardTransient {
     }
 
     /// @notice Returns the index of the first unspent nullifier hash in the given list.
+    /// @notice This function assumes the array input represents the nullifier hashes for a given sempahore key and monotonically increasing nonces for a given month.
     /// @param hashes The list of nullifier hashes to search through.
     /// @return The index of the first unspent nullifier hash in the given list.
     /// @dev Returns -1 if no unspent nullifier hash is found.
-    function getUnspentNullifierHash(uint256[] calldata hashes) public view virtual returns (int256) {
-        for (uint256 i = 0; i < hashes.length; ++i) {
+    function getFirstUnspentNullifierHash(uint256[] calldata hashes) public view virtual returns (int256) {
+        for (uint256 i = 0; i < hashes.length; i++) {
             if (nullifierHashes[i] == 0) {
                 return int256(i);
             }
         }
         return -1;
+    }
+
+    /// @notice Returns all indexes of unspent nullifier hashes in the given list.
+    /// @param hashes The list of nullifier hashes to search through.
+    /// @return The indexes of the unspent nullifier hashes in the given list.
+    /// @dev Returns an empty array if no unspent nullifier hashes are found.
+    function getUnspentNullifierHashes(uint256[] calldata hashes) public view virtual returns (uint256[] memory) {
+        uint256[] memory tempIndexes = new uint256[](hashes.length);
+        uint256 unspentCount = 0;
+
+        for (uint256 i = 0; i < hashes.length; i++) {
+            if (nullifierHashes[hashes[i]] == 0) {
+                tempIndexes[unspentCount] = i;
+                unspentCount++;
+            }
+        }
+
+        uint256[] memory unspentIndexes = new uint256[](unspentCount);
+        for (uint256 i = 0; i < unspentCount; ++i) {
+            unspentIndexes[i] = tempIndexes[i];
+        }
+
+        return unspentIndexes;
     }
 }

--- a/contracts/src/PBHEntryPointImplV1.sol
+++ b/contracts/src/PBHEntryPointImplV1.sol
@@ -367,7 +367,8 @@ contract PBHEntryPointImplV1 is IPBHEntryPoint, Base, ReentrancyGuardTransient {
     }
 
     /// @notice Returns the index of the first unspent nullifier hash in the given list.
-    /// @notice This function assumes the array input represents the nullifier hashes for a given sempahore key and monotonically increasing nonces for a given month.
+    /// @notice This function assumes the input array represents nullifier hashes that are
+    /// @notice generated from the same sempahore key and monotonically increasing nonces.
     /// @param hashes The list of nullifier hashes to search through.
     /// @return The index of the first unspent nullifier hash in the given list.
     /// @dev Returns -1 if no unspent nullifier hash is found.

--- a/contracts/src/PBHEntryPointImplV1.sol
+++ b/contracts/src/PBHEntryPointImplV1.sol
@@ -365,4 +365,17 @@ contract PBHEntryPointImplV1 is IPBHEntryPoint, Base, ReentrancyGuardTransient {
     function getUserOpHash(PackedUserOperation calldata userOp) public view virtual returns (bytes32 hash) {
         hash = keccak256(abi.encode(userOp.hash(), address(entryPoint), block.chainid));
     }
+
+    /// @notice Returns the index of the first unspent nullifier hash in the given list.
+    /// @param hashes The list of nullifier hashes to search through.
+    /// @return The index of the first unspent nullifier hash in the given list.
+    /// @dev Returns -1 if no unspent nullifier hash is found.
+    function getUnspentNullifierHash(uint256[] calldata hashes) public view virtual returns (int256) {
+        for (uint256 i = 0; i < hashes.length; ++i) {
+            if (nullifierHashes[i] == 0) {
+                return int256(i);
+            }
+        }
+        return -1;
+    }
 }

--- a/contracts/src/PBHEntryPointImplV1.sol
+++ b/contracts/src/PBHEntryPointImplV1.sol
@@ -372,7 +372,7 @@ contract PBHEntryPointImplV1 is IPBHEntryPoint, Base, ReentrancyGuardTransient {
     /// @return The index of the first unspent nullifier hash in the given list.
     /// @dev Returns -1 if no unspent nullifier hash is found.
     function getFirstUnspentNullifierHash(uint256[] calldata hashes) public view virtual returns (int256) {
-        for (uint256 i = 0; i < hashes.length; i++) {
+        for (uint256 i = 0; i < hashes.length; ++i) {
             if (nullifierHashes[i] == 0) {
                 return int256(i);
             }
@@ -388,7 +388,7 @@ contract PBHEntryPointImplV1 is IPBHEntryPoint, Base, ReentrancyGuardTransient {
         uint256[] memory tempIndexes = new uint256[](hashes.length);
         uint256 unspentCount = 0;
 
-        for (uint256 i = 0; i < hashes.length; i++) {
+        for (uint256 i = 0; i < hashes.length; ++i) {
             if (nullifierHashes[hashes[i]] == 0) {
                 tempIndexes[unspentCount] = i;
                 unspentCount++;

--- a/contracts/src/interfaces/IPBHEntryPoint.sol
+++ b/contracts/src/interfaces/IPBHEntryPoint.sol
@@ -45,5 +45,6 @@ interface IPBHEntryPoint {
     function addBuilder(address builder) external;
     function removeBuilder(address builder) external;
     function getUserOpHash(PackedUserOperation calldata userOp) external view returns (bytes32);
-    function getUnspentNullifierHash(uint256[] calldata nullifierHashes) external view returns (int256);
+    function getFirstUnspentNullifierHash(uint256[] calldata hashes) external view returns (int256);
+    function getUnspentNullifierHashes(uint256[] calldata hashes) external view returns (uint256[] memory);
 }

--- a/contracts/src/interfaces/IPBHEntryPoint.sol
+++ b/contracts/src/interfaces/IPBHEntryPoint.sol
@@ -45,4 +45,5 @@ interface IPBHEntryPoint {
     function addBuilder(address builder) external;
     function removeBuilder(address builder) external;
     function getUserOpHash(PackedUserOperation calldata userOp) external view returns (bytes32);
+    function getUnspentNullifierHash(uint256[] calldata nullifierHashes) external view returns (int256);
 }

--- a/contracts/test/PBHEntryPointImplV1.t.sol
+++ b/contracts/test/PBHEntryPointImplV1.t.sol
@@ -300,8 +300,13 @@ contract PBHEntryPointImplV1Test is TestSetup {
         assertEq(userOpHash, expectedHash, "UserOp hash does not match expected hash");
     }
 
-    function test_getUnspentNullifierHash(uint256[] memory nullifierHashes) public {
+    function test_getUnspentNullifierHash() public {
         vm.prank(BLOCK_BUILDER);
+
+        uint256[] memory nullifierHashes = new uint256[](7);
+        for (uint256 i = 0; i < 7; i++) {
+            nullifierHashes[i] = i;
+        }
 
         // Spend the first 5
         uint256[] memory nullifierHashesToSpend = new uint256[](5);

--- a/contracts/test/PBHEntryPointImplV1.t.sol
+++ b/contracts/test/PBHEntryPointImplV1.t.sol
@@ -300,5 +300,27 @@ contract PBHEntryPointImplV1Test is TestSetup {
         assertEq(userOpHash, expectedHash, "UserOp hash does not match expected hash");
     }
 
+    function test_getUnspentNullifierHash(uint256[] memory nullifierHashes) public {
+        vm.prank(BLOCK_BUILDER);
+
+        // Spend the first 5
+        uint256[] memory nullifierHashesToSpend = new uint256[](5);
+        for (uint256 i = 0; i < 5; i++) {
+            nullifierHashesToSpend[i] = i;
+        }
+        pbhEntryPoint.spendNullifierHashes(nullifierHashesToSpend);
+
+        // Expect the first the returned index to be 5
+        assertEq(pbhEntryPoint.getUnspentNullifierHash(nullifierHashes), 5);
+
+        uint256[] memory firstThreeNullifierHashes = new uint256[](3);
+        for (uint256 i = 0; i < 3; i++) {
+            firstThreeNullifierHashes[i] = i;
+        }
+
+        // Expect the last returned index to be -1
+        assertEq(pbhEntryPoint.getUnspentNullifierHash(firstThreeNullifierHashes), -1);
+    }
+
     receive() external payable {}
 }

--- a/contracts/test/PBHEntryPointImplV1.t.sol
+++ b/contracts/test/PBHEntryPointImplV1.t.sol
@@ -300,7 +300,7 @@ contract PBHEntryPointImplV1Test is TestSetup {
         assertEq(userOpHash, expectedHash, "UserOp hash does not match expected hash");
     }
 
-    function test_getUnspentNullifierHash() public {
+    function test_getFirstUnspentNullifierHash_Returns_CorrectIndex() public {
         vm.prank(BLOCK_BUILDER);
 
         uint256[] memory nullifierHashes = new uint256[](7);
@@ -316,15 +316,49 @@ contract PBHEntryPointImplV1Test is TestSetup {
         pbhEntryPoint.spendNullifierHashes(nullifierHashesToSpend);
 
         // Expect the first the returned index to be 5
-        assertEq(pbhEntryPoint.getUnspentNullifierHash(nullifierHashes), 5);
+        assertEq(pbhEntryPoint.getFirstUnspentNullifierHash(nullifierHashes), 5);
+    }
+
+    function test_getFirstUnspentNullifierHash_Returns_Negative_One() public {
+        vm.prank(BLOCK_BUILDER);
+
+        uint256[] memory nullifierHashes = new uint256[](7);
+        for (uint256 i = 0; i < 7; i++) {
+            nullifierHashes[i] = i;
+        }
+
+        pbhEntryPoint.spendNullifierHashes(nullifierHashes);
 
         uint256[] memory firstThreeNullifierHashes = new uint256[](3);
         for (uint256 i = 0; i < 3; i++) {
             firstThreeNullifierHashes[i] = i;
         }
-
         // Expect the last returned index to be -1
-        assertEq(pbhEntryPoint.getUnspentNullifierHash(firstThreeNullifierHashes), -1);
+        assertEq(pbhEntryPoint.getFirstUnspentNullifierHash(firstThreeNullifierHashes), -1);
+    }
+
+    function test_getUnspentNullifierHashes() public {
+        vm.prank(BLOCK_BUILDER);
+
+        uint256[] memory nullifierHashes = new uint256[](7);
+        for (uint256 i = 0; i < 7; i++) {
+            nullifierHashes[i] = i;
+        }
+
+        uint256[] memory threeHashes = new uint256[](3);
+
+        threeHashes[0] = 1;
+        threeHashes[1] = 2;
+        threeHashes[2] = 4;
+
+        pbhEntryPoint.spendNullifierHashes(threeHashes);
+
+        uint256[] memory unspentHashes = pbhEntryPoint.getUnspentNullifierHashes(nullifierHashes);
+        assertEq(unspentHashes.length, 4);
+        assertEq(unspentHashes[0], 0);
+        assertEq(unspentHashes[1], 3);
+        assertEq(unspentHashes[2], 5);
+        assertEq(unspentHashes[3], 6);
     }
 
     receive() external payable {}


### PR DESCRIPTION
The client must calculate, given the semaphore private key + nonce, the list of nullifierHashes for the month. This function will return the index of the first unused nullifierHash or -1 if all have been consumed.

