### PR TITLE
chore: tag image with nightly, releases with latest

### DIFF
--- a/.github/actions/docker-merge-manifest/action.yml
+++ b/.github/actions/docker-merge-manifest/action.yml
@@ -8,6 +8,9 @@ inputs:
   image_name:
     description: Full image name path (for example org/repo).
     required: true
+  tags:
+    description: Tag rules for docker/metadata-action (newline-separated).
+    required: true
 
 runs:
   using: composite
@@ -34,11 +37,7 @@ runs:
       uses: docker/metadata-action@v5
       with:
         images: ${{ inputs.registry }}/${{ inputs.image_name }}
-        tags: |
-          type=ref,event=branch
-          type=ref,event=tag
-          type=sha
-          type=raw,value=latest
+        tags: ${{ inputs.tags }}
 
     - name: Create manifest list and push
       shell: bash

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,3 +55,6 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           image_name: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=nightly
+            type=sha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,10 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           image_name: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=ref,event=tag
+            type=sha
 
   build-binaries:
     name: build binaries

--- a/crates/node/src/payload_service.rs
+++ b/crates/node/src/payload_service.rs
@@ -132,7 +132,7 @@ where
 
             Ok(payload_service_handle)
         } else {
-            // flahsblocks disabled
+            // flashblocks disabled
             let payload_job_config = BasicPayloadJobGeneratorConfig::default()
                 .interval(conf.interval)
                 .deadline(conf.deadline)


### PR DESCRIPTION
right now we have the latest tag on most recent push to main. we change this to nightly and use latest only for the most recent actual release.
better because we can then just pull nightly  on our devnet and also if others run our image they prob should not run the state of main branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily CI/release-pipeline changes that alter which Docker tags get published; mistakes could mis-tag or overwrite images consumed by deployments. No runtime logic changes beyond a comment fix.
> 
> **Overview**
> Updates the `docker-merge-manifest` composite action to accept a required `tags` input and pass it through to `docker/metadata-action`, instead of hardcoding tag rules.
> 
> Adjusts workflows so `main` branch builds publish multi-arch images tagged as `nightly` (plus `sha`), while tagged releases publish `latest`, the git tag, and `sha`. Also fixes a small typo in a comment in `payload_service.rs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce5a35d56da5b98f2dd0e2ba05c2ebae7a67ff81. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->