### PR TITLE
Fix typos in code comments

### DIFF
--- a/crates/world/pool/src/root.rs
+++ b/crates/world/pool/src/root.rs
@@ -26,7 +26,7 @@ where
 {
     /// Address of the WorldID contract
     world_id: Address,
-    /// The client used to aquire account state from the database.
+    /// The client used to acquire account state from the database.
     client: Client,
     /// A map of valid roots indexed by block timestamp.
     valid_roots: BTreeMap<u64, Field>,
@@ -45,7 +45,7 @@ where
     ///
     /// # Arguments
     ///
-    /// * `client` - The client used to aquire account state from the database.
+    /// * `client` - The client used to acquire account state from the database.
     pub fn new(client: Client, world_id: Address) -> Result<Self, WorldChainTransactionPoolError> {
         let mut this = Self {
             client,

--- a/crates/world/pool/src/validator.rs
+++ b/crates/world/pool/src/validator.rs
@@ -348,7 +348,7 @@ pub mod tests {
         let body = BlockBody::<OpTransactionSigned>::default();
         let block = SealedBlock::seal_slow(Block { header, body });
 
-        // Propogate the block to the root validator
+        // Propagate the block to the root validator
         validator.on_new_head_block(&block);
 
         let ordering = WorldChainOrdering::default();


### PR DESCRIPTION


## Description

This PR fixes several typos found in code comments across the codebase:

### Changes Made

- **`crates/world/pool/src/root.rs`**
  - Fixed "aquire" → "acquire" in documentation comments (lines 29, 48)

- **`crates/world/pool/src/validator.rs`**
  - Fixed "Propogate" → "Propagate" in inline comment (line 351)

