### PR TITLE
chore: Allow for auto devnet deployments on main-merge

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,3 +58,34 @@ jobs:
           tags: |
             type=raw,value=nightly
             type=sha
+
+  dispatch-devnet-bump:
+    name: dispatch devnet bump to crypto-apps
+    needs: merge
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.DEVNET_DEPLOYMENT_APPID }}
+          private-key: ${{ secrets.DEVNET_DEPLOYMENT_SECRET }}
+          owner: worldcoin
+          repositories: crypto-apps
+
+      - name: Send repository_dispatch
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SHA: ${{ github.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          SHORT=${SHA::7}
+          gh api repos/worldcoin/crypto-apps/dispatches \
+            -f event_type=bump-world-chain-dev \
+            -f "client_payload[tag]=sha-${SHORT}" \
+            -f "client_payload[sha]=${SHA}" \
+            -f "client_payload[issuer]=${RUN_URL}"
+          echo "Dispatched bump-world-chain-dev with tag sha-${SHORT}"


### PR DESCRIPTION
calls https://github.com/worldcoin/crypto-apps/actions/workflows/bump-world-chain-dev.yaml with the new tagged sha

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new cross-repo deployment trigger in CI that mints a GitHub App token and sends a `repository_dispatch`, which could impact downstream devnet deployments if misconfigured or secrets/permissions are wrong.
> 
> **Overview**
> After the Docker build/manifest merge completes on `main`, the workflow now **mints a GitHub App token** and sends a `repository_dispatch` to `worldcoin/crypto-apps` to trigger `bump-world-chain-dev`.
> 
> The dispatch includes the current commit SHA plus a short `sha-<7>` tag and a run URL in `client_payload` for traceability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5c7f094ba35f8a8cdde309952f3919bb56c0d09. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->