### PR TITLE
Align snake case with other parameters.

### DIFF
--- a/crates/cli/src/cli/builder.rs
+++ b/crates/cli/src/cli/builder.rs
@@ -68,8 +68,8 @@ pub struct FlashblocksArgs {
     /// Flashblocks signing key
     /// used to sign authorized flashblocks payloads.
     #[arg(
-        long = "flashblocks.builder_sk",
-        alias = "flashblocks.builder-sk",
+        long = "flashblocks.builder-sk",
+        alias = "flashblocks.builder_sk",
         env = "FLASHBLOCKS_BUILDER_SK",
         required = false,
         value_parser = parse_sk,

--- a/specs/cli/reference.md
+++ b/specs/cli/reference.md
@@ -142,7 +142,7 @@ Flashblocks:
           
           [env: FLASHBLOCKS_AUTHORIZER_VK=]
 
-      --flashblocks.builder_sk <BUILDER_SK>
+      --flashblocks.builder-sk <BUILDER_SK>
           Flashblocks signing key used to sign authorized flashblocks payloads
           
           [env: FLASHBLOCKS_BUILDER_SK=]


### PR DESCRIPTION
Just to align with others long/alias casing used in file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely CLI flag naming/documentation change with backwards compatibility preserved via an alias; minimal runtime impact aside from potential confusion in scripts that rely on help output.
> 
> **Overview**
> Aligns the Flashblocks builder signing key CLI option with the project’s kebab-case convention by switching the primary flag from `--flashblocks.builder_sk` to `--flashblocks.builder-sk` while retaining the old form as an alias.
> 
> Updates the auto-generated CLI reference (`specs/cli/reference.md`) to reflect the new canonical flag name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52b088171ae326cbdf9169e80a4e6341a05fc6fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->