### PR TITLE
feat: add metrics to BAL builder / validator

### DIFF
--- a/crates/builder/src/bal_executor.rs
+++ b/crates/builder/src/bal_executor.rs
@@ -22,8 +22,11 @@ use revm::{
 use tracing::trace;
 
 use crate::{
-    BlockBuilderExt, access_list::BlockAccessIndex, database::bal_builder_db::BalBuilderDb,
-    metrics::FlashblockExecutionMetrics, state_db::StateDB,
+    BlockBuilderExt,
+    access_list::BlockAccessIndex,
+    database::bal_builder_db::BalBuilderDb,
+    metrics::{FlashblockExecutionMetrics, PayloadBuildStage},
+    state_db::StateDB,
 };
 use alloy_consensus::{Block, BlockHeader, Header, transaction::TxHashRef};
 use alloy_primitives::{FixedBytes, U256};
@@ -36,7 +39,7 @@ use reth_optimism_node::{OpBlockAssembler, OpBuiltPayload};
 use reth_primitives::{NodePrimitives, Recovered, RecoveredBlock, SealedHeader};
 use reth_provider::StateProvider;
 use revm::{context::result::ExecutionResult, database::states::bundle_state::BundleRetention};
-use std::sync::Arc;
+use std::{sync::Arc, time::Instant};
 use world_chain_primitives::access_list::FlashblockAccessList;
 
 #[derive(thiserror::Error, Debug, serde::Serialize)]
@@ -244,13 +247,20 @@ where
     fn finish_with_bundle(
         self,
         state: impl StateProvider,
-        _metrics: Option<impl FlashblockExecutionMetrics>,
+        mut metrics: Option<impl FlashblockExecutionMetrics>,
     ) -> Result<(BlockBuilderOutcome<Self::Primitives>, BundleState), BlockExecutionError> {
         let (evm, result) = self.executor.finish()?;
         let (mut db, evm_env) = evm.finish();
 
         // merge all transitions into bundle state
+        let merge_started = Instant::now();
         db.merge_transitions(BundleRetention::Reverts);
+        if let Some(metrics) = metrics.as_mut() {
+            metrics.record_stage_duration(
+                PayloadBuildStage::MergeTransitions,
+                merge_started.elapsed(),
+            );
+        }
 
         // Flatten reverts into a single transition:
         // - per account: keep earliest `previous_status`
@@ -264,10 +274,15 @@ where
         db.bundle_state_mut().reverts = flattened;
 
         // calculate the state root
+        let state_root_started = Instant::now();
         let hashed_state = state.hashed_post_state(db.bundle_state());
         let (state_root, trie_updates) = state
             .state_root_with_updates(hashed_state.clone())
             .map_err(BlockExecutionError::other)?;
+        if let Some(metrics) = metrics.as_mut() {
+            metrics
+                .record_stage_duration(PayloadBuildStage::StateRoot, state_root_started.elapsed());
+        }
 
         let (transactions, senders) = self
             .transactions
@@ -275,6 +290,7 @@ where
             .map(|tx| tx.into_parts())
             .unzip();
 
+        let block_assembly_started = Instant::now();
         let block = self.assembler.assemble_block(BlockAssemblerInput::<
             '_,
             '_,
@@ -289,6 +305,12 @@ where
             &state,
             state_root,
         ))?;
+        if let Some(metrics) = metrics.as_mut() {
+            metrics.record_stage_duration(
+                PayloadBuildStage::BlockAssembly,
+                block_assembly_started.elapsed(),
+            );
+        }
 
         let block = RecoveredBlock::new_unhashed(block, senders);
 

--- a/crates/builder/src/executor.rs
+++ b/crates/builder/src/executor.rs
@@ -184,14 +184,15 @@ where
         db.bundle_state_mut().reverts = flattened;
 
         // calculate the state root
-        let hashed_state = state.hashed_post_state(db.bundle_state());
         let state_root_started = Instant::now();
-        let state_root_result = state.state_root_with_updates(hashed_state.clone());
+        let hashed_state = state.hashed_post_state(db.bundle_state());
+        let (state_root, trie_updates) = state
+            .state_root_with_updates(hashed_state.clone())
+            .map_err(BlockExecutionError::other)?;
         if let Some(metrics) = metrics.as_mut() {
             metrics
                 .record_stage_duration(PayloadBuildStage::StateRoot, state_root_started.elapsed());
         }
-        let (state_root, trie_updates) = state_root_result.map_err(BlockExecutionError::other)?;
 
         let (transactions, senders) = self
             .inner
@@ -201,7 +202,7 @@ where
             .unzip();
 
         let block_assembly_started = Instant::now();
-        let block_result = self.inner.assembler.assemble_block(BlockAssemblerInput::<
+        let block = self.inner.assembler.assemble_block(BlockAssemblerInput::<
             '_,
             '_,
             OpBlockExecutorFactory<R>,
@@ -214,14 +215,13 @@ where
             db.bundle_state(),
             &state,
             state_root,
-        ));
+        ))?;
         if let Some(metrics) = metrics.as_mut() {
             metrics.record_stage_duration(
                 PayloadBuildStage::BlockAssembly,
                 block_assembly_started.elapsed(),
             );
         }
-        let block = block_result?;
 
         let block = RecoveredBlock::new_unhashed(block, senders);
 

--- a/crates/builder/src/validator.rs
+++ b/crates/builder/src/validator.rs
@@ -108,6 +108,7 @@ impl FlashblocksBlockValidator {
                             parent,
                             payload_id,
                             committed_state,
+                            &mut attempt_metrics,
                         )
                     } else {
                         self.validate_flashblock(
@@ -309,6 +310,7 @@ impl FlashblocksBlockValidator {
         parent: &SealedHeader<Header>,
         payload_id: PayloadId,
         committed_state: CommittedState<OpRethReceiptBuilder>,
+        attempt_metrics: &mut FlashblockValidationAttemptMetrics,
     ) -> Result<OpBuiltPayload, BalExecutorError> {
         let FlashblockAccessListData {
             access_list,
@@ -383,6 +385,7 @@ impl FlashblocksBlockValidator {
             state_root_receiver,
             self.evm_env.clone(),
             (access_list.min_tx_index, access_list.max_tx_index),
+            attempt_metrics,
         );
 
         // Decode diff transactions for parallel execution.
@@ -548,6 +551,7 @@ pub struct BalBlockValidator<'a, DbRef: DatabaseRef + 'a, R: OpReceiptBuilder, E
     pub temporal_db_factory: &'a TemporalDbFactory<DbRef>,
     pub evm_env: EvmEnv<OpSpecId>,
     pub index_range: (u16, u16),
+    pub attempt_metrics: &'a mut FlashblockValidationAttemptMetrics,
 }
 
 impl<'a, DBRef, R, E> BalBlockValidator<'a, DBRef, R, E>
@@ -576,6 +580,7 @@ where
         >,
         evm_env: EvmEnv<OpSpecId>,
         index_range: (u16, u16),
+        attempt_metrics: &'a mut FlashblockValidationAttemptMetrics,
     ) -> (Self, crossbeam_channel::Receiver<FlashblockAccessList>) {
         let (tx, rx) = crossbeam_channel::bounded(1);
 
@@ -594,6 +599,7 @@ where
                 temporal_db_factory,
                 evm_env,
                 index_range,
+                attempt_metrics,
             },
             rx,
         )
@@ -659,6 +665,7 @@ where
         let (db, evm_env) = evm.finish();
 
         // Wait for the state root result from the async computation
+        let state_root_started = Instant::now();
         let StateRootResult {
             state_root,
             trie_updates,
@@ -667,6 +674,8 @@ where
             .state_root_receiver
             .recv()
             .map_err(BlockExecutionError::other)??;
+        self.attempt_metrics
+            .record_stage_duration(PayloadBuildStage::StateRoot, state_root_started.elapsed());
 
         let (transactions, senders) = self
             .inner
@@ -675,6 +684,7 @@ where
             .map(|tx| tx.into_parts())
             .unzip();
 
+        let block_assembly_started = Instant::now();
         let block = self.inner.assembler.assemble_block(BlockAssemblerInput::<
             '_,
             '_,
@@ -689,6 +699,10 @@ where
             &state,
             state_root,
         ))?;
+        self.attempt_metrics.record_stage_duration(
+            PayloadBuildStage::BlockAssembly,
+            block_assembly_started.elapsed(),
+        );
 
         let block = RecoveredBlock::new_unhashed(block, senders);
 
@@ -770,6 +784,7 @@ where
         // formed from the BAL provided. We reduce the results to aggregate the state transitions,
         // receipts, gas used, and access list. Then pre-load the aggregated results into the base
         // executor to finalize the block.
+        let txs_execution_started = Instant::now();
         let mut results = transactions
             .clone()
             // .into_par_iter()
@@ -792,9 +807,12 @@ where
                 )
             })
             .collect::<Result<Vec<_>, BalExecutorError>>()?;
-
         // Sort results by transaction ascending index
         results.sort_unstable_by_key(|r| r.index);
+        self.attempt_metrics.record_stage_duration(
+            PayloadBuildStage::SequencerTxExecution,
+            txs_execution_started.elapsed(),
+        );
 
         let merged_result = merge_transaction_results(results, gas_used);
         let database = self.inner.executor.evm_mut().db_mut();

--- a/crates/builder/src/validator.rs
+++ b/crates/builder/src/validator.rs
@@ -658,9 +658,13 @@ where
     }
 
     fn finish(
-        self,
+        mut self,
         state: impl StateProvider,
     ) -> Result<BlockBuilderOutcome<OpPrimitives>, BlockExecutionError> {
+        let finalize_started = Instant::now();
+        // finalize the database index
+        self.prepare_database(self.index_range.1)?;
+
         let (evm, result) = self.inner.executor.finish()?;
         let (db, evm_env) = evm.finish();
 
@@ -715,6 +719,9 @@ where
             .send(access_list)
             .map_err(BlockExecutionError::other)?;
 
+        self.attempt_metrics
+            .record_stage_duration(PayloadBuildStage::Finalize, finalize_started.elapsed());
+
         Ok(BlockBuilderOutcome {
             execution_result: result,
             hashed_state,
@@ -763,7 +770,12 @@ where
     ) -> Result<(BlockBuilderOutcome<OpPrimitives>, u128), BalExecutorError> {
         if self.index_range.0 == 0 {
             self.prepare_database(0)?;
+            let pre_execution_changes_started = Instant::now();
             self.apply_pre_execution_changes()?;
+            self.attempt_metrics.record_stage_duration(
+                PayloadBuildStage::PreExecutionChanges,
+                pre_execution_changes_started.elapsed(),
+            );
         }
 
         let spec = self.inner.executor.spec.clone();
@@ -840,9 +852,6 @@ where
             self.index_range.1,
             "Final transaction index should match the expected range"
         );
-
-        // finalize the database index
-        self.prepare_database(self.index_range.1)?;
 
         Ok((self.finish(state_provider)?, merged_result.fees))
     }

--- a/e2e-tests/src/fuzz/proptest.rs
+++ b/e2e-tests/src/fuzz/proptest.rs
@@ -8,7 +8,10 @@ use reth_optimism_evm::OpRethReceiptBuilder;
 use reth_optimism_node::OpBuiltPayload;
 use revm::database::BundleState;
 use world_chain_builder::{
-    bal_executor::CommittedState, flashblock_validation_metrics::FlashblockValidationMetrics,
+    bal_executor::CommittedState,
+    flashblock_validation_metrics::{
+        FlashblockValidationAttemptMetrics, FlashblockValidationMetrics,
+    },
     validator::FlashblocksBlockValidator,
 };
 use world_chain_primitives::primitives::ExecutionPayloadFlashblockDeltaV1;
@@ -33,6 +36,7 @@ pub fn validate(
         flashblock_validation_metrics: Arc::new(FlashblockValidationMetrics::default()),
     };
 
+    let mut flashblock_validatoin_metrics_attempt = FlashblockValidationAttemptMetrics::default();
     let payload_id = PayloadId::default();
     let payload = validator.validate_flashblock_parallel(
         state_provider,
@@ -40,6 +44,7 @@ pub fn validate(
         &SEALED_HEADER,
         payload_id,
         committed_state,
+        &mut flashblock_validatoin_metrics_attempt,
     )?;
 
     Ok(payload)


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4469/add-payload-builder-validator-metrics-to-bal-builder

This PR adds metrics to the BAL (block access list) payload builder and validator such that it's equal to the flashblock payload builder / validator.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily adds timing instrumentation, but it also adjusts finalize sequencing in the parallel BAL validator (database index finalization and error handling), which could subtly impact execution correctness or performance.
> 
> **Overview**
> Adds *per-stage timing metrics* to the BAL payload builder and parallel validator, recording durations for `MergeTransitions`, `StateRoot`, `BlockAssembly`, `PreExecutionChanges`, `SequencerTxExecution`, and `Finalize` via `PayloadBuildStage`.
> 
> Refactors parts of block finalization to support this instrumentation (e.g., making metrics mutable, moving database index finalization into `finish`, and simplifying error handling/ordering in `executor.rs`), and updates e2e fuzz tests to pass the new attempt-metrics reference into `validate_flashblock_parallel`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8886f1cde5428a6ef3b8d63be3fbebc404a4ddd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->