### PR TITLE
feat: add tests for profiling with samply

### DIFF
--- a/crates/builder/src/validator.rs
+++ b/crates/builder/src/validator.rs
@@ -33,7 +33,10 @@ use reth_optimism_evm::{OpBlockAssembler, OpEvmConfig, OpRethReceiptBuilder};
 use reth_optimism_node::OpBuiltPayload;
 use reth_optimism_primitives::{OpPrimitives, OpTransactionSigned};
 use reth_primitives::{Recovered, RecoveredBlock, SealedHeader};
-use reth_provider::{BlockExecutionOutput, StateProvider, StateProviderFactory};
+use reth_provider::{
+    AccountReader, BlockExecutionOutput, BlockHashReader, BytecodeReader, ProviderError,
+    StateProvider, StateProviderBox, StateProviderFactory,
+};
 use reth_revm::database::StateProviderDatabase;
 use reth_trie_common::{HashedPostState, KeccakKeyHasher, updates::TrieUpdates};
 use revm::{
@@ -64,6 +67,56 @@ use crate::{
 
 /// A type alias for the BAL builder database with a cache layer.
 pub type ValidatorDb<'a, DB> = BalBuilderDb<&'a mut NoOpCommitDB<TemporalDb<DB>>>;
+
+#[derive(Clone)]
+struct SharedStateProviderDatabase {
+    provider: Arc<Mutex<StateProviderBox>>,
+}
+
+impl SharedStateProviderDatabase {
+    fn new(provider: StateProviderBox) -> Self {
+        Self {
+            provider: Arc::new(Mutex::new(provider)),
+        }
+    }
+}
+
+impl std::fmt::Debug for SharedStateProviderDatabase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SharedStateProviderDatabase")
+            .finish_non_exhaustive()
+    }
+}
+
+impl DatabaseRef for SharedStateProviderDatabase {
+    type Error = ProviderError;
+
+    fn basic_ref(&self, address: Address) -> Result<Option<revm::state::AccountInfo>, Self::Error> {
+        let provider = self.provider.lock();
+        Ok(AccountReader::basic_account(&**provider, &address)?.map(Into::into))
+    }
+
+    fn code_by_hash_ref(&self, code_hash: B256) -> Result<revm::state::Bytecode, Self::Error> {
+        let provider = self.provider.lock();
+        Ok(BytecodeReader::bytecode_by_hash(&**provider, &code_hash)?
+            .unwrap_or_default()
+            .0)
+    }
+
+    fn storage_ref(
+        &self,
+        address: Address,
+        index: revm::primitives::StorageKey,
+    ) -> Result<revm::primitives::StorageValue, Self::Error> {
+        let provider = self.provider.lock();
+        Ok(StateProvider::storage(&**provider, address, index.into())?.unwrap_or_default())
+    }
+
+    fn block_hash_ref(&self, number: u64) -> Result<B256, Self::Error> {
+        let provider = self.provider.lock();
+        Ok(BlockHashReader::block_hash(&**provider, number)?.unwrap_or_default())
+    }
+}
 
 pub struct FlashblocksBlockValidator {
     pub chain_spec: Arc<OpChainSpec>,

--- a/crates/builder/src/validator.rs
+++ b/crates/builder/src/validator.rs
@@ -33,10 +33,7 @@ use reth_optimism_evm::{OpBlockAssembler, OpEvmConfig, OpRethReceiptBuilder};
 use reth_optimism_node::OpBuiltPayload;
 use reth_optimism_primitives::{OpPrimitives, OpTransactionSigned};
 use reth_primitives::{Recovered, RecoveredBlock, SealedHeader};
-use reth_provider::{
-    AccountReader, BlockExecutionOutput, BlockHashReader, BytecodeReader, ProviderError,
-    StateProvider, StateProviderBox, StateProviderFactory,
-};
+use reth_provider::{BlockExecutionOutput, StateProvider, StateProviderFactory};
 use reth_revm::database::StateProviderDatabase;
 use reth_trie_common::{HashedPostState, KeccakKeyHasher, updates::TrieUpdates};
 use revm::{
@@ -67,56 +64,6 @@ use crate::{
 
 /// A type alias for the BAL builder database with a cache layer.
 pub type ValidatorDb<'a, DB> = BalBuilderDb<&'a mut NoOpCommitDB<TemporalDb<DB>>>;
-
-#[derive(Clone)]
-struct SharedStateProviderDatabase {
-    provider: Arc<Mutex<StateProviderBox>>,
-}
-
-impl SharedStateProviderDatabase {
-    fn new(provider: StateProviderBox) -> Self {
-        Self {
-            provider: Arc::new(Mutex::new(provider)),
-        }
-    }
-}
-
-impl std::fmt::Debug for SharedStateProviderDatabase {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SharedStateProviderDatabase")
-            .finish_non_exhaustive()
-    }
-}
-
-impl DatabaseRef for SharedStateProviderDatabase {
-    type Error = ProviderError;
-
-    fn basic_ref(&self, address: Address) -> Result<Option<revm::state::AccountInfo>, Self::Error> {
-        let provider = self.provider.lock();
-        Ok(AccountReader::basic_account(&**provider, &address)?.map(Into::into))
-    }
-
-    fn code_by_hash_ref(&self, code_hash: B256) -> Result<revm::state::Bytecode, Self::Error> {
-        let provider = self.provider.lock();
-        Ok(BytecodeReader::bytecode_by_hash(&**provider, &code_hash)?
-            .unwrap_or_default()
-            .0)
-    }
-
-    fn storage_ref(
-        &self,
-        address: Address,
-        index: revm::primitives::StorageKey,
-    ) -> Result<revm::primitives::StorageValue, Self::Error> {
-        let provider = self.provider.lock();
-        Ok(StateProvider::storage(&**provider, address, index.into())?.unwrap_or_default())
-    }
-
-    fn block_hash_ref(&self, number: u64) -> Result<B256, Self::Error> {
-        let provider = self.provider.lock();
-        Ok(BlockHashReader::block_hash(&**provider, number)?.unwrap_or_default())
-    }
-}
 
 pub struct FlashblocksBlockValidator {
     pub chain_spec: Arc<OpChainSpec>,

--- a/crates/builder/tests/README.md
+++ b/crates/builder/tests/README.md
@@ -1,0 +1,21 @@
+# Samply Profiling Tests
+
+These tests are for profiling node's performances using `samply`.
+
+## Requirements
+
+1. Install [samply](https://github.com/mstange/samply)
+
+## How to profile
+
+To run profiling with `samply` you need to run:
+
+```bash
+samply record cargo test -p world-chain-builder --release --test flashblock_validation_synthetic_profile <TEST_NAME> -- --ignored --exact --nocapture
+```
+
+A real example:
+
+```bash
+samply record cargo test -p world-chain-builder --release --test flashblock_validation_synthetic_profile profile_process_flashblock_world_id_like_bn254_without_bal_50_txs -- --ignored --exact --nocapture
+```

--- a/crates/builder/tests/flashblock_validation_synthetic_profile.rs
+++ b/crates/builder/tests/flashblock_validation_synthetic_profile.rs
@@ -1,0 +1,115 @@
+use std::sync::Arc;
+
+use reth_chain_state::ExecutedBlock;
+use reth_optimism_primitives::OpPrimitives;
+use world_chain_builder::{
+    coordinator::{FlashblocksExecutionCoordinator, process_flashblock},
+    flashblock_validation_metrics::FlashblockValidationMetrics,
+};
+use world_chain_p2p::protocol::handler::FlashblocksHandle;
+use world_chain_primitives::{ed25519_dalek::SigningKey, primitives::FlashblocksPayloadV1};
+use world_chain_test_utils::builder::{
+    BenchProvider, CHAIN_SPEC, EVM_CONFIG, build_flashblock_fixture_eth_transfers,
+    build_flashblock_fixture_fib, build_flashblock_fixture_world_id_like_bn254,
+};
+
+const MAX_DEFAULT_TX_COUNT: usize = 1000;
+const MAX_WORLD_ID_LIKE_BN254_TX_COUNT: usize = 50;
+
+fn fresh_coordinator(
+    rt: &tokio::runtime::Runtime,
+) -> (
+    FlashblocksExecutionCoordinator,
+    tokio::sync::watch::Receiver<Option<ExecutedBlock<OpPrimitives>>>,
+    tokio::sync::watch::Sender<Option<ExecutedBlock<OpPrimitives>>>,
+) {
+    let _guard = rt.enter();
+    let sk = SigningKey::from_bytes(&[1u8; 32]);
+    let vk = sk.verifying_key();
+    let handle = FlashblocksHandle::new(vk, Some(sk));
+    let (pending_tx, pending_rx) =
+        tokio::sync::watch::channel::<Option<ExecutedBlock<OpPrimitives>>>(None);
+    let coordinator = FlashblocksExecutionCoordinator::new(handle, pending_tx.clone());
+    (coordinator, pending_rx, pending_tx)
+}
+
+#[test]
+#[ignore = "profiling harness for samply; run explicitly"]
+fn profile_process_flashblock_eth_transfers_with_bal_1000_txs() {
+    run_profile_process_flashblock_case(
+        MAX_DEFAULT_TX_COUNT,
+        true,
+        build_flashblock_fixture_eth_transfers,
+    );
+}
+
+#[test]
+#[ignore = "profiling harness for samply; run explicitly"]
+fn profile_process_flashblock_eth_transfers_without_bal_1000_txs() {
+    run_profile_process_flashblock_case(
+        MAX_DEFAULT_TX_COUNT,
+        false,
+        build_flashblock_fixture_eth_transfers,
+    );
+}
+
+#[test]
+#[ignore = "profiling harness for samply; run explicitly"]
+fn profile_process_flashblock_fib_with_bal_1000_txs() {
+    run_profile_process_flashblock_case(MAX_DEFAULT_TX_COUNT, true, build_flashblock_fixture_fib);
+}
+
+#[test]
+#[ignore = "profiling harness for samply; run explicitly"]
+fn profile_process_flashblock_fib_without_bal_1000_txs() {
+    run_profile_process_flashblock_case(MAX_DEFAULT_TX_COUNT, false, build_flashblock_fixture_fib);
+}
+
+#[test]
+#[ignore = "profiling harness for samply; run explicitly"]
+fn profile_process_flashblock_world_id_like_bn254_with_bal_50_txs() {
+    run_profile_process_flashblock_case(
+        MAX_WORLD_ID_LIKE_BN254_TX_COUNT,
+        true,
+        build_flashblock_fixture_world_id_like_bn254,
+    );
+}
+
+#[test]
+#[ignore = "profiling harness for samply; run explicitly"]
+fn profile_process_flashblock_world_id_like_bn254_without_bal_50_txs() {
+    run_profile_process_flashblock_case(
+        MAX_WORLD_ID_LIKE_BN254_TX_COUNT,
+        false,
+        build_flashblock_fixture_world_id_like_bn254,
+    );
+}
+
+fn run_profile_process_flashblock_case<F>(num_txs: usize, bal: bool, build_flashblock: F)
+where
+    F: Fn(usize, bool) -> FlashblocksPayloadV1,
+{
+    let rt = tokio::runtime::Runtime::new().expect("failed to build tokio runtime");
+    let provider = BenchProvider::new();
+    let flashblock = build_flashblock(num_txs, bal);
+    let expected_index = flashblock.index;
+    let (coordinator, pending_rx, pending_tx) = fresh_coordinator(&rt);
+
+    process_flashblock(
+        provider,
+        &EVM_CONFIG,
+        &coordinator,
+        CHAIN_SPEC.clone(),
+        flashblock,
+        pending_tx,
+        Arc::new(FlashblockValidationMetrics::default()),
+    )
+    .expect("process_flashblock failed");
+
+    assert_eq!(coordinator.flashblocks().flashblocks().len(), 1);
+    assert_eq!(coordinator.last().flashblock.index, expected_index);
+    assert!(
+        pending_rx.borrow().is_some(),
+        "pending block should be published"
+    );
+}


### PR DESCRIPTION
### Problem

`world-chain-builder` didn't have a single run profiling entrypoint for the synthetic flashblock validation workloads. The existing `cargo bench` flow is useful for measurement, but it repeats execution many times, which makes `samply` captures harder to inspect.

### Solution

Add ignored integration tests that run `process_flashblock` once for the synthetic `eth_transfers`, `fib`, and `world_id_like_bn254` fixtures, with and without BAL.

### Notes

I've also added a `README` file to easily understand how to run this test with `samply` to profile node's perfomances.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds new ignored test-only profiling harnesses and documentation; no production code paths are modified, so risk is low aside from potential extra test compile/runtime cost when run explicitly.
> 
> **Overview**
> Adds a `samply` profiling harness under `crates/builder/tests`, including a README with the exact `cargo test` command to run under `samply`.
> 
> Introduces `flashblock_validation_synthetic_profile.rs` with multiple **ignored** tests that generate synthetic flashblocks (ETH transfers, fib, World ID-like BN254) and run them through `process_flashblock`, asserting the coordinator publishes the expected pending block for profiling/benchmarking purposes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1769c849f35e25a781831926c4b8a4ec68ef3475. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->