### PR TITLE
bench: add payload builder benchmarks against a testing node

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -47,7 +47,7 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           git checkout --detach "$BASE_SHA"
-          cargo bench --package world-chain-builder --bench coordinator -- --save-baseline base
+          cargo bench --package world-chain-builder --bench flashblock_validation_synthetic -- --save-baseline base
 
       - name: Run PR benchmarks
         if: github.event_name == 'pull_request'
@@ -55,11 +55,11 @@ jobs:
           PR_SHA: ${{ github.sha }}
         run: |
           git checkout --detach "$PR_SHA"
-          cargo bench --package world-chain-builder --bench coordinator -- --save-baseline pr
+          cargo bench --package world-chain-builder --bench flashblock_validation_synthetic -- --save-baseline pr
 
       - name: Run benchmarks
         if: github.event_name == 'workflow_dispatch'
-        run: cargo bench --package world-chain-builder --bench coordinator
+        run: cargo bench --package world-chain-builder --bench flashblock_validation_synthetic
 
       # Compare against main baseline if available
       - name: Check for regressions

--- a/crates/builder/Cargo.toml
+++ b/crates/builder/Cargo.toml
@@ -84,9 +84,13 @@ bon.workspace = true
 criterion.workspace = true
 
 [[bench]]
-name = "coordinator"
+name = "flashblock_validation_synthetic"
 harness = false
 
 [[bench]]
-name = "live_node"
+name = "flashblock_validation_live_node"
+harness = false
+
+[[bench]]
+name = "flashblock_building_live_node"
 harness = false

--- a/crates/builder/benches/flashblock_building_live_node.rs
+++ b/crates/builder/benches/flashblock_building_live_node.rs
@@ -1,0 +1,287 @@
+use std::sync::Arc;
+
+use alloy_primitives::{Address, B256, Bytes};
+use alloy_rpc_types_engine::PayloadAttributes as RpcPayloadAttributes;
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use op_alloy_consensus::OpTxEnvelope;
+use reth_basic_payload_builder::{BuildArguments, BuildOutcome, PayloadConfig};
+use reth_optimism_node::{
+    OpPayloadAttributes, OpPayloadBuilderAttributes, utils::optimism_payload_attributes,
+};
+use reth_optimism_payload_builder::config::OpBuilderConfig;
+use reth_provider::{StateProvider, StateProviderFactory};
+use world_chain_builder::{
+    WorldChainPayloadBuilderCtxBuilder, payload_builder::FlashblocksPayloadBuilder,
+    traits::payload_builder::FlashblockPayloadBuilder,
+};
+use world_chain_node::context::WorldChainDefaultContext;
+use world_chain_test_utils::{
+    PBH_DEV_ENTRYPOINT, PBH_DEV_SIGNATURE_AGGREGATOR,
+    builder::{
+        CHAIN_SPEC, build_flashblock_fixture_eth_transfers_with_provider,
+        build_flashblock_fixture_fib_with_provider,
+        build_flashblock_fixture_world_id_like_bn254_with_provider,
+    },
+    e2e_harness::setup::{
+        TX_SET_L1_BLOCK, encode_eip1559_params, setup_with_block_uncompressed_size_limit,
+    },
+    utils::signer,
+};
+
+const TOTAL_TX_COUNTS: [usize; 3] = [50, 500, 1000];
+const WORLD_ID_TOTAL_TX_COUNTS: [usize; 3] = [10, 25, 50];
+const PAYLOAD_VERSION: u8 = 3;
+
+fn deterministic_payload_attributes(
+    timestamp: u64,
+    transactions: Vec<Bytes>,
+) -> OpPayloadAttributes {
+    let eip1559_params = encode_eip1559_params(CHAIN_SPEC.as_ref(), timestamp)
+        .expect("failed to encode eip1559 params");
+
+    OpPayloadAttributes {
+        payload_attributes: RpcPayloadAttributes {
+            timestamp,
+            prev_randao: B256::ZERO,
+            suggested_fee_recipient: Address::ZERO,
+            withdrawals: Some(vec![]),
+            parent_beacon_block_root: Some(B256::ZERO),
+        },
+        transactions: Some(transactions),
+        no_tx_pool: Some(true),
+        eip_1559_params: Some(eip1559_params),
+        gas_limit: Some(CHAIN_SPEC.genesis_header().gas_limit),
+        min_base_fee: Some(0),
+    }
+}
+
+fn build_payload_transactions<F>(
+    state_provider: &dyn StateProvider,
+    total_tx_count: usize,
+    build_flashblock: F,
+) -> Vec<Bytes>
+where
+    F: Fn(
+        &dyn StateProvider,
+        usize,
+        bool,
+    ) -> world_chain_primitives::primitives::FlashblocksPayloadV1,
+{
+    let user_tx_count = total_tx_count
+        .checked_sub(1)
+        .expect("flashblock building bench requires room for the L1 attributes tx");
+
+    let flashblock = build_flashblock(state_provider, user_tx_count, false);
+    let mut transactions = Vec::with_capacity(total_tx_count);
+    transactions.push(TX_SET_L1_BLOCK.clone());
+    transactions.extend(flashblock.diff.transactions);
+    assert_eq!(transactions.len(), total_tx_count);
+    transactions
+}
+
+fn build_live_payload_builder<Pool, Client>(
+    pool: Pool,
+    client: Client,
+    evm_config: reth_optimism_node::OpEvmConfig,
+    bal_enabled: bool,
+) -> FlashblocksPayloadBuilder<Pool, Client, WorldChainPayloadBuilderCtxBuilder, ()>
+where
+    Pool: Clone,
+    Client: Clone,
+{
+    FlashblocksPayloadBuilder {
+        evm_config,
+        pool,
+        client,
+        builder_config: OpBuilderConfig::default(),
+        bal_enabled,
+        best_transactions: (),
+        ctx_builder: WorldChainPayloadBuilderCtxBuilder {
+            verified_blockspace_capacity: 70,
+            pbh_entry_point: PBH_DEV_ENTRYPOINT,
+            pbh_signature_aggregator: PBH_DEV_SIGNATURE_AGGREGATOR,
+            builder_private_key: signer(6),
+            block_uncompressed_size_limit: None,
+        },
+        metrics: Default::default(),
+    }
+}
+
+fn bench_build_flashblock_case<F>(
+    c: &mut Criterion,
+    group_name: &str,
+    bal_enabled: bool,
+    tx_counts: &[usize],
+    build_transactions: F,
+) where
+    F: Fn(&dyn StateProvider, usize) -> Vec<Bytes>,
+{
+    let rt = tokio::runtime::Runtime::new().expect("failed to build tokio runtime");
+    let mut group = c.benchmark_group(group_name);
+    group.sample_size(20);
+
+    for &tx_count in tx_counts {
+        let (_, nodes, _, _, _) = rt
+            .block_on(setup_with_block_uncompressed_size_limit::<
+                WorldChainDefaultContext,
+            >(
+                1,
+                optimism_payload_attributes,
+                true,
+                None,
+                CHAIN_SPEC.clone(),
+            ))
+            .unwrap();
+        let node = &nodes[0];
+        let provider = node.node.inner.provider.clone();
+        let latest = provider
+            .latest()
+            .expect("failed to obtain latest state provider from node");
+        let transactions = build_transactions(latest.as_ref(), tx_count);
+        let parent_header = node.node.inner.chain_spec().sealed_genesis_header();
+        let timestamp = parent_header.timestamp + 2; // 2s block time
+        let rpc_attributes = deterministic_payload_attributes(timestamp, transactions);
+        let attributes =
+            <OpPayloadBuilderAttributes<OpTxEnvelope> as reth_payload_primitives::PayloadBuilderAttributes>::try_new(
+                parent_header.hash(),
+                rpc_attributes,
+                PAYLOAD_VERSION,
+            )
+            .expect("failed to decode payload attributes transactions");
+        let config = PayloadConfig::new(Arc::new(parent_header.clone()), attributes);
+        let builder = build_live_payload_builder(
+            node.node.inner.pool.clone(),
+            provider,
+            node.node.inner.evm_config.clone(),
+            bal_enabled,
+        );
+
+        group.bench_with_input(BenchmarkId::new("txs", tx_count), &tx_count, |b, &_n| {
+            b.iter(|| {
+                let args = BuildArguments {
+                    config: config.clone(),
+                    cached_reads: Default::default(),
+                    cancel: Default::default(),
+                    best_payload: None,
+                };
+
+                let (outcome, access_list) = builder
+                    .try_build_with_precommit(args, None)
+                    .expect("flashblock build failed");
+
+                let payload = match outcome {
+                    BuildOutcome::Freeze(payload) => payload,
+                    other => panic!("expected a frozen payload, got {other:?}"),
+                };
+
+                assert_eq!(payload.block().body().transactions().count(), tx_count);
+                assert_eq!(access_list.is_some(), bal_enabled);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_build_flashblock_eth_transfers_live(c: &mut Criterion) {
+    bench_build_flashblock_case(
+        c,
+        "build_flashblock_eth_transfers_live",
+        false,
+        &TOTAL_TX_COUNTS,
+        |state_provider: &dyn StateProvider, tx_count| {
+            build_payload_transactions(state_provider, tx_count, |provider, user_tx_count, bal| {
+                build_flashblock_fixture_eth_transfers_with_provider(provider, user_tx_count, bal)
+            })
+        },
+    );
+}
+
+fn bench_build_flashblock_eth_transfers_with_bal_live(c: &mut Criterion) {
+    bench_build_flashblock_case(
+        c,
+        "build_flashblock_eth_transfers_with_bal_live",
+        true,
+        &TOTAL_TX_COUNTS,
+        |state_provider: &dyn StateProvider, tx_count| {
+            build_payload_transactions(state_provider, tx_count, |provider, user_tx_count, bal| {
+                build_flashblock_fixture_eth_transfers_with_provider(provider, user_tx_count, bal)
+            })
+        },
+    );
+}
+
+fn bench_build_flashblock_fib_live(c: &mut Criterion) {
+    bench_build_flashblock_case(
+        c,
+        "build_flashblock_fib_live",
+        false,
+        &TOTAL_TX_COUNTS,
+        |state_provider: &dyn StateProvider, tx_count| {
+            build_payload_transactions(state_provider, tx_count, |provider, user_tx_count, bal| {
+                build_flashblock_fixture_fib_with_provider(provider, user_tx_count, bal)
+            })
+        },
+    );
+}
+
+fn bench_build_flashblock_fib_with_bal_live(c: &mut Criterion) {
+    bench_build_flashblock_case(
+        c,
+        "build_flashblock_fib_with_bal_live",
+        true,
+        &TOTAL_TX_COUNTS,
+        |state_provider: &dyn StateProvider, tx_count| {
+            build_payload_transactions(state_provider, tx_count, |provider, user_tx_count, bal| {
+                build_flashblock_fixture_fib_with_provider(provider, user_tx_count, bal)
+            })
+        },
+    );
+}
+
+fn bench_build_flashblock_world_id_like_bn254_live(c: &mut Criterion) {
+    bench_build_flashblock_case(
+        c,
+        "build_flashblock_world_id_like_bn254_live",
+        false,
+        &WORLD_ID_TOTAL_TX_COUNTS,
+        |state_provider: &dyn StateProvider, tx_count| {
+            build_payload_transactions(state_provider, tx_count, |provider, user_tx_count, bal| {
+                build_flashblock_fixture_world_id_like_bn254_with_provider(
+                    provider,
+                    user_tx_count,
+                    bal,
+                )
+            })
+        },
+    );
+}
+
+fn bench_build_flashblock_world_id_like_bn254_with_bal_live(c: &mut Criterion) {
+    bench_build_flashblock_case(
+        c,
+        "build_flashblock_world_id_like_bn254_with_bal_live",
+        true,
+        &WORLD_ID_TOTAL_TX_COUNTS,
+        |state_provider: &dyn StateProvider, tx_count| {
+            build_payload_transactions(state_provider, tx_count, |provider, user_tx_count, bal| {
+                build_flashblock_fixture_world_id_like_bn254_with_provider(
+                    provider,
+                    user_tx_count,
+                    bal,
+                )
+            })
+        },
+    );
+}
+
+criterion_group!(
+    benches,
+    bench_build_flashblock_eth_transfers_live,
+    bench_build_flashblock_eth_transfers_with_bal_live,
+    bench_build_flashblock_fib_live,
+    bench_build_flashblock_fib_with_bal_live,
+    bench_build_flashblock_world_id_like_bn254_live,
+    bench_build_flashblock_world_id_like_bn254_with_bal_live,
+);
+criterion_main!(benches);

--- a/crates/builder/benches/flashblock_validation_live_node.rs
+++ b/crates/builder/benches/flashblock_validation_live_node.rs
@@ -204,7 +204,7 @@ fn bench_launch_flashblock_sequence_case<F>(
 fn bench_process_flashblock_eth_transfers_live(c: &mut Criterion) {
     bench_process_flashblock_case(
         c,
-        "process_flashblock_eth_transfers_live",
+        "flashblock_validation_process_flashblock_eth_transfers_live",
         false,
         &TX_COUNTS,
         |p: &dyn StateProvider, n, b| build_flashblock_fixture_eth_transfers_with_provider(p, n, b),
@@ -214,7 +214,7 @@ fn bench_process_flashblock_eth_transfers_live(c: &mut Criterion) {
 fn bench_process_flashblock_eth_transfers_with_bal_live(c: &mut Criterion) {
     bench_process_flashblock_case(
         c,
-        "process_flashblock_eth_transfers_with_bal_live",
+        "flashblock_validation_process_flashblock_eth_transfers_with_bal_live",
         true,
         &TX_COUNTS,
         |p: &dyn StateProvider, n, b| build_flashblock_fixture_eth_transfers_with_provider(p, n, b),
@@ -224,7 +224,7 @@ fn bench_process_flashblock_eth_transfers_with_bal_live(c: &mut Criterion) {
 fn bench_process_flashblock_fib_live(c: &mut Criterion) {
     bench_process_flashblock_case(
         c,
-        "process_flashblock_fib_live",
+        "flashblock_validation_process_flashblock_fib_live",
         false,
         &TX_COUNTS,
         |p: &dyn StateProvider, n, b| build_flashblock_fixture_fib_with_provider(p, n, b),
@@ -234,7 +234,7 @@ fn bench_process_flashblock_fib_live(c: &mut Criterion) {
 fn bench_process_flashblock_fib_with_bal_live(c: &mut Criterion) {
     bench_process_flashblock_case(
         c,
-        "process_flashblock_fib_with_bal_live",
+        "flashblock_validation_process_flashblock_fib_with_bal_live",
         true,
         &TX_COUNTS,
         |p: &dyn StateProvider, n, b| build_flashblock_fixture_fib_with_provider(p, n, b),
@@ -244,7 +244,7 @@ fn bench_process_flashblock_fib_with_bal_live(c: &mut Criterion) {
 fn bench_process_flashblock_world_id_like_bn254_live(c: &mut Criterion) {
     bench_process_flashblock_case(
         c,
-        "process_flashblock_world_id_like_bn254_live",
+        "flashblock_validation_process_flashblock_world_id_like_bn254_live",
         false,
         &WORLD_ID_TX_COUNTS,
         |p: &dyn StateProvider, n, b| {
@@ -256,7 +256,7 @@ fn bench_process_flashblock_world_id_like_bn254_live(c: &mut Criterion) {
 fn bench_process_flashblock_world_id_like_bn254_with_bal_live(c: &mut Criterion) {
     bench_process_flashblock_case(
         c,
-        "process_flashblock_world_id_like_bn254_with_bal_live",
+        "flashblock_validation_process_flashblock_world_id_like_bn254_with_bal_live",
         true,
         &WORLD_ID_TX_COUNTS,
         |p: &dyn StateProvider, n, b| {
@@ -272,7 +272,7 @@ fn bench_process_flashblock_world_id_like_bn254_with_bal_live(c: &mut Criterion)
 fn bench_launch_flashblock_sequence_eth_transfers_live(c: &mut Criterion) {
     bench_launch_flashblock_sequence_case(
         c,
-        "launch_flashblock_sequence_eth_transfers_live",
+        "flashblock_validation_launch_flashblock_sequence_eth_transfers_live",
         false,
         &FLASHBLOCK_SEQUENCE_PARAMS,
         |p: &dyn StateProvider, num_fb, txs_per_fb, bal| {
@@ -286,7 +286,7 @@ fn bench_launch_flashblock_sequence_eth_transfers_live(c: &mut Criterion) {
 fn bench_launch_flashblock_sequence_eth_transfers_with_bal_live(c: &mut Criterion) {
     bench_launch_flashblock_sequence_case(
         c,
-        "launch_flashblock_sequence_eth_transfers_with_bal_live",
+        "flashblock_validation_launch_flashblock_sequence_eth_transfers_with_bal_live",
         true,
         &FLASHBLOCK_SEQUENCE_PARAMS,
         |p: &dyn StateProvider, num_fb, txs_per_fb, bal| {
@@ -300,7 +300,7 @@ fn bench_launch_flashblock_sequence_eth_transfers_with_bal_live(c: &mut Criterio
 fn bench_launch_flashblock_sequence_fib_live(c: &mut Criterion) {
     bench_launch_flashblock_sequence_case(
         c,
-        "launch_flashblock_sequence_fib_live",
+        "flashblock_validation_launch_flashblock_sequence_fib_live",
         false,
         &FLASHBLOCK_SEQUENCE_PARAMS,
         |p: &dyn StateProvider, num_fb, txs_per_fb, bal| {
@@ -312,7 +312,7 @@ fn bench_launch_flashblock_sequence_fib_live(c: &mut Criterion) {
 fn bench_launch_flashblock_sequence_fib_with_bal_live(c: &mut Criterion) {
     bench_launch_flashblock_sequence_case(
         c,
-        "launch_flashblock_sequence_fib_with_bal_live",
+        "flashblock_validation_launch_flashblock_sequence_fib_with_bal_live",
         true,
         &FLASHBLOCK_SEQUENCE_PARAMS,
         |p: &dyn StateProvider, num_fb, txs_per_fb, bal| {
@@ -324,7 +324,7 @@ fn bench_launch_flashblock_sequence_fib_with_bal_live(c: &mut Criterion) {
 fn bench_launch_flashblock_sequence_world_id_like_bn254_live(c: &mut Criterion) {
     bench_launch_flashblock_sequence_case(
         c,
-        "launch_flashblock_sequence_world_id_like_bn254_live",
+        "flashblock_validation_launch_flashblock_sequence_world_id_like_bn254_live",
         false,
         &WORLD_ID_FLASHBLOCK_SEQUENCE_PARAMS,
         |p: &dyn StateProvider, num_fb, txs_per_fb, bal| {
@@ -338,7 +338,7 @@ fn bench_launch_flashblock_sequence_world_id_like_bn254_live(c: &mut Criterion) 
 fn bench_launch_flashblock_sequence_world_id_like_bn254_with_bal_live(c: &mut Criterion) {
     bench_launch_flashblock_sequence_case(
         c,
-        "launch_flashblock_sequence_world_id_like_bn254_with_bal_live",
+        "flashblock_validation_launch_flashblock_sequence_world_id_like_bn254_with_bal_live",
         true,
         &WORLD_ID_FLASHBLOCK_SEQUENCE_PARAMS,
         |p: &dyn StateProvider, num_fb, txs_per_fb, bal| {

--- a/crates/builder/benches/flashblock_validation_synthetic.rs
+++ b/crates/builder/benches/flashblock_validation_synthetic.rs
@@ -155,7 +155,7 @@ fn bench_launch_flashblock_sequence_case<F>(
 fn bench_process_flashblock_eth_transfers(c: &mut Criterion) {
     bench_process_flashblock_case(
         c,
-        "process_flashblock_eth_transfers",
+        "flashblock_validation_process_flashblock_eth_transfers",
         false,
         &TX_COUNTS,
         build_flashblock_fixture_eth_transfers,
@@ -165,7 +165,7 @@ fn bench_process_flashblock_eth_transfers(c: &mut Criterion) {
 fn bench_process_flashblock_eth_transfers_with_bal(c: &mut Criterion) {
     bench_process_flashblock_case(
         c,
-        "process_flashblock_eth_transfers_with_bal",
+        "flashblock_validation_process_flashblock_eth_transfers_with_bal",
         true,
         &TX_COUNTS,
         build_flashblock_fixture_eth_transfers,
@@ -175,7 +175,7 @@ fn bench_process_flashblock_eth_transfers_with_bal(c: &mut Criterion) {
 fn bench_process_flashblock_fib(c: &mut Criterion) {
     bench_process_flashblock_case(
         c,
-        "process_flashblock_fib",
+        "flashblock_validation_process_flashblock_fib",
         false,
         &TX_COUNTS,
         build_flashblock_fixture_fib,
@@ -185,7 +185,7 @@ fn bench_process_flashblock_fib(c: &mut Criterion) {
 fn bench_process_flashblock_fib_with_bal(c: &mut Criterion) {
     bench_process_flashblock_case(
         c,
-        "process_flashblock_fib_with_bal",
+        "flashblock_validation_process_flashblock_fib_with_bal",
         true,
         &TX_COUNTS,
         build_flashblock_fixture_fib,
@@ -195,7 +195,7 @@ fn bench_process_flashblock_fib_with_bal(c: &mut Criterion) {
 fn bench_process_flashblock_world_id_like_bn254(c: &mut Criterion) {
     bench_process_flashblock_case(
         c,
-        "process_flashblock_world_id_like_bn254",
+        "flashblock_validation_process_flashblock_world_id_like_bn254",
         false,
         &WORLD_ID_TX_COUNTS,
         build_flashblock_fixture_world_id_like_bn254,
@@ -205,7 +205,7 @@ fn bench_process_flashblock_world_id_like_bn254(c: &mut Criterion) {
 fn bench_process_flashblock_world_id_like_bn254_with_bal(c: &mut Criterion) {
     bench_process_flashblock_case(
         c,
-        "process_flashblock_world_id_like_bn254_with_bal",
+        "flashblock_validation_process_flashblock_world_id_like_bn254_with_bal",
         true,
         &WORLD_ID_TX_COUNTS,
         build_flashblock_fixture_world_id_like_bn254,
@@ -219,7 +219,7 @@ fn bench_process_flashblock_world_id_like_bn254_with_bal(c: &mut Criterion) {
 fn bench_launch_flashblock_sequence_eth_transfers(c: &mut Criterion) {
     bench_launch_flashblock_sequence_case(
         c,
-        "launch_flashblock_sequence_eth_transfers",
+        "flashblock_validation_launch_flashblock_sequence_eth_transfers",
         false,
         &FLASHBLOCK_SEQUENCE_PARAMS,
         build_flashblock_sequence_fixture_eth_transfers,
@@ -229,7 +229,7 @@ fn bench_launch_flashblock_sequence_eth_transfers(c: &mut Criterion) {
 fn bench_launch_flashblock_sequence_eth_transfers_with_bal(c: &mut Criterion) {
     bench_launch_flashblock_sequence_case(
         c,
-        "launch_flashblock_sequence_eth_transfers_with_bal",
+        "flashblock_validation_launch_flashblock_sequence_eth_transfers_with_bal",
         true,
         &FLASHBLOCK_SEQUENCE_PARAMS,
         build_flashblock_sequence_fixture_eth_transfers,
@@ -239,7 +239,7 @@ fn bench_launch_flashblock_sequence_eth_transfers_with_bal(c: &mut Criterion) {
 fn bench_launch_flashblock_sequence_fib(c: &mut Criterion) {
     bench_launch_flashblock_sequence_case(
         c,
-        "launch_flashblock_sequence_fib",
+        "flashblock_validation_launch_flashblock_sequence_fib",
         false,
         &FLASHBLOCK_SEQUENCE_PARAMS,
         build_flashblock_sequence_fixture_fib,
@@ -249,7 +249,7 @@ fn bench_launch_flashblock_sequence_fib(c: &mut Criterion) {
 fn bench_launch_flashblock_sequence_fib_with_bal(c: &mut Criterion) {
     bench_launch_flashblock_sequence_case(
         c,
-        "launch_flashblock_sequence_fib_with_bal",
+        "flashblock_validation_launch_flashblock_sequence_fib_with_bal",
         true,
         &FLASHBLOCK_SEQUENCE_PARAMS,
         build_flashblock_sequence_fixture_fib,
@@ -259,7 +259,7 @@ fn bench_launch_flashblock_sequence_fib_with_bal(c: &mut Criterion) {
 fn bench_launch_flashblock_sequence_world_id_like_bn254(c: &mut Criterion) {
     bench_launch_flashblock_sequence_case(
         c,
-        "launch_flashblock_sequence_world_id_like_bn254",
+        "flashblock_validation_launch_flashblock_sequence_world_id_like_bn254",
         false,
         &WORLD_ID_FLASHBLOCK_SEQUENCE_PARAMS,
         build_flashblock_sequence_fixture_world_id_like_bn254,
@@ -269,7 +269,7 @@ fn bench_launch_flashblock_sequence_world_id_like_bn254(c: &mut Criterion) {
 fn bench_launch_flashblock_sequence_world_id_like_bn254_with_bal(c: &mut Criterion) {
     bench_launch_flashblock_sequence_case(
         c,
-        "launch_flashblock_sequence_world_id_like_bn254_with_bal",
+        "flashblock_validation_launch_flashblock_sequence_world_id_like_bn254_with_bal",
         true,
         &WORLD_ID_FLASHBLOCK_SEQUENCE_PARAMS,
         build_flashblock_sequence_fixture_world_id_like_bn254,


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4502/benchmark-flashblock-payload-building-with-full-provider

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily adds/rewires benchmarks and test harness settings, but it also changes test chain gas limits and flashblocks timing defaults, which could affect benchmark comparability and e2e test behavior.
> 
> **Overview**
> Adds new Criterion benchmarks that run flashblock *validation* and *payload building* against a real `WorldChainTestingNodeContext` (in addition to the existing synthetic provider-based benchmark), including single-flashblock and streamed multi-flashblock cases.
> 
> Updates benchmark plumbing to support these live-node benches: switches the CI benchmark workflow to run `flashblock_validation_synthetic`, registers the new benches in `world-chain-builder` with additional dev-dependencies, and extends `world-chain-test-utils` fixture builders to accept an explicit `StateProvider` (plus deterministic recipients) so fixtures can be generated from a node’s real state.
> 
> Adjusts test harness defaults to accommodate heavier workloads by raising test chain/payload-builder gas limits to `200_000_000`, allowing passing a custom `chain_spec` into setup helpers, and increasing the flashblocks `recommit_interval` used in test node configs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4da8a65e1a29d43e1c6a5b14e3f14362a7375d4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->