### PR TITLE
chore: bump to reth v2.0.0 and op-reth v2.1.0

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -12,6 +12,8 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_PROFILE_DEV_DEBUG: 0
+  CARGO_PROFILE_TEST_DEBUG: 0
 
 jobs:
   cargo-tests:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -106,9 +106,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e9e31d834fe25fe991b8884e4b9f0e59db4a97d86e05d1464d6899c013cd62"
+checksum = "84e0378e959aa6a885897522080a990e80eb317f1e9a222a604492ea50e13096"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4ff99651d46cef43767b5e8262ea228cd05287409ccb0c947cc25e70a952f9"
+checksum = "7f16daaf7e1f95f62c6c3bf8a3fc3d78b08ae9777810c0bb5e94966c7cd57ef0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -137,7 +137,7 @@ dependencies = [
  "either",
  "k256",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "secp256k1 0.30.0",
  "serde",
  "serde_json",
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0701b0eda8051a2398591113e7862f807ccdd3315d0b441f06c2a0865a379b"
+checksum = "118998d9015332ab1b4720ae1f1e3009491966a0349938a1f43ff45a8a4c6299"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c83c7a3c4e1151e8cac383d0a67ddf358f37e5ea51c95a1283d897c9de0a5a"
+checksum = "7ac9e0c34dc6bce643b182049cdfcca1b8ce7d9c260cbdd561f511873b7e26cd"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -180,6 +180,7 @@ dependencies = [
  "futures-util",
  "serde_json",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -219,7 +220,7 @@ dependencies = [
  "alloy-rlp",
  "arbitrary",
  "crc",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -234,7 +235,7 @@ dependencies = [
  "alloy-rlp",
  "arbitrary",
  "borsh",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
 ]
 
@@ -249,7 +250,7 @@ dependencies = [
  "arbitrary",
  "borsh",
  "k256",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_with",
  "thiserror 2.0.18",
@@ -257,14 +258,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8222b1d88f9a6d03be84b0f5e76bb60cd83991b43ad8ab6477f0e4a7809b98d"
+checksum = "407510740da514b694fecb44d8b3cebdc60d448f70cc5d24743e8ba273448a6e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
  "borsh",
+ "once_cell",
  "serde",
 ]
 
@@ -296,31 +298,29 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.27.3"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b991c370ce44e70a3a9e474087e3d65e42e66f967644ad729dc4cec09a21fd09"
+checksum = "e13146597a586a4166ac31b192883e08c044272d6b8c43de231ee1f43dd9a115"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-hardforks",
- "alloy-op-hardforks",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "alloy-sol-types",
  "auto_impl",
  "derive_more",
- "op-alloy",
- "op-revm",
  "revm",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
 name = "alloy-genesis"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d9d1aba3f914f0e8db9e4616ae37f3d811426d95bdccf44e47d0605ab202f6"
+checksum = "bbf9480307b09d22876efb67d30cadd9013134c21f3a17ec9f93fd7536d38024"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -374,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b36c2a0ed74e48851f78415ca5b465211bd678891ba11e88fee09eac534bab1"
+checksum = "7197a66d94c4de1591cdc16a9bcea5f8cccd0da81b865b49aef97b1b4016e0fa"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -400,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "636c8051da58802e757b76c3b65af610b95799f72423dc955737dec73de234fd"
+checksum = "eb82711d59a43fdfd79727c99f270b974c784ec4eb5728a0d0d22f26716c87ef"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -413,17 +413,35 @@ dependencies = [
 
 [[package]]
 name = "alloy-op-evm"
-version = "0.26.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv1.11.3#aadf0fcf078255fa973232f2f16bc06a8eeb514f"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b18bebd1d9f70d768e00b66c07474a65c812bad442dc3347d980f5758927f44b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
- "alloy-op-hardforks",
+ "alloy-op-hardforks 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "alloy-primitives",
  "auto_impl",
- "op-alloy",
- "op-revm",
+ "op-alloy 0.23.1",
+ "op-revm 17.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "revm",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-op-evm"
+version = "0.30.0"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0#6de21d0f81036bc76f14a7bdec89304c60c97f14"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm",
+ "alloy-op-hardforks 0.4.7 (git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0)",
+ "alloy-primitives",
+ "auto_impl",
+ "op-alloy 0.24.0",
+ "op-revm 17.0.0 (git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0)",
  "revm",
  "thiserror 2.0.18",
 ]
@@ -431,7 +449,19 @@ dependencies = [
 [[package]]
 name = "alloy-op-hardforks"
 version = "0.4.7"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv1.11.3#aadf0fcf078255fa973232f2f16bc06a8eeb514f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6472c610150c4c4c15be9e1b964c9b78068f933bda25fb9cdf09b9ac2bb66f36"
+dependencies = [
+ "alloy-chains",
+ "alloy-hardforks",
+ "alloy-primitives",
+ "auto_impl",
+]
+
+[[package]]
+name = "alloy-op-hardforks"
+version = "0.4.7"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0#6de21d0f81036bc76f14a7bdec89304c60c97f14"
 dependencies = [
  "alloy-chains",
  "alloy-hardforks",
@@ -454,14 +484,14 @@ dependencies = [
  "foldhash 0.2.0",
  "getrandom 0.4.2",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "k256",
  "keccak-asm",
  "paste",
  "proptest",
  "proptest-derive",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rapidhash",
  "ruint",
  "rustc-hash",
@@ -471,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3dd56e2eafe8b1803e325867ac2c8a4c73c9fb5f341ffd8347f9344458c5922"
+checksum = "bf6b18b929ef1d078b834c3631e9c925177f3b23ddc6fa08a722d13047205876"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -503,7 +533,7 @@ dependencies = [
  "lru",
  "parking_lot",
  "pin-project",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -515,9 +545,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eebf54983d4fccea08053c218ee5c288adf2e660095a243d0532a8070b43955"
+checksum = "5ad54073131e7292d4e03e1aa2287730f737280eb160d8b579fb31939f558c11"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -537,9 +567,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93e50f64a77ad9c5470bf2ad0ca02f228da70c792a8f06634801e202579f35e"
+checksum = "dc90b1e703d3c03f4ff7f48e82dd0bc1c8211ab7d079cd836a06fcfeb06651cb"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -548,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8849c74c9ca0f5a03da1c865e3eb6f768df816e67dd3721a398a8a7e398011"
+checksum = "f36834a5c0a2fa56e171bf256c34d70fca07d0c0031583edea1c4946b7889c9e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -559,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91577235d341a1bdbee30a463655d08504408a4d51e9f72edbfc5a622829f402"
+checksum = "94fcc9604042ca80bd37aa5e232ea1cd851f337e31e2babbbb345bc0b1c30de3"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -572,7 +602,7 @@ dependencies = [
  "alloy-transport-ws",
  "futures",
  "pin-project",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "tokio",
@@ -585,9 +615,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cff039bf01a17d76c0aace3a3a773d5f895eb4c68baaae729ec9da9e86c99c"
+checksum = "4faad925d3a669ffc15f43b3deec7fbdf2adeb28a4d6f9cf4bc661698c0f8f4b"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -598,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "564afceae126df73b95f78c81eb46e2ef689a45ace0fcdaf5c9a178693a5ccca"
+checksum = "b38080c2b01ad1bacbd3583cf7f6f800e5e0ffc11eaddaad7321225733a2d818"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -610,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22250cf438b6a3926de67683c08163bfa1fd1efa47ee9512cbcd631b6b0243c"
+checksum = "47df51bedb3e6062cb9981187a51e86d0d64a4de66eb0855e9efe6574b044ddf"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -622,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73234a141ecce14e2989748c04fcac23deee67a445e2c4c167cfb42d4dacd1b6"
+checksum = "3823026d1ed239a40f12364fac50726c8daf1b6ab8077a97212c5123910429ed"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -633,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625af0c3ebd3c31322edb1fb6b8e3e518acc39e164ed07e422eaff05310ff2fa"
+checksum = "f526dbd7bb039327cfd0ccf18c8a29ffd7402616b0c7a0239512bf8417d544c7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -665,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10620d600cc46538f613c561ac9a923843c6c74c61f054828dcdb8dd18c72ec4"
+checksum = "bb9b97b6e7965679ad22df297dda809b11cebc13405c1b537e5cffecc95834fa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -678,16 +708,16 @@ dependencies = [
  "ethereum_ssz 0.9.1",
  "ethereum_ssz_derive 0.9.1",
  "jsonwebtoken",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "strum",
 ]
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010e101dbebe0c678248907a2545b574a87d078d82c2f6f5d0e8e7c9a6149a10"
+checksum = "59c095f92c4e1ff4981d89e9aa02d5f98c762a1980ab66bec49c44be11349da2"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -707,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375e4bf001135fe4f344db6197fafed8c2b61e99fa14d3597f44cd413f79e45b"
+checksum = "8eae9c65ff60dcc262247b6ebb5ad391ddf36d09029802c1768c5723e0cfa2f4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -722,9 +752,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be096f74d85e1f927580b398bf7bc5b4aa62326f149680ec0867e3c040c9aced"
+checksum = "2e5a4d010f86cd4e01e5205ec273911e538e1738e76d8bafe9ecd245910ea5a3"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -736,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14ab75189fbc29c5dd6f0bc1529bccef7b00773b458763f4d9d81a77ae4a1a2d"
+checksum = "942d26a2ca8891b26de4a8529d21091e21c1093e27eb99698f1a86405c76b1ff"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -760,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97f40010b5e8f79b70bf163b38cd15f529b18ca88c4427c0e43441ee54e4ed82"
+checksum = "43f447aefab0f1c0649f71edc33f590992d4e122bc35fb9cdbbf67d4421ace85"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -775,9 +805,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c4ec1cc27473819399a3f0da83bc1cef0ceaac8c1c93997696e46dc74377a58"
+checksum = "f721f4bf2e4812e5505aaf5de16ef3065a8e26b9139ac885862d00b5a55a659a"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -787,7 +817,7 @@ dependencies = [
  "coins-bip32",
  "coins-bip39",
  "k256",
- "rand 0.8.5",
+ "rand 0.8.6",
  "thiserror 2.0.18",
  "zeroize",
 ]
@@ -815,7 +845,7 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -864,9 +894,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a03bb3f02b9a7ab23dacd1822fa7f69aa5c8eefcdcf57fad085e0b8d76fb4334"
+checksum = "8098f965442a9feb620965ba4b4be5e2b320f4ec5a3fff6bfa9e1ff7ef42bed1"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -887,14 +917,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce599598ef8ebe067f3627509358d9faaa1ef94f77f834a7783cd44209ef55c"
+checksum = "e8597d36d546e1dab822345ad563243ec3920e199322cb554ce56c8ef1a1e2e7"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
  "itertools 0.14.0",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "serde_json",
  "tower",
  "tracing",
@@ -903,9 +933,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49963a2561ebd439549915ea61efb70a7b13b97500ec16ca507721c9d9957d07"
+checksum = "a1bd98c3870b8a44b79091dde5216a81d58ffbc1fd8ed61b776f9fee0f3bdf20"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -923,18 +953,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed38ea573c6658e0c2745af9d1f1773b1ed83aa59fbd9c286358ad469c3233a"
+checksum = "ec3ab7a72b180992881acc112628b7668337a19ce15293ee974600ea7b693691"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
  "futures",
  "http",
+ "rustls",
  "serde_json",
  "tokio",
- "tokio-tungstenite 0.26.2",
+ "tokio-tungstenite",
  "tracing",
+ "url",
  "ws_stream_wasm",
 ]
 
@@ -1397,7 +1429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1407,7 +1439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1417,7 +1449,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
 ]
 
@@ -1541,6 +1573,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "backon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1562,7 +1616,7 @@ dependencies = [
  "miniz_oxide 0.8.9",
  "object",
  "rustc-demangle",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1652,7 +1706,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -1703,9 +1757,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
@@ -1734,16 +1788,16 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -1899,6 +1953,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "c-kzg"
 version = "2.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1925,9 +1989,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
 dependencies = [
  "serde",
  "serde_core",
@@ -1941,7 +2005,7 @@ checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.27",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1964,9 +2028,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2012,7 +2076,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2065,9 +2129,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2087,9 +2151,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2102,6 +2166,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "cobs"
@@ -2150,7 +2223,7 @@ dependencies = [
  "hmac",
  "once_cell",
  "pbkdf2",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sha2",
  "thiserror 1.0.69",
 ]
@@ -2278,7 +2351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
@@ -2297,11 +2370,12 @@ checksum = "2f421161cb492475f1661ddc9815a745a1c894592070661180fdec3d4872e9c3"
 
 [[package]]
 name = "const_format"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
 dependencies = [
  "const_format_proc_macros",
+ "konst",
 ]
 
 [[package]]
@@ -2347,19 +2421,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -2459,6 +2533,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2470,7 +2553,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -2536,7 +2619,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -2564,7 +2647,7 @@ checksum = "b0f4697d190a142477b16aef7da8a99bfdc41e7e8b1687583c0d23a79c7afc1e"
 dependencies = [
  "cc",
  "codespan-reporting",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "proc-macro2",
  "quote",
  "scratch",
@@ -2836,15 +2919,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2855,25 +2929,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users 0.5.2",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "dirs-sys-next"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users 0.4.6",
+ "redox_users",
  "winapi",
 ]
 
@@ -2900,7 +2962,7 @@ dependencies = [
  "more-asserts",
  "multiaddr",
  "parking_lot",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "socket2",
  "tokio",
@@ -3060,7 +3122,7 @@ dependencies = [
  "hex",
  "k256",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "secp256k1 0.30.0",
  "serde",
  "sha3",
@@ -3121,7 +3183,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c853bd72c9e5787f8aafc3df2907c2ed03cff3150c3acd94e2e53a98ab70a8ab"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "ring",
  "sha2",
 ]
@@ -3156,9 +3218,9 @@ dependencies = [
 
 [[package]]
 name = "ethereum_ssz"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2128a84f7a3850d54ee343334e3392cca61f9f6aa9441eec481b9394b43c238b"
+checksum = "368a4a4e4273b0135111fe9464e35465067766a8f664615b5a86338b73864407"
 dependencies = [
  "alloy-primitives",
  "ethereum_serde_utils",
@@ -3183,9 +3245,9 @@ dependencies = [
 
 [[package]]
 name = "ethereum_ssz_derive"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd596f91cff004fc8d02be44c21c0f9b93140a04b66027ae052f5f8e05b48eba"
+checksum = "f2cd82c68120c89361e1a457245cf212f7d9f541bffaffed530c8f2d54a160b2"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -3205,9 +3267,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fastrlp"
@@ -3292,7 +3354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc-hex",
  "static_assertions",
 ]
@@ -3354,6 +3416,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -3547,7 +3615,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "libc",
  "libgit2-sys",
  "log",
@@ -3629,7 +3697,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3702,6 +3770,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -3785,7 +3859,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "serde",
  "thiserror 2.0.18",
@@ -3808,7 +3882,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "resolv-conf",
  "serde",
  "smallvec",
@@ -3910,9 +3984,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3925,7 +3999,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -3933,21 +4006,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "log",
  "rustls",
- "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -3998,7 +4069,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4012,12 +4083,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -4025,13 +4097,12 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
- "serde",
  "tinystr",
  "writeable",
  "zerovec",
@@ -4039,11 +4110,10 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b24a59706036ba941c9476a55cd57b82b77f38a3c667d637ee7cabbc85eaedc"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -4054,42 +4124,38 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a97b8ac6235e69506e8dacfb2adf38461d2ce6d3e9bd9c94c4cbc3cd4400a4"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "serde",
- "stable_deref_trait",
  "writeable",
  "yoke",
  "zerofrom",
@@ -4198,13 +4264,13 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "arbitrary",
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -4224,7 +4290,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "inotify-sys",
  "libc",
 ]
@@ -4263,9 +4329,9 @@ dependencies = [
 
 [[package]]
 name = "interprocess"
-version = "2.4.0"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6be5e5c847dbdb44564bd85294740d031f4f8aeb3464e5375ef7141f7538db69"
+checksum = "069323743400cb7ab06a8fe5c1ed911d36b6919ec531661d034c89083629595b"
 dependencies = [
  "doctest-file",
  "futures-core",
@@ -4273,7 +4339,7 @@ dependencies = [
  "recvmsg",
  "tokio",
  "widestring",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4285,7 +4351,7 @@ dependencies = [
  "socket2",
  "widestring",
  "windows-registry",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-sys 0.61.2",
 ]
 
@@ -4297,9 +4363,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -4400,9 +4466,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4443,7 +4509,7 @@ dependencies = [
  "pin-project",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.5.3",
  "soketto",
  "thiserror 2.0.18",
  "tokio",
@@ -4469,7 +4535,7 @@ dependencies = [
  "jsonrpsee-types",
  "parking_lot",
  "pin-project",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -4495,7 +4561,7 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-types",
  "rustls",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.5.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -4629,7 +4695,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -4641,6 +4707,21 @@ dependencies = [
  "digest 0.10.7",
  "sha3-asm",
 ]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "kqueue"
@@ -4676,9 +4757,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libgit2-sys"
@@ -4699,7 +4780,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4740,21 +4821,36 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
+]
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.17.3+10.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+ "zstd-sys",
 ]
 
 [[package]]
 name = "libz-sys"
-version = "1.1.25"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
 dependencies = [
  "cc",
  "libc",
@@ -4768,7 +4864,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -4795,9 +4891,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -4823,9 +4919,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -4980,7 +5076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3589659543c04c7dc5526ec858591015b87cd8746583b51b48ef4353f99dbcda"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "metrics",
  "metrics-util",
  "quanta",
@@ -5014,7 +5110,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "metrics",
  "quanta",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_xoshiro",
  "sketches-ddsketch",
 ]
@@ -5167,11 +5263,11 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.19.3"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
+checksum = "89ace881e3f514092ce9efbcb8f413d0ad9763860b828981c2de51ddc666936c"
 dependencies = [
- "core2",
+ "no_std_io2",
  "unsigned-varint",
 ]
 
@@ -5186,6 +5282,15 @@ dependencies = [
  "libc",
  "memoffset",
  "pin-utils",
+]
+
+[[package]]
+name = "no_std_io2"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a3564ce7035b1e4778d8cb6cacebb5d766b5e8fe5a75b9e441e33fb61a872c6"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -5204,7 +5309,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -5222,7 +5327,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -5265,7 +5370,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -5386,7 +5491,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -5433,9 +5538,18 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 [[package]]
 name = "op-alloy"
 version = "0.23.1"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv1.11.3#aadf0fcf078255fa973232f2f16bc06a8eeb514f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9b8fee21003dd4f076563de9b9d26f8c97840157ef78593cd7f262c5ca99848"
 dependencies = [
- "op-alloy-consensus",
+ "op-alloy-consensus 0.23.1",
+]
+
+[[package]]
+name = "op-alloy"
+version = "0.24.0"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0#6de21d0f81036bc76f14a7bdec89304c60c97f14"
+dependencies = [
+ "op-alloy-consensus 0.24.0",
  "op-alloy-network",
  "op-alloy-provider",
  "op-alloy-rpc-types",
@@ -5445,7 +5559,21 @@ dependencies = [
 [[package]]
 name = "op-alloy-consensus"
 version = "0.23.1"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv1.11.3#aadf0fcf078255fa973232f2f16bc06a8eeb514f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736381a95471d23e267263cfcee9e1d96d30b9754a94a2819148f83379de8a86"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "derive_more",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "op-alloy-consensus"
+version = "0.24.0"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0#6de21d0f81036bc76f14a7bdec89304c60c97f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5455,7 +5583,12 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-serde",
  "arbitrary",
+ "bytes",
  "derive_more",
+ "modular-bitfield",
+ "reth-codecs",
+ "reth-codecs-derive",
+ "reth-zstd-compressors",
  "serde",
  "serde_with",
  "thiserror 2.0.18",
@@ -5469,23 +5602,22 @@ checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
 
 [[package]]
 name = "op-alloy-network"
-version = "0.23.1"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv1.11.3#aadf0fcf078255fa973232f2f16bc06a8eeb514f"
+version = "0.24.0"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0#6de21d0f81036bc76f14a7bdec89304c60c97f14"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types-eth",
- "alloy-signer",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.24.0",
  "op-alloy-rpc-types",
 ]
 
 [[package]]
 name = "op-alloy-provider"
-version = "0.23.1"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv1.11.3#aadf0fcf078255fa973232f2f16bc06a8eeb514f"
+version = "0.24.0"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0#6de21d0f81036bc76f14a7bdec89304c60c97f14"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -5498,8 +5630,8 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-jsonrpsee"
-version = "0.23.1"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv1.11.3#aadf0fcf078255fa973232f2f16bc06a8eeb514f"
+version = "0.24.0"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0#6de21d0f81036bc76f14a7bdec89304c60c97f14"
 dependencies = [
  "alloy-primitives",
  "jsonrpsee",
@@ -5507,17 +5639,20 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types"
-version = "0.23.1"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv1.11.3#aadf0fcf078255fa973232f2f16bc06a8eeb514f"
+version = "0.24.0"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0#6de21d0f81036bc76f14a7bdec89304c60c97f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
+ "alloy-network",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-serde",
+ "alloy-signer",
  "derive_more",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.24.0",
+ "reth-rpc-traits",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -5525,8 +5660,8 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.23.1"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv1.11.3#aadf0fcf078255fa973232f2f16bc06a8eeb514f"
+version = "0.24.0"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0#6de21d0f81036bc76f14a7bdec89304c60c97f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5537,7 +5672,7 @@ dependencies = [
  "derive_more",
  "ethereum_ssz 0.9.1",
  "ethereum_ssz_derive 0.9.1",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.24.0",
  "serde",
  "sha2",
  "snap",
@@ -5546,9 +5681,18 @@ dependencies = [
 
 [[package]]
 name = "op-revm"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c92b75162c2ed1661849fa51683b11254a5b661798360a2c24be918edafd40"
+checksum = "57a98f3a512a7e02a1dcf1242b57302d83657b265a665d50ad98d0b158efaf2c"
+dependencies = [
+ "auto_impl",
+ "revm",
+]
+
+[[package]]
+name = "op-revm"
+version = "17.0.0"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0#6de21d0f81036bc76f14a7bdec89304c60c97f14"
 dependencies = [
  "auto_impl",
  "revm",
@@ -5643,15 +5787,9 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.4",
  "thiserror 2.0.18",
 ]
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "owo-colors"
@@ -5687,7 +5825,6 @@ version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
 dependencies = [
- "arbitrary",
  "arrayvec",
  "bitvec",
  "byte-slice-cast",
@@ -5731,7 +5868,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5873,9 +6010,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -5927,7 +6064,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -5953,9 +6090,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -6061,7 +6198,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "chrono",
  "flate2",
  "procfs-core",
@@ -6074,7 +6211,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "chrono",
  "hex",
 ]
@@ -6087,9 +6224,9 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -6198,10 +6335,11 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -6256,9 +6394,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -6268,9 +6406,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -6340,7 +6478,7 @@ version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.4",
  "rustversion",
 ]
 
@@ -6362,7 +6500,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "compact_str",
  "hashbrown 0.16.1",
  "indoc",
@@ -6394,7 +6532,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.16.1",
  "indoc",
  "instability",
@@ -6413,14 +6551,14 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -6448,16 +6586,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -6469,17 +6607,6 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6554,8 +6681,48 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier 0.6.2",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -6571,36 +6738,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.6",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
@@ -6611,8 +6748,8 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6621,6 +6758,7 @@ dependencies = [
  "futures-util",
  "metrics",
  "reth-chain-state",
+ "reth-execution-cache",
  "reth-metrics",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
@@ -6629,14 +6767,16 @@ dependencies = [
  "reth-revm",
  "reth-storage-api",
  "reth-tasks",
+ "reth-trie-parallel",
+ "serde",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "reth-chain-state"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6647,7 +6787,7 @@ dependencies = [
  "metrics",
  "parking_lot",
  "pin-project",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rayon",
  "reth-chainspec",
  "reth-errors",
@@ -6667,8 +6807,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6687,8 +6827,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -6696,13 +6836,12 @@ dependencies = [
  "reth-cli-runner",
  "reth-db",
  "serde_json",
- "shellexpand",
 ]
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6710,6 +6849,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "backon",
+ "blake3",
  "clap",
  "comfy-table",
  "crossterm",
@@ -6723,7 +6863,8 @@ dependencies = [
  "metrics",
  "parking_lot",
  "ratatui",
- "reqwest 0.12.28",
+ "rayon",
+ "reqwest 0.13.2",
  "reth-chainspec",
  "reth-cli",
  "reth-cli-runner",
@@ -6758,14 +6899,15 @@ dependencies = [
  "reth-primitives-traits",
  "reth-provider",
  "reth-prune",
+ "reth-prune-types",
  "reth-revm",
  "reth-stages",
+ "reth-stages-types",
  "reth-static-file",
  "reth-static-file-types",
  "reth-storage-api",
  "reth-tasks",
  "reth-trie",
- "reth-trie-common",
  "reth-trie-db",
  "secp256k1 0.30.0",
  "serde",
@@ -6781,8 +6923,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -6791,15 +6933,15 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "cfg-if",
  "eyre",
  "libc",
- "rand 0.8.5",
+ "rand 0.8.6",
  "reth-fs-util",
  "secp256k1 0.30.0",
  "serde",
@@ -6808,8 +6950,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a96e584e01478c951911946a7864f18e967c1cd90965e136e2d1b51aa3da9126"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6819,7 +6962,7 @@ dependencies = [
  "arbitrary",
  "bytes",
  "modular-bitfield",
- "op-alloy-consensus",
+ "parity-scale-codec",
  "reth-codecs-derive",
  "reth-zstd-compressors",
  "serde",
@@ -6828,8 +6971,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c342ae46f5a886b8bf506205b9501b1032b896defd0f4f156edb423007fef880"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6838,8 +6982,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -6854,8 +6998,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6867,11 +7011,12 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
+ "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
  "reth-primitives-traits",
@@ -6879,8 +7024,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6893,7 +7038,7 @@ dependencies = [
  "derive_more",
  "eyre",
  "futures",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "reth-node-api",
  "reth-primitives-traits",
  "reth-tracing",
@@ -6905,8 +7050,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -6914,6 +7059,7 @@ dependencies = [
  "metrics",
  "page_size",
  "parking_lot",
+ "quanta",
  "reth-db-api",
  "reth-fs-util",
  "reth-libmdbx",
@@ -6932,11 +7078,10 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
- "alloy-genesis",
  "alloy-primitives",
  "arbitrary",
  "arrayvec",
@@ -6944,8 +7089,6 @@ dependencies = [
  "derive_more",
  "metrics",
  "modular-bitfield",
- "op-alloy-consensus",
- "parity-scale-codec",
  "proptest",
  "reth-codecs",
  "reth-db-models",
@@ -6961,8 +7104,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -6991,8 +7134,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7006,8 +7149,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7015,7 +7158,7 @@ dependencies = [
  "enr",
  "itertools 0.14.0",
  "parking_lot",
- "rand 0.8.5",
+ "rand 0.8.6",
  "reth-ethereum-forks",
  "reth-net-banlist",
  "reth-net-nat",
@@ -7031,8 +7174,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7042,7 +7185,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "metrics",
- "rand 0.9.2",
+ "rand 0.9.4",
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-metrics",
@@ -7055,8 +7198,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -7079,8 +7222,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7114,8 +7257,8 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7150,7 +7293,6 @@ dependencies = [
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
- "reth-primitives",
  "reth-primitives-traits",
  "reth-provider",
  "reth-rpc-api",
@@ -7172,8 +7314,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -7187,7 +7329,7 @@ dependencies = [
  "futures",
  "hmac",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.8.6",
  "reth-network-peers",
  "secp256k1 0.30.0",
  "sha2",
@@ -7200,15 +7342,14 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "eyre",
  "futures-util",
- "op-alloy-rpc-types-engine",
  "reth-chainspec",
  "reth-engine-primitives",
  "reth-ethereum-engine-primitives",
@@ -7224,8 +7365,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7248,31 +7389,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-engine-service"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
-dependencies = [
- "futures",
- "pin-project",
- "reth-chainspec",
- "reth-consensus",
- "reth-engine-primitives",
- "reth-engine-tree",
- "reth-evm",
- "reth-network-p2p",
- "reth-node-types",
- "reth-payload-builder",
- "reth-provider",
- "reth-prune",
- "reth-stages-api",
- "reth-tasks",
- "reth-trie-db",
-]
-
-[[package]]
 name = "reth-engine-tree"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -7283,7 +7402,6 @@ dependencies = [
  "alloy-rpc-types-engine",
  "crossbeam-channel",
  "derive_more",
- "fixed-cache",
  "futures",
  "metrics",
  "moka",
@@ -7297,6 +7415,7 @@ dependencies = [
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-evm",
+ "reth-execution-cache",
  "reth-execution-types",
  "reth-metrics",
  "reth-network-p2p",
@@ -7320,7 +7439,6 @@ dependencies = [
  "revm",
  "revm-primitives",
  "schnellru",
- "smallvec",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7328,8 +7446,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -7356,29 +7474,29 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "ethereum_ssz 0.10.1",
- "ethereum_ssz_derive 0.10.1",
+ "ethereum_ssz 0.10.3",
+ "ethereum_ssz_derive 0.10.3",
  "snap",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-primitives",
  "bytes",
  "eyre",
  "futures-util",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "reth-era",
  "reth-fs-util",
  "sha2",
@@ -7387,8 +7505,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7409,8 +7527,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -7420,8 +7538,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7448,8 +7566,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7469,8 +7587,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "reth-chainspec",
  "reth-eth-wire",
@@ -7483,8 +7601,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7499,26 +7617,24 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
- "alloy-rlp",
  "alloy-rpc-types-engine",
  "reth-engine-primitives",
  "reth-ethereum-primitives",
  "reth-payload-primitives",
  "reth-primitives-traits",
  "serde",
- "sha2",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -7530,8 +7646,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7545,6 +7661,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-evm-ethereum",
+ "reth-execution-cache",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
@@ -7559,28 +7676,22 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
- "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde",
- "arbitrary",
- "modular-bitfield",
  "reth-codecs",
  "reth-primitives-traits",
- "reth-zstd-compressors",
  "serde",
- "serde_with",
 ]
 
 [[package]]
 name = "reth-etl"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -7589,8 +7700,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7613,16 +7724,14 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rpc-types-engine",
- "derive_more",
- "parking_lot",
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-ethereum-primitives",
@@ -7634,9 +7743,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-execution-cache"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
+dependencies = [
+ "alloy-primitives",
+ "fixed-cache",
+ "metrics",
+ "parking_lot",
+ "reth-errors",
+ "reth-metrics",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-revm",
+ "reth-trie",
+ "tracing",
+]
+
+[[package]]
 name = "reth-execution-errors"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -7648,13 +7775,14 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
+ "alloy-rlp",
  "derive_more",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
@@ -7666,8 +7794,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7704,8 +7832,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7718,8 +7846,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "serde",
  "serde_json",
@@ -7728,8 +7856,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7756,8 +7884,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "bytes",
  "futures",
@@ -7776,11 +7904,12 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "byteorder",
+ "crossbeam-queue",
  "dashmap",
  "derive_more",
  "parking_lot",
@@ -7792,8 +7921,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "bindgen",
  "cc",
@@ -7801,8 +7930,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "futures",
  "metrics",
@@ -7813,8 +7942,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -7822,12 +7951,12 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "futures-util",
  "if-addrs",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "serde_with",
  "thiserror 2.0.18",
  "tokio",
@@ -7836,8 +7965,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7853,8 +7982,8 @@ dependencies = [
  "metrics",
  "parking_lot",
  "pin-project",
- "rand 0.8.5",
- "rand 0.9.2",
+ "rand 0.8.6",
+ "rand 0.9.4",
  "rayon",
  "reth-chainspec",
  "reth-consensus",
@@ -7893,8 +8022,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7918,8 +8047,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7941,8 +8070,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7956,8 +8085,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -7970,8 +8099,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -7987,8 +8116,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8011,8 +8140,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8039,7 +8168,6 @@ dependencies = [
  "reth-downloaders",
  "reth-engine-local",
  "reth-engine-primitives",
- "reth-engine-service",
  "reth-engine-tree",
  "reth-engine-util",
  "reth-evm",
@@ -8080,8 +8208,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8094,7 +8222,7 @@ dependencies = [
  "futures",
  "humantime",
  "ipnet",
- "rand 0.9.2",
+ "rand 0.9.4",
  "reth-chainspec",
  "reth-cli-util",
  "reth-config",
@@ -8118,12 +8246,12 @@ dependencies = [
  "reth-stages-types",
  "reth-storage-api",
  "reth-storage-errors",
+ "reth-tasks",
  "reth-tracing",
  "reth-tracing-otlp",
  "reth-transaction-pool",
  "secp256k1 0.30.0",
  "serde",
- "shellexpand",
  "strum",
  "thiserror 2.0.18",
  "toml",
@@ -8135,8 +8263,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -8173,8 +8301,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8190,15 +8318,15 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "reth-node-events"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8221,8 +8349,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "bytes",
  "eyre",
@@ -8234,7 +8362,7 @@ dependencies = [
  "metrics-process",
  "metrics-util",
  "procfs",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "reth-metrics",
  "reth-tasks",
  "tokio",
@@ -8244,8 +8372,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -8257,7 +8385,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-chainspec"
 version = "1.11.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv1.11.3#aadf0fcf078255fa973232f2f16bc06a8eeb514f"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0#6de21d0f81036bc76f14a7bdec89304c60c97f14"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8267,7 +8395,7 @@ dependencies = [
  "alloy-primitives",
  "derive_more",
  "miniz_oxide 0.9.1",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.24.0",
  "op-alloy-rpc-types",
  "paste",
  "reth-chainspec",
@@ -8285,7 +8413,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-cli"
 version = "1.11.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv1.11.3#aadf0fcf078255fa973232f2f16bc06a8eeb514f"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0#6de21d0f81036bc76f14a7bdec89304c60c97f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8295,7 +8423,7 @@ dependencies = [
  "derive_more",
  "eyre",
  "futures-util",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.24.0",
  "reth-chainspec",
  "reth-cli",
  "reth-cli-commands",
@@ -8324,6 +8452,7 @@ dependencies = [
  "reth-stages",
  "reth-static-file",
  "reth-static-file-types",
+ "reth-tasks",
  "reth-tracing",
  "serde",
  "tokio",
@@ -8334,7 +8463,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-consensus"
 version = "1.11.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv1.11.3#aadf0fcf078255fa973232f2f16bc06a8eeb514f"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0#6de21d0f81036bc76f14a7bdec89304c60c97f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8359,16 +8488,17 @@ dependencies = [
 [[package]]
 name = "reth-optimism-evm"
 version = "1.11.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv1.11.3#aadf0fcf078255fa973232f2f16bc06a8eeb514f"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0#6de21d0f81036bc76f14a7bdec89304c60c97f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
- "alloy-op-evm",
+ "alloy-op-evm 0.30.0 (git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0)",
  "alloy-primitives",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.24.0",
+ "op-alloy-rpc-types",
  "op-alloy-rpc-types-engine",
- "op-revm",
+ "op-revm 17.0.0 (git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0)",
  "reth-chainspec",
  "reth-evm",
  "reth-execution-errors",
@@ -8387,7 +8517,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-exex"
 version = "1.11.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv1.11.3#aadf0fcf078255fa973232f2f16bc06a8eeb514f"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0#6de21d0f81036bc76f14a7bdec89304c60c97f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8406,7 +8536,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-flashblocks"
 version = "1.11.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv1.11.3#aadf0fcf078255fa973232f2f16bc06a8eeb514f"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0#6de21d0f81036bc76f14a7bdec89304c60c97f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8436,7 +8566,7 @@ dependencies = [
  "ringbuffer",
  "serde_json",
  "tokio",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite",
  "tracing",
  "url",
 ]
@@ -8444,9 +8574,9 @@ dependencies = [
 [[package]]
 name = "reth-optimism-forks"
 version = "1.11.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv1.11.3#aadf0fcf078255fa973232f2f16bc06a8eeb514f"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0#6de21d0f81036bc76f14a7bdec89304c60c97f14"
 dependencies = [
- "alloy-op-hardforks",
+ "alloy-op-hardforks 0.4.7 (git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0)",
  "alloy-primitives",
  "once_cell",
  "reth-ethereum-forks",
@@ -8455,7 +8585,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-node"
 version = "1.11.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv1.11.3#aadf0fcf078255fa973232f2f16bc06a8eeb514f"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0#6de21d0f81036bc76f14a7bdec89304c60c97f14"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8466,15 +8596,14 @@ dependencies = [
  "eyre",
  "futures-util",
  "humantime",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.24.0",
  "op-alloy-rpc-types-engine",
- "op-revm",
+ "op-revm 17.0.0 (git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0)",
  "reth-chainspec",
  "reth-consensus",
  "reth-db",
  "reth-db-api",
  "reth-e2e-test-utils",
- "reth-engine-local",
  "reth-evm",
  "reth-network",
  "reth-node-api",
@@ -8512,7 +8641,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-payload-builder"
 version = "1.11.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv1.11.3#aadf0fcf078255fa973232f2f16bc06a8eeb514f"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0#6de21d0f81036bc76f14a7bdec89304c60c97f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8523,8 +8652,9 @@ dependencies = [
  "alloy-rpc-types-engine",
  "derive_more",
  "either",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.24.0",
  "op-alloy-rpc-types-engine",
+ "op-revm 17.0.0 (git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0)",
  "reth-basic-payload-builder",
  "reth-chainspec",
  "reth-evm",
@@ -8533,7 +8663,6 @@ dependencies = [
  "reth-optimism-forks",
  "reth-optimism-primitives",
  "reth-optimism-txpool",
- "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-payload-util",
@@ -8552,13 +8681,13 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.11.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv1.11.3#aadf0fcf078255fa973232f2f16bc06a8eeb514f"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0#6de21d0f81036bc76f14a7bdec89304c60c97f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.24.0",
  "reth-primitives-traits",
  "serde",
  "serde_with",
@@ -8567,11 +8696,12 @@ dependencies = [
 [[package]]
 name = "reth-optimism-rpc"
 version = "1.11.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv1.11.3#aadf0fcf078255fa973232f2f16bc06a8eeb514f"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0#6de21d0f81036bc76f14a7bdec89304c60c97f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-json-rpc",
+ "alloy-op-evm 0.30.0 (git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0)",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-client",
@@ -8589,12 +8719,12 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-types",
  "metrics",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.24.0",
  "op-alloy-network",
  "op-alloy-rpc-jsonrpsee",
  "op-alloy-rpc-types",
  "op-alloy-rpc-types-engine",
- "op-revm",
+ "op-revm 17.0.0 (git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0)",
  "reqwest 0.13.2",
  "reth-basic-payload-builder",
  "reth-chain-state",
@@ -8637,7 +8767,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-storage"
 version = "1.11.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv1.11.3#aadf0fcf078255fa973232f2f16bc06a8eeb514f"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0#6de21d0f81036bc76f14a7bdec89304c60c97f14"
 dependencies = [
  "alloy-consensus",
  "reth-optimism-primitives",
@@ -8647,7 +8777,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-trie"
 version = "1.11.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv1.11.3#aadf0fcf078255fa973232f2f16bc06a8eeb514f"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0#6de21d0f81036bc76f14a7bdec89304c60c97f14"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8658,6 +8788,7 @@ dependencies = [
  "eyre",
  "metrics",
  "parking_lot",
+ "reth-codecs",
  "reth-db",
  "reth-ethereum-primitives",
  "reth-evm",
@@ -8679,7 +8810,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-txpool"
 version = "1.11.3"
-source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv1.11.3#aadf0fcf078255fa973232f2f16bc06a8eeb514f"
+source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0#6de21d0f81036bc76f14a7bdec89304c60c97f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8692,14 +8823,16 @@ dependencies = [
  "derive_more",
  "futures-util",
  "metrics",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.24.0",
  "op-alloy-flz",
  "op-alloy-rpc-types",
- "op-revm",
+ "op-revm 17.0.0 (git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0)",
  "parking_lot",
  "reth-chain-state",
  "reth-chainspec",
+ "reth-eth-wire-types",
  "reth-evm",
+ "reth-execution-types",
  "reth-metrics",
  "reth-optimism-evm",
  "reth-optimism-forks",
@@ -8715,20 +8848,23 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rpc-types",
+ "derive_more",
  "futures-util",
  "metrics",
  "reth-chain-state",
  "reth-ethereum-engine-primitives",
+ "reth-execution-cache",
  "reth-metrics",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-primitives-traits",
+ "reth-trie-parallel",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -8736,8 +8872,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -8748,16 +8884,16 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
+ "alloy-rlp",
  "alloy-rpc-types-engine",
  "auto_impl",
  "either",
- "op-alloy-rpc-types-engine",
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
@@ -8765,14 +8901,15 @@ dependencies = [
  "reth-primitives-traits",
  "reth-trie-common",
  "serde",
+ "sha2",
  "thiserror 2.0.18",
  "tokio",
 ]
 
 [[package]]
 name = "reth-payload-util"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8781,8 +8918,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8790,24 +8927,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-primitives"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "c-kzg",
- "once_cell",
- "reth-ethereum-forks",
- "reth-ethereum-primitives",
- "reth-primitives-traits",
- "reth-static-file-types",
-]
-
-[[package]]
 name = "reth-primitives-traits"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca36e245593498020c31e707154fc13391164eb90444da76d67361f646e7669"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8817,16 +8940,15 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-trie",
  "arbitrary",
- "auto_impl",
  "byteorder",
  "bytes",
  "dashmap",
  "derive_more",
  "modular-bitfield",
  "once_cell",
- "op-alloy-consensus",
  "proptest",
  "proptest-arbitrary-interop",
+ "quanta",
  "rayon",
  "reth-codecs",
  "revm-bytecode",
@@ -8834,17 +8956,17 @@ dependencies = [
  "revm-state",
  "secp256k1 0.30.0",
  "serde",
- "serde_with",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-provider"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
+ "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "eyre",
@@ -8877,6 +8999,7 @@ dependencies = [
  "reth-trie-db",
  "revm-database",
  "revm-state",
+ "rocksdb",
  "strum",
  "tokio",
  "tracing",
@@ -8884,8 +9007,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8913,8 +9036,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8929,10 +9052,12 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-debug",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",
@@ -8942,8 +9067,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9002,6 +9127,7 @@ dependencies = [
  "reth-rpc-server-types",
  "reth-storage-api",
  "reth-tasks",
+ "reth-tracing",
  "reth-transaction-pool",
  "reth-trie-common",
  "revm",
@@ -9019,8 +9145,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -9044,13 +9170,14 @@ dependencies = [
  "reth-network-peers",
  "reth-rpc-eth-api",
  "reth-trie-common",
+ "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9068,9 +9195,11 @@ dependencies = [
  "reth-metrics",
  "reth-network-api",
  "reth-node-core",
+ "reth-payload-primitives",
  "reth-primitives-traits",
  "reth-rpc",
  "reth-rpc-api",
+ "reth-rpc-engine-api",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
  "reth-rpc-layer",
@@ -9090,8 +9219,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9099,26 +9228,23 @@ dependencies = [
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-signer",
  "auto_impl",
  "dyn-clone",
  "jsonrpsee-types",
- "op-alloy-consensus",
- "op-alloy-network",
- "op-alloy-rpc-types",
- "reth-ethereum-primitives",
  "reth-evm",
  "reth-primitives-traits",
+ "reth-rpc-traits",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
+ "alloy-rlp",
  "alloy-rpc-types-engine",
  "async-trait",
  "jsonrpsee-core",
@@ -9144,11 +9270,12 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
+ "alloy-eip7928",
  "alloy-eips",
  "alloy-evm",
  "alloy-json-rpc",
@@ -9182,14 +9309,15 @@ dependencies = [
  "reth-trie-common",
  "revm",
  "revm-inspectors",
+ "serde_json",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9206,8 +9334,8 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-types",
  "metrics",
- "rand 0.9.2",
- "reqwest 0.12.28",
+ "rand 0.9.4",
+ "reqwest 0.13.2",
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
@@ -9236,8 +9364,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -9250,8 +9378,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9265,20 +9393,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-rpc-traits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66ebbc3cc6f1808c2838bf8da9928f3ef9b8a6f969c6522174c1598ddb34bc0f"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-signer",
+ "reth-primitives-traits",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "reth-stages"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
- "bincode 1.3.3",
+ "alloy-rlp",
  "eyre",
  "futures-util",
  "itertools 0.14.0",
  "num-traits",
+ "page_size",
  "rayon",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "reth-chainspec",
  "reth-codecs",
  "reth-config",
@@ -9294,6 +9438,7 @@ dependencies = [
  "reth-execution-types",
  "reth-exex",
  "reth-fs-util",
+ "reth-libmdbx",
  "reth-network-p2p",
  "reth-primitives-traits",
  "reth-provider",
@@ -9316,8 +9461,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9325,6 +9470,7 @@ dependencies = [
  "auto_impl",
  "futures-util",
  "metrics",
+ "reth-codecs",
  "reth-consensus",
  "reth-errors",
  "reth-metrics",
@@ -9343,8 +9489,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9357,8 +9503,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9377,8 +9523,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9392,8 +9538,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9416,13 +9562,14 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
+ "reth-codecs",
  "reth-primitives-traits",
  "reth-prune-types",
  "reth-static-file-types",
@@ -9433,17 +9580,20 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
- "auto_impl",
- "dyn-clone",
+ "crossbeam-utils",
+ "dashmap",
  "futures-util",
+ "libc",
  "metrics",
+ "parking_lot",
  "pin-project",
  "rayon",
  "reth-metrics",
  "thiserror 2.0.18",
+ "thread-priority",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -9451,15 +9601,15 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
- "rand 0.8.5",
- "rand 0.9.2",
+ "rand 0.8.6",
+ "rand 0.9.4",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "secp256k1 0.30.0",
@@ -9467,8 +9617,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9477,8 +9627,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "clap",
  "eyre",
@@ -9493,8 +9643,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "clap",
  "eyre",
@@ -9510,8 +9660,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9519,13 +9669,13 @@ dependencies = [
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "futures-util",
  "metrics",
  "parking_lot",
  "paste",
  "pin-project",
- "rand 0.9.2",
+ "rand 0.9.4",
  "reth-chain-state",
  "reth-chainspec",
  "reth-eth-wire-types",
@@ -9554,8 +9704,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9580,8 +9730,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9607,8 +9757,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -9627,12 +9777,15 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
+ "alloy-eip7928",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "crossbeam-channel",
+ "crossbeam-utils",
  "derive_more",
  "itertools 0.14.0",
  "metrics",
@@ -9644,16 +9797,16 @@ dependencies = [
  "reth-storage-errors",
  "reth-tasks",
  "reth-trie",
- "reth-trie-common",
  "reth-trie-sparse",
+ "revm-state",
  "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v2.0.0#eb4c15e5e36d8776d46629beae4c0a69af7ab04f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9665,23 +9818,27 @@ dependencies = [
  "reth-metrics",
  "reth-primitives-traits",
  "reth-trie-common",
+ "serde",
+ "serde_json",
+ "slotmap",
  "smallvec",
  "tracing",
 ]
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.3#d6324d63e27ef6b7c49cdc9b1977c1b808234c7b"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a621aef55fe4da8935abede9d1d105f227bcb673f212b3575a748a6a2f8f688e"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "34.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2aabdebaa535b3575231a88d72b642897ae8106cf6b0d12eafc6bfdf50abfc7"
+checksum = "b0abc15d09cd211e9e73410ada10134069c794d4bcdb787dfc16a1bf0939849c"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -9698,9 +9855,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d1e5c1eaa44d39d537f668bc5c3409dc01e5c8be954da6c83370bbdf006457"
+checksum = "e86e468df3cf5cf59fa7ef71a3e9ccabb76bb336401ea2c0674f563104cf3c5e"
 dependencies = [
  "bitvec",
  "phf",
@@ -9710,9 +9867,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "13.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "892ff3e6a566cf8d72ffb627fdced3becebbd9ba64089c25975b9b028af326a5"
+checksum = "9eb1f0a76b14d684a444fc52f7bf6b7564bf882599d91ee62e76d602e7a187c7"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -9727,9 +9884,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "14.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f61cc6d23678c4840af895b19f8acfbbd546142ec8028b6526c53cc1c16c98"
+checksum = "fc256b27743e2912ca16899568e6652a372eb5d1d573e6edb16c7836b16cf487"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -9743,9 +9900,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "10.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529528d0b05fe646be86223032c3e77aa8b05caa2a35447d538c55965956a511"
+checksum = "2c0a7d6da41061f2c50f99a2632571026b23684b5449ff319914151f4449b6c8"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -9757,9 +9914,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7bf93ac5b91347c057610c0d96e923db8c62807e03f036762d03e981feddc1d"
+checksum = "bd497a38a79057b94a049552cb1f925ad15078bc1a479c132aeeebd1d2ccc768"
 dependencies = [
  "auto_impl",
  "either",
@@ -9771,9 +9928,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cd0e43e815a85eded249df886c4badec869195e70cdd808a13cfca2794622d2"
+checksum = "9f1eed729ca9b228ae98688f352235871e9b8be3d568d488e4070f64c56e9d3d"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -9790,9 +9947,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3ccad59db91ef93696536a0dbaf2f6f17cfe20d4d8843ae118edb7e97947ef"
+checksum = "cbf5102391706513689f91cb3cb3d97b5f13a02e8647e6e9cb7620877ef84847"
 dependencies = [
  "auto_impl",
  "either",
@@ -9808,9 +9965,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.34.3"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e341d9777b1903a8428bc6f8fe7a8f80671d2249837c9749566e61328ef14125"
+checksum = "9487362b728f80dd2033ef5f4d0688453435bbe7caa721fa7e3b8fa25d89242b"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -9826,9 +9983,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "32.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11406408597bc249392d39295831c4b641b3a6f5c471a7c41104a7a1e3564c07"
+checksum = "cf22f80612bb8f58fd1f578750281f2afadb6c93835b14ae6a4d6b75ca26f445"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -9875,12 +10032,12 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311720d4f0f239b041375e7ddafdbd20032a33b7bae718562ea188e188ed9fd3"
+checksum = "d29404707763da607e5d6e4771cb203998c28159279c2f64cc32de08d2814651"
 dependencies = [
  "alloy-eip7928",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "revm-bytecode",
  "revm-primitives",
  "serde",
@@ -9974,6 +10131,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rocksdb"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddb7af00d2b17dbd07d82c0063e25411959748ff03e8d4f96134c2ff41fce34f"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
+]
+
+[[package]]
 name = "rolling-file"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9990,9 +10157,9 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
 name = "ruint"
-version = "1.17.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -10009,8 +10176,8 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "proptest",
- "rand 0.8.5",
- "rand 0.9.2",
+ "rand 0.8.6",
+ "rand 0.9.4",
  "rlp",
  "ruint-macro",
  "serde_core",
@@ -10036,7 +10203,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -10060,7 +10227,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.27",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -10069,7 +10236,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -10078,10 +10245,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -10135,6 +10303,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs 1.0.7",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10142,10 +10331,11 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -10262,7 +10452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.5",
+ "rand 0.8.6",
  "secp256k1-sys 0.10.1",
  "serde",
 ]
@@ -10274,7 +10464,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.9.2",
+ "rand 0.9.4",
  "secp256k1-sys 0.11.0",
 ]
 
@@ -10302,7 +10492,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -10340,7 +10530,7 @@ dependencies = [
  "lazy_static",
  "num-bigint",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
  "reqwest 0.12.28",
  "ruint",
@@ -10541,7 +10731,7 @@ dependencies = [
  "cxx-build",
  "hex",
  "postcard",
- "rand 0.8.5",
+ "rand 0.8.6",
  "ruint",
  "serde",
  "serde_json",
@@ -10558,9 +10748,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -10623,7 +10813,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -10633,9 +10823,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -10662,7 +10852,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -10700,7 +10890,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -10711,15 +10901,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest 0.10.7",
  "keccak",
@@ -10742,15 +10932,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "shellexpand"
-version = "3.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
-dependencies = [
- "dirs",
 ]
 
 [[package]]
@@ -10837,6 +11018,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10874,7 +11064,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sha1",
 ]
 
@@ -10943,6 +11133,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11002,7 +11198,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7dddc5f0fee506baf8b9fdb989e242f17e4b11c61dfbb0635b705217199eea"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "byteorder",
  "enum-as-inner",
  "libc",
@@ -11053,7 +11249,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "715f9a4586706a61c571cb5ee1c3ac2bbb2cf63e15bce772307b95befef5f5ee"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "log",
  "num-traits",
 ]
@@ -11154,6 +11350,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread-priority"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2210811179577da3d54eb69ab0b50490ee40491a25d95b8c6011ba40771cb721"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows 0.61.3",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11235,12 +11445,11 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
- "serde_core",
  "zerovec",
 ]
 
@@ -11271,9 +11480,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -11288,9 +11497,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11321,30 +11530,19 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
-dependencies = [
- "futures-util",
- "log",
- "rustls",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tungstenite 0.26.2",
- "webpki-roots 0.26.11",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "tokio",
- "tungstenite 0.28.0",
+ "tokio-rustls",
+ "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -11368,7 +11566,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -11388,39 +11586,39 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.8+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap 2.13.0",
- "toml_datetime 1.1.0+spec-1.1.0",
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.0",
+ "winnow 1.0.2",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.0",
+ "winnow 1.0.2",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -11468,7 +11666,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hdrhistogram",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -11487,7 +11685,7 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -11536,11 +11734,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
+ "symlink",
  "thiserror 2.0.18",
  "time",
  "tracing-subscriber 0.3.23",
@@ -11611,9 +11810,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-logfmt"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1f47d22deb79c3f59fcf2a1f00f60cbdc05462bf17d1cd356c1fefa3f444bd"
+checksum = "a250055a3518b5efba928a18ffac8d32d42ea607a9affff4532144cd5b2e378e"
 dependencies = [
  "time",
  "tracing",
@@ -11736,25 +11935,6 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
-dependencies = [
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand 0.9.2",
- "rustls",
- "rustls-pki-types",
- "sha1",
- "thiserror 2.0.18",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
@@ -11764,7 +11944,9 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -11778,9 +11960,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -11920,9 +12102,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -12041,11 +12223,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -12054,14 +12236,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -12072,9 +12254,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.65"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -12082,9 +12264,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -12092,9 +12274,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -12105,9 +12287,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -12129,16 +12311,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -12153,10 +12335,10 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
- "semver 1.0.27",
+ "indexmap 2.14.0",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -12175,9 +12357,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.92"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -12199,14 +12381,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
 dependencies = [
- "webpki-root-certs 1.0.6",
+ "webpki-root-certs 1.0.7",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -12217,14 +12399,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -12277,14 +12459,36 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
+ "windows-link 0.1.3",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-numerics",
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -12293,7 +12497,20 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -12304,9 +12521,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading 0.1.0",
 ]
 
 [[package]]
@@ -12315,9 +12543,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -12344,9 +12572,25 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-numerics"
@@ -12354,8 +12598,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core",
- "windows-link",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -12364,9 +12608,18 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -12375,7 +12628,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -12384,7 +12646,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -12429,7 +12691,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -12484,7 +12746,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -12497,11 +12759,20 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -12695,9 +12966,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
@@ -12710,6 +12981,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -12730,7 +13007,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -12760,8 +13037,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "bitflags 2.11.1",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -12780,9 +13057,9 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
- "semver 1.0.27",
+ "semver 1.0.28",
  "serde",
  "serde_derive",
  "serde_json",
@@ -12814,7 +13091,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-network",
- "alloy-op-evm",
+ "alloy-op-evm 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "alloy-signer-local",
@@ -12828,7 +13105,7 @@ dependencies = [
  "futures",
  "metrics",
  "metrics-derive",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.24.0",
  "op-alloy-rpc-types",
  "parking_lot",
  "rayon",
@@ -12846,7 +13123,6 @@ dependencies = [
  "reth-optimism-primitives",
  "reth-payload-primitives",
  "reth-payload-util",
- "reth-primitives",
  "reth-provider",
  "reth-revm",
  "reth-tasks",
@@ -12903,7 +13179,7 @@ dependencies = [
  "color-eyre",
  "ed25519-dalek",
  "hex",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.24.0",
  "op-alloy-rpc-types-engine",
  "reth-basic-payload-builder",
  "reth-db",
@@ -12923,7 +13199,6 @@ dependencies = [
  "reth-optimism-primitives",
  "reth-optimism-rpc",
  "reth-payload-builder",
- "reth-primitives",
  "reth-provider",
  "reth-rpc-engine-api",
  "reth-rpc-eth-api",
@@ -12956,7 +13231,7 @@ dependencies = [
  "metrics-derive",
  "parking_lot",
  "pin-project",
- "rand 0.9.2",
+ "rand 0.9.4",
  "reth-eth-wire",
  "reth-ethereum",
  "reth-network",
@@ -12981,7 +13256,7 @@ dependencies = [
  "alloy-primitives",
  "color-eyre",
  "futures",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.24.0",
  "reth-basic-payload-builder",
  "reth-optimism-chainspec",
  "reth-optimism-node",
@@ -12989,7 +13264,6 @@ dependencies = [
  "reth-optimism-primitives",
  "reth-payload-builder",
  "reth-payload-primitives",
- "reth-primitives",
  "reth-primitives-traits",
  "reth-provider",
  "reth-revm",
@@ -13030,7 +13304,7 @@ dependencies = [
  "alloy-sol-types",
  "chrono",
  "color-eyre",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.24.0",
  "parking_lot",
  "rayon",
  "reth-db",
@@ -13040,7 +13314,6 @@ dependencies = [
  "reth-optimism-forks",
  "reth-optimism-node",
  "reth-optimism-primitives",
- "reth-primitives",
  "reth-primitives-traits",
  "reth-provider",
  "reth-transaction-pool",
@@ -13073,14 +13346,13 @@ dependencies = [
  "chrono",
  "color-eyre",
  "ed25519-dalek",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.24.0",
  "op-alloy-network",
  "reth-basic-payload-builder",
  "reth-optimism-chainspec",
  "reth-optimism-node",
  "reth-optimism-primitives",
  "reth-payload-primitives",
- "reth-primitives",
  "reth-primitives-traits",
  "reth-revm",
  "serde",
@@ -13115,7 +13387,6 @@ dependencies = [
  "reth-optimism-node",
  "reth-optimism-primitives",
  "reth-optimism-rpc",
- "reth-primitives",
  "reth-primitives-traits",
  "reth-provider",
  "reth-rpc-api",
@@ -13142,7 +13413,7 @@ dependencies = [
  "alloy-eips",
  "alloy-genesis",
  "alloy-network",
- "alloy-op-evm",
+ "alloy-op-evm 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
@@ -13159,12 +13430,12 @@ dependencies = [
  "ed25519-dalek",
  "futures",
  "lazy_static",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.24.0",
  "op-alloy-network",
  "op-alloy-rpc-types",
  "op-alloy-rpc-types-engine",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "reqwest 0.12.28",
  "reth-chain-state",
  "reth-chainspec",
@@ -13184,7 +13455,6 @@ dependencies = [
  "reth-optimism-node",
  "reth-optimism-payload-builder",
  "reth-optimism-primitives",
- "reth-primitives",
  "reth-primitives-traits",
  "reth-provider",
  "reth-prune-types",
@@ -13231,7 +13501,7 @@ dependencies = [
  "color-eyre",
  "ed25519-dalek",
  "futures",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.24.0",
  "op-alloy-network",
  "op-alloy-rpc-types",
  "proptest",
@@ -13272,9 +13542,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws_stream_wasm"
@@ -13339,7 +13609,7 @@ dependencies = [
  "futures",
  "hex",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.4",
  "reqwest 0.12.28",
  "reth-node-api",
  "reth-optimism-node",
@@ -13366,9 +13636,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -13377,9 +13647,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13389,18 +13659,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13409,18 +13679,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13450,9 +13720,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -13461,11 +13731,10 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
- "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",
@@ -13473,9 +13742,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,48 +414,18 @@ dependencies = [
 [[package]]
 name = "alloy-op-evm"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b18bebd1d9f70d768e00b66c07474a65c812bad442dc3347d980f5758927f44b"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-evm",
- "alloy-op-hardforks 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "alloy-primitives",
- "auto_impl",
- "op-alloy 0.23.1",
- "op-revm 17.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "revm",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "alloy-op-evm"
-version = "0.30.0"
 source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0#6de21d0f81036bc76f14a7bdec89304c60c97f14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
- "alloy-op-hardforks 0.4.7 (git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0)",
+ "alloy-op-hardforks",
  "alloy-primitives",
  "auto_impl",
- "op-alloy 0.24.0",
- "op-revm 17.0.0 (git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0)",
+ "op-alloy",
+ "op-revm",
  "revm",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "alloy-op-hardforks"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6472c610150c4c4c15be9e1b964c9b78068f933bda25fb9cdf09b9ac2bb66f36"
-dependencies = [
- "alloy-chains",
- "alloy-hardforks",
- "alloy-primitives",
- "auto_impl",
 ]
 
 [[package]]
@@ -5537,37 +5507,14 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "op-alloy"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9b8fee21003dd4f076563de9b9d26f8c97840157ef78593cd7f262c5ca99848"
-dependencies = [
- "op-alloy-consensus 0.23.1",
-]
-
-[[package]]
-name = "op-alloy"
 version = "0.24.0"
 source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0#6de21d0f81036bc76f14a7bdec89304c60c97f14"
 dependencies = [
- "op-alloy-consensus 0.24.0",
+ "op-alloy-consensus",
  "op-alloy-network",
  "op-alloy-provider",
  "op-alloy-rpc-types",
  "op-alloy-rpc-types-engine",
-]
-
-[[package]]
-name = "op-alloy-consensus"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736381a95471d23e267263cfcee9e1d96d30b9754a94a2819148f83379de8a86"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "derive_more",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5610,7 +5557,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types-eth",
- "op-alloy-consensus 0.24.0",
+ "op-alloy-consensus",
  "op-alloy-rpc-types",
 ]
 
@@ -5651,7 +5598,7 @@ dependencies = [
  "alloy-serde",
  "alloy-signer",
  "derive_more",
- "op-alloy-consensus 0.24.0",
+ "op-alloy-consensus",
  "reth-rpc-traits",
  "serde",
  "serde_json",
@@ -5672,21 +5619,11 @@ dependencies = [
  "derive_more",
  "ethereum_ssz 0.9.1",
  "ethereum_ssz_derive 0.9.1",
- "op-alloy-consensus 0.24.0",
+ "op-alloy-consensus",
  "serde",
  "sha2",
  "snap",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "op-revm"
-version = "17.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a98f3a512a7e02a1dcf1242b57302d83657b265a665d50ad98d0b158efaf2c"
-dependencies = [
- "auto_impl",
- "revm",
 ]
 
 [[package]]
@@ -8395,7 +8332,7 @@ dependencies = [
  "alloy-primitives",
  "derive_more",
  "miniz_oxide 0.9.1",
- "op-alloy-consensus 0.24.0",
+ "op-alloy-consensus",
  "op-alloy-rpc-types",
  "paste",
  "reth-chainspec",
@@ -8423,7 +8360,7 @@ dependencies = [
  "derive_more",
  "eyre",
  "futures-util",
- "op-alloy-consensus 0.24.0",
+ "op-alloy-consensus",
  "reth-chainspec",
  "reth-cli",
  "reth-cli-commands",
@@ -8493,12 +8430,12 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
- "alloy-op-evm 0.30.0 (git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0)",
+ "alloy-op-evm",
  "alloy-primitives",
- "op-alloy-consensus 0.24.0",
+ "op-alloy-consensus",
  "op-alloy-rpc-types",
  "op-alloy-rpc-types-engine",
- "op-revm 17.0.0 (git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0)",
+ "op-revm",
  "reth-chainspec",
  "reth-evm",
  "reth-execution-errors",
@@ -8576,7 +8513,7 @@ name = "reth-optimism-forks"
 version = "1.11.3"
 source = "git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0#6de21d0f81036bc76f14a7bdec89304c60c97f14"
 dependencies = [
- "alloy-op-hardforks 0.4.7 (git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0)",
+ "alloy-op-hardforks",
  "alloy-primitives",
  "once_cell",
  "reth-ethereum-forks",
@@ -8596,9 +8533,9 @@ dependencies = [
  "eyre",
  "futures-util",
  "humantime",
- "op-alloy-consensus 0.24.0",
+ "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
- "op-revm 17.0.0 (git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0)",
+ "op-revm",
  "reth-chainspec",
  "reth-consensus",
  "reth-db",
@@ -8652,9 +8589,9 @@ dependencies = [
  "alloy-rpc-types-engine",
  "derive_more",
  "either",
- "op-alloy-consensus 0.24.0",
+ "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
- "op-revm 17.0.0 (git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0)",
+ "op-revm",
  "reth-basic-payload-builder",
  "reth-chainspec",
  "reth-evm",
@@ -8687,7 +8624,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "op-alloy-consensus 0.24.0",
+ "op-alloy-consensus",
  "reth-primitives-traits",
  "serde",
  "serde_with",
@@ -8701,7 +8638,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-json-rpc",
- "alloy-op-evm 0.30.0 (git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0)",
+ "alloy-op-evm",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-client",
@@ -8719,12 +8656,12 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-types",
  "metrics",
- "op-alloy-consensus 0.24.0",
+ "op-alloy-consensus",
  "op-alloy-network",
  "op-alloy-rpc-jsonrpsee",
  "op-alloy-rpc-types",
  "op-alloy-rpc-types-engine",
- "op-revm 17.0.0 (git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0)",
+ "op-revm",
  "reqwest 0.13.2",
  "reth-basic-payload-builder",
  "reth-chain-state",
@@ -8823,10 +8760,10 @@ dependencies = [
  "derive_more",
  "futures-util",
  "metrics",
- "op-alloy-consensus 0.24.0",
+ "op-alloy-consensus",
  "op-alloy-flz",
  "op-alloy-rpc-types",
- "op-revm 17.0.0 (git+https://github.com/ethereum-optimism/optimism?tag=op-reth%2Fv2.1.0)",
+ "op-revm",
  "parking_lot",
  "reth-chain-state",
  "reth-chainspec",
@@ -13091,7 +13028,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-network",
- "alloy-op-evm 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "alloy-op-evm",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "alloy-signer-local",
@@ -13105,8 +13042,9 @@ dependencies = [
  "futures",
  "metrics",
  "metrics-derive",
- "op-alloy-consensus 0.24.0",
+ "op-alloy-consensus",
  "op-alloy-rpc-types",
+ "op-revm",
  "parking_lot",
  "rayon",
  "reth-basic-payload-builder",
@@ -13123,6 +13061,7 @@ dependencies = [
  "reth-optimism-primitives",
  "reth-payload-primitives",
  "reth-payload-util",
+ "reth-primitives-traits",
  "reth-provider",
  "reth-revm",
  "reth-tasks",
@@ -13173,17 +13112,18 @@ name = "world-chain-node"
 version = "1.11.3"
 dependencies = [
  "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types",
+ "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "color-eyre",
  "ed25519-dalek",
  "hex",
- "op-alloy-consensus 0.24.0",
+ "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
  "reth-basic-payload-builder",
  "reth-db",
- "reth-engine-local",
  "reth-eth-wire",
  "reth-eth-wire-types",
  "reth-evm",
@@ -13199,6 +13139,7 @@ dependencies = [
  "reth-optimism-primitives",
  "reth-optimism-rpc",
  "reth-payload-builder",
+ "reth-primitives-traits",
  "reth-provider",
  "reth-rpc-engine-api",
  "reth-rpc-eth-api",
@@ -13252,12 +13193,14 @@ dependencies = [
 name = "world-chain-payload"
 version = "1.11.3"
 dependencies = [
+ "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "color-eyre",
  "futures",
- "op-alloy-consensus 0.24.0",
+ "op-alloy-consensus",
  "reth-basic-payload-builder",
+ "reth-execution-cache",
  "reth-optimism-chainspec",
  "reth-optimism-node",
  "reth-optimism-payload-builder",
@@ -13268,6 +13211,7 @@ dependencies = [
  "reth-provider",
  "reth-revm",
  "reth-tasks",
+ "reth-trie-parallel",
  "tokio",
  "tracing",
  "world-chain-builder",
@@ -13304,7 +13248,7 @@ dependencies = [
  "alloy-sol-types",
  "chrono",
  "color-eyre",
- "op-alloy-consensus 0.24.0",
+ "op-alloy-consensus",
  "parking_lot",
  "rayon",
  "reth-db",
@@ -13346,7 +13290,7 @@ dependencies = [
  "chrono",
  "color-eyre",
  "ed25519-dalek",
- "op-alloy-consensus 0.24.0",
+ "op-alloy-consensus",
  "op-alloy-network",
  "reth-basic-payload-builder",
  "reth-optimism-chainspec",
@@ -13413,7 +13357,7 @@ dependencies = [
  "alloy-eips",
  "alloy-genesis",
  "alloy-network",
- "alloy-op-evm 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "alloy-op-evm",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
@@ -13430,10 +13374,11 @@ dependencies = [
  "ed25519-dalek",
  "futures",
  "lazy_static",
- "op-alloy-consensus 0.24.0",
+ "op-alloy-consensus",
  "op-alloy-network",
  "op-alloy-rpc-types",
  "op-alloy-rpc-types-engine",
+ "op-revm",
  "parking_lot",
  "rand 0.9.4",
  "reqwest 0.12.28",
@@ -13501,7 +13446,7 @@ dependencies = [
  "color-eyre",
  "ed25519-dalek",
  "futures",
- "op-alloy-consensus 0.24.0",
+ "op-alloy-consensus",
  "op-alloy-network",
  "op-alloy-rpc-types",
  "proptest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13296,7 +13296,6 @@ dependencies = [
  "reth-optimism-chainspec",
  "reth-optimism-node",
  "reth-optimism-primitives",
- "reth-payload-primitives",
  "reth-primitives-traits",
  "reth-revm",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,104 +56,99 @@ world-chain-rpc = { path = "crates/rpc", default-features = false }
 world-chain-pool = { path = "crates/pool", default-features = false }
 world-chain-test-utils = { path = "crates/test-utils", default-features = false }
 
-# reth
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false, features = [
-    "op",
-] }
-reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-chain-state = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false, features = [
+# reth crates.io
+reth-primitives-traits = { version = "0.1.0", default-features = false }
+
+# reth github
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-chain-state = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false, features = [
     "network",
 ] }
-reth-eth-wire = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-stages-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false, features = [
-    "op",
-] }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-payload-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-network = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false, features = [
-    "c-kzg",
-] }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-rpc-layer = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.3", default-features = false }
+reth-eth-wire = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-stages-types = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-payload-util = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-network = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-rpc-layer = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
 
 # reth-optimism
-reth-optimism-evm = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v1.11.3", default-features = false }
-reth-optimism-node = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v1.11.3", default-features = false }
-reth-optimism-cli = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v1.11.3", default-features = false }
-reth-optimism-rpc = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v1.11.3", default-features = false }
-reth-optimism-consensus = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v1.11.3", default-features = false }
-reth-optimism-chainspec = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v1.11.3", default-features = false }
-reth-optimism-payload-builder = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v1.11.3", default-features = false }
-reth-optimism-forks = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v1.11.3", default-features = false }
-reth-optimism-primitives = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v1.11.3", default-features = false }
-reth-optimism-storage = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v1.11.3", default-features = false }
-reth-optimism-flashblocks = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v1.11.3", default-features = false }
+reth-optimism-evm = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v2.1.0", default-features = false }
+reth-optimism-node = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v2.1.0", default-features = false }
+reth-optimism-cli = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v2.1.0", default-features = false }
+reth-optimism-rpc = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v2.1.0", default-features = false }
+reth-optimism-consensus = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v2.1.0", default-features = false }
+reth-optimism-chainspec = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v2.1.0", default-features = false }
+reth-optimism-payload-builder = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v2.1.0", default-features = false }
+reth-optimism-forks = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v2.1.0", default-features = false }
+reth-optimism-primitives = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v2.1.0", default-features = false }
+reth-optimism-storage = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v2.1.0", default-features = false }
+reth-optimism-flashblocks = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v2.1.0", default-features = false }
 
 # alloy op
-op-alloy-consensus = { version = "0.23.1", default-features = false }
-op-alloy-rpc-types = { version = "0.23.1", default-features = false }
-op-alloy-rpc-types-engine = { version = "0.23.1", default-features = false }
-op-alloy-network = { version = "0.23.1", default-features = false }
-alloy-op-hardforks = { version = "0.4.5", default-features = false }
-op-alloy-provider = { version = "0.23.1", default-features = false }
+op-alloy-consensus = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v2.1.0", default-features = false }
+op-alloy-rpc-types = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v2.1.0", default-features = false }
+op-alloy-rpc-types-engine = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v2.1.0", default-features = false }
+op-alloy-network = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v2.1.0", default-features = false }
+alloy-op-hardforks = { version = "0.4.7", default-features = false }
+op-alloy-provider = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v2.1.0", default-features = false }
 
 # alloy
-alloy = { version = "=1.6.3" }
-alloy-json-rpc = { version = "=1.6.3", default-features = false }
-alloy-chains = { version = "0.2.5", default-features = false }
-alloy-provider = { version = "=1.6.3", default-features = false }
-alloy-rpc-client = { version = "=1.6.3", default-features = false }
-alloy-transport-http = { version = "=1.6.3", default-features = false }
-alloy-transport = { version = "=1.6.3", default-features = false }
-alloy-consensus = { version = "=1.6.3", default-features = false }
-alloy-network = { version = "=1.6.3", default-features = false }
+alloy = { version = "1.8.2" }
+alloy-json-rpc = { version = "1.8.2", default-features = false }
+alloy-chains = { version = "0.2.33", default-features = false }
+alloy-provider = { version = "1.8.2", default-features = false }
+alloy-rpc-client = { version = "1.8.2", default-features = false }
+alloy-transport-http = { version = "1.8.2", default-features = false }
+alloy-transport = { version = "1.8.2", default-features = false }
+alloy-consensus = { version = "1.8.2", default-features = false }
+alloy-network = { version = "1.8.2", default-features = false }
 alloy-primitives = { version = "1.5.7", default-features = false, features = [
     "std",
     "map-foldhash",
 ] }
-alloy-contract = { version = "=1.6.3", default-features = false }
-alloy-rpc-types-eth = { version = "=1.6.3", default-features = false }
-alloy-rpc-types = { version = "=1.6.3", features = [
+alloy-contract = { version = "1.8.2", default-features = false }
+alloy-rpc-types-eth = { version = "1.8.2", default-features = false }
+alloy-rpc-types = { version = "1.8.2", features = [
     "eth",
 ], default-features = false }
-alloy-rpc-types-engine = { version = "=1.6.3", default-features = false }
+alloy-rpc-types-engine = { version = "1.8.2", default-features = false }
 alloy-rlp = { version = "0.3.13", default-features = false, features = [
     "derive",
 ] }
@@ -166,33 +161,34 @@ alloy-eip7928 = { version = "0.3.3", default-features = false, features = [
     "rlp",
 ] }
 
-alloy-genesis = { version = "=1.6.3", default-features = false }
-alloy-rpc-types-debug = "=1.6.3"
-alloy-signer = { version = "=1.6.3", default-features = false }
-alloy-signer-local = { version = "=1.6.3", default-features = false, features = [
+alloy-genesis = { version = "1.8.2", default-features = false }
+alloy-rpc-types-debug = "1.8.2"
+alloy-signer = { version = "1.8.2", default-features = false }
+alloy-signer-local = { version = "1.8.2", default-features = false, features = [
     "mnemonic",
 ] }
 alloy-sol-types = "1.5.6"
 alloy-serde = { version = "1.8.3", default-features = false }
-alloy-hardforks = { version = "0.4.5", default-features = false }
+alloy-hardforks = { version = "0.4.7", default-features = false }
 alloy-trie = { version = "0.9.4", default-features = false, features = [
     "ethereum",
 ] }
 
 
 # revm
-revm = { version = "34", default-features = false }
-revm-bytecode = { version = "8", default-features = false }
-revm-database = { version = "10", default-features = false }
-revm-state = { version = "9", default-features = false }
-revm-primitives = { version = "22", default-features = false }
-revm-interpreter = { version = "32", default-features = false }
-revm-database-interface = { version = "9", default-features = false }
-op-revm = { version = "15", default-features = false }
-revm-inspectors = "0.34"
+revm = { version = "36.0.0", default-features = false }
+revm-bytecode = { version = "9.0.0", default-features = false }
+revm-database = { version = "12.0.0", default-features = false }
+revm-state = { version = "10.0.0", default-features = false }
+revm-primitives = { version = "22.1.0", default-features = false }
+revm-interpreter = { version = "34.0.0", default-features = false }
+revm-database-interface = { version = "10.0.0", default-features = false }
+op-revm = { version = "17.0.0", default-features = false }
+revm-inspectors = "0.36.1"
 
-alloy-op-evm = { version = "0.26", default-features = false }
-alloy-evm = { version = "0.27", default-features = false }
+alloy-op-evm = { version = "0.30.0", default-features = false }
+alloy-evm = { version = "0.30.0", default-features = false }
+
 # rpc
 jsonrpsee = { version = "0.26.0", features = ["server", "client", "macros"] }
 jsonrpsee-core = { version = "0.26.0" }
@@ -256,12 +252,3 @@ testcontainers-modules = { version = "0.14", features = ["redis"] }
 tracing-test = { version = "0.2", features = ["no-env-filter"] }
 lazy_static = "1.4"
 proptest = "1.9.0"
-
-[patch.crates-io]
-op-alloy = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v1.11.3" }
-op-alloy-consensus = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v1.11.3" }
-op-alloy-network = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v1.11.3" }
-op-alloy-rpc-types = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v1.11.3" }
-op-alloy-rpc-types-engine = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v1.11.3" }
-alloy-op-evm = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v1.11.3" }
-alloy-op-hardforks = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v1.11.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,8 @@ world-chain-test-utils = { path = "crates/test-utils", default-features = false 
 reth-primitives-traits = { version = "0.1.0", default-features = false }
 
 # reth github
+reth-trie-parallel = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
 reth-cli-util = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
 reth-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
 reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.0.0", default-features = false }
@@ -183,10 +185,10 @@ revm-state = { version = "10.0.0", default-features = false }
 revm-primitives = { version = "22.1.0", default-features = false }
 revm-interpreter = { version = "34.0.0", default-features = false }
 revm-database-interface = { version = "10.0.0", default-features = false }
-op-revm = { version = "17.0.0", default-features = false }
+op-revm = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v2.1.0", default-features = false }
 revm-inspectors = "0.36.1"
 
-alloy-op-evm = { version = "0.30.0", default-features = false }
+alloy-op-evm = { git = "https://github.com/ethereum-optimism/optimism", tag = "op-reth/v2.1.0", default-features = false }
 alloy-evm = { version = "0.30.0", default-features = false }
 
 # rpc

--- a/crates/builder/Cargo.toml
+++ b/crates/builder/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 
 [dependencies]
 # reth
-reth-primitives.workspace = true
 reth-basic-payload-builder.workspace = true
 reth-chain-state.workspace = true
 reth-chainspec.workspace = true

--- a/crates/builder/Cargo.toml
+++ b/crates/builder/Cargo.toml
@@ -19,6 +19,7 @@ reth-evm.workspace = true
 reth-node-api.workspace = true
 reth-node-builder.workspace = true
 reth-revm.workspace = true
+reth-primitives-traits.workspace = true
 
 # op-reth
 reth-optimism-forks.workspace = true
@@ -47,6 +48,9 @@ world-chain-rpc.workspace = true
 # revm
 revm.workspace = true
 revm-database.workspace = true
+
+# op-revm
+op-revm.workspace = true
 
 # tokio
 tokio.workspace = true

--- a/crates/builder/benches/flashblock_building_live_node.rs
+++ b/crates/builder/benches/flashblock_building_live_node.rs
@@ -7,8 +7,8 @@ use reth_basic_payload_builder::{BuildArguments, BuildOutcome, PayloadConfig};
 use reth_optimism_node::{
     OpPayloadAttributes, payload::OpPayloadAttrs, utils::optimism_payload_attributes,
 };
-use reth_payload_primitives::PayloadAttributes as _;
 use reth_optimism_payload_builder::config::OpBuilderConfig;
+use reth_payload_primitives::PayloadAttributes as _;
 use reth_provider::{StateProvider, StateProviderFactory};
 use world_chain_builder::{
     WorldChainPayloadBuilderCtxBuilder, payload_builder::FlashblocksPayloadBuilder,
@@ -142,8 +142,7 @@ fn bench_build_flashblock_case<F>(
         let rpc_attributes = deterministic_payload_attributes(timestamp, transactions);
         let attributes = OpPayloadAttrs::from(rpc_attributes);
         let payload_id = attributes.payload_id(&parent_header.hash());
-        let config =
-            PayloadConfig::new(Arc::new(parent_header.clone()), attributes, payload_id);
+        let config = PayloadConfig::new(Arc::new(parent_header.clone()), attributes, payload_id);
         let builder = build_live_payload_builder(
             node.node.inner.pool.clone(),
             provider,

--- a/crates/builder/benches/flashblock_building_live_node.rs
+++ b/crates/builder/benches/flashblock_building_live_node.rs
@@ -3,11 +3,11 @@ use std::sync::Arc;
 use alloy_primitives::{Address, B256, Bytes};
 use alloy_rpc_types_engine::PayloadAttributes as RpcPayloadAttributes;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use op_alloy_consensus::OpTxEnvelope;
 use reth_basic_payload_builder::{BuildArguments, BuildOutcome, PayloadConfig};
 use reth_optimism_node::{
-    OpPayloadAttributes, OpPayloadBuilderAttributes, utils::optimism_payload_attributes,
+    OpPayloadAttributes, payload::OpPayloadAttrs, utils::optimism_payload_attributes,
 };
+use reth_payload_primitives::PayloadAttributes as _;
 use reth_optimism_payload_builder::config::OpBuilderConfig;
 use reth_provider::{StateProvider, StateProviderFactory};
 use world_chain_builder::{
@@ -30,7 +30,6 @@ use world_chain_test_utils::{
 
 const TOTAL_TX_COUNTS: [usize; 3] = [50, 500, 1000];
 const WORLD_ID_TOTAL_TX_COUNTS: [usize; 3] = [10, 25, 50];
-const PAYLOAD_VERSION: u8 = 3;
 
 fn deterministic_payload_attributes(
     timestamp: u64,
@@ -141,14 +140,10 @@ fn bench_build_flashblock_case<F>(
         let parent_header = node.node.inner.chain_spec().sealed_genesis_header();
         let timestamp = parent_header.timestamp + 2; // 2s block time
         let rpc_attributes = deterministic_payload_attributes(timestamp, transactions);
-        let attributes =
-            <OpPayloadBuilderAttributes<OpTxEnvelope> as reth_payload_primitives::PayloadBuilderAttributes>::try_new(
-                parent_header.hash(),
-                rpc_attributes,
-                PAYLOAD_VERSION,
-            )
-            .expect("failed to decode payload attributes transactions");
-        let config = PayloadConfig::new(Arc::new(parent_header.clone()), attributes);
+        let attributes = OpPayloadAttrs::from(rpc_attributes);
+        let payload_id = attributes.payload_id(&parent_header.hash());
+        let config =
+            PayloadConfig::new(Arc::new(parent_header.clone()), attributes, payload_id);
         let builder = build_live_payload_builder(
             node.node.inner.pool.clone(),
             provider,
@@ -163,6 +158,8 @@ fn bench_build_flashblock_case<F>(
                     cached_reads: Default::default(),
                     cancel: Default::default(),
                     best_payload: None,
+                    execution_cache: None,
+                    trie_handle: None,
                 };
 
                 let (outcome, access_list) = builder

--- a/crates/builder/src/bal_executor.rs
+++ b/crates/builder/src/bal_executor.rs
@@ -5,9 +5,9 @@ use alloy_op_evm::{
     block::receipt_builder::OpReceiptBuilder,
 };
 use op_alloy_consensus::OpReceipt;
-use op_revm::{OpHaltReason, OpSpecId, OpTransaction};
+use op_revm::{OpHaltReason, OpSpecId};
 use reth_evm::{
-    Database, Evm, FromRecoveredTx, FromTxWithEncoded,
+    Database, Evm,
     block::{BlockExecutionError, BlockExecutor, InternalBlockExecutionError},
 };
 use reth_node_api::NodePrimitives;
@@ -17,11 +17,7 @@ use reth_optimism_primitives::OpTransactionSigned;
 use reth_payload_primitives::BuiltPayload;
 use reth_primitives_traits::{Recovered, RecoveredBlock, SealedHeader};
 use reth_trie_common::updates::TrieUpdates;
-use revm::{
-    DatabaseCommit,
-    context::{BlockEnv, TxEnv},
-    database::BundleState,
-};
+use revm::{DatabaseCommit, context::BlockEnv, database::BundleState};
 use tracing::trace;
 
 use crate::{

--- a/crates/builder/src/bal_executor.rs
+++ b/crates/builder/src/bal_executor.rs
@@ -1,19 +1,22 @@
 //! A block executor and builder for flashblocks that constructs a BAL (Block Access List) sidecar.
 
 use alloy_op_evm::{
-    OpBlockExecutionCtx, OpBlockExecutor, OpBlockExecutorFactory,
+    OpBlockExecutionCtx, OpBlockExecutor, OpBlockExecutorFactory, OpTx,
     block::receipt_builder::OpReceiptBuilder,
 };
 use op_alloy_consensus::OpReceipt;
+use op_revm::{OpHaltReason, OpSpecId, OpTransaction};
 use reth_evm::{
     Database, Evm, FromRecoveredTx, FromTxWithEncoded,
     block::{BlockExecutionError, BlockExecutor, InternalBlockExecutionError},
-    op_revm::{OpSpecId, OpTransaction},
 };
+use reth_node_api::NodePrimitives;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_evm::OpRethReceiptBuilder;
 use reth_optimism_primitives::OpTransactionSigned;
 use reth_payload_primitives::BuiltPayload;
+use reth_primitives_traits::{Recovered, RecoveredBlock, SealedHeader};
+use reth_trie_common::updates::TrieUpdates;
 use revm::{
     DatabaseCommit,
     context::{BlockEnv, TxEnv},
@@ -29,14 +32,12 @@ use crate::{
     state_db::StateDB,
 };
 use alloy_consensus::{Block, BlockHeader, Header, transaction::TxHashRef};
-use alloy_primitives::{FixedBytes, U256};
+use alloy_primitives::{B256, FixedBytes, U256};
 use reth_evm::{
     block::CommitChanges,
     execute::{BlockAssemblerInput, BlockBuilder, BlockBuilderOutcome, ExecutorTx},
-    op_revm::OpHaltReason,
 };
 use reth_optimism_node::{OpBlockAssembler, OpBuiltPayload};
-use reth_primitives::{NodePrimitives, Recovered, RecoveredBlock, SealedHeader};
 use reth_provider::StateProvider;
 use revm::{context::result::ExecutionResult, database::states::bundle_state::BundleRetention};
 use std::{sync::Arc, time::Instant};
@@ -107,8 +108,7 @@ impl<'a, DB, R, N: NodePrimitives, E> BalBlockBuilder<'a, R, N, E>
 where
     R: OpReceiptBuilder<Transaction = OpTransactionSigned, Receipt = OpReceipt>,
     DB: StateDB + DatabaseCommit + Database + 'a,
-    E: Evm<DB = BalBuilderDb<DB>, Tx = OpTransaction<TxEnv>, Spec = OpSpecId, BlockEnv = BlockEnv>,
-    OpTransaction<TxEnv>: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>,
+    E: Evm<DB = BalBuilderDb<DB>, Tx = OpTx, Spec = OpSpecId, BlockEnv = BlockEnv>,
 {
     /// Creates a new [`FlashblocksBlockBuilder`] with the given executor factory and assembler.
     pub fn new(
@@ -162,14 +162,12 @@ where
         >,
     E: Evm<
             DB = BalBuilderDb<DB>,
-            Tx = OpTransaction<TxEnv>,
+            Tx = OpTx,
             Spec = OpSpecId,
             HaltReason = OpHaltReason,
             BlockEnv = BlockEnv,
         >,
     R: OpReceiptBuilder<Receipt = OpReceipt, Transaction = OpTransactionSigned>,
-    OpTransaction<TxEnv>:
-        FromRecoveredTx<OpTransactionSigned> + FromTxWithEncoded<OpTransactionSigned>,
 {
     type Primitives = N;
     type Executor = OpBlockExecutor<E, R, Arc<OpChainSpec>>;
@@ -205,6 +203,7 @@ where
     fn finish(
         self,
         _state: impl StateProvider,
+        _state_root_precomputed: Option<(B256, TrieUpdates)>,
     ) -> Result<BlockBuilderOutcome<N>, BlockExecutionError> {
         unimplemented!(
             "finish is not supported on FlashblocksBlockBuilder; use finish_with_bundle instead"
@@ -235,14 +234,12 @@ where
         >,
     E: Evm<
             DB = BalBuilderDb<DB>,
-            Tx = OpTransaction<TxEnv>,
+            Tx = OpTx,
             Spec = OpSpecId,
             HaltReason = OpHaltReason,
             BlockEnv = BlockEnv,
         >,
     R: OpReceiptBuilder<Receipt = OpReceipt, Transaction = OpTransactionSigned>,
-    OpTransaction<TxEnv>:
-        FromRecoveredTx<OpTransactionSigned> + FromTxWithEncoded<OpTransactionSigned>,
 {
     fn finish_with_bundle(
         self,

--- a/crates/builder/src/database/bal_builder_db.rs
+++ b/crates/builder/src/database/bal_builder_db.rs
@@ -6,7 +6,7 @@ use crossbeam_channel::Sender;
 use revm::{
     Database, DatabaseCommit, DatabaseRef,
     database::{BundleState, states::bundle_state::BundleRetention},
-    primitives::{HashMap, StorageKey, StorageValue},
+    primitives::{AddressMap, StorageKey, StorageValue},
     state::{AccountInfo, Bytecode},
 };
 use tracing::error;
@@ -16,7 +16,7 @@ use crate::access_list::FlashblockAccessListConstruction;
 /// Messages sent to the background builder for recording reads/writes.
 enum BalBuilderMsg {
     StorageRead(Address, StorageKey),
-    Commit(HashMap<Address, revm::state::Account>),
+    Commit(AddressMap<revm::state::Account>),
     SetIndex(u16),
     MergeAcccessList(FlashblockAccessListConstruction),
 }
@@ -88,7 +88,7 @@ where
     /// capture only new values in the access list.
     fn try_commit(
         &mut self,
-        changes: HashMap<Address, revm::state::Account>,
+        changes: AddressMap<revm::state::Account>,
     ) -> Result<(), <DB as Database>::Error> {
         // When we commit new account state we must first load the previous account state. Only
         // what's changed should be published to the access list.
@@ -216,7 +216,7 @@ impl<DB: DatabaseCommit> DatabaseCommit for BalBuilderDb<DB>
 where
     DB: DatabaseCommit + Database,
 {
-    fn commit(&mut self, changes: HashMap<Address, revm::state::Account>) {
+    fn commit(&mut self, changes: AddressMap<revm::state::Account>) {
         if let Err(e) = self.try_commit(changes) {
             error!("Error committing to BalBuilderDb: {:?}", e);
             self.error = Some(e);
@@ -244,15 +244,6 @@ where
         self.db.take_bundle()
     }
 
-    fn set_state_clear_flag(&mut self, has_state_clear: bool) {
-        self.db.set_state_clear_flag(has_state_clear);
-    }
-}
-
-impl<DB> reth_evm::block::StateDB for BalBuilderDb<DB>
-where
-    DB: StateDB + DatabaseCommit + Database,
-{
     fn set_state_clear_flag(&mut self, has_state_clear: bool) {
         self.db.set_state_clear_flag(has_state_clear);
     }
@@ -369,7 +360,7 @@ impl<DB: Database> Database for AsyncBalBuilderDb<DB> {
 }
 
 impl<DB: Database + DatabaseCommit> DatabaseCommit for AsyncBalBuilderDb<DB> {
-    fn commit(&mut self, changes: HashMap<Address, revm::state::Account>) {
+    fn commit(&mut self, changes: AddressMap<revm::state::Account>) {
         // Ignore errors from the builder channel.
         // relevent errors will be propagated through `finish()`.
         self.tx.send(BalBuilderMsg::Commit(changes.clone())).ok();
@@ -394,12 +385,6 @@ impl<DB: StateDB> StateDB for AsyncBalBuilderDb<DB> {
         self.db.take_bundle()
     }
 
-    fn set_state_clear_flag(&mut self, has_state_clear: bool) {
-        self.db.set_state_clear_flag(has_state_clear);
-    }
-}
-
-impl<DB: StateDB> reth_evm::block::StateDB for AsyncBalBuilderDb<DB> {
     fn set_state_clear_flag(&mut self, has_state_clear: bool) {
         self.db.set_state_clear_flag(has_state_clear);
     }
@@ -449,7 +434,7 @@ impl<DB: DatabaseRef> Database for NoOpCommitDB<DB> {
 }
 
 impl<DB: DatabaseRef> DatabaseCommit for NoOpCommitDB<DB> {
-    fn commit(&mut self, _changes: HashMap<Address, revm::state::Account>) {
+    fn commit(&mut self, _changes: AddressMap<revm::state::Account>) {
         // No-op
     }
 }
@@ -471,12 +456,6 @@ impl<DB: DatabaseRef + std::fmt::Debug> StateDB for NoOpCommitDB<DB> {
         unimplemented!()
     }
 
-    fn set_state_clear_flag(&mut self, _has_state_clear: bool) {
-        // No-op
-    }
-}
-
-impl<DB: DatabaseRef + std::fmt::Debug> reth_evm::block::StateDB for NoOpCommitDB<DB> {
     fn set_state_clear_flag(&mut self, _has_state_clear: bool) {
         // No-op
     }

--- a/crates/builder/src/execution_context.rs
+++ b/crates/builder/src/execution_context.rs
@@ -13,15 +13,15 @@ use op_alloy_consensus::EIP1559ParamError;
 use op_alloy_rpc_types::OpTransactionRequest;
 
 use alloy_rpc_types_engine::PayloadId;
+use op_revm::OpSpecId;
 use reth_basic_payload_builder::PayloadConfig;
 use reth_chainspec::EthChainSpec;
 use reth_evm::{
     ConfigureEvm, Database, Evm, EvmEnv,
     block::{BlockExecutionError, BlockValidationError},
     execute::{BlockBuilder, BlockExecutor},
-    op_revm::OpSpecId,
 };
-use reth_node_api::{PayloadBuilderAttributes, PayloadBuilderError};
+use reth_node_api::{NodePrimitives, PayloadBuilderError};
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_node::{
@@ -34,7 +34,7 @@ use reth_optimism_payload_builder::{
 };
 use reth_optimism_primitives::OpTransactionSigned;
 use reth_payload_util::PayloadTransactions;
-use reth_primitives::{NodePrimitives, Recovered, SealedHeader, TxTy};
+use reth_primitives_traits::{Recovered, SealedHeader, TxTy};
 use reth_provider::{BlockReaderIdExt, ChainSpecProvider, StateProviderFactory};
 use reth_revm::cancelled::CancelOnDrop;
 use reth_transaction_pool::{BestTransactionsAttributes, PoolTransaction, TransactionPool};

--- a/crates/builder/src/executor.rs
+++ b/crates/builder/src/executor.rs
@@ -4,20 +4,23 @@ use alloy_op_evm::{
     block::{OpTxEnv, receipt_builder::OpReceiptBuilder},
 };
 
+use alloy_primitives::B256;
+use op_revm::{OpHaltReason, OpSpecId};
 use reth_evm::{
     Database, Evm, FromRecoveredTx, FromTxWithEncoded,
     block::{BlockExecutionError, BlockExecutor, CommitChanges},
     execute::{
         BasicBlockBuilder, BlockAssemblerInput, BlockBuilder, BlockBuilderOutcome, ExecutorTx,
     },
-    op_revm::{OpHaltReason, OpSpecId},
 };
+use reth_node_api::NodePrimitives;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_evm::OpRethReceiptBuilder;
 use reth_optimism_node::OpBlockAssembler;
 use reth_optimism_primitives::{OpReceipt, OpTransactionSigned};
-use reth_primitives::{NodePrimitives, Recovered, RecoveredBlock, SealedHeader};
+use reth_primitives_traits::{Recovered, RecoveredBlock, SealedHeader};
 use reth_provider::StateProvider;
+use reth_trie_common::updates::TrieUpdates;
 use revm::{
     DatabaseCommit,
     context::{BlockEnv, result::ExecutionResult},
@@ -114,6 +117,7 @@ where
     fn finish(
         self,
         _state: impl StateProvider,
+        _state_root_precomputed: Option<(B256, TrieUpdates)>,
     ) -> Result<BlockBuilderOutcome<N>, BlockExecutionError> {
         unimplemented!(
             "finish is not supported on FlashblocksBlockBuilder; use finish_with_bundle instead"

--- a/crates/builder/src/payload_builder.rs
+++ b/crates/builder/src/payload_builder.rs
@@ -16,6 +16,7 @@ use crate::{
 };
 use alloy_eips::Encodable2718;
 use alloy_primitives::TxHash;
+use op_revm::OpSpecId;
 use reth_evm::{
     Evm, EvmFactory,
     block::{BlockExecutor, BlockExecutorFactory},
@@ -34,11 +35,9 @@ use reth_basic_payload_builder::{
     PayloadConfig,
 };
 use reth_evm::{
-    ConfigureEvm, Database, EvmEnv, execute::BlockBuilderOutcome, op_revm::OpSpecId,
-    precompiles::PrecompilesMap,
+    ConfigureEvm, Database, EvmEnv, execute::BlockBuilderOutcome, precompiles::PrecompilesMap,
 };
-use reth_node_api::{BuiltPayloadExecutedBlock, PayloadBuilderAttributes, PayloadBuilderError};
-use reth_primitives::NodePrimitives;
+use reth_node_api::{BuiltPayloadExecutedBlock, NodePrimitives, PayloadBuilderError};
 use reth_revm::database::StateProviderDatabase;
 use revm_database::State;
 use tracing::trace;
@@ -52,7 +51,7 @@ use reth_optimism_node::{
 use reth_optimism_payload_builder::{
     builder::{ExecutionInfo, OpPayloadTransactions},
     config::OpBuilderConfig,
-    payload::{OpBuiltPayload, OpPayloadBuilderAttributes},
+    payload::{OpBuiltPayload, OpPayloadAttrs, OpPayloadBuilderAttributes},
 };
 use reth_optimism_primitives::{OpPrimitives, OpReceipt, OpTransactionSigned};
 use reth_payload_util::{NoopPayloadTransactions, PayloadTransactions};
@@ -120,6 +119,8 @@ where
             mut cached_reads,
             cancel,
             best_payload,
+            execution_cache: _,
+            trie_handle: _,
         } = args;
         self.metrics.increment_attempts();
         let build_started = Instant::now();
@@ -180,15 +181,16 @@ where
             PayloadBuilderCtx: PayloadBuilderCtx<Transaction = Pool::Transaction>,
         >,
 {
-    type Attributes = OpPayloadBuilderAttributes<OpTxEnvelope>;
+    type Attributes = OpPayloadAttrs;
     type BuiltPayload = OpBuiltPayload;
 
     fn try_build(
         &self,
         args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
     ) -> Result<BuildOutcome<Self::BuiltPayload>, PayloadBuilderError> {
+        let converted_args = convert_build_args(args)?;
         self.build_payload(
-            args,
+            converted_args,
             |attrs| {
                 self.best_transactions
                     .best_transactions(self.pool.clone(), attrs)
@@ -216,9 +218,12 @@ where
             cached_reads: Default::default(),
             cancel: Default::default(),
             best_payload: None,
+            execution_cache: None,
+            trie_handle: None,
         };
+        let converted_args = convert_build_args(args)?;
         self.build_payload(
-            args,
+            converted_args,
             |_| NoopPayloadTransactions::<Pool::Transaction>::default(),
             None,
         )?
@@ -259,8 +264,9 @@ where
         ),
         PayloadBuilderError,
     > {
+        let converted_args = convert_build_args(args)?;
         self.build_payload(
-            args,
+            converted_args,
             |attrs| {
                 self.best_transactions
                     .best_transactions(self.pool.clone(), attrs)
@@ -268,6 +274,39 @@ where
             committed_payload,
         )
     }
+}
+
+/// Converts `BuildArguments` from [`OpPayloadAttrs`] to [`OpPayloadBuilderAttributes`], decoding
+/// the RPC transaction bytes into typed transactions.
+fn convert_build_args(
+    args: BuildArguments<OpPayloadAttrs, OpBuiltPayload>,
+) -> Result<BuildArguments<OpPayloadBuilderAttributes<OpTxEnvelope>, OpBuiltPayload>, PayloadBuilderError>
+{
+    let BuildArguments {
+        config,
+        cached_reads,
+        execution_cache,
+        trie_handle,
+        cancel,
+        best_payload,
+    } = args;
+    let parent_hash = config.parent_header.hash();
+    let payload_id = config.payload_id;
+    let builder_attrs =
+        OpPayloadBuilderAttributes::from_rpc_attrs(parent_hash, payload_id, config.attributes.0)
+            .map_err(PayloadBuilderError::other)?;
+    Ok(BuildArguments {
+        config: PayloadConfig {
+            parent_header: config.parent_header,
+            attributes: builder_attrs,
+            payload_id,
+        },
+        cached_reads,
+        execution_cache,
+        trie_handle,
+        cancel,
+        best_payload,
+    })
 }
 
 /// Builds the payload on top of the state.

--- a/crates/builder/src/payload_builder.rs
+++ b/crates/builder/src/payload_builder.rs
@@ -280,8 +280,10 @@ where
 /// the RPC transaction bytes into typed transactions.
 fn convert_build_args(
     args: BuildArguments<OpPayloadAttrs, OpBuiltPayload>,
-) -> Result<BuildArguments<OpPayloadBuilderAttributes<OpTxEnvelope>, OpBuiltPayload>, PayloadBuilderError>
-{
+) -> Result<
+    BuildArguments<OpPayloadBuilderAttributes<OpTxEnvelope>, OpBuiltPayload>,
+    PayloadBuilderError,
+> {
     let BuildArguments {
         config,
         cached_reads,

--- a/crates/builder/src/state_db.rs
+++ b/crates/builder/src/state_db.rs
@@ -61,8 +61,8 @@ impl<DB: Database> StateDB for State<DB> {
         self.take_bundle()
     }
 
-    fn set_state_clear_flag(&mut self, has_state_clear: bool) {
-        self.set_state_clear_flag(has_state_clear);
+    fn set_state_clear_flag(&mut self, _has_state_clear: bool) {
+        // revm-database v12 handles state clearing in the EVM journal.
     }
 }
 

--- a/crates/builder/src/traits/context.rs
+++ b/crates/builder/src/traits/context.rs
@@ -6,10 +6,9 @@ use alloy_eips::eip4895::Withdrawals;
 use alloy_primitives::U256;
 use alloy_rpc_types_engine::PayloadId;
 use op_alloy_consensus::EIP1559ParamError;
+use op_revm::OpSpecId;
 use reth_chainspec::EthereumHardforks;
-use reth_evm::{
-    ConfigureEvm, Evm, EvmEnv, block::BlockExecutor, execute::BlockBuilder, op_revm::OpSpecId,
-};
+use reth_evm::{ConfigureEvm, Evm, EvmEnv, block::BlockExecutor, execute::BlockBuilder};
 use reth_node_api::PayloadBuilderError;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_forks::OpHardforks;
@@ -24,7 +23,7 @@ use reth_optimism_payload_builder::{
 };
 use reth_payload_primitives::BuildNextEnv;
 use reth_payload_util::PayloadTransactions;
-use reth_primitives::{SealedHeader, TxTy};
+use reth_primitives_traits::{SealedHeader, TxTy};
 use reth_provider::ChainSpecProvider;
 use reth_transaction_pool::{BestTransactionsAttributes, PoolTransaction, TransactionPool};
 use revm::{DatabaseCommit, context::BlockEnv};
@@ -181,8 +180,8 @@ pub trait PayloadBuilderCtx: Send + Sync {
     /// represent validator stake withdrawals that must be processed automatically.
     fn withdrawals(&self) -> Option<&Withdrawals> {
         self.spec()
-            .is_shanghai_active_at_timestamp(self.attributes().payload_attributes.timestamp)
-            .then(|| &self.attributes().payload_attributes.withdrawals)
+            .is_shanghai_active_at_timestamp(self.attributes().timestamp)
+            .then(|| &self.attributes().withdrawals)
     }
 }
 
@@ -301,8 +300,8 @@ impl PayloadBuilderCtx for OpPayloadBuilderCtx<OpEvmConfig, OpChainSpec> {
     /// represent validator stake withdrawals that must be processed automatically.
     fn withdrawals(&self) -> Option<&Withdrawals> {
         self.spec()
-            .is_shanghai_active_at_timestamp(self.attributes().payload_attributes.timestamp)
-            .then(|| &self.attributes().payload_attributes.withdrawals)
+            .is_shanghai_active_at_timestamp(self.attributes().timestamp)
+            .then(|| &self.attributes().withdrawals)
     }
 
     fn block_builder<'a, DB>(

--- a/crates/builder/src/traits/context_builder.rs
+++ b/crates/builder/src/traits/context_builder.rs
@@ -2,9 +2,9 @@ use crate::traits::context::PayloadBuilderCtx;
 use op_alloy_consensus::OpTxEnvelope;
 use reth_basic_payload_builder::PayloadConfig;
 use reth_evm::ConfigureEvm;
+use reth_node_api::NodePrimitives;
 use reth_optimism_node::{OpBuiltPayload, OpEvmConfig, OpPayloadBuilderAttributes};
 use reth_optimism_payload_builder::config::OpBuilderConfig;
-use reth_primitives::NodePrimitives;
 use reth_revm::cancelled::CancelOnDrop;
 
 /// Builder trait for creating [`PayloadBuilderCtx`] instances with specific configurations.

--- a/crates/builder/src/validator.rs
+++ b/crates/builder/src/validator.rs
@@ -33,7 +33,10 @@ use reth_optimism_evm::{OpBlockAssembler, OpEvmConfig, OpRethReceiptBuilder};
 use reth_optimism_node::OpBuiltPayload;
 use reth_optimism_primitives::{OpPrimitives, OpTransactionSigned};
 use reth_primitives::{Recovered, RecoveredBlock, SealedHeader};
-use reth_provider::{BlockExecutionOutput, StateProvider, StateProviderFactory};
+use reth_provider::{
+    AccountReader, BlockExecutionOutput, BlockHashReader, BytecodeReader, ProviderError,
+    StateProvider, StateProviderBox, StateProviderFactory,
+};
 use reth_revm::database::StateProviderDatabase;
 use reth_trie_common::{HashedPostState, KeccakKeyHasher, updates::TrieUpdates};
 use revm::{
@@ -64,6 +67,56 @@ use crate::{
 
 /// A type alias for the BAL builder database with a cache layer.
 pub type ValidatorDb<'a, DB> = BalBuilderDb<&'a mut NoOpCommitDB<TemporalDb<DB>>>;
+
+#[derive(Clone)]
+struct SharedStateProviderDatabase {
+    provider: Arc<Mutex<StateProviderBox>>,
+}
+
+impl SharedStateProviderDatabase {
+    fn new(provider: StateProviderBox) -> Self {
+        Self {
+            provider: Arc::new(Mutex::new(provider)),
+        }
+    }
+}
+
+impl std::fmt::Debug for SharedStateProviderDatabase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SharedStateProviderDatabase")
+            .finish_non_exhaustive()
+    }
+}
+
+impl DatabaseRef for SharedStateProviderDatabase {
+    type Error = ProviderError;
+
+    fn basic_ref(&self, address: Address) -> Result<Option<revm::state::AccountInfo>, Self::Error> {
+        let provider = self.provider.lock();
+        Ok(AccountReader::basic_account(&**provider, &address)?.map(Into::into))
+    }
+
+    fn code_by_hash_ref(&self, code_hash: B256) -> Result<revm::state::Bytecode, Self::Error> {
+        let provider = self.provider.lock();
+        Ok(BytecodeReader::bytecode_by_hash(&**provider, &code_hash)?
+            .unwrap_or_default()
+            .0)
+    }
+
+    fn storage_ref(
+        &self,
+        address: Address,
+        index: revm::primitives::StorageKey,
+    ) -> Result<revm::primitives::StorageValue, Self::Error> {
+        let provider = self.provider.lock();
+        Ok(StateProvider::storage(&**provider, address, index.into())?.unwrap_or_default())
+    }
+
+    fn block_hash_ref(&self, number: u64) -> Result<B256, Self::Error> {
+        let provider = self.provider.lock();
+        Ok(BlockHashReader::block_hash(&**provider, number)?.unwrap_or_default())
+    }
+}
 
 pub struct FlashblocksBlockValidator {
     pub chain_spec: Arc<OpChainSpec>,

--- a/crates/builder/src/validator.rs
+++ b/crates/builder/src/validator.rs
@@ -33,10 +33,7 @@ use reth_optimism_evm::{OpBlockAssembler, OpEvmConfig, OpRethReceiptBuilder};
 use reth_optimism_node::OpBuiltPayload;
 use reth_optimism_primitives::{OpPrimitives, OpTransactionSigned};
 use reth_primitives::{Recovered, RecoveredBlock, SealedHeader};
-use reth_provider::{
-    AccountReader, BlockExecutionOutput, BlockHashReader, BytecodeReader, ProviderError,
-    StateProvider, StateProviderBox, StateProviderFactory,
-};
+use reth_provider::{BlockExecutionOutput, StateProvider, StateProviderFactory};
 use reth_revm::database::StateProviderDatabase;
 use reth_trie_common::{HashedPostState, KeccakKeyHasher, updates::TrieUpdates};
 use revm::{
@@ -67,56 +64,6 @@ use crate::{
 
 /// A type alias for the BAL builder database with a cache layer.
 pub type ValidatorDb<'a, DB> = BalBuilderDb<&'a mut NoOpCommitDB<TemporalDb<DB>>>;
-
-#[derive(Clone)]
-struct SharedStateProviderDatabase {
-    provider: Arc<Mutex<StateProviderBox>>,
-}
-
-impl SharedStateProviderDatabase {
-    fn new(provider: StateProviderBox) -> Self {
-        Self {
-            provider: Arc::new(Mutex::new(provider)),
-        }
-    }
-}
-
-impl std::fmt::Debug for SharedStateProviderDatabase {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SharedStateProviderDatabase")
-            .finish_non_exhaustive()
-    }
-}
-
-impl DatabaseRef for SharedStateProviderDatabase {
-    type Error = ProviderError;
-
-    fn basic_ref(&self, address: Address) -> Result<Option<revm::state::AccountInfo>, Self::Error> {
-        let provider = self.provider.lock();
-        Ok(AccountReader::basic_account(&**provider, &address)?.map(Into::into))
-    }
-
-    fn code_by_hash_ref(&self, code_hash: B256) -> Result<revm::state::Bytecode, Self::Error> {
-        let provider = self.provider.lock();
-        Ok(BytecodeReader::bytecode_by_hash(&**provider, &code_hash)?
-            .unwrap_or_default()
-            .0)
-    }
-
-    fn storage_ref(
-        &self,
-        address: Address,
-        index: revm::primitives::StorageKey,
-    ) -> Result<revm::primitives::StorageValue, Self::Error> {
-        let provider = self.provider.lock();
-        Ok(StateProvider::storage(&**provider, address, index.into())?.unwrap_or_default())
-    }
-
-    fn block_hash_ref(&self, number: u64) -> Result<B256, Self::Error> {
-        let provider = self.provider.lock();
-        Ok(BlockHashReader::block_hash(&**provider, number)?.unwrap_or_default())
-    }
-}
 
 pub struct FlashblocksBlockValidator {
     pub chain_spec: Arc<OpChainSpec>,

--- a/crates/builder/src/validator.rs
+++ b/crates/builder/src/validator.rs
@@ -21,7 +21,7 @@ use world_chain_primitives::{
 };
 
 use reth_evm::{
-    Evm, EvmEnv, EvmEnvFor, EvmFactory, FromRecoveredTx, FromTxWithEncoded,
+    Evm, EvmEnv, EvmEnvFor, EvmFactory,
     block::{BlockExecutionError, BlockExecutor, CommitChanges, InternalBlockExecutionError},
     execute::{
         BasicBlockBuilder, BlockAssemblerInput, BlockBuilder, BlockBuilderOutcome, ExecutorTx,
@@ -37,7 +37,7 @@ use reth_revm::database::StateProviderDatabase;
 use reth_trie_common::{HashedPostState, KeccakKeyHasher, updates::TrieUpdates};
 use revm::{
     DatabaseRef,
-    context::{BlockEnv, TxEnv, result::ExecutionResult},
+    context::{BlockEnv, result::ExecutionResult},
     database::{BundleAccount, BundleState},
     primitives::AddressMap,
 };

--- a/crates/builder/src/validator.rs
+++ b/crates/builder/src/validator.rs
@@ -1,11 +1,13 @@
 use alloy_consensus::{BlockHeader, Header, Transaction};
 use alloy_eips::Decodable2718;
+use op_revm::{OpHaltReason, OpSpecId};
+use reth_primitives_traits::{Recovered, RecoveredBlock, SealedHeader, SignedTransaction};
 use std::{sync::Arc, time::Instant};
 
-use alloy_primitives::{Address, B256, Bytes, U256};
+use alloy_primitives::{B256, Bytes, U256};
 
 use alloy_op_evm::{
-    OpBlockExecutionCtx, OpBlockExecutor, OpBlockExecutorFactory, OpEvmFactory,
+    OpBlockExecutionCtx, OpBlockExecutor, OpBlockExecutorFactory, OpEvmFactory, OpTx,
     block::receipt_builder::OpReceiptBuilder,
 };
 use alloy_rpc_types_engine::PayloadId;
@@ -13,7 +15,6 @@ use eyre::eyre::bail;
 use op_alloy_consensus::OpReceipt;
 use rayon::prelude::*;
 use reth_chain_state::ExecutedBlock;
-use reth_primitives::transaction::SignedTransaction;
 use world_chain_primitives::{
     access_list::{FlashblockAccessList, FlashblockAccessListData},
     primitives::ExecutionPayloadFlashblockDeltaV1,
@@ -25,14 +26,12 @@ use reth_evm::{
     execute::{
         BasicBlockBuilder, BlockAssemblerInput, BlockBuilder, BlockBuilderOutcome, ExecutorTx,
     },
-    op_revm::{OpHaltReason, OpSpecId, OpTransaction},
 };
 use reth_node_api::{BuiltPayload, BuiltPayloadExecutedBlock};
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_evm::{OpBlockAssembler, OpEvmConfig, OpRethReceiptBuilder};
 use reth_optimism_node::OpBuiltPayload;
 use reth_optimism_primitives::{OpPrimitives, OpTransactionSigned};
-use reth_primitives::{Recovered, RecoveredBlock, SealedHeader};
 use reth_provider::{BlockExecutionOutput, StateProvider, StateProviderFactory};
 use reth_revm::database::StateProviderDatabase;
 use reth_trie_common::{HashedPostState, KeccakKeyHasher, updates::TrieUpdates};
@@ -40,6 +39,7 @@ use revm::{
     DatabaseRef,
     context::{BlockEnv, TxEnv, result::ExecutionResult},
     database::{BundleAccount, BundleState},
+    primitives::AddressMap,
 };
 use revm_database::State;
 use tracing::{error, info, trace};
@@ -206,7 +206,7 @@ impl FlashblocksBlockValidator {
             .build();
 
         // 2. Create EVM and executor
-        let evm = OpEvmFactory::default().create_evm(&mut db, self.evm_env.clone());
+        let evm = OpEvmFactory::<OpTx>::default().create_evm(&mut db, self.evm_env.clone());
 
         let mut executor = OpBlockExecutor::new(
             evm,
@@ -559,13 +559,7 @@ impl<'a, DBRef, R, E> BalBlockValidator<'a, DBRef, R, E>
 where
     R: OpReceiptBuilder<Transaction = OpTransactionSigned, Receipt = OpReceipt>,
     DBRef: DatabaseRef + Clone + std::fmt::Debug + 'a,
-    E: Evm<
-            DB = ValidatorDb<'a, DBRef>,
-            Tx = OpTransaction<TxEnv>,
-            Spec = OpSpecId,
-            BlockEnv = BlockEnv,
-        >,
-    OpTransaction<TxEnv>: FromRecoveredTx<R::Transaction> + FromTxWithEncoded<R::Transaction>,
+    E: Evm<DB = ValidatorDb<'a, DBRef>, Tx = OpTx, Spec = OpSpecId, BlockEnv = BlockEnv>,
 {
     /// Creates a new [`FlashblocksBlockBuilder`] with the given executor factory and assembler.
     pub fn new(
@@ -622,14 +616,12 @@ where
     DB: DatabaseRef + Clone + std::fmt::Debug + 'a,
     E: Evm<
             DB = ValidatorDb<'a, DB>,
-            Tx = OpTransaction<TxEnv>,
+            Tx = OpTx,
             Spec = OpSpecId,
             HaltReason = OpHaltReason,
             BlockEnv = BlockEnv,
         >,
     R: OpReceiptBuilder<Receipt = OpReceipt, Transaction = OpTransactionSigned>,
-    OpTransaction<TxEnv>:
-        FromRecoveredTx<OpTransactionSigned> + FromTxWithEncoded<OpTransactionSigned>,
 {
     type Primitives = OpPrimitives;
     type Executor = OpBlockExecutor<E, R, Arc<OpChainSpec>>;
@@ -661,6 +653,7 @@ where
     fn finish(
         mut self,
         state: impl StateProvider,
+        _state_root_precomputed: Option<(B256, TrieUpdates)>,
     ) -> Result<BlockBuilderOutcome<OpPrimitives>, BlockExecutionError> {
         let finalize_started = Instant::now();
         // finalize the database index
@@ -749,7 +742,7 @@ where
     DbRef: DatabaseRef + Clone + std::fmt::Debug + 'a,
     E: Evm<
             DB = ValidatorDb<'a, DbRef>,
-            Tx = OpTransaction<TxEnv>,
+            Tx = OpTx,
             Spec = OpSpecId,
             HaltReason = OpHaltReason,
             BlockEnv = BlockEnv,
@@ -758,8 +751,6 @@ where
         + Send
         + Sync
         + Clone,
-    OpTransaction<TxEnv>:
-        FromRecoveredTx<OpTransactionSigned> + FromTxWithEncoded<OpTransactionSigned>,
 {
     pub fn execute_block(
         mut self,
@@ -855,7 +846,7 @@ where
             "Final transaction index should match the expected range"
         );
 
-        Ok((self.finish(state_provider)?, merged_result.fees))
+        Ok((self.finish(state_provider, None)?, merged_result.fees))
     }
 }
 
@@ -898,8 +889,6 @@ where
         + Send
         + Sync
         + Clone,
-    OpTransaction<TxEnv>:
-        FromRecoveredTx<OpTransactionSigned> + FromTxWithEncoded<OpTransactionSigned>,
 {
     let temporal_db = db_factory.db(index as u64);
     let state = NoOpCommitDB::new(temporal_db);
@@ -907,7 +896,7 @@ where
 
     database.set_index(index);
 
-    let evm = OpEvmFactory::default().create_evm(database, evm_env);
+    let evm = OpEvmFactory::<OpTx>::default().create_evm(database, evm_env);
 
     let mut executor = OpBlockExecutor::new(
         evm,
@@ -961,7 +950,7 @@ pub struct StateRootResult {
 
 pub fn compute_state_root(
     state_provider: Arc<dyn StateProvider + Send>,
-    bundle_state: &alloy_primitives::map::HashMap<Address, BundleAccount>,
+    bundle_state: &AddressMap<BundleAccount>,
 ) -> Result<StateRootResult, BlockExecutionError> {
     // compute hashed post state
     let hashed_state = HashedPostState::from_bundle_state::<KeccakKeyHasher>(bundle_state);

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -21,7 +21,6 @@ world-chain-payload.workspace = true
 
 reth-node-builder.workspace = true
 reth-evm.workspace = true
-reth-engine-local.workspace = true
 reth-optimism-chainspec.workspace = true
 reth-optimism-primitives.workspace = true
 reth-optimism-rpc.workspace = true
@@ -39,11 +38,14 @@ reth-basic-payload-builder.workspace = true
 reth-payload-builder.workspace = true
 reth-rpc-eth-api.workspace = true
 reth-node-core.workspace = true
+reth-primitives-traits.workspace = true
 
 alloy-primitives.workspace = true
 alloy-rpc-types.workspace = true
 alloy-rpc-types-eth.workspace = true
+alloy-rpc-types-engine.workspace = true
 alloy-consensus.workspace = true
+alloy-eips.workspace = true
 
 op-alloy-consensus.workspace = true
 op-alloy-rpc-types-engine.workspace = true

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -36,7 +36,6 @@ reth-network-peers.workspace = true
 reth-eth-wire-types.workspace = true
 reth-rpc-engine-api.workspace = true
 reth-basic-payload-builder.workspace = true
-reth-primitives.workspace = true
 reth-payload-builder.workspace = true
 reth-rpc-eth-api.workspace = true
 reth-node-core.workspace = true

--- a/crates/node/src/context.rs
+++ b/crates/node/src/context.rs
@@ -18,6 +18,7 @@ use reth_node_builder::{
     components::{ComponentsBuilder, PayloadServiceBuilder},
     rpc::{BasicEngineValidatorBuilder, RpcAddOns},
 };
+use reth_node_core::primitives::Hardforks;
 use reth_optimism_evm::OpEvmConfig;
 use reth_optimism_node::{
     OpAddOns, OpConsensusBuilder, OpEngineValidatorBuilder, OpExecutorBuilder, OpNetworkBuilder,
@@ -41,7 +42,6 @@ use crate::tx_propagation::WorldChainTransactionPropagationPolicy;
 use reth_network::PeersInfo;
 use reth_network_peers::PeerId;
 use reth_node_builder::{BuilderContext, components::NetworkBuilder};
-use reth_primitives::Hardforks;
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
 
 /// Network builder for World Chain that optionally applies custom transaction propagation policy

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -1,15 +1,16 @@
 use alloy_rpc_types::engine::ClientVersionV1;
 use ed25519_dalek::VerifyingKey;
-use op_alloy_rpc_types_engine::OpExecutionData;
 use reth_node_api::{
     AddOnsContext, EngineApiValidator, EngineTypes, FullNodeComponents, NodeTypes,
 };
 use reth_node_builder::rpc::{EngineApiBuilder, PayloadValidatorBuilder};
-use reth_node_core::version::{CLIENT_CODE, version_metadata};
-use reth_optimism_node::OP_NAME_CLIENT;
+use reth_node_core::{
+    primitives::EthereumHardforks,
+    version::{CLIENT_CODE, version_metadata},
+};
+use reth_optimism_node::{OP_NAME_CLIENT, payload::OpExecData};
 use reth_optimism_rpc::{OP_ENGINE_CAPABILITIES, OpEngineApi};
 use reth_payload_builder::PayloadStore;
-use reth_primitives::EthereumHardforks;
 use reth_rpc_engine_api::{EngineApi, EngineCapabilities};
 use world_chain_p2p::protocol::handler::FlashblocksHandle;
 use world_chain_primitives::p2p::Authorization;
@@ -43,7 +44,7 @@ where
     N: FullNodeComponents<
         Types: NodeTypes<
             ChainSpec: EthereumHardforks + Clone,
-            Payload: EngineTypes<ExecutionData = OpExecutionData>,
+            Payload: EngineTypes<ExecutionData = OpExecData>,
         >,
     >,
     EV: PayloadValidatorBuilder<N>,
@@ -89,7 +90,7 @@ where
             ctx.beacon_engine_handle.clone(),
             PayloadStore::new(ctx.node.payload_builder_handle().clone()),
             ctx.node.pool().clone(),
-            Box::new(ctx.node.task_executor().clone()),
+            ctx.node.task_executor().clone(),
             client,
             capabilities,
             engine_validator,

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1,35 +1,32 @@
 use std::{fmt::Debug, sync::Arc};
 
+use crate::pool::WorldChainPoolBuilder;
+use alloy_eips::eip1559::BaseFeeParams;
 use op_alloy_consensus::OpTxEnvelope;
-use reth_node_builder::{Node, NodeAdapter, NodeComponentsBuilder, components::ComponentsBuilder};
-
-use reth_rpc_eth_api::EthApiTypes;
-use reth_transaction_pool::blobstore::DiskFileBlobStore;
-
-use reth_engine_local::LocalPayloadAttributesBuilder;
-
+use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use reth_evm::ConfigureEvm;
 use reth_node_api::{FullNodeTypes, NodeAddOns, NodeTypes, PayloadAttributesBuilder};
 use reth_node_builder::{
-    DebugNode, FullNodeComponents, NodeComponents, PayloadTypes, PrimitivesTy,
-    components::{NetworkBuilder, PayloadServiceBuilder},
+    DebugNode, FullNodeComponents, Node, NodeAdapter, NodeComponents, NodeComponentsBuilder,
+    PayloadTypes, PrimitivesTy,
+    components::{ComponentsBuilder, NetworkBuilder, PayloadServiceBuilder},
     rpc::{EngineValidatorAddOn, RethRpcAddOns},
 };
+use reth_node_core::primitives::EthereumHardforks;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_evm::OpNextBlockEnvAttributes;
 use reth_optimism_node::{
     OpEngineTypes, OpStorage,
     node::{OpConsensusBuilder, OpExecutorBuilder},
+    payload::OpPayloadAttrs,
     txpool::OpPooledTx,
 };
 use reth_optimism_primitives::OpPrimitives;
-
-use reth_transaction_pool::TransactionPool;
-
+use reth_primitives_traits::SealedHeader;
+use reth_rpc_eth_api::EthApiTypes;
+use reth_transaction_pool::{TransactionPool, blobstore::DiskFileBlobStore};
 use world_chain_cli::WorldChainNodeConfig;
 use world_chain_pool::{WorldChainTransactionPool, tx::WorldChainPoolTransaction};
-
-use crate::pool::WorldChainPoolBuilder;
 
 /// Context trait for World Chain node implementations.
 ///
@@ -193,7 +190,9 @@ where
     fn local_payload_attributes_builder(
         chain_spec: &Self::ChainSpec,
     ) -> impl PayloadAttributesBuilder<<Self::Payload as PayloadTypes>::PayloadAttributes> {
-        LocalPayloadAttributesBuilder::new(Arc::new(chain_spec.clone()))
+        OpLocalPayloadAttributesBuilder {
+            chain_spec: Arc::new(chain_spec.clone()),
+        }
     }
 }
 
@@ -202,4 +201,73 @@ impl<T: Unpin + Send + Clone + Sync + Debug + 'static> NodeTypes for WorldChainN
     type ChainSpec = OpChainSpec;
     type Storage = OpStorage;
     type Payload = OpEngineTypes;
+}
+
+/// Builds [`OpPayloadAttrs`] for local/dev-mode payload generation.
+///
+/// Mirrors `reth_optimism_node::node::OpLocalPayloadAttributesBuilder`, which is
+/// not re-exported by upstream. Used by [`DebugNode`] when running in dev mode.
+struct OpLocalPayloadAttributesBuilder {
+    chain_spec: Arc<OpChainSpec>,
+}
+
+impl PayloadAttributesBuilder<OpPayloadAttrs> for OpLocalPayloadAttributesBuilder {
+    fn build(&self, parent: &SealedHeader<alloy_consensus::Header>) -> OpPayloadAttrs {
+        use alloy_consensus::BlockHeader;
+        use alloy_primitives::{Address, B64};
+
+        let timestamp = std::cmp::max(
+            parent.timestamp().saturating_add(1),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        );
+
+        let eth_attrs = alloy_rpc_types_engine::PayloadAttributes {
+            timestamp,
+            prev_randao: alloy_primitives::B256::random(),
+            suggested_fee_recipient: Address::random(),
+            withdrawals: self
+                .chain_spec
+                .is_shanghai_active_at_timestamp(timestamp)
+                .then(Default::default),
+            parent_beacon_block_root: self
+                .chain_spec
+                .is_cancun_active_at_timestamp(timestamp)
+                .then(alloy_primitives::B256::random),
+        };
+
+        // Dummy system transaction for dev mode.
+        // OP Mainnet transaction at index 0 in block 124665056.
+        const TX_SET_L1_BLOCK: [u8; 251] = alloy_primitives::hex!(
+            "7ef8f8a0683079df94aa5b9cf86687d739a60a9b4f0835e520ec4d664e2e415dca17a6df94deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8a4440a5e200000146b000f79c500000000000000040000000066d052e700000000013ad8a3000000000000000000000000000000000000000000000000000000003ef1278700000000000000000000000000000000000000000000000000000000000000012fdf87b89884a61e74b322bbcf60386f543bfae7827725efaaf0ab1de2294a590000000000000000000000006887246668a3b87f54deb3b94ba47a6f63f32985"
+        );
+
+        let default_params = BaseFeeParams::optimism();
+        let denominator = std::env::var("OP_DEV_EIP1559_DENOMINATOR")
+            .ok()
+            .and_then(|v| v.parse::<u32>().ok())
+            .unwrap_or(default_params.max_change_denominator as u32);
+        let elasticity = std::env::var("OP_DEV_EIP1559_ELASTICITY")
+            .ok()
+            .and_then(|v| v.parse::<u32>().ok())
+            .unwrap_or(default_params.elasticity_multiplier as u32);
+        let gas_limit = std::env::var("OP_DEV_GAS_LIMIT")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok());
+
+        let mut eip1559_bytes = [0u8; 8];
+        eip1559_bytes[0..4].copy_from_slice(&denominator.to_be_bytes());
+        eip1559_bytes[4..8].copy_from_slice(&elasticity.to_be_bytes());
+
+        OpPayloadAttrs(OpPayloadAttributes {
+            payload_attributes: eth_attrs,
+            transactions: Some(vec![TX_SET_L1_BLOCK.into()]),
+            no_tx_pool: None,
+            gas_limit,
+            eip_1559_params: Some(B64::from(eip1559_bytes)),
+            min_base_fee: Some(0),
+        })
+    }
 }

--- a/crates/node/src/payload.rs
+++ b/crates/node/src/payload.rs
@@ -11,7 +11,7 @@ use reth_node_api::{FullNodeTypes, NodeTypes, PayloadTypes};
 use reth_node_builder::{BuilderContext, components::PayloadBuilderBuilder};
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_node::{
-    OpBuiltPayload, OpEvmConfig, OpPayloadBuilderAttributes, txpool::OpPooledTx,
+    OpBuiltPayload, OpEvmConfig, payload::OpPayloadAttrs, txpool::OpPooledTx,
 };
 use reth_provider::{
     ChainSpecProvider, DatabaseProviderFactory, HeaderProvider, StateProviderFactory,
@@ -55,9 +55,7 @@ where
             ChainSpec = OpChainSpec,
             Payload: PayloadTypes<
                 BuiltPayload = OpBuiltPayload,
-                PayloadBuilderAttributes = OpPayloadBuilderAttributes<
-                    op_alloy_consensus::OpTxEnvelope,
-                >,
+                PayloadAttributes = OpPayloadAttrs,
             >,
         >,
     Pool: TransactionPool<Transaction: OpPooledTx + PoolTransaction<Consensus = OpTxEnvelope>>

--- a/crates/node/src/payload_service.rs
+++ b/crates/node/src/payload_service.rs
@@ -8,7 +8,7 @@ use reth_node_builder::{
     components::{PayloadBuilderBuilder, PayloadServiceBuilder},
 };
 use reth_optimism_chainspec::OpChainSpec;
-use reth_optimism_node::{OpBuiltPayload, OpEngineTypes, OpNodeTypes, OpPayloadBuilderAttributes};
+use reth_optimism_node::{OpBuiltPayload, OpEngineTypes, OpNodeTypes, payload::OpPayloadAttrs};
 use reth_payload_builder::{PayloadBuilderHandle, PayloadBuilderService};
 use reth_provider::{
     CanonStateSubscriptions, ChainSpecProvider, DatabaseProviderFactory, HeaderProvider,
@@ -75,9 +75,7 @@ where
             ChainSpec = OpChainSpec,
             Payload: PayloadTypes<
                 BuiltPayload = OpBuiltPayload,
-                PayloadBuilderAttributes = OpPayloadBuilderAttributes<
-                    op_alloy_consensus::OpTxEnvelope,
-                >,
+                PayloadAttributes = OpPayloadAttrs,
             >,
         >,
     Pool: TransactionPool,

--- a/crates/payload/Cargo.toml
+++ b/crates/payload/Cargo.toml
@@ -19,7 +19,6 @@ reth-optimism-payload-builder.workspace = true
 reth-optimism-primitives.workspace = true
 reth-payload-primitives.workspace = true
 reth-payload-builder.workspace = true
-reth-primitives.workspace = true
 reth-primitives-traits.workspace = true
 reth-provider.workspace = true
 reth-revm.workspace = true

--- a/crates/payload/Cargo.toml
+++ b/crates/payload/Cargo.toml
@@ -23,9 +23,12 @@ reth-primitives-traits.workspace = true
 reth-provider.workspace = true
 reth-revm.workspace = true
 reth-tasks.workspace = true
+reth-execution-cache.workspace = true
+reth-trie-parallel.workspace = true
 
 # alloy
 alloy-eips.workspace = true
+alloy-consensus.workspace = true
 alloy-primitives.workspace = true
 op-alloy-consensus.workspace = true
 

--- a/crates/payload/src/generator.rs
+++ b/crates/payload/src/generator.rs
@@ -4,30 +4,31 @@ use std::{
 };
 
 use ::eyre::eyre::eyre;
+use alloy_consensus::Block;
 use alloy_primitives::B256;
 use op_alloy_consensus::OpTxEnvelope;
 use reth_basic_payload_builder::{
     HeaderForPayload, PayloadBuilder, PayloadConfig, PayloadState, PayloadTaskGuard, PrecachedState,
 };
-use reth_payload_builder::{PayloadJob, PayloadJobGenerator};
-use reth_payload_primitives::{PayloadBuilderAttributes, PayloadBuilderError};
+use reth_optimism_chainspec::OpChainSpec;
+use reth_optimism_node::OpBuiltPayload;
+use reth_optimism_payload_builder::OpPayloadAttrs;
+use reth_optimism_primitives::OpPrimitives;
+use reth_payload_builder::{BuildNewPayload, PayloadId, PayloadJobGenerator};
+use reth_payload_primitives::{PayloadAttributes, PayloadBuilderError};
+use reth_primitives_traits::{NodePrimitives, RecoveredBlock};
+use reth_provider::{
+    BlockReaderIdExt, CanonStateNotification, ChainSpecProvider, StateProviderFactory,
+};
 use reth_revm::cached::CachedReads;
-use reth_tasks::TaskSpawner;
+use reth_tasks::Runtime;
+use tokio::runtime::Handle;
+use tracing::{debug, warn};
 use world_chain_p2p::protocol::handler::FlashblocksHandle;
 use world_chain_primitives::{
     access_list::FlashblockAccessList, ed25519_dalek::SigningKey,
     flashblocks::recovered_block_from_flashblocks, p2p::Authorization,
 };
-
-use reth_optimism_chainspec::OpChainSpec;
-use reth_optimism_node::{OpBuiltPayload, OpPayloadBuilderAttributes};
-use reth_optimism_primitives::OpPrimitives;
-use reth_primitives::{Block, NodePrimitives, RecoveredBlock};
-use reth_provider::{
-    BlockReaderIdExt, CanonStateNotification, ChainSpecProvider, StateProviderFactory,
-};
-use tokio::runtime::Handle;
-use tracing::{debug, warn};
 
 use crate::job::{CommittedPayloadState, FlashblocksPayloadJob};
 use world_chain_builder::{
@@ -36,11 +37,11 @@ use world_chain_builder::{
 use world_chain_primitives::flashblocks::Flashblock;
 
 /// A type that initiates payload building jobs on the [`crate::builder::FlashblocksPayloadBuilder`].
-pub struct FlashblocksPayloadJobGenerator<Client, Tasks, Builder> {
+pub struct FlashblocksPayloadJobGenerator<Client, Builder> {
     /// The client that can interact with the chain.
     client: Client,
     /// The task executor to spawn payload building tasks on.
-    executor: Tasks,
+    executor: Runtime,
     /// The configuration for the job generator.
     config: FlashblocksJobGeneratorConfig,
     /// The type responsible for building payloads.
@@ -61,13 +62,13 @@ pub struct FlashblocksPayloadJobGenerator<Client, Tasks, Builder> {
     flashblocks_state: FlashblocksExecutionCoordinator,
 }
 
-impl<Client, Tasks: TaskSpawner, Builder> FlashblocksPayloadJobGenerator<Client, Tasks, Builder> {
+impl<Client, Builder> FlashblocksPayloadJobGenerator<Client, Builder> {
     /// Creates a new [`WorldChainPayloadJobGenerator`] with the given config and custom
     /// [`PayloadBuilder`]
     #[allow(clippy::too_many_arguments)]
     pub fn with_builder(
         client: Client,
-        executor: Tasks,
+        executor: Runtime,
         config: FlashblocksJobGeneratorConfig,
         builder: Builder,
         p2p_handler: FlashblocksHandle,
@@ -116,7 +117,7 @@ impl<Client, Tasks: TaskSpawner, Builder> FlashblocksPayloadJobGenerator<Client,
     }
 
     /// Returns a reference to the tasks type
-    pub const fn tasks(&self) -> &Tasks {
+    pub const fn tasks(&self) -> &Runtime {
         &self.executor
     }
 
@@ -130,8 +131,7 @@ impl<Client, Tasks: TaskSpawner, Builder> FlashblocksPayloadJobGenerator<Client,
     }
 }
 
-impl<Client, Tasks, Builder> PayloadJobGenerator
-    for FlashblocksPayloadJobGenerator<Client, Tasks, Builder>
+impl<Client, Builder> PayloadJobGenerator for FlashblocksPayloadJobGenerator<Client, Builder>
 where
     Client: StateProviderFactory
         + BlockReaderIdExt<Header = HeaderForPayload<Builder::BuiltPayload>>
@@ -139,24 +139,20 @@ where
         + Clone
         + Unpin
         + 'static,
-    Tasks: TaskSpawner + Clone + Unpin + 'static,
-    Builder: PayloadBuilder<
-            BuiltPayload = OpBuiltPayload<OpPrimitives>,
-            Attributes = OpPayloadBuilderAttributes<OpTxEnvelope>,
-        > + FlashblockPayloadBuilder
+    Builder: PayloadBuilder<BuiltPayload = OpBuiltPayload<OpPrimitives>, Attributes = OpPayloadAttrs>
+        + FlashblockPayloadBuilder
         + Unpin
         + Clone
         + 'static,
-    Builder::Attributes: Unpin + Clone,
-    Builder::BuiltPayload: Unpin + Clone,
 {
-    type Job = FlashblocksPayloadJob<Tasks, Builder>;
+    type Job = FlashblocksPayloadJob<Builder>;
 
     fn new_payload_job(
         &self,
-        attributes: <Self::Job as PayloadJob>::PayloadAttributes,
+        input: BuildNewPayload<Builder::Attributes>,
+        id: PayloadId,
     ) -> Result<Self::Job, PayloadBuilderError> {
-        let parent_header = if attributes.parent().is_zero() {
+        let parent_header = if input.parent_hash.is_zero() {
             // Use latest header for genesis block case
             self.client
                 .latest_header()
@@ -165,14 +161,12 @@ where
         } else {
             // Fetch specific header by hash
             self.client
-                .sealed_header_by_hash(attributes.parent())
+                .sealed_header_by_hash(input.parent_hash)
                 .map_err(PayloadBuilderError::from)?
-                .ok_or(PayloadBuilderError::MissingParentHeader(
-                    attributes.parent(),
-                ))?
+                .ok_or(PayloadBuilderError::MissingParentHeader(input.parent_hash))?
         };
 
-        let config = PayloadConfig::new(Arc::new(parent_header.clone()), attributes);
+        let config = PayloadConfig::new(Arc::new(parent_header.clone()), input.attributes, id);
 
         let timestamp = config.attributes.timestamp();
         let until = self.job_deadline(timestamp);
@@ -184,10 +178,9 @@ where
 
         let payload_task_guard = PayloadTaskGuard::new(self.config.max_payload_tasks);
 
-        let maybe_pre_state =
-            self.check_for_pre_state(self.client.chain_spec(), &config.attributes)?;
+        let maybe_pre_state = self.check_for_pre_state(self.client.chain_spec(), id)?;
 
-        let payload_id = config.attributes.payload_id();
+        let payload_id = config.payload_id();
         let mut authorization = self.authorizations.clone();
 
         let pending = async move {
@@ -295,6 +288,8 @@ where
             p2p_handler: self.p2p_handler.clone(),
             flashblocks_state: self.flashblocks_state.clone(),
             block_index: index,
+            execution_cache: input.cache,
+            trie_handle: input.trie_handle,
         };
 
         // start the first job right away
@@ -329,7 +324,7 @@ where
     }
 }
 
-impl<Builder, Client, Tasks> FlashblocksPayloadJobGenerator<Client, Tasks, Builder>
+impl<Builder, Client> FlashblocksPayloadJobGenerator<Client, Builder>
 where
     Builder: PayloadBuilder<BuiltPayload = OpBuiltPayload>,
 {
@@ -339,7 +334,7 @@ where
     fn check_for_pre_state(
         &self,
         chain_spec: Arc<OpChainSpec>,
-        attributes: &<Builder as PayloadBuilder>::Attributes,
+        id: PayloadId,
     ) -> Result<
         Option<(Builder::BuiltPayload, u64, Option<FlashblockAccessList>)>,
         PayloadBuilderError,
@@ -351,9 +346,9 @@ where
             PayloadBuilderError::Other(eyre!("Failed to reduce flashblocks: {}", e).into())
         })?;
 
-        if *flashblock.payload_id() == attributes.payload_id() {
+        if *flashblock.payload_id() == id {
             // If we have a pre-confirmed state, we can use it to build the payload
-            debug!(target: "flashblocks::payload_builder", payload_id = %attributes.payload_id(), "Using pre-confirmed state for payload");
+            debug!(target: "flashblocks::payload_builder", payload_id = %id, "Using pre-confirmed state for payload");
 
             let block: RecoveredBlock<Block<OpTxEnvelope>> =
                 recovered_block_from_flashblocks(chain_spec, flashblock.clone()).map_err(|e| {
@@ -364,7 +359,7 @@ where
             let sealed = block.into_sealed_block();
 
             let payload = OpBuiltPayload::new(
-                attributes.payload_id(),
+                id,
                 Arc::new(sealed),
                 flashblock.flashblock().metadata.fees,
                 None,

--- a/crates/payload/src/job.rs
+++ b/crates/payload/src/job.rs
@@ -1,15 +1,34 @@
 use std::{
     future::Future,
     pin::{Pin, pin},
-    task::{Context, Poll},
+    task::{Context, Poll, ready},
     time::Duration,
 };
 
+use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{B256, ruint::aliases::U256};
+use futures::FutureExt;
+use reth_basic_payload_builder::{
+    BuildArguments, BuildOutcome, HeaderForPayload, MissingPayloadBehaviour, PayloadBuilder,
+    PayloadConfig, PayloadState, PayloadTaskGuard, PendingPayload, ResolveBestPayload,
+};
+use reth_execution_cache::SavedCache;
+use reth_optimism_payload_builder::{OpBuiltPayload, OpPayloadAttrs};
+use reth_optimism_primitives::OpPrimitives;
+use reth_payload_builder::{KeepPayloadJobAlive, PayloadJob};
+use reth_payload_primitives::{BuiltPayload, PayloadBuilderError, PayloadKind};
+use reth_primitives_traits::BlockBody;
+use reth_revm::{cached::CachedReads, cancelled::CancelOnDrop};
+use reth_tasks::Runtime;
+use reth_trie_parallel::state_root_task::StateRootHandle;
+use tokio::{
+    sync::oneshot,
+    time::{Interval, Sleep},
+};
+use tracing::{debug, error, info, span, trace};
 use world_chain_builder::{
     coordinator::FlashblocksExecutionCoordinator, traits::payload_builder::FlashblockPayloadBuilder,
 };
-
 use world_chain_p2p::protocol::{error::FlashblocksP2PError, handler::FlashblocksHandle};
 use world_chain_primitives::{
     access_list::{FlashblockAccessList, FlashblockAccessListData},
@@ -17,29 +36,6 @@ use world_chain_primitives::{
     p2p::{Authorization, AuthorizedPayload},
     primitives::FlashblocksPayloadV1,
 };
-
-use std::task::ready;
-
-use alloy_eips::eip2718::Encodable2718;
-use futures::FutureExt;
-use op_alloy_consensus::OpTxEnvelope;
-use reth_basic_payload_builder::{
-    BuildArguments, BuildOutcome, HeaderForPayload, MissingPayloadBehaviour, PayloadBuilder,
-    PayloadConfig, PayloadState, PayloadTaskGuard, PendingPayload, ResolveBestPayload,
-};
-use reth_optimism_node::OpPayloadBuilderAttributes;
-use reth_optimism_payload_builder::OpBuiltPayload;
-use reth_optimism_primitives::OpPrimitives;
-use reth_payload_builder::{KeepPayloadJobAlive, PayloadJob};
-use reth_payload_primitives::{BuiltPayload, PayloadBuilderError, PayloadKind};
-use reth_primitives_traits::BlockBody;
-use reth_revm::{cached::CachedReads, cancelled::CancelOnDrop};
-use reth_tasks::TaskSpawner;
-use tokio::{
-    sync::oneshot,
-    time::{Interval, Sleep},
-};
-use tracing::{debug, error, info, span, trace};
 
 /// A future that resolves to the result of the block building job.
 #[derive(Debug)]
@@ -219,11 +215,11 @@ where
 /// is marked as frozen: [`BuildOutcome::Freeze`]. Once a frozen payload is returned, no additional
 /// payloads will be built and this future will wait to be resolved: [`PayloadJob::resolve`] or
 /// terminated if the deadline is reached.
-pub struct FlashblocksPayloadJob<Tasks, Builder: PayloadBuilder> {
+pub struct FlashblocksPayloadJob<Builder: PayloadBuilder> {
     /// The configuration for how the payload will be created.
     pub(crate) config: PayloadConfig<Builder::Attributes, HeaderForPayload<Builder::BuiltPayload>>,
     /// How to spawn building tasks
-    pub(crate) executor: Tasks,
+    pub(crate) executor: Runtime,
     /// The best payload so far and its state.
     pub(crate) best_payload: (
         PayloadState<Builder::BuiltPayload>,
@@ -241,6 +237,10 @@ pub struct FlashblocksPayloadJob<Tasks, Builder: PayloadBuilder> {
     /// This is used to avoid reading the same state over and over again when new attempts are
     /// triggered, because during the building process we'll repeatedly execute the transactions.
     pub(crate) cached_reads: Option<CachedReads>,
+    /// Optional execution cache shared with the engine.
+    pub(crate) execution_cache: Option<SavedCache>,
+    /// Optional state root task handle, shared with the engine.
+    pub(crate) trie_handle: Option<StateRootHandle>,
     /// The type responsible for building payloads.
     ///
     /// See [`PayloadBuilder`]
@@ -264,13 +264,10 @@ pub struct FlashblocksPayloadJob<Tasks, Builder: PayloadBuilder> {
     pub(crate) block_index: u64,
 }
 
-impl<Tasks, Builder> FlashblocksPayloadJob<Tasks, Builder>
+impl<Builder> FlashblocksPayloadJob<Builder>
 where
-    Tasks: TaskSpawner + Clone + 'static,
-    Builder: PayloadBuilder<
-            BuiltPayload = OpBuiltPayload<OpPrimitives>,
-            Attributes = OpPayloadBuilderAttributes<OpTxEnvelope>,
-        > + FlashblockPayloadBuilder
+    Builder: PayloadBuilder<BuiltPayload = OpBuiltPayload<OpPrimitives>, Attributes = OpPayloadAttrs>
+        + FlashblockPayloadBuilder
         + Unpin
         + 'static,
     Builder::Attributes: Unpin + Clone,
@@ -291,6 +288,8 @@ where
         let committed_payload = self.committed_payload.clone();
 
         let cached_reads = self.cached_reads.take().unwrap_or_default();
+        let execution_cache = self.execution_cache.clone();
+        let trie_handle = self.trie_handle.take();
         let builder = self.builder.clone();
 
         self.executor.spawn_blocking_task(Box::pin(async move {
@@ -300,6 +299,8 @@ where
                 config: payload_config,
                 cancel,
                 best_payload,
+                execution_cache,
+                trie_handle,
             };
 
             trace!(
@@ -398,13 +399,10 @@ where
     }
 }
 
-impl<Tasks, Builder> Future for FlashblocksPayloadJob<Tasks, Builder>
+impl<Builder> Future for FlashblocksPayloadJob<Builder>
 where
-    Tasks: TaskSpawner + Clone + 'static,
-    Builder: PayloadBuilder<
-            BuiltPayload = OpBuiltPayload<OpPrimitives>,
-            Attributes = OpPayloadBuilderAttributes<OpTxEnvelope>,
-        > + FlashblockPayloadBuilder
+    Builder: PayloadBuilder<BuiltPayload = OpBuiltPayload<OpPrimitives>, Attributes = OpPayloadAttrs>
+        + FlashblockPayloadBuilder
         + Unpin
         + 'static,
     Builder::Attributes: Unpin + Clone,
@@ -592,13 +590,10 @@ where
     }
 }
 
-impl<Tasks, Builder> PayloadJob for FlashblocksPayloadJob<Tasks, Builder>
+impl<Builder> PayloadJob for FlashblocksPayloadJob<Builder>
 where
-    Tasks: TaskSpawner + Clone + 'static,
-    Builder: PayloadBuilder<
-            BuiltPayload = OpBuiltPayload<OpPrimitives>,
-            Attributes = OpPayloadBuilderAttributes<OpTxEnvelope>,
-        > + FlashblockPayloadBuilder
+    Builder: PayloadBuilder<BuiltPayload = OpBuiltPayload<OpPrimitives>, Attributes = OpPayloadAttrs>
+        + FlashblockPayloadBuilder
         + Unpin
         + 'static,
     Builder::Attributes: Unpin + Clone,
@@ -645,7 +640,7 @@ where
         // During syncing, it could happen that the CL sends the `getPayload` engine API request
         // before the EL has completed the execution of the block, therefore it's important to take
         // the `pending_block` so that EL can complete the execution and return the payload to the CL.
-        let maybe_better = if self.config.attributes.no_tx_pool {
+        let maybe_better = if self.config.attributes.no_tx_pool.unwrap_or(false) {
             self.pending_block.take().map(Into::into)
         } else {
             None
@@ -661,6 +656,8 @@ where
                 config: self.config.clone(),
                 cancel: CancelOnDrop::default(),
                 best_payload: None,
+                execution_cache: self.execution_cache.clone(),
+                trie_handle: None,
             };
 
             match self.builder.on_missing_payload(args) {

--- a/crates/pool/Cargo.toml
+++ b/crates/pool/Cargo.toml
@@ -12,7 +12,6 @@ world-chain-pbh.workspace = true
 
 reth-db.workspace = true
 reth-optimism-node.workspace = true
-reth-primitives.workspace = true
 reth-provider.workspace = true
 reth-eth-wire-types.workspace = true
 reth-optimism-primitives.workspace = true

--- a/crates/pool/src/noop.rs
+++ b/crates/pool/src/noop.rs
@@ -4,7 +4,7 @@ use super::tx::WorldChainPooledTransaction;
 use alloy_eips::eip4844::{BlobAndProofV1, BlobAndProofV2};
 use alloy_primitives::{Address, B256, TxHash};
 use reth_eth_wire_types::HandleMempoolData;
-use reth_primitives::Recovered;
+use reth_primitives_traits::Recovered;
 use reth_transaction_pool::{
     AddedTransactionOutcome, AllPoolTransactions, AllTransactionsEvents, BestTransactions,
     BestTransactionsAttributes, BlobStoreError, BlockInfo, GetPooledTransactionLimit,
@@ -318,17 +318,17 @@ impl TransactionPool for NoopWorldChainTransactionPool {
         None
     }
 
-    async fn add_transactions_with_origins(
-        &self,
-        _transactions: impl IntoIterator<Item = (TransactionOrigin, Self::Transaction)> + Send,
-    ) -> Vec<PoolResult<AddedTransactionOutcome>> {
-        vec![]
-    }
-
     fn prune_transactions(
         &self,
         _hashes: Vec<TxHash>,
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        vec![]
+    }
+
+    async fn add_transactions_with_origins(
+        &self,
+        _transactions: Vec<(TransactionOrigin, Self::Transaction)>,
+    ) -> Vec<PoolResult<AddedTransactionOutcome>> {
         vec![]
     }
 }

--- a/crates/pool/src/root.rs
+++ b/crates/pool/src/root.rs
@@ -181,14 +181,13 @@ where
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{Address, address};
-    use reth_primitives::Header;
     use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
 
     /// Devnet World ID for testing
     const DEV_WORLD_ID: Address = address!("5FbDB2315678afecb367f032d93F642f64180aa3");
 
     use super::*;
-    use alloy_consensus::Block as AlloyBlock;
+    use alloy_consensus::{Block as AlloyBlock, Header};
 
     pub fn world_chain_root_validator() -> eyre::Result<WorldChainRootValidator<MockEthProvider>> {
         let client = MockEthProvider::default();

--- a/crates/pool/src/root.rs
+++ b/crates/pool/src/root.rs
@@ -3,8 +3,7 @@ use std::{collections::BTreeMap, sync::Arc};
 use alloy_consensus::{BlockHeader, Sealable};
 use alloy_primitives::{Address, U256};
 use parking_lot::RwLock;
-use reth_primitives::SealedBlock;
-use reth_primitives_traits::Block;
+use reth_primitives_traits::{Block, SealedBlock};
 use reth_provider::{BlockReaderIdExt, StateProviderFactory};
 
 use semaphore_rs::Field;

--- a/crates/pool/src/tx.rs
+++ b/crates/pool/src/tx.rs
@@ -1,7 +1,10 @@
 use std::sync::Arc;
 
 use alloy_consensus::BlobTransactionValidationError;
-use alloy_eips::{Typed2718, eip7594::BlobTransactionSidecarVariant, eip7702::SignedAuthorization};
+use alloy_eips::{
+    Typed2718, eip4844::c_kzg::KzgSettings, eip7594::BlobTransactionSidecarVariant,
+    eip7702::SignedAuthorization,
+};
 use alloy_primitives::{Bytes, TxHash};
 use alloy_rpc_types::{AccessList, erc4337::TransactionConditional};
 use reth_optimism_node::txpool::{
@@ -9,8 +12,7 @@ use reth_optimism_node::txpool::{
     estimated_da_size::DataAvailabilitySized, interop::MaybeInteropTransaction,
 };
 use reth_optimism_primitives::OpTransactionSigned;
-use reth_primitives::{Recovered, kzg::KzgSettings};
-use reth_primitives_traits::InMemorySize;
+use reth_primitives_traits::{InMemorySize, Recovered};
 use reth_transaction_pool::{
     EthBlobTransactionSidecar, EthPoolTransaction, PoolTransaction, TransactionValidationOutcome,
     error::{InvalidPoolTransactionError, PoolTransactionError},
@@ -248,6 +250,10 @@ impl PoolTransaction for WorldChainPooledTransaction {
 
     fn encoded_length(&self) -> usize {
         self.inner.encoded_length()
+    }
+
+    fn consensus_ref(&self) -> Recovered<&Self::Consensus> {
+        self.inner.consensus_ref()
     }
 }
 

--- a/crates/pool/src/validator.rs
+++ b/crates/pool/src/validator.rs
@@ -13,15 +13,17 @@ use crate::{
     error::WorldChainTransactionPoolError,
     tx::WorldChainPoolTransactionError,
 };
+use alloy_consensus::Block;
 use alloy_eips::BlockId;
 use alloy_primitives::Address;
 use alloy_sol_types::{SolCall, SolValue};
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 use reth_evm::ConfigureEvm;
+use reth_node_api::NodePrimitives;
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_node::txpool::OpTransactionValidator;
 use reth_optimism_primitives::OpTransactionSigned;
-use reth_primitives::{Block, NodePrimitives, SealedBlock};
+use reth_primitives_traits::SealedBlock;
 use reth_provider::{BlockReaderIdExt, ChainSpecProvider, StateProviderFactory};
 use reth_transaction_pool::{
     TransactionOrigin, TransactionValidationOutcome, TransactionValidator,
@@ -67,7 +69,7 @@ impl<Client, Tx, Evm> WorldChainTransactionValidator<Client, Tx, Evm>
 where
     Client: ChainSpecProvider<ChainSpec: OpHardforks>
         + StateProviderFactory
-        + BlockReaderIdExt<Block = reth_primitives::Block<OpTransactionSigned>>,
+        + BlockReaderIdExt<Block = Block<OpTransactionSigned>>,
     Tx: WorldChainPoolTransaction,
     Evm: ConfigureEvm,
 {

--- a/crates/pool/src/validator.rs
+++ b/crates/pool/src/validator.rs
@@ -311,12 +311,12 @@ where
 
 #[cfg(test)]
 pub mod tests {
-    use alloy_consensus::{Block, Header};
+    use alloy_consensus::{Block, BlockBody, Header};
     use alloy_primitives::{Address, address};
     use alloy_sol_types::SolCall;
     use reth_optimism_node::OpEvmConfig;
     use reth_optimism_primitives::OpTransactionSigned;
-    use reth_primitives::{BlockBody, SealedBlock};
+    use reth_primitives_traits::SealedBlock;
     use reth_transaction_pool::{
         Pool, TransactionPool, TransactionValidator, blobstore::InMemoryBlobStore,
     };

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -17,7 +17,6 @@ reth-payload-primitives.workspace = true
 reth-basic-payload-builder.workspace = true
 reth-optimism-primitives.workspace = true
 reth-optimism-node.workspace = true
-reth-primitives.workspace = true
 reth-primitives-traits.workspace = true
 reth-optimism-chainspec.workspace = true
 alloy-eips.workspace = true

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -13,7 +13,6 @@ eyre.workspace = true
 alloy-primitives = { workspace = true }
 
 reth-revm.workspace = true
-reth-payload-primitives.workspace = true
 reth-basic-payload-builder.workspace = true
 reth-optimism-primitives.workspace = true
 reth-optimism-node.workspace = true

--- a/crates/primitives/src/flashblocks.rs
+++ b/crates/primitives/src/flashblocks.rs
@@ -14,14 +14,12 @@ use alloy_rpc_types_engine::PayloadId;
 use chrono::Utc;
 use eyre::eyre::{bail, eyre};
 use op_alloy_consensus::OpTxEnvelope;
-use reth_payload_primitives::PayloadBuilderAttributes;
-use reth_primitives_traits::{Block as _, BlockBody as _};
+use reth_primitives_traits::{Block as _, BlockBody as _, NodePrimitives, RecoveredBlock};
 
 use reth_basic_payload_builder::PayloadConfig;
 use reth_optimism_chainspec::{OpChainSpec, OpHardforks};
 use reth_optimism_node::{OpBuiltPayload, OpPayloadBuilderAttributes};
 use reth_optimism_primitives::OpPrimitives;
-use reth_primitives::{NodePrimitives, RecoveredBlock};
 use serde::{Deserialize, Serialize};
 
 /// A type wrapper around a single flashblock payload.
@@ -47,18 +45,14 @@ impl Flashblock {
             Some(ExecutionPayloadBaseV1 {
                 parent_beacon_block_root: config
                     .attributes
-                    .payload_attributes
                     .parent_beacon_block_root
                     .unwrap_or_default(),
                 parent_hash: config.attributes.parent(),
-                fee_recipient: config
-                    .attributes
-                    .payload_attributes
-                    .suggested_fee_recipient(),
-                prev_randao: config.attributes.payload_attributes.prev_randao,
+                fee_recipient: config.attributes.suggested_fee_recipient(),
+                prev_randao: config.attributes.prev_randao,
                 block_number: block.number(),
                 gas_limit: block.gas_limit(),
-                timestamp: config.attributes.payload_attributes.timestamp,
+                timestamp: config.attributes.timestamp,
                 extra_data: block.extra_data().clone(),
                 base_fee_per_gas: block.base_fee_per_gas().map(U256::from).unwrap_or_default(), // Potential Issue
             })

--- a/crates/primitives/src/flashblocks.rs
+++ b/crates/primitives/src/flashblocks.rs
@@ -18,7 +18,7 @@ use reth_primitives_traits::{Block as _, BlockBody as _, NodePrimitives, Recover
 
 use reth_basic_payload_builder::PayloadConfig;
 use reth_optimism_chainspec::{OpChainSpec, OpHardforks};
-use reth_optimism_node::{OpBuiltPayload, OpPayloadBuilderAttributes};
+use reth_optimism_node::{OpBuiltPayload, payload::OpPayloadAttrs};
 use reth_optimism_primitives::OpPrimitives;
 use serde::{Deserialize, Serialize};
 
@@ -31,7 +31,7 @@ pub struct Flashblock {
 impl Flashblock {
     pub fn new(
         payload: &OpBuiltPayload,
-        config: &PayloadConfig<OpPayloadBuilderAttributes<OpTxEnvelope>, Header>,
+        config: &PayloadConfig<OpPayloadAttrs, Header>,
         index: u64,
         transactions_offset: usize,
         withdrawal_offset: usize,
@@ -45,14 +45,15 @@ impl Flashblock {
             Some(ExecutionPayloadBaseV1 {
                 parent_beacon_block_root: config
                     .attributes
+                    .payload_attributes
                     .parent_beacon_block_root
                     .unwrap_or_default(),
-                parent_hash: config.attributes.parent(),
-                fee_recipient: config.attributes.suggested_fee_recipient(),
-                prev_randao: config.attributes.prev_randao,
+                parent_hash: config.parent_header.hash(),
+                fee_recipient: config.attributes.payload_attributes.suggested_fee_recipient,
+                prev_randao: config.attributes.payload_attributes.prev_randao,
                 block_number: block.number(),
                 gas_limit: block.gas_limit(),
-                timestamp: config.attributes.timestamp,
+                timestamp: config.attributes.payload_attributes.timestamp,
                 extra_data: block.extra_data().clone(),
                 base_fee_per_gas: block.base_fee_per_gas().map(U256::from).unwrap_or_default(), // Potential Issue
             })
@@ -100,7 +101,7 @@ impl Flashblock {
 
         Flashblock {
             flashblock: FlashblocksPayloadV1 {
-                payload_id: config.attributes.payload_id(),
+                payload_id: config.payload_id(),
                 index,
                 base: payload_base,
                 diff: ExecutionPayloadFlashblockDeltaV1 {

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -18,7 +18,6 @@ world-chain-primitives.workspace = true
 # reth
 reth-chainspec.workspace = true
 reth-provider.workspace = true
-reth-primitives.workspace = true
 reth-transaction-pool.workspace = true
 reth-evm.workspace = true
 reth-node-api.workspace = true

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -59,7 +59,7 @@ tracing.workspace = true
 jsonrpsee.workspace = true
 jsonrpsee-core.workspace = true
 jsonrpsee-types.workspace = true
-reqwest.workspace = true
+reqwest = { workspace = true, features = ["rustls-tls"] }
 serde_json.workspace = true
 thiserror.workspace = true
 eyre.workspace = true

--- a/crates/rpc/src/engine.rs
+++ b/crates/rpc/src/engine.rs
@@ -6,11 +6,10 @@ use alloy_rpc_types_engine::{
 };
 use jsonrpsee::{proc_macros::rpc, types::ErrorObject};
 use jsonrpsee_core::{RpcResult, async_trait, server::RpcModule};
-use op_alloy_rpc_types_engine::{
-    OpExecutionData, OpExecutionPayloadV4, ProtocolVersion, SuperchainSignal,
-};
+use op_alloy_rpc_types_engine::{OpExecutionPayloadV4, ProtocolVersion, SuperchainSignal};
 use reth_chainspec::EthereumHardforks;
 use reth_node_api::{EngineApiValidator, EngineTypes};
+use reth_optimism_node::payload::OpExecData;
 use reth_optimism_rpc::{OpEngineApi, OpEngineApiServer};
 use reth_provider::{BlockReader, HeaderProvider, StateProviderFactory};
 use reth_rpc_api::IntoEngineApiRpcModule;
@@ -46,7 +45,7 @@ impl<Provider, EngineT, Pool, Validator, ChainSpec> OpEngineApiServer<EngineT>
     for OpEngineApiExt<Provider, EngineT, Pool, Validator, ChainSpec>
 where
     Provider: HeaderProvider + BlockReader + StateProviderFactory + 'static,
-    EngineT: EngineTypes<ExecutionData = OpExecutionData>,
+    EngineT: EngineTypes<ExecutionData = OpExecData>,
     Pool: TransactionPool + 'static,
     Validator: EngineApiValidator<EngineT>,
     ChainSpec: EthereumHardforks + Send + Sync + 'static,
@@ -215,7 +214,7 @@ impl<Provider, EngineT, Pool, Validator, ChainSpec> FlashblocksEngineApiExtServe
     for OpEngineApiExt<Provider, EngineT, Pool, Validator, ChainSpec>
 where
     Provider: HeaderProvider + BlockReader + StateProviderFactory + 'static,
-    EngineT: EngineTypes<ExecutionData = OpExecutionData>,
+    EngineT: EngineTypes<ExecutionData = OpExecData>,
     Pool: TransactionPool + 'static,
     Validator: EngineApiValidator<EngineT>,
     ChainSpec: EthereumHardforks + Send + Sync + 'static,

--- a/crates/rpc/src/eth/block.rs
+++ b/crates/rpc/src/eth/block.rs
@@ -3,7 +3,7 @@
 use alloy_eips::BlockId;
 use reth_optimism_primitives::OpPrimitives;
 use reth_optimism_rpc::{OpEthApi, OpEthApiError};
-use reth_primitives::RecoveredBlock;
+use reth_primitives_traits::RecoveredBlock;
 use reth_provider::{BlockIdReader, BlockReader};
 use reth_rpc_eth_api::{
     EthApiTypes, FromEthApiError, FromEvmError, RpcConvert, RpcNodeCore, RpcNodeCoreExt,

--- a/crates/rpc/src/eth/mod.rs
+++ b/crates/rpc/src/eth/mod.rs
@@ -11,19 +11,20 @@ use std::sync::Arc;
 
 use alloy_primitives::U256;
 use op_alloy_network::Optimism;
-use op_alloy_rpc_types_engine::{OpExecutionData, OpFlashblockPayloadBase};
+use op_alloy_rpc_types_engine::OpFlashblockPayloadBase;
 use reth_chain_state::ExecutedBlock;
 use reth_chainspec::{EthereumHardforks, Hardforks};
 use reth_evm::ConfigureEvm;
 use reth_node_api::{FullNodeComponents, HeaderTy, NodeTypes, PayloadTypes};
 use reth_node_builder::rpc::{EthApiBuilder, EthApiCtx};
+use reth_optimism_node::payload::OpExecData;
 use reth_optimism_primitives::OpPrimitives;
 use reth_optimism_rpc::{OpEthApi, OpEthApiBuilder, OpEthApiError, eth::OpRpcConvert};
 use reth_rpc_eth_api::{
     EthApiTypes, FromEvmError, FullEthApiServer, RpcConvert, RpcNodeCore, RpcNodeCoreExt, RpcTypes,
     helpers::{
-        EthApiSpec, EthFees, EthState, LoadFee, LoadPendingBlock, LoadState, SpawnBlocking, Trace,
-        pending_block::BuildPendingEnv,
+        EthApiSpec, EthFees, EthState, GetBlockAccessList, LoadFee, LoadPendingBlock, LoadState,
+        SpawnBlocking, Trace, pending_block::BuildPendingEnv,
     },
 };
 use reth_rpc_eth_types::{EthStateCache, FeeHistoryCache, GasPriceOracle};
@@ -243,6 +244,20 @@ where
 {
 }
 
+impl<N, Rpc> GetBlockAccessList for FlashblocksEthApi<N, Rpc>
+where
+    N: RpcNodeCore<Primitives = OpPrimitives>,
+    Rpc: RpcConvert + Clone,
+    OpEthApiError: FromEvmError<N::Evm>,
+    OpEthApi<N, Rpc>: Trace
+        + SpawnBlocking
+        + RpcNodeCore<Primitives = OpPrimitives>
+        + EthApiTypes<Error = OpEthApiError>
+        + GetBlockAccessList
+        + Clone,
+{
+}
+
 impl<N, Rpc> std::fmt::Debug for FlashblocksEthApi<N, Rpc>
 where
     N: RpcNodeCore,
@@ -293,7 +308,7 @@ where
             >,
             Types: NodeTypes<
                 ChainSpec: Hardforks + EthereumHardforks,
-                Payload: PayloadTypes<ExecutionData: for<'a> Into<OpExecutionData>>,
+                Payload: PayloadTypes<ExecutionData = OpExecData>,
             >,
         >,
     NetworkT: RpcTypes,

--- a/crates/rpc/src/eth/mod.rs
+++ b/crates/rpc/src/eth/mod.rs
@@ -29,7 +29,7 @@ use reth_rpc_eth_api::{
 use reth_rpc_eth_types::{EthStateCache, FeeHistoryCache, GasPriceOracle};
 use reth_storage_api::ProviderHeader;
 use reth_tasks::{
-    TaskSpawner,
+    Runtime,
     pool::{BlockingTaskGuard, BlockingTaskPool},
 };
 use tokio::sync::Semaphore;
@@ -144,7 +144,7 @@ where
     OpEthApi<N, Rpc>: SpawnBlocking,
 {
     #[inline]
-    fn io_task_spawner(&self) -> impl TaskSpawner {
+    fn io_task_spawner(&self) -> &Runtime {
         self.inner.io_task_spawner()
     }
 

--- a/crates/rpc/src/eth/receipt.rs
+++ b/crates/rpc/src/eth/receipt.rs
@@ -1,13 +1,15 @@
-use alloy_consensus::{TxReceipt, transaction::SignerRecoverable};
+use std::sync::Arc;
+
+use alloy_consensus::TxReceipt;
 use op_alloy_rpc_types::OpTransactionReceipt;
 use reth_chainspec::ChainSpecProvider;
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_primitives::OpPrimitives;
 use reth_optimism_rpc::{OpEthApi, OpEthApiError, OpReceiptBuilder};
-use reth_primitives::TransactionMeta;
+use reth_primitives_traits::{Recovered, TransactionMeta};
 use reth_provider::{ProviderReceipt, ProviderTx};
 use reth_rpc_eth_api::{
-    EthApiTypes, FromEthApiError, RpcConvert, RpcNodeCore, RpcNodeCoreExt, RpcReceipt, RpcTypes,
+    EthApiTypes, RpcConvert, RpcNodeCore, RpcNodeCoreExt, RpcReceipt, RpcTypes,
     helpers::{LoadPendingBlock, LoadReceipt},
     transaction::ConvertReceiptInput,
 };
@@ -35,26 +37,32 @@ where
     /// Helper method for `eth_getBlockReceipts` and `eth_getTransactionReceipt`.
     async fn build_transaction_receipt(
         &self,
-        tx: ProviderTx<Self::Provider>,
+        tx: Recovered<ProviderTx<Self::Provider>>,
         meta: TransactionMeta,
         receipt: ProviderReceipt<Self::Provider>,
+        all_receipts: Option<Arc<Vec<ProviderReceipt<Self::Provider>>>>,
     ) -> Result<RpcReceipt<Self::NetworkTypes>, Self::Error> {
         let hash = meta.block_hash;
 
         // get all receipts for the block
-        let all_receipts = if let Ok(Some(receipts)) = self.cache().get_receipts(hash).await {
-            Some((receipts, None))
-        } else {
-            // try the pending block
-            let pending_block = self.local_pending_block().await?;
-            if let Some(BlockAndReceipts { block, receipts }) = pending_block {
-                if block.hash_slow() == hash {
-                    Some((receipts, Some(block)))
+        let all_receipts = match all_receipts {
+            Some(all_receipts) => Some((all_receipts, None)),
+            None => {
+                if let Ok(Some(receipts)) = self.cache().get_receipts(hash).await {
+                    Some((receipts, None))
                 } else {
-                    None
+                    // try the pending block
+                    let pending_block = self.local_pending_block().await?;
+                    if let Some(BlockAndReceipts { block, receipts }) = pending_block {
+                        if block.hash_slow() == hash {
+                            Some((receipts, Some(block)))
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
                 }
-            } else {
-                None
             }
         };
 
@@ -70,9 +78,6 @@ where
                 next_log_index += receipt.logs().len();
             }
         }
-        let tx = tx
-            .try_into_recovered_unchecked()
-            .map_err(Self::Error::from_eth_err)?;
         let hash = tx.hash();
         trace!(
             target: "flashblocks",
@@ -108,14 +113,13 @@ where
                 // new transaction input has changed, since otherwise the L1 cost wouldn't.
                 l1_block_info.clear_tx_l1_cost();
 
-                Ok(
-                    OpReceiptBuilder::new(
-                        &self.provider().chain_spec(),
-                        input,
-                        &mut l1_block_info,
-                    )?
-                    .build(),
-                )
+                Ok(OpReceiptBuilder::new(
+                    &self.provider().chain_spec(),
+                    input,
+                    &mut l1_block_info,
+                    None,
+                )?
+                .build())
             }
         }
     }

--- a/crates/rpc/src/eth/transaction.rs
+++ b/crates/rpc/src/eth/transaction.rs
@@ -6,10 +6,10 @@ use alloy_primitives::{B256, Bytes, TxHash};
 use reth_node_api::BlockBody;
 use reth_optimism_primitives::OpPrimitives;
 use reth_optimism_rpc::{OpEthApi, OpEthApiError};
-use reth_primitives::{Recovered, TransactionMeta};
+use reth_primitives_traits::{Recovered, SignerRecoverable, TransactionMeta};
 use reth_provider::{ProviderReceipt, ProviderTx, ReceiptProvider, TransactionsProvider};
 use reth_rpc_eth_api::{
-    EthApiTypes, FromEthApiError, FromEvmError, RpcConvert, RpcNodeCore,
+    EthApiTypes, FromEthApiError, FromEvmError, RpcConvert, RpcNodeCore, RpcNodeCoreExt,
     helpers::{
         EthTransactions, LoadPendingBlock, LoadTransaction, SpawnBlocking, spec::SignersForRpc,
     },
@@ -17,7 +17,7 @@ use reth_rpc_eth_api::{
 use reth_rpc_eth_types::block::BlockAndReceipts;
 use reth_transaction_pool::{PoolPooledTx, TransactionOrigin};
 
-use std::{future::Future, time::Duration};
+use std::{future::Future, sync::Arc, time::Duration};
 
 use crate::eth::FlashblocksEthApi;
 
@@ -62,9 +62,10 @@ where
     ) -> impl Future<
         Output = Result<
             Option<(
-                ProviderTx<Self::Provider>,
+                Recovered<ProviderTx<Self::Provider>>,
                 TransactionMeta,
                 ProviderReceipt<Self::Provider>,
+                Option<Arc<Vec<ProviderReceipt<Self::Provider>>>>,
             )>,
             Self::Error,
         >,
@@ -72,56 +73,91 @@ where
     where
         Self: 'static,
     {
-        self.spawn_blocking_io_fut(async move |this| {
-            let pending_block = this.local_pending_block().await?;
-            if let Some(BlockAndReceipts { block, receipts }) = pending_block.clone()
-                && let Some(pos) = block
-                    .body()
-                    .transactions_iter()
-                    .position(|t| *t.tx_hash() == hash)
+        async move {
+            if let Some(cached) = self.cache().get_transaction_by_hash(hash).await
+                && let Some(tx) = cached.recovered_transaction().map(|tx| tx.cloned())
             {
-                let receipt = &receipts[pos];
-                let tx = block
-                    .clone()
-                    .body()
-                    .transactions_iter()
-                    .nth(pos)
-                    .expect("position is valid; qed")
-                    .clone();
+                let meta = cached.transaction_meta(hash);
 
-                let meta = TransactionMeta {
-                    tx_hash: tx.tx_hash(),
-                    block_hash: block.hash_slow(),
-                    block_number: block.number(),
-                    index: pos as u64,
-                    base_fee: block.base_fee_per_gas(),
-                    timestamp: block.header().timestamp(),
-                    ..Default::default()
-                };
+                // Best case: receipts are also cached.
+                if let Some(all_receipts) = cached.receipts.clone()
+                    && let Some(receipt) = all_receipts.get(cached.tx_index).cloned()
+                {
+                    return Ok(Some((tx, meta, receipt, Some(all_receipts))));
+                }
 
-                return Ok(Some((tx, meta, receipt.clone())));
+                // Block still cached but receipts evicted — fetch via cache since
+                // `build_transaction_receipt` needs all receipts for gas accounting
+                // anyway.
+                if let Some(receipts) = self
+                    .cache()
+                    .get_receipts(cached.block.hash())
+                    .await
+                    .map_err(Self::Error::from_eth_err)?
+                    && let Some(receipt) = receipts.get(cached.tx_index).cloned()
+                {
+                    return Ok(Some((tx, meta, receipt, Some(receipts))));
+                }
             }
 
-            let provider = this.provider();
+            self.spawn_blocking_io_fut(async move |this| {
+                let pending_block = this.local_pending_block().await?;
+                if let Some(BlockAndReceipts { block, receipts }) = pending_block.clone()
+                    && let Some(pos) = block
+                        .body()
+                        .transactions_iter()
+                        .position(|t| *t.tx_hash() == hash)
+                {
+                    let receipt = &receipts[pos];
+                    let tx = block
+                        .clone()
+                        .body()
+                        .transactions_iter()
+                        .nth(pos)
+                        .expect("position is valid; qed")
+                        .clone();
 
-            let (tx, meta) = match provider
-                .transaction_by_hash_with_meta(hash)
-                .map_err(Self::Error::from_eth_err)?
-            {
-                Some((tx, meta)) => (tx, meta),
-                None => return Ok(None),
-            };
+                    let meta = TransactionMeta {
+                        tx_hash: tx.tx_hash(),
+                        block_hash: block.hash_slow(),
+                        block_number: block.number(),
+                        index: pos as u64,
+                        base_fee: block.base_fee_per_gas(),
+                        timestamp: block.header().timestamp(),
+                        ..Default::default()
+                    };
+                    let tx = tx
+                        .try_into_recovered_unchecked()
+                        .map_err(Self::Error::from_eth_err)?;
 
-            let receipt = match provider
-                .receipt_by_hash(hash)
-                .map_err(Self::Error::from_eth_err)?
-            {
-                Some(recpt) => recpt,
-                None => return Ok(None),
-            };
+                    return Ok(Some((tx, meta, receipt.clone(), None)));
+                }
 
-            Ok(Some((tx, meta, receipt)))
-        })
+                let provider = this.provider();
+
+                let (tx, meta) = match provider
+                    .transaction_by_hash_with_meta(hash)
+                    .map_err(Self::Error::from_eth_err)?
+                {
+                    Some((tx, meta)) => (tx, meta),
+                    None => return Ok(None),
+                };
+                let tx = tx
+                    .try_into_recovered_unchecked()
+                    .map_err(Self::Error::from_eth_err)?;
+
+                let receipt = match provider
+                    .receipt_by_hash(hash)
+                    .map_err(Self::Error::from_eth_err)?
+                {
+                    Some(recpt) => recpt,
+                    None => return Ok(None),
+                };
+
+                Ok(Some((tx, meta, receipt, None)))
+            })
+            .await
+        }
     }
 }
 

--- a/crates/rpc/src/eth/transaction.rs
+++ b/crates/rpc/src/eth/transaction.rs
@@ -56,108 +56,104 @@ where
     }
 
     /// Helper method that loads a transaction and its receipt.
-    fn load_transaction_and_receipt(
+    async fn load_transaction_and_receipt(
         &self,
         hash: TxHash,
-    ) -> impl Future<
-        Output = Result<
-            Option<(
-                Recovered<ProviderTx<Self::Provider>>,
-                TransactionMeta,
-                ProviderReceipt<Self::Provider>,
-                Option<Arc<Vec<ProviderReceipt<Self::Provider>>>>,
-            )>,
-            Self::Error,
-        >,
-    > + Send
+    ) -> Result<
+        Option<(
+            Recovered<ProviderTx<Self::Provider>>,
+            TransactionMeta,
+            ProviderReceipt<Self::Provider>,
+            Option<Arc<Vec<ProviderReceipt<Self::Provider>>>>,
+        )>,
+        Self::Error,
+    >
     where
         Self: 'static,
     {
-        async move {
-            if let Some(cached) = self.cache().get_transaction_by_hash(hash).await
-                && let Some(tx) = cached.recovered_transaction().map(|tx| tx.cloned())
+        if let Some(cached) = self.cache().get_transaction_by_hash(hash).await
+            && let Some(tx) = cached.recovered_transaction().map(|tx| tx.cloned())
+        {
+            let meta = cached.transaction_meta(hash);
+
+            // Best case: receipts are also cached.
+            if let Some(all_receipts) = cached.receipts.clone()
+                && let Some(receipt) = all_receipts.get(cached.tx_index).cloned()
             {
-                let meta = cached.transaction_meta(hash);
-
-                // Best case: receipts are also cached.
-                if let Some(all_receipts) = cached.receipts.clone()
-                    && let Some(receipt) = all_receipts.get(cached.tx_index).cloned()
-                {
-                    return Ok(Some((tx, meta, receipt, Some(all_receipts))));
-                }
-
-                // Block still cached but receipts evicted — fetch via cache since
-                // `build_transaction_receipt` needs all receipts for gas accounting
-                // anyway.
-                if let Some(receipts) = self
-                    .cache()
-                    .get_receipts(cached.block.hash())
-                    .await
-                    .map_err(Self::Error::from_eth_err)?
-                    && let Some(receipt) = receipts.get(cached.tx_index).cloned()
-                {
-                    return Ok(Some((tx, meta, receipt, Some(receipts))));
-                }
+                return Ok(Some((tx, meta, receipt, Some(all_receipts))));
             }
 
-            self.spawn_blocking_io_fut(async move |this| {
-                let pending_block = this.local_pending_block().await?;
-                if let Some(BlockAndReceipts { block, receipts }) = pending_block.clone()
-                    && let Some(pos) = block
-                        .body()
-                        .transactions_iter()
-                        .position(|t| *t.tx_hash() == hash)
-                {
-                    let receipt = &receipts[pos];
-                    let tx = block
-                        .clone()
-                        .body()
-                        .transactions_iter()
-                        .nth(pos)
-                        .expect("position is valid; qed")
-                        .clone();
+            // Block still cached but receipts evicted — fetch via cache since
+            // `build_transaction_receipt` needs all receipts for gas accounting
+            // anyway.
+            if let Some(receipts) = self
+                .cache()
+                .get_receipts(cached.block.hash())
+                .await
+                .map_err(Self::Error::from_eth_err)?
+                && let Some(receipt) = receipts.get(cached.tx_index).cloned()
+            {
+                return Ok(Some((tx, meta, receipt, Some(receipts))));
+            }
+        }
 
-                    let meta = TransactionMeta {
-                        tx_hash: tx.tx_hash(),
-                        block_hash: block.hash_slow(),
-                        block_number: block.number(),
-                        index: pos as u64,
-                        base_fee: block.base_fee_per_gas(),
-                        timestamp: block.header().timestamp(),
-                        ..Default::default()
-                    };
-                    let tx = tx
-                        .try_into_recovered_unchecked()
-                        .map_err(Self::Error::from_eth_err)?;
+        self.spawn_blocking_io_fut(async move |this| {
+            let pending_block = this.local_pending_block().await?;
+            if let Some(BlockAndReceipts { block, receipts }) = pending_block.clone()
+                && let Some(pos) = block
+                    .body()
+                    .transactions_iter()
+                    .position(|t| *t.tx_hash() == hash)
+            {
+                let receipt = &receipts[pos];
+                let tx = block
+                    .clone()
+                    .body()
+                    .transactions_iter()
+                    .nth(pos)
+                    .expect("position is valid; qed")
+                    .clone();
 
-                    return Ok(Some((tx, meta, receipt.clone(), None)));
-                }
-
-                let provider = this.provider();
-
-                let (tx, meta) = match provider
-                    .transaction_by_hash_with_meta(hash)
-                    .map_err(Self::Error::from_eth_err)?
-                {
-                    Some((tx, meta)) => (tx, meta),
-                    None => return Ok(None),
+                let meta = TransactionMeta {
+                    tx_hash: tx.tx_hash(),
+                    block_hash: block.hash_slow(),
+                    block_number: block.number(),
+                    index: pos as u64,
+                    base_fee: block.base_fee_per_gas(),
+                    timestamp: block.header().timestamp(),
+                    ..Default::default()
                 };
                 let tx = tx
                     .try_into_recovered_unchecked()
                     .map_err(Self::Error::from_eth_err)?;
 
-                let receipt = match provider
-                    .receipt_by_hash(hash)
-                    .map_err(Self::Error::from_eth_err)?
-                {
-                    Some(recpt) => recpt,
-                    None => return Ok(None),
-                };
+                return Ok(Some((tx, meta, receipt.clone(), None)));
+            }
 
-                Ok(Some((tx, meta, receipt, None)))
-            })
-            .await
-        }
+            let provider = this.provider();
+
+            let (tx, meta) = match provider
+                .transaction_by_hash_with_meta(hash)
+                .map_err(Self::Error::from_eth_err)?
+            {
+                Some((tx, meta)) => (tx, meta),
+                None => return Ok(None),
+            };
+            let tx = tx
+                .try_into_recovered_unchecked()
+                .map_err(Self::Error::from_eth_err)?;
+
+            let receipt = match provider
+                .receipt_by_hash(hash)
+                .map_err(Self::Error::from_eth_err)?
+            {
+                Some(recpt) => recpt,
+                None => return Ok(None),
+            };
+
+            Ok(Some((tx, meta, receipt, None)))
+        })
+        .await
     }
 }
 

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -22,7 +22,6 @@ world-chain-cli.workspace = true
 world-chain-rpc.workspace = true
 
 reth-optimism-node.workspace = true
-reth-primitives.workspace = true
 reth-optimism-primitives.workspace = true
 reth-optimism-payload-builder.workspace = true
 reth-primitives-traits.workspace = true

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -66,6 +66,8 @@ op-alloy-network.workspace = true
 op-alloy-rpc-types.workspace = true
 op-alloy-rpc-types-engine.workspace = true
 
+op-revm.workspace = true
+
 ed25519-dalek.workspace = true
 semaphore-rs.workspace = true
 bon.workspace = true

--- a/crates/test-utils/src/builder.rs
+++ b/crates/test-utils/src/builder.rs
@@ -19,16 +19,16 @@ use alloy_trie::TrieAccount;
 use crossbeam_channel::bounded;
 use op_alloy_consensus::{OpTxEnvelope, OpTypedTransaction};
 use op_alloy_network::TxSignerSync;
+use op_revm::OpSpecId;
 use reth_chainspec::ChainInfo;
 use reth_evm::{
     ConfigureEvm, EvmEnv, EvmFactory,
     execute::{BlockBuilder, BlockBuilderOutcome},
-    op_revm::OpSpecId,
 };
 use reth_optimism_chainspec::{OpChainSpec, OpChainSpecBuilder};
 use reth_optimism_evm::{OpEvmConfig, OpNextBlockEnvAttributes, OpRethReceiptBuilder};
 use reth_optimism_primitives::{OpPrimitives, OpTransactionSigned};
-use reth_primitives::{Account, Recovered, SealedHeader, transaction::SignedTransaction};
+use reth_primitives_traits::{Account, Bytecode, Recovered, SealedHeader, SignedTransaction};
 use reth_provider::{
     BlockIdReader, BlockNumReader, BytecodeReader, CanonStateSubscriptions, ChainSpecProvider,
     HeaderProvider, NodePrimitivesProvider, ProviderResult, StateProvider, StateProviderBox,
@@ -39,7 +39,6 @@ use reth_trie_common::HashedPostState;
 use revm::{
     DatabaseRef,
     database::{BundleState, InMemoryDB},
-    primitives::StorageValue,
     state::AccountInfo,
 };
 use std::{
@@ -48,16 +47,15 @@ use std::{
     sync::Arc,
 };
 use tracing::error;
-use world_chain_primitives::{
-    access_list::{FlashblockAccessListData, access_list_hash},
-    primitives::{ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, FlashblocksPayloadV1},
-};
-
 use world_chain_builder::{
     BlockBuilderExt,
     bal_executor::{BalBlockBuilder, CommittedState},
     database::bal_builder_db::BalBuilderDb,
     payload_builder_metrics::PayloadBuildAttemptMetrics,
+};
+use world_chain_primitives::{
+    access_list::{FlashblockAccessListData, access_list_hash},
+    primitives::{ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, FlashblocksPayloadV1},
 };
 
 const WORLD_ID_ALT_INPUT_INTERVAL: usize = 5;
@@ -922,13 +920,13 @@ impl BytecodeReader for TestStateProvider {
     fn bytecode_by_hash(
         &self,
         code_hash: &alloy_primitives::B256,
-    ) -> reth_provider::ProviderResult<Option<reth_primitives::Bytecode>> {
+    ) -> reth_provider::ProviderResult<Option<Bytecode>> {
         use revm::DatabaseRef;
         Ok(self
             .db
             .code_by_hash_ref(*code_hash)
             .ok()
-            .map(|bc| reth_primitives::Bytecode::new_raw(bc.original_bytes())))
+            .map(|bc| Bytecode::new_raw(bc.original_bytes())))
     }
 }
 
@@ -940,27 +938,16 @@ impl StateProvider for TestStateProvider {
     ) -> reth_provider::ProviderResult<Option<alloy_primitives::StorageValue>> {
         Ok(self.db.storage_ref(account, storage_key.into()).ok())
     }
-
-    fn storage_by_hashed_key(
-        &self,
-        _address: Address,
-        _hashed_storage_key: StorageKey,
-    ) -> ProviderResult<Option<StorageValue>> {
-        todo!()
-    }
 }
 
 impl reth_provider::AccountReader for TestStateProvider {
-    fn basic_account(
-        &self,
-        address: &Address,
-    ) -> reth_provider::ProviderResult<Option<reth_primitives::Account>> {
+    fn basic_account(&self, address: &Address) -> reth_provider::ProviderResult<Option<Account>> {
         Ok(self
             .db
             .basic_ref(*address)
             .ok()
             .flatten()
-            .map(|info| reth_primitives::Account {
+            .map(|info| Account {
                 balance: info.balance,
                 nonce: info.nonce,
                 bytecode_hash: if info.code_hash == KECCAK_EMPTY {
@@ -1259,10 +1246,7 @@ impl BenchProvider {
 // Delegate all TestStateProvider traits to self.inner
 
 impl BytecodeReader for BenchProvider {
-    fn bytecode_by_hash(
-        &self,
-        code_hash: &B256,
-    ) -> ProviderResult<Option<reth_primitives::Bytecode>> {
+    fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
         self.inner.bytecode_by_hash(code_hash)
     }
 }
@@ -1274,15 +1258,6 @@ impl StateProvider for BenchProvider {
         storage_key: StorageKey,
     ) -> ProviderResult<Option<alloy_primitives::StorageValue>> {
         self.inner.storage(account, storage_key)
-    }
-
-    fn storage_by_hashed_key(
-        &self,
-        address: Address,
-        hashed_storage_key: StorageKey,
-    ) -> ProviderResult<Option<StorageValue>> {
-        self.inner
-            .storage_by_hashed_key(address, hashed_storage_key)
     }
 }
 

--- a/crates/test-utils/src/e2e_harness/actions.rs
+++ b/crates/test-utils/src/e2e_harness/actions.rs
@@ -13,11 +13,10 @@ use futures::{
 use op_alloy_rpc_types::OpTransactionReceipt;
 use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelopeV4;
 use reth_e2e_test_utils::testsuite::{Environment, actions::Action};
-use reth_node_api::{ConsensusEngineHandle, EngineApiMessageVersion};
+use reth_node_api::ConsensusEngineHandle;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_node::{OpEngineTypes, OpPayloadAttributes};
 use reth_optimism_primitives::OpTransactionSigned;
-use reth_primitives::TransactionSigned;
 use reth_rpc_api::{EngineApiClient, EthApiClient};
 use revm_primitives::{Address, B256, Bytes, U256};
 use std::{pin::Pin, sync::Arc, time::Duration};
@@ -418,11 +417,11 @@ impl Action<OpEngineTypes> for FlashblocksValidatonStream {
                     .map(|beacon_handle| {
                         let execution_data = execution_data.clone();
                         async move {
-                            beacon_handle
-                                .fork_choice_updated(forkchoice, None, EngineApiMessageVersion::V3)
-                                .await?;
+                            beacon_handle.fork_choice_updated(forkchoice, None).await?;
 
-                            let status = beacon_handle.new_payload(execution_data.clone()).await?;
+                            let status = beacon_handle
+                                .new_payload(execution_data.clone().into())
+                                .await?;
 
                             Ok::<_, eyre::Report>(status)
                         }
@@ -545,7 +544,7 @@ impl Action<OpEngineTypes> for GetReceipts {
                                 alloy_rpc_types_eth::Block,
                                 OpTransactionReceipt,
                                 Header,
-                                TransactionSigned,
+                                OpTransactionSigned,
                             >::transaction_receipt(rpc, *hash)
                             .await?;
 
@@ -606,7 +605,7 @@ impl Action<OpEngineTypes> for EthCall {
                     alloy_rpc_types_eth::Block,
                     alloy_consensus::Receipt,
                     Header,
-                    TransactionSigned,
+                    OpTransactionSigned,
                 >::call(
                     &env.node_clients[idx].rpc,
                     self.tx.clone(),
@@ -687,7 +686,7 @@ impl Action<OpEngineTypes> for GetBlockByHash {
                             alloy_rpc_types_eth::Block,
                             alloy_consensus::Receipt,
                             Header,
-                            TransactionSigned,
+                            OpTransactionSigned,
                         >::block_by_hash(
                             &env.node_clients[idx].rpc, hash, true
                         )
@@ -754,7 +753,7 @@ impl Action<OpEngineTypes> for GetCode {
                     alloy_rpc_types_eth::Block,
                     alloy_consensus::Receipt,
                     Header,
-                    TransactionSigned,
+                    OpTransactionSigned,
                 >::get_code(
                     &env.node_clients[idx].rpc,
                     self.address,
@@ -822,7 +821,7 @@ impl Action<OpEngineTypes> for GetTransactionCount {
                     alloy_rpc_types_eth::Block,
                     alloy_consensus::Receipt,
                     Header,
-                    TransactionSigned,
+                    OpTransactionSigned,
                 >::transaction_count(
                     &env.node_clients[idx].rpc,
                     self.address,
@@ -892,7 +891,7 @@ impl Action<OpEngineTypes> for GetStorage {
                     alloy_rpc_types_eth::Block,
                     alloy_consensus::Receipt,
                     Header,
-                    TransactionSigned,
+                    OpTransactionSigned,
                 >::storage_at(
                     &env.node_clients[idx].rpc,
                     self.address,
@@ -1012,7 +1011,7 @@ where
                         alloy_rpc_types_eth::Block,
                         alloy_consensus::Receipt,
                         Header,
-                        TransactionSigned,
+                        OpTransactionSigned,
                     >::block_by_number(
                         &client.rpc, alloy_eips::BlockNumberOrTag::Latest, false
                     )
@@ -1034,7 +1033,7 @@ where
                 FlashblocksEngineApiExtClient::<OpEngineTypes>::flashblocks_fork_choice_updated_v3(
                     &engine,
                     fcu_state,
-                    Some(self.attributes.clone()),
+                    Some(self.attributes.clone().into()),
                     Some((self.authorization_gen)(self.attributes.clone())),
                 )
                 .await?
@@ -1042,7 +1041,7 @@ where
                 EngineApiClient::<OpEngineTypes>::fork_choice_updated_v3(
                     &engine,
                     fcu_state,
-                    Some(self.attributes.clone()),
+                    Some(self.attributes.clone().into()),
                 )
                 .await?
             };
@@ -1253,7 +1252,7 @@ where
                         alloy_rpc_types_eth::Block,
                         alloy_consensus::Receipt,
                         Header,
-                        TransactionSigned,
+                        OpTransactionSigned,
                     >::block_by_number(
                         &builder.rpc, alloy_eips::BlockNumberOrTag::Latest, false
                     )
@@ -1286,7 +1285,7 @@ where
                     FlashblocksEngineApiExtClient::<OpEngineTypes>::flashblocks_fork_choice_updated_v3(
                         &engine,
                         fcu_state,
-                        Some(attributes.clone()),
+                        Some(attributes.clone().into()),
                         Some((self.authorization_gen)(parent_hash, attributes.clone())),
                     )
                     .await?
@@ -1294,7 +1293,7 @@ where
                     EngineApiClient::<OpEngineTypes>::fork_choice_updated_v3(
                         &engine,
                         fcu_state,
-                        Some(attributes.clone()),
+                        Some(attributes.clone().into()),
                     )
                     .await?
                 };
@@ -1397,7 +1396,6 @@ where
                             .fork_choice_updated(
                                 parent_fcu,
                                 None,
-                                EngineApiMessageVersion::V3,
                             )
                             .await
                             .map_err(|e| {
@@ -1418,7 +1416,7 @@ where
                         };
 
                         let status = beacon_handle
-                            .new_payload(execution_data)
+                            .new_payload(execution_data.into())
                             .await
                             .map_err(|e| {
                                 eyre!("block {block_num}: newPayload failed on follower {follower_idx}: {e:?}")
@@ -1441,7 +1439,6 @@ where
                             .fork_choice_updated(
                                 head_fcu,
                                 None,
-                                EngineApiMessageVersion::V3,
                             )
                             .await
                             .map_err(|e| {

--- a/crates/test-utils/src/e2e_harness/actions.rs
+++ b/crates/test-utils/src/e2e_harness/actions.rs
@@ -1034,7 +1034,7 @@ where
                 FlashblocksEngineApiExtClient::<OpEngineTypes>::flashblocks_fork_choice_updated_v3(
                     &engine,
                     fcu_state,
-                    Some(self.attributes.clone().into()),
+                    Some(self.attributes.clone()),
                     Some((self.authorization_gen)(self.attributes.clone())),
                 )
                 .await?
@@ -1042,7 +1042,7 @@ where
                 EngineApiClient::<OpEngineTypes>::fork_choice_updated_v3(
                     &engine,
                     fcu_state,
-                    Some(self.attributes.clone().into()),
+                    Some(self.attributes.clone()),
                 )
                 .await?
             };
@@ -1286,15 +1286,15 @@ where
                     FlashblocksEngineApiExtClient::<OpEngineTypes>::flashblocks_fork_choice_updated_v3(
                         &engine,
                         fcu_state,
-                        Some(attributes.clone().into()),
-                        Some((self.authorization_gen)(parent_hash, attributes.clone().into())),
+                        Some(attributes.clone()),
+                        Some((self.authorization_gen)(parent_hash, attributes.clone())),
                     )
                     .await?
                 } else {
                     EngineApiClient::<OpEngineTypes>::fork_choice_updated_v3(
                         &engine,
                         fcu_state,
-                        Some(attributes.clone().into()),
+                        Some(attributes.clone()),
                     )
                     .await?
                 };

--- a/crates/test-utils/src/e2e_harness/actions.rs
+++ b/crates/test-utils/src/e2e_harness/actions.rs
@@ -15,7 +15,8 @@ use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelopeV4;
 use reth_e2e_test_utils::testsuite::{Environment, actions::Action};
 use reth_node_api::ConsensusEngineHandle;
 use reth_optimism_chainspec::OpChainSpec;
-use reth_optimism_node::{OpEngineTypes, OpPayloadAttributes};
+use reth_optimism_node::OpEngineTypes;
+use reth_optimism_payload_builder::OpPayloadAttrs;
 use reth_optimism_primitives::OpTransactionSigned;
 use reth_rpc_api::{EngineApiClient, EthApiClient};
 use revm_primitives::{Address, B256, Bytes, U256};
@@ -957,7 +958,7 @@ pub mod assert {
 pub struct AssertMineBlock<A> {
     pub node_idx: usize,
     pub parent_hash: Option<B256>,
-    pub attributes: OpPayloadAttributes,
+    pub attributes: OpPayloadAttrs,
     pub authorization_gen: A,
     pub block_interval: Duration,
     pub flashblocks: bool,
@@ -966,12 +967,12 @@ pub struct AssertMineBlock<A> {
 
 impl<A> AssertMineBlock<A>
 where
-    A: Fn(OpPayloadAttributes) -> Authorization + Clone + Send + Sync,
+    A: Fn(OpPayloadAttrs) -> Authorization + Clone + Send + Sync,
 {
     pub async fn new(
         node_idx: usize,
         parent_hash: Option<B256>,
-        attributes: OpPayloadAttributes,
+        attributes: OpPayloadAttrs,
         authorization_gen: A,
         block_interval: Duration,
         flashblocks: bool,
@@ -991,7 +992,7 @@ where
 
 impl<A> Action<OpEngineTypes> for AssertMineBlock<A>
 where
-    A: Fn(OpPayloadAttributes) -> Authorization + Clone + Send + Sync + 'static,
+    A: Fn(OpPayloadAttrs) -> Authorization + Clone + Send + Sync + 'static,
 {
     fn execute<'a>(
         &'a mut self,
@@ -1221,7 +1222,7 @@ pub struct EngineDriver<A> {
     /// Generates `Authorization` from `(parent_hash, OpPayloadAttributes)`.
     pub authorization_gen: A,
     /// Generates attributes for the next block given (block_number, parent_timestamp).
-    pub attributes_gen: Box<dyn Fn(u64, u64) -> Result<OpPayloadAttributes> + Send + Sync>,
+    pub attributes_gen: Box<dyn Fn(u64, u64) -> Result<OpPayloadAttrs> + Send + Sync>,
     /// Optional callback during the build interval (between FCU and getPayload).
     /// Called while the payload builder is actively working.
     pub during_build: Option<MidBuildCallback>,
@@ -1231,7 +1232,7 @@ pub struct EngineDriver<A> {
 
 impl<A> EngineDriver<A>
 where
-    A: Fn(B256, OpPayloadAttributes) -> Authorization + Clone + Send + Sync + 'static,
+    A: Fn(B256, OpPayloadAttrs) -> Authorization + Clone + Send + Sync + 'static,
 {
     pub fn execute<'a>(
         &'a mut self,
@@ -1286,7 +1287,7 @@ where
                         &engine,
                         fcu_state,
                         Some(attributes.clone().into()),
-                        Some((self.authorization_gen)(parent_hash, attributes.clone())),
+                        Some((self.authorization_gen)(parent_hash, attributes.clone().into())),
                     )
                     .await?
                 } else {
@@ -1482,7 +1483,7 @@ where
 
 impl<A> Action<OpEngineTypes> for EngineDriver<A>
 where
-    A: Fn(B256, OpPayloadAttributes) -> Authorization + Clone + Send + Sync + 'static,
+    A: Fn(B256, OpPayloadAttrs) -> Authorization + Clone + Send + Sync + 'static,
 {
     fn execute<'a>(
         &'a mut self,

--- a/crates/test-utils/src/e2e_harness/setup.rs
+++ b/crates/test-utils/src/e2e_harness/setup.rs
@@ -38,7 +38,7 @@ use reth_node_core::args::{PayloadBuilderArgs, RpcServerArgs};
 use reth_optimism_chainspec::{OpChainSpec, OpChainSpecBuilder};
 use reth_optimism_forks::OpHardfork;
 use reth_optimism_node::{OpEngineTypes, OpPayloadAttributes};
-use reth_optimism_payload_builder::payload_id_optimism;
+use reth_optimism_payload_builder::{OpPayloadAttrs, payload_id_optimism};
 use reth_optimism_primitives::OpPrimitives;
 use reth_provider::providers::{BlockchainProvider, ChainStorage};
 use reth_tasks::{Runtime, TaskExecutor};
@@ -429,13 +429,13 @@ pub fn current_timestamp() -> u64 {
 pub fn create_authorization_generator(
     block_hash: B256,
     builder_verifying_key: ed25519_dalek::VerifyingKey,
-) -> impl Fn(OpPayloadAttributes) -> Authorization + Clone {
-    move |attrs: OpPayloadAttributes| {
+) -> impl Fn(OpPayloadAttrs) -> Authorization + Clone {
+    move |attrs: OpPayloadAttrs| {
         let authorizer_sk = SigningKey::from_bytes(&[0; 32]);
         let payload_id = payload_id_optimism(&block_hash, &attrs, 3);
         Authorization::new(
             payload_id,
-            attrs.payload_attributes.timestamp(),
+            attrs.payload_attributes.timestamp,
             &authorizer_sk,
             builder_verifying_key,
         )
@@ -447,7 +447,7 @@ pub fn build_payload_attributes(
     timestamp: u64,
     eip1559_params: B64,
     transactions: Option<Vec<Bytes>>,
-) -> OpPayloadAttributes {
+) -> OpPayloadAttrs {
     OpPayloadAttributes {
         payload_attributes: alloy_rpc_types_engine::PayloadAttributes {
             timestamp,
@@ -462,6 +462,7 @@ pub fn build_payload_attributes(
         gas_limit: Some(200_000_000), // 200MGas
         min_base_fee: Some(0),
     }
+    .into()
 }
 
 /// Encode EIP-1559 parameters for Holocene from a chain spec at a given timestamp

--- a/crates/test-utils/src/e2e_harness/setup.rs
+++ b/crates/test-utils/src/e2e_harness/setup.rs
@@ -26,7 +26,8 @@ use reth_e2e_test_utils::{
 use reth_engine_tree::tree::TreeConfig;
 use reth_network_api::test_utils::PeersHandleProvider;
 use reth_node_api::{
-    FullNodeTypesAdapter, NodeAddOns, NodeTypes, NodeTypesWithDBAdapter, PayloadTypes,
+    FullNodeTypesAdapter, NodeAddOns, NodeTypes, NodeTypesWithDBAdapter, PayloadAttributes,
+    PayloadTypes,
 };
 use reth_node_builder::{
     EngineNodeLauncher, Node, NodeBuilder, NodeComponents, NodeComponentsBuilder, NodeConfig,
@@ -37,7 +38,7 @@ use reth_node_core::args::{PayloadBuilderArgs, RpcServerArgs};
 use reth_optimism_chainspec::{OpChainSpec, OpChainSpecBuilder};
 use reth_optimism_forks::OpHardfork;
 use reth_optimism_node::{OpEngineTypes, OpPayloadAttributes};
-use reth_optimism_payload_builder::{OpPayloadAttrs, payload_id_optimism};
+use reth_optimism_payload_builder::OpPayloadAttrs;
 use reth_optimism_primitives::OpPrimitives;
 use reth_provider::providers::{BlockchainProvider, ChainStorage};
 use reth_tasks::{Runtime, TaskExecutor};
@@ -431,7 +432,7 @@ pub fn create_authorization_generator(
 ) -> impl Fn(OpPayloadAttrs) -> Authorization + Clone {
     move |attrs: OpPayloadAttrs| {
         let authorizer_sk = SigningKey::from_bytes(&[0; 32]);
-        let payload_id = payload_id_optimism(&block_hash, &attrs, 3);
+        let payload_id = attrs.payload_id(&block_hash);
         Authorization::new(
             payload_id,
             attrs.payload_attributes.timestamp,

--- a/crates/test-utils/src/e2e_harness/setup.rs
+++ b/crates/test-utils/src/e2e_harness/setup.rs
@@ -41,7 +41,7 @@ use reth_optimism_node::{OpEngineTypes, OpPayloadAttributes};
 use reth_optimism_payload_builder::payload_id_optimism;
 use reth_optimism_primitives::OpPrimitives;
 use reth_provider::providers::{BlockchainProvider, ChainStorage};
-use reth_tasks::TaskExecutor;
+use reth_tasks::{Runtime, TaskExecutor};
 use revm_primitives::{B256, Bytes, TxKind, U256};
 use std::{
     collections::BTreeMap,
@@ -124,7 +124,7 @@ type WorldChainNodeTestContext<T> = NodeHelperType<
 
 pub async fn setup<T>(
     num_nodes: u8,
-    attributes_generator: impl Fn(u64) -> <<WorldChainNode<T> as NodeTypes>::Payload as PayloadTypes>::PayloadBuilderAttributes + Send + Sync + Copy + 'static,
+    attributes_generator: impl Fn(u64) -> <<WorldChainNode<T> as NodeTypes>::Payload as PayloadTypes>::PayloadAttributes + Send + Sync + Copy + 'static,
     flashblocks_enabled: bool,
 ) -> eyre::Result<(
     Range<u8>,
@@ -151,7 +151,7 @@ where
 
 pub async fn setup_with_block_uncompressed_size_limit<T>(
     num_nodes: u8,
-    attributes_generator: impl Fn(u64) -> <<WorldChainNode<T> as NodeTypes>::Payload as PayloadTypes>::PayloadBuilderAttributes + Send + Sync + Copy + 'static,
+    attributes_generator: impl Fn(u64) -> <<WorldChainNode<T> as NodeTypes>::Payload as PayloadTypes>::PayloadAttributes + Send + Sync + Copy + 'static,
     flashblocks_enabled: bool,
     block_uncompressed_size_limit: Option<u64>,
     chain_spec: Arc<OpChainSpec>,
@@ -181,7 +181,7 @@ where
 /// Setup multiple nodes with optional transaction propagation peer configuration
 pub async fn setup_with_tx_peers<T>(
     num_nodes: u8,
-    attributes_generator: impl Fn(u64) -> <<WorldChainNode<T> as NodeTypes>::Payload as PayloadTypes>::PayloadBuilderAttributes + Send + Sync + Copy + 'static,
+    attributes_generator: impl Fn(u64) -> <<WorldChainNode<T> as NodeTypes>::Payload as PayloadTypes>::PayloadAttributes + Send + Sync + Copy + 'static,
     enable_tx_peers: bool,
     disable_gossip: bool,
     flashblocks_enabled: bool,
@@ -211,7 +211,7 @@ where
 
 async fn setup_inner<T>(
     num_nodes: u8,
-    attributes_generator: impl Fn(u64) -> <<WorldChainNode<T> as NodeTypes>::Payload as PayloadTypes>::PayloadBuilderAttributes + Send + Sync + Copy + 'static,
+    attributes_generator: impl Fn(u64) -> <<WorldChainNode<T> as NodeTypes>::Payload as PayloadTypes>::PayloadAttributes + Send + Sync + Copy + 'static,
     enable_tx_peers: bool,
     disable_gossip: bool,
     flashblocks_enabled: bool,
@@ -232,7 +232,7 @@ where
         std::env::set_var("PRIVATE_KEY", DEV_WORLD_ID.to_string());
     }
 
-    let exec = TaskExecutor::default();
+    let exec = Runtime::test();
 
     let mut node_config: NodeConfig<OpChainSpec> = NodeConfig::new(chain_spec.clone())
         .with_chain(chain_spec)
@@ -435,7 +435,7 @@ pub fn create_authorization_generator(
         let payload_id = payload_id_optimism(&block_hash, &attrs, 3);
         Authorization::new(
             payload_id,
-            attrs.timestamp(),
+            attrs.payload_attributes.timestamp(),
             &authorizer_sk,
             builder_verifying_key,
         )

--- a/crates/test-utils/src/e2e_harness/setup.rs
+++ b/crates/test-utils/src/e2e_harness/setup.rs
@@ -26,8 +26,7 @@ use reth_e2e_test_utils::{
 use reth_engine_tree::tree::TreeConfig;
 use reth_network_api::test_utils::PeersHandleProvider;
 use reth_node_api::{
-    FullNodeTypesAdapter, NodeAddOns, NodeTypes, NodeTypesWithDBAdapter, PayloadAttributes,
-    PayloadTypes,
+    FullNodeTypesAdapter, NodeAddOns, NodeTypes, NodeTypesWithDBAdapter, PayloadTypes,
 };
 use reth_node_builder::{
     EngineNodeLauncher, Node, NodeBuilder, NodeComponents, NodeComponentsBuilder, NodeConfig,

--- a/crates/test-utils/src/mock.rs
+++ b/crates/test-utils/src/mock.rs
@@ -4,16 +4,16 @@ use std::{
     sync::Arc,
 };
 
-use alloy_eips::{BlockHashOrNumber, BlockNumberOrTag};
+use alloy_consensus::{Header, constants::EMPTY_ROOT_HASH, transaction::TransactionMeta};
+use alloy_eips::{BlockHashOrNumber, BlockId, BlockNumberOrTag};
 use alloy_genesis::Genesis;
 use alloy_primitives::{
     Address, B256, BlockHash, BlockNumber, Bytes, StorageKey, StorageValue, TxHash, TxNumber, U256,
     keccak256, map::HashMap,
 };
-
-use alloy_consensus::{Header, constants::EMPTY_ROOT_HASH, transaction::TransactionMeta};
-use alloy_eips::BlockId;
+use op_alloy_consensus::{OpBlock, OpReceipt};
 use parking_lot::Mutex;
+use reth_chain_state::EthPrimitives;
 use reth_chainspec::{ChainInfo, ChainSpec};
 use reth_db::{
     mock::{DatabaseMock, TxMock},
@@ -23,10 +23,9 @@ use reth_node_api::NodeTypes;
 use reth_node_ethereum::EthEngineTypes;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_primitives::OpTransactionSigned;
-use reth_primitives::{
-    Account, Block, Bytecode, EthPrimitives, GotExpected, Receipt, RecoveredBlock, SealedHeader,
+use reth_primitives_traits::{
+    Account, Bytecode, GotExpected, RecoveredBlock, SealedHeader, SignerRecoverable,
 };
-use reth_primitives_traits::SignerRecoverable;
 use reth_provider::{
     AccountReader, BlockBodyIndicesProvider, BlockHashReader, BlockIdReader, BlockNumReader,
     BlockReader, BlockReaderIdExt, BlockSource, BytecodeReader, ChainSpecProvider, ChangeSetReader,
@@ -45,9 +44,9 @@ use reth_trie::{
 
 /// A mock implementation for Provider interfaces.
 #[derive(Debug, Clone)]
-pub struct MockEthProvider<T = OpTransactionSigned> {
+pub struct MockEthProvider {
     /// Local block store
-    pub blocks: Arc<Mutex<HashMap<B256, Block<T>>>>,
+    pub blocks: Arc<Mutex<HashMap<B256, OpBlock>>>,
     /// Local header store
     pub headers: Arc<Mutex<HashMap<B256, Header>>>,
     /// Local account store
@@ -121,16 +120,13 @@ impl ExtendedAccount {
 
 impl MockEthProvider {
     /// Add block to local block store
-    pub fn add_block(&self, hash: B256, block: Block<OpTransactionSigned>) {
+    pub fn add_block(&self, hash: B256, block: OpBlock) {
         self.add_header(hash, block.header.clone());
         self.blocks.lock().insert(hash, block);
     }
 
     /// Add multiple blocks to local block store
-    pub fn extend_blocks(
-        &self,
-        iter: impl IntoIterator<Item = (B256, Block<OpTransactionSigned>)>,
-    ) {
+    pub fn extend_blocks(&self, iter: impl IntoIterator<Item = (B256, OpBlock)>) {
         for (hash, block) in iter {
             self.add_header(hash, block.header.clone());
             self.add_block(hash, block)
@@ -381,24 +377,27 @@ impl TransactionsProvider for MockEthProvider {
 }
 
 impl ReceiptProvider for MockEthProvider {
-    type Receipt = Receipt;
+    type Receipt = OpReceipt;
 
-    fn receipt(&self, _id: TxNumber) -> ProviderResult<Option<Receipt>> {
+    fn receipt(&self, _id: TxNumber) -> ProviderResult<Option<OpReceipt>> {
         Ok(None)
     }
 
-    fn receipt_by_hash(&self, _hash: TxHash) -> ProviderResult<Option<Receipt>> {
+    fn receipt_by_hash(&self, _hash: TxHash) -> ProviderResult<Option<OpReceipt>> {
         Ok(None)
     }
 
-    fn receipts_by_block(&self, _block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>> {
+    fn receipts_by_block(
+        &self,
+        _block: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Vec<OpReceipt>>> {
         Ok(None)
     }
 
     fn receipts_by_tx_range(
         &self,
         _range: impl RangeBounds<TxNumber>,
-    ) -> ProviderResult<Vec<Receipt>> {
+    ) -> ProviderResult<Vec<OpReceipt>> {
         Ok(vec![])
     }
 
@@ -491,17 +490,17 @@ impl BlockIdReader for MockEthProvider {
 }
 
 impl BlockReader for MockEthProvider {
-    type Block = Block<OpTransactionSigned>;
+    type Block = OpBlock;
 
     fn find_block_by_hash(
         &self,
         hash: B256,
         _source: BlockSource,
-    ) -> ProviderResult<Option<Block<OpTransactionSigned>>> {
+    ) -> ProviderResult<Option<OpBlock>> {
         self.block(hash.into())
     }
 
-    fn block(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Block<OpTransactionSigned>>> {
+    fn block(&self, id: BlockHashOrNumber) -> ProviderResult<Option<OpBlock>> {
         let lock = self.blocks.lock();
         match id {
             BlockHashOrNumber::Hash(hash) => Ok(lock.get(&hash).cloned()),
@@ -525,7 +524,7 @@ impl BlockReader for MockEthProvider {
         &self,
         _id: BlockHashOrNumber,
         _transaction_kind: TransactionVariant,
-    ) -> ProviderResult<Option<RecoveredBlock<Block<OpTransactionSigned>>>> {
+    ) -> ProviderResult<Option<RecoveredBlock<OpBlock>>> {
         Ok(None)
     }
 
@@ -533,14 +532,11 @@ impl BlockReader for MockEthProvider {
         &self,
         _id: BlockHashOrNumber,
         _transaction_kind: TransactionVariant,
-    ) -> ProviderResult<Option<RecoveredBlock<Block<OpTransactionSigned>>>> {
+    ) -> ProviderResult<Option<RecoveredBlock<OpBlock>>> {
         Ok(None)
     }
 
-    fn block_range(
-        &self,
-        range: RangeInclusive<BlockNumber>,
-    ) -> ProviderResult<Vec<Block<OpTransactionSigned>>> {
+    fn block_range(&self, range: RangeInclusive<BlockNumber>) -> ProviderResult<Vec<OpBlock>> {
         let lock = self.blocks.lock();
 
         let mut blocks: Vec<_> = lock
@@ -556,14 +552,14 @@ impl BlockReader for MockEthProvider {
     fn block_with_senders_range(
         &self,
         _range: RangeInclusive<BlockNumber>,
-    ) -> ProviderResult<Vec<RecoveredBlock<Block<OpTransactionSigned>>>> {
+    ) -> ProviderResult<Vec<RecoveredBlock<OpBlock>>> {
         Ok(vec![])
     }
 
     fn recovered_block_range(
         &self,
         _range: RangeInclusive<BlockNumber>,
-    ) -> ProviderResult<Vec<RecoveredBlock<Block<OpTransactionSigned>>>> {
+    ) -> ProviderResult<Vec<RecoveredBlock<OpBlock>>> {
         Ok(vec![])
     }
 
@@ -573,7 +569,7 @@ impl BlockReader for MockEthProvider {
 }
 
 impl BlockReaderIdExt for MockEthProvider {
-    fn block_by_id(&self, id: BlockId) -> ProviderResult<Option<Block<OpTransactionSigned>>> {
+    fn block_by_id(&self, id: BlockId) -> ProviderResult<Option<OpBlock>> {
         match id {
             BlockId::Number(num) => self.block_by_number_or_tag(num),
             BlockId::Hash(hash) => self.block_by_hash(hash.block_hash),
@@ -730,18 +726,6 @@ impl StateProvider for MockEthProvider {
             .and_then(|account| account.storage.get(&storage_key))
             .copied())
     }
-
-    fn storage_by_hashed_key(
-        &self,
-        address: Address,
-        hashed_storage_key: StorageKey,
-    ) -> ProviderResult<Option<StorageValue>> {
-        let lock = self.accounts.lock();
-        Ok(lock
-            .get(&address)
-            .and_then(|account| account.storage.get(&hashed_storage_key))
-            .copied())
-    }
 }
 
 impl StateProviderFactory for MockEthProvider {
@@ -838,16 +822,15 @@ impl ChangeSetReader for MockEthProvider {
     ) -> ProviderResult<Vec<(BlockNumber, AccountBeforeTx)>> {
         Ok(Vec::default())
     }
-
-    fn account_changeset_count(&self) -> ProviderResult<usize> {
-        Ok(0)
-    }
 }
 
 impl StateReader for MockEthProvider {
-    type Receipt = Receipt;
+    type Receipt = OpReceipt;
 
-    fn get_state(&self, _block: BlockNumber) -> ProviderResult<Option<ExecutionOutcome>> {
+    fn get_state(
+        &self,
+        _block: BlockNumber,
+    ) -> ProviderResult<Option<ExecutionOutcome<Self::Receipt>>> {
         Ok(None)
     }
 }

--- a/crates/test-utils/src/node.rs
+++ b/crates/test-utils/src/node.rs
@@ -2,25 +2,33 @@ use crate::{
     DEV_WORLD_ID, PBH_DEV_ENTRYPOINT, PBH_DEV_SIGNATURE_AGGREGATOR,
     utils::{pbh_bundle, pbh_multicall, signer, user_op},
 };
-use alloy_eips::{BlockHashOrNumber, BlockId, BlockNumHash, BlockNumberOrTag};
+use alloy_consensus::Header;
+use alloy_eips::{
+    BlockHashOrNumber, BlockId, BlockNumHash, BlockNumberOrTag, eip2718::Encodable2718,
+};
 use alloy_primitives::{
     Address, B256, BlockHash, BlockNumber, Bytes, StorageKey, StorageValue, TxHash, TxNumber, U256,
 };
 use alloy_rpc_types::{TransactionInput, TransactionRequest};
 use alloy_sol_types::SolCall;
+use chrono::Datelike;
 use futures::future::join_all;
+use op_alloy_consensus::OpReceipt;
+use rand::Rng as _;
 use reth_chain_state::{
-    CanonStateNotifications, CanonStateSubscriptions, ForkChoiceNotifications,
+    CanonStateNotifications, CanonStateSubscriptions, EthPrimitives, ForkChoiceNotifications,
     ForkChoiceSubscriptions,
 };
 use reth_chainspec::{ChainInfo, MAINNET};
 use reth_db::models::{AccountBeforeTx, StoredBlockBodyIndices};
 use reth_e2e_test_utils::transaction::TransactionTestContext;
+use reth_network_peers::PeerId;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_node::OpEvmConfig;
-use reth_primitives::{
-    Account, Block, Bytecode, EthPrimitives, Header, Receipt, RecoveredBlock, SealedBlock,
-    SealedHeader, TransactionMeta, TransactionSigned,
+use reth_optimism_payload_builder::config::OpBuilderConfig;
+use reth_optimism_primitives::{OpBlock, OpTransactionSigned};
+use reth_primitives_traits::{
+    Account, Bytecode, RecoveredBlock, SealedBlock, SealedHeader, TransactionMeta,
 };
 use reth_provider::{
     AccountReader, BlockBodyIndicesProvider, BlockHashReader, BlockIdReader, BlockNumReader,
@@ -49,25 +57,15 @@ use std::{
 };
 use tokio::sync::{broadcast, watch};
 use world_chain_cli::{
-    FlashblocksPayloadBuilderConfig,
+    BuilderArgs, FlashblocksPayloadBuilderConfig, PbhArgs, WorldChainArgs, WorldChainNodeConfig,
     cli::{builder::FlashblocksArgs, p2p::FanoutArgs},
 };
 use world_chain_pbh::external_nullifier::ExternalNullifier;
-
-use alloy_eips::eip2718::Encodable2718;
-use chrono::Datelike;
 use world_chain_pool::{
     tx::{WorldChainPoolTransaction, WorldChainPooledTransaction},
     validator::WorldChainTransactionValidator,
 };
-
-use rand::Rng as _;
-use reth_network_peers::PeerId;
 use world_chain_primitives::ed25519_dalek::SigningKey;
-
-use reth_optimism_payload_builder::config::OpBuilderConfig;
-
-use world_chain_cli::{BuilderArgs, PbhArgs, WorldChainArgs, WorldChainNodeConfig};
 
 pub fn test_config() -> WorldChainNodeConfig {
     test_config_with_peers_and_gossip(None, false, true)
@@ -270,16 +268,16 @@ impl BlockNumReader for WorldChainNoopProvider {
 }
 
 impl BlockReader for WorldChainNoopProvider {
-    type Block = Block;
+    type Block = OpBlock;
     fn find_block_by_hash(
         &self,
         hash: B256,
         _source: BlockSource,
-    ) -> ProviderResult<Option<Block>> {
+    ) -> ProviderResult<Option<OpBlock>> {
         self.block(hash.into())
     }
 
-    fn block(&self, _id: BlockHashOrNumber) -> ProviderResult<Option<Block>> {
+    fn block(&self, _id: BlockHashOrNumber) -> ProviderResult<Option<OpBlock>> {
         Ok(None)
     }
 
@@ -297,7 +295,7 @@ impl BlockReader for WorldChainNoopProvider {
         &self,
         _id: BlockHashOrNumber,
         _transaction_kind: TransactionVariant,
-    ) -> ProviderResult<Option<RecoveredBlock<Block>>> {
+    ) -> ProviderResult<Option<RecoveredBlock<OpBlock>>> {
         Ok(None)
     }
 
@@ -305,25 +303,25 @@ impl BlockReader for WorldChainNoopProvider {
         &self,
         _id: BlockHashOrNumber,
         _transaction_kind: TransactionVariant,
-    ) -> ProviderResult<Option<RecoveredBlock<Block>>> {
+    ) -> ProviderResult<Option<RecoveredBlock<OpBlock>>> {
         Ok(None)
     }
 
-    fn block_range(&self, _range: RangeInclusive<BlockNumber>) -> ProviderResult<Vec<Block>> {
+    fn block_range(&self, _range: RangeInclusive<BlockNumber>) -> ProviderResult<Vec<OpBlock>> {
         Ok(vec![])
     }
 
     fn block_with_senders_range(
         &self,
         _range: RangeInclusive<BlockNumber>,
-    ) -> ProviderResult<Vec<RecoveredBlock<Block>>> {
+    ) -> ProviderResult<Vec<RecoveredBlock<OpBlock>>> {
         Ok(vec![])
     }
 
     fn recovered_block_range(
         &self,
         _range: RangeInclusive<BlockNumber>,
-    ) -> ProviderResult<Vec<RecoveredBlock<Block>>> {
+    ) -> ProviderResult<Vec<RecoveredBlock<OpBlock>>> {
         Ok(vec![])
     }
 
@@ -354,7 +352,7 @@ impl BlockBodyIndicesProvider for WorldChainNoopProvider {
 }
 
 impl BlockReaderIdExt for WorldChainNoopProvider {
-    fn block_by_id(&self, _id: BlockId) -> ProviderResult<Option<Block>> {
+    fn block_by_id(&self, _id: BlockId) -> ProviderResult<Option<OpBlock>> {
         Ok(None)
     }
 
@@ -382,7 +380,7 @@ impl BlockIdReader for WorldChainNoopProvider {
 }
 
 impl TransactionsProvider for WorldChainNoopProvider {
-    type Transaction = TransactionSigned;
+    type Transaction = OpTransactionSigned;
 
     fn transaction_by_id_unhashed(
         &self,
@@ -395,32 +393,32 @@ impl TransactionsProvider for WorldChainNoopProvider {
         Ok(None)
     }
 
-    fn transaction_by_id(&self, _id: TxNumber) -> ProviderResult<Option<TransactionSigned>> {
+    fn transaction_by_id(&self, _id: TxNumber) -> ProviderResult<Option<OpTransactionSigned>> {
         Ok(None)
     }
 
-    fn transaction_by_hash(&self, _hash: TxHash) -> ProviderResult<Option<TransactionSigned>> {
+    fn transaction_by_hash(&self, _hash: TxHash) -> ProviderResult<Option<OpTransactionSigned>> {
         Ok(None)
     }
 
     fn transaction_by_hash_with_meta(
         &self,
         _hash: TxHash,
-    ) -> ProviderResult<Option<(TransactionSigned, TransactionMeta)>> {
+    ) -> ProviderResult<Option<(OpTransactionSigned, TransactionMeta)>> {
         Ok(None)
     }
 
     fn transactions_by_block(
         &self,
         _block_id: BlockHashOrNumber,
-    ) -> ProviderResult<Option<Vec<TransactionSigned>>> {
+    ) -> ProviderResult<Option<Vec<OpTransactionSigned>>> {
         Ok(None)
     }
 
     fn transactions_by_block_range(
         &self,
         _range: impl RangeBounds<BlockNumber>,
-    ) -> ProviderResult<Vec<Vec<TransactionSigned>>> {
+    ) -> ProviderResult<Vec<Vec<OpTransactionSigned>>> {
         Ok(Vec::default())
     }
 
@@ -444,23 +442,26 @@ impl TransactionsProvider for WorldChainNoopProvider {
 }
 
 impl ReceiptProvider for WorldChainNoopProvider {
-    type Receipt = Receipt;
-    fn receipt(&self, _id: TxNumber) -> ProviderResult<Option<Receipt>> {
+    type Receipt = OpReceipt;
+    fn receipt(&self, _id: TxNumber) -> ProviderResult<Option<OpReceipt>> {
         Ok(None)
     }
 
-    fn receipt_by_hash(&self, _hash: TxHash) -> ProviderResult<Option<Receipt>> {
+    fn receipt_by_hash(&self, _hash: TxHash) -> ProviderResult<Option<OpReceipt>> {
         Ok(None)
     }
 
-    fn receipts_by_block(&self, _block: BlockHashOrNumber) -> ProviderResult<Option<Vec<Receipt>>> {
+    fn receipts_by_block(
+        &self,
+        _block: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Vec<OpReceipt>>> {
         Ok(None)
     }
 
     fn receipts_by_tx_range(
         &self,
         _range: impl RangeBounds<TxNumber>,
-    ) -> ProviderResult<Vec<Receipt>> {
+    ) -> ProviderResult<Vec<OpReceipt>> {
         Ok(vec![])
     }
 
@@ -529,10 +530,6 @@ impl ChangeSetReader for WorldChainNoopProvider {
         _range: impl RangeBounds<BlockNumber>,
     ) -> ProviderResult<Vec<(BlockNumber, AccountBeforeTx)>> {
         Ok(Vec::default())
-    }
-
-    fn account_changeset_count(&self) -> ProviderResult<usize> {
-        Ok(0)
     }
 }
 
@@ -616,14 +613,6 @@ impl StateProvider for WorldChainNoopProvider {
         &self,
         _account: Address,
         _storage_key: StorageKey,
-    ) -> ProviderResult<Option<StorageValue>> {
-        Ok(None)
-    }
-
-    fn storage_by_hashed_key(
-        &self,
-        _address: Address,
-        _hashed_storage_key: StorageKey,
     ) -> ProviderResult<Option<StorageValue>> {
         Ok(None)
     }
@@ -711,7 +700,7 @@ impl NodePrimitivesProvider for WorldChainNoopProvider {
 }
 impl StaticFileProviderFactory for WorldChainNoopProvider {
     fn static_file_provider(&self) -> StaticFileProvider<Self::Primitives> {
-        StaticFileProvider::read_only(PathBuf::default(), false).unwrap()
+        StaticFileProvider::read_only(PathBuf::default()).unwrap()
     }
 
     fn get_static_file_writer(

--- a/crates/test-utils/src/utils.rs
+++ b/crates/test-utils/src/utils.rs
@@ -1,4 +1,4 @@
-use alloy_consensus::{SignableTransaction, TxEip1559};
+use alloy_consensus::{InMemorySize, SignableTransaction, TxEip1559};
 use alloy_eips::{eip2718::Encodable2718, eip2930::AccessList};
 use alloy_network::TxSigner;
 use alloy_primitives::{
@@ -12,8 +12,7 @@ use bon::builder;
 use op_alloy_consensus::OpTypedTransaction;
 use reth_optimism_node::txpool::OpPooledTransaction;
 use reth_optimism_primitives::OpTransactionSigned;
-use reth_primitives::transaction::SignedTransaction;
-use reth_primitives_traits::size::InMemorySize;
+use reth_primitives_traits::SignedTransaction;
 use semaphore_rs::{Field, hash_to_field, identity::Identity, poseidon_tree::LazyPoseidonTree};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{str::FromStr, sync::LazyLock};

--- a/e2e-tests/src/it/testsuite.rs
+++ b/e2e-tests/src/it/testsuite.rs
@@ -9,6 +9,7 @@ use op_alloy_consensus::OpTxEnvelope;
 use reth_chainspec::EthChainSpec;
 use reth_e2e_test_utils::testsuite::actions::Action;
 use reth_network::{NetworkSyncUpdater, SyncState};
+use reth_node_api::PayloadAttributes;
 use reth_optimism_node::utils::optimism_payload_attributes;
 use reth_tasks::Runtime;
 use reth_transaction_pool::TransactionPool;
@@ -1280,8 +1281,7 @@ async fn test_engine_driver_pending_block_queries() -> eyre::Result<()> {
     let authorization_gen =
         move |parent_hash: B256, attrs: reth_optimism_payload_builder::OpPayloadAttrs| {
             let authorizer_sk = ed25519_dalek::SigningKey::from_bytes(&[0; 32]);
-            let payload_id =
-                reth_optimism_payload_builder::payload_id_optimism(&parent_hash, &attrs, 3);
+            let payload_id = attrs.payload_id(&parent_hash);
             world_chain_primitives::p2p::Authorization::new(
                 payload_id,
                 attrs.payload_attributes.timestamp,
@@ -1475,8 +1475,7 @@ async fn test_eth_api_assertions() -> eyre::Result<()> {
     let authorization_gen =
         move |parent_hash: B256, attrs: reth_optimism_payload_builder::OpPayloadAttrs| {
             let authorizer_sk = ed25519_dalek::SigningKey::from_bytes(&[0; 32]);
-            let payload_id =
-                reth_optimism_payload_builder::payload_id_optimism(&parent_hash, &attrs, 3);
+            let payload_id = attrs.payload_id(&parent_hash);
             world_chain_primitives::p2p::Authorization::new(
                 payload_id,
                 attrs.payload_attributes.timestamp,
@@ -1710,8 +1709,7 @@ async fn test_assertion_driven_event_stream() -> eyre::Result<()> {
     let authorization_gen =
         move |parent_hash: B256, attrs: reth_optimism_payload_builder::OpPayloadAttrs| {
             let authorizer_sk = ed25519_dalek::SigningKey::from_bytes(&[0; 32]);
-            let payload_id =
-                reth_optimism_payload_builder::payload_id_optimism(&parent_hash, &attrs, 3);
+            let payload_id = attrs.payload_id(&parent_hash);
             world_chain_primitives::p2p::Authorization::new(
                 payload_id,
                 attrs.payload_attributes.timestamp,

--- a/e2e-tests/src/it/testsuite.rs
+++ b/e2e-tests/src/it/testsuite.rs
@@ -10,7 +10,6 @@ use reth_chainspec::EthChainSpec;
 use reth_e2e_test_utils::testsuite::actions::Action;
 use reth_network::{NetworkSyncUpdater, SyncState};
 use reth_optimism_node::utils::optimism_payload_attributes;
-use reth_optimism_payload_builder::OpPayloadAttrs;
 use reth_tasks::Runtime;
 use reth_transaction_pool::TransactionPool;
 use revm_primitives::{Address, B256, U256};
@@ -432,7 +431,7 @@ async fn test_flashblocks() -> eyre::Result<()> {
     let mine_block = world_chain_test_utils::e2e_harness::actions::AssertMineBlock::new(
         0,
         None,
-        attributes.into(),
+        attributes,
         authorization_generator,
         std::time::Duration::from_millis(3000),
         true,

--- a/e2e-tests/src/it/testsuite.rs
+++ b/e2e-tests/src/it/testsuite.rs
@@ -10,6 +10,8 @@ use reth_chainspec::EthChainSpec;
 use reth_e2e_test_utils::testsuite::actions::Action;
 use reth_network::{NetworkSyncUpdater, SyncState};
 use reth_optimism_node::utils::optimism_payload_attributes;
+use reth_optimism_payload_builder::OpPayloadAttrs;
+use reth_tasks::Runtime;
 use reth_transaction_pool::TransactionPool;
 use revm_primitives::{Address, B256, U256};
 use std::{
@@ -430,7 +432,7 @@ async fn test_flashblocks() -> eyre::Result<()> {
     let mine_block = world_chain_test_utils::e2e_harness::actions::AssertMineBlock::new(
         0,
         None,
-        attributes,
+        attributes.into(),
         authorization_generator,
         std::time::Duration::from_millis(3000),
         true,
@@ -1277,13 +1279,13 @@ async fn test_engine_driver_pending_block_queries() -> eyre::Result<()> {
         .verifying_key();
 
     let authorization_gen =
-        move |parent_hash: B256, attrs: reth_optimism_node::OpPayloadAttributes| {
+        move |parent_hash: B256, attrs: reth_optimism_payload_builder::OpPayloadAttrs| {
             let authorizer_sk = ed25519_dalek::SigningKey::from_bytes(&[0; 32]);
             let payload_id =
                 reth_optimism_payload_builder::payload_id_optimism(&parent_hash, &attrs, 3);
             world_chain_primitives::p2p::Authorization::new(
                 payload_id,
-                reth_node_api::PayloadAttributes::timestamp(&attrs),
+                attrs.payload_attributes.timestamp,
                 &authorizer_sk,
                 builder_vk,
             )
@@ -1472,13 +1474,13 @@ async fn test_eth_api_assertions() -> eyre::Result<()> {
         .verifying_key();
 
     let authorization_gen =
-        move |parent_hash: B256, attrs: reth_optimism_node::OpPayloadAttributes| {
+        move |parent_hash: B256, attrs: reth_optimism_payload_builder::OpPayloadAttrs| {
             let authorizer_sk = ed25519_dalek::SigningKey::from_bytes(&[0; 32]);
             let payload_id =
                 reth_optimism_payload_builder::payload_id_optimism(&parent_hash, &attrs, 3);
             world_chain_primitives::p2p::Authorization::new(
                 payload_id,
-                reth_node_api::PayloadAttributes::timestamp(&attrs),
+                attrs.payload_attributes.timestamp,
                 &authorizer_sk,
                 builder_vk,
             )
@@ -1707,13 +1709,13 @@ async fn test_assertion_driven_event_stream() -> eyre::Result<()> {
         .verifying_key();
 
     let authorization_gen =
-        move |parent_hash: B256, attrs: reth_optimism_node::OpPayloadAttributes| {
+        move |parent_hash: B256, attrs: reth_optimism_payload_builder::OpPayloadAttrs| {
             let authorizer_sk = ed25519_dalek::SigningKey::from_bytes(&[0; 32]);
             let payload_id =
                 reth_optimism_payload_builder::payload_id_optimism(&parent_hash, &attrs, 3);
             world_chain_primitives::p2p::Authorization::new(
                 payload_id,
-                reth_node_api::PayloadAttributes::timestamp(&attrs),
+                attrs.payload_attributes.timestamp,
                 &authorizer_sk,
                 builder_vk,
             )
@@ -2333,7 +2335,7 @@ async fn test_peer_monitoring() -> eyre::Result<()> {
     p2p_key_file.flush()?;
     let p2p_key_path = p2p_key_file.path().to_path_buf();
 
-    let exec1 = TaskExecutor::default();
+    let exec1 = Runtime::test();
 
     let builder1 = SigningKey::from_bytes(&[1; 32]);
     let (p2p_1, record_1, network_1, _exit_1, _node_1) = setup_monitoring_node(
@@ -2346,7 +2348,7 @@ async fn test_peer_monitoring() -> eyre::Result<()> {
     )
     .await?;
 
-    let exec2 = TaskExecutor::default();
+    let exec2 = Runtime::test();
 
     let peer1_id = record_1.id;
     let peer1_addr = record_1.tcp_addr();

--- a/specs/cli/reference.md
+++ b/specs/cli/reference.md
@@ -36,9 +36,7 @@ Rollup:
           Enable transaction conditional support on sequencer
 
       --rollup.supervisor-http <SUPERVISOR_HTTP_URL>
-          HTTP endpoint for the supervisor
-          
-          [default: http://localhost:1337/]
+          HTTP endpoint for the supervisor. When not set, interop transaction validation is disabled
 
       --rollup.supervisor-safety-level <SUPERVISOR_SAFETY_LEVEL>
           Safety level for the supervisor

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -49,7 +49,7 @@ futures.workspace = true
 hex.workspace = true
 once_cell.workspace = true
 rand.workspace = true
-reqwest.workspace = true
+reqwest = { workspace = true, features = ["json"] }
 semaphore-rs.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/xtask/src/stress/cli/transactions.rs
+++ b/xtask/src/stress/cli/transactions.rs
@@ -11,15 +11,12 @@ use alloy_rpc_types_eth::{BlockNumberOrTag, TransactionInput, TransactionRequest
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::{SolCall, SolInterface, SolValue, sol};
-use alloy_transport_http::Http;
+use alloy_transport_http::{Client as HttpClient, Http};
 use eyre::eyre::{Context, bail};
 use futures::{StreamExt, TryStreamExt, stream};
 use once_cell::sync::Lazy;
 use rand::Rng;
-use reqwest::{
-    Client,
-    header::{AUTHORIZATION, HeaderMap},
-};
+use reqwest::header::{AUTHORIZATION, HeaderMap};
 use reth_rpc_layer::secret_to_bearer_header;
 use semaphore_rs::{Field, hash_to_field, identity::Identity};
 use serde::{Deserialize, Serialize};
@@ -480,7 +477,7 @@ pub async fn send_bundle(args: SendArgs) -> eyre::Result<()> {
         headers.insert(AUTHORIZATION, secret_to_bearer_header(&secret));
     }
 
-    let client = Client::builder().default_headers(headers).build()?;
+    let client = HttpClient::builder().default_headers(headers).build()?;
 
     // Create the HTTP transport.
     let http = Http::with_client(client, args.rpc_url.parse()?);

--- a/xtask/src/swarm.rs
+++ b/xtask/src/swarm.rs
@@ -13,8 +13,8 @@ use std::{sync::Arc, time::Duration};
 use alloy_primitives::B256;
 use clap::Parser;
 use eyre::Result;
-use reth_node_api::PayloadAttributes;
 use reth_optimism_node::{OpPayloadAttributes, utils::optimism_payload_attributes};
+use reth_optimism_payload_builder::OpPayloadAttrs;
 use reth_optimism_payload_builder::payload_id_optimism;
 use tracing::info;
 
@@ -118,7 +118,7 @@ pub async fn run(args: Args) -> Result<()> {
         None
     };
 
-    let authorization_gen = move |parent_hash: B256, attrs: OpPayloadAttributes| -> Authorization {
+    let authorization_gen = move |parent_hash: B256, attrs: OpPayloadAttrs| -> Authorization {
         let authorizer_sk = ed25519_dalek::SigningKey::from_bytes(&[0; 32]);
         let payload_id = payload_id_optimism(&parent_hash, &attrs, 3);
         let vk = maybe_builder_vk.unwrap_or_else(|| authorizer_sk.verifying_key());

--- a/xtask/src/swarm.rs
+++ b/xtask/src/swarm.rs
@@ -124,7 +124,7 @@ pub async fn run(args: Args) -> Result<()> {
         let vk = maybe_builder_vk.unwrap_or_else(|| authorizer_sk.verifying_key());
         Authorization::new(
             payload_id,
-            PayloadAttributes::timestamp(&attrs),
+            attrs.payload_attributes.timestamp,
             &authorizer_sk,
             vk,
         )

--- a/xtask/src/swarm.rs
+++ b/xtask/src/swarm.rs
@@ -13,9 +13,8 @@ use std::{sync::Arc, time::Duration};
 use alloy_primitives::B256;
 use clap::Parser;
 use eyre::Result;
-use reth_optimism_node::{OpPayloadAttributes, utils::optimism_payload_attributes};
-use reth_optimism_payload_builder::OpPayloadAttrs;
-use reth_optimism_payload_builder::payload_id_optimism;
+use reth_optimism_node::utils::optimism_payload_attributes;
+use reth_optimism_payload_builder::{OpPayloadAttrs, payload_id_optimism};
 use tracing::info;
 
 use world_chain_node::context::WorldChainDefaultContext;

--- a/xtask/src/swarm.rs
+++ b/xtask/src/swarm.rs
@@ -13,8 +13,9 @@ use std::{sync::Arc, time::Duration};
 use alloy_primitives::B256;
 use clap::Parser;
 use eyre::Result;
+use reth_node_api::PayloadAttributes;
 use reth_optimism_node::utils::optimism_payload_attributes;
-use reth_optimism_payload_builder::{OpPayloadAttrs, payload_id_optimism};
+use reth_optimism_payload_builder::OpPayloadAttrs;
 use tracing::info;
 
 use world_chain_node::context::WorldChainDefaultContext;
@@ -119,7 +120,7 @@ pub async fn run(args: Args) -> Result<()> {
 
     let authorization_gen = move |parent_hash: B256, attrs: OpPayloadAttrs| -> Authorization {
         let authorizer_sk = ed25519_dalek::SigningKey::from_bytes(&[0; 32]);
-        let payload_id = payload_id_optimism(&parent_hash, &attrs, 3);
+        let payload_id = attrs.payload_id(&parent_hash);
         let vk = maybe_builder_vk.unwrap_or_else(|| authorizer_sk.verifying_key());
         Authorization::new(
             payload_id,


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4518/bump-world-chain-to-reth-v200

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adjusts Cargo env settings to reduce debug info generation; no production code paths are affected.
> 
> **Overview**
> Updates Rust CI workflow environment to set `CARGO_PROFILE_DEV_DEBUG=0` and `CARGO_PROFILE_TEST_DEBUG=0`, disabling debug info generation for `dev` and `test` builds in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9758682b0f24988a7100f4b6291ad3014727b10f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->