### PR TITLE
wip(1003): private delegated keyrings over 7702 precompile authority

### DIFF
--- a/wips/wip-1003.md
+++ b/wips/wip-1003.md
@@ -1,0 +1,187 @@
+|             |                                                                                                                                                                                                     |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| WIP         | 1003                                                                                                                                                                                                |
+| Title       | Native Private Account KeyRing Authorizations                                                                                                                                                       |
+| Description | The KeyRing is an abstract cryptographic authority — a blinded Pedersen vector commitment — that accounts delegate to via EIP-7702. The precompile verifies ring-signature-equivalent anonymous authorization. |
+| Author      | 0xOsiris                                                                                                                                                                                            |
+| Status      | Draft                                                                                                                                                                                               |
+| Category    | Core                                                                                                                                                                                                |
+| Created     | 2026/04/03                                                                                                                                                                                          |
+| Requires    | [WIP-1001](./wip-1001.md), [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702)                                                                                                                     |
+
+## Abstract
+
+A *KeyRing* is an abstract cryptographic authority whose sole identity is a blinded Pedersen vector commitment $C$ over BN254 $\mathbb{G}_1$. Accounts delegate to it via [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702). The KeyRing precompile verifies authorization proofs against $C$ — no new transaction type is introduced.
+
+Three authorization modes:
+
+- **Signed** — single signature, O(1) key hash lookup.
+- **MultiSigned** — threshold $k$-of-$n$.
+- **Anonymous** — Groth16 ZK proof. Realizes a **ring signature** over the committed key set: proves *some* key authorized the transaction without revealing *which*. Combined with scoped nullifiers, this yields **anonymously authenticated transactions** — provably authorized by a KeyRing member, yet unconditionally signer-hidden.
+
+Signature algorithms are generic: every scheme reduces to `verify(msg) → key_bytes → hash_key() → U256`. The commitment layer never sees algorithm details.
+
+---
+
+## Motivation
+
+Existing keychains (WIP-1001, Tempo `AccountKeychain`) are account-intrinsic: keys stored per-account, root key as single point of failure, all operations visible on-chain. This proposal inverts the model — the KeyRing is an independent authority, accounts merely point to it.
+
+**Ring signatures** ([Rivest, Shamir, Tauman 2001](https://people.csail.mit.edu/rivest/pubs/RST01.pdf)) let a signer prove membership in an ad-hoc group without revealing which member signed. The KeyRing's *Anonymous* mode achieves this via Groth16 against the Pedersen commitment — constant-size proofs (~192 bytes regardless of ring size), EVM-native verification via BN254 precompiles, and scoped nullifiers for replay protection without breaking anonymity.
+
+**Anonymously authenticated transactions** enable: privacy-preserving multi-sig, agent privacy (which key transacted is hidden), whistleblower-safe DAO governance, and plausible deniability for any ring member.
+
+---
+
+## Specification
+
+### 1. Pedersen Vector Commitment
+
+#### Generators
+
+$\mathcal{G} = \{G_1, \ldots, G_n, B\}$ on BN254 $\mathbb{G}_1$, $n = 20$. Derived deterministically via try-and-increment with domain tags (`"WorldChain.Pedersen.G{i}"`, `"WorldChain.Pedersen.B"`). No trusted setup.
+
+#### Key Hashing
+
+$$h = \text{keccak256}(\text{key\_bytes}) \mod r$$
+
+where $r$ is the BN254 scalar field order. This is the sole interface between signature algorithms and the commitment.
+
+#### Commitment
+
+$$C = \sum_{i=0}^{m-1} h_i \cdot G_{i+1} + \rho \cdot B$$
+
+$C$ compressed to 32 bytes **IS** the KeyRing identity. Perfectly hiding (blinding $\rho$), computationally binding (discrete log).
+
+---
+
+### 2. Signature System
+
+Every algorithm implements one interface:
+
+```
+verify_prehash(message_hash) → key_bytes
+```
+
+| Type | Byte | Key Recovery |
+| ---- | ---- | ------------ |
+| Secp256k1 | `0x00` | ecrecover → address |
+| P256 | `0x01` | explicit key (64 bytes) |
+| WebAuthn | `0x02` | P256 key + authenticator validation |
+| Ed25519 | `0x03` | explicit verifying key (32 bytes) |
+
+Pipeline for all algorithms:
+
+```
+verify_prehash(msg_hash) → key_bytes → keccak256(key_bytes) mod r → key_hash
+precompile: key_membership[C][key_hash] == 1 → authorized
+```
+
+New algorithms require only a new `verify_prehash` impl. No changes to commitment, proofs, policies, or precompile.
+
+---
+
+### 3. Authorization Modes
+
+```
+KeyRingAuthorization ::= RLP([mode_byte, ...fields])
+```
+
+#### 3.1 Signed (`0x00`)
+
+Single signature → recover key → hash → O(1) state lookup.
+
+#### 3.2 MultiSigned (`0x01`)
+
+$k$-of-$n$ threshold. Each signature independently verified. May mix algorithms.
+
+#### 3.3 Anonymous (`0x02`)
+
+```
+Anonymous ::= RLP([0x02, proof, nullifier, scope])
+```
+
+Groth16 proof against $C$ proving:
+
+1. Prover knows a key whose hash $h_j$ is a component of $C$.
+2. Prover signed `signing_hash` with that key.
+3. Nullifier $\nu = f(h_j, \text{scope})$ — deterministic, scoped.
+
+**Ring signature equivalence**: Among $m$ keys in $C$, each is equally likely to be the signer. The proof reveals nothing about slot $j$, algorithm, or key identity. Two transactions sharing $(C, \text{scope}, \nu)$ are linked (same signer in that scope); across scopes, unlinkable.
+
+**Gas**: ~350,000 (BN254 pairing via 0x06/0x07/0x08).
+
+---
+
+### 4. Policies
+
+Per-KeyRing, not per-key. Only `policy_root = keccak256(rlp(policy_tree))` stored on-chain. Transactions carry the relevant branch as witness.
+
+| Condition | Description |
+| --------- | ----------- |
+| Threshold | $k$-of-$n$ signers required |
+| Timelock | Key valid only in $[\text{not\_before}, \text{not\_after}]$ |
+| OperationRestriction | Key can only call specific (address, selector) pairs |
+| SpendingCap | Per-token limit with time window |
+| RateLimit | Max transactions per window |
+| WorldIdGate | Requires World ID proof for action scope |
+| And / Or | Boolean composition |
+
+---
+
+### 5. Precompile State
+
+All state at `KEYRING_PRECOMPILE` (`0x1D`), keyed by commitment $C$:
+
+| State | Slot Derivation | Description |
+| ----- | --------------- | ----------- |
+| `num_keys` | `keccak256("keyring.state" \|\| C)` | Key slot count |
+| `policy_root` | base + 1 | Policy tree hash |
+| `world_id_nullifier` | base + 2 | Optional, for recovery |
+| `superseded` | base + 3 | True after rotation |
+| `successor` | base + 4 | Successor commitment |
+| Key membership | `keccak256("keyring.key" \|\| C \|\| key_hash)` | O(1) lookup |
+| Nonce | `keccak256("keyring.nonce" \|\| C \|\| account)` | Replay protection |
+| Nullifier spent | `keccak256("keyring.nullifier" \|\| C \|\| nullifier)` | Anonymous replay |
+
+Per-account delegation (in account's own storage via 7702):
+
+```
+keccak256("keyring.delegation") → C
+```
+
+---
+
+### 6. EIP-7702 Integration
+
+No new transaction type. Accounts delegate to the KeyRing precompile via standard EIP-7702 authorization:
+
+1. EOA signs an EIP-7702 `Authorization { chain_id, address: KEYRING_PRECOMPILE, nonce }`.
+2. The account's delegation slot stores which commitment $C$ governs it.
+3. Subsequent transactions from that account are validated by the KeyRing precompile against $C$.
+
+Multiple accounts may delegate to the same $C$. One KeyRing governs many accounts.
+
+---
+
+### 7. Lifecycle
+
+**Creation**: `createKeyRing(C, num_keys, policy_root, key_hashes[])` — stores state, populates membership mapping.
+
+**Rotation**: $C_{\text{old}} \to C_{\text{new}}$ via threshold MultiSigned or World ID recovery. Sets `superseded = true`, `successor = C_new`. Lazy migration via successor chain.
+
+**Recovery**: Semaphore proof with `action = keccak256("KEYRING_RECOVERY" \|\| C_old)`, `signal = keccak256(C_new)`. Rotates commitment even with all keys lost.
+
+---
+
+## Security Considerations
+
+**Commitment binding**: Computationally binding under discrete log on BN254. No two distinct key sets produce the same $C$.
+
+**Signer ambiguity (Anonymous)**: Perfect hiding of $C$ + ZK of Groth16 = information-theoretic signer ambiguity. No observer, including the verifier, can determine which key signed.
+
+**Nullifier scoping**: Nullifiers scoped to $(C, \text{scope})$. Rotation to $C_{\text{new}}$ creates fresh nullifier domain. Old nullifiers unreplayable.
+
+**7702 re-delegation**: An authorized key could re-delegate away from the KeyRing precompile. Implementations SHOULD require threshold authorization for re-delegation or restrict the authorization list.
+
+**Successor chain**: Compromised $C_{\text{old}}$ could set malicious successor. Mitigated by threshold/World ID requirement for rotation.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk because this PR only adds a new markdown WIP specification and makes no executable code changes.
> 
> **Overview**
> Adds a new draft spec `wips/wip-1003.md` proposing **KeyRing-based account authorization** via an EIP-7702-delegated precompile, with three modes: `Signed`, `MultiSigned` (threshold), and `Anonymous` (Groth16 ring-signature-equivalent proofs with scoped nullifiers).
> 
> The document defines the Pedersen vector commitment identity, generic signature-to-key-hash pipeline, proposed precompile state layout, and lifecycle flows for creation, rotation, and World ID–gated recovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7bc2e799ce98b9231f364c871e62fbd075ed6b9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->