### PR TITLE
fix: align logged block_number_max with actual test conditions in transact_conditional_test

### DIFF
--- a/crates/tests/devnet/src/cases.rs
+++ b/crates/tests/devnet/src/cases.rs
@@ -204,7 +204,7 @@ where
     info!(
         block = %receipt.unwrap().block_number().unwrap_or_default(),
         block_number_min = %latest,
-        block_number_max = %latest + 2,
+        block_number_max = %latest + 10,
         hash = ?hash,
         "Transaction Receipt Received"
     );


### PR DESCRIPTION

Changes logged value from %latest + 2 to %latest + 10 to match 
block_number_max: Some(latest + 10) in the test setup.