### PR TITLE
chore: cleanup WorldChainNode type def

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, marker::PhantomData, sync::Arc};
+use std::{fmt::Debug, sync::Arc};
 
 use op_alloy_consensus::OpTxEnvelope;
 use reth_node_builder::{Node, NodeAdapter, NodeComponentsBuilder, components::ComponentsBuilder};
@@ -113,12 +113,7 @@ pub trait WorldChainNodeContext<N: FullNodeTypes<Types = WorldChainNode<Self>>>:
 /// A Generic World Chain node type.
 #[derive(Debug, Default, Clone)]
 #[non_exhaustive]
-pub struct WorldChainNode<T> {
-    /// World Chain Args
-    pub node_context: T,
-    /// Marker type that defines the `Components` and `AddOns` types for this node.
-    _marker: PhantomData<T>,
-}
+pub struct WorldChainNode<T>(T);
 
 /// A [`ComponentsBuilder`] with its generic arguments set to a stack of World Chain specific builders.
 pub type WorldChainNodeComponentBuilder<Node, T> = ComponentsBuilder<
@@ -136,10 +131,7 @@ where
 {
     /// Creates a new instance of the World Chain node type.
     pub fn new(config: WorldChainNodeConfig) -> Self {
-        Self {
-            node_context: config.into(),
-            _marker: PhantomData,
-        }
+        Self(config.into())
     }
 
     /// Returns the components for the given [`WorldChainArgs`].
@@ -148,7 +140,7 @@ where
         Node: FullNodeTypes<Types = Self>,
         T: WorldChainNodeContext<Node> + From<WorldChainNodeConfig>,
     {
-        <T as WorldChainNodeContext<Node>>::components(&self.node_context)
+        <T as WorldChainNodeContext<Node>>::components(&self.0)
     }
 
     pub fn add_ons<Node>(&self) -> T::AddOns
@@ -156,7 +148,7 @@ where
         Node: FullNodeTypes<Types = Self>,
         T: WorldChainNodeContext<Node> + From<WorldChainNodeConfig>,
     {
-        <T as WorldChainNodeContext<Node>>::add_ons(&self.node_context)
+        <T as WorldChainNodeContext<Node>>::add_ons(&self.0)
     }
 
     pub fn ext_context<Node>(&self) -> T::ExtContext
@@ -164,7 +156,7 @@ where
         Node: FullNodeTypes<Types = Self>,
         T: WorldChainNodeContext<Node> + From<WorldChainNodeConfig>,
     {
-        <T as WorldChainNodeContext<Node>>::ext_context(&self.node_context)
+        <T as WorldChainNodeContext<Node>>::ext_context(&self.0)
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Pure type-shape cleanup with no behavioral changes; main risk is minor downstream breakage for any external code relying on the old struct fields.
> 
> **Overview**
> Refactors `WorldChainNode<T>` from a named-field struct using `PhantomData` into a tuple newtype wrapper around the node context `T`.
> 
> Updates `new`, `components`, `add_ons`, and `ext_context` to delegate through the new inner field (`self.0`), and drops the now-unused `PhantomData` import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c7c15dbe2115a1a90cc02aa74937c8d475a84c6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->