### PR TITLE
add flashbots authorizer contract

### DIFF
--- a/contracts/src/Flashbots.sol
+++ b/contracts/src/Flashbots.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/**
+ * @title FlashbotsAuthorizerRegistry
+ * @dev All flashbots enabled nodes will use this contract to get the authorizer address
+ * and expect a valid signature from the authorize
+ */
+contract FlashbotsAuthorizerRegistry is Ownable {
+    address public flashbotsAuthorizer;
+
+    event FlashbotsAuthorizerUpdated(address indexed previousAuthorizer, address indexed newAuthorizer);
+
+    error ZeroAddress();
+
+    /**
+     * @dev Constructor sets the initial owner and flashbots authorizer
+     * @param initialAuthorizer The initial flashbots authorizer address
+     */
+    constructor(address initialAuthorizer) Ownable(msg.sender) {
+        require(initialAuthorizer != address(0), ZeroAddress());
+        flashbotsAuthorizer = initialAuthorizer;
+        emit FlashbotsAuthorizerUpdated(address(0), initialAuthorizer);
+    }
+
+    /**
+     * @dev Updates the flashbots authorizer address
+     * Can only be called by the contract owner
+     * @param newAuthorizer The new flashbots authorizer address
+     */
+    function updateFlashbotsAuthorizer(address newAuthorizer) external onlyOwner {
+        require(newAuthorizer != address(0), ZeroAddress());
+
+        address previousAuthorizer = flashbotsAuthorizer;
+        flashbotsAuthorizer = newAuthorizer;
+
+        emit FlashbotsAuthorizerUpdated(previousAuthorizer, newAuthorizer);
+    }
+
+    /**
+     * @dev Returns the current flashbots authorizer address
+     * @return The current flashbots authorizer address
+     */
+    function getFlashbotsAuthorizer() external view returns (address) {
+        return flashbotsAuthorizer;
+    }
+}

--- a/contracts/src/FlashbotsAuthorizer.sol
+++ b/contracts/src/FlashbotsAuthorizer.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/**
+ * @title FlashbotsAuthorizerRegistry
+ * @dev All flashbots enabled nodes will use this contract to get the authorizer address
+ * and expect a valid signature from the authorize
+ */
+contract FlashbotsAuthorizerRegistry is Ownable {
+    address public flashbotsAuthorizer;
+
+    event FlashbotsAuthorizerUpdated(address indexed previousAuthorizer, address indexed newAuthorizer);
+
+    error ZeroAddress();
+
+    /**
+     * @dev Constructor sets the initial owner and flashbots authorizer
+     * @param initialAuthorizer The initial flashbots authorizer address
+     */
+    constructor(address initialAuthorizer) Ownable(msg.sender) {
+        require(initialAuthorizer != address(0), ZeroAddress());
+        flashbotsAuthorizer = initialAuthorizer;
+        emit FlashbotsAuthorizerUpdated(address(0), initialAuthorizer);
+    }
+
+    /**
+     * @dev Updates the flashbots authorizer address
+     * Can only be called by the contract owner
+     * @param newAuthorizer The new flashbots authorizer address
+     */
+    function updateFlashbotsAuthorizer(address newAuthorizer) external onlyOwner {
+        require(newAuthorizer != address(0), ZeroAddress());
+
+        address previousAuthorizer = flashbotsAuthorizer;
+        flashbotsAuthorizer = newAuthorizer;
+
+        emit FlashbotsAuthorizerUpdated(previousAuthorizer, newAuthorizer);
+    }
+
+    /**
+     * @dev Returns the current flashbots authorizer address
+     * @return The current flashbots authorizer address
+     */
+    function getFlashbotsAuthorizer() external view returns (address) {
+        return flashbotsAuthorizer;
+    }
+}

--- a/contracts/test/FlashbotsAuthorizer.t.sol
+++ b/contracts/test/FlashbotsAuthorizer.t.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {Test} from "forge-std/Test.sol";
+import {FlashbotsAuthorizerRegistry} from "../src/FlashbotsAuthorizer.sol";
+
+contract FlashbotsAuthorizerTest is Test {
+    FlashbotsAuthorizerRegistry public registry;
+
+    address public owner = address(0x1);
+    address public initialAuthorizer = address(0x2);
+    address public newAuthorizer = address(0x3);
+    address public nonOwner = address(0x4);
+
+    function setUp() public {
+        vm.prank(owner);
+        registry = new FlashbotsAuthorizerRegistry(initialAuthorizer);
+    }
+
+    function test_constructor_setsInitialAuthorizer() public {
+        assertEq(registry.getFlashbotsAuthorizer(), initialAuthorizer);
+        assertEq(registry.owner(), owner);
+    }
+
+    function test_updateFlashbotsAuthorizer_updatesAuthorizerSuccessfully() public {
+        vm.prank(owner);
+        registry.updateFlashbotsAuthorizer(newAuthorizer);
+
+        assertEq(registry.getFlashbotsAuthorizer(), newAuthorizer);
+    }
+
+    function test_updateFlashbotsAuthorizer_revertsOnZeroAddress() public {
+        vm.expectRevert(abi.encodeWithSelector(FlashbotsAuthorizerRegistry.ZeroAddress.selector));
+
+        vm.prank(owner);
+        registry.updateFlashbotsAuthorizer(address(0));
+    }
+
+    function test_multipleUpdates_maintainCorrectState() public {
+        address authorizer1 = address(0x5);
+        address authorizer2 = address(0x6);
+
+        // First update
+        vm.prank(owner);
+        registry.updateFlashbotsAuthorizer(authorizer1);
+        assertEq(registry.getFlashbotsAuthorizer(), authorizer1);
+
+        // Second update
+        vm.prank(owner);
+        registry.updateFlashbotsAuthorizer(authorizer2);
+        assertEq(registry.getFlashbotsAuthorizer(), authorizer2);
+    }
+}


### PR DESCRIPTION
We need to be able to update the flashbots authorizer on all flashbots enabled nodes in case Alchemy wants to rotate the keys. Currently it is passed as a CLI arg and would require a restart, instead nodes will read from this contract instead.