### PR TITLE
Bring back healthcheck feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1612,6 +1612,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5731,6 +5783,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5894,7 +5952,7 @@ dependencies = [
  "combine",
  "libc",
  "mach2 0.4.3",
- "nix",
+ "nix 0.26.4",
  "sysctl",
  "thiserror 1.0.69",
  "widestring",
@@ -5997,6 +6055,18 @@ dependencies = [
  "libc",
  "memoffset 0.7.1",
  "pin-utils",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -11667,6 +11737,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14181,6 +14262,8 @@ dependencies = [
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
+ "async-trait",
+ "axum",
  "backon",
  "bytes",
  "chrono",
@@ -14197,6 +14280,7 @@ dependencies = [
  "futures",
  "hex",
  "jsonrpsee",
+ "nix 0.29.0",
  "op-alloy-consensus",
  "op-alloy-rpc-types",
  "op-alloy-rpc-types-engine",
@@ -14205,6 +14289,7 @@ dependencies = [
  "reqwest 0.12.28",
  "reth",
  "reth-basic-payload-builder",
+ "reth-chainspec",
  "reth-db",
  "reth-e2e-test-utils",
  "reth-engine-local",
@@ -14227,11 +14312,13 @@ dependencies = [
  "reth-optimism-primitives",
  "reth-optimism-rpc",
  "reth-primitives",
+ "reth-primitives-traits",
  "reth-provider",
  "reth-tracing",
  "reth-transaction-pool",
  "revm-primitives",
  "semaphore-rs",
+ "serde",
  "serde_json",
  "tokio",
  "tokio-tungstenite 0.28.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,6 +201,7 @@ alloy-op-evm = { version = "0.27", default-features = false }
 alloy-evm = { version = "0.27", default-features = false }
 
 # rpc
+axum = "0.8"
 jsonrpsee = { version = "0.26.0", features = ["server", "client", "macros"] }
 jsonrpsee-core = { version = "0.26.0" }
 jsonrpsee-types = "0.26.0"
@@ -210,6 +211,7 @@ metrics = "0.24.0"
 metrics-derive = "0.1"
 
 tokio = { version = "1.44.2", features = ["full"] }
+nix = { version = "0.29", features = ["fs"] }
 tokio-util = "0.7.15"
 tokio-stream = "0.1.17"
 tokio-tungstenite = "0.28.0"

--- a/crates/flashblocks/node/tests/p2p.rs
+++ b/crates/flashblocks/node/tests/p2p.rs
@@ -219,11 +219,8 @@ async fn setup_node_extended_cfg(
                 access_list: true,
             }),
             tx_peers: None,
-<<<<<<< HEAD
             disable_bootnodes: true,
-=======
             health: Default::default(),
->>>>>>> dff87cb (Add health server.)
         },
         builder_config: Default::default(),
     };

--- a/crates/flashblocks/node/tests/p2p.rs
+++ b/crates/flashblocks/node/tests/p2p.rs
@@ -219,7 +219,11 @@ async fn setup_node_extended_cfg(
                 access_list: true,
             }),
             tx_peers: None,
+<<<<<<< HEAD
             disable_bootnodes: true,
+=======
+            health: Default::default(),
+>>>>>>> dff87cb (Add health server.)
         },
         builder_config: Default::default(),
     };

--- a/crates/world/bin/src/main.rs
+++ b/crates/world/bin/src/main.rs
@@ -45,12 +45,12 @@ fn main() {
             let config: WorldChainNodeConfig = args.into_config(builder.config_mut())?;
 
             info!(target: "reth::cli", "Starting in Flashblocks mode");
-            let node = WorldChainNode::<FlashblocksContext>::new(config.clone());
+            let worldchain_node = WorldChainNode::<FlashblocksContext>::new(config.clone());
             let NodeHandle {
                 node_exit_future,
-                node: _node,
+                node,
             } = builder
-                .node(node)
+                .node(worldchain_node)
                 .extend_rpc_modules(move |ctx| {
                     let provider = ctx.provider().clone();
                     let pool = ctx.pool().clone();

--- a/crates/world/bin/src/main.rs
+++ b/crates/world/bin/src/main.rs
@@ -1,3 +1,5 @@
+use std::net::SocketAddr;
+
 use clap::Parser;
 use eyre::config::HookBuilder;
 use reth_node_builder::NodeHandle;
@@ -62,13 +64,15 @@ fn main() {
                 .launch()
                 .await?;
 
-            if let Some(addr) = config.args.health.addr {
+            if config.args.health.enabled {
+                let health_addr =
+                    SocketAddr::new(config.args.health.addr, config.args.health.port);
                 let health_config = match &config.args.health.config {
                     Some(path) => HealthConfig::from_file(path)?,
                     None => HealthConfig::default(),
                 };
                 let health_server =
-                    health_config.build(addr, node.provider.clone(), node.network.clone());
+                    health_config.build(health_addr, node.provider.clone(), node.network.clone());
                 node.task_executor.spawn(health_server.serve());
             }
 

--- a/crates/world/bin/src/main.rs
+++ b/crates/world/bin/src/main.rs
@@ -65,8 +65,7 @@ fn main() {
                 .await?;
 
             if config.args.health.enabled {
-                let health_addr =
-                    SocketAddr::new(config.args.health.addr, config.args.health.port);
+                let health_addr = SocketAddr::new(config.args.health.addr, config.args.health.port);
                 let health_config = match &config.args.health.config {
                     Some(path) => HealthConfig::from_file(path)?,
                     None => HealthConfig::default(),

--- a/crates/world/bin/src/main.rs
+++ b/crates/world/bin/src/main.rs
@@ -48,7 +48,7 @@ fn main() {
             let node = WorldChainNode::<FlashblocksContext>::new(config.clone());
             let NodeHandle {
                 node_exit_future,
-                node,
+                node: _node,
             } = builder
                 .node(node)
                 .extend_rpc_modules(move |ctx| {

--- a/crates/world/bin/src/main.rs
+++ b/crates/world/bin/src/main.rs
@@ -5,7 +5,7 @@ use reth_optimism_cli::{Cli, chainspec::OpChainSpecParser};
 use reth_tracing::tracing::info;
 use world_chain_node::{
     FlashblocksOpApi, OpApiExtServer, args::WorldChainArgs, config::WorldChainNodeConfig,
-    context::FlashblocksContext, node::WorldChainNode,
+    context::FlashblocksContext, health::HealthConfig, node::WorldChainNode,
 };
 use world_chain_rpc::{EthApiExtServer, SequencerClient, WorldChainEthApiExt};
 
@@ -46,7 +46,7 @@ fn main() {
             let node = WorldChainNode::<FlashblocksContext>::new(config.clone());
             let NodeHandle {
                 node_exit_future,
-                node: _node,
+                node,
             } = builder
                 .node(node)
                 .extend_rpc_modules(move |ctx| {
@@ -61,6 +61,17 @@ fn main() {
                 })
                 .launch()
                 .await?;
+
+            if let Some(addr) = config.args.health.addr {
+                let health_config = match &config.args.health.config {
+                    Some(path) => HealthConfig::from_file(path)?,
+                    None => HealthConfig::default(),
+                };
+                let health_server =
+                    health_config.build(addr, node.provider.clone(), node.network.clone());
+                node.task_executor.spawn(health_server.serve());
+            }
+
             node_exit_future.await?;
 
             Ok(())

--- a/crates/world/node/Cargo.toml
+++ b/crates/world/node/Cargo.toml
@@ -45,6 +45,14 @@ alloy-signer-local.workspace = true
 
 op-alloy-consensus.workspace = true
 
+reth-network-api.workspace = true
+
+axum.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+async-trait.workspace = true
+nix.workspace = true
+alloy-consensus.workspace = true
 tokio.workspace = true
 eyre.workspace = true
 clap.workspace = true
@@ -59,6 +67,8 @@ world-chain-pool.workspace = true
 world-chain-test.workspace = true
 world-chain-node.workspace = true
 
+reth-chainspec.workspace = true
+tokio = { version = "1", features = ["test-util"] }
 reth-db.workspace = true
 reth-e2e-test-utils.workspace = true
 reth-engine-primitives.workspace = true
@@ -68,6 +78,7 @@ reth-optimism-node = { workspace = true, features = ["test-utils"] }
 revm-primitives.workspace = true
 reth-basic-payload-builder.workspace = true
 reth-primitives.workspace = true
+reth-primitives-traits.workspace = true
 reth-tracing.workspace = true
 reth-network-api.workspace = true
 reth-eth-wire.workspace = true

--- a/crates/world/node/src/args.rs
+++ b/crates/world/node/src/args.rs
@@ -10,7 +10,7 @@ use reth_network_peers::{PeerId, TrustedPeer};
 use reth_node_builder::NodeConfig;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_node::args::RollupArgs;
-use std::str::FromStr;
+use std::{net::SocketAddr, path::PathBuf, str::FromStr};
 use tracing::{debug, info, warn};
 
 pub const DEFAULT_FLASHBLOCKS_BOOTNODES: &str = "enode://78ca7daeb63956cbc3985853d5699a6404d976a2612575563f46876968fdca2383a195ee7db40de348757b2256195996933708f351169ca3f3fe93ab2a774608@16.62.98.53:30303,enode://c96dcadf4cdea4c39ec3fd775637d9e67d455b856b1514cfcf55b72f873a34b96d69e47ccea9fc797a446d4e6948aa80f6b9d479a1727ca166758a900b08f422@16.63.14.166:30303,enode://15688a7b281c32a4da633252dcc5019d60f037ee9eb46d05093dd3023bdd688b9b207d10a39e054a5ed87db666b2cb75696f6537de74d1e1f8dcabc53dc8d2ab@16.63.123.160:30303";
@@ -46,6 +46,24 @@ pub struct WorldChainArgs {
         default_value_t = false
     )]
     pub disable_bootnodes: bool,
+
+    /// Health check args
+    #[command(flatten)]
+    pub health: HealthArgs,
+}
+
+#[derive(Debug, Clone, Default, clap::Args)]
+#[command(next_help_heading = "Health")]
+pub struct HealthArgs {
+    /// Enable the health HTTP server on this address (startup/ready/live endpoints).
+    /// If omitted, no health server is started.
+    #[arg(long = "health.addr")]
+    pub addr: Option<SocketAddr>,
+
+    /// Path to health check configuration file (JSON).
+    /// If omitted, all probes return 200 OK unconditionally.
+    #[arg(long = "health.config")]
+    pub config: Option<PathBuf>,
 }
 
 impl WorldChainArgs {
@@ -354,6 +372,7 @@ mod tests {
             flashblocks: None,
             tx_peers: Some(vec![peer_id.parse().unwrap()]),
             disable_bootnodes: true,
+            health: HealthArgs::default(),
         };
 
         let spec = reth_optimism_chainspec::OpChainSpec::from_genesis(Genesis::default());

--- a/crates/world/node/src/args.rs
+++ b/crates/world/node/src/args.rs
@@ -10,7 +10,11 @@ use reth_network_peers::{PeerId, TrustedPeer};
 use reth_node_builder::NodeConfig;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_node::args::RollupArgs;
-use std::{net::SocketAddr, path::PathBuf, str::FromStr};
+use std::{
+    net::{IpAddr, Ipv4Addr},
+    path::PathBuf,
+    str::FromStr,
+};
 use tracing::{debug, info, warn};
 
 pub const DEFAULT_FLASHBLOCKS_BOOTNODES: &str = "enode://78ca7daeb63956cbc3985853d5699a6404d976a2612575563f46876968fdca2383a195ee7db40de348757b2256195996933708f351169ca3f3fe93ab2a774608@16.62.98.53:30303,enode://c96dcadf4cdea4c39ec3fd775637d9e67d455b856b1514cfcf55b72f873a34b96d69e47ccea9fc797a446d4e6948aa80f6b9d479a1727ca166758a900b08f422@16.63.14.166:30303,enode://15688a7b281c32a4da633252dcc5019d60f037ee9eb46d05093dd3023bdd688b9b207d10a39e054a5ed87db666b2cb75696f6537de74d1e1f8dcabc53dc8d2ab@16.63.123.160:30303";
@@ -50,20 +54,6 @@ pub struct WorldChainArgs {
     /// Health check args
     #[command(flatten)]
     pub health: HealthArgs,
-}
-
-#[derive(Debug, Clone, Default, clap::Args)]
-#[command(next_help_heading = "Health")]
-pub struct HealthArgs {
-    /// Enable the health HTTP server on this address (startup/ready/live endpoints).
-    /// If omitted, no health server is started.
-    #[arg(long = "health.addr")]
-    pub addr: Option<SocketAddr>,
-
-    /// Path to health check configuration file (JSON).
-    /// If omitted, all probes return 200 OK unconditionally.
-    #[arg(long = "health.config")]
-    pub config: Option<PathBuf>,
 }
 
 impl WorldChainArgs {
@@ -218,6 +208,38 @@ pub struct PbhArgs {
         default_value_t = Default::default(),
     )]
     pub signature_aggregator: Address,
+}
+
+#[derive(Debug, Clone, clap::Args)]
+#[command(next_help_heading = "Health")]
+pub struct HealthArgs {
+    /// Enable the health HTTP server.
+    #[arg(long = "health.enabled", id = "health.enabled", required = false)]
+    pub enabled: bool,
+
+    /// Address for the health HTTP server.
+    #[arg(long = "health.addr", id = "health.addr", default_value_t = IpAddr::V4(Ipv4Addr::LOCALHOST))]
+    pub addr: IpAddr,
+
+    /// Port for the health HTTP server.
+    #[arg(long = "health.port", id = "health.port", default_value_t = 8080)]
+    pub port: u16,
+
+    /// Path to health check configuration file (JSON).
+    /// If omitted, all probes return 200 OK unconditionally.
+    #[arg(long = "health.config", id = "health.config", required = false)]
+    pub config: Option<PathBuf>,
+}
+
+impl Default for HealthArgs {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            addr: IpAddr::V4(Ipv4Addr::LOCALHOST),
+            port: 8080,
+            config: None,
+        }
+    }
 }
 
 /// Parameters for pbh builder configuration

--- a/crates/world/node/src/health/checks.rs
+++ b/crates/world/node/src/health/checks.rs
@@ -1,0 +1,562 @@
+use std::{
+    path::{Path, PathBuf},
+    sync::Mutex,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use tokio::time::Instant;
+
+use alloy_consensus::BlockHeader;
+use async_trait::async_trait;
+use reth_network_api::{NetworkInfo, PeersInfo};
+use reth_provider::{BlockNumReader, HeaderProvider};
+
+use super::{CheckResult, HealthCheck};
+
+pub struct HeartbeatCheck;
+
+#[async_trait]
+impl HealthCheck for HeartbeatCheck {
+    fn name(&self) -> &'static str {
+        "heartbeat"
+    }
+
+    async fn check(&self) -> CheckResult {
+        CheckResult {
+            healthy: true,
+            detail: None,
+        }
+    }
+}
+
+pub struct MinPeersCheck<N> {
+    pub min: usize,
+    pub network: N,
+}
+
+#[async_trait]
+impl<N: PeersInfo + Send + Sync + 'static> HealthCheck for MinPeersCheck<N> {
+    fn name(&self) -> &'static str {
+        "min_peers"
+    }
+
+    async fn check(&self) -> CheckResult {
+        let count = self.network.num_connected_peers();
+        let healthy = count >= self.min;
+        CheckResult {
+            healthy,
+            detail: (!healthy).then(|| format!("peers: {count}/{}", self.min)),
+        }
+    }
+}
+
+pub struct NotSyncingCheck<N> {
+    pub network: N,
+}
+
+#[async_trait]
+impl<N: NetworkInfo + Send + Sync + 'static> HealthCheck for NotSyncingCheck<N> {
+    fn name(&self) -> &'static str {
+        "not_syncing"
+    }
+
+    async fn check(&self) -> CheckResult {
+        let syncing = self.network.is_syncing();
+        CheckResult {
+            healthy: !syncing,
+            detail: syncing.then(|| "node is syncing".to_string()),
+        }
+    }
+}
+
+/// Which block number to track for progress.
+#[derive(Debug, Clone, Copy, serde::Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum BlockNumberMode {
+    /// Canonical head — blocks fully executed. Use for liveness/readiness.
+    #[default]
+    Best,
+    /// Last stored — includes downloaded-but-not-yet-executed blocks. Use for startup during IBD.
+    Last,
+}
+
+/// Fails if the tracked block number has not advanced within `period`.
+/// On the first call the baseline is established and the check returns healthy.
+pub struct BlockProgressCheck<P> {
+    pub period: Duration,
+    pub mode: BlockNumberMode,
+    pub provider: P,
+    /// (last_block, time_we_first_saw_it_stuck)
+    state: Mutex<Option<(u64, Instant)>>,
+}
+
+impl<P> BlockProgressCheck<P> {
+    pub fn new(period: Duration, mode: BlockNumberMode, provider: P) -> Self {
+        Self {
+            period,
+            mode,
+            provider,
+            state: Mutex::new(None),
+        }
+    }
+}
+
+#[async_trait]
+impl<P: BlockNumReader + Send + Sync + 'static> HealthCheck for BlockProgressCheck<P> {
+    fn name(&self) -> &'static str {
+        "block_progress"
+    }
+
+    async fn check(&self) -> CheckResult {
+        let current = match match self.mode {
+            BlockNumberMode::Best => self.provider.best_block_number(),
+            BlockNumberMode::Last => self.provider.last_block_number(),
+        } {
+            Ok(n) => n,
+            Err(e) => {
+                return CheckResult {
+                    healthy: false,
+                    detail: Some(format!("provider error: {e}")),
+                };
+            }
+        };
+
+        let mut state = self
+            .state
+            .lock()
+            .expect("block progress check mutex poisoned");
+        match *state {
+            None => {
+                *state = Some((current, Instant::now()));
+                CheckResult {
+                    healthy: true,
+                    detail: None,
+                }
+            }
+            Some((last_block, stuck_since)) => {
+                if current > last_block {
+                    *state = Some((current, Instant::now()));
+                    CheckResult {
+                        healthy: true,
+                        detail: None,
+                    }
+                } else {
+                    let elapsed = stuck_since.elapsed();
+                    let healthy = elapsed < self.period;
+                    CheckResult {
+                        healthy,
+                        detail: (!healthy).then(|| {
+                            format!(
+                                "block stuck at {current} for {elapsed:.0?}, limit {:.0?}",
+                                self.period
+                            )
+                        }),
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Fails if the latest block's timestamp is older than `max_age` relative to wall-clock time.
+pub struct BlockTimestampCheck<P> {
+    pub max_age: Duration,
+    pub provider: P,
+}
+
+#[async_trait]
+impl<P> HealthCheck for BlockTimestampCheck<P>
+where
+    P: BlockNumReader + HeaderProvider + Send + Sync + 'static,
+{
+    fn name(&self) -> &'static str {
+        "block_timestamp"
+    }
+
+    async fn check(&self) -> CheckResult {
+        let block_num = match self.provider.best_block_number() {
+            Ok(n) => n,
+            Err(e) => {
+                return CheckResult {
+                    healthy: false,
+                    detail: Some(format!("provider error: {e}")),
+                };
+            }
+        };
+
+        let header = match self.provider.header_by_number(block_num) {
+            Ok(Some(h)) => h,
+            Ok(None) => {
+                return CheckResult {
+                    healthy: false,
+                    detail: Some(format!("no header for block {block_num}")),
+                };
+            }
+            Err(e) => {
+                return CheckResult {
+                    healthy: false,
+                    detail: Some(format!("provider error: {e}")),
+                };
+            }
+        };
+
+        let block_ts = header.timestamp();
+        let now_ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let age_secs = now_ts.saturating_sub(block_ts);
+        let max_age_secs = self.max_age.as_secs();
+        let healthy = age_secs <= max_age_secs;
+        CheckResult {
+            healthy,
+            detail: (!healthy)
+                .then(|| format!("latest block is {age_secs}s old, limit {max_age_secs}s")),
+        }
+    }
+}
+
+/// Fails if available disk space on the filesystem containing `path` drops below `min_bytes`.
+pub struct DiskSpaceCheck {
+    pub path: PathBuf,
+    pub min_bytes: u64,
+}
+
+fn available_bytes(path: &Path) -> eyre::Result<u64> {
+    let stat = nix::sys::statvfs::statvfs(path)?;
+    #[allow(clippy::useless_conversion)]
+    Ok(u64::from(stat.blocks_available()) * stat.fragment_size())
+}
+
+fn format_gib(bytes: u64) -> f64 {
+    bytes as f64 / (1u64 << 30) as f64
+}
+
+#[async_trait]
+impl HealthCheck for DiskSpaceCheck {
+    fn name(&self) -> &'static str {
+        "disk_space"
+    }
+
+    async fn check(&self) -> CheckResult {
+        match available_bytes(&self.path) {
+            Ok(avail) => {
+                let healthy = avail >= self.min_bytes;
+                CheckResult {
+                    healthy,
+                    detail: (!healthy).then(|| {
+                        format!(
+                            "{:.1} GiB free on {}, need {:.1} GiB",
+                            format_gib(avail),
+                            self.path.display(),
+                            format_gib(self.min_bytes),
+                        )
+                    }),
+                }
+            }
+            Err(e) => CheckResult {
+                healthy: false,
+                detail: Some(format!(
+                    "failed to read disk stats for {}: {e}",
+                    self.path.display()
+                )),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    };
+
+    use alloy_primitives::{B256, BlockNumber};
+    use reth_chainspec::ChainInfo;
+    use reth_provider::{BlockHashReader, BlockNumReader, ProviderResult};
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct MockProvider(Arc<AtomicU64>);
+
+    impl MockProvider {
+        fn new(block: u64) -> Self {
+            Self(Arc::new(AtomicU64::new(block)))
+        }
+
+        fn set(&self, block: u64) {
+            self.0.store(block, Ordering::SeqCst);
+        }
+    }
+
+    impl BlockHashReader for MockProvider {
+        fn block_hash(&self, _number: BlockNumber) -> ProviderResult<Option<B256>> {
+            Ok(None)
+        }
+
+        fn canonical_hashes_range(
+            &self,
+            _start: BlockNumber,
+            _end: BlockNumber,
+        ) -> ProviderResult<Vec<B256>> {
+            Ok(vec![])
+        }
+    }
+
+    impl BlockNumReader for MockProvider {
+        fn chain_info(&self) -> ProviderResult<ChainInfo> {
+            let n = self.0.load(Ordering::SeqCst);
+            Ok(ChainInfo {
+                best_hash: B256::ZERO,
+                best_number: n,
+            })
+        }
+
+        fn best_block_number(&self) -> ProviderResult<BlockNumber> {
+            Ok(self.0.load(Ordering::SeqCst))
+        }
+
+        fn last_block_number(&self) -> ProviderResult<BlockNumber> {
+            Ok(self.0.load(Ordering::SeqCst))
+        }
+
+        fn block_number(&self, _hash: B256) -> ProviderResult<Option<BlockNumber>> {
+            Ok(None)
+        }
+    }
+
+    #[tokio::test]
+    async fn heartbeat_always_healthy() {
+        let result = HeartbeatCheck.check().await;
+        assert!(result.healthy);
+        assert!(result.detail.is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn block_progress_first_call_healthy() {
+        let check = BlockProgressCheck::new(
+            Duration::from_secs(60),
+            BlockNumberMode::Best,
+            MockProvider::new(10),
+        );
+
+        let result = check.check().await;
+        assert!(result.healthy);
+        assert!(result.detail.is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn block_progress_advancing_healthy() {
+        let provider = MockProvider::new(10);
+        let check = BlockProgressCheck::new(
+            Duration::from_secs(60),
+            BlockNumberMode::Best,
+            provider.clone(),
+        );
+
+        check.check().await;
+        provider.set(11);
+        let result = check.check().await;
+        assert!(result.healthy);
+        assert!(result.detail.is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn block_progress_stuck_within_period_healthy() {
+        let check = BlockProgressCheck::new(
+            Duration::from_secs(60),
+            BlockNumberMode::Best,
+            MockProvider::new(10),
+        );
+
+        check.check().await;
+        tokio::time::advance(Duration::from_secs(30)).await;
+        let result = check.check().await;
+        assert!(result.healthy);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn block_progress_stuck_past_period_unhealthy() {
+        let check = BlockProgressCheck::new(
+            Duration::from_secs(60),
+            BlockNumberMode::Best,
+            MockProvider::new(10),
+        );
+
+        check.check().await;
+        tokio::time::advance(Duration::from_secs(61)).await;
+        let result = check.check().await;
+        assert!(!result.healthy);
+        assert!(result.detail.is_some());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn block_progress_reset_after_advance() {
+        let provider = MockProvider::new(10);
+        let check = BlockProgressCheck::new(
+            Duration::from_secs(60),
+            BlockNumberMode::Best,
+            provider.clone(),
+        );
+
+        check.check().await;
+        tokio::time::advance(Duration::from_secs(61)).await;
+        provider.set(11);
+        let result = check.check().await;
+        assert!(result.healthy);
+        assert!(result.detail.is_none());
+    }
+
+    // ---- BlockTimestampCheck tests ----
+
+    use alloy_consensus::Header as AlloyHeader;
+    use reth_primitives_traits::SealedHeader;
+    use std::ops::RangeBounds;
+
+    #[derive(Clone)]
+    struct MockTimestampProvider {
+        block_num: u64,
+        block_timestamp: u64,
+    }
+
+    impl BlockHashReader for MockTimestampProvider {
+        fn block_hash(&self, _num: BlockNumber) -> ProviderResult<Option<B256>> {
+            Ok(None)
+        }
+        fn canonical_hashes_range(
+            &self,
+            _s: BlockNumber,
+            _e: BlockNumber,
+        ) -> ProviderResult<Vec<B256>> {
+            Ok(vec![])
+        }
+    }
+
+    impl BlockNumReader for MockTimestampProvider {
+        fn chain_info(&self) -> ProviderResult<ChainInfo> {
+            Ok(ChainInfo {
+                best_hash: B256::ZERO,
+                best_number: self.block_num,
+            })
+        }
+        fn best_block_number(&self) -> ProviderResult<BlockNumber> {
+            Ok(self.block_num)
+        }
+        fn last_block_number(&self) -> ProviderResult<BlockNumber> {
+            Ok(self.block_num)
+        }
+        fn block_number(&self, _hash: B256) -> ProviderResult<Option<BlockNumber>> {
+            Ok(None)
+        }
+    }
+
+    impl HeaderProvider for MockTimestampProvider {
+        type Header = AlloyHeader;
+
+        fn header(
+            &self,
+            _hash: alloy_primitives::BlockHash,
+        ) -> ProviderResult<Option<Self::Header>> {
+            Ok(None)
+        }
+
+        fn header_by_number(&self, _num: BlockNumber) -> ProviderResult<Option<Self::Header>> {
+            Ok(Some(AlloyHeader {
+                timestamp: self.block_timestamp,
+                ..Default::default()
+            }))
+        }
+
+        fn headers_range(
+            &self,
+            _range: impl RangeBounds<BlockNumber>,
+        ) -> ProviderResult<Vec<Self::Header>> {
+            Ok(vec![])
+        }
+
+        fn sealed_header(
+            &self,
+            _num: BlockNumber,
+        ) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
+            Ok(None)
+        }
+
+        fn sealed_headers_while(
+            &self,
+            _range: impl RangeBounds<BlockNumber>,
+            _predicate: impl FnMut(&SealedHeader<Self::Header>) -> bool,
+        ) -> ProviderResult<Vec<SealedHeader<Self::Header>>> {
+            Ok(vec![])
+        }
+    }
+
+    #[tokio::test]
+    async fn block_timestamp_recent_healthy() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let provider = MockTimestampProvider {
+            block_num: 1,
+            block_timestamp: now - 10,
+        };
+        let check = BlockTimestampCheck {
+            max_age: Duration::from_secs(60),
+            provider,
+        };
+        let result = check.check().await;
+        assert!(result.healthy);
+        assert!(result.detail.is_none());
+    }
+
+    #[tokio::test]
+    async fn block_timestamp_stale_unhealthy() {
+        let provider = MockTimestampProvider {
+            block_num: 1,
+            block_timestamp: 0,
+        };
+        let check = BlockTimestampCheck {
+            max_age: Duration::from_secs(60),
+            provider,
+        };
+        let result = check.check().await;
+        assert!(!result.healthy);
+        assert!(result.detail.is_some());
+    }
+
+    // ---- DiskSpaceCheck tests ----
+
+    #[tokio::test]
+    async fn disk_space_zero_min_bytes_healthy() {
+        let check = DiskSpaceCheck {
+            path: std::env::temp_dir(),
+            min_bytes: 0,
+        };
+        let result = check.check().await;
+        assert!(result.healthy);
+    }
+
+    #[tokio::test]
+    async fn disk_space_u64_max_unhealthy() {
+        let check = DiskSpaceCheck {
+            path: std::env::temp_dir(),
+            min_bytes: u64::MAX,
+        };
+        let result = check.check().await;
+        assert!(!result.healthy);
+        assert!(result.detail.is_some());
+    }
+
+    #[tokio::test]
+    async fn disk_space_bad_path_unhealthy() {
+        let check = DiskSpaceCheck {
+            path: PathBuf::from("/nonexistent/path/that/does/not/exist"),
+            min_bytes: 0,
+        };
+        let result = check.check().await;
+        assert!(!result.healthy);
+        assert!(result.detail.is_some());
+    }
+}

--- a/crates/world/node/src/health/config.rs
+++ b/crates/world/node/src/health/config.rs
@@ -1,0 +1,275 @@
+use std::{
+    net::SocketAddr,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
+
+use reth_network_api::{NetworkInfo, PeersInfo};
+use reth_provider::{BlockNumReader, HeaderProvider};
+use serde::Deserialize;
+
+use super::{
+    HealthCheck, HealthServer, Probe,
+    checks::{
+        BlockNumberMode, BlockProgressCheck, BlockTimestampCheck, DiskSpaceCheck, HeartbeatCheck,
+        MinPeersCheck, NotSyncingCheck,
+    },
+};
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(default)]
+pub struct HealthConfig {
+    pub startup: ProbeConfig,
+    pub readiness: ProbeConfig,
+    pub liveness: ProbeConfig,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ProbeConfig {
+    #[serde(default = "defaults::interval_secs")]
+    pub interval_secs: u64,
+    #[serde(default)]
+    pub checks: Vec<CheckConfig>,
+}
+
+impl Default for ProbeConfig {
+    fn default() -> Self {
+        Self {
+            interval_secs: defaults::interval_secs(),
+            checks: vec![],
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum CheckConfig {
+    BlockProgress {
+        #[serde(default = "defaults::period_secs")]
+        period_secs: u64,
+        #[serde(default)]
+        mode: BlockNumberMode,
+    },
+    BlockTimestamp {
+        #[serde(default = "defaults::max_age_secs")]
+        max_age_secs: u64,
+    },
+    DiskSpace {
+        path: PathBuf,
+        #[serde(default = "defaults::min_gb")]
+        min_gb: f64,
+    },
+    MinPeers {
+        #[serde(default = "defaults::min_peers")]
+        min: usize,
+    },
+    NotSyncing,
+    Heartbeat,
+}
+
+mod defaults {
+    pub fn interval_secs() -> u64 {
+        30
+    }
+    pub fn period_secs() -> u64 {
+        60
+    }
+    pub fn max_age_secs() -> u64 {
+        60
+    }
+    pub fn min_gb() -> f64 {
+        10.0
+    }
+    pub fn min_peers() -> usize {
+        1
+    }
+}
+
+impl HealthConfig {
+    pub fn from_file(path: &Path) -> eyre::Result<Self> {
+        let content = std::fs::read_to_string(path)?;
+        Ok(serde_json::from_str(&content)?)
+    }
+
+    pub fn build<P, N>(self, addr: SocketAddr, provider: P, network: N) -> HealthServer
+    where
+        P: BlockNumReader + HeaderProvider + Clone + Send + Sync + 'static,
+        N: PeersInfo + NetworkInfo + Clone + Send + Sync + 'static,
+    {
+        HealthServer::new(
+            build_probe(self.startup, &provider, &network),
+            build_probe(self.readiness, &provider, &network),
+            build_probe(self.liveness, &provider, &network),
+            addr,
+        )
+    }
+}
+
+fn build_probe<P, N>(config: ProbeConfig, provider: &P, network: &N) -> Probe
+where
+    P: BlockNumReader + HeaderProvider + Clone + Send + Sync + 'static,
+    N: PeersInfo + NetworkInfo + Clone + Send + Sync + 'static,
+{
+    let checks: Vec<Arc<dyn HealthCheck>> = config
+        .checks
+        .into_iter()
+        .map(|c| -> Arc<dyn HealthCheck> {
+            match c {
+                CheckConfig::Heartbeat => Arc::new(HeartbeatCheck),
+                CheckConfig::MinPeers { min } => Arc::new(MinPeersCheck {
+                    min,
+                    network: network.clone(),
+                }),
+                CheckConfig::NotSyncing => Arc::new(NotSyncingCheck {
+                    network: network.clone(),
+                }),
+                CheckConfig::BlockProgress { period_secs, mode } => {
+                    Arc::new(BlockProgressCheck::new(
+                        Duration::from_secs(period_secs),
+                        mode,
+                        provider.clone(),
+                    ))
+                }
+                CheckConfig::BlockTimestamp { max_age_secs } => Arc::new(BlockTimestampCheck {
+                    max_age: Duration::from_secs(max_age_secs),
+                    provider: provider.clone(),
+                }),
+                CheckConfig::DiskSpace { path, min_gb } => Arc::new(DiskSpaceCheck {
+                    path,
+                    min_bytes: (min_gb * (1u64 << 30) as f64) as u64,
+                }),
+            }
+        })
+        .collect();
+    Probe::new(checks, Duration::from_secs(config.interval_secs))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_config_deserializes() {
+        let config: HealthConfig = serde_json::from_str("{}").unwrap();
+        assert!(config.startup.checks.is_empty());
+        assert!(config.readiness.checks.is_empty());
+        assert!(config.liveness.checks.is_empty());
+    }
+
+    #[test]
+    fn probe_config_interval_default() {
+        let config: ProbeConfig = serde_json::from_str(r#"{"checks":[]}"#).unwrap();
+        assert_eq!(config.interval_secs, 30);
+    }
+
+    #[test]
+    fn probe_config_interval_explicit() {
+        let config: ProbeConfig =
+            serde_json::from_str(r#"{"interval_secs":10,"checks":[]}"#).unwrap();
+        assert_eq!(config.interval_secs, 10);
+    }
+
+    #[test]
+    fn heartbeat_check_deserializes() {
+        let config: ProbeConfig =
+            serde_json::from_str(r#"{"checks":[{"type":"heartbeat"}]}"#).unwrap();
+        assert_eq!(config.checks.len(), 1);
+        assert!(matches!(config.checks[0], CheckConfig::Heartbeat));
+    }
+
+    #[test]
+    fn min_peers_check_with_default() {
+        let config: ProbeConfig =
+            serde_json::from_str(r#"{"checks":[{"type":"min_peers"}]}"#).unwrap();
+        assert!(matches!(config.checks[0], CheckConfig::MinPeers { min: 1 }));
+    }
+
+    #[test]
+    fn min_peers_check_explicit_value() {
+        let config: ProbeConfig =
+            serde_json::from_str(r#"{"checks":[{"type":"min_peers","min":3}]}"#).unwrap();
+        assert!(matches!(config.checks[0], CheckConfig::MinPeers { min: 3 }));
+    }
+
+    #[test]
+    fn not_syncing_check_deserializes() {
+        let config: ProbeConfig =
+            serde_json::from_str(r#"{"checks":[{"type":"not_syncing"}]}"#).unwrap();
+        assert!(matches!(config.checks[0], CheckConfig::NotSyncing));
+    }
+
+    #[test]
+    fn block_progress_defaults() {
+        let config: ProbeConfig =
+            serde_json::from_str(r#"{"checks":[{"type":"block_progress"}]}"#).unwrap();
+        assert!(matches!(
+            config.checks[0],
+            CheckConfig::BlockProgress {
+                period_secs: 60,
+                mode: BlockNumberMode::Best
+            }
+        ));
+    }
+
+    #[test]
+    fn block_progress_explicit_last_mode() {
+        let config: ProbeConfig = serde_json::from_str(
+            r#"{"checks":[{"type":"block_progress","period_secs":120,"mode":"last"}]}"#,
+        )
+        .unwrap();
+        assert!(matches!(
+            config.checks[0],
+            CheckConfig::BlockProgress {
+                period_secs: 120,
+                mode: BlockNumberMode::Last
+            }
+        ));
+    }
+
+    #[test]
+    fn block_timestamp_defaults() {
+        let config: ProbeConfig =
+            serde_json::from_str(r#"{"checks":[{"type":"block_timestamp"}]}"#).unwrap();
+        assert!(matches!(
+            config.checks[0],
+            CheckConfig::BlockTimestamp { max_age_secs: 60 }
+        ));
+    }
+
+    #[test]
+    fn block_timestamp_explicit() {
+        let config: ProbeConfig =
+            serde_json::from_str(r#"{"checks":[{"type":"block_timestamp","max_age_secs":30}]}"#)
+                .unwrap();
+        assert!(matches!(
+            config.checks[0],
+            CheckConfig::BlockTimestamp { max_age_secs: 30 }
+        ));
+    }
+
+    #[test]
+    fn disk_space_deserializes() {
+        let config: ProbeConfig =
+            serde_json::from_str(r#"{"checks":[{"type":"disk_space","path":"/var/lib/data"}]}"#)
+                .unwrap();
+        assert!(matches!(config.checks[0], CheckConfig::DiskSpace { .. }));
+        if let CheckConfig::DiskSpace { ref path, min_gb } = config.checks[0] {
+            assert_eq!(path, std::path::Path::new("/var/lib/data"));
+            assert!((min_gb - 10.0).abs() < f64::EPSILON);
+        }
+    }
+
+    #[test]
+    fn full_health_config_deserializes() {
+        let json = r#"{
+            "startup":  {"checks":[{"type":"block_progress","mode":"last"}]},
+            "readiness":{"checks":[{"type":"not_syncing"},{"type":"min_peers","min":2}]},
+            "liveness": {"checks":[{"type":"heartbeat"},{"type":"block_timestamp"}]}
+        }"#;
+        let config: HealthConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.startup.checks.len(), 1);
+        assert_eq!(config.readiness.checks.len(), 2);
+        assert_eq!(config.liveness.checks.len(), 2);
+    }
+}

--- a/crates/world/node/src/health/mod.rs
+++ b/crates/world/node/src/health/mod.rs
@@ -1,0 +1,284 @@
+use std::{
+    net::SocketAddr,
+    sync::{Arc, RwLock},
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use axum::{Json, Router, extract::State, http::StatusCode, routing::get};
+use serde::Serialize;
+use tokio::net::TcpListener;
+use tracing::{error, info, warn};
+
+pub mod checks;
+pub mod config;
+
+pub use config::{CheckConfig, HealthConfig, ProbeConfig};
+
+pub struct CheckResult {
+    pub healthy: bool,
+    pub detail: Option<String>,
+}
+
+#[async_trait]
+pub trait HealthCheck: Send + Sync + 'static {
+    fn name(&self) -> &'static str;
+    async fn check(&self) -> CheckResult;
+}
+
+#[derive(Clone, Serialize)]
+pub struct CheckOutcome {
+    pub name: &'static str,
+    pub healthy: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+#[derive(Clone, Serialize)]
+pub struct ProbeResult {
+    pub healthy: bool,
+    pub checks: Vec<CheckOutcome>,
+}
+
+impl Default for ProbeResult {
+    fn default() -> Self {
+        Self {
+            healthy: true,
+            checks: vec![],
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct Probe {
+    checks: Vec<Arc<dyn HealthCheck>>,
+    pub interval: Duration,
+    result: Arc<RwLock<ProbeResult>>,
+}
+
+impl Default for Probe {
+    fn default() -> Self {
+        Self::new(vec![], Duration::from_secs(30))
+    }
+}
+
+impl Probe {
+    pub fn new(checks: Vec<Arc<dyn HealthCheck>>, interval: Duration) -> Self {
+        Self {
+            checks,
+            interval,
+            result: Arc::new(RwLock::new(ProbeResult::default())),
+        }
+    }
+
+    pub async fn evaluate(&self) -> ProbeResult {
+        let mut outcomes = Vec::with_capacity(self.checks.len());
+        let mut healthy = true;
+
+        for check in &self.checks {
+            let result = check.check().await;
+            if !result.healthy {
+                warn!(
+                    target: "world_chain::health",
+                    check = check.name(),
+                    detail = ?result.detail,
+                    "health check failed"
+                );
+                healthy = false;
+            }
+            outcomes.push(CheckOutcome {
+                name: check.name(),
+                healthy: result.healthy,
+                detail: result.detail,
+            });
+        }
+
+        ProbeResult {
+            healthy,
+            checks: outcomes,
+        }
+    }
+
+    async fn init(&self) {
+        let r = self.evaluate().await;
+        *self.result.write().expect("probe result lock poisoned") = r;
+    }
+
+    pub fn last_result(&self) -> ProbeResult {
+        self.result
+            .read()
+            .expect("probe result lock poisoned")
+            .clone()
+    }
+
+    pub async fn run_loop(self) {
+        loop {
+            tokio::time::sleep(self.interval).await;
+            let r = self.evaluate().await;
+            *self.result.write().expect("probe result lock poisoned") = r;
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct HealthServer {
+    pub startup: Probe,
+    pub readiness: Probe,
+    pub liveness: Probe,
+    addr: SocketAddr,
+}
+
+impl HealthServer {
+    pub fn new(startup: Probe, readiness: Probe, liveness: Probe, addr: SocketAddr) -> Self {
+        Self {
+            startup,
+            readiness,
+            liveness,
+            addr,
+        }
+    }
+
+    pub async fn serve(self) {
+        let listener = match TcpListener::bind(self.addr).await {
+            Ok(l) => l,
+            Err(e) => {
+                error!(target: "world_chain::health", addr = %self.addr, "Failed to bind health server: {e}");
+                return;
+            }
+        };
+        info!(target: "world_chain::health", addr = %self.addr, "Health server listening");
+
+        // Run initial evaluation before accepting connections.
+        self.startup.init().await;
+        self.readiness.init().await;
+        self.liveness.init().await;
+
+        // Spawn background evaluation loops.
+        tokio::spawn(self.startup.clone().run_loop());
+        tokio::spawn(self.readiness.clone().run_loop());
+        tokio::spawn(self.liveness.clone().run_loop());
+
+        let state = Arc::new(self);
+        let app = Router::new()
+            .route("/startup", get(startup_handler))
+            .route("/ready", get(readiness_handler))
+            .route("/live", get(liveness_handler))
+            .with_state(state);
+
+        if let Err(e) = axum::serve(listener, app).await {
+            error!(target: "world_chain::health", "Health server error: {e}");
+        }
+    }
+}
+
+async fn startup_handler(State(s): State<Arc<HealthServer>>) -> (StatusCode, Json<ProbeResult>) {
+    probe_response(s.startup.last_result())
+}
+
+async fn readiness_handler(State(s): State<Arc<HealthServer>>) -> (StatusCode, Json<ProbeResult>) {
+    probe_response(s.readiness.last_result())
+}
+
+async fn liveness_handler(State(s): State<Arc<HealthServer>>) -> (StatusCode, Json<ProbeResult>) {
+    probe_response(s.liveness.last_result())
+}
+
+fn probe_response(result: ProbeResult) -> (StatusCode, Json<ProbeResult>) {
+    let status = if result.healthy {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    (status, Json(result))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Arc, time::Duration};
+
+    use async_trait::async_trait;
+
+    use super::*;
+
+    struct AlwaysHealthy;
+
+    #[async_trait]
+    impl HealthCheck for AlwaysHealthy {
+        fn name(&self) -> &'static str {
+            "always_healthy"
+        }
+
+        async fn check(&self) -> CheckResult {
+            CheckResult {
+                healthy: true,
+                detail: None,
+            }
+        }
+    }
+
+    struct AlwaysUnhealthy;
+
+    #[async_trait]
+    impl HealthCheck for AlwaysUnhealthy {
+        fn name(&self) -> &'static str {
+            "always_unhealthy"
+        }
+
+        async fn check(&self) -> CheckResult {
+            CheckResult {
+                healthy: false,
+                detail: Some("broken".to_string()),
+            }
+        }
+    }
+
+    fn interval() -> Duration {
+        Duration::from_secs(30)
+    }
+
+    #[tokio::test]
+    async fn probe_all_healthy() {
+        let probe = Probe::new(
+            vec![Arc::new(AlwaysHealthy), Arc::new(AlwaysHealthy)],
+            interval(),
+        );
+        let result = probe.evaluate().await;
+        assert!(result.healthy);
+        assert_eq!(result.checks.len(), 2);
+        assert!(result.checks.iter().all(|c| c.healthy));
+    }
+
+    #[tokio::test]
+    async fn probe_one_unhealthy_marks_probe_unhealthy() {
+        let probe = Probe::new(
+            vec![Arc::new(AlwaysHealthy), Arc::new(AlwaysUnhealthy)],
+            interval(),
+        );
+        let result = probe.evaluate().await;
+        assert!(!result.healthy);
+        assert_eq!(result.checks.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn probe_all_checks_run_even_after_failure() {
+        let probe = Probe::new(
+            vec![Arc::new(AlwaysUnhealthy), Arc::new(AlwaysHealthy)],
+            interval(),
+        );
+        let result = probe.evaluate().await;
+        assert!(!result.healthy);
+        assert_eq!(result.checks.len(), 2);
+        assert_eq!(result.checks[0].name, "always_unhealthy");
+        assert!(!result.checks[0].healthy);
+        assert_eq!(result.checks[1].name, "always_healthy");
+        assert!(result.checks[1].healthy);
+    }
+
+    #[tokio::test]
+    async fn probe_empty_is_healthy() {
+        let probe = Probe::default();
+        let result = probe.evaluate().await;
+        assert!(result.healthy);
+        assert!(result.checks.is_empty());
+    }
+}

--- a/crates/world/node/src/lib.rs
+++ b/crates/world/node/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod args;
 pub mod config;
 pub mod context;
+pub mod health;
 pub mod node;
 pub mod tx_propagation;
 

--- a/crates/world/test/src/node.rs
+++ b/crates/world/test/src/node.rs
@@ -122,6 +122,7 @@ pub fn test_config_with_peers_and_gossip(
             flashblocks,
             tx_peers,
             disable_bootnodes: true,
+            health: Default::default(),
         },
         builder_config: FlashblocksPayloadBuilderConfig {
             inner: OpBuilderConfig::default(),

--- a/specs/SUMMARY.md
+++ b/specs/SUMMARY.md
@@ -1,5 +1,6 @@
 # Summary
 - [Introduction](./overview.md)
+- [Health Checks](./health_checks.md)
 - [Priority Blockspace for Humans](./pbh/overview.md)
     - [Architecture](./pbh/architecture.md)
     - [PBH Transactions](./pbh/txs.md)

--- a/specs/health_checks.md
+++ b/specs/health_checks.md
@@ -1,0 +1,217 @@
+# Health Checks
+
+World Chain nodes expose a configurable health check HTTP server for use with Kubernetes liveness, readiness, and startup probes.
+
+## CLI Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--health.addr` | `0.0.0.0:8080` | Address for the health HTTP server |
+| `--health.config` | _(none)_ | Path to a JSON config file. If omitted, all probes return 200 OK unconditionally. |
+
+## HTTP Endpoints
+
+| Endpoint | Kubernetes probe |
+|----------|-----------------|
+| `GET /startup` | startupProbe |
+| `GET /ready` | readinessProbe |
+| `GET /live` | livenessProbe |
+
+Each endpoint returns HTTP 200 when healthy, 503 when unhealthy, with a JSON body:
+
+```json
+{
+  "healthy": true,
+  "checks": [
+    { "name": "heartbeat", "healthy": true },
+    { "name": "min_peers", "healthy": false, "detail": "peers: 0/1" }
+  ]
+}
+```
+
+All configured checks run regardless of overall result — no short-circuiting. The `detail` field is only present on failing checks.
+
+## Background Evaluation
+
+Checks run on a background timer, not on each HTTP request. On startup, all probes are evaluated once before the server begins accepting connections. After that, each probe re-evaluates on its configured `interval_secs`. HTTP handlers return the most recently cached result.
+
+This means: a probe that has never been polled by Kubernetes will still detect block stalls, disk exhaustion, etc., and the cached result will already reflect the failure when the first request arrives.
+
+## Configuration File
+
+The config file is JSON. All fields have defaults — an empty object `{}` is valid.
+
+```json
+{
+  "startup": {
+    "interval_secs": 10,
+    "checks": [
+      { "type": "block_progress", "mode": "last", "period_secs": 300 }
+    ]
+  },
+  "readiness": {
+    "interval_secs": 15,
+    "checks": [
+      { "type": "not_syncing" },
+      { "type": "min_peers", "min": 2 }
+    ]
+  },
+  "liveness": {
+    "interval_secs": 30,
+    "checks": [
+      { "type": "heartbeat" },
+      { "type": "block_timestamp", "max_age_secs": 120 },
+      { "type": "disk_space", "path": "/var/lib/worldchain", "min_gb": 20.0 }
+    ]
+  }
+}
+```
+
+### Top-level fields
+
+| Field | Default |
+|-------|---------|
+| `startup` | empty probe (always healthy) |
+| `readiness` | empty probe (always healthy) |
+| `liveness` | empty probe (always healthy) |
+
+### Probe fields
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `interval_secs` | `30` | How often to re-evaluate checks in the background |
+| `checks` | `[]` | List of check configurations |
+
+## Check Types
+
+### `heartbeat`
+
+Always returns healthy. Useful as a no-op placeholder or to verify the server itself is reachable.
+
+```json
+{ "type": "heartbeat" }
+```
+
+---
+
+### `min_peers`
+
+Fails if the number of connected peers drops below `min`.
+
+```json
+{ "type": "min_peers", "min": 1 }
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `min` | `1` | Minimum required connected peers |
+
+---
+
+### `not_syncing`
+
+Fails if the node reports that it is currently syncing.
+
+```json
+{ "type": "not_syncing" }
+```
+
+---
+
+### `block_progress`
+
+Fails if the tracked block number has not advanced within `period_secs`. On the first evaluation the baseline is established and the check returns healthy.
+
+```json
+{ "type": "block_progress", "period_secs": 60, "mode": "best" }
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `period_secs` | `60` | Maximum allowed time (seconds) for the block number to remain unchanged |
+| `mode` | `"best"` | Which block number to track: `"best"` (canonical head, fully executed) or `"last"` (downloaded but potentially not yet executed, useful during initial block download) |
+
+Use `mode: "last"` for the startup probe during IBD; use `mode: "best"` for liveness and readiness once the node is in sync.
+
+---
+
+### `block_timestamp`
+
+Fails if the latest block's timestamp is older than `max_age_secs` relative to wall-clock time.
+
+```json
+{ "type": "block_timestamp", "max_age_secs": 60 }
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `max_age_secs` | `60` | Maximum allowed block age in seconds |
+
+---
+
+### `disk_space`
+
+Fails if available disk space on the filesystem containing `path` drops below `min_gb` GiB.
+
+Uses a single `statvfs(2)` syscall — equivalent to `df`, not a recursive directory scan.
+
+```json
+{ "type": "disk_space", "path": "/var/lib/worldchain", "min_gb": 10.0 }
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `path` | _(required)_ | Any path on the filesystem to check |
+| `min_gb` | `10.0` | Minimum required free space in GiB |
+
+## Kubernetes Example
+
+```yaml
+startupProbe:
+  httpGet:
+    path: /startup
+    port: 8080
+  failureThreshold: 30
+  periodSeconds: 10
+
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: 8080
+  failureThreshold: 3
+  periodSeconds: 15
+
+livenessProbe:
+  httpGet:
+    path: /live
+    port: 8080
+  failureThreshold: 3
+  periodSeconds: 30
+```
+
+Pair with a config file:
+
+```json
+{
+  "startup": {
+    "interval_secs": 10,
+    "checks": [
+      { "type": "block_progress", "mode": "last", "period_secs": 300 }
+    ]
+  },
+  "readiness": {
+    "interval_secs": 15,
+    "checks": [
+      { "type": "not_syncing" },
+      { "type": "min_peers", "min": 1 }
+    ]
+  },
+  "liveness": {
+    "interval_secs": 30,
+    "checks": [
+      { "type": "block_timestamp", "max_age_secs": 120 },
+      { "type": "disk_space", "path": "/var/lib/worldchain", "min_gb": 10.0 }
+    ]
+  }
+}
+```


### PR DESCRIPTION
This is not only revert but also includes other changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new optional HTTP server with background probe evaluation and disk/network/provider checks; while gated behind `--health.enabled`, it introduces new runtime tasks and an exposed endpoint that could affect operations if misconfigured.
> 
> **Overview**
> Reintroduces an *optional* healthcheck HTTP server for World Chain nodes, enabled via new CLI flags (`--health.enabled`, `--health.addr`, `--health.port`, `--health.config`) and started from `crates/world/bin` using the node’s provider/network handles.
> 
> Adds a `world_chain_node::health` module backed by `axum` with `/startup`, `/ready`, and `/live` endpoints returning cached probe results, plus a JSON-configurable set of checks (peer count, syncing status, block progress/timestamp freshness, and disk space via `statvfs`). Updates tests/config constructors to include default `health` args, wires in new deps (`axum`, `nix`, `serde`), and documents configuration/usage in `specs/health_checks.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69a5ff65c0429b8c83290477429ccd228b1912bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->