### PR TITLE
fix(payload-builder): ensure syncing phase works correctly

### DIFF
--- a/crates/payload/src/job.rs
+++ b/crates/payload/src/job.rs
@@ -555,6 +555,19 @@ where
                     }
                     BuildOutcome::Freeze(payload) => {
                         trace!(target: "flashblocks::payload_builder", "payload frozen, no further building will occur");
+                        // If the payload is frozen, we need to commit it into `committed_payload` so
+                        // that it can later be returned to the CL's `getPayload` request, because
+                        // no further payload building will occur.
+                        if this
+                            .committed_payload
+                            .payload()
+                            .is_none_or(|p| p.block().hash() != payload.block().hash())
+                        {
+                            this.committed_payload = CommittedPayloadState::from((
+                                PayloadState::Frozen(payload.clone()),
+                                access_list.clone(),
+                            ))
+                        }
                         this.best_payload = (PayloadState::Frozen(payload), access_list);
                     }
                     BuildOutcome::Aborted { fees, cached_reads } => {
@@ -627,6 +640,17 @@ where
             self.spawn_build_job();
         }
 
+        // If `no_tx_pool` is true, it means we're in the syncing phase, therefore it's fine to
+        // take the `pending_block` and inserts it into the `maybe_better` field.
+        // During syncing, it could happen that the CL sends the `getPayload` engine API request
+        // before the EL has completed the execution of the block, therefore it's important to take
+        // the `pending_block` so that EL can complete the execution and return the payload to the CL.
+        let maybe_better = if self.config.attributes.no_tx_pool {
+            self.pending_block.take().map(Into::into)
+        } else {
+            None
+        };
+
         let mut empty_payload = None;
 
         if self.committed_payload.is_empty() {
@@ -671,7 +695,7 @@ where
 
         let fut = ResolveBestPayload {
             best_payload: self.committed_payload.clone_payload(),
-            maybe_better: None,
+            maybe_better,
             empty_payload: empty_payload.filter(|_| kind != PayloadKind::WaitForPending),
         };
 


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4486/debug-world-chain-node-issue-node-doesnt-sync-with-flashblocks-enabled

### Problem

During sync, the CL can call `getPayload` before the EL has finished executing the in-flight payload. At the same time, frozen payloads were not being committed into `committed_payload`. That could cause payload resolution to miss the latest payload and return an empty or stale result.

### Solution

Commit frozen payloads into `committed_payload` as soon as a build returns `BuildOutcome::Freeze`. When resolving payloads in `no_tx_pool` sync mode, pass the in-flight `pending_block` into `ResolveBestPayload` so `getPayload` can wait for the pending execution result instead of dropping it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payload resolution/commit behavior during EL↔CL syncing; mistakes could cause `getPayload` to return stale/empty payloads or stall on pending execution.
> 
> **Overview**
> Ensures frozen payloads are immediately committed into `committed_payload` when a build returns `BuildOutcome::Freeze`, so `getPayload` can still return the final payload after building stops.
> 
> Adjusts payload resolution in sync (`attributes.no_tx_pool`) mode to pass the in-flight `pending_block` into `ResolveBestPayload` (`maybe_better`), allowing `getPayload` to wait for pending execution instead of dropping it and falling back to empty payload behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7763468878894656d60b7e761b1c3d51a5420675. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->