### PR TITLE
fix(typos): correct typos in PBH validation docs and transaction comments

### DIFF
--- a/crates/tests/sepolia/src/cli/transactions.rs
+++ b/crates/tests/sepolia/src/cli/transactions.rs
@@ -807,7 +807,7 @@ pub async fn send_invalid_pbh(args: SendInvalidProofPBHArgs) -> eyre::Result<()>
         };
 
         // This should revert on builder PBH validation error if the builders are up
-        // If all the builders are down/tx-proxy is down, the tx will be mined as the relays simulate the tx without valdiating the proof
+        // If all the builders are down/tx-proxy is down, the tx will be mined as the relays simulate the tx without validating the proof
         _ = provider.send_transaction(tx).await;
 
         // println!("Tx hash: {tx_hash:?}");

--- a/specs/pbh/validation.md
+++ b/specs/pbh/validation.md
@@ -2,7 +2,7 @@
 
 Upon receiving new transactions, the World Chain Builder will first ensure that the payload is [a valid OP Stack transaction](https://github.com/paradigmxyz/reth/blob/1e965caf5fa176f244a31c0d2662ba1b590938db/crates/optimism/txpool/src/validator.rs#L136-L203). In addition to the default checks, the builder will also [evaluate transactions for PBH conditions](https://github.com/worldcoin/world-chain/blob/kit/docs/world-chain-builder/crates/world/pool/src/validator.rs#L180-L204).
 
-Any transaction that calls the `pbhMulticall()` or `handleAggregatedOps()` function on the `PBHEntyrPoint` will be considered a PBH transaction and must clear PBH Validation. PBH transactions must contain a valid `PBHPayload` or `PBHPayload[]` in the case of PBH 4337 bundles.
+Any transaction that calls the `pbhMulticall()` or `handleAggregatedOps()` function on the `PBHEntryPoint` will be considered a PBH transaction and must clear PBH Validation. PBH transactions must contain a valid `PBHPayload` or `PBHPayload[]` in the case of PBH 4337 bundles.
 
 ```solidity
     struct PBHPayload {

--- a/specs/pbh/validation.md
+++ b/specs/pbh/validation.md
@@ -1,6 +1,6 @@
 # PBH Validation
 
-Upon receiving new transactions, the World Chain Builder will first ensure that the payload is [a valid OP Stack tranasaction](https://github.com/paradigmxyz/reth/blob/1e965caf5fa176f244a31c0d2662ba1b590938db/crates/optimism/txpool/src/validator.rs#L136-L203). In addition to the default checks, the builder will also [evaluate transactions for PBH conditions](https://github.com/worldcoin/world-chain/blob/kit/docs/world-chain-builder/crates/world/pool/src/validator.rs#L180-L204).
+Upon receiving new transactions, the World Chain Builder will first ensure that the payload is [a valid OP Stack transaction](https://github.com/paradigmxyz/reth/blob/1e965caf5fa176f244a31c0d2662ba1b590938db/crates/optimism/txpool/src/validator.rs#L136-L203). In addition to the default checks, the builder will also [evaluate transactions for PBH conditions](https://github.com/worldcoin/world-chain/blob/kit/docs/world-chain-builder/crates/world/pool/src/validator.rs#L180-L204).
 
 Any transaction that calls the `pbhMulticall()` or `handleAggregatedOps()` function on the `PBHEntyrPoint` will be considered a PBH transaction and must clear PBH Validation. PBH transactions must contain a valid `PBHPayload` or `PBHPayload[]` in the case of PBH 4337 bundles.
 


### PR DESCRIPTION
Corrected spelling mistakes in documentation and code comments:

transactions.rs:

- valdiating → validating

validation.md:

- tranasaction → transaction

- PBHEntyrPoint → PBHEntryPoint