### PR TITLE
feat: add metrics to flashblocks p2p pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12951,6 +12951,7 @@ dependencies = [
  "enr",
  "futures",
  "metrics",
+ "metrics-derive",
  "parking_lot",
  "pin-project",
  "rand 0.9.2",

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -19,6 +19,7 @@ alloy-rpc-types-engine.workspace = true
 
 ed25519-dalek.workspace = true
 metrics.workspace = true
+metrics-derive.workspace = true
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true }

--- a/crates/p2p/src/protocol/connection.rs
+++ b/crates/p2p/src/protocol/connection.rs
@@ -1,10 +1,10 @@
 use crate::protocol::handler::{
     FlashblocksP2PNetworkHandle, FlashblocksP2PProtocol, MAX_FLASHBLOCK_INDEX, PublishingStatus,
 };
+use crate::protocol::metrics::FlashblocksPeerMetrics;
 use alloy_primitives::bytes::BytesMut;
 use chrono::Utc;
 use futures::{Stream, StreamExt};
-use metrics::gauge;
 use reth_ethereum::network::{api::PeerId, eth_wire::multiplex::ProtocolConnection};
 use reth_network::types::ReputationChangeKind;
 use world_chain_primitives::{
@@ -48,6 +48,8 @@ pub enum ReceiveStatus {
 /// Shared connection metadata for a single peer connection.
 #[derive(Clone, Debug)]
 pub struct FlashblocksPeerState {
+    /// Metric handles bound to this peer's stable label set.
+    pub metrics: FlashblocksPeerMetrics,
     /// Whether this peer is marked as trusted or not.
     pub trusted: bool,
     /// Whether we are currently sending flashblocks to this peer.
@@ -66,8 +68,9 @@ pub struct FlashblocksPeerState {
 }
 
 impl FlashblocksPeerState {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(peer_id: PeerId) -> Self {
         Self {
+            metrics: FlashblocksPeerMetrics::for_peer(peer_id),
             trusted: false,
             send_enabled: false,
             receive_status: ReceiveStatus::NotReceiving,
@@ -75,14 +78,6 @@ impl FlashblocksPeerState {
             outbound_tx: None,
             control_msg_count: 0,
             control_msg_window_start: Instant::now(),
-        }
-    }
-
-    pub(crate) fn peer_id_labels(&self, peer_id: PeerId) -> Vec<(&'static str, String)> {
-        if self.trusted {
-            vec![("peer_id", format!("{:#x}", peer_id))]
-        } else {
-            vec![("peer_id", "untrusted".to_string())]
         }
     }
 }
@@ -124,8 +119,6 @@ impl<N: FlashblocksP2PNetworkHandle> FlashblocksConnection<N> {
             .handle
             .on_peer_connected(protocol.network.clone(), peer_id, outbound_tx);
 
-        gauge!("flashblocks.peers", "capability" => FlashblocksP2PProtocol::<N>::capability().to_string()).increment(1);
-
         Self {
             protocol,
             conn,
@@ -144,8 +137,6 @@ impl<N> Drop for FlashblocksConnection<N> {
         );
 
         self.protocol.handle.on_peer_disconnected(self.peer_id);
-
-        gauge!("flashblocks.peers", "capability" => FlashblocksP2PProtocol::<N>::capability().to_string()).decrement(1);
     }
 }
 
@@ -364,10 +355,8 @@ impl<N: FlashblocksP2PNetworkHandle> FlashblocksConnection<N> {
             return;
         };
 
-        let peer_id_labels = peer_state.peer_id_labels(self.peer_id);
-
-        metrics::counter!("flashblocks.bandwidth_inbound", &peer_id_labels)
-            .increment(buf_len as u64);
+        let peer_metrics = peer_state.metrics.clone();
+        peer_metrics.record_inbound_bandwidth_bytes(buf_len);
 
         match &peer_state.receive_status {
             ReceiveStatus::Requesting => {
@@ -448,15 +437,13 @@ impl<N: FlashblocksP2PNetworkHandle> FlashblocksConnection<N> {
                 .expect("time went backwards");
             let latency = now - flashblock_timestamp;
             let latency_secs = latency as f64 / 1_000_000_000.0;
-            metrics::histogram!("flashblocks.latency", &peer_id_labels).record(latency_secs);
+            peer_metrics.record_flashblock_latency_seconds(latency_secs);
             if let Some(peer_state) = p2p_state.connection_state_mut(&self.peer_id)
                 && let ReceiveStatus::Receiving { score } = &mut peer_state.receive_status
             {
                 score.record(latency);
-                if let Some(value) = score.value()
-                    && peer_state.trusted
-                {
-                    metrics::gauge!("flashblocks.peer_score", &peer_id_labels).set(value as f64);
+                if let Some(value) = score.value() {
+                    peer_metrics.set_score(value);
                 }
             }
         }

--- a/crates/p2p/src/protocol/connection.rs
+++ b/crates/p2p/src/protocol/connection.rs
@@ -50,7 +50,8 @@ pub enum ReceiveStatus {
 /// Shared connection metadata for a single peer connection.
 #[derive(Clone, Debug)]
 pub struct FlashblocksPeerState {
-    /// Metric handles bound to this peer's stable label set.
+    /// Metric handles bound to this peer's current label set.
+    /// Peers begin as `untrusted` until trust classification resolves.
     pub metrics: FlashblocksPeerMetrics,
     /// Whether this peer is marked as trusted or not.
     pub trusted: bool,
@@ -72,7 +73,7 @@ pub struct FlashblocksPeerState {
 impl FlashblocksPeerState {
     pub(crate) fn new(peer_id: PeerId) -> Self {
         Self {
-            metrics: FlashblocksPeerMetrics::for_peer(peer_id),
+            metrics: FlashblocksPeerMetrics::for_peer(peer_id, false),
             trusted: false,
             send_enabled: false,
             receive_status: ReceiveStatus::NotReceiving,
@@ -81,6 +82,15 @@ impl FlashblocksPeerState {
             control_msg_count: 0,
             control_msg_window_start: Instant::now(),
         }
+    }
+
+    pub(crate) fn set_trusted(&mut self, peer_id: PeerId, trusted: bool) {
+        if self.trusted == trusted {
+            return;
+        }
+
+        self.trusted = trusted;
+        self.metrics = FlashblocksPeerMetrics::for_peer(peer_id, trusted);
     }
 }
 

--- a/crates/p2p/src/protocol/connection.rs
+++ b/crates/p2p/src/protocol/connection.rs
@@ -454,7 +454,9 @@ impl<N: FlashblocksP2PNetworkHandle> FlashblocksConnection<N> {
                 && let ReceiveStatus::Receiving { score } = &mut peer_state.receive_status
             {
                 score.record(latency);
-                if let Some(value) = score.value() {
+                if peer_state.trusted
+                    && let Some(value) = score.value()
+                {
                     peer_metrics.set_score(value);
                 }
             }

--- a/crates/p2p/src/protocol/connection.rs
+++ b/crates/p2p/src/protocol/connection.rs
@@ -1,7 +1,9 @@
-use crate::protocol::handler::{
-    FlashblocksP2PNetworkHandle, FlashblocksP2PProtocol, MAX_FLASHBLOCK_INDEX, PublishingStatus,
+use crate::protocol::{
+    handler::{
+        FlashblocksP2PNetworkHandle, FlashblocksP2PProtocol, MAX_FLASHBLOCK_INDEX, PublishingStatus,
+    },
+    metrics::FlashblocksPeerMetrics,
 };
-use crate::protocol::metrics::FlashblocksPeerMetrics;
 use alloy_primitives::bytes::BytesMut;
 use chrono::Utc;
 use futures::{Stream, StreamExt};

--- a/crates/p2p/src/protocol/event.rs
+++ b/crates/p2p/src/protocol/event.rs
@@ -5,6 +5,7 @@
 //! the current canonical tip, and [`ChainEvent::Canon`] whenever the tip
 //! changes.
 
+use crate::protocol::metrics::FlashblocksP2PMetrics;
 use alloy_eips::BlockNumHash;
 use alloy_rpc_types_engine::PayloadId;
 use futures::{
@@ -57,6 +58,7 @@ pub type WorldChainEventsStream<T> = Pin<Box<dyn Stream<Item = WorldChainEvent<T
 pub fn world_chain_events_stream<T, F>(
     flashblocks: Pin<Box<dyn Stream<Item = ChainEvent> + Send>>,
     canon: Pin<Box<dyn Stream<Item = ChainEvent> + Send>>,
+    metrics: FlashblocksP2PMetrics,
     mut hook: F,
 ) -> WorldChainEventsStream<T>
 where
@@ -66,7 +68,7 @@ where
     let merged =
         futures::stream::select_with_strategy(canon, flashblocks, |_: &mut ()| PollNext::Left);
 
-    BufferedStream::new(merged)
+    BufferedStream::new(merged, metrics)
         .map(WorldChainEvent::Chain)
         .flat_map(move |event| {
             let extra = hook(&event);
@@ -89,10 +91,10 @@ struct BufferedStream<S> {
 }
 
 impl<S> BufferedStream<S> {
-    fn new(inner: S) -> Self {
+    fn new(inner: S, metrics: FlashblocksP2PMetrics) -> Self {
         Self {
             inner,
-            state: BufferedFlashblocks::default(),
+            state: BufferedFlashblocks::new(metrics),
         }
     }
 }
@@ -154,7 +156,11 @@ pub(crate) struct BlockEpochState {
 impl BlockEpochState {
     /// Create a new epoch from a base flashblock. Returns `None` if the base
     /// is stale (parent behind the canonical tip) or missing its base field.
-    fn try_new(fb: Arc<FlashblocksPayloadV1>, canon_tip: Option<BlockNumHash>) -> Option<Self> {
+    fn try_new(
+        fb: Arc<FlashblocksPayloadV1>,
+        canon_tip: Option<BlockNumHash>,
+        metrics: &FlashblocksP2PMetrics,
+    ) -> Option<Self> {
         let base = fb.base.as_ref()?;
 
         // Stale check: reject if the epoch's parent is behind the canon tip.
@@ -167,7 +173,7 @@ impl BlockEpochState {
                 canon_tip_number = canon_tip.map(|t| t.number),
                 "stale epoch rejected"
             );
-            metrics::counter!("flashblocks.event_stream.epochs_stale").increment(1);
+            metrics.increment_stale_event_stream_epochs();
             return None;
         }
 
@@ -213,8 +219,9 @@ impl BlockEpochState {
 ///
 /// Implements [`Extend<ChainEvent>`] to accept input events and
 /// [`Iterator<Item = ChainEvent>`] to drain output events.
-#[derive(Default)]
 pub struct BufferedFlashblocks {
+    /// Aggregate metrics shared with the event stream reducer.
+    metrics: FlashblocksP2PMetrics,
     /// Current epoch, if any. `None` means no active epoch.
     epoch: Option<BlockEpochState>,
     /// Most recent canonical tip.
@@ -224,6 +231,15 @@ pub struct BufferedFlashblocks {
 }
 
 impl BufferedFlashblocks {
+    fn new(metrics: FlashblocksP2PMetrics) -> Self {
+        Self {
+            metrics,
+            epoch: None,
+            canon_tip: None,
+            output: VecDeque::new(),
+        }
+    }
+
     /// Process a single input event, updating state and buffering output.
     fn step(&mut self, event: ChainEvent) {
         match event {
@@ -244,7 +260,8 @@ impl BufferedFlashblocks {
                 }
             }
             ChainEvent::Pending(ref fb) if fb.base.is_some() => {
-                self.epoch = BlockEpochState::try_new(Arc::clone(fb), self.canon_tip);
+                self.epoch =
+                    BlockEpochState::try_new(Arc::clone(fb), self.canon_tip, &self.metrics);
             }
             ChainEvent::Pending(fb) => {
                 if let Some(epoch) = &mut self.epoch {
@@ -271,6 +288,12 @@ impl BufferedFlashblocks {
             epoch.cursor += 1;
             self.output.push_back(ChainEvent::Pending(fb));
         }
+    }
+}
+
+impl Default for BufferedFlashblocks {
+    fn default() -> Self {
+        Self::new(FlashblocksP2PMetrics::default())
     }
 }
 
@@ -579,7 +602,9 @@ mod tests {
 
     async fn collect_stream(events: Vec<ChainEvent>) -> Vec<ChainEvent> {
         let inner = futures::stream::iter(events);
-        BufferedStream::new(inner).collect().await
+        BufferedStream::new(inner, FlashblocksP2PMetrics::default())
+            .collect()
+            .await
     }
 
     /// Base flashblock before canon tip must not terminate the stream.

--- a/crates/p2p/src/protocol/handler.rs
+++ b/crates/p2p/src/protocol/handler.rs
@@ -1378,8 +1378,10 @@ impl FlashblocksP2PCtx {
             }
 
             self.metrics.record_flashblock_size_bytes(len);
-            self.metrics.record_flashblock_gas_used(payload.diff.gas_used);
-            self.metrics.record_flashblock_tx_count(payload.diff.transactions.len());
+            self.metrics
+                .record_flashblock_gas_used(payload.diff.gas_used);
+            self.metrics
+                .record_flashblock_tx_count(payload.diff.transactions.len());
 
             state.send_flashblock_to_send_set(payload.payload_id, payload.index, &bytes);
 
@@ -1401,7 +1403,8 @@ impl FlashblocksP2PCtx {
                 // Don't measure the interval at the block boundary
                 if state.flashblock_index != 0 {
                     let interval = now - state.flashblock_timestamp;
-                    self.metrics.record_flashblock_interval_seconds(interval as f64 / 1_000_000_000.0);
+                    self.metrics
+                        .record_flashblock_interval_seconds(interval as f64 / 1_000_000_000.0);
                 }
 
                 // Update the index and timestamp

--- a/crates/p2p/src/protocol/handler.rs
+++ b/crates/p2p/src/protocol/handler.rs
@@ -754,7 +754,9 @@ impl FlashblocksHandle {
             for attempt in 1..=MAX_RETRIES {
                 match network.get_peer_by_id(peer_id).await {
                     Ok(Some(peer_info)) => {
-                        trusted = peer_info.kind.is_trusted();
+                        // we consider trusted both trusted peers inserted in the startup command
+                        // and peers inserted through the `admin_addTrustedPeer` JSON RPC
+                        trusted = peer_info.kind.is_trusted() || peer_info.kind.is_static();
                         break;
                     }
                     Ok(None) if attempt < MAX_RETRIES => {
@@ -798,7 +800,7 @@ impl FlashblocksHandle {
 
             let mut state = handle.state.lock();
             if let Some(conn) = state.connection_state_mut(&peer_id) {
-                conn.trusted = trusted;
+                conn.set_trusted(peer_id, trusted);
                 info!(
                     target: "flashblocks::p2p",
                     %peer_id,
@@ -1609,8 +1611,9 @@ mod tests {
     }
 
     fn test_peer_state(trusted: bool) -> FlashblocksPeerState {
-        let mut state = FlashblocksPeerState::new(PeerId::random());
-        state.trusted = trusted;
+        let peer_id = PeerId::random();
+        let mut state = FlashblocksPeerState::new(peer_id);
+        state.set_trusted(peer_id, trusted);
         state
     }
 
@@ -1619,8 +1622,9 @@ mod tests {
         trusted: bool,
     ) -> (FlashblocksPeerState, mpsc::Receiver<BytesMut>) {
         let (tx, rx) = mpsc::channel(100);
-        let mut state = FlashblocksPeerState::new(PeerId::random());
-        state.trusted = trusted;
+        let peer_id = PeerId::random();
+        let mut state = FlashblocksPeerState::new(peer_id);
+        state.set_trusted(peer_id, trusted);
         state.outbound_tx = Some(tx);
         (state, rx)
     }

--- a/crates/p2p/src/protocol/handler.rs
+++ b/crates/p2p/src/protocol/handler.rs
@@ -2,13 +2,13 @@ use crate::protocol::{
     connection::{FlashblocksConnection, FlashblocksPeerState, ReceiveStatus, Score},
     error::FlashblocksP2PError,
     event::{ChainEvent, WorldChainEvent, WorldChainEventsStream, world_chain_events_stream},
+    metrics::FlashblocksP2PMetrics,
 };
 use alloy_rlp::BytesMut;
 use alloy_rpc_types_engine::PayloadId;
 use chrono::Utc;
 use ed25519_dalek::{SigningKey, VerifyingKey};
 use futures::{Stream, StreamExt, stream};
-use metrics::histogram;
 use parking_lot::Mutex;
 use rand::Rng;
 use reth_eth_wire::Capability;
@@ -226,12 +226,7 @@ impl FlashblocksP2PState {
                         "scoring peer for missed flashblock",
                     );
                     score.record(MISSED_FLASHBLOCK_PENALTY_NS);
-
-                    metrics::counter!(
-                        "flashblocks.missed_flashblocks",
-                        &connection.peer_id_labels(*peer_id)
-                    )
-                    .increment(1);
+                    connection.metrics.increment_missed_flashblocks();
                 }
             }
         }
@@ -297,11 +292,7 @@ impl FlashblocksP2PState {
             if let Some(tx) = &conn.outbound_tx
                 && tx.try_send(bytes.clone()).is_ok()
             {
-                metrics::counter!(
-                    "flashblocks.bandwidth_outbound",
-                    &conn.peer_id_labels(*peer_id)
-                )
-                .increment(bytes.len() as u64);
+                conn.metrics.record_outbound_bandwidth_bytes(bytes.len());
             }
         }
     }
@@ -656,6 +647,8 @@ pub struct FlashblocksP2PCtx {
     pub authorizer_vk: VerifyingKey,
     /// Flashblocks configuration including signing keys and fanout args.
     pub fanout_args: FanoutArgs,
+    /// Aggregate metrics for the flashblocks P2P protocol.
+    pub metrics: FlashblocksP2PMetrics,
     /// Broadcast sender for verified and strictly ordered flashblock payloads.
     /// Used by RPC overlays and other consumers of flashblock data.
     pub flashblock_tx: broadcast::Sender<FlashblocksPayloadV1>,
@@ -688,9 +681,11 @@ impl FlashblocksHandle {
     ) -> Self {
         let flashblock_tx = broadcast::Sender::new(BROADCAST_BUFFER_CAPACITY);
         let state = Arc::new(Mutex::new(FlashblocksP2PState::default()));
+        let metrics = FlashblocksP2PMetrics::default();
         let ctx = FlashblocksP2PCtx {
             authorizer_vk,
             fanout_args,
+            metrics,
             flashblock_tx,
         };
         let handle = Self {
@@ -732,9 +727,9 @@ impl FlashblocksHandle {
 
         {
             let mut state = self.state.lock();
-            let mut conn_state = FlashblocksPeerState::new();
+            let mut conn_state = FlashblocksPeerState::new(peer_id);
             conn_state.outbound_tx = Some(outbound_tx);
-            state.peers.insert(peer_id, conn_state);
+            let replaced = state.peers.insert(peer_id, conn_state);
 
             info!(
                 target: "flashblocks::p2p",
@@ -742,6 +737,10 @@ impl FlashblocksHandle {
                 total_peers = state.peers.len(),
                 "flashblocks peer connected",
             );
+
+            if replaced.is_none() {
+                self.ctx.metrics.increment_connected_peers();
+            }
 
             state.maybe_request_receive_peers(&self.ctx);
         }
@@ -823,6 +822,7 @@ impl FlashblocksHandle {
                 remaining_peers = state.peers.len(),
                 "flashblocks peer disconnected",
             );
+            self.ctx.metrics.decrement_connected_peers();
         }
 
         state.maybe_request_receive_peers(&self.ctx);
@@ -909,6 +909,7 @@ impl FlashblocksHandle {
                 .map(|fb| ChainEvent::Pending(Arc::new(fb)))
                 .boxed(),
             canon,
+            self.ctx.metrics.clone(),
             hook,
         )
     }
@@ -1376,10 +1377,9 @@ impl FlashblocksP2PCtx {
                 );
             }
 
-            metrics::histogram!("flashblocks.size").record(len as f64);
-            metrics::histogram!("flashblocks.gas_used").record(payload.diff.gas_used as f64);
-            metrics::histogram!("flashblocks.tx_count")
-                .record(payload.diff.transactions.len() as f64);
+            self.metrics.record_flashblock_size_bytes(len);
+            self.metrics.record_flashblock_gas_used(payload.diff.gas_used);
+            self.metrics.record_flashblock_tx_count(payload.diff.transactions.len());
 
             state.send_flashblock_to_send_set(payload.payload_id, payload.index, &bytes);
 
@@ -1401,7 +1401,7 @@ impl FlashblocksP2PCtx {
                 // Don't measure the interval at the block boundary
                 if state.flashblock_index != 0 {
                     let interval = now - state.flashblock_timestamp;
-                    histogram!("flashblocks.interval").record(interval as f64 / 1_000_000_000.0);
+                    self.metrics.record_flashblock_interval_seconds(interval as f64 / 1_000_000_000.0);
                 }
 
                 // Update the index and timestamp
@@ -1600,12 +1600,13 @@ mod tests {
         FlashblocksP2PCtx {
             authorizer_vk: authorizer.verifying_key(),
             fanout_args,
+            metrics: FlashblocksP2PMetrics::default(),
             flashblock_tx: broadcast::Sender::new(16),
         }
     }
 
     fn test_peer_state(trusted: bool) -> FlashblocksPeerState {
-        let mut state = FlashblocksPeerState::new();
+        let mut state = FlashblocksPeerState::new(PeerId::random());
         state.trusted = trusted;
         state
     }
@@ -1615,7 +1616,7 @@ mod tests {
         trusted: bool,
     ) -> (FlashblocksPeerState, mpsc::Receiver<BytesMut>) {
         let (tx, rx) = mpsc::channel(100);
-        let mut state = FlashblocksPeerState::new();
+        let mut state = FlashblocksPeerState::new(PeerId::random());
         state.trusted = trusted;
         state.outbound_tx = Some(tx);
         (state, rx)

--- a/crates/p2p/src/protocol/metrics.rs
+++ b/crates/p2p/src/protocol/metrics.rs
@@ -4,7 +4,7 @@ use reth_ethereum::network::api::PeerId;
 
 /// Aggregate metrics for the flashblocks P2P protocol.
 #[derive(Clone, Metrics)]
-#[metrics(scope = "flashblocks.aggregated_p2p")]
+#[metrics(scope = "flashblocks.p2p")]
 pub struct FlashblocksP2PMetrics {
     /// Current number of connected flashblocks peers.
     #[metric(rename = "peers")]
@@ -58,7 +58,7 @@ impl FlashblocksP2PMetrics {
 
 /// Peer-scoped flashblocks P2P metrics.
 #[derive(Clone, Metrics)]
-#[metrics(scope = "flashblocks.peer_scoped_p2p")]
+#[metrics(scope = "flashblocks.p2p")]
 pub struct FlashblocksPeerMetrics {
     /// Total inbound bandwidth attributed to this peer in bytes.
     #[metric(rename = "bandwidth_inbound")]

--- a/crates/p2p/src/protocol/metrics.rs
+++ b/crates/p2p/src/protocol/metrics.rs
@@ -4,7 +4,7 @@ use reth_ethereum::network::api::PeerId;
 
 /// Aggregate metrics for the flashblocks P2P protocol.
 #[derive(Clone, Metrics)]
-#[metrics(scope = "flashblocks")]
+#[metrics(scope = "flashblocks.aggregated_p2p")]
 pub struct FlashblocksP2PMetrics {
     /// Current number of connected flashblocks peers.
     #[metric(rename = "peers")]
@@ -58,7 +58,7 @@ impl FlashblocksP2PMetrics {
 
 /// Peer-scoped flashblocks P2P metrics.
 #[derive(Clone, Metrics)]
-#[metrics(scope = "flashblocks")]
+#[metrics(scope = "flashblocks.peer_scoped_p2p")]
 pub struct FlashblocksPeerMetrics {
     /// Total inbound bandwidth attributed to this peer in bytes.
     #[metric(rename = "bandwidth_inbound")]

--- a/crates/p2p/src/protocol/metrics.rs
+++ b/crates/p2p/src/protocol/metrics.rs
@@ -2,6 +2,8 @@ use metrics::{Counter, Gauge, Histogram, Label};
 use metrics_derive::Metrics;
 use reth_ethereum::network::api::PeerId;
 
+const UNTRUSTED_PEER_LABEL: &str = "untrusted";
+
 /// Aggregate metrics for the flashblocks P2P protocol.
 #[derive(Clone, Metrics)]
 #[metrics(scope = "flashblocks.p2p")]
@@ -78,8 +80,23 @@ pub struct FlashblocksPeerMetrics {
 }
 
 impl FlashblocksPeerMetrics {
-    pub fn for_peer(peer_id: PeerId) -> Self {
-        Self::new_with_labels(vec![Label::new("peer_id", format!("{:#x}", peer_id))])
+    pub fn for_peer(peer_id: PeerId, trusted: bool) -> Self {
+        Self::new_with_labels(Self::peer_labels(peer_id, trusted))
+    }
+
+    fn peer_labels(peer_id: PeerId, trusted: bool) -> Vec<Label> {
+        vec![Label::new(
+            "peer_id",
+            Self::peer_id_label_value(peer_id, trusted),
+        )]
+    }
+
+    fn peer_id_label_value(peer_id: PeerId, trusted: bool) -> String {
+        if trusted {
+            format!("{:#x}", peer_id)
+        } else {
+            UNTRUSTED_PEER_LABEL.to_string()
+        }
     }
 
     pub fn record_inbound_bandwidth_bytes(&self, size_bytes: usize) {
@@ -102,5 +119,36 @@ impl FlashblocksPeerMetrics {
 
     pub fn increment_missed_flashblocks(&self) {
         self.missed_flashblocks_total.increment(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FlashblocksPeerMetrics, UNTRUSTED_PEER_LABEL};
+    use reth_ethereum::network::api::PeerId;
+
+    #[test]
+    fn trusted_peers_use_concrete_peer_id_labels() {
+        let peer_id = PeerId::random();
+
+        assert_eq!(
+            FlashblocksPeerMetrics::peer_id_label_value(peer_id, true),
+            format!("{:#x}", peer_id)
+        );
+    }
+
+    #[test]
+    fn untrusted_peers_share_a_single_label() {
+        let peer_a = PeerId::random();
+        let peer_b = PeerId::random();
+
+        assert_eq!(
+            FlashblocksPeerMetrics::peer_id_label_value(peer_a, false),
+            UNTRUSTED_PEER_LABEL
+        );
+        assert_eq!(
+            FlashblocksPeerMetrics::peer_id_label_value(peer_b, false),
+            UNTRUSTED_PEER_LABEL
+        );
     }
 }

--- a/crates/p2p/src/protocol/metrics.rs
+++ b/crates/p2p/src/protocol/metrics.rs
@@ -1,0 +1,106 @@
+use metrics::{Counter, Gauge, Histogram, Label};
+use metrics_derive::Metrics;
+use reth_ethereum::network::api::PeerId;
+
+/// Aggregate metrics for the flashblocks P2P protocol.
+#[derive(Clone, Metrics)]
+#[metrics(scope = "flashblocks")]
+pub struct FlashblocksP2PMetrics {
+    /// Current number of connected flashblocks peers.
+    #[metric(rename = "peers")]
+    pub connected_peers: Gauge,
+    /// Total number of stale epochs rejected by the event stream reducer.
+    #[metric(rename = "event_stream.epochs_stale")]
+    pub stale_event_stream_epochs_total: Counter,
+    /// Histogram of encoded flashblock message sizes in bytes.
+    #[metric(rename = "size")]
+    pub flashblock_size_bytes: Histogram,
+    /// Histogram of gas used by broadcast flashblocks.
+    #[metric(rename = "gas_used")]
+    pub flashblock_gas_used: Histogram,
+    /// Histogram of transaction counts per broadcast flashblock.
+    #[metric(rename = "tx_count")]
+    pub flashblock_tx_count: Histogram,
+    /// Histogram of time between sequential flashblocks in seconds.
+    #[metric(rename = "interval")]
+    pub flashblock_interval_seconds: Histogram,
+}
+
+impl FlashblocksP2PMetrics {
+    pub fn increment_connected_peers(&self) {
+        self.connected_peers.increment(1.0);
+    }
+
+    pub fn decrement_connected_peers(&self) {
+        self.connected_peers.decrement(1.0);
+    }
+
+    pub fn increment_stale_event_stream_epochs(&self) {
+        self.stale_event_stream_epochs_total.increment(1);
+    }
+
+    pub fn record_flashblock_size_bytes(&self, size_bytes: usize) {
+        self.flashblock_size_bytes.record(size_bytes as f64);
+    }
+
+    pub fn record_flashblock_gas_used(&self, gas_used: u64) {
+        self.flashblock_gas_used.record(gas_used as f64);
+    }
+
+    pub fn record_flashblock_tx_count(&self, tx_count: usize) {
+        self.flashblock_tx_count.record(tx_count as f64);
+    }
+
+    pub fn record_flashblock_interval_seconds(&self, interval_seconds: f64) {
+        self.flashblock_interval_seconds.record(interval_seconds);
+    }
+}
+
+/// Peer-scoped flashblocks P2P metrics.
+#[derive(Clone, Metrics)]
+#[metrics(scope = "flashblocks")]
+pub struct FlashblocksPeerMetrics {
+    /// Total inbound bandwidth attributed to this peer in bytes.
+    #[metric(rename = "bandwidth_inbound")]
+    pub inbound_bandwidth_bytes_total: Counter,
+    /// Total outbound bandwidth attributed to this peer in bytes.
+    #[metric(rename = "bandwidth_outbound")]
+    pub outbound_bandwidth_bytes_total: Counter,
+    /// Histogram of flashblock delivery latency from this peer in seconds.
+    #[metric(rename = "latency")]
+    pub flashblock_latency_seconds: Histogram,
+    /// Latest moving score for this peer.
+    #[metric(rename = "peer_score")]
+    pub score: Gauge,
+    /// Number of flashblocks this peer failed to deliver within the grace window.
+    #[metric(rename = "missed_flashblocks")]
+    pub missed_flashblocks_total: Counter,
+}
+
+impl FlashblocksPeerMetrics {
+    pub fn for_peer(peer_id: PeerId) -> Self {
+        Self::new_with_labels(vec![Label::new("peer_id", format!("{:#x}", peer_id))])
+    }
+
+    pub fn record_inbound_bandwidth_bytes(&self, size_bytes: usize) {
+        self.inbound_bandwidth_bytes_total
+            .increment(size_bytes as u64);
+    }
+
+    pub fn record_outbound_bandwidth_bytes(&self, size_bytes: usize) {
+        self.outbound_bandwidth_bytes_total
+            .increment(size_bytes as u64);
+    }
+
+    pub fn record_flashblock_latency_seconds(&self, latency_seconds: f64) {
+        self.flashblock_latency_seconds.record(latency_seconds);
+    }
+
+    pub fn set_score(&self, score: i64) {
+        self.score.set(score as f64);
+    }
+
+    pub fn increment_missed_flashblocks(&self) {
+        self.missed_flashblocks_total.increment(1);
+    }
+}

--- a/crates/p2p/src/protocol/mod.rs
+++ b/crates/p2p/src/protocol/mod.rs
@@ -2,3 +2,4 @@ pub mod connection;
 pub mod error;
 pub mod event;
 pub mod handler;
+pub mod metrics;

--- a/pkg/devnet/Justfile
+++ b/pkg/devnet/Justfile
@@ -22,5 +22,5 @@ fmt:
     kurtosis lint --format
 
 stress-test *args='':
-    chmod +x ./stress/stress.sh \
-    && ./stress/stress.sh $@
+    chmod +x ../../scripts/stress/stress.sh \
+    && ../../scripts/stress/stress.sh $@

--- a/pkg/devnet/README.md
+++ b/pkg/devnet/README.md
@@ -18,6 +18,9 @@ just devnet-up
 just e2e-test -n
 
 # Run stress tests with contender (requires contender is installed)
+# By default the script resolves the builder and tx-proxy URLs from the
+# running `world-chain` Kurtosis enclave. Override with `BUILDER=...`,
+# `TX_PROXY=...`, or `KURTOSIS_ENCLAVE=...` when needed.
 just stress-test <stress | stress-precompile>
 
 # Generate a performance report

--- a/pkg/devnet/README.md
+++ b/pkg/devnet/README.md
@@ -31,8 +31,14 @@ provision a custom World Chain dashboard into that Grafana automatically, so imp
 JSON manually from:
 
 ```text
-devnet/grafana/dashboards/flashblocks-payload-builder.json
+pkg/devnet/grafana/dashboards/flashblocks-payload-builder.json
+pkg/devnet/grafana/dashboards/flashblocks-validation-pipeline.json
+pkg/devnet/grafana/dashboards/flashblocks-p2p.json
 ```
 
-It is built for the `reth_flashblocks_payload_build_*` metrics exposed by the flashblocks-enabled
-payload builder.
+Available dashboards:
+
+- `flashblocks-payload-builder.json` for `reth_flashblocks_payload_build_*`.
+- `flashblocks-validation-pipeline.json` for `reth_flashblocks_validation_*`.
+- `flashblocks-p2p.json` for `reth_flashblocks_p2p*` P2P metrics, including peer-scoped `peer_id`
+  series.

--- a/pkg/devnet/grafana/dashboards/flashblocks-p2p.json
+++ b/pkg/devnet/grafana/dashboards/flashblocks-p2p.json
@@ -382,7 +382,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum(increase(reth_flashblocks_p2p_tx_count_sum{instance=~\"$node\"}[$__rate_interval])) / clamp_min(sum(increase(reth_flashblocks_p2p_tx_count_count{instance=~\"$node\"}[$__rate_interval])), 1)",
+          "expr": "sum(increase(reth_flashblocks_p2p_tx_count_sum{instance=~\"$node\"}[$__rate_interval])) / clamp_min(sum(increase(reth_flashblocks_p2p_tx_count{instance=~\"$node\"}[$__rate_interval])), 1)",
           "legendFormat": "avg tx count",
           "range": true,
           "refId": "A"
@@ -1173,7 +1173,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum(increase(reth_flashblocks_p2p_tx_count_sum{instance=~\"$node\"}[$__rate_interval])) / clamp_min(sum(increase(reth_flashblocks_p2p_tx_count_count{instance=~\"$node\"}[$__rate_interval])), 1)",
+          "expr": "sum(increase(reth_flashblocks_p2p_tx_count_sum{instance=~\"$node\"}[$__rate_interval])) / clamp_min(sum(increase(reth_flashblocks_p2p_tx_count{instance=~\"$node\"}[$__rate_interval])), 1)",
           "legendFormat": "avg",
           "range": true,
           "refId": "A"

--- a/pkg/devnet/grafana/dashboards/flashblocks-p2p.json
+++ b/pkg/devnet/grafana/dashboards/flashblocks-p2p.json
@@ -1,0 +1,1277 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Select a single node instance and optionally filter specific peer IDs. Aggregate panels are scoped to the selected node; peer panels use the flashblocks p2p peer_id label.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "panels": [],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "max(reth_flashblocks_p2p_peers{instance=~\"$node\"})",
+          "legendFormat": "peers",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Connected Peers",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 0.01
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(reth_flashblocks_p2p_event_stream_epochs_stale{instance=~\"$node\"}[$__rate_interval]))",
+          "legendFormat": "stale/s",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Stale Epochs / s",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(increase(reth_flashblocks_p2p_interval_sum{instance=~\"$node\"}[$__rate_interval])) / clamp_min(sum(increase(reth_flashblocks_p2p_interval_count{instance=~\"$node\"}[$__rate_interval])), 1)",
+          "legendFormat": "avg interval",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Avg Interval",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(increase(reth_flashblocks_p2p_size_sum{instance=~\"$node\"}[$__rate_interval])) / clamp_min(sum(increase(reth_flashblocks_p2p_size_count{instance=~\"$node\"}[$__rate_interval])), 1)",
+          "legendFormat": "avg size",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Avg Flashblock Size",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(increase(reth_flashblocks_p2p_gas_used_sum{instance=~\"$node\"}[$__rate_interval])) / clamp_min(sum(increase(reth_flashblocks_p2p_gas_used_count{instance=~\"$node\"}[$__rate_interval])), 1)",
+          "legendFormat": "avg gas",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Avg Gas Used",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(increase(reth_flashblocks_p2p_tx_count_sum{instance=~\"$node\"}[$__rate_interval])) / clamp_min(sum(increase(reth_flashblocks_p2p_tx_count_count{instance=~\"$node\"}[$__rate_interval])), 1)",
+          "legendFormat": "avg tx count",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Avg Tx Count",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 200,
+      "panels": [],
+      "title": "Peer Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 6
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (peer_id) (rate(reth_flashblocks_p2p_bandwidth_inbound{instance=~\"$node\",peer_id=~\"$peer\"}[$__rate_interval]))",
+          "legendFormat": "{{peer_id}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Inbound Bandwidth by Peer",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 6
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (peer_id) (rate(reth_flashblocks_p2p_bandwidth_outbound{instance=~\"$node\",peer_id=~\"$peer\"}[$__rate_interval]))",
+          "legendFormat": "{{peer_id}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Outbound Bandwidth by Peer",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 6
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "max by (peer_id) (reth_flashblocks_p2p_peer_score{instance=~\"$node\",peer_id=~\"$peer\"})",
+          "legendFormat": "{{peer_id}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Peer Score",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 300,
+      "panels": [],
+      "title": "Latency & Reliability",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 15
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (peer_id) (increase(reth_flashblocks_p2p_latency_sum{instance=~\"$node\",peer_id=~\"$peer\"}[$__rate_interval])) / clamp_min(sum by (peer_id) (increase(reth_flashblocks_p2p_latency_count{instance=~\"$node\",peer_id=~\"$peer\"}[$__rate_interval])), 1)",
+          "legendFormat": "{{peer_id}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Average Latency by Peer",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 15
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "max by (peer_id) (reth_flashblocks_p2p_latency{instance=~\"$node\",peer_id=~\"$peer\",quantile=\"0.95\"})",
+          "legendFormat": "{{peer_id}} p95",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "P95 Latency by Peer",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 0.01
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 15
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (peer_id) (rate(reth_flashblocks_p2p_missed_flashblocks{instance=~\"$node\",peer_id=~\"$peer\"}[$__rate_interval]))",
+          "legendFormat": "{{peer_id}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Missed Flashblocks / s by Peer",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 400,
+      "panels": [],
+      "title": "Flashblock Shape",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 24
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(increase(reth_flashblocks_p2p_size_sum{instance=~\"$node\"}[$__rate_interval])) / clamp_min(sum(increase(reth_flashblocks_p2p_size_count{instance=~\"$node\"}[$__rate_interval])), 1)",
+          "legendFormat": "avg",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "max(reth_flashblocks_p2p_size{instance=~\"$node\",quantile=\"0.95\"})",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "max(reth_flashblocks_p2p_size{instance=~\"$node\",quantile=\"0.99\"})",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Flashblock Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 24
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(increase(reth_flashblocks_p2p_gas_used_sum{instance=~\"$node\"}[$__rate_interval])) / clamp_min(sum(increase(reth_flashblocks_p2p_gas_used_count{instance=~\"$node\"}[$__rate_interval])), 1)",
+          "legendFormat": "avg",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "max(reth_flashblocks_p2p_gas_used{instance=~\"$node\",quantile=\"0.95\"})",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "max(reth_flashblocks_p2p_gas_used{instance=~\"$node\",quantile=\"0.99\"})",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Flashblock Gas Used",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 24
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(increase(reth_flashblocks_p2p_tx_count_sum{instance=~\"$node\"}[$__rate_interval])) / clamp_min(sum(increase(reth_flashblocks_p2p_tx_count_count{instance=~\"$node\"}[$__rate_interval])), 1)",
+          "legendFormat": "avg",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "max(reth_flashblocks_p2p_tx_count{instance=~\"$node\",quantile=\"0.95\"})",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "max(reth_flashblocks_p2p_tx_count{instance=~\"$node\",quantile=\"0.99\"})",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Flashblock Tx Count",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": [
+    "world-chain",
+    "flashblocks",
+    "p2p"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(up{instance=~\".*:9001\"}, instance)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Node Instance",
+        "multi": false,
+        "name": "node",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(up{instance=~\".*:9001\"}, instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values({__name__=~\"reth_flashblocks_p2p_(bandwidth_inbound|bandwidth_outbound|latency|peer_score|missed_flashblocks)\",instance=~\"$node\"}, peer_id)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Peer ID",
+        "multi": true,
+        "name": "peer",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values({__name__=~\"reth_flashblocks_p2p_(bandwidth_inbound|bandwidth_outbound|latency|peer_score|missed_flashblocks)\",instance=~\"$node\"}, peer_id)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Flashblocks P2P",
+  "uid": "flashblocks-p2p",
+  "version": 1,
+  "weekStart": ""
+}

--- a/scripts/stress/stress.sh
+++ b/scripts/stress/stress.sh
@@ -1,32 +1,123 @@
-set -ex
+#!/usr/bin/env bash
 
-BUILDER=${BUILDER:-http://localhost:8551}
-TX_PROXY=${TX_PROXY:-http://localhost:8545}
+set -euo pipefail
 
-PRIVATE_KEY=${PRIVATE_KEY:-$(echo "0x$(echo $(openssl rand -hex 32))")}
+if [[ "${TRACE:-0}" == "1" ]]; then
+    set -x
+fi
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+STRESS_SCENARIO="${SCRIPT_DIR}/scenarios/stress.toml"
+PRECOMPILE_STRESS_SCENARIO="${SCRIPT_DIR}/scenarios/precompileStress.toml"
+
+KURTOSIS_ENCLAVE="${KURTOSIS_ENCLAVE:-world-chain}"
+KURTOSIS_BUILDER_SERVICE="${KURTOSIS_BUILDER_SERVICE:-op-el-builder-2151908-1-custom-op-node-op-kurtosis}"
+KURTOSIS_TX_PROXY_SERVICE="${KURTOSIS_TX_PROXY_SERVICE:-tx-proxy}"
+
+LOCAL_BUILDER_FALLBACK="${LOCAL_BUILDER_FALLBACK:-http://localhost:8545}"
+LOCAL_TX_PROXY_FALLBACK="${LOCAL_TX_PROXY_FALLBACK:-http://localhost:8545}"
+
+resolve_kurtosis_url() {
+    local service_name="$1"
+    local port_name="$2"
+    local output
+    local url
+    local host_port
+
+    if ! command -v kurtosis >/dev/null 2>&1; then
+        return 1
+    fi
+
+    output="$(kurtosis port print "$KURTOSIS_ENCLAVE" "$service_name" "$port_name" 2>/dev/null || true)"
+    url="$(printf '%s\n' "$output" | sed -nE 's/.*(https?:\/\/127\.0\.0\.1:[0-9]+).*/\1/p' | head -n1)"
+    if [[ -n "$url" ]]; then
+        printf '%s\n' "$url"
+        return 0
+    fi
+
+    host_port="$(printf '%s\n' "$output" | sed -nE 's/.*(127\.0\.0\.1:[0-9]+).*/\1/p' | head -n1)"
+    if [[ -n "$host_port" ]]; then
+        printf 'http://%s\n' "$host_port"
+        return 0
+    fi
+
+    return 1
+}
+
+resolve_endpoint() {
+    local override="${1:-}"
+    local service_name="$2"
+    local port_name="$3"
+    local fallback="$4"
+    local resolved=""
+
+    if [[ -n "$override" ]]; then
+        printf '%s\n' "$override"
+        return 0
+    fi
+
+    resolved="$(resolve_kurtosis_url "$service_name" "$port_name" || true)"
+    if [[ -n "$resolved" ]]; then
+        printf '%s\n' "$resolved"
+        return 0
+    fi
+
+    printf '%s\n' "$fallback"
+}
+
+BUILDER="$(resolve_endpoint "${BUILDER:-}" "$KURTOSIS_BUILDER_SERVICE" "rpc" "$LOCAL_BUILDER_FALLBACK")"
+TX_PROXY="$(resolve_endpoint "${TX_PROXY:-}" "$KURTOSIS_TX_PROXY_SERVICE" "rpc" "$LOCAL_TX_PROXY_FALLBACK")"
+
+PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+SEED="${SEED:-0x$(openssl rand -hex 32)}"
+
+run_setup() {
+    local scenario_file="$1"
+
+    contender setup \
+        -p "$PRIVATE_KEY" \
+        "$scenario_file" \
+        -r "$TX_PROXY" \
+        --optimism
+}
+
+run_spam() {
+    local scenario_file="$1"
+
+    contender spam \
+        --builder-url "$BUILDER" \
+        --txs-per-second "${TPS:-50}" \
+        --duration "${DURATION:-600}" \
+        --seed "$SEED" \
+        -p "$PRIVATE_KEY" \
+        "$scenario_file" \
+        -r "$TX_PROXY" \
+        --optimism \
+        --min-balance 0.7eth
+}
 
 stress() {
-    contender setup -p $PRIVATE_KEY "./stress/scenarios/stress.toml" -r $BUILDER --optimism
-    contender spam --builder-url "$BUILDER" --txs-per-second ${TPS:-50} --duration ${DURATION:-600} --seed $(echo "0x$(echo $(openssl rand -hex 32))") -p $PRIVATE_KEY "./stress/scenarios/stress.toml" -r "$BUILDER" --optimism --min-balance 0.7eth
+    run_setup "$STRESS_SCENARIO"
+    run_spam "$STRESS_SCENARIO"
 }
 
 stress_precompile() {
-    contender setup -p $PRIVATE_KEY "./stress/scenarios/precompileStress.toml" -r $BUILDER --optimism
-    contender spam --builder-url "$BUILDER" --txs-per-second ${TPS:-50} --duration ${DURATION:-600} --seed $(echo "0x$(echo $(openssl rand -hex 32))") -p "$PRIVATE_KEY" './stress/scenarios/precompileStress.toml' -r "$BUILDER" --optimism --min-balance 0.7eth
+    run_setup "$PRECOMPILE_STRESS_SCENARIO"
+    run_spam "$PRECOMPILE_STRESS_SCENARIO"
 }
 
 generate_report() {
-    contender report "$BUILDER"
+    contender report
 }
-    
-case "$1" in
-"stress-precompile")
+
+case "${1:-}" in
+stress-precompile)
     stress_precompile
     ;;
-"stress")
+stress)
     stress
     ;;
-"report")
+report)
     generate_report
     ;;
 *)


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4470/add-metrics-to-flashblocks-p2p-pipeline

Here is an example of our local devnet grafana dashboard showing these new metrics for the flashblocks p2p pipeline.

<img width="2692" height="1259" alt="Screenshot 2026-04-08 at 10 40 15 AM" src="https://github.com/user-attachments/assets/f4425fe9-29b8-4fc5-ae55-ec68247db026" />

### Next Step

- add metrics for payload building pipeline with BAL
- create datadogs dashboards for dev/stage/prod

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches flashblocks P2P connection/state paths to add peer-scoped metrics and to rebind labels when trust classification resolves, which could affect runtime behavior/overhead despite being mostly observability-focused.
> 
> **Overview**
> **Adds first-class flashblocks P2P observability.** Introduces `FlashblocksP2PMetrics` + `FlashblocksPeerMetrics` (via `metrics-derive`) and replaces ad-hoc `metrics::*` calls with typed helpers to track connected peers, stale epochs, flashblock size/gas/tx count/interval, and per-peer bandwidth/latency/score/missed blocks.
> 
> **Changes peer state/trust handling to support labeled metrics.** `FlashblocksPeerState` now owns a metrics handle that is rebound when `set_trusted()` resolves trust (trusted peers use concrete `peer_id` labels; untrusted share a single label), and the event stream reducer now receives metrics to count stale epochs.
> 
> **Dev tooling updates.** Adds a new `flashblocks-p2p.json` Grafana dashboard, updates devnet docs/`Justfile` to point at the shared `scripts/stress/stress.sh`, and rewrites the stress script to auto-resolve endpoints from Kurtosis with sane fallbacks and stricter bash settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f1700b136dc7ce68007a24e0052e2ad65f802bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->