### PR TITLE
Osiris/remove in memory state implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3756,6 +3756,7 @@ dependencies = [
  "op-alloy-rpc-types",
  "op-alloy-rpc-types-engine",
  "reth",
+ "reth-chain-state",
  "reth-chainspec",
  "reth-evm",
  "reth-node-api",

--- a/crates/flashblocks/builder/src/executor.rs
+++ b/crates/flashblocks/builder/src/executor.rs
@@ -1,6 +1,5 @@
 use alloy_eips::eip2718::WithEncoded;
 use alloy_rpc_types_engine::PayloadId;
-use eyre::eyre::OptionExt;
 use flashblocks_p2p::protocol::handler::FlashblocksHandle;
 use flashblocks_primitives::p2p::AuthorizedPayload;
 use flashblocks_primitives::primitives::FlashblocksPayloadV1;
@@ -767,11 +766,7 @@ where
                     && latest_payload.1 >= flashblock.flashblock.index
                 {
                     // Already processed this flashblock
-                    provider.in_memory_state().set_pending_block(
-                        latest_payload.0.executed_block().ok_or_eyre(
-                            "`latest_payload` doesn't contain `ExecutedBlockWithTrieUpdates`",
-                        )?,
-                    );
+                    pending_block.send_replace(latest_payload.0.executed_block());
                     return Ok(());
                 }
             }

--- a/crates/flashblocks/builder/src/executor.rs
+++ b/crates/flashblocks/builder/src/executor.rs
@@ -820,8 +820,8 @@ where
 
     // The header either exists in the in memory state (has not been persisted to disk) or exists within
     // the database. First check the in memory state, then fall back to the database.
-    // TODO: Figure out a way to see if there is a writer on the DB and avoid crashing the node by reading 
-    // the header from disk if 
+    // TODO: Figure out a way to see if there is a writer on the DB and avoid crashing the node by reading
+    // the header from disk if
     let sealed_header = provider.in_memory_state().header_by_hash(base.parent_hash);
 
     if let Some(sealed_header) = sealed_header {

--- a/crates/flashblocks/builder/src/executor.rs
+++ b/crates/flashblocks/builder/src/executor.rs
@@ -731,6 +731,7 @@ impl FlashblocksStateExecutor {
     }
 }
 
+#[expect(clippy::too_many_arguments)]
 fn process_flashblock<Provider, Pool, P>(
     provider: &Provider,
     pool: &Pool,

--- a/crates/flashblocks/builder/src/executor.rs
+++ b/crates/flashblocks/builder/src/executor.rs
@@ -820,8 +820,8 @@ where
 
     // The header either exists in the in memory state (has not been persisted to disk) or exists within
     // the database. First check the in memory state, then fall back to the database.
-    // TODO: Figure out a way to see if there is a writer on the DB and avoid crashing the node by reading
-    // the header from disk if it is not in memory.
+    // TODO: Figure out a way to see if there is a writer on the DB and avoid crashing the node by reading 
+    // the header from disk if 
     let sealed_header = provider.in_memory_state().header_by_hash(base.parent_hash);
 
     if let Some(sealed_header) = sealed_header {

--- a/crates/flashblocks/rpc/Cargo.toml
+++ b/crates/flashblocks/rpc/Cargo.toml
@@ -23,6 +23,7 @@ reth-rpc-eth-types.workspace = true
 reth-storage-api.workspace = true
 reth-node-builder.workspace = true
 reth-tasks.workspace = true
+reth-chain-state.workspace = true
 
 # op-reth
 reth-optimism-rpc.workspace = true

--- a/crates/flashblocks/rpc/src/eth/block.rs
+++ b/crates/flashblocks/rpc/src/eth/block.rs
@@ -46,15 +46,6 @@ where
     ) -> Result<Option<Arc<RecoveredBlock<<Self::Provider as BlockReader>::Block>>>, Self::Error>
     {
         if block_id.is_pending() {
-            // Pending block can be fetched directly without need for caching
-            if let Some(pending_block) = self
-                .provider()
-                .pending_block()
-                .map_err(Self::Error::from_eth_err)?
-            {
-                return Ok(Some(Arc::new(pending_block)));
-            }
-
             // If no pending block from provider, try to get local pending block
             return match self.local_pending_block().await? {
                 Some(BlockAndReceipts { block, receipts: _ }) => Ok(Some(block)),

--- a/crates/flashblocks/rpc/src/eth/block.rs
+++ b/crates/flashblocks/rpc/src/eth/block.rs
@@ -62,15 +62,12 @@ where
             None => return Ok(None),
         };
 
-        let pending_block = self
-            .provider()
-            .pending_block()
-            .map_err(Self::Error::from_eth_err)?;
+        let pending_block = self.local_pending_block().await?;
 
-        if let Some(pending_block) = pending_block {
+        if let Some(BlockAndReceipts { block, receipts: _ }) = pending_block {
             // If the requested block hash matches the pending block, return it
-            if pending_block.hash() == block_hash {
-                return Ok(Some(Arc::new(pending_block)));
+            if block.hash() == block_hash {
+                return Ok(Some(block));
             }
         }
 

--- a/crates/flashblocks/rpc/src/eth/pending_block.rs
+++ b/crates/flashblocks/rpc/src/eth/pending_block.rs
@@ -59,10 +59,10 @@ where
                 .clone()
                 .into_iter()
                 .flatten()
-                .collect::<Vec<_>>();
+                .collect::<Vec<_>>(); // always a single block executed through the state executor
 
             let block_and_receipts = BlockAndReceipts {
-                block: block.into(),
+                block: block,
                 receipts: receipts.into(),
             };
             return Ok(Some(block_and_receipts));

--- a/crates/flashblocks/rpc/src/eth/pending_block.rs
+++ b/crates/flashblocks/rpc/src/eth/pending_block.rs
@@ -62,7 +62,7 @@ where
                 .collect::<Vec<_>>(); // always a single block executed through the state executor
 
             let block_and_receipts = BlockAndReceipts {
-                block: block,
+                block,
                 receipts: receipts.into(),
             };
             return Ok(Some(block_and_receipts));

--- a/crates/flashblocks/rpc/src/eth/pending_block.rs
+++ b/crates/flashblocks/rpc/src/eth/pending_block.rs
@@ -47,12 +47,20 @@ where
     async fn local_pending_block(
         &self,
     ) -> Result<Option<BlockAndReceipts<<N as RpcNodeCore>::Primitives>>, Self::Error> {
-        let pending_block = self
-            .provider()
-            .in_memory_state()
-            .pending_block_and_receipts();
+        // check the pending block from the executor
+        let pending_block = self.pending_block.borrow().clone();
 
-        if let Some((block, receipts)) = pending_block {
+        if let Some(pending_block) = pending_block {
+            let block = pending_block.block.recovered_block;
+            let receipts = pending_block
+                .block
+                .execution_output
+                .receipts
+                .clone()
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>();
+
             let block_and_receipts = BlockAndReceipts {
                 block: block.into(),
                 receipts: receipts.into(),

--- a/crates/world/node/src/flashblocks/rpc.rs
+++ b/crates/world/node/src/flashblocks/rpc.rs
@@ -78,7 +78,9 @@ where
         };
 
         let mut capabilities = EngineCapabilities::new(OP_ENGINE_CAPABILITIES.iter().copied());
-        capabilities.add_capability("flashblocks_forkChoiceUpdatedV3");
+
+        capabilities.add_capability("flashblocks_forkchoiceUpdatedV3");
+
         let inner = EngineApi::new(
             ctx.node.provider().clone(),
             ctx.config.chain.clone(),

--- a/crates/world/node/tests/e2e-testsuite/testsuite.rs
+++ b/crates/world/node/tests/e2e-testsuite/testsuite.rs
@@ -540,6 +540,7 @@ async fn test_eth_api_call() -> eyre::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_eth_block_by_hash_pending() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
     let (_, nodes, _tasks, mut env) =
@@ -598,7 +599,7 @@ async fn test_eth_block_by_hash_pending() -> eyre::Result<()> {
     let pending_hash =
         fixed_bytes!("f8e1bed42c0ef37d2452900e0fcdd638b857136651c91dd2f6492ceb56b44923");
 
-    let eth_block_by_hash = crate::actions::EthGetBlockByHash::new(pending_hash, vec![0], 300, tx);
+    let eth_block_by_hash = crate::actions::EthGetBlockByHash::new(pending_hash, vec![0], 350, tx);
     let mut action = crate::actions::EthApiAction::new(mine_block, eth_block_by_hash);
 
     action.execute(&mut env).await?;

--- a/devnet/src/el/world_chain_builder_launcher.star
+++ b/devnet/src/el/world_chain_builder_launcher.star
@@ -286,7 +286,7 @@ def get_config(
     env_vars = participant.el_builder_extra_env_vars
     env_vars["BUILDER_PRIVATE_KEY"] = BUILDER_PRIVATE_KEY
 
-    env_vars["RUST_LOG"] = "info,payload_builder=trace,engine::persistence=trace"
+    env_vars["RUST_LOG"] = "info,payload_builder=trace,engine::persistence=trace,flashblocks::state_executor=trace"
     env_vars["RUST_BACKTRACE"] = "full"
     config_args = {
         "image": participant.el_builder_image,


### PR DESCRIPTION
Sends the pending block to the `FlashblocksEthApi` through a watch channel rather than the `CanonicalInMemoryState` as this state is crucial for persistence of blocks to the database.