### PR TITLE
chore: update GitHub actions in CI workflows

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup Rust toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Prepare
         run: |
           platform=${{ matrix.platform }}

--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -16,7 +16,7 @@ jobs:
     name: Foundry project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Prepare
         run: |
           platform=${{ matrix.platform }}
@@ -158,7 +158,7 @@ jobs:
             binary: world-chain-builder
     runs-on: ${{ matrix.runner }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
       with:
@@ -195,7 +195,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Download artifacts

--- a/.github/workflows/run-k8s.yml
+++ b/.github/workflows/run-k8s.yml
@@ -15,7 +15,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - uses: taiki-e/install-action@just

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -17,7 +17,7 @@ jobs:
   cargo-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: taiki-e/install-action@just
       - uses: dtolnay/rust-toolchain@stable
       - name: Cache
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 20
     name: lint
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: taiki-e/install-action@just
       - uses: dtolnay/rust-toolchain@nightly
         with:
@@ -63,7 +63,7 @@ jobs:
     timeout-minutes: 20
     name: clippy
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
         - uses: taiki-e/install-action@just
         - uses: dtolnay/rust-toolchain@nightly
           with:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -37,7 +37,7 @@ jobs:
             unwind-target: "0x118a6e922a8c6cab221fc5adfe5056d2b72d58c6580e9c5629de55299e2cf8de"
         # TODO: Add World Chain Mainnet
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@just
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Updates actions/checkout@v4 to actions/checkout@v5 across CI workflows.

Upgrade to actions/checkout@v5 for improved performance and stability.

Reference:
Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0

