### PR TITLE
spec: add WIP template for WorldID accounts

### DIFF
--- a/specs/SUMMARY.md
+++ b/specs/SUMMARY.md
@@ -9,5 +9,10 @@
         - [Validation](./pbh/validation.md)
     <!-- - [PBH Contracts](./pbh/contracts.md)
     - [PBH Bundlers](./pbh/bundlers.md) -->
+- [WorldID Accounts](./wid-accounts/overview.md)
+    - [Gas Accounting](./wid-accounts/gas-accounting.md)
+    - [Native Multi-Auth](./wid-accounts/multi-auth.md)
+    - [WorldID Recovery](./wid-accounts/recovery.md)
+    - [New Transaction Type](./wid-accounts/transaction-type.md)
 - [CLI Reference](./cli/reference.md)
 - [Development Guide](./development.md)

--- a/specs/wid-accounts/gas-accounting.md
+++ b/specs/wid-accounts/gas-accounting.md
@@ -1,0 +1,3 @@
+# WorldID Gas Accounting
+
+> **Status: WIP**

--- a/specs/wid-accounts/multi-auth.md
+++ b/specs/wid-accounts/multi-auth.md
@@ -1,0 +1,3 @@
+# Native Multi-Auth
+
+> **Status: WIP**

--- a/specs/wid-accounts/overview.md
+++ b/specs/wid-accounts/overview.md
@@ -1,0 +1,12 @@
+# WorldID Accounts
+
+> **Status: WIP**
+
+WorldID Accounts introduces native account abstraction for World Chain, enabling WorldID-based gas subsidies, multi-authentication, and account recovery.
+
+## Features
+
+- **WorldID Gas Accounting** -- An authorization and accounting layer that enables gas subsidies for verified WorldID holders.
+- **Native Multi-Auth** -- Native support for multiple authentication methods (e.g., passkeys, different signature schemes) without requiring bundler infrastructure.
+- **WorldID Recovery** -- Account recovery via WorldID proofs, allowing users to update authenticators on their account.
+- **New Transaction Type** -- A new EIP-style transaction type that supports the above features.

--- a/specs/wid-accounts/recovery.md
+++ b/specs/wid-accounts/recovery.md
@@ -1,0 +1,3 @@
+# WorldID Recovery
+
+> **Status: WIP**

--- a/specs/wid-accounts/transaction-type.md
+++ b/specs/wid-accounts/transaction-type.md
@@ -1,0 +1,3 @@
+# New Transaction Type
+
+> **Status: WIP**


### PR DESCRIPTION
## Summary
- Adds empty WIP spec template for the WorldID Accounts feature set
- Covers gas accounting, native multi-auth, WorldID recovery, and new transaction type
- All pages are stubs marked as WIP, to be filled in as the design is finalized