### PR TITLE
chore: always collect execution metrics in finish_with_bundle

### DIFF
--- a/crates/builder/src/bal_executor.rs
+++ b/crates/builder/src/bal_executor.rs
@@ -247,7 +247,7 @@ where
     fn finish_with_bundle(
         self,
         state: impl StateProvider,
-        mut metrics: Option<impl FlashblockExecutionMetrics>,
+        mut metrics: impl FlashblockExecutionMetrics,
     ) -> Result<(BlockBuilderOutcome<Self::Primitives>, BundleState), BlockExecutionError> {
         let (evm, result) = self.executor.finish()?;
         let (mut db, evm_env) = evm.finish();
@@ -255,12 +255,7 @@ where
         // merge all transitions into bundle state
         let merge_started = Instant::now();
         db.merge_transitions(BundleRetention::Reverts);
-        if let Some(metrics) = metrics.as_mut() {
-            metrics.record_stage_duration(
-                PayloadBuildStage::MergeTransitions,
-                merge_started.elapsed(),
-            );
-        }
+        metrics.record_stage_duration(PayloadBuildStage::MergeTransitions, merge_started.elapsed());
 
         // Flatten reverts into a single transition:
         // - per account: keep earliest `previous_status`
@@ -279,10 +274,7 @@ where
         let (state_root, trie_updates) = state
             .state_root_with_updates(hashed_state.clone())
             .map_err(BlockExecutionError::other)?;
-        if let Some(metrics) = metrics.as_mut() {
-            metrics
-                .record_stage_duration(PayloadBuildStage::StateRoot, state_root_started.elapsed());
-        }
+        metrics.record_stage_duration(PayloadBuildStage::StateRoot, state_root_started.elapsed());
 
         let (transactions, senders) = self
             .transactions
@@ -305,12 +297,10 @@ where
             &state,
             state_root,
         ))?;
-        if let Some(metrics) = metrics.as_mut() {
-            metrics.record_stage_duration(
-                PayloadBuildStage::BlockAssembly,
-                block_assembly_started.elapsed(),
-            );
-        }
+        metrics.record_stage_duration(
+            PayloadBuildStage::BlockAssembly,
+            block_assembly_started.elapsed(),
+        );
 
         let block = RecoveredBlock::new_unhashed(block, senders);
 

--- a/crates/builder/src/executor.rs
+++ b/crates/builder/src/executor.rs
@@ -157,7 +157,7 @@ where
     fn finish_with_bundle(
         self,
         state: impl StateProvider,
-        mut metrics: Option<impl FlashblockExecutionMetrics>,
+        mut metrics: impl FlashblockExecutionMetrics,
     ) -> Result<(BlockBuilderOutcome<Self::Primitives>, BundleState), BlockExecutionError> {
         let (evm, result) = self.inner.executor.finish()?;
         let (mut db, evm_env) = evm.finish();
@@ -165,12 +165,7 @@ where
         // merge all transitions into bundle state
         let merge_started = Instant::now();
         db.merge_transitions(BundleRetention::Reverts);
-        if let Some(metrics) = metrics.as_mut() {
-            metrics.record_stage_duration(
-                PayloadBuildStage::MergeTransitions,
-                merge_started.elapsed(),
-            );
-        }
+        metrics.record_stage_duration(PayloadBuildStage::MergeTransitions, merge_started.elapsed());
 
         // Flatten reverts into a single transition:
         // - per account: keep earliest `previous_status`
@@ -189,10 +184,7 @@ where
         let (state_root, trie_updates) = state
             .state_root_with_updates(hashed_state.clone())
             .map_err(BlockExecutionError::other)?;
-        if let Some(metrics) = metrics.as_mut() {
-            metrics
-                .record_stage_duration(PayloadBuildStage::StateRoot, state_root_started.elapsed());
-        }
+        metrics.record_stage_duration(PayloadBuildStage::StateRoot, state_root_started.elapsed());
 
         let (transactions, senders) = self
             .inner
@@ -216,12 +208,10 @@ where
             &state,
             state_root,
         ))?;
-        if let Some(metrics) = metrics.as_mut() {
-            metrics.record_stage_duration(
-                PayloadBuildStage::BlockAssembly,
-                block_assembly_started.elapsed(),
-            );
-        }
+        metrics.record_stage_duration(
+            PayloadBuildStage::BlockAssembly,
+            block_assembly_started.elapsed(),
+        );
 
         let block = RecoveredBlock::new_unhashed(block, senders);
 

--- a/crates/builder/src/lib.rs
+++ b/crates/builder/src/lib.rs
@@ -208,6 +208,6 @@ pub trait BlockBuilderExt: BlockBuilder {
     fn finish_with_bundle(
         self,
         state_provider: impl StateProvider,
-        metrics: Option<impl FlashblockExecutionMetrics>,
+        metrics: impl FlashblockExecutionMetrics,
     ) -> Result<(BlockBuilderOutcome<Self::Primitives>, BundleState), BlockExecutionError>;
 }

--- a/crates/builder/src/payload_builder.rs
+++ b/crates/builder/src/payload_builder.rs
@@ -569,8 +569,7 @@ where
     // 6. Build the block
     let state_provider = client.state_by_block_hash(ctx.parent().hash())?;
     let finalize_started = Instant::now();
-    let finalize_result =
-        builder.finish_with_bundle(state_provider.as_ref(), Some(&mut attempt_metrics));
+    let finalize_result = builder.finish_with_bundle(state_provider.as_ref(), &mut attempt_metrics);
     attempt_metrics.record_stage_duration(PayloadBuildStage::Finalize, finalize_started.elapsed());
     let (build_outcome, bundle) = finalize_result?;
 

--- a/crates/builder/src/validator.rs
+++ b/crates/builder/src/validator.rs
@@ -269,8 +269,8 @@ impl FlashblocksBlockValidator {
             .map_err(BalExecutorError::other)?;
 
         let finalize_started = Instant::now();
-        let (outcome, bundle) = builder
-            .finish_with_bundle(finish_state_provider.as_ref(), Some(&mut *attempt_metrics))?;
+        let (outcome, bundle) =
+            builder.finish_with_bundle(finish_state_provider.as_ref(), &mut *attempt_metrics)?;
         attempt_metrics
             .record_stage_duration(PayloadBuildStage::Finalize, finalize_started.elapsed());
 

--- a/crates/test-utils/src/builder.rs
+++ b/crates/test-utils/src/builder.rs
@@ -663,8 +663,10 @@ pub fn execute_serial(
         builder.execute_transaction_with_result_closure(tx.clone(), |_| {})?;
     }
 
-    let (outcome, bundle_state) =
-        builder.finish_with_bundle(state_provider.as_ref(), None::<PayloadBuildAttemptMetrics>)?;
+    let (outcome, bundle_state) = builder.finish_with_bundle(
+        state_provider.as_ref(),
+        PayloadBuildAttemptMetrics::default(),
+    )?;
 
     let access_list = access_list_rx.recv()?;
 


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4487/flashblockexecutionmetric-is-optional-right-now-so-that-tests-can-use

### Problem

`finish_with_bundle` accepted optional execution metrics even though the builder and validator finalize paths already provide a metrics collector. This added unnecessary branching and made merge, state-root, and block-assembly timing collection optional.

### Solution

Require `finish_with_bundle` to always receive a `FlashblockExecutionMetrics` implementation, remove the optional metric checks in the executor paths, update callers to pass their metrics collector directly, and use a default `PayloadBuildAttemptMetrics` in test helpers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a signature/usage change that removes optional metrics branching; behavior is largely unchanged aside from always recording stage timings, and compile-time errors will catch missed call-site updates.
> 
> **Overview**
> `finish_with_bundle` now **requires** a `FlashblockExecutionMetrics` implementation (no `Option`) across `BlockBuilderExt`, `FlashblocksBlockBuilder`, and `BalBlockBuilder`, and the executors unconditionally record durations for `MergeTransitions`, `StateRoot`, and `BlockAssembly`.
> 
> Call sites in `payload_builder` and `validator` are updated to pass their existing attempt metrics directly, and test utilities now pass `PayloadBuildAttemptMetrics::default()` instead of `None`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a0a72bd65f2a2f47828c6f2a98ee0a488615f50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->