### PR TITLE
Add trait abstraction over validator.

### DIFF
--- a/crates/builder/src/bal_executor.rs
+++ b/crates/builder/src/bal_executor.rs
@@ -348,6 +348,8 @@ impl BlockAccessIndexCounter {
 /// for which we are executing on top of.
 #[derive(Default, Debug, Clone)]
 pub struct CommittedState<R: OpReceiptBuilder + Default = OpRethReceiptBuilder> {
+    /// True when there is no prior committed payload (i.e. this is the first flashblock).
+    pub is_first: bool,
     /// The total gas used in previous committed transactions.
     pub gas_used: u64,
     /// The total fees accumulated in previous committed transactions.
@@ -427,6 +429,7 @@ where
                 .collect();
 
             Ok(Self {
+                is_first: false,
                 transactions,
                 receipts,
                 gas_used,
@@ -435,6 +438,7 @@ where
             })
         } else {
             Ok(Self {
+                is_first: true,
                 transactions: vec![],
                 receipts: vec![],
                 gas_used: 0,

--- a/crates/builder/src/coordinator.rs
+++ b/crates/builder/src/coordinator.rs
@@ -34,11 +34,10 @@ use tokio::{
 };
 use tracing::{error, trace};
 
+use crate::flashblock_types::{BalFlashblockTypes, LegacyFlashblockTypes};
+use crate::state_root_strategy::AsyncStateRootStrategy;
 use crate::{
-    execution_strategy::{
-        AsyncStateRootStrategy, BalFlashblockTypes, FlashblocksBalExecutionStrategy,
-        FlashblocksLegacyExecutionStrategy, LegacyFlashblockTypes,
-    },
+    execution_strategy::{FlashblocksBalExecutionStrategy, FlashblocksLegacyExecutionStrategy},
     flashblock_validation_metrics::FlashblockValidationMetrics,
     validator::FlashblocksBlockValidator,
 };

--- a/crates/builder/src/coordinator.rs
+++ b/crates/builder/src/coordinator.rs
@@ -34,11 +34,11 @@ use tokio::{
 };
 use tracing::{error, trace};
 
-use crate::flashblock_types::{BalFlashblockTypes, LegacyFlashblockTypes};
-use crate::state_root_strategy::AsyncStateRootStrategy;
 use crate::{
     execution_strategy::{FlashblocksBalExecutionStrategy, FlashblocksLegacyExecutionStrategy},
+    flashblock_types::{BalFlashblockTypes, LegacyFlashblockTypes},
     flashblock_validation_metrics::FlashblockValidationMetrics,
+    state_root_strategy::AsyncStateRootStrategy,
     validator::FlashblocksBlockValidator,
 };
 use world_chain_primitives::flashblocks::{Flashblock, Flashblocks};

--- a/crates/builder/src/coordinator.rs
+++ b/crates/builder/src/coordinator.rs
@@ -38,7 +38,6 @@ use crate::{
     execution_strategy::{FlashblocksBalExecutionStrategy, FlashblocksLegacyExecutionStrategy},
     flashblock_types::{BalFlashblockTypes, LegacyFlashblockTypes},
     flashblock_validation_metrics::FlashblockValidationMetrics,
-    state_root_strategy::AsyncStateRootStrategy,
     validator::FlashblocksBlockValidator,
 };
 use world_chain_primitives::flashblocks::{Flashblock, Flashblocks};
@@ -431,9 +430,7 @@ where
             evm_env.clone(),
             execution_context.clone(),
             flashblock_validation_metrics.clone(),
-            FlashblocksBalExecutionStrategy {
-                state_root_strategy: AsyncStateRootStrategy,
-            },
+            FlashblocksBalExecutionStrategy,
         )
         .validate_flashblock_with_state(
             provider,

--- a/crates/builder/src/coordinator.rs
+++ b/crates/builder/src/coordinator.rs
@@ -35,6 +35,10 @@ use tokio::{
 use tracing::{error, trace};
 
 use crate::{
+    execution_strategy::{
+        AsyncStateRootStrategy, BalFlashblockTypes, FlashblocksBalExecutionStrategy,
+        FlashblocksLegacyExecutionStrategy, LegacyFlashblockTypes,
+    },
     flashblock_validation_metrics::FlashblockValidationMetrics,
     validator::FlashblocksBlockValidator,
 };
@@ -420,22 +424,45 @@ where
 
     let sealed_header = Arc::new(sealed_header);
 
-    let block_validator = FlashblocksBlockValidator {
-        chain_spec: chain_spec.clone(),
-        evm_config: evm_config.clone(),
-        execution_context: execution_context.clone(),
-        evm_env: evm_env.clone(),
-        header: sealed_header.clone(),
-        flashblock_validation_metrics: flashblock_validation_metrics.clone(),
-    };
+    let has_bal = diff.access_list_data.is_some();
 
-    let next_payload = block_validator.validate_flashblock_with_state(
-        provider,
-        diff.clone(),
-        &sealed_header,
-        flashblock.flashblock.payload_id,
-        latest_payload.as_ref(),
-    )?;
+    let next_payload = if has_bal {
+        FlashblocksBlockValidator::<_, BalFlashblockTypes>::new(
+            chain_spec.clone(),
+            evm_env.clone(),
+            evm_config.clone(),
+            execution_context.clone(),
+            sealed_header.clone(),
+            flashblock_validation_metrics.clone(),
+            FlashblocksBalExecutionStrategy {
+                state_root_strategy: AsyncStateRootStrategy,
+            },
+        )
+        .validate_flashblock_with_state(
+            provider,
+            diff,
+            &sealed_header,
+            flashblock.flashblock.payload_id,
+            latest_payload.as_ref(),
+        )?
+    } else {
+        FlashblocksBlockValidator::<_, LegacyFlashblockTypes>::new(
+            chain_spec.clone(),
+            evm_env.clone(),
+            evm_config.clone(),
+            execution_context.clone(),
+            sealed_header.clone(),
+            flashblock_validation_metrics.clone(),
+            FlashblocksLegacyExecutionStrategy,
+        )
+        .validate_flashblock_with_state(
+            provider,
+            diff,
+            &sealed_header,
+            flashblock.flashblock.payload_id,
+            latest_payload.as_ref(),
+        )?
+    };
 
     {
         let mut inner = coordinator.inner.write();

--- a/crates/builder/src/coordinator.rs
+++ b/crates/builder/src/coordinator.rs
@@ -429,9 +429,7 @@ where
         FlashblocksBlockValidator::<_, BalFlashblockTypes>::new(
             chain_spec.clone(),
             evm_env.clone(),
-            evm_config.clone(),
             execution_context.clone(),
-            sealed_header.clone(),
             flashblock_validation_metrics.clone(),
             FlashblocksBalExecutionStrategy {
                 state_root_strategy: AsyncStateRootStrategy,
@@ -448,9 +446,7 @@ where
         FlashblocksBlockValidator::<_, LegacyFlashblockTypes>::new(
             chain_spec.clone(),
             evm_env.clone(),
-            evm_config.clone(),
             execution_context.clone(),
-            sealed_header.clone(),
             flashblock_validation_metrics.clone(),
             FlashblocksLegacyExecutionStrategy,
         )

--- a/crates/builder/src/execution_strategy.rs
+++ b/crates/builder/src/execution_strategy.rs
@@ -68,9 +68,7 @@ pub struct ValidationCtx<'a, Evm: ConfigureEvm> {
     pub attempt_metrics: &'a mut FlashblockValidationAttemptMetrics,
     pub chain_spec: Arc<OpChainSpec>,
     pub evm_env: EvmEnvFor<Evm>,
-    pub evm_config: Evm,
     pub execution_context: OpBlockExecutionCtx,
-    pub header: Arc<SealedHeader>,
 }
 
 /// Strategy for executing flashblock diff transactions.

--- a/crates/builder/src/execution_strategy.rs
+++ b/crates/builder/src/execution_strategy.rs
@@ -319,7 +319,7 @@ impl ExecutionStrategy<OpEvmConfig> for FlashblocksLegacyExecutionStrategy {
         );
 
         // Apply pre-execution changes on the first flashblock (no prior committed state).
-        if committed_state.transactions.is_empty() {
+        if committed_state.is_first {
             let pre_execution_changes_started = Instant::now();
             builder.apply_pre_execution_changes()?;
             ctx.attempt_metrics.record_stage_duration(

--- a/crates/builder/src/execution_strategy.rs
+++ b/crates/builder/src/execution_strategy.rs
@@ -1,7 +1,9 @@
 use std::{sync::Arc, time::Instant};
 
 use alloy_consensus::{BlockHeader, Header, Transaction};
-use alloy_op_evm::{OpBlockExecutionCtx, OpBlockExecutor, OpBlockExecutorFactory, OpEvmFactory, OpTx};
+use alloy_op_evm::{
+    OpBlockExecutionCtx, OpBlockExecutor, OpBlockExecutorFactory, OpEvmFactory, OpTx,
+};
 use alloy_primitives::{Address, B256, U256};
 use alloy_rpc_types_engine::PayloadId;
 use reth_evm::{
@@ -27,7 +29,6 @@ use world_chain_primitives::{
 
 use crate::{
     bal_executor::{BalExecutorError, BalValidationError, CommittedState},
-    state_db::StateDB,
     database::{
         bal_builder_db::{BalBuilderDb, NoOpCommitDB},
         bundle_db::BundleDb,
@@ -36,6 +37,7 @@ use crate::{
     executor::FlashblocksBlockBuilder,
     flashblock_validation_metrics::FlashblockValidationAttemptMetrics,
     metrics::PayloadBuildStage,
+    state_db::StateDB,
     state_root_strategy::{StateRootHandle, StateRootStrategy},
     validator::{BalBlockValidator, decode_transactions_with_indices},
 };
@@ -170,8 +172,11 @@ impl<S: StateRootStrategy> ExecutionStrategy<OpEvmConfig, S> for FlashblocksBalE
             .state_by_block_hash(ctx.parent.hash())
             .map_err(BalExecutorError::other)?;
 
-        let (outcome, fees): (BlockBuilderOutcome<OpPrimitives>, u128) =
-            validator.execute_block(client.clone(), finish_state_provider.as_ref(), executor_transactions)?;
+        let (outcome, fees): (BlockBuilderOutcome<OpPrimitives>, u128) = validator.execute_block(
+            client.clone(),
+            finish_state_provider.as_ref(),
+            executor_transactions,
+        )?;
 
         let computed_access_list = access_list_receiver
             .recv()
@@ -281,7 +286,9 @@ impl<S: StateRootStrategy> ExecutionStrategy<OpEvmConfig, S> for FlashblocksBalE
 
 pub struct FlashblocksLegacyExecutionStrategy;
 
-impl<S: StateRootStrategy> ExecutionStrategy<OpEvmConfig, S> for FlashblocksLegacyExecutionStrategy {
+impl<S: StateRootStrategy> ExecutionStrategy<OpEvmConfig, S>
+    for FlashblocksLegacyExecutionStrategy
+{
     fn execute(
         &self,
         ctx: ValidationCtx<'_, OpEvmConfig, S>,
@@ -369,7 +376,7 @@ impl<S: StateRootStrategy> ExecutionStrategy<OpEvmConfig, S> for FlashblocksLega
 
         let finalize_started = Instant::now();
 
-        let (evm, executor_result) = builder.inner.executor.finish()?;
+        let (evm, execution_result) = builder.inner.executor.finish()?;
         let (db, evm_env) = evm.finish();
 
         let merge_started = Instant::now();
@@ -381,8 +388,8 @@ impl<S: StateRootStrategy> ExecutionStrategy<OpEvmConfig, S> for FlashblocksLega
         db.bundle_state_mut().reverts = flattened;
 
         let state_root_started = Instant::now();
-        let state_root_handle = state_root_strategy
-            .prepare(client, parent_hash, db.bundle_state().clone())?;
+        let state_root_handle =
+            state_root_strategy.prepare(client, parent_hash, db.bundle_state().clone())?;
         let StateRootResult {
             state_root,
             trie_updates,
@@ -399,20 +406,23 @@ impl<S: StateRootStrategy> ExecutionStrategy<OpEvmConfig, S> for FlashblocksLega
             .unzip();
 
         let block_assembly_started = Instant::now();
-        let block = builder.inner.assembler.assemble_block(BlockAssemblerInput::<
-            '_,
-            '_,
-            OpBlockExecutorFactory<OpRethReceiptBuilder>,
-        >::new(
-            evm_env,
-            builder.inner.ctx,
-            builder.inner.parent,
-            transactions,
-            &executor_result,
-            db.bundle_state(),
-            finish_state_provider.as_ref(),
-            state_root,
-        ))?;
+        let block = builder
+            .inner
+            .assembler
+            .assemble_block(BlockAssemblerInput::<
+                '_,
+                '_,
+                OpBlockExecutorFactory<OpRethReceiptBuilder>,
+            >::new(
+                evm_env,
+                builder.inner.ctx,
+                builder.inner.parent,
+                transactions,
+                &execution_result,
+                db.bundle_state(),
+                finish_state_provider.as_ref(),
+                state_root,
+            ))?;
         ctx.attempt_metrics.record_stage_duration(
             PayloadBuildStage::BlockAssembly,
             block_assembly_started.elapsed(),
@@ -420,22 +430,9 @@ impl<S: StateRootStrategy> ExecutionStrategy<OpEvmConfig, S> for FlashblocksLega
 
         let bundle = db.take_bundle();
         let block = RecoveredBlock::new_unhashed(block, senders);
-        let outcome = BlockBuilderOutcome::<OpPrimitives> {
-            execution_result: executor_result,
-            hashed_state,
-            trie_updates,
-            block,
-        };
 
         ctx.attempt_metrics
             .record_stage_duration(PayloadBuildStage::Finalize, finalize_started.elapsed());
-
-        let BlockBuilderOutcome {
-            execution_result,
-            block,
-            hashed_state,
-            trie_updates,
-        } = outcome;
 
         let sealed_block = Arc::new(block.sealed_block().clone());
         let execution_output = BlockExecutionOutput {

--- a/crates/builder/src/execution_strategy.rs
+++ b/crates/builder/src/execution_strategy.rs
@@ -25,7 +25,6 @@ use world_chain_primitives::{
     access_list::FlashblockAccessListData, primitives::ExecutionPayloadFlashblockDeltaV1,
 };
 
-use crate::state_root_strategy::StateRootStrategy;
 use crate::{
     BlockBuilderExt,
     bal_executor::{BalExecutorError, BalValidationError, CommittedState},
@@ -37,6 +36,7 @@ use crate::{
     executor::FlashblocksBlockBuilder,
     flashblock_validation_metrics::FlashblockValidationAttemptMetrics,
     metrics::PayloadBuildStage,
+    state_root_strategy::StateRootStrategy,
     validator::{BalBlockValidator, decode_transactions_with_indices},
 };
 

--- a/crates/builder/src/execution_strategy.rs
+++ b/crates/builder/src/execution_strategy.rs
@@ -18,13 +18,14 @@ use reth_primitives_traits::SealedHeader;
 use reth_provider::{BlockExecutionOutput, StateProvider, StateProviderFactory};
 use reth_revm::database::StateProviderDatabase;
 use reth_trie_common::{HashedPostState, KeccakKeyHasher, updates::TrieUpdates};
-use revm::database::{BundleAccount, BundleState};
+use revm::database::BundleAccount;
 use revm_database::State;
 use tracing::error;
 use world_chain_primitives::{
     access_list::FlashblockAccessListData, primitives::ExecutionPayloadFlashblockDeltaV1,
 };
 
+use crate::state_root_strategy::StateRootStrategy;
 use crate::{
     BlockBuilderExt,
     bal_executor::{BalExecutorError, BalValidationError, CommittedState},
@@ -38,10 +39,6 @@ use crate::{
     metrics::PayloadBuildStage,
     validator::{BalBlockValidator, decode_transactions_with_indices},
 };
-
-// ---------------------------------------------------------------------------
-// State root result + free computation function
-// ---------------------------------------------------------------------------
 
 /// Result of computing the state root from a bundle state.
 pub struct StateRootResult {
@@ -65,10 +62,6 @@ pub fn compute_state_root<'a>(
     })
 }
 
-// ---------------------------------------------------------------------------
-// Traits
-// ---------------------------------------------------------------------------
-
 /// Context passed to an [`ExecutionStrategy`] for each flashblock.
 pub struct ValidationCtx<'a, Evm: ConfigureEvm> {
     pub parent: &'a SealedHeader<Header>,
@@ -91,70 +84,6 @@ pub trait ExecutionStrategy<Evm: ConfigureEvm>: Send + Sync {
         payload_id: PayloadId,
     ) -> Result<OpBuiltPayload, BalExecutorError>;
 }
-
-/// Strategy for state root computation.
-pub trait StateRootStrategy: Send + Sync {
-    type EpochState: Default + Send;
-    type Handle: StateRootHandle;
-
-    fn prepare(
-        &self,
-        client: impl StateProviderFactory + Clone + 'static,
-        parent_hash: B256,
-        bundle_state: BundleState,
-    ) -> Self::Handle;
-}
-
-pub trait StateRootHandle: Send {
-    fn finish(self) -> Result<StateRootResult, BlockExecutionError>;
-}
-
-/// Associates execution and state-root strategies for an EVM.
-pub trait FlashblockTypes<Evm: ConfigureEvm> {
-    type Execution: ExecutionStrategy<Evm>;
-}
-
-// ---------------------------------------------------------------------------
-// StateRootStrategy: async (BAL path)
-// ---------------------------------------------------------------------------
-
-pub struct AsyncStateRootStrategy;
-
-pub struct ChannelStateRootHandle {
-    pub receiver: crossbeam_channel::Receiver<Result<StateRootResult, BlockExecutionError>>,
-}
-
-impl StateRootStrategy for AsyncStateRootStrategy {
-    type EpochState = ();
-    type Handle = ChannelStateRootHandle;
-
-    fn prepare(
-        &self,
-        client: impl StateProviderFactory + Clone + 'static,
-        parent_hash: B256,
-        bundle_state: BundleState,
-    ) -> Self::Handle {
-        let (sender, receiver) = crossbeam_channel::bounded(1);
-        let state_root_provider = client
-            .state_by_block_hash(parent_hash)
-            .expect("state provider must be available for state root computation");
-        rayon::spawn(move || {
-            let result = compute_state_root(state_root_provider.into(), bundle_state.state.iter());
-            let _ = sender.send(result);
-        });
-        ChannelStateRootHandle { receiver }
-    }
-}
-
-impl StateRootHandle for ChannelStateRootHandle {
-    fn finish(self) -> Result<StateRootResult, BlockExecutionError> {
-        self.receiver.recv().map_err(BlockExecutionError::other)?
-    }
-}
-
-// ---------------------------------------------------------------------------
-// ExecutionStrategy: BAL path
-// ---------------------------------------------------------------------------
 
 pub struct FlashblocksBalExecutionStrategy<S: StateRootStrategy> {
     pub state_root_strategy: S,
@@ -198,11 +127,10 @@ impl<S: StateRootStrategy> ExecutionStrategy<OpEvmConfig> for FlashblocksBalExec
         let mut database = BalBuilderDb::new(&mut noop_state);
         database.set_index(block_access_index);
 
-        let state_root_handle = self.state_root_strategy.prepare(
-            client.clone(),
-            ctx.parent.hash(),
-            bundle_state.clone(),
-        );
+        let state_root_handle = self
+            .state_root_strategy
+            .prepare(client.clone(), ctx.parent.hash(), bundle_state.clone())
+            .map_err(BalExecutorError::other)?;
 
         let evm = OpEvmFactory::default().create_evm(database, ctx.evm_env.clone());
 
@@ -349,10 +277,6 @@ impl<S: StateRootStrategy> ExecutionStrategy<OpEvmConfig> for FlashblocksBalExec
     }
 }
 
-// ---------------------------------------------------------------------------
-// ExecutionStrategy: legacy (non-BAL) path
-// ---------------------------------------------------------------------------
-
 pub struct FlashblocksLegacyExecutionStrategy;
 
 impl ExecutionStrategy<OpEvmConfig> for FlashblocksLegacyExecutionStrategy {
@@ -437,10 +361,8 @@ impl ExecutionStrategy<OpEvmConfig> for FlashblocksLegacyExecutionStrategy {
             .map_err(BalExecutorError::other)?;
 
         let finalize_started = Instant::now();
-        let (outcome, bundle) = builder.finish_with_bundle(
-            finish_state_provider.as_ref(),
-            &mut *ctx.attempt_metrics,
-        )?;
+        let (outcome, bundle) = builder
+            .finish_with_bundle(finish_state_provider.as_ref(), &mut *ctx.attempt_metrics)?;
         ctx.attempt_metrics
             .record_stage_duration(PayloadBuildStage::Finalize, finalize_started.elapsed());
 
@@ -470,22 +392,4 @@ impl ExecutionStrategy<OpEvmConfig> for FlashblocksLegacyExecutionStrategy {
             Some(executed_block),
         ))
     }
-}
-
-// ---------------------------------------------------------------------------
-// Concrete FlashblockTypes bundles
-// ---------------------------------------------------------------------------
-
-/// BAL-enabled flashblock types: parallel execution with parallel state root.
-pub struct BalFlashblockTypes;
-
-impl FlashblockTypes<OpEvmConfig> for BalFlashblockTypes {
-    type Execution = FlashblocksBalExecutionStrategy<AsyncStateRootStrategy>;
-}
-
-/// Legacy (non-BAL) flashblock types: sequential execution, no external state root.
-pub struct LegacyFlashblockTypes;
-
-impl FlashblockTypes<OpEvmConfig> for LegacyFlashblockTypes {
-    type Execution = FlashblocksLegacyExecutionStrategy;
 }

--- a/crates/builder/src/execution_strategy.rs
+++ b/crates/builder/src/execution_strategy.rs
@@ -134,7 +134,7 @@ impl<S: StateRootStrategy> ExecutionStrategy<OpEvmConfig, S> for FlashblocksBalE
             .prepare(client.clone(), ctx.parent.hash(), bundle_state.clone())
             .map_err(BalExecutorError::other)?;
 
-        let evm = OpEvmFactory::default().create_evm(database, ctx.evm_env.clone());
+        let evm = OpEvmFactory::<OpTx>::default().create_evm(database, ctx.evm_env.clone());
 
         let mut executor: OpBlockExecutor<_, OpRethReceiptBuilder, Arc<OpChainSpec>> =
             OpBlockExecutor::new(

--- a/crates/builder/src/execution_strategy.rs
+++ b/crates/builder/src/execution_strategy.rs
@@ -1,0 +1,491 @@
+use std::{sync::Arc, time::Instant};
+
+use alloy_consensus::{BlockHeader, Header, Transaction};
+use alloy_op_evm::{OpBlockExecutionCtx, OpBlockExecutor, OpEvmFactory, OpTx};
+use alloy_primitives::{Address, B256, U256};
+use alloy_rpc_types_engine::PayloadId;
+use reth_evm::{
+    ConfigureEvm, EvmEnvFor, EvmFactory,
+    block::{BlockExecutionError, CommitChanges},
+    execute::{BlockBuilder, BlockBuilderOutcome},
+};
+use reth_node_api::BuiltPayloadExecutedBlock;
+use reth_optimism_chainspec::OpChainSpec;
+use reth_optimism_evm::{OpEvmConfig, OpRethReceiptBuilder};
+use reth_optimism_node::OpBuiltPayload;
+use reth_optimism_primitives::OpPrimitives;
+use reth_primitives_traits::SealedHeader;
+use reth_provider::{BlockExecutionOutput, StateProvider, StateProviderFactory};
+use reth_revm::database::StateProviderDatabase;
+use reth_trie_common::{HashedPostState, KeccakKeyHasher, updates::TrieUpdates};
+use revm::database::{BundleAccount, BundleState};
+use revm_database::State;
+use tracing::error;
+use world_chain_primitives::{
+    access_list::FlashblockAccessListData, primitives::ExecutionPayloadFlashblockDeltaV1,
+};
+
+use crate::{
+    BlockBuilderExt,
+    bal_executor::{BalExecutorError, BalValidationError, CommittedState},
+    database::{
+        bal_builder_db::{BalBuilderDb, NoOpCommitDB},
+        bundle_db::BundleDb,
+        temporal_db::TemporalDbFactory,
+    },
+    executor::FlashblocksBlockBuilder,
+    flashblock_validation_metrics::FlashblockValidationAttemptMetrics,
+    metrics::PayloadBuildStage,
+    validator::{BalBlockValidator, decode_transactions_with_indices},
+};
+
+// ---------------------------------------------------------------------------
+// State root result + free computation function
+// ---------------------------------------------------------------------------
+
+/// Result of computing the state root from a bundle state.
+pub struct StateRootResult {
+    pub state_root: B256,
+    pub trie_updates: TrieUpdates,
+    pub hashed_state: HashedPostState,
+}
+
+pub fn compute_state_root<'a>(
+    state_provider: Arc<dyn StateProvider + Send>,
+    bundle_state: impl IntoIterator<Item = (&'a Address, &'a BundleAccount)>,
+) -> Result<StateRootResult, BlockExecutionError> {
+    let hashed_state = HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state);
+    let (state_root, trie_updates) = state_provider
+        .state_root_with_updates(hashed_state.clone())
+        .map_err(BlockExecutionError::other)?;
+    Ok(StateRootResult {
+        state_root,
+        trie_updates,
+        hashed_state,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Traits
+// ---------------------------------------------------------------------------
+
+/// Context passed to an [`ExecutionStrategy`] for each flashblock.
+pub struct ValidationCtx<'a, Evm: ConfigureEvm> {
+    pub parent: &'a SealedHeader<Header>,
+    pub attempt_metrics: &'a mut FlashblockValidationAttemptMetrics,
+    pub chain_spec: Arc<OpChainSpec>,
+    pub evm_env: EvmEnvFor<Evm>,
+    pub evm_config: Evm,
+    pub execution_context: OpBlockExecutionCtx,
+    pub header: Arc<SealedHeader>,
+}
+
+/// Strategy for executing flashblock diff transactions.
+pub trait ExecutionStrategy<Evm: ConfigureEvm>: Send + Sync {
+    fn execute(
+        &self,
+        ctx: ValidationCtx<'_, Evm>,
+        client: impl StateProviderFactory + Clone + Sync + 'static,
+        diff: ExecutionPayloadFlashblockDeltaV1,
+        committed_state: CommittedState<OpRethReceiptBuilder>,
+        payload_id: PayloadId,
+    ) -> Result<OpBuiltPayload, BalExecutorError>;
+}
+
+/// Strategy for state root computation.
+pub trait StateRootStrategy: Send + Sync {
+    type EpochState: Default + Send;
+    type Handle: StateRootHandle;
+
+    fn prepare(
+        &self,
+        client: impl StateProviderFactory + Clone + 'static,
+        parent_hash: B256,
+        bundle_state: BundleState,
+    ) -> Self::Handle;
+}
+
+pub trait StateRootHandle: Send {
+    fn finish(self) -> Result<StateRootResult, BlockExecutionError>;
+}
+
+/// Associates execution and state-root strategies for an EVM.
+pub trait FlashblockTypes<Evm: ConfigureEvm> {
+    type Execution: ExecutionStrategy<Evm>;
+}
+
+// ---------------------------------------------------------------------------
+// StateRootStrategy: async (BAL path)
+// ---------------------------------------------------------------------------
+
+pub struct AsyncStateRootStrategy;
+
+pub struct ChannelStateRootHandle {
+    pub receiver: crossbeam_channel::Receiver<Result<StateRootResult, BlockExecutionError>>,
+}
+
+impl StateRootStrategy for AsyncStateRootStrategy {
+    type EpochState = ();
+    type Handle = ChannelStateRootHandle;
+
+    fn prepare(
+        &self,
+        client: impl StateProviderFactory + Clone + 'static,
+        parent_hash: B256,
+        bundle_state: BundleState,
+    ) -> Self::Handle {
+        let (sender, receiver) = crossbeam_channel::bounded(1);
+        let state_root_provider = client
+            .state_by_block_hash(parent_hash)
+            .expect("state provider must be available for state root computation");
+        rayon::spawn(move || {
+            let result = compute_state_root(state_root_provider.into(), bundle_state.state.iter());
+            let _ = sender.send(result);
+        });
+        ChannelStateRootHandle { receiver }
+    }
+}
+
+impl StateRootHandle for ChannelStateRootHandle {
+    fn finish(self) -> Result<StateRootResult, BlockExecutionError> {
+        self.receiver.recv().map_err(BlockExecutionError::other)?
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ExecutionStrategy: BAL path
+// ---------------------------------------------------------------------------
+
+pub struct FlashblocksBalExecutionStrategy<S: StateRootStrategy> {
+    pub state_root_strategy: S,
+}
+
+impl<S: StateRootStrategy> ExecutionStrategy<OpEvmConfig> for FlashblocksBalExecutionStrategy<S> {
+    fn execute(
+        &self,
+        ctx: ValidationCtx<'_, OpEvmConfig>,
+        client: impl StateProviderFactory + Clone + Sync + 'static,
+        diff: ExecutionPayloadFlashblockDeltaV1,
+        committed_state: CommittedState<OpRethReceiptBuilder>,
+        payload_id: PayloadId,
+    ) -> Result<OpBuiltPayload, BalExecutorError> {
+        let FlashblockAccessListData {
+            access_list,
+            access_list_hash,
+        } = diff
+            .access_list_data
+            .ok_or(BalValidationError::MissingAccessListData.boxed())
+            .map_err(BalExecutorError::from)?;
+
+        let state_provider_ref = client
+            .state_by_block_hash(ctx.parent.hash())
+            .map_err(BalExecutorError::other)?;
+        let state_provider_database = StateProviderDatabase::new(state_provider_ref.as_ref());
+        let block_access_index = access_list.min_tx_index;
+
+        let mut bundle_state = committed_state.bundle.clone();
+
+        let bundle_database =
+            BundleDb::new(state_provider_database.clone(), bundle_state.clone().into());
+        let temporal_db_factory = TemporalDbFactory::new(&bundle_database, &access_list);
+        let temporal_db = temporal_db_factory.db(bundle_database, block_access_index as u64);
+
+        access_list
+            .extend_bundle(&mut bundle_state, &state_provider_database)
+            .map_err(BalExecutorError::other)?;
+
+        let mut noop_state = NoOpCommitDB::new(temporal_db);
+        let mut database = BalBuilderDb::new(&mut noop_state);
+        database.set_index(block_access_index);
+
+        let state_root_handle = self.state_root_strategy.prepare(
+            client.clone(),
+            ctx.parent.hash(),
+            bundle_state.clone(),
+        );
+
+        let evm = OpEvmFactory::default().create_evm(database, ctx.evm_env.clone());
+
+        let mut executor: OpBlockExecutor<_, OpRethReceiptBuilder, Arc<OpChainSpec>> =
+            OpBlockExecutor::new(
+                evm,
+                ctx.execution_context.clone(),
+                ctx.chain_spec.clone(),
+                OpRethReceiptBuilder::default(),
+            );
+
+        executor.gas_used = committed_state.gas_used;
+        executor.receipts = committed_state.receipts_iter().cloned().collect();
+
+        let (validator, access_list_receiver) = BalBlockValidator::new(
+            ctx.execution_context.clone(),
+            ctx.parent,
+            executor,
+            bundle_state.clone().into(),
+            committed_state.bundle.clone().into(),
+            committed_state.transactions_iter().cloned().collect(),
+            ctx.chain_spec.clone(),
+            &temporal_db_factory,
+            state_root_handle,
+            ctx.evm_env.clone(),
+            (access_list.min_tx_index, access_list.max_tx_index),
+            ctx.attempt_metrics,
+        );
+
+        let transactions_offset = committed_state.transactions.len() as u16 + 1;
+        let executor_transactions =
+            decode_transactions_with_indices(&diff.transactions, transactions_offset)?;
+
+        let finish_state_provider = client
+            .state_by_block_hash(ctx.parent.hash())
+            .map_err(BalExecutorError::other)?;
+
+        let (outcome, fees): (BlockBuilderOutcome<OpPrimitives>, u128) =
+            validator.execute_block(client.clone(), finish_state_provider.as_ref(), executor_transactions)?;
+
+        let computed_access_list = access_list_receiver
+            .recv()
+            .map_err(BalExecutorError::other)?;
+
+        let computed_access_list_hash =
+            world_chain_primitives::access_list::access_list_hash(&computed_access_list);
+
+        if computed_access_list_hash != access_list_hash {
+            error!(
+                target: "flashblocks::state_executor",
+                ?access_list_hash,
+                expected = ?access_list_hash,
+                access_list = ?computed_access_list,
+                expected_access_list = ?access_list.clone(),
+                block_number = outcome.block.number(),
+                block_hash = ?outcome.block.hash(),
+                execution_context = ?ctx.execution_context,
+                "Access list hash mismatch"
+            );
+            return Err(BalValidationError::BalHashMismatch {
+                expected: access_list_hash,
+                got: computed_access_list_hash,
+                expected_bal: access_list,
+                got_bal: computed_access_list,
+            }
+            .boxed()
+            .into());
+        }
+
+        if outcome.block.receipts_root != diff.receipts_root {
+            error!(
+                target: "flashblocks::state_executor",
+                got = ?outcome.block.receipts_root,
+                expected = ?diff.receipts_root,
+                "Receipts root mismatch"
+            );
+            return Err(BalValidationError::ReceiptsRootMismatch {
+                expected: diff.receipts_root,
+                got: outcome.block.receipts_root,
+            }
+            .boxed()
+            .into());
+        }
+
+        if outcome.block.state_root != diff.state_root {
+            error!(
+                target: "flashblocks::state_executor",
+                got = ?outcome.block.state_root,
+                expected = ?diff.state_root,
+                expected_bundle = ?bundle_state,
+                "State root mismatch"
+            );
+            return Err(BalValidationError::StateRootMismatch {
+                expected: diff.state_root,
+                got: outcome.block.state_root,
+                bundle_state: bundle_state.clone(),
+            }
+            .boxed()
+            .into());
+        }
+
+        if outcome.block.hash() != diff.block_hash {
+            error!(
+                target: "flashblocks::state_executor",
+                got = ?outcome.block.hash(),
+                expected = ?diff.block_hash,
+                "Block hash mismatch"
+            );
+            return Err(BalValidationError::BalHashMismatch {
+                expected: diff.block_hash,
+                got: outcome.block.hash(),
+                expected_bal: access_list,
+                got_bal: computed_access_list,
+            }
+            .boxed()
+            .into());
+        }
+
+        let BlockBuilderOutcome {
+            execution_result,
+            block,
+            hashed_state,
+            trie_updates,
+        } = outcome;
+
+        let sealed_block = Arc::new(block.sealed_block().clone());
+        let execution_output = BlockExecutionOutput {
+            state: bundle_state.clone(),
+            result: execution_result,
+        };
+        let executed_block: BuiltPayloadExecutedBlock<OpPrimitives> = BuiltPayloadExecutedBlock {
+            recovered_block: Arc::new(block),
+            execution_output: Arc::new(execution_output),
+            hashed_state: either::Left(Arc::new(hashed_state)),
+            trie_updates: either::Left(Arc::new(trie_updates)),
+        };
+
+        Ok(OpBuiltPayload::new(
+            payload_id,
+            sealed_block,
+            U256::from(fees),
+            Some(executed_block),
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ExecutionStrategy: legacy (non-BAL) path
+// ---------------------------------------------------------------------------
+
+pub struct FlashblocksLegacyExecutionStrategy;
+
+impl ExecutionStrategy<OpEvmConfig> for FlashblocksLegacyExecutionStrategy {
+    fn execute(
+        &self,
+        ctx: ValidationCtx<'_, OpEvmConfig>,
+        client: impl StateProviderFactory + Clone + Sync + 'static,
+        diff: ExecutionPayloadFlashblockDeltaV1,
+        committed_state: CommittedState<OpRethReceiptBuilder>,
+        payload_id: PayloadId,
+    ) -> Result<OpBuiltPayload, BalExecutorError> {
+        let bundle_state = committed_state.bundle.clone();
+
+        let state_provider = client
+            .state_by_block_hash(ctx.parent.hash())
+            .map_err(BalExecutorError::other)?;
+
+        let mut db = State::builder()
+            .with_database(StateProviderDatabase::new(state_provider.as_ref()))
+            .with_bundle_prestate(bundle_state)
+            .with_bundle_update()
+            .build();
+
+        let evm = OpEvmFactory::<OpTx>::default().create_evm(&mut db, ctx.evm_env.clone());
+
+        let mut executor = OpBlockExecutor::new(
+            evm,
+            ctx.execution_context.clone(),
+            (*ctx.chain_spec).clone(),
+            OpRethReceiptBuilder::default(),
+        );
+
+        executor.gas_used = committed_state.gas_used;
+        executor.receipts = committed_state.receipts_iter().cloned().collect();
+
+        let mut builder = FlashblocksBlockBuilder::<OpPrimitives, _>::new(
+            ctx.execution_context.clone(),
+            ctx.parent,
+            executor,
+            committed_state.transactions_iter().cloned().collect(),
+            ctx.chain_spec.clone(),
+        );
+
+        // Apply pre-execution changes on the first flashblock (no prior committed state).
+        if committed_state.transactions.is_empty() {
+            let pre_execution_changes_started = Instant::now();
+            builder.apply_pre_execution_changes()?;
+            ctx.attempt_metrics.record_stage_duration(
+                PayloadBuildStage::PreExecutionChanges,
+                pre_execution_changes_started.elapsed(),
+            );
+        }
+
+        let basefee = ctx.evm_env.block_env.basefee;
+        let transactions = decode_transactions_with_indices(
+            &diff.transactions,
+            committed_state.transactions_iter().count() as u16,
+        )?;
+
+        let mut fees = U256::ZERO;
+        let txs_execution_started = Instant::now();
+        for (_, tx) in &transactions {
+            let gas_used = builder
+                .execute_transaction_with_commit_condition(tx.clone(), |_| CommitChanges::Yes)?;
+
+            if !tx.is_deposit()
+                && let Some(gas_used) = gas_used
+            {
+                let miner_fee = tx
+                    .effective_tip_per_gas(basefee)
+                    .expect("fee is always valid; execution succeeded");
+                fees += U256::from(gas_used) * U256::from(miner_fee);
+            }
+        }
+        ctx.attempt_metrics.record_stage_duration(
+            PayloadBuildStage::SequencerTxExecution,
+            txs_execution_started.elapsed(),
+        );
+
+        let finish_state_provider = client
+            .state_by_block_hash(ctx.parent.hash())
+            .map_err(BalExecutorError::other)?;
+
+        let finalize_started = Instant::now();
+        let (outcome, bundle) = builder.finish_with_bundle(
+            finish_state_provider.as_ref(),
+            &mut *ctx.attempt_metrics,
+        )?;
+        ctx.attempt_metrics
+            .record_stage_duration(PayloadBuildStage::Finalize, finalize_started.elapsed());
+
+        let BlockBuilderOutcome {
+            execution_result,
+            block,
+            hashed_state,
+            trie_updates,
+        } = outcome;
+
+        let sealed_block = Arc::new(block.sealed_block().clone());
+        let execution_output = BlockExecutionOutput {
+            state: bundle,
+            result: execution_result,
+        };
+        let executed_block: BuiltPayloadExecutedBlock<OpPrimitives> = BuiltPayloadExecutedBlock {
+            recovered_block: Arc::new(block),
+            execution_output: Arc::new(execution_output),
+            hashed_state: either::Left(Arc::new(hashed_state)),
+            trie_updates: either::Left(Arc::new(trie_updates)),
+        };
+
+        Ok(OpBuiltPayload::new(
+            payload_id,
+            sealed_block,
+            committed_state.fees + fees,
+            Some(executed_block),
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Concrete FlashblockTypes bundles
+// ---------------------------------------------------------------------------
+
+/// BAL-enabled flashblock types: parallel execution with parallel state root.
+pub struct BalFlashblockTypes;
+
+impl FlashblockTypes<OpEvmConfig> for BalFlashblockTypes {
+    type Execution = FlashblocksBalExecutionStrategy<AsyncStateRootStrategy>;
+}
+
+/// Legacy (non-BAL) flashblock types: sequential execution, no external state root.
+pub struct LegacyFlashblockTypes;
+
+impl FlashblockTypes<OpEvmConfig> for LegacyFlashblockTypes {
+    type Execution = FlashblocksLegacyExecutionStrategy;
+}

--- a/crates/builder/src/execution_strategy.rs
+++ b/crates/builder/src/execution_strategy.rs
@@ -63,19 +63,24 @@ pub fn compute_state_root<'a>(
 }
 
 /// Context passed to an [`ExecutionStrategy`] for each flashblock.
-pub struct ValidationCtx<'a, Evm: ConfigureEvm> {
+pub struct ValidationCtx<'a, Evm: ConfigureEvm, S: StateRootStrategy> {
     pub parent: &'a SealedHeader<Header>,
     pub attempt_metrics: &'a mut FlashblockValidationAttemptMetrics,
     pub chain_spec: Arc<OpChainSpec>,
     pub evm_env: EvmEnvFor<Evm>,
     pub execution_context: OpBlockExecutionCtx,
+    /// State root strategy for this flashblock execution.
+    pub state_root_strategy: S,
 }
 
 /// Strategy for executing flashblock diff transactions.
-pub trait ExecutionStrategy<Evm: ConfigureEvm>: Send + Sync {
+///
+/// The `S` parameter is the [`StateRootStrategy`] paired with this execution
+/// strategy via [`FlashblockTypes`].
+pub trait ExecutionStrategy<Evm: ConfigureEvm, S: StateRootStrategy>: Send + Sync {
     fn execute(
         &self,
-        ctx: ValidationCtx<'_, Evm>,
+        ctx: ValidationCtx<'_, Evm, S>,
         client: impl StateProviderFactory + Clone + Sync + 'static,
         diff: ExecutionPayloadFlashblockDeltaV1,
         committed_state: CommittedState<OpRethReceiptBuilder>,
@@ -83,14 +88,13 @@ pub trait ExecutionStrategy<Evm: ConfigureEvm>: Send + Sync {
     ) -> Result<OpBuiltPayload, BalExecutorError>;
 }
 
-pub struct FlashblocksBalExecutionStrategy<S: StateRootStrategy> {
-    pub state_root_strategy: S,
-}
+/// BAL execution strategy: parallel transaction execution with an external state root handle.
+pub struct FlashblocksBalExecutionStrategy;
 
-impl<S: StateRootStrategy> ExecutionStrategy<OpEvmConfig> for FlashblocksBalExecutionStrategy<S> {
+impl<S: StateRootStrategy> ExecutionStrategy<OpEvmConfig, S> for FlashblocksBalExecutionStrategy {
     fn execute(
         &self,
-        ctx: ValidationCtx<'_, OpEvmConfig>,
+        ctx: ValidationCtx<'_, OpEvmConfig, S>,
         client: impl StateProviderFactory + Clone + Sync + 'static,
         diff: ExecutionPayloadFlashblockDeltaV1,
         committed_state: CommittedState<OpRethReceiptBuilder>,
@@ -125,7 +129,7 @@ impl<S: StateRootStrategy> ExecutionStrategy<OpEvmConfig> for FlashblocksBalExec
         let mut database = BalBuilderDb::new(&mut noop_state);
         database.set_index(block_access_index);
 
-        let state_root_handle = self
+        let state_root_handle = ctx
             .state_root_strategy
             .prepare(client.clone(), ctx.parent.hash(), bundle_state.clone())
             .map_err(BalExecutorError::other)?;
@@ -277,10 +281,10 @@ impl<S: StateRootStrategy> ExecutionStrategy<OpEvmConfig> for FlashblocksBalExec
 
 pub struct FlashblocksLegacyExecutionStrategy;
 
-impl ExecutionStrategy<OpEvmConfig> for FlashblocksLegacyExecutionStrategy {
+impl<S: StateRootStrategy> ExecutionStrategy<OpEvmConfig, S> for FlashblocksLegacyExecutionStrategy {
     fn execute(
         &self,
-        ctx: ValidationCtx<'_, OpEvmConfig>,
+        ctx: ValidationCtx<'_, OpEvmConfig, S>,
         client: impl StateProviderFactory + Clone + Sync + 'static,
         diff: ExecutionPayloadFlashblockDeltaV1,
         committed_state: CommittedState<OpRethReceiptBuilder>,

--- a/crates/builder/src/execution_strategy.rs
+++ b/crates/builder/src/execution_strategy.rs
@@ -1,24 +1,24 @@
 use std::{sync::Arc, time::Instant};
 
 use alloy_consensus::{BlockHeader, Header, Transaction};
-use alloy_op_evm::{OpBlockExecutionCtx, OpBlockExecutor, OpEvmFactory, OpTx};
+use alloy_op_evm::{OpBlockExecutionCtx, OpBlockExecutor, OpBlockExecutorFactory, OpEvmFactory, OpTx};
 use alloy_primitives::{Address, B256, U256};
 use alloy_rpc_types_engine::PayloadId;
 use reth_evm::{
-    ConfigureEvm, EvmEnvFor, EvmFactory,
+    ConfigureEvm, Evm, EvmEnvFor, EvmFactory,
     block::{BlockExecutionError, CommitChanges},
-    execute::{BlockBuilder, BlockBuilderOutcome},
+    execute::{BlockAssemblerInput, BlockBuilder, BlockBuilderOutcome, BlockExecutor},
 };
 use reth_node_api::BuiltPayloadExecutedBlock;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_evm::{OpEvmConfig, OpRethReceiptBuilder};
 use reth_optimism_node::OpBuiltPayload;
 use reth_optimism_primitives::OpPrimitives;
-use reth_primitives_traits::SealedHeader;
+use reth_primitives_traits::{RecoveredBlock, SealedHeader};
 use reth_provider::{BlockExecutionOutput, StateProvider, StateProviderFactory};
 use reth_revm::database::StateProviderDatabase;
 use reth_trie_common::{HashedPostState, KeccakKeyHasher, updates::TrieUpdates};
-use revm::database::BundleAccount;
+use revm::database::{BundleAccount, states::bundle_state::BundleRetention};
 use revm_database::State;
 use tracing::error;
 use world_chain_primitives::{
@@ -26,8 +26,8 @@ use world_chain_primitives::{
 };
 
 use crate::{
-    BlockBuilderExt,
     bal_executor::{BalExecutorError, BalValidationError, CommittedState},
+    state_db::StateDB,
     database::{
         bal_builder_db::{BalBuilderDb, NoOpCommitDB},
         bundle_db::BundleDb,
@@ -36,7 +36,7 @@ use crate::{
     executor::FlashblocksBlockBuilder,
     flashblock_validation_metrics::FlashblockValidationAttemptMetrics,
     metrics::PayloadBuildStage,
-    state_root_strategy::StateRootStrategy,
+    state_root_strategy::{StateRootHandle, StateRootStrategy},
     validator::{BalBlockValidator, decode_transactions_with_indices},
 };
 
@@ -358,13 +358,75 @@ impl<S: StateRootStrategy> ExecutionStrategy<OpEvmConfig, S> for FlashblocksLega
             txs_execution_started.elapsed(),
         );
 
+        // Extract state root strategy from ctx; bundle state is only available after
+        // merging transitions, so prepare() cannot be called until then.
+        let state_root_strategy = ctx.state_root_strategy;
+        let parent_hash = ctx.parent.hash();
+
         let finish_state_provider = client
-            .state_by_block_hash(ctx.parent.hash())
+            .state_by_block_hash(parent_hash)
             .map_err(BalExecutorError::other)?;
 
         let finalize_started = Instant::now();
-        let (outcome, bundle) = builder
-            .finish_with_bundle(finish_state_provider.as_ref(), &mut *ctx.attempt_metrics)?;
+
+        let (evm, executor_result) = builder.inner.executor.finish()?;
+        let (db, evm_env) = evm.finish();
+
+        let merge_started = Instant::now();
+        db.merge_transitions(BundleRetention::Reverts);
+        ctx.attempt_metrics
+            .record_stage_duration(PayloadBuildStage::MergeTransitions, merge_started.elapsed());
+
+        let flattened = crate::utils::flatten_reverts(&db.bundle_state().reverts);
+        db.bundle_state_mut().reverts = flattened;
+
+        let state_root_started = Instant::now();
+        let state_root_handle = state_root_strategy
+            .prepare(client, parent_hash, db.bundle_state().clone())?;
+        let StateRootResult {
+            state_root,
+            trie_updates,
+            hashed_state,
+        } = state_root_handle.finish()?;
+        ctx.attempt_metrics
+            .record_stage_duration(PayloadBuildStage::StateRoot, state_root_started.elapsed());
+
+        let (transactions, senders) = builder
+            .inner
+            .transactions
+            .into_iter()
+            .map(|tx| tx.into_parts())
+            .unzip();
+
+        let block_assembly_started = Instant::now();
+        let block = builder.inner.assembler.assemble_block(BlockAssemblerInput::<
+            '_,
+            '_,
+            OpBlockExecutorFactory<OpRethReceiptBuilder>,
+        >::new(
+            evm_env,
+            builder.inner.ctx,
+            builder.inner.parent,
+            transactions,
+            &executor_result,
+            db.bundle_state(),
+            finish_state_provider.as_ref(),
+            state_root,
+        ))?;
+        ctx.attempt_metrics.record_stage_duration(
+            PayloadBuildStage::BlockAssembly,
+            block_assembly_started.elapsed(),
+        );
+
+        let bundle = db.take_bundle();
+        let block = RecoveredBlock::new_unhashed(block, senders);
+        let outcome = BlockBuilderOutcome::<OpPrimitives> {
+            execution_result: executor_result,
+            hashed_state,
+            trie_updates,
+            block,
+        };
+
         ctx.attempt_metrics
             .record_stage_duration(PayloadBuildStage::Finalize, finalize_started.elapsed());
 

--- a/crates/builder/src/flashblock_types.rs
+++ b/crates/builder/src/flashblock_types.rs
@@ -1,19 +1,21 @@
 use crate::{
     execution_strategy::{FlashblocksBalExecutionStrategy, FlashblocksLegacyExecutionStrategy},
-    state_root_strategy::{AsyncStateRootStrategy, FlashblockTypes},
+    state_root_strategy::{AsyncStateRootStrategy, FlashblockTypes, SyncStateRootStrategy},
 };
 use reth_optimism_evm::OpEvmConfig;
 
-/// BAL-enabled flashblock types: parallel execution with parallel state root.
+/// BAL-enabled flashblock types: parallel execution with async state root.
 pub struct BalFlashblockTypes;
 
 impl FlashblockTypes<OpEvmConfig> for BalFlashblockTypes {
     type Execution = FlashblocksBalExecutionStrategy<AsyncStateRootStrategy>;
+    type StateRoot = AsyncStateRootStrategy;
 }
 
-/// Legacy (non-BAL) flashblock types: sequential execution, no external state root.
+/// Legacy (non-BAL) flashblock types: sequential execution with inline state root.
 pub struct LegacyFlashblockTypes;
 
 impl FlashblockTypes<OpEvmConfig> for LegacyFlashblockTypes {
     type Execution = FlashblocksLegacyExecutionStrategy;
+    type StateRoot = SyncStateRootStrategy;
 }

--- a/crates/builder/src/flashblock_types.rs
+++ b/crates/builder/src/flashblock_types.rs
@@ -1,7 +1,7 @@
-use crate::execution_strategy::{
-    FlashblocksBalExecutionStrategy, FlashblocksLegacyExecutionStrategy,
+use crate::{
+    execution_strategy::{FlashblocksBalExecutionStrategy, FlashblocksLegacyExecutionStrategy},
+    state_root_strategy::{AsyncStateRootStrategy, FlashblockTypes},
 };
-use crate::state_root_strategy::{AsyncStateRootStrategy, FlashblockTypes};
 use reth_optimism_evm::OpEvmConfig;
 
 /// BAL-enabled flashblock types: parallel execution with parallel state root.

--- a/crates/builder/src/flashblock_types.rs
+++ b/crates/builder/src/flashblock_types.rs
@@ -1,0 +1,19 @@
+use crate::execution_strategy::{
+    FlashblocksBalExecutionStrategy, FlashblocksLegacyExecutionStrategy,
+};
+use crate::state_root_strategy::{AsyncStateRootStrategy, FlashblockTypes};
+use reth_optimism_evm::OpEvmConfig;
+
+/// BAL-enabled flashblock types: parallel execution with parallel state root.
+pub struct BalFlashblockTypes;
+
+impl FlashblockTypes<OpEvmConfig> for BalFlashblockTypes {
+    type Execution = FlashblocksBalExecutionStrategy<AsyncStateRootStrategy>;
+}
+
+/// Legacy (non-BAL) flashblock types: sequential execution, no external state root.
+pub struct LegacyFlashblockTypes;
+
+impl FlashblockTypes<OpEvmConfig> for LegacyFlashblockTypes {
+    type Execution = FlashblocksLegacyExecutionStrategy;
+}

--- a/crates/builder/src/flashblock_types.rs
+++ b/crates/builder/src/flashblock_types.rs
@@ -8,14 +8,14 @@ use reth_optimism_evm::OpEvmConfig;
 pub struct BalFlashblockTypes;
 
 impl FlashblockTypes<OpEvmConfig> for BalFlashblockTypes {
-    type Execution = FlashblocksBalExecutionStrategy<AsyncStateRootStrategy>;
     type StateRoot = AsyncStateRootStrategy;
+    type Execution = FlashblocksBalExecutionStrategy;
 }
 
 /// Legacy (non-BAL) flashblock types: sequential execution with inline state root.
 pub struct LegacyFlashblockTypes;
 
 impl FlashblockTypes<OpEvmConfig> for LegacyFlashblockTypes {
-    type Execution = FlashblocksLegacyExecutionStrategy;
     type StateRoot = SyncStateRootStrategy;
+    type Execution = FlashblocksLegacyExecutionStrategy;
 }

--- a/crates/builder/src/lib.rs
+++ b/crates/builder/src/lib.rs
@@ -202,7 +202,7 @@ pub mod execution_strategy;
 mod flashblock_types;
 /// Flashblock validation metrics.
 pub mod flashblock_validation_metrics;
-mod state_root_strategy;
+pub mod state_root_strategy;
 
 pub use execution_context::{WorldChainPayloadBuilderCtx, WorldChainPayloadBuilderCtxBuilder};
 

--- a/crates/builder/src/lib.rs
+++ b/crates/builder/src/lib.rs
@@ -199,8 +199,10 @@ pub mod payload_builder_metrics;
 /// Execution and state-root strategy traits and concrete implementations.
 pub mod execution_strategy;
 
+mod flashblock_types;
 /// Flashblock validation metrics.
 pub mod flashblock_validation_metrics;
+mod state_root_strategy;
 
 pub use execution_context::{WorldChainPayloadBuilderCtx, WorldChainPayloadBuilderCtxBuilder};
 

--- a/crates/builder/src/lib.rs
+++ b/crates/builder/src/lib.rs
@@ -196,6 +196,9 @@ pub mod metrics;
 /// Payload builder metrics.
 pub mod payload_builder_metrics;
 
+/// Execution and state-root strategy traits and concrete implementations.
+pub mod execution_strategy;
+
 /// Flashblock validation metrics.
 pub mod flashblock_validation_metrics;
 

--- a/crates/builder/src/state_root_strategy.rs
+++ b/crates/builder/src/state_root_strategy.rs
@@ -1,7 +1,4 @@
-use crate::{
-    execution_strategy,
-    execution_strategy::{ExecutionStrategy, StateRootResult},
-};
+use crate::execution_strategy::{self, ExecutionStrategy, StateRootResult};
 use alloy_primitives::B256;
 use reth_evm::{ConfigureEvm, block::BlockExecutionError};
 use reth_provider::StateProviderFactory;
@@ -24,11 +21,17 @@ pub trait StateRootHandle: Send {
 }
 
 /// Associates execution and state-root strategies for an EVM.
+///
+/// The `Execution` strategy receives the `StateRoot` strategy via [`ValidationCtx`],
+/// so the state root type is declared once here and flows through to the executor.
+///
+/// [`ValidationCtx`]: crate::execution_strategy::ValidationCtx
 pub trait FlashblockTypes<Evm: ConfigureEvm> {
-    type Execution: ExecutionStrategy<Evm>;
-    type StateRoot: StateRootStrategy;
+    type StateRoot: StateRootStrategy + Default;
+    type Execution: ExecutionStrategy<Evm, Self::StateRoot>;
 }
 
+#[derive(Default)]
 pub struct AsyncStateRootStrategy;
 
 pub struct ChannelStateRootHandle {
@@ -66,6 +69,7 @@ impl StateRootHandle for ChannelStateRootHandle {
 }
 
 /// Synchronous state root strategy: computes the state root inline on `prepare`.
+#[derive(Default)]
 pub struct SyncStateRootStrategy;
 
 pub struct SyncStateRootHandle(Result<StateRootResult, BlockExecutionError>);
@@ -83,7 +87,7 @@ impl StateRootStrategy for SyncStateRootStrategy {
             .state_by_block_hash(parent_hash)
             .map_err(BlockExecutionError::other)?;
         let result =
-            execution_strategy::compute_state_root(state_root_provider.into(), &bundle_state.state);
+            execution_strategy::compute_state_root(state_root_provider.into(), bundle_state.state.iter());
         Ok(SyncStateRootHandle(result))
     }
 }

--- a/crates/builder/src/state_root_strategy.rs
+++ b/crates/builder/src/state_root_strategy.rs
@@ -26,6 +26,7 @@ pub trait StateRootHandle: Send {
 /// Associates execution and state-root strategies for an EVM.
 pub trait FlashblockTypes<Evm: ConfigureEvm> {
     type Execution: ExecutionStrategy<Evm>;
+    type StateRoot: StateRootStrategy;
 }
 
 pub struct AsyncStateRootStrategy;
@@ -61,5 +62,34 @@ impl StateRootStrategy for AsyncStateRootStrategy {
 impl StateRootHandle for ChannelStateRootHandle {
     fn finish(self) -> Result<StateRootResult, BlockExecutionError> {
         self.receiver.recv().map_err(BlockExecutionError::other)?
+    }
+}
+
+/// Synchronous state root strategy: computes the state root inline on `prepare`.
+pub struct SyncStateRootStrategy;
+
+pub struct SyncStateRootHandle(Result<StateRootResult, BlockExecutionError>);
+
+impl StateRootStrategy for SyncStateRootStrategy {
+    type Handle = SyncStateRootHandle;
+
+    fn prepare(
+        &self,
+        client: impl StateProviderFactory + Clone + 'static,
+        parent_hash: B256,
+        bundle_state: BundleState,
+    ) -> Result<Self::Handle, BlockExecutionError> {
+        let state_root_provider = client
+            .state_by_block_hash(parent_hash)
+            .map_err(BlockExecutionError::other)?;
+        let result =
+            execution_strategy::compute_state_root(state_root_provider.into(), &bundle_state.state);
+        Ok(SyncStateRootHandle(result))
+    }
+}
+
+impl StateRootHandle for SyncStateRootHandle {
+    fn finish(self) -> Result<StateRootResult, BlockExecutionError> {
+        self.0
     }
 }

--- a/crates/builder/src/state_root_strategy.rs
+++ b/crates/builder/src/state_root_strategy.rs
@@ -1,8 +1,9 @@
-use crate::execution_strategy;
-use crate::execution_strategy::{ExecutionStrategy, StateRootResult};
+use crate::{
+    execution_strategy,
+    execution_strategy::{ExecutionStrategy, StateRootResult},
+};
 use alloy_primitives::B256;
-use reth_evm::ConfigureEvm;
-use reth_evm::block::BlockExecutionError;
+use reth_evm::{ConfigureEvm, block::BlockExecutionError};
 use reth_provider::StateProviderFactory;
 use revm_database::BundleState;
 

--- a/crates/builder/src/state_root_strategy.rs
+++ b/crates/builder/src/state_root_strategy.rs
@@ -86,8 +86,10 @@ impl StateRootStrategy for SyncStateRootStrategy {
         let state_root_provider = client
             .state_by_block_hash(parent_hash)
             .map_err(BlockExecutionError::other)?;
-        let result =
-            execution_strategy::compute_state_root(state_root_provider.into(), bundle_state.state.iter());
+        let result = execution_strategy::compute_state_root(
+            state_root_provider.into(),
+            bundle_state.state.iter(),
+        );
         Ok(SyncStateRootHandle(result))
     }
 }

--- a/crates/builder/src/state_root_strategy.rs
+++ b/crates/builder/src/state_root_strategy.rs
@@ -1,0 +1,64 @@
+use crate::execution_strategy;
+use crate::execution_strategy::{ExecutionStrategy, StateRootResult};
+use alloy_primitives::B256;
+use reth_evm::ConfigureEvm;
+use reth_evm::block::BlockExecutionError;
+use reth_provider::StateProviderFactory;
+use revm_database::BundleState;
+
+/// Strategy for state root computation.
+pub trait StateRootStrategy: Send + Sync {
+    type Handle: StateRootHandle;
+
+    fn prepare(
+        &self,
+        client: impl StateProviderFactory + Clone + 'static,
+        parent_hash: B256,
+        bundle_state: BundleState,
+    ) -> Result<Self::Handle, BlockExecutionError>;
+}
+
+pub trait StateRootHandle: Send {
+    fn finish(self) -> Result<StateRootResult, BlockExecutionError>;
+}
+
+/// Associates execution and state-root strategies for an EVM.
+pub trait FlashblockTypes<Evm: ConfigureEvm> {
+    type Execution: ExecutionStrategy<Evm>;
+}
+
+pub struct AsyncStateRootStrategy;
+
+pub struct ChannelStateRootHandle {
+    pub receiver: crossbeam_channel::Receiver<Result<StateRootResult, BlockExecutionError>>,
+}
+
+impl StateRootStrategy for AsyncStateRootStrategy {
+    type Handle = ChannelStateRootHandle;
+
+    fn prepare(
+        &self,
+        client: impl StateProviderFactory + Clone + 'static,
+        parent_hash: B256,
+        bundle_state: BundleState,
+    ) -> Result<Self::Handle, BlockExecutionError> {
+        let (sender, receiver) = crossbeam_channel::bounded(1);
+        let state_root_provider = client
+            .state_by_block_hash(parent_hash)
+            .map_err(BlockExecutionError::other)?;
+        rayon::spawn(move || {
+            let result = execution_strategy::compute_state_root(
+                state_root_provider.into(),
+                bundle_state.state.iter(),
+            );
+            let _ = sender.send(result);
+        });
+        Ok(ChannelStateRootHandle { receiver })
+    }
+}
+
+impl StateRootHandle for ChannelStateRootHandle {
+    fn finish(self) -> Result<StateRootResult, BlockExecutionError> {
+        self.receiver.recv().map_err(BlockExecutionError::other)?
+    }
+}

--- a/crates/builder/src/validator.rs
+++ b/crates/builder/src/validator.rs
@@ -40,7 +40,6 @@ use revm::{
 };
 use tracing::{error, info, trace};
 
-use crate::state_root_strategy::{FlashblockTypes, StateRootHandle};
 use crate::{
     access_list::{BlockAccessIndex, FlashblockAccessListConstruction},
     bal_executor::{BalExecutorError, CommittedState},
@@ -55,6 +54,7 @@ use crate::{
     },
     metrics::PayloadBuildStage,
     payload_builder_metrics::metered_fn,
+    state_root_strategy::{FlashblockTypes, StateRootHandle},
 };
 
 /// A type alias for the BAL builder database with a cache layer.

--- a/crates/builder/src/validator.rs
+++ b/crates/builder/src/validator.rs
@@ -1,10 +1,10 @@
-use alloy_consensus::{BlockHeader, Header, Transaction};
+use alloy_consensus::{Header, Transaction};
 use alloy_eips::Decodable2718;
 use op_revm::{OpHaltReason, OpSpecId};
-use reth_primitives_traits::{Recovered, RecoveredBlock, SealedHeader, SignedTransaction};
+use reth_primitives_traits::{Recovered, RecoveredBlock, SealedHeader, SignerRecoverable};
 use std::{io::Error, marker::PhantomData, sync::Arc, time::Instant};
 
-use alloy_primitives::{B256, Bytes, U256};
+use alloy_primitives::Bytes;
 
 use alloy_op_evm::{
     OpBlockExecutionCtx, OpBlockExecutor, OpBlockExecutorFactory, OpEvmFactory, OpTx,
@@ -13,47 +13,44 @@ use alloy_op_evm::{
 use alloy_rpc_types_engine::PayloadId;
 use eyre::eyre::bail;
 use op_alloy_consensus::OpReceipt;
-use rayon::prelude::*;
+use rayon::{iter::IntoParallelIterator, prelude::ParallelIterator};
 use reth_chain_state::ExecutedBlock;
+use reth_revm::database::StateProviderDatabase;
 use world_chain_primitives::{
-    access_list::{FlashblockAccessList, FlashblockAccessListData},
-    primitives::ExecutionPayloadFlashblockDeltaV1,
+    access_list::FlashblockAccessList, primitives::ExecutionPayloadFlashblockDeltaV1,
 };
 
 use reth_evm::{
-    Evm, EvmEnv, EvmEnvFor, EvmFactory,
+    ConfigureEvm, Evm, EvmEnv, EvmEnvFor, EvmFactory, FromRecoveredTx, FromTxWithEncoded,
     block::{BlockExecutionError, BlockExecutor, CommitChanges, InternalBlockExecutionError},
     execute::{
         BasicBlockBuilder, BlockAssemblerInput, BlockBuilder, BlockBuilderOutcome, ExecutorTx,
     },
 };
-use reth_node_api::{BuiltPayload, BuiltPayloadExecutedBlock};
+use reth_node_api::BuiltPayload;
 use reth_optimism_chainspec::OpChainSpec;
-use reth_optimism_evm::{OpBlockAssembler, OpEvmConfig, OpRethReceiptBuilder};
+use reth_optimism_evm::{OpBlockAssembler, OpRethReceiptBuilder};
 use reth_optimism_node::OpBuiltPayload;
 use reth_optimism_primitives::{OpPrimitives, OpTransactionSigned};
-use reth_provider::{BlockExecutionOutput, StateProvider, StateProviderFactory};
-use reth_revm::database::StateProviderDatabase;
-use reth_trie_common::{HashedPostState, KeccakKeyHasher, updates::TrieUpdates};
+use reth_provider::{StateProvider, StateProviderFactory};
 use revm::{
     DatabaseRef,
     context::{BlockEnv, result::ExecutionResult},
-    database::{BundleAccount, BundleState},
-    primitives::AddressMap,
+    database::BundleState,
 };
-use revm_database::State;
 use tracing::{error, info, trace};
 
 use crate::{
-    BlockBuilderExt,
     access_list::{BlockAccessIndex, FlashblockAccessListConstruction},
-    bal_executor::{BalExecutorError, BalValidationError, CommittedState},
+    bal_executor::{BalExecutorError, CommittedState},
     database::{
         bal_builder_db::{BalBuilderDb, NoOpCommitDB},
         bundle_db::BundleDb,
         temporal_db::{TemporalDb, TemporalDbFactory},
     },
-    executor::FlashblocksBlockBuilder,
+    execution_strategy::{
+        ExecutionStrategy, FlashblockTypes, StateRootHandle, StateRootResult, ValidationCtx,
+    },
     flashblock_validation_metrics::{
         FlashblockValidationAttemptMetrics, FlashblockValidationMetrics,
     },
@@ -64,19 +61,42 @@ use crate::{
 /// A type alias for the BAL builder database with a cache layer.
 pub type ValidatorDb<'a, DB> = BalBuilderDb<&'a mut NoOpCommitDB<TemporalDb<DB>>>;
 
-pub struct FlashblocksBlockValidator {
+pub struct FlashblocksBlockValidator<Evm: ConfigureEvm, T: FlashblockTypes<Evm>> {
     pub chain_spec: Arc<OpChainSpec>,
-    pub evm_env: EvmEnvFor<OpEvmConfig>,
-    pub evm_config: OpEvmConfig,
+    pub evm_env: EvmEnvFor<Evm>,
+    pub evm_config: Evm,
     pub execution_context: OpBlockExecutionCtx,
     pub header: Arc<SealedHeader>,
     pub flashblock_validation_metrics: Arc<FlashblockValidationMetrics>,
+    pub execution_strategy: T::Execution,
+    _phantom: PhantomData<fn() -> T>,
 }
 
-impl FlashblocksBlockValidator {
+impl<Evm: ConfigureEvm + Clone, T: FlashblockTypes<Evm>> FlashblocksBlockValidator<Evm, T> {
+    pub fn new(
+        chain_spec: Arc<OpChainSpec>,
+        evm_env: EvmEnvFor<Evm>,
+        evm_config: Evm,
+        execution_context: OpBlockExecutionCtx,
+        header: Arc<SealedHeader>,
+        flashblock_validation_metrics: Arc<FlashblockValidationMetrics>,
+        execution_strategy: T::Execution,
+    ) -> Self {
+        Self {
+            chain_spec,
+            evm_env,
+            evm_config,
+            execution_context,
+            header,
+            flashblock_validation_metrics,
+            execution_strategy,
+            _phantom: PhantomData,
+        }
+    }
+
     pub fn validate_flashblock_with_state(
         &self,
-        client: impl StateProviderFactory + Clone + Sync,
+        client: impl StateProviderFactory + Clone + Sync + 'static,
         diff: ExecutionPayloadFlashblockDeltaV1,
         parent: &SealedHeader<Header>,
         payload_id: PayloadId,
@@ -88,6 +108,8 @@ impl FlashblocksBlockValidator {
         let mut attempt_metrics = FlashblockValidationAttemptMetrics::default();
 
         let result = (|| -> Result<OpBuiltPayload, BalExecutorError> {
+            let committed_state = CommittedState::<OpRethReceiptBuilder>::try_from(state)?;
+
             let next_payload = metered_fn(
                 tracing::trace_span!(
                     target: "flashblocks::coordinator",
@@ -99,27 +121,21 @@ impl FlashblocksBlockValidator {
                 ),
                 metrics::histogram!("flashblocks.validate", "access_list" => has_bal.to_string()),
                 |_span| {
-                    if has_bal {
-                        let committed_state =
-                            CommittedState::<OpRethReceiptBuilder>::try_from(state)?;
-                        self.validate_flashblock_parallel(
-                            client,
-                            diff,
+                    self.execution_strategy.execute(
+                        ValidationCtx {
                             parent,
-                            payload_id,
-                            committed_state,
-                            &mut attempt_metrics,
-                        )
-                    } else {
-                        self.validate_flashblock(
-                            client,
-                            diff,
-                            parent,
-                            payload_id,
-                            state,
-                            &mut attempt_metrics,
-                        )
-                    }
+                            attempt_metrics: &mut attempt_metrics,
+                            chain_spec: self.chain_spec.clone(),
+                            evm_env: self.evm_env.clone(),
+                            evm_config: self.evm_config.clone(),
+                            execution_context: self.execution_context.clone(),
+                            header: self.header.clone(),
+                        },
+                        client,
+                        diff,
+                        committed_state,
+                        payload_id,
+                    )
                 },
             )?;
 
@@ -180,345 +196,6 @@ impl FlashblocksBlockValidator {
 
         Ok(())
     }
-
-    pub fn validate_flashblock(
-        &self,
-        client: impl StateProviderFactory + Clone,
-        diff: ExecutionPayloadFlashblockDeltaV1,
-        parent: &SealedHeader<Header>,
-        payload_id: PayloadId,
-        state: Option<&OpBuiltPayload<OpPrimitives>>,
-        attempt_metrics: &mut FlashblockValidationAttemptMetrics,
-    ) -> Result<OpBuiltPayload, BalExecutorError> {
-        let committed_state = CommittedState::<OpRethReceiptBuilder>::try_from(state)?;
-        let bundle_state = committed_state.bundle.clone();
-
-        // 1. Setup state database with committed bundle
-        let state_provider = client
-            .state_by_block_hash(parent.hash())
-            .map_err(BalExecutorError::other)?;
-
-        let mut db = State::builder()
-            .with_database(StateProviderDatabase::new(state_provider.as_ref()))
-            .with_bundle_prestate(bundle_state)
-            .with_bundle_update()
-            .build();
-
-        // 2. Create EVM and executor
-        let evm = OpEvmFactory::<OpTx>::default().create_evm(&mut db, self.evm_env.clone());
-
-        let mut executor = OpBlockExecutor::new(
-            evm,
-            self.execution_context.clone(),
-            (*self.chain_spec).clone(),
-            OpRethReceiptBuilder::default(),
-        );
-
-        executor.gas_used = committed_state.gas_used;
-        executor.receipts = committed_state.receipts_iter().cloned().collect();
-
-        // 3. Create block builder with committed transactions
-        let mut builder = FlashblocksBlockBuilder::<OpPrimitives, _>::new(
-            self.execution_context.clone(),
-            &self.header,
-            executor,
-            committed_state.transactions_iter().cloned().collect(),
-            self.chain_spec.clone(),
-        );
-
-        // 4. Apply pre-execution changes on first flashblock
-        if state.is_none() {
-            let pre_execution_changes_started = Instant::now();
-            builder.apply_pre_execution_changes()?;
-            attempt_metrics.record_stage_duration(
-                PayloadBuildStage::PreExecutionChanges,
-                pre_execution_changes_started.elapsed(),
-            );
-        }
-
-        // 5. Decode and execute diff transactions, tracking fees
-        let basefee = self.evm_env.block_env.basefee;
-        let transactions = decode_transactions_with_indices(
-            &diff.transactions,
-            committed_state.transactions_iter().count() as u16,
-        )?;
-
-        let mut fees = U256::ZERO;
-        let txs_execution_started = Instant::now();
-        for (_, tx) in &transactions {
-            let gag_used = builder
-                .execute_transaction_with_commit_condition(tx.clone(), |_| CommitChanges::Yes)?;
-
-            if !tx.is_deposit()
-                && let Some(gas_used) = gag_used
-            {
-                let miner_fee = tx
-                    .effective_tip_per_gas(basefee)
-                    .expect("fee is always valid; execution succeeded");
-                fees += U256::from(gas_used) * U256::from(miner_fee);
-            }
-        }
-        attempt_metrics.record_stage_duration(
-            PayloadBuildStage::SequencerTxExecution,
-            txs_execution_started.elapsed(),
-        );
-
-        // 6. Finish and seal the block
-        let finish_state_provider = client
-            .state_by_block_hash(parent.hash())
-            .map_err(BalExecutorError::other)?;
-
-        let finalize_started = Instant::now();
-        let (outcome, bundle) =
-            builder.finish_with_bundle(finish_state_provider.as_ref(), &mut *attempt_metrics)?;
-        attempt_metrics
-            .record_stage_duration(PayloadBuildStage::Finalize, finalize_started.elapsed());
-
-        let BlockBuilderOutcome {
-            execution_result,
-            block,
-            hashed_state,
-            trie_updates,
-        } = outcome;
-
-        let sealed_block = Arc::new(block.sealed_block().clone());
-
-        let execution_output = BlockExecutionOutput {
-            state: bundle,
-            result: execution_result,
-        };
-
-        let executed_block: BuiltPayloadExecutedBlock<OpPrimitives> = BuiltPayloadExecutedBlock {
-            recovered_block: Arc::new(block),
-            execution_output: Arc::new(execution_output),
-            hashed_state: either::Left(Arc::new(hashed_state)),
-            trie_updates: either::Left(Arc::new(trie_updates)),
-        };
-
-        Ok(OpBuiltPayload::new(
-            payload_id,
-            sealed_block,
-            committed_state.fees + fees,
-            Some(executed_block),
-        ))
-    }
-
-    pub fn validate_flashblock_parallel(
-        &self,
-        client: impl StateProviderFactory + Clone + Sync,
-        diff: ExecutionPayloadFlashblockDeltaV1,
-        parent: &SealedHeader<Header>,
-        payload_id: PayloadId,
-        committed_state: CommittedState<OpRethReceiptBuilder>,
-        attempt_metrics: &mut FlashblockValidationAttemptMetrics,
-    ) -> Result<OpBuiltPayload, BalExecutorError> {
-        let FlashblockAccessListData {
-            access_list,
-            access_list_hash,
-        } = diff
-            .access_list_data
-            .ok_or(BalValidationError::MissingAccessListData.boxed())
-            .map_err(BalExecutorError::from)?;
-
-        // 1. Setup database layers for the base evm/executor
-        let state_provider = client
-            .state_by_block_hash(parent.hash())
-            .map_err(BalExecutorError::other)?;
-        let block_access_index = access_list.min_tx_index;
-
-        // 2. Create channel for state root computation
-        let (state_root_sender, state_root_receiver) = crossbeam_channel::bounded(1);
-
-        let mut bundle_state = committed_state.bundle.clone();
-
-        let fallback_bundle_state: Arc<BundleState> = bundle_state.clone().into();
-
-        // The cumulative bundle for state root computation contains all state changes
-        // from prior flashblocks plus the current access list.
-        let state_provider_database = StateProviderDatabase::new(state_provider.as_ref());
-        access_list
-            .extend_bundle(&mut bundle_state, &state_provider_database)
-            .map_err(BalExecutorError::other)?;
-
-        let bundle_database = BundleDb::new(state_provider_database, fallback_bundle_state.clone());
-        let temporal_db_factory = TemporalDbFactory::new(&bundle_database, &access_list);
-        let temporal_db = temporal_db_factory.db(bundle_database, block_access_index as u64);
-        let mut noop_state = NoOpCommitDB::new(temporal_db);
-
-        let mut database = BalBuilderDb::new(&mut noop_state);
-        database.set_index(block_access_index);
-
-        let bundle_clone = bundle_state.clone();
-
-        let state_root_provider = client
-            .state_by_block_hash(parent.hash())
-            .map_err(BalExecutorError::other)?;
-
-        // 3. Spawn the state root computation in a separate thread
-        rayon::spawn(move || {
-            let result = compute_state_root(state_root_provider.into(), &bundle_clone.state);
-            let _ = state_root_sender.send(result);
-        });
-
-        let evm = OpEvmFactory::default().create_evm(database, self.evm_env.clone());
-
-        let mut executor: OpBlockExecutor<_, OpRethReceiptBuilder, Arc<OpChainSpec>> =
-            OpBlockExecutor::new(
-                evm,
-                self.execution_context.clone(),
-                self.chain_spec.clone(),
-                OpRethReceiptBuilder::default(),
-            );
-
-        executor.gas_used = committed_state.gas_used;
-        executor.receipts = committed_state.receipts_iter().cloned().collect();
-
-        let (validator, access_list_receiver) = BalBlockValidator::new(
-            self.execution_context.clone(),
-            parent,
-            executor,
-            bundle_state.clone().into(),
-            fallback_bundle_state,
-            committed_state.transactions_iter().cloned().collect(),
-            self.chain_spec.clone(),
-            &temporal_db_factory,
-            state_root_receiver,
-            self.evm_env.clone(),
-            (access_list.min_tx_index, access_list.max_tx_index),
-            attempt_metrics,
-        );
-
-        // Decode diff transactions for parallel execution.
-        // Start index is committed tx count + 1 (accounting for pre-execution at index 0).
-        let transactions_offset = committed_state.transactions.len() as u16 + 1;
-        let executor_transactions =
-            decode_transactions_with_indices(&diff.transactions, transactions_offset)?;
-
-        let finish_state_provider = client
-            .state_by_block_hash(parent.hash())
-            .map_err(BalExecutorError::other)?;
-
-        // 4. Compute the block using BAL in parallel
-        let (outcome, fees): (BlockBuilderOutcome<OpPrimitives>, u128) = validator.execute_block(
-            client.clone(),
-            finish_state_provider.as_ref(),
-            executor_transactions,
-        )?;
-
-        let computed_access_list = access_list_receiver
-            .recv()
-            .map_err(BalExecutorError::other)?;
-
-        let computed_access_list_hash =
-            world_chain_primitives::access_list::access_list_hash(&computed_access_list);
-
-        // 5. Verify computed results
-        if computed_access_list_hash != access_list_hash {
-            error!(
-                target: "flashblocks::state_executor",
-                ?access_list_hash,
-                expected = ?access_list_hash,
-                access_list = ?computed_access_list,
-                expected_access_list = ?access_list.clone(),
-                block_number = outcome.block.number(),
-                block_hash = ?outcome.block.hash(),
-                execution_context = ?self.execution_context,
-                "Access list hash mismatch"
-            );
-
-            return Err(BalValidationError::BalHashMismatch {
-                expected: access_list_hash,
-                got: computed_access_list_hash,
-                expected_bal: access_list,
-                got_bal: computed_access_list,
-            }
-            .boxed()
-            .into());
-        }
-
-        if outcome.block.receipts_root != diff.receipts_root {
-            error!(
-                target: "flashblocks::state_executor",
-                got = ?outcome.block.receipts_root,
-                expected = ?diff.receipts_root,
-                "Receipts root mismatch"
-            );
-
-            return Err(BalValidationError::ReceiptsRootMismatch {
-                expected: diff.receipts_root,
-                got: outcome.block.receipts_root,
-            }
-            .boxed()
-            .into());
-        }
-
-        if outcome.block.state_root != diff.state_root {
-            error!(
-                target: "flashblocks::state_executor",
-                got = ?outcome.block.state_root,
-                expected = ?diff.state_root,
-                expected_bundle = ?bundle_state,
-                "State root mismatch"
-            );
-
-            return Err(BalValidationError::StateRootMismatch {
-                expected: diff.state_root,
-                got: outcome.block.state_root,
-                bundle_state: bundle_state.clone(),
-            }
-            .boxed()
-            .into());
-        }
-
-        if outcome.block.hash() != diff.block_hash {
-            error!(
-                target: "flashblocks::state_executor",
-                got = ?outcome.block.hash(),
-                expected = ?diff.block_hash,
-                "Block hash mismatch"
-            );
-
-            return Err(BalValidationError::BalHashMismatch {
-                expected: diff.block_hash,
-                got: outcome.block.hash(),
-                expected_bal: access_list,
-                got_bal: computed_access_list,
-            }
-            .boxed()
-            .into());
-        }
-
-        // 6. Seal the block
-        let BlockBuilderOutcome {
-            execution_result,
-            block,
-            hashed_state,
-            trie_updates,
-        } = outcome;
-
-        let sealed_block = Arc::new(block.sealed_block().clone());
-
-        let execution_output = BlockExecutionOutput {
-            state: bundle_state.clone(),
-            result: execution_result,
-        };
-
-        let executed_block: BuiltPayloadExecutedBlock<OpPrimitives> = BuiltPayloadExecutedBlock {
-            recovered_block: Arc::new(block),
-            execution_output: Arc::new(execution_output),
-            hashed_state: either::Left(Arc::new(hashed_state)),
-            trie_updates: either::Left(Arc::new(trie_updates)),
-        };
-
-        let payload = OpBuiltPayload::new(
-            payload_id,
-            sealed_block,
-            U256::from(fees),
-            Some(executed_block),
-        );
-
-        Ok(payload)
-    }
 }
 
 /// Result of executing a single transaction in parallel.
@@ -526,7 +203,7 @@ impl FlashblocksBlockValidator {
 /// This struct accumulates execution artifacts that will be merged
 /// after all transactions complete.
 #[derive(Default)]
-pub struct ParalleExecutionResult {
+pub struct ParallelExecutionResult {
     pub receipts: Vec<OpReceipt>,
     /// Gas consumed by this transaction
     pub gas_used: u64,
@@ -539,7 +216,13 @@ pub struct ParalleExecutionResult {
 }
 
 /// A wrapper around the [`BasicBlockBuilder`] for flashblocks.
-pub struct BalBlockValidator<'a, DbRef: DatabaseRef + 'a, R: OpReceiptBuilder, Evm> {
+pub struct BalBlockValidator<
+    'a,
+    DbRef: DatabaseRef + 'a,
+    R: OpReceiptBuilder,
+    Evm,
+    H: StateRootHandle,
+> {
     pub inner: BasicBlockBuilder<
         'a,
         OpBlockExecutorFactory<OpRethReceiptBuilder, OpChainSpec>,
@@ -550,8 +233,7 @@ pub struct BalBlockValidator<'a, DbRef: DatabaseRef + 'a, R: OpReceiptBuilder, E
     pub bundle_state: Arc<BundleState>,
     pub fallback_bundle_state: Arc<BundleState>,
     pub access_list_sender: crossbeam_channel::Sender<FlashblockAccessList>,
-    pub state_root_receiver:
-        crossbeam_channel::Receiver<Result<StateRootResult, BlockExecutionError>>,
+    pub state_root_handle: H,
     pub temporal_db_factory: &'a TemporalDbFactory,
     pub evm_env: EvmEnv<OpSpecId>,
     pub index_range: (u16, u16),
@@ -559,11 +241,18 @@ pub struct BalBlockValidator<'a, DbRef: DatabaseRef + 'a, R: OpReceiptBuilder, E
     _db_ref: PhantomData<DbRef>,
 }
 
-impl<'a, DBRef, R, E> BalBlockValidator<'a, DBRef, R, E>
+impl<'a, DBRef, R, E, H> BalBlockValidator<'a, DBRef, R, E, H>
 where
     R: OpReceiptBuilder<Transaction = OpTransactionSigned, Receipt = OpReceipt>,
     DBRef: DatabaseRef + Clone + std::fmt::Debug + 'a,
-    E: Evm<DB = ValidatorDb<'a, DBRef>, Tx = OpTx, Spec = OpSpecId, BlockEnv = BlockEnv>,
+    E: Evm<
+            DB = ValidatorDb<'a, DBRef>,
+            Tx = OpTx,
+            Spec = OpSpecId,
+            BlockEnv = BlockEnv,
+        >,
+    H: StateRootHandle,
+    OpTx: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>,
 {
     /// Creates a new [`FlashblocksBlockBuilder`] with the given executor factory and assembler.
     pub fn new(
@@ -575,9 +264,7 @@ where
         transactions: Vec<Recovered<OpTransactionSigned>>,
         chain_spec: Arc<OpChainSpec>,
         temporal_db_factory: &'a TemporalDbFactory,
-        state_root_receiver: crossbeam_channel::Receiver<
-            Result<StateRootResult, BlockExecutionError>,
-        >,
+        state_root_handle: H,
         evm_env: EvmEnv<OpSpecId>,
         index_range: (u16, u16),
         attempt_metrics: &'a mut FlashblockValidationAttemptMetrics,
@@ -596,7 +283,7 @@ where
                 bundle_state,
                 fallback_bundle_state,
                 access_list_sender: tx,
-                state_root_receiver,
+                state_root_handle,
                 temporal_db_factory,
                 evm_env,
                 index_range,
@@ -618,7 +305,7 @@ where
     }
 }
 
-impl<'a, DB, R, E> BlockBuilder for BalBlockValidator<'a, DB, R, E>
+impl<'a, DB, R, E, H> BlockBuilder for BalBlockValidator<'a, DB, R, E, H>
 where
     DB: DatabaseRef + Clone + std::fmt::Debug + 'a,
     E: Evm<
@@ -629,6 +316,8 @@ where
             BlockEnv = BlockEnv,
         >,
     R: OpReceiptBuilder<Receipt = OpReceipt, Transaction = OpTransactionSigned>,
+    H: StateRootHandle,
+    OpTx: FromRecoveredTx<OpTransactionSigned> + FromTxWithEncoded<OpTransactionSigned>,
 {
     type Primitives = OpPrimitives;
     type Executor = OpBlockExecutor<E, R, Arc<OpChainSpec>>;
@@ -660,7 +349,10 @@ where
     fn finish(
         mut self,
         state: impl StateProvider,
-        _state_root_precomputed: Option<(B256, TrieUpdates)>,
+        _state_root_precomputed: Option<(
+            alloy_primitives::B256,
+            reth_trie_common::updates::TrieUpdates,
+        )>,
     ) -> Result<BlockBuilderOutcome<OpPrimitives>, BlockExecutionError> {
         let finalize_started = Instant::now();
         // finalize the database index
@@ -675,10 +367,7 @@ where
             state_root,
             trie_updates,
             hashed_state,
-        } = self
-            .state_root_receiver
-            .recv()
-            .map_err(BlockExecutionError::other)??;
+        } = self.state_root_handle.finish()?;
         self.attempt_metrics
             .record_stage_duration(PayloadBuildStage::StateRoot, state_root_started.elapsed());
 
@@ -744,7 +433,7 @@ where
     }
 }
 
-impl<'a, DbRef, R, E> BalBlockValidator<'a, DbRef, R, E>
+impl<'a, DbRef, R, E, H> BalBlockValidator<'a, DbRef, R, E, H>
 where
     DbRef: DatabaseRef + Clone + std::fmt::Debug + 'a,
     E: Evm<
@@ -758,6 +447,8 @@ where
         + Send
         + Sync
         + Clone,
+    H: StateRootHandle,
+    OpTx: FromRecoveredTx<OpTransactionSigned> + FromTxWithEncoded<OpTransactionSigned>,
 {
     pub fn execute_block<Client>(
         mut self,
@@ -879,11 +570,11 @@ where
 
 /// Merge individual transaction results into an aggregated result.
 fn merge_transaction_results(
-    results: Vec<ParalleExecutionResult>,
+    results: Vec<ParallelExecutionResult>,
     initial_gas_used: u64,
-) -> ParalleExecutionResult {
+) -> ParallelExecutionResult {
     results.into_iter().fold(
-        ParalleExecutionResult {
+        ParallelExecutionResult {
             gas_used: initial_gas_used,
             ..Default::default()
         },
@@ -910,13 +601,14 @@ pub fn execute_transaction<R, DBRef>(
     evm_env: EvmEnv<OpSpecId>,
     db_factory: &TemporalDbFactory,
     db: DBRef,
-) -> Result<ParalleExecutionResult, BalExecutorError>
+) -> Result<ParallelExecutionResult, BalExecutorError>
 where
     DBRef: DatabaseRef + std::fmt::Debug,
     R: OpReceiptBuilder<Receipt = OpReceipt, Transaction = OpTransactionSigned>
         + Send
         + Sync
         + Clone,
+    OpTx: FromRecoveredTx<OpTransactionSigned> + FromTxWithEncoded<OpTransactionSigned>,
 {
     let temporal_db = db_factory.db(db, index as u64);
     let state = NoOpCommitDB::new(temporal_db);
@@ -960,38 +652,12 @@ where
     let (db, _evm_env) = evm.finish();
     let access_list = db.finish().map_err(BalExecutorError::other)?;
 
-    Ok(ParalleExecutionResult {
+    Ok(ParallelExecutionResult {
         receipts: result.receipts,
         gas_used: result.gas_used,
         fees,
         access_list,
         index,
-    })
-}
-
-/// Result of computing the state root from a bundle state.
-pub struct StateRootResult {
-    pub state_root: B256,
-    pub trie_updates: TrieUpdates,
-    pub hashed_state: HashedPostState,
-}
-
-pub fn compute_state_root(
-    state_provider: Arc<dyn StateProvider + Send>,
-    bundle_state: &AddressMap<BundleAccount>,
-) -> Result<StateRootResult, BlockExecutionError> {
-    // compute hashed post state
-    let hashed_state = HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state);
-
-    // compute state root & trie updates
-    let (state_root, trie_updates) = state_provider
-        .state_root_with_updates(hashed_state.clone())
-        .map_err(BlockExecutionError::other)?;
-
-    Ok(StateRootResult {
-        state_root,
-        trie_updates,
-        hashed_state,
     })
 }
 
@@ -1007,9 +673,10 @@ pub fn decode_transactions_with_indices(
             let tx_envelope = OpTransactionSigned::decode_2718(&mut tx.as_ref())
                 .map_err(BalExecutorError::other)?;
 
-            let recovered = tx_envelope
-                .try_clone_into_recovered()
+            let signer = tx_envelope
+                .recover_signer()
                 .map_err(BalExecutorError::other)?;
+            let recovered = Recovered::new_unchecked(tx_envelope, signer);
 
             Ok((start_index + i as BlockAccessIndex, recovered))
         })

--- a/crates/builder/src/validator.rs
+++ b/crates/builder/src/validator.rs
@@ -1,7 +1,10 @@
-use alloy_consensus::{Header, Transaction};
+use alloy_consensus::{
+    Header, Transaction,
+    transaction::{Recovered, SignerRecoverable},
+};
 use alloy_eips::Decodable2718;
 use op_revm::{OpHaltReason, OpSpecId};
-use reth_primitives_traits::{Recovered, RecoveredBlock, SealedHeader, SignerRecoverable};
+use reth_primitives_traits::{RecoveredBlock, SealedHeader};
 use std::{io::Error, marker::PhantomData, sync::Arc, time::Instant};
 
 use alloy_primitives::Bytes;
@@ -13,7 +16,7 @@ use alloy_op_evm::{
 use alloy_rpc_types_engine::PayloadId;
 use eyre::eyre::bail;
 use op_alloy_consensus::OpReceipt;
-use rayon::{iter::IntoParallelIterator, prelude::ParallelIterator};
+use rayon::prelude::*;
 use reth_chain_state::ExecutedBlock;
 use reth_revm::database::StateProviderDatabase;
 use world_chain_primitives::{
@@ -237,12 +240,7 @@ impl<'a, DBRef, R, E, H> BalBlockValidator<'a, DBRef, R, E, H>
 where
     R: OpReceiptBuilder<Transaction = OpTransactionSigned, Receipt = OpReceipt>,
     DBRef: DatabaseRef + Clone + std::fmt::Debug + 'a,
-    E: Evm<
-            DB = ValidatorDb<'a, DBRef>,
-            Tx = OpTx,
-            Spec = OpSpecId,
-            BlockEnv = BlockEnv,
-        >,
+    E: Evm<DB = ValidatorDb<'a, DBRef>, Tx = OpTx, Spec = OpSpecId, BlockEnv = BlockEnv>,
     H: StateRootHandle,
     OpTx: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>,
 {

--- a/crates/builder/src/validator.rs
+++ b/crates/builder/src/validator.rs
@@ -121,6 +121,7 @@ impl<Evm: ConfigureEvm + Clone, T: FlashblockTypes<Evm>> FlashblocksBlockValidat
                             chain_spec: self.chain_spec.clone(),
                             evm_env: self.evm_env.clone(),
                             execution_context: self.execution_context.clone(),
+                            state_root_strategy: T::StateRoot::default(),
                         },
                         client,
                         diff,

--- a/crates/builder/src/validator.rs
+++ b/crates/builder/src/validator.rs
@@ -40,6 +40,7 @@ use revm::{
 };
 use tracing::{error, info, trace};
 
+use crate::state_root_strategy::{FlashblockTypes, StateRootHandle};
 use crate::{
     access_list::{BlockAccessIndex, FlashblockAccessListConstruction},
     bal_executor::{BalExecutorError, CommittedState},
@@ -48,9 +49,7 @@ use crate::{
         bundle_db::BundleDb,
         temporal_db::{TemporalDb, TemporalDbFactory},
     },
-    execution_strategy::{
-        ExecutionStrategy, FlashblockTypes, StateRootHandle, StateRootResult, ValidationCtx,
-    },
+    execution_strategy::{ExecutionStrategy, StateRootResult, ValidationCtx},
     flashblock_validation_metrics::{
         FlashblockValidationAttemptMetrics, FlashblockValidationMetrics,
     },

--- a/crates/builder/src/validator.rs
+++ b/crates/builder/src/validator.rs
@@ -63,9 +63,7 @@ pub type ValidatorDb<'a, DB> = BalBuilderDb<&'a mut NoOpCommitDB<TemporalDb<DB>>
 pub struct FlashblocksBlockValidator<Evm: ConfigureEvm, T: FlashblockTypes<Evm>> {
     pub chain_spec: Arc<OpChainSpec>,
     pub evm_env: EvmEnvFor<Evm>,
-    pub evm_config: Evm,
     pub execution_context: OpBlockExecutionCtx,
-    pub header: Arc<SealedHeader>,
     pub flashblock_validation_metrics: Arc<FlashblockValidationMetrics>,
     pub execution_strategy: T::Execution,
     _phantom: PhantomData<fn() -> T>,
@@ -75,18 +73,14 @@ impl<Evm: ConfigureEvm + Clone, T: FlashblockTypes<Evm>> FlashblocksBlockValidat
     pub fn new(
         chain_spec: Arc<OpChainSpec>,
         evm_env: EvmEnvFor<Evm>,
-        evm_config: Evm,
         execution_context: OpBlockExecutionCtx,
-        header: Arc<SealedHeader>,
         flashblock_validation_metrics: Arc<FlashblockValidationMetrics>,
         execution_strategy: T::Execution,
     ) -> Self {
         Self {
             chain_spec,
             evm_env,
-            evm_config,
             execution_context,
-            header,
             flashblock_validation_metrics,
             execution_strategy,
             _phantom: PhantomData,
@@ -126,9 +120,7 @@ impl<Evm: ConfigureEvm + Clone, T: FlashblockTypes<Evm>> FlashblocksBlockValidat
                             attempt_metrics: &mut attempt_metrics,
                             chain_spec: self.chain_spec.clone(),
                             evm_env: self.evm_env.clone(),
-                            evm_config: self.evm_config.clone(),
                             execution_context: self.execution_context.clone(),
-                            header: self.header.clone(),
                         },
                         client,
                         diff,

--- a/crates/test-utils/src/builder.rs
+++ b/crates/test-utils/src/builder.rs
@@ -598,6 +598,7 @@ where
         payloads.push((
             payload,
             prev_outcome.as_ref().map(|(o, state)| CommittedState {
+                is_first: false,
                 gas_used: o.block.gas_used(),
                 fees: U256::ZERO,
                 bundle: state.clone(),

--- a/e2e-tests/src/fuzz/proptest.rs
+++ b/e2e-tests/src/fuzz/proptest.rs
@@ -24,9 +24,7 @@ pub fn validate(
 ) -> Result<OpBuiltPayload, Box<dyn std::error::Error + Send + Sync>> {
     let state_provider = create_test_state_provider();
 
-    let strategy = FlashblocksBalExecutionStrategy {
-        state_root_strategy: AsyncStateRootStrategy,
-    };
+    let strategy = FlashblocksBalExecutionStrategy;
 
     let mut attempt_metrics = FlashblockValidationAttemptMetrics::default();
     let payload_id = PayloadId::default();
@@ -38,6 +36,7 @@ pub fn validate(
             chain_spec: CHAIN_SPEC.clone(),
             evm_env: EVM_ENV.clone(),
             execution_context: BLOCK_EXECUTION_CTX.clone(),
+            state_root_strategy: AsyncStateRootStrategy,
         },
         state_provider,
         diff.clone(),

--- a/e2e-tests/src/fuzz/proptest.rs
+++ b/e2e-tests/src/fuzz/proptest.rs
@@ -1,7 +1,5 @@
 //! Property tests for chaos contract interactions and BAL validation.
 
-use std::sync::Arc;
-
 use alloy_primitives::U256;
 use alloy_rpc_types_engine::PayloadId;
 use reth_optimism_evm::OpRethReceiptBuilder;
@@ -9,42 +7,42 @@ use reth_optimism_node::OpBuiltPayload;
 use revm::database::BundleState;
 use world_chain_builder::{
     bal_executor::CommittedState,
-    flashblock_validation_metrics::{
-        FlashblockValidationAttemptMetrics, FlashblockValidationMetrics,
-    },
-    validator::FlashblocksBlockValidator,
+    execution_strategy::{ExecutionStrategy, FlashblocksBalExecutionStrategy, ValidationCtx},
+    flashblock_validation_metrics::FlashblockValidationAttemptMetrics,
+    state_root_strategy::AsyncStateRootStrategy,
 };
 use world_chain_primitives::primitives::ExecutionPayloadFlashblockDeltaV1;
 
 use super::fixtures::{
-    BLOCK_EXECUTION_CTX, CHAIN_SPEC, EVM_CONFIG, EVM_ENV, SEALED_HEADER, create_test_state_provider,
+    BLOCK_EXECUTION_CTX, CHAIN_SPEC, EVM_ENV, SEALED_HEADER, create_test_state_provider,
 };
 
-/// Execute transactions in parallel using FlashblocksBlockValidator
+/// Execute transactions in parallel using FlashblocksBalExecutionStrategy
 pub fn validate(
     diff: &ExecutionPayloadFlashblockDeltaV1,
     committed_state: CommittedState<OpRethReceiptBuilder>,
 ) -> Result<OpBuiltPayload, Box<dyn std::error::Error + Send + Sync>> {
     let state_provider = create_test_state_provider();
 
-    let validator = FlashblocksBlockValidator {
-        chain_spec: CHAIN_SPEC.clone(),
-        evm_config: EVM_CONFIG.clone(),
-        execution_context: BLOCK_EXECUTION_CTX.clone(),
-        evm_env: EVM_ENV.clone(),
-        header: std::sync::Arc::new(SEALED_HEADER.clone()),
-        flashblock_validation_metrics: Arc::new(FlashblockValidationMetrics::default()),
+    let strategy = FlashblocksBalExecutionStrategy {
+        state_root_strategy: AsyncStateRootStrategy,
     };
 
-    let mut flashblock_validatoin_metrics_attempt = FlashblockValidationAttemptMetrics::default();
+    let mut attempt_metrics = FlashblockValidationAttemptMetrics::default();
     let payload_id = PayloadId::default();
-    let payload = validator.validate_flashblock_parallel(
+
+    let payload = strategy.execute(
+        ValidationCtx {
+            parent: &SEALED_HEADER,
+            attempt_metrics: &mut attempt_metrics,
+            chain_spec: CHAIN_SPEC.clone(),
+            evm_env: EVM_ENV.clone(),
+            execution_context: BLOCK_EXECUTION_CTX.clone(),
+        },
         state_provider,
         diff.clone(),
-        &SEALED_HEADER,
-        payload_id,
         committed_state,
-        &mut flashblock_validatoin_metrics_attempt,
+        payload_id,
     )?;
 
     Ok(payload)

--- a/e2e-tests/src/fuzz/proptest.rs
+++ b/e2e-tests/src/fuzz/proptest.rs
@@ -53,6 +53,7 @@ fn unwrap_committed_state(
     state: Option<CommittedState<OpRethReceiptBuilder>>,
 ) -> CommittedState<OpRethReceiptBuilder> {
     state.unwrap_or_else(|| CommittedState {
+        is_first: true,
         gas_used: 0,
         fees: U256::ZERO,
         receipts: vec![],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core flashblock execution/validation and state-root computation paths; although largely a refactor, strategy selection and first-flashblock handling could alter block construction behavior if miswired.
> 
> **Overview**
> Refactors flashblock validation to route execution through a new `ExecutionStrategy` + `StateRootStrategy` abstraction, with concrete BAL (parallel + async state-root) and legacy (sequential + sync state-root) implementations selected at runtime based on whether `access_list_data` is present.
> 
> Moves the previously inlined legacy and BAL validation/execution logic out of `FlashblocksBlockValidator` into `execution_strategy.rs`, introduces `flashblock_types.rs` to bind strategy pairs, and adds `CommittedState.is_first` so the legacy path only applies pre-execution changes on the first flashblock.
> 
> Updates transaction decoding to recover signers via `recover_signer()` and adjusts test/fuzz helpers to use the new strategy API and initialize `CommittedState` with `is_first`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53e1e6673bc34e69e126d0dec531539a9e5fa125. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->