### PR TITLE
feat(primitives): wip-1001 typed transaction codec and signature payload

### DIFF
--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -5,4 +5,5 @@ pub mod error;
 pub mod flashblocks;
 pub mod p2p;
 pub mod primitives;
+pub mod transaction;
 pub use ed25519_dalek;

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -3,13 +3,13 @@
 //! [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
 
 use alloy_consensus::{
-    error::ValueError,
-    transaction::{RlpEcdsaEncodableTx, TxHashRef},
     EthereumTxEnvelope, Sealable, Sealed, SignableTransaction, Signed, TransactionEnvelope,
     TxEip1559, TxEip2930, TxEip7702, TxEnvelope, TxLegacy, Typed2718,
+    error::ValueError,
+    transaction::{RlpEcdsaEncodableTx, TxHashRef},
 };
 use alloy_eips::eip2718::Encodable2718;
-use alloy_primitives::{bytes::BufMut, Bytes, ChainId, Signature, TxHash, B256};
+use alloy_primitives::{B256, Bytes, ChainId, Signature, TxHash, bytes::BufMut};
 use op_alloy_consensus::{OpTransaction, OpTxEnvelope, TxDeposit};
 
 /// The World Chain [EIP-2718] transaction envelope.

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -12,6 +12,8 @@ use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::{B256, Bytes, ChainId, Signature, TxHash, bytes::BufMut};
 use op_alloy_consensus::{OpTransaction, OpTxEnvelope, TxDeposit};
 
+use crate::transaction::wip_1001::{SignedWip1001, TxWip1001, Wip1001Signature};
+
 /// The World Chain [EIP-2718] transaction envelope.
 ///
 /// This enum is structurally identical to [`op_alloy_consensus::OpTxEnvelope`] and exists as a
@@ -32,6 +34,14 @@ pub enum WorldChainTxEnvelope {
     /// A [`TxEip7702`] tagged with type 4.
     #[envelope(ty = 4)]
     Eip7702(Signed<TxEip7702>),
+    /// A [`TxWip1001`] tagged with type 0x1D.
+    ///
+    /// Wraps [`Signed<TxWip1001, Wip1001Signature>`] via [`SignedWip1001`], a
+    /// thin local newtype that satisfies Rust's orphan rule for the
+    /// `Encodable2718`/`Decodable2718` impls. See `wips/wip-1001.md` for the
+    /// full specification.
+    #[envelope(ty = 29, typed = TxWip1001)]
+    Wip1001(SignedWip1001),
     /// A [`TxDeposit`] tagged with type 0x7E.
     #[envelope(ty = 126)]
     #[serde(serialize_with = "op_alloy_consensus::serde_deposit_tx_rpc")]
@@ -78,6 +88,18 @@ impl From<Signed<TxEip7702>> for WorldChainTxEnvelope {
     }
 }
 
+impl From<SignedWip1001> for WorldChainTxEnvelope {
+    fn from(v: SignedWip1001) -> Self {
+        Self::Wip1001(v)
+    }
+}
+
+impl From<Signed<TxWip1001, Wip1001Signature>> for WorldChainTxEnvelope {
+    fn from(v: Signed<TxWip1001, Wip1001Signature>) -> Self {
+        Self::Wip1001(SignedWip1001::new(v))
+    }
+}
+
 impl From<TxDeposit> for WorldChainTxEnvelope {
     fn from(v: TxDeposit) -> Self {
         v.seal_slow().into()
@@ -106,6 +128,10 @@ impl From<Signed<WorldChainTypedTransaction>> for WorldChainTxEnvelope {
             WorldChainTypedTransaction::Eip7702(tx_eip7702) => {
                 Self::Eip7702(Signed::new_unchecked(tx_eip7702, sig, hash))
             }
+            // Default `Signature` is secp256k1; wrap it into the WIP-1001 signature enum.
+            WorldChainTypedTransaction::Wip1001(tx_wip) => Self::Wip1001(SignedWip1001::new(
+                Signed::new_unchecked(tx_wip, Wip1001Signature::Secp256k1(sig), hash),
+            )),
             WorldChainTypedTransaction::Deposit(tx) => {
                 Self::Deposit(Sealed::new_unchecked(tx, hash))
             }
@@ -147,14 +173,20 @@ impl From<OpTxEnvelope> for WorldChainTxEnvelope {
     }
 }
 
-impl From<WorldChainTxEnvelope> for OpTxEnvelope {
-    fn from(value: WorldChainTxEnvelope) -> Self {
+impl TryFrom<WorldChainTxEnvelope> for OpTxEnvelope {
+    type Error = ValueError<WorldChainTxEnvelope>;
+
+    fn try_from(value: WorldChainTxEnvelope) -> Result<Self, Self::Error> {
         match value {
-            WorldChainTxEnvelope::Legacy(tx) => Self::Legacy(tx),
-            WorldChainTxEnvelope::Eip2930(tx) => Self::Eip2930(tx),
-            WorldChainTxEnvelope::Eip1559(tx) => Self::Eip1559(tx),
-            WorldChainTxEnvelope::Eip7702(tx) => Self::Eip7702(tx),
-            WorldChainTxEnvelope::Deposit(tx) => Self::Deposit(tx),
+            WorldChainTxEnvelope::Legacy(tx) => Ok(Self::Legacy(tx)),
+            WorldChainTxEnvelope::Eip2930(tx) => Ok(Self::Eip2930(tx)),
+            WorldChainTxEnvelope::Eip1559(tx) => Ok(Self::Eip1559(tx)),
+            WorldChainTxEnvelope::Eip7702(tx) => Ok(Self::Eip7702(tx)),
+            WorldChainTxEnvelope::Deposit(tx) => Ok(Self::Deposit(tx)),
+            tx @ WorldChainTxEnvelope::Wip1001(_) => Err(ValueError::new(
+                tx,
+                "WIP-1001 transactions cannot be converted to an Optimism transaction",
+            )),
         }
     }
 }
@@ -197,6 +229,12 @@ impl WorldChainTxEnvelope {
         matches!(self, Self::Eip1559(_))
     }
 
+    /// Returns true if the transaction is a WIP-1001 transaction.
+    #[inline]
+    pub const fn is_wip1001(&self) -> bool {
+        matches!(self, Self::Wip1001(_))
+    }
+
     /// Returns true if the transaction is a deposit transaction.
     #[inline]
     pub const fn is_deposit(&self) -> bool {
@@ -236,6 +274,14 @@ impl WorldChainTxEnvelope {
         }
     }
 
+    /// Returns the [`TxWip1001`] variant if the transaction is a WIP-1001 transaction.
+    pub const fn as_wip1001(&self) -> Option<&SignedWip1001> {
+        match self {
+            Self::Wip1001(tx) => Some(tx),
+            _ => None,
+        }
+    }
+
     /// Returns the [`TxDeposit`] variant if the transaction is a deposit transaction.
     pub const fn as_deposit(&self) -> Option<&Sealed<TxDeposit>> {
         match self {
@@ -246,14 +292,16 @@ impl WorldChainTxEnvelope {
 
     /// Return the reference to signature.
     ///
-    /// Returns `None` if this is a deposit variant.
+    /// Returns `None` for deposit transactions (unsigned) and for WIP-1001
+    /// transactions (which use [`Wip1001Signature`], obtainable via
+    /// [`Self::as_wip1001`]).
     pub const fn signature(&self) -> Option<&Signature> {
         match self {
             Self::Legacy(tx) => Some(tx.signature()),
             Self::Eip2930(tx) => Some(tx.signature()),
             Self::Eip1559(tx) => Some(tx.signature()),
             Self::Eip7702(tx) => Some(tx.signature()),
-            Self::Deposit(_) => None,
+            Self::Wip1001(_) | Self::Deposit(_) => None,
         }
     }
 
@@ -264,6 +312,7 @@ impl WorldChainTxEnvelope {
             Self::Eip2930(_) => WorldChainTxType::Eip2930,
             Self::Eip1559(_) => WorldChainTxType::Eip1559,
             Self::Eip7702(_) => WorldChainTxType::Eip7702,
+            Self::Wip1001(_) => WorldChainTxType::Wip1001,
             Self::Deposit(_) => WorldChainTxType::Deposit,
         }
     }
@@ -275,6 +324,7 @@ impl WorldChainTxEnvelope {
             Self::Eip1559(tx) => tx.hash(),
             Self::Eip2930(tx) => tx.hash(),
             Self::Eip7702(tx) => tx.hash(),
+            Self::Wip1001(tx) => tx.hash(),
             Self::Deposit(tx) => tx.hash_ref(),
         }
     }
@@ -291,6 +341,7 @@ impl WorldChainTxEnvelope {
             Self::Eip2930(t) => t.eip2718_encoded_length(),
             Self::Eip1559(t) => t.eip2718_encoded_length(),
             Self::Eip7702(t) => t.eip2718_encoded_length(),
+            Self::Wip1001(t) => t.encode_2718_len(),
             Self::Deposit(t) => t.eip2718_encoded_length(),
         }
     }
@@ -298,13 +349,17 @@ impl WorldChainTxEnvelope {
     /// Attempts to convert the World Chain variant into an ethereum [`TxEnvelope`].
     ///
     /// Returns the envelope as error if it is a variant unsupported on ethereum
-    /// (e.g. [`TxDeposit`]).
+    /// (e.g. [`TxDeposit`] or [`TxWip1001`]).
     pub fn try_into_eth_envelope(self) -> Result<TxEnvelope, ValueError<Self>> {
         match self {
             Self::Legacy(tx) => Ok(tx.into()),
             Self::Eip2930(tx) => Ok(tx.into()),
             Self::Eip1559(tx) => Ok(tx.into()),
             Self::Eip7702(tx) => Ok(tx.into()),
+            tx @ Self::Wip1001(_) => Err(ValueError::new(
+                tx,
+                "WIP-1001 transactions cannot be converted to ethereum transaction",
+            )),
             tx @ Self::Deposit(_) => Err(ValueError::new(
                 tx,
                 "Deposit transactions cannot be converted to ethereum transaction",
@@ -339,6 +394,7 @@ impl WorldChainTxEnvelope {
             Self::Eip2930(tx) => &mut tx.tx_mut().input,
             Self::Legacy(tx) => &mut tx.tx_mut().input,
             Self::Eip7702(tx) => &mut tx.tx_mut().input,
+            Self::Wip1001(tx) => &mut SignedWip1001::tx_mut(tx).input,
             Self::Deposit(tx) => &mut tx.inner_mut().input,
         }
     }
@@ -354,21 +410,18 @@ impl alloy_consensus::transaction::SignerRecoverable for WorldChainTxEnvelope {
     fn recover_signer(
         &self,
     ) -> Result<alloy_primitives::Address, alloy_consensus::crypto::RecoveryError> {
-        let signature_hash = match self {
-            Self::Legacy(tx) => tx.signature_hash(),
-            Self::Eip2930(tx) => tx.signature_hash(),
-            Self::Eip1559(tx) => tx.signature_hash(),
-            Self::Eip7702(tx) => tx.signature_hash(),
+        let (signature, signature_hash) = match self {
+            Self::Legacy(tx) => (tx.signature(), tx.signature_hash()),
+            Self::Eip2930(tx) => (tx.signature(), tx.signature_hash()),
+            Self::Eip1559(tx) => (tx.signature(), tx.signature_hash()),
+            Self::Eip7702(tx) => (tx.signature(), tx.signature_hash()),
+            Self::Wip1001(tx) => (
+                wip1001_secp256k1_sig(tx.signature())?,
+                tx.tx().signing_hash(),
+            ),
             // Optimism's Deposit transaction does not have a signature. Directly return the
             // `from` address.
             Self::Deposit(tx) => return Ok(tx.from),
-        };
-        let signature = match self {
-            Self::Legacy(tx) => tx.signature(),
-            Self::Eip2930(tx) => tx.signature(),
-            Self::Eip1559(tx) => tx.signature(),
-            Self::Eip7702(tx) => tx.signature(),
-            Self::Deposit(_) => unreachable!("Deposit transactions should not be handled here"),
         };
         alloy_consensus::crypto::secp256k1::recover_signer(signature, signature_hash)
     }
@@ -376,21 +429,18 @@ impl alloy_consensus::transaction::SignerRecoverable for WorldChainTxEnvelope {
     fn recover_signer_unchecked(
         &self,
     ) -> Result<alloy_primitives::Address, alloy_consensus::crypto::RecoveryError> {
-        let signature_hash = match self {
-            Self::Legacy(tx) => tx.signature_hash(),
-            Self::Eip2930(tx) => tx.signature_hash(),
-            Self::Eip1559(tx) => tx.signature_hash(),
-            Self::Eip7702(tx) => tx.signature_hash(),
+        let (signature, signature_hash) = match self {
+            Self::Legacy(tx) => (tx.signature(), tx.signature_hash()),
+            Self::Eip2930(tx) => (tx.signature(), tx.signature_hash()),
+            Self::Eip1559(tx) => (tx.signature(), tx.signature_hash()),
+            Self::Eip7702(tx) => (tx.signature(), tx.signature_hash()),
+            Self::Wip1001(tx) => (
+                wip1001_secp256k1_sig(tx.signature())?,
+                tx.tx().signing_hash(),
+            ),
             // Optimism's Deposit transaction does not have a signature. Directly return the
             // `from` address.
             Self::Deposit(tx) => return Ok(tx.from),
-        };
-        let signature = match self {
-            Self::Legacy(tx) => tx.signature(),
-            Self::Eip2930(tx) => tx.signature(),
-            Self::Eip1559(tx) => tx.signature(),
-            Self::Eip7702(tx) => tx.signature(),
-            Self::Deposit(_) => unreachable!("Deposit transactions should not be handled here"),
         };
         alloy_consensus::crypto::secp256k1::recover_signer_unchecked(signature, signature_hash)
     }
@@ -412,9 +462,27 @@ impl alloy_consensus::transaction::SignerRecoverable for WorldChainTxEnvelope {
             Self::Eip7702(tx) => {
                 alloy_consensus::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
             }
+            Self::Wip1001(tx) => {
+                let sig = wip1001_secp256k1_sig(tx.signature())?;
+                alloy_consensus::crypto::secp256k1::recover_signer_unchecked(
+                    sig,
+                    tx.tx().signing_hash(),
+                )
+            }
             Self::Deposit(tx) => Ok(tx.from),
         }
     }
+}
+
+/// Projects a [`Wip1001Signature`] down to its secp256k1 [`Signature`] if possible.
+///
+/// Recovery paths for non-secp256k1 variants (P256, WebAuthn, EdDSA) are out of
+/// scope for this implementation and surfaced as a recovery error.
+fn wip1001_secp256k1_sig(
+    sig: &Wip1001Signature,
+) -> Result<&Signature, alloy_consensus::crypto::RecoveryError> {
+    sig.as_secp256k1()
+        .ok_or_else(alloy_consensus::crypto::RecoveryError::new)
 }
 
 impl WorldChainTypedTransaction {
@@ -427,19 +495,23 @@ impl WorldChainTypedTransaction {
             Self::Eip2930(tx) => Some(tx.signature_hash()),
             Self::Eip1559(tx) => Some(tx.signature_hash()),
             Self::Eip7702(tx) => Some(tx.signature_hash()),
+            Self::Wip1001(tx) => Some(tx.signing_hash()),
             Self::Deposit(_) => None,
         }
     }
 
     /// Calculate the transaction hash for the given signature.
     ///
-    /// Note: returns the regular tx hash if this is a deposit variant.
+    /// Note: returns the regular tx hash if this is a deposit variant. For
+    /// WIP-1001 transactions the signature is interpreted as the secp256k1
+    /// variant of [`Wip1001Signature`].
     pub fn tx_hash(&self, signature: &Signature) -> TxHash {
         match self {
             Self::Legacy(tx) => tx.tx_hash(signature),
             Self::Eip2930(tx) => tx.tx_hash(signature),
             Self::Eip1559(tx) => tx.tx_hash(signature),
             Self::Eip7702(tx) => tx.tx_hash(signature),
+            Self::Wip1001(tx) => tx.tx_hash(&Wip1001Signature::Secp256k1(*signature)),
             Self::Deposit(tx) => tx.tx_hash(),
         }
     }
@@ -460,6 +532,7 @@ impl RlpEcdsaEncodableTx for WorldChainTypedTransaction {
             Self::Eip2930(tx) => tx.rlp_encoded_fields_length(),
             Self::Eip1559(tx) => tx.rlp_encoded_fields_length(),
             Self::Eip7702(tx) => tx.rlp_encoded_fields_length(),
+            Self::Wip1001(tx) => tx.rlp_encoded_fields_length(),
             Self::Deposit(tx) => deposit_rlp_encoded_fields_length(tx),
         }
     }
@@ -470,6 +543,7 @@ impl RlpEcdsaEncodableTx for WorldChainTypedTransaction {
             Self::Eip2930(tx) => tx.rlp_encode_fields(out),
             Self::Eip1559(tx) => tx.rlp_encode_fields(out),
             Self::Eip7702(tx) => tx.rlp_encode_fields(out),
+            Self::Wip1001(tx) => tx.rlp_encode_fields(out),
             Self::Deposit(tx) => deposit_rlp_encode_fields(tx, out),
         }
     }
@@ -480,6 +554,7 @@ impl RlpEcdsaEncodableTx for WorldChainTypedTransaction {
             Self::Eip2930(tx) => tx.eip2718_encode_with_type(signature, tx.ty(), out),
             Self::Eip1559(tx) => tx.eip2718_encode_with_type(signature, tx.ty(), out),
             Self::Eip7702(tx) => tx.eip2718_encode_with_type(signature, tx.ty(), out),
+            Self::Wip1001(tx) => tx.eip2718_encode(&Wip1001Signature::Secp256k1(*signature), out),
             Self::Deposit(tx) => tx.encode_2718(out),
         }
     }
@@ -490,6 +565,7 @@ impl RlpEcdsaEncodableTx for WorldChainTypedTransaction {
             Self::Eip2930(tx) => tx.eip2718_encode(signature, out),
             Self::Eip1559(tx) => tx.eip2718_encode(signature, out),
             Self::Eip7702(tx) => tx.eip2718_encode(signature, out),
+            Self::Wip1001(tx) => tx.eip2718_encode(&Wip1001Signature::Secp256k1(*signature), out),
             Self::Deposit(tx) => tx.encode_2718(out),
         }
     }
@@ -500,6 +576,9 @@ impl RlpEcdsaEncodableTx for WorldChainTypedTransaction {
             Self::Eip2930(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
             Self::Eip1559(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
             Self::Eip7702(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
+            Self::Wip1001(tx) => {
+                wip1001_network_encode(tx, &Wip1001Signature::Secp256k1(*signature), out)
+            }
             Self::Deposit(tx) => tx.network_encode(out),
         }
     }
@@ -510,6 +589,9 @@ impl RlpEcdsaEncodableTx for WorldChainTypedTransaction {
             Self::Eip2930(tx) => tx.network_encode(signature, out),
             Self::Eip1559(tx) => tx.network_encode(signature, out),
             Self::Eip7702(tx) => tx.network_encode(signature, out),
+            Self::Wip1001(tx) => {
+                wip1001_network_encode(tx, &Wip1001Signature::Secp256k1(*signature), out)
+            }
             Self::Deposit(tx) => tx.network_encode(out),
         }
     }
@@ -520,6 +602,7 @@ impl RlpEcdsaEncodableTx for WorldChainTypedTransaction {
             Self::Eip2930(tx) => tx.tx_hash_with_type(signature, tx.ty()),
             Self::Eip1559(tx) => tx.tx_hash_with_type(signature, tx.ty()),
             Self::Eip7702(tx) => tx.tx_hash_with_type(signature, tx.ty()),
+            Self::Wip1001(tx) => tx.tx_hash(&Wip1001Signature::Secp256k1(*signature)),
             Self::Deposit(tx) => tx.tx_hash(),
         }
     }
@@ -530,9 +613,23 @@ impl RlpEcdsaEncodableTx for WorldChainTypedTransaction {
             Self::Eip2930(tx) => tx.tx_hash(signature),
             Self::Eip1559(tx) => tx.tx_hash(signature),
             Self::Eip7702(tx) => tx.tx_hash(signature),
+            Self::Wip1001(tx) => tx.tx_hash(&Wip1001Signature::Secp256k1(*signature)),
             Self::Deposit(tx) => tx.tx_hash(),
         }
     }
+}
+
+/// Wraps a [`TxWip1001`] EIP-2718 encoding with an outer RLP byte-string header,
+/// matching the legacy-style `network_encode` used by [`RlpEcdsaEncodableTx`].
+fn wip1001_network_encode(tx: &TxWip1001, signature: &Wip1001Signature, out: &mut dyn BufMut) {
+    use alloy_rlp::Header;
+    let payload_length = tx.eip2718_encoded_length(signature);
+    Header {
+        list: false,
+        payload_length,
+    }
+    .encode(out);
+    tx.eip2718_encode(signature, out);
 }
 
 impl SignableTransaction<Signature> for WorldChainTypedTransaction {
@@ -542,6 +639,9 @@ impl SignableTransaction<Signature> for WorldChainTypedTransaction {
             Self::Eip2930(tx) => tx.set_chain_id(chain_id),
             Self::Eip1559(tx) => tx.set_chain_id(chain_id),
             Self::Eip7702(tx) => tx.set_chain_id(chain_id),
+            Self::Wip1001(tx) => {
+                <TxWip1001 as SignableTransaction<Wip1001Signature>>::set_chain_id(tx, chain_id)
+            }
             Self::Deposit(_) => {}
         }
     }
@@ -552,6 +652,9 @@ impl SignableTransaction<Signature> for WorldChainTypedTransaction {
             Self::Eip2930(tx) => tx.encode_for_signing(out),
             Self::Eip1559(tx) => tx.encode_for_signing(out),
             Self::Eip7702(tx) => tx.encode_for_signing(out),
+            Self::Wip1001(tx) => {
+                <TxWip1001 as SignableTransaction<Wip1001Signature>>::encode_for_signing(tx, out)
+            }
             Self::Deposit(_) => {}
         }
     }
@@ -562,6 +665,9 @@ impl SignableTransaction<Signature> for WorldChainTypedTransaction {
             Self::Eip2930(tx) => tx.payload_len_for_signature(),
             Self::Eip1559(tx) => tx.payload_len_for_signature(),
             Self::Eip7702(tx) => tx.payload_len_for_signature(),
+            Self::Wip1001(tx) => {
+                <TxWip1001 as SignableTransaction<Wip1001Signature>>::payload_len_for_signature(tx)
+            }
             Self::Deposit(_) => 0,
         }
     }
@@ -604,4 +710,185 @@ fn deposit_rlp_encode_fields(tx: &TxDeposit, out: &mut dyn alloy_rlp::BufMut) {
     tx.gas_limit.encode(out);
     tx.is_system_transaction.encode(out);
     tx.input.encode(out);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::transaction::SignerRecoverable;
+    use alloy_eips::{Decodable2718, eip2930::AccessList};
+    use alloy_primitives::{Address, U256, address, hex};
+    use alloy_rlp::Encodable as _;
+    use alloy_signer_local::PrivateKeySigner;
+    use op_alloy_network::TxSignerSync;
+
+    fn sample_eip1559() -> TxEip1559 {
+        TxEip1559 {
+            chain_id: 480,
+            nonce: 1,
+            max_priority_fee_per_gas: 1_000_000_000,
+            max_fee_per_gas: 2_000_000_000,
+            gas_limit: 21_000,
+            to: Address::with_last_byte(0xAB).into(),
+            value: U256::from(7u64),
+            input: Bytes::default(),
+            access_list: AccessList::default(),
+        }
+    }
+
+    fn sample_wip1001() -> TxWip1001 {
+        TxWip1001 {
+            chain_id: 480,
+            nonce: 3,
+            max_priority_fee_per_gas: 2_000_000_000,
+            max_fee_per_gas: 4_000_000_000,
+            gas_limit: 100_000,
+            to: address!("6069a6c32cf691f5982febae4faf8a6f3ab2f0f6").into(),
+            value: U256::from(42u64),
+            input: hex!("deadbeef").into(),
+            access_list: AccessList::default(),
+            keyring: address!("000000000000000000000000000000000000001d"),
+        }
+    }
+
+    fn sign_wip1001(signer: &PrivateKeySigner, tx: TxWip1001) -> SignedWip1001 {
+        // Sign the WIP-1001 signing hash via the `SignableTransaction<Signature>`
+        // bridge and wrap the secp256k1 result as a Wip1001Signature.
+        let mut tx = tx;
+        let signature = signer
+            .sign_transaction_sync(&mut tx)
+            .expect("signing works");
+        SignedWip1001::new_signed(tx, Wip1001Signature::Secp256k1(signature))
+    }
+
+    #[test]
+    fn envelope_wip1001_variant_accessors() {
+        let signer = PrivateKeySigner::random();
+        let signed = sign_wip1001(&signer, sample_wip1001());
+        let envelope: WorldChainTxEnvelope = signed.clone().into();
+
+        assert!(envelope.is_wip1001());
+        assert!(!envelope.is_eip1559());
+        assert!(!envelope.is_deposit());
+        assert_eq!(envelope.tx_type(), WorldChainTxType::Wip1001);
+        assert_eq!(envelope.hash(), signed.hash());
+        assert_eq!(envelope.eip2718_encoded_length(), signed.encode_2718_len());
+        assert!(
+            envelope.signature().is_none(),
+            "use as_wip1001 for WIP-1001 sig"
+        );
+        let via_accessor = envelope.as_wip1001().expect("is wip1001");
+        assert_eq!(via_accessor, &signed);
+    }
+
+    #[test]
+    fn envelope_wip1001_eip2718_round_trip() {
+        let signer = PrivateKeySigner::random();
+        let signed = sign_wip1001(&signer, sample_wip1001());
+        let envelope: WorldChainTxEnvelope = signed.clone().into();
+
+        let mut buf = Vec::new();
+        envelope.encode_2718(&mut buf);
+        assert_eq!(buf[0], crate::transaction::wip_1001::WIP_1001_TX_TYPE);
+
+        let decoded =
+            WorldChainTxEnvelope::decode_2718(&mut buf.as_slice()).expect("envelope decode_2718");
+        assert_eq!(decoded.hash(), envelope.hash());
+        let decoded_wip = decoded.as_wip1001().expect("is wip1001");
+        assert_eq!(decoded_wip.tx(), signed.tx());
+        assert_eq!(decoded_wip.signature(), signed.signature());
+    }
+
+    #[test]
+    fn envelope_wip1001_network_round_trip() {
+        use alloy_rlp::Decodable as _;
+
+        let signer = PrivateKeySigner::random();
+        let signed = sign_wip1001(&signer, sample_wip1001());
+        let envelope: WorldChainTxEnvelope = signed.clone().into();
+
+        // network_encode wraps the 2718 bytes in an outer byte-string header.
+        let mut buf = Vec::new();
+        envelope.encode(&mut buf);
+        let decoded =
+            WorldChainTxEnvelope::decode(&mut buf.as_slice()).expect("envelope network decode");
+        assert_eq!(decoded.hash(), envelope.hash());
+    }
+
+    #[test]
+    fn envelope_wip1001_signer_recoverable() {
+        let signer = PrivateKeySigner::random();
+        let expected = signer.address();
+        let signed = sign_wip1001(&signer, sample_wip1001());
+        let envelope: WorldChainTxEnvelope = signed.into();
+
+        let recovered = envelope.recover_signer().expect("recover");
+        assert_eq!(recovered, expected);
+    }
+
+    #[test]
+    fn envelope_wip1001_try_into_eth_envelope_rejected() {
+        let signer = PrivateKeySigner::random();
+        let signed = sign_wip1001(&signer, sample_wip1001());
+        let envelope: WorldChainTxEnvelope = signed.into();
+
+        let err = envelope
+            .try_into_eth_envelope()
+            .expect_err("wip1001 must not convert to eth envelope");
+        assert!(err.to_string().contains("WIP-1001"));
+    }
+
+    #[test]
+    fn envelope_wip1001_try_into_op_envelope_rejected() {
+        let signer = PrivateKeySigner::random();
+        let signed = sign_wip1001(&signer, sample_wip1001());
+        let envelope: WorldChainTxEnvelope = signed.into();
+
+        let err =
+            OpTxEnvelope::try_from(envelope).expect_err("wip1001 must not convert to op envelope");
+        assert!(err.to_string().contains("WIP-1001"));
+    }
+
+    #[test]
+    fn envelope_eip1559_still_round_trips() {
+        // Regression: make sure adding the WIP-1001 variant didn't disturb the
+        // existing `Signed<T>` variants' RLP/2718 behavior.
+        let signer = PrivateKeySigner::random();
+        let mut tx = sample_eip1559();
+        let signature = signer
+            .sign_transaction_sync(&mut tx)
+            .expect("signing works");
+        let signed = Signed::new_unhashed(tx, signature);
+        let envelope = WorldChainTxEnvelope::from(signed.clone());
+
+        let mut buf = Vec::new();
+        envelope.encode_2718(&mut buf);
+        let decoded = WorldChainTxEnvelope::decode_2718(&mut buf.as_slice()).expect("decode_2718");
+        assert!(decoded.is_eip1559());
+        assert_eq!(decoded.hash(), envelope.hash());
+
+        let recovered = envelope.recover_signer().expect("recover");
+        assert_eq!(recovered, signer.address());
+    }
+
+    #[test]
+    fn envelope_wip1001_via_typed_transaction_path() {
+        // Exercise the `Signed<WorldChainTypedTransaction>` -> `WorldChainTxEnvelope`
+        // conversion for the WIP-1001 variant: the default secp256k1 Signature
+        // should be wrapped as `Wip1001Signature::Secp256k1`.
+        let signer = PrivateKeySigner::random();
+        let tx = sample_wip1001();
+        let mut typed = WorldChainTypedTransaction::Wip1001(tx.clone());
+        let signature = signer
+            .sign_transaction_sync(&mut typed)
+            .expect("signing works");
+        let envelope: WorldChainTxEnvelope = Signed::new_unhashed(typed, signature).into();
+
+        let wip = envelope.as_wip1001().expect("is wip1001");
+        assert_eq!(wip.tx(), &tx);
+        match wip.signature() {
+            Wip1001Signature::Secp256k1(inner) => assert_eq!(*inner, signature),
+        }
+        assert_eq!(envelope.recover_signer().unwrap(), signer.address());
+    }
 }

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -1,0 +1,607 @@
+//! The World Chain [EIP-2718] transaction envelope.
+//!
+//! [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
+
+use alloy_consensus::{
+    error::ValueError,
+    transaction::{RlpEcdsaEncodableTx, TxHashRef},
+    EthereumTxEnvelope, Sealable, Sealed, SignableTransaction, Signed, TransactionEnvelope,
+    TxEip1559, TxEip2930, TxEip7702, TxEnvelope, TxLegacy, Typed2718,
+};
+use alloy_eips::eip2718::Encodable2718;
+use alloy_primitives::{bytes::BufMut, Bytes, ChainId, Signature, TxHash, B256};
+use op_alloy_consensus::{OpTransaction, OpTxEnvelope, TxDeposit};
+
+/// The World Chain [EIP-2718] transaction envelope.
+///
+/// This enum is structurally identical to [`op_alloy_consensus::OpTxEnvelope`] and exists as a
+/// standalone type so that World Chain-specific transaction variants can be added in-repo without
+/// forking `op-alloy-consensus`.
+#[derive(Debug, Clone, TransactionEnvelope)]
+#[envelope(tx_type_name = WorldChainTxType, typed = WorldChainTypedTransaction)]
+pub enum WorldChainTxEnvelope {
+    /// An untagged [`TxLegacy`].
+    #[envelope(ty = 0)]
+    Legacy(Signed<TxLegacy>),
+    /// A [`TxEip2930`] tagged with type 1.
+    #[envelope(ty = 1)]
+    Eip2930(Signed<TxEip2930>),
+    /// A [`TxEip1559`] tagged with type 2.
+    #[envelope(ty = 2)]
+    Eip1559(Signed<TxEip1559>),
+    /// A [`TxEip7702`] tagged with type 4.
+    #[envelope(ty = 4)]
+    Eip7702(Signed<TxEip7702>),
+    /// A [`TxDeposit`] tagged with type 0x7E.
+    #[envelope(ty = 126)]
+    #[serde(serialize_with = "op_alloy_consensus::serde_deposit_tx_rpc")]
+    Deposit(Sealed<TxDeposit>),
+}
+
+impl OpTransaction for WorldChainTxEnvelope {
+    fn is_deposit(&self) -> bool {
+        self.is_deposit()
+    }
+
+    fn as_deposit(&self) -> Option<&Sealed<TxDeposit>> {
+        self.as_deposit()
+    }
+}
+
+impl AsRef<Self> for WorldChainTxEnvelope {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
+impl From<Signed<TxLegacy>> for WorldChainTxEnvelope {
+    fn from(v: Signed<TxLegacy>) -> Self {
+        Self::Legacy(v)
+    }
+}
+
+impl From<Signed<TxEip2930>> for WorldChainTxEnvelope {
+    fn from(v: Signed<TxEip2930>) -> Self {
+        Self::Eip2930(v)
+    }
+}
+
+impl From<Signed<TxEip1559>> for WorldChainTxEnvelope {
+    fn from(v: Signed<TxEip1559>) -> Self {
+        Self::Eip1559(v)
+    }
+}
+
+impl From<Signed<TxEip7702>> for WorldChainTxEnvelope {
+    fn from(v: Signed<TxEip7702>) -> Self {
+        Self::Eip7702(v)
+    }
+}
+
+impl From<TxDeposit> for WorldChainTxEnvelope {
+    fn from(v: TxDeposit) -> Self {
+        v.seal_slow().into()
+    }
+}
+
+impl From<Sealed<TxDeposit>> for WorldChainTxEnvelope {
+    fn from(v: Sealed<TxDeposit>) -> Self {
+        Self::Deposit(v)
+    }
+}
+
+impl From<Signed<WorldChainTypedTransaction>> for WorldChainTxEnvelope {
+    fn from(value: Signed<WorldChainTypedTransaction>) -> Self {
+        let (tx, sig, hash) = value.into_parts();
+        match tx {
+            WorldChainTypedTransaction::Legacy(tx_legacy) => {
+                Self::Legacy(Signed::new_unchecked(tx_legacy, sig, hash))
+            }
+            WorldChainTypedTransaction::Eip2930(tx_eip2930) => {
+                Self::Eip2930(Signed::new_unchecked(tx_eip2930, sig, hash))
+            }
+            WorldChainTypedTransaction::Eip1559(tx_eip1559) => {
+                Self::Eip1559(Signed::new_unchecked(tx_eip1559, sig, hash))
+            }
+            WorldChainTypedTransaction::Eip7702(tx_eip7702) => {
+                Self::Eip7702(Signed::new_unchecked(tx_eip7702, sig, hash))
+            }
+            WorldChainTypedTransaction::Deposit(tx) => {
+                Self::Deposit(Sealed::new_unchecked(tx, hash))
+            }
+        }
+    }
+}
+
+impl From<(WorldChainTypedTransaction, Signature)> for WorldChainTxEnvelope {
+    fn from(value: (WorldChainTypedTransaction, Signature)) -> Self {
+        Self::new_unhashed(value.0, value.1)
+    }
+}
+
+impl<T> TryFrom<EthereumTxEnvelope<T>> for WorldChainTxEnvelope {
+    type Error = EthereumTxEnvelope<T>;
+
+    fn try_from(value: EthereumTxEnvelope<T>) -> Result<Self, Self::Error> {
+        Self::try_from_eth_envelope(value)
+    }
+}
+
+impl TryFrom<WorldChainTxEnvelope> for TxEnvelope {
+    type Error = ValueError<WorldChainTxEnvelope>;
+
+    fn try_from(value: WorldChainTxEnvelope) -> Result<Self, Self::Error> {
+        value.try_into_eth_envelope()
+    }
+}
+
+impl From<OpTxEnvelope> for WorldChainTxEnvelope {
+    fn from(value: OpTxEnvelope) -> Self {
+        match value {
+            OpTxEnvelope::Legacy(tx) => Self::Legacy(tx),
+            OpTxEnvelope::Eip2930(tx) => Self::Eip2930(tx),
+            OpTxEnvelope::Eip1559(tx) => Self::Eip1559(tx),
+            OpTxEnvelope::Eip7702(tx) => Self::Eip7702(tx),
+            OpTxEnvelope::Deposit(tx) => Self::Deposit(tx),
+        }
+    }
+}
+
+impl From<WorldChainTxEnvelope> for OpTxEnvelope {
+    fn from(value: WorldChainTxEnvelope) -> Self {
+        match value {
+            WorldChainTxEnvelope::Legacy(tx) => Self::Legacy(tx),
+            WorldChainTxEnvelope::Eip2930(tx) => Self::Eip2930(tx),
+            WorldChainTxEnvelope::Eip1559(tx) => Self::Eip1559(tx),
+            WorldChainTxEnvelope::Eip7702(tx) => Self::Eip7702(tx),
+            WorldChainTxEnvelope::Deposit(tx) => Self::Deposit(tx),
+        }
+    }
+}
+
+impl WorldChainTxEnvelope {
+    /// Creates a new enveloped transaction from the given transaction, signature and hash.
+    ///
+    /// Caution: This assumes the given hash is the correct transaction hash.
+    pub fn new_unchecked(
+        transaction: WorldChainTypedTransaction,
+        signature: Signature,
+        hash: B256,
+    ) -> Self {
+        Signed::new_unchecked(transaction, signature, hash).into()
+    }
+
+    /// Creates a new signed transaction from the given typed transaction and signature without the
+    /// hash.
+    ///
+    /// Note: this only calculates the hash on the first [`WorldChainTxEnvelope::hash`] call.
+    pub fn new_unhashed(transaction: WorldChainTypedTransaction, signature: Signature) -> Self {
+        transaction.into_signed(signature).into()
+    }
+
+    /// Returns true if the transaction is a legacy transaction.
+    #[inline]
+    pub const fn is_legacy(&self) -> bool {
+        matches!(self, Self::Legacy(_))
+    }
+
+    /// Returns true if the transaction is an EIP-2930 transaction.
+    #[inline]
+    pub const fn is_eip2930(&self) -> bool {
+        matches!(self, Self::Eip2930(_))
+    }
+
+    /// Returns true if the transaction is an EIP-1559 transaction.
+    #[inline]
+    pub const fn is_eip1559(&self) -> bool {
+        matches!(self, Self::Eip1559(_))
+    }
+
+    /// Returns true if the transaction is a deposit transaction.
+    #[inline]
+    pub const fn is_deposit(&self) -> bool {
+        matches!(self, Self::Deposit(_))
+    }
+
+    /// Returns true if the transaction is a system transaction.
+    #[inline]
+    pub const fn is_system_transaction(&self) -> bool {
+        match self {
+            Self::Deposit(tx) => tx.inner().is_system_transaction,
+            _ => false,
+        }
+    }
+
+    /// Returns the [`TxLegacy`] variant if the transaction is a legacy transaction.
+    pub const fn as_legacy(&self) -> Option<&Signed<TxLegacy>> {
+        match self {
+            Self::Legacy(tx) => Some(tx),
+            _ => None,
+        }
+    }
+
+    /// Returns the [`TxEip2930`] variant if the transaction is an EIP-2930 transaction.
+    pub const fn as_eip2930(&self) -> Option<&Signed<TxEip2930>> {
+        match self {
+            Self::Eip2930(tx) => Some(tx),
+            _ => None,
+        }
+    }
+
+    /// Returns the [`TxEip1559`] variant if the transaction is an EIP-1559 transaction.
+    pub const fn as_eip1559(&self) -> Option<&Signed<TxEip1559>> {
+        match self {
+            Self::Eip1559(tx) => Some(tx),
+            _ => None,
+        }
+    }
+
+    /// Returns the [`TxDeposit`] variant if the transaction is a deposit transaction.
+    pub const fn as_deposit(&self) -> Option<&Sealed<TxDeposit>> {
+        match self {
+            Self::Deposit(tx) => Some(tx),
+            _ => None,
+        }
+    }
+
+    /// Return the reference to signature.
+    ///
+    /// Returns `None` if this is a deposit variant.
+    pub const fn signature(&self) -> Option<&Signature> {
+        match self {
+            Self::Legacy(tx) => Some(tx.signature()),
+            Self::Eip2930(tx) => Some(tx.signature()),
+            Self::Eip1559(tx) => Some(tx.signature()),
+            Self::Eip7702(tx) => Some(tx.signature()),
+            Self::Deposit(_) => None,
+        }
+    }
+
+    /// Return the [`WorldChainTxType`] of the inner txn.
+    pub const fn tx_type(&self) -> WorldChainTxType {
+        match self {
+            Self::Legacy(_) => WorldChainTxType::Legacy,
+            Self::Eip2930(_) => WorldChainTxType::Eip2930,
+            Self::Eip1559(_) => WorldChainTxType::Eip1559,
+            Self::Eip7702(_) => WorldChainTxType::Eip7702,
+            Self::Deposit(_) => WorldChainTxType::Deposit,
+        }
+    }
+
+    /// Returns the inner transaction hash.
+    pub fn hash(&self) -> &B256 {
+        match self {
+            Self::Legacy(tx) => tx.hash(),
+            Self::Eip1559(tx) => tx.hash(),
+            Self::Eip2930(tx) => tx.hash(),
+            Self::Eip7702(tx) => tx.hash(),
+            Self::Deposit(tx) => tx.hash_ref(),
+        }
+    }
+
+    /// Returns the inner transaction hash.
+    pub fn tx_hash(&self) -> B256 {
+        *self.hash()
+    }
+
+    /// Return the length of the inner txn, including type byte length.
+    pub fn eip2718_encoded_length(&self) -> usize {
+        match self {
+            Self::Legacy(t) => t.eip2718_encoded_length(),
+            Self::Eip2930(t) => t.eip2718_encoded_length(),
+            Self::Eip1559(t) => t.eip2718_encoded_length(),
+            Self::Eip7702(t) => t.eip2718_encoded_length(),
+            Self::Deposit(t) => t.eip2718_encoded_length(),
+        }
+    }
+
+    /// Attempts to convert the World Chain variant into an ethereum [`TxEnvelope`].
+    ///
+    /// Returns the envelope as error if it is a variant unsupported on ethereum
+    /// (e.g. [`TxDeposit`]).
+    pub fn try_into_eth_envelope(self) -> Result<TxEnvelope, ValueError<Self>> {
+        match self {
+            Self::Legacy(tx) => Ok(tx.into()),
+            Self::Eip2930(tx) => Ok(tx.into()),
+            Self::Eip1559(tx) => Ok(tx.into()),
+            Self::Eip7702(tx) => Ok(tx.into()),
+            tx @ Self::Deposit(_) => Err(ValueError::new(
+                tx,
+                "Deposit transactions cannot be converted to ethereum transaction",
+            )),
+        }
+    }
+
+    /// Attempts to convert an ethereum [`EthereumTxEnvelope`] into the World Chain variant.
+    ///
+    /// Returns the given envelope as error if [`WorldChainTxEnvelope`] doesn't support the variant
+    /// (e.g. EIP-4844).
+    #[allow(clippy::result_large_err)]
+    pub fn try_from_eth_envelope<T>(
+        tx: EthereumTxEnvelope<T>,
+    ) -> Result<Self, EthereumTxEnvelope<T>> {
+        match tx {
+            EthereumTxEnvelope::Legacy(tx) => Ok(tx.into()),
+            EthereumTxEnvelope::Eip2930(tx) => Ok(tx.into()),
+            EthereumTxEnvelope::Eip1559(tx) => Ok(tx.into()),
+            tx @ EthereumTxEnvelope::<T>::Eip4844(_) => Err(tx),
+            EthereumTxEnvelope::Eip7702(tx) => Ok(tx.into()),
+        }
+    }
+
+    /// Returns mutable access to the input bytes.
+    ///
+    /// Caution: modifying this will cause side-effects on the hash.
+    #[doc(hidden)]
+    pub const fn input_mut(&mut self) -> &mut Bytes {
+        match self {
+            Self::Eip1559(tx) => &mut tx.tx_mut().input,
+            Self::Eip2930(tx) => &mut tx.tx_mut().input,
+            Self::Legacy(tx) => &mut tx.tx_mut().input,
+            Self::Eip7702(tx) => &mut tx.tx_mut().input,
+            Self::Deposit(tx) => &mut tx.inner_mut().input,
+        }
+    }
+}
+
+impl TxHashRef for WorldChainTxEnvelope {
+    fn tx_hash(&self) -> &B256 {
+        Self::hash(self)
+    }
+}
+
+impl alloy_consensus::transaction::SignerRecoverable for WorldChainTxEnvelope {
+    fn recover_signer(
+        &self,
+    ) -> Result<alloy_primitives::Address, alloy_consensus::crypto::RecoveryError> {
+        let signature_hash = match self {
+            Self::Legacy(tx) => tx.signature_hash(),
+            Self::Eip2930(tx) => tx.signature_hash(),
+            Self::Eip1559(tx) => tx.signature_hash(),
+            Self::Eip7702(tx) => tx.signature_hash(),
+            // Optimism's Deposit transaction does not have a signature. Directly return the
+            // `from` address.
+            Self::Deposit(tx) => return Ok(tx.from),
+        };
+        let signature = match self {
+            Self::Legacy(tx) => tx.signature(),
+            Self::Eip2930(tx) => tx.signature(),
+            Self::Eip1559(tx) => tx.signature(),
+            Self::Eip7702(tx) => tx.signature(),
+            Self::Deposit(_) => unreachable!("Deposit transactions should not be handled here"),
+        };
+        alloy_consensus::crypto::secp256k1::recover_signer(signature, signature_hash)
+    }
+
+    fn recover_signer_unchecked(
+        &self,
+    ) -> Result<alloy_primitives::Address, alloy_consensus::crypto::RecoveryError> {
+        let signature_hash = match self {
+            Self::Legacy(tx) => tx.signature_hash(),
+            Self::Eip2930(tx) => tx.signature_hash(),
+            Self::Eip1559(tx) => tx.signature_hash(),
+            Self::Eip7702(tx) => tx.signature_hash(),
+            // Optimism's Deposit transaction does not have a signature. Directly return the
+            // `from` address.
+            Self::Deposit(tx) => return Ok(tx.from),
+        };
+        let signature = match self {
+            Self::Legacy(tx) => tx.signature(),
+            Self::Eip2930(tx) => tx.signature(),
+            Self::Eip1559(tx) => tx.signature(),
+            Self::Eip7702(tx) => tx.signature(),
+            Self::Deposit(_) => unreachable!("Deposit transactions should not be handled here"),
+        };
+        alloy_consensus::crypto::secp256k1::recover_signer_unchecked(signature, signature_hash)
+    }
+
+    fn recover_unchecked_with_buf(
+        &self,
+        buf: &mut Vec<u8>,
+    ) -> Result<alloy_primitives::Address, alloy_consensus::crypto::RecoveryError> {
+        match self {
+            Self::Legacy(tx) => {
+                alloy_consensus::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
+            }
+            Self::Eip2930(tx) => {
+                alloy_consensus::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
+            }
+            Self::Eip1559(tx) => {
+                alloy_consensus::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
+            }
+            Self::Eip7702(tx) => {
+                alloy_consensus::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
+            }
+            Self::Deposit(tx) => Ok(tx.from),
+        }
+    }
+}
+
+impl WorldChainTypedTransaction {
+    /// Calculates the signing hash for the transaction.
+    ///
+    /// Returns `None` if the tx is a deposit transaction.
+    pub fn checked_signature_hash(&self) -> Option<B256> {
+        match self {
+            Self::Legacy(tx) => Some(tx.signature_hash()),
+            Self::Eip2930(tx) => Some(tx.signature_hash()),
+            Self::Eip1559(tx) => Some(tx.signature_hash()),
+            Self::Eip7702(tx) => Some(tx.signature_hash()),
+            Self::Deposit(_) => None,
+        }
+    }
+
+    /// Calculate the transaction hash for the given signature.
+    ///
+    /// Note: returns the regular tx hash if this is a deposit variant.
+    pub fn tx_hash(&self, signature: &Signature) -> TxHash {
+        match self {
+            Self::Legacy(tx) => tx.tx_hash(signature),
+            Self::Eip2930(tx) => tx.tx_hash(signature),
+            Self::Eip1559(tx) => tx.tx_hash(signature),
+            Self::Eip7702(tx) => tx.tx_hash(signature),
+            Self::Deposit(tx) => tx.tx_hash(),
+        }
+    }
+
+    /// Convenience function to convert this typed transaction into a [`WorldChainTxEnvelope`].
+    ///
+    /// Note: if this is a [`WorldChainTypedTransaction::Deposit`] variant, the signature will be
+    /// ignored.
+    pub fn into_envelope(self, signature: Signature) -> WorldChainTxEnvelope {
+        self.into_signed(signature).into()
+    }
+}
+
+impl RlpEcdsaEncodableTx for WorldChainTypedTransaction {
+    fn rlp_encoded_fields_length(&self) -> usize {
+        match self {
+            Self::Legacy(tx) => tx.rlp_encoded_fields_length(),
+            Self::Eip2930(tx) => tx.rlp_encoded_fields_length(),
+            Self::Eip1559(tx) => tx.rlp_encoded_fields_length(),
+            Self::Eip7702(tx) => tx.rlp_encoded_fields_length(),
+            Self::Deposit(tx) => deposit_rlp_encoded_fields_length(tx),
+        }
+    }
+
+    fn rlp_encode_fields(&self, out: &mut dyn alloy_rlp::BufMut) {
+        match self {
+            Self::Legacy(tx) => tx.rlp_encode_fields(out),
+            Self::Eip2930(tx) => tx.rlp_encode_fields(out),
+            Self::Eip1559(tx) => tx.rlp_encode_fields(out),
+            Self::Eip7702(tx) => tx.rlp_encode_fields(out),
+            Self::Deposit(tx) => deposit_rlp_encode_fields(tx, out),
+        }
+    }
+
+    fn eip2718_encode_with_type(&self, signature: &Signature, _ty: u8, out: &mut dyn BufMut) {
+        match self {
+            Self::Legacy(tx) => tx.eip2718_encode_with_type(signature, tx.ty(), out),
+            Self::Eip2930(tx) => tx.eip2718_encode_with_type(signature, tx.ty(), out),
+            Self::Eip1559(tx) => tx.eip2718_encode_with_type(signature, tx.ty(), out),
+            Self::Eip7702(tx) => tx.eip2718_encode_with_type(signature, tx.ty(), out),
+            Self::Deposit(tx) => tx.encode_2718(out),
+        }
+    }
+
+    fn eip2718_encode(&self, signature: &Signature, out: &mut dyn BufMut) {
+        match self {
+            Self::Legacy(tx) => tx.eip2718_encode(signature, out),
+            Self::Eip2930(tx) => tx.eip2718_encode(signature, out),
+            Self::Eip1559(tx) => tx.eip2718_encode(signature, out),
+            Self::Eip7702(tx) => tx.eip2718_encode(signature, out),
+            Self::Deposit(tx) => tx.encode_2718(out),
+        }
+    }
+
+    fn network_encode_with_type(&self, signature: &Signature, _ty: u8, out: &mut dyn BufMut) {
+        match self {
+            Self::Legacy(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
+            Self::Eip2930(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
+            Self::Eip1559(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
+            Self::Eip7702(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
+            Self::Deposit(tx) => tx.network_encode(out),
+        }
+    }
+
+    fn network_encode(&self, signature: &Signature, out: &mut dyn BufMut) {
+        match self {
+            Self::Legacy(tx) => tx.network_encode(signature, out),
+            Self::Eip2930(tx) => tx.network_encode(signature, out),
+            Self::Eip1559(tx) => tx.network_encode(signature, out),
+            Self::Eip7702(tx) => tx.network_encode(signature, out),
+            Self::Deposit(tx) => tx.network_encode(out),
+        }
+    }
+
+    fn tx_hash_with_type(&self, signature: &Signature, _ty: u8) -> TxHash {
+        match self {
+            Self::Legacy(tx) => tx.tx_hash_with_type(signature, tx.ty()),
+            Self::Eip2930(tx) => tx.tx_hash_with_type(signature, tx.ty()),
+            Self::Eip1559(tx) => tx.tx_hash_with_type(signature, tx.ty()),
+            Self::Eip7702(tx) => tx.tx_hash_with_type(signature, tx.ty()),
+            Self::Deposit(tx) => tx.tx_hash(),
+        }
+    }
+
+    fn tx_hash(&self, signature: &Signature) -> TxHash {
+        match self {
+            Self::Legacy(tx) => tx.tx_hash(signature),
+            Self::Eip2930(tx) => tx.tx_hash(signature),
+            Self::Eip1559(tx) => tx.tx_hash(signature),
+            Self::Eip7702(tx) => tx.tx_hash(signature),
+            Self::Deposit(tx) => tx.tx_hash(),
+        }
+    }
+}
+
+impl SignableTransaction<Signature> for WorldChainTypedTransaction {
+    fn set_chain_id(&mut self, chain_id: ChainId) {
+        match self {
+            Self::Legacy(tx) => tx.set_chain_id(chain_id),
+            Self::Eip2930(tx) => tx.set_chain_id(chain_id),
+            Self::Eip1559(tx) => tx.set_chain_id(chain_id),
+            Self::Eip7702(tx) => tx.set_chain_id(chain_id),
+            Self::Deposit(_) => {}
+        }
+    }
+
+    fn encode_for_signing(&self, out: &mut dyn BufMut) {
+        match self {
+            Self::Legacy(tx) => tx.encode_for_signing(out),
+            Self::Eip2930(tx) => tx.encode_for_signing(out),
+            Self::Eip1559(tx) => tx.encode_for_signing(out),
+            Self::Eip7702(tx) => tx.encode_for_signing(out),
+            Self::Deposit(_) => {}
+        }
+    }
+
+    fn payload_len_for_signature(&self) -> usize {
+        match self {
+            Self::Legacy(tx) => tx.payload_len_for_signature(),
+            Self::Eip2930(tx) => tx.payload_len_for_signature(),
+            Self::Eip1559(tx) => tx.payload_len_for_signature(),
+            Self::Eip7702(tx) => tx.payload_len_for_signature(),
+            Self::Deposit(_) => 0,
+        }
+    }
+
+    fn into_signed(self, signature: Signature) -> Signed<Self, Signature>
+    where
+        Self: Sized,
+    {
+        let hash = self.tx_hash(&signature);
+        Signed::new_unchecked(self, signature, hash)
+    }
+}
+
+/// Length of the RLP-encoded fields of a [`TxDeposit`], without a list header.
+///
+/// Mirrors the crate-private `TxDeposit::rlp_encoded_fields_length` in `op-alloy-consensus`.
+/// See: <https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/deposits.md#the-deposited-transaction-type>.
+fn deposit_rlp_encoded_fields_length(tx: &TxDeposit) -> usize {
+    use alloy_rlp::Encodable;
+    tx.source_hash.length()
+        + tx.from.length()
+        + tx.to.length()
+        + tx.mint.length()
+        + tx.value.length()
+        + tx.gas_limit.length()
+        + tx.is_system_transaction.length()
+        + tx.input.0.length()
+}
+
+/// RLP-encodes the fields of a [`TxDeposit`] into the given buffer, without a list header.
+///
+/// Mirrors the crate-private `TxDeposit::rlp_encode_fields` in `op-alloy-consensus`.
+fn deposit_rlp_encode_fields(tx: &TxDeposit, out: &mut dyn alloy_rlp::BufMut) {
+    use alloy_rlp::Encodable;
+    tx.source_hash.encode(out);
+    tx.from.encode(out);
+    tx.to.encode(out);
+    tx.mint.encode(out);
+    tx.value.encode(out);
+    tx.gas_limit.encode(out);
+    tx.is_system_transaction.encode(out);
+    tx.input.encode(out);
+}

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1,5 +1,7 @@
 //! World Chain transaction types.
 
 pub mod envelope;
+pub mod wip_1001;
 
 pub use envelope::{WorldChainTxEnvelope, WorldChainTxType, WorldChainTypedTransaction};
+pub use wip_1001::{SignedWip1001, TxWip1001, WIP_1001_TX_TYPE, Wip1001Signature};

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1,0 +1,5 @@
+//! World Chain transaction types.
+
+pub mod envelope;
+
+pub use envelope::{WorldChainTxEnvelope, WorldChainTxType, WorldChainTypedTransaction};

--- a/crates/primitives/src/transaction/wip_1001.rs
+++ b/crates/primitives/src/transaction/wip_1001.rs
@@ -1,0 +1,949 @@
+//! WIP-1001 typed transaction envelope (`0x1D`).
+//!
+//! See `wips/wip-1001.md` for the full specification. This module implements the
+//! transaction body ([`TxWip1001`]), the multi-scheme signature enum
+//! ([`Wip1001Signature`]) — scoped to ECDSA over secp256k1 for now, but extensible
+//! to the additional variants defined in the spec (P256, WebAuthn, EdDSA) — and
+//! the RLP / EIP-2718 codecs required to wire `Signed<TxWip1001, Wip1001Signature>`
+//! into [`WorldChainTxEnvelope`](crate::transaction::WorldChainTxEnvelope).
+
+use alloy_consensus::{SignableTransaction, Signed, Transaction, transaction::TxHashable};
+use alloy_eips::{
+    Decodable2718, Encodable2718, Typed2718,
+    eip2718::{Eip2718Error, Eip2718Result, IsTyped2718},
+    eip2930::AccessList,
+    eip7702::SignedAuthorization,
+};
+use alloy_primitives::{
+    Address, B256, Bytes, ChainId, Signature, TxHash, TxKind, U256, bytes::BufMut, keccak256,
+};
+use alloy_rlp::{Decodable, Encodable, Header};
+
+/// The EIP-2718 transaction type byte for WIP-1001 transactions.
+pub const WIP_1001_TX_TYPE: u8 = 0x1D;
+
+/// Signature scheme for a [`TxWip1001`].
+///
+/// The WIP-1001 envelope is polymorphic over the signing algorithm: each session
+/// key may be a secp256k1, P256, WebAuthn (P256 under WebAuthn), or Ed25519 key.
+/// Only the ECDSA-over-secp256k1 variant is implemented here; the remaining
+/// variants are intentionally left out of scope but can be added as additional
+/// enum variants without breaking the wire format, since `signature_type` is
+/// encoded as an opaque tag byte followed by an opaque `signature_payload`
+/// RLP byte-string.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "signatureType", content = "signaturePayload")]
+#[non_exhaustive]
+pub enum Wip1001Signature {
+    /// secp256k1 ECDSA signature, `signature_type = 0x00`.
+    ///
+    /// `signature_payload = rlp([y_parity, r, s])`.
+    #[serde(rename = "0x0")]
+    Secp256k1(Signature),
+    // Future: P256 (0x01), WebAuthn (0x02), EdDSA (0x03).
+}
+
+impl Wip1001Signature {
+    /// `signature_type` byte for the secp256k1 variant.
+    pub const SECP256K1_TYPE: u8 = 0x00;
+
+    /// Returns the `signature_type` tag byte.
+    #[inline]
+    pub const fn signature_type(&self) -> u8 {
+        match self {
+            Self::Secp256k1(_) => Self::SECP256K1_TYPE,
+        }
+    }
+
+    /// Returns the inner secp256k1 [`Signature`] if this is the `Secp256k1` variant.
+    pub const fn as_secp256k1(&self) -> Option<&Signature> {
+        match self {
+            Self::Secp256k1(sig) => Some(sig),
+        }
+    }
+
+    /// Length of the RLP-encoded `signature_payload` bytes (no outer string header).
+    fn payload_encoded_len(&self) -> usize {
+        match self {
+            Self::Secp256k1(sig) => {
+                let y_parity = sig.v() as u8;
+                let list_payload_len = y_parity.length() + sig.r().length() + sig.s().length();
+                Header {
+                    list: true,
+                    payload_length: list_payload_len,
+                }
+                .length_with_payload()
+            }
+        }
+    }
+
+    /// Encodes the `signature_payload` into `out` without an outer RLP string header.
+    ///
+    /// For secp256k1, this writes `rlp([y_parity, r, s])` directly.
+    fn encode_payload_raw(&self, out: &mut dyn BufMut) {
+        match self {
+            Self::Secp256k1(sig) => {
+                let y_parity = sig.v() as u8;
+                let list_payload_len = y_parity.length() + sig.r().length() + sig.s().length();
+                Header {
+                    list: true,
+                    payload_length: list_payload_len,
+                }
+                .encode(out);
+                y_parity.encode(out);
+                sig.r().encode(out);
+                sig.s().encode(out);
+            }
+        }
+    }
+
+    /// Decodes a `signature_payload` byte string, given its `signature_type`.
+    ///
+    /// The caller has already consumed the outer RLP string header around
+    /// `signature_payload`; this reads the raw payload bytes.
+    fn decode_payload_raw(ty: u8, buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        match ty {
+            Self::SECP256K1_TYPE => {
+                let header = Header::decode(buf)?;
+                if !header.list {
+                    return Err(alloy_rlp::Error::UnexpectedString);
+                }
+                let start = buf.len();
+                let y_parity: u8 = Decodable::decode(buf)?;
+                let r: U256 = Decodable::decode(buf)?;
+                let s: U256 = Decodable::decode(buf)?;
+                let consumed = start - buf.len();
+                if consumed != header.payload_length {
+                    return Err(alloy_rlp::Error::ListLengthMismatch {
+                        expected: header.payload_length,
+                        got: consumed,
+                    });
+                }
+                if y_parity > 1 {
+                    return Err(alloy_rlp::Error::Custom("invalid y_parity"));
+                }
+                Ok(Self::Secp256k1(Signature::new(r, s, y_parity != 0)))
+            }
+            _ => Err(alloy_rlp::Error::Custom(
+                "unsupported wip-1001 signature type",
+            )),
+        }
+    }
+}
+
+/// A WIP-1001 typed transaction (`0x1D`).
+///
+/// The transaction is signed by a *session key* authorized on a *World ID Key
+/// Ring* — the [`keyring`](Self::keyring) field is the protocol-level sender.
+/// Protocol validation authorizes the recovered public key against the
+/// precompile-managed keyset of `keyring`.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TxWip1001 {
+    /// EIP-155 chain id.
+    #[serde(with = "alloy_serde::quantity")]
+    pub chain_id: ChainId,
+    /// Session-key nonce at the keyring.
+    #[serde(with = "alloy_serde::quantity")]
+    pub nonce: u64,
+    /// EIP-1559 priority fee (tip cap).
+    #[serde(with = "alloy_serde::quantity")]
+    pub max_priority_fee_per_gas: u128,
+    /// EIP-1559 fee cap.
+    #[serde(with = "alloy_serde::quantity")]
+    pub max_fee_per_gas: u128,
+    /// Gas limit.
+    #[serde(with = "alloy_serde::quantity", rename = "gas", alias = "gasLimit")]
+    pub gas_limit: u64,
+    /// Target of the message call, or `Create` for contract creation.
+    #[serde(default)]
+    pub to: TxKind,
+    /// Value transferred with the call.
+    pub value: U256,
+    /// Calldata / init code.
+    pub input: Bytes,
+    /// EIP-2930 access list.
+    #[serde(default)]
+    pub access_list: AccessList,
+    /// Address of the signing keyring. Protocol validation authorizes the
+    /// recovered session public key against the keyring's session key set.
+    pub keyring: Address,
+}
+
+impl TxWip1001 {
+    /// Length of the RLP-encoded fields (positions 0..=9), without a list header.
+    #[inline]
+    pub fn rlp_encoded_fields_length(&self) -> usize {
+        self.chain_id.length()
+            + self.nonce.length()
+            + self.max_priority_fee_per_gas.length()
+            + self.max_fee_per_gas.length()
+            + self.gas_limit.length()
+            + self.to.length()
+            + self.value.length()
+            + self.input.0.length()
+            + self.access_list.length()
+            + self.keyring.length()
+    }
+
+    /// Encodes the fields (positions 0..=9) into `out`, without a list header.
+    pub fn rlp_encode_fields(&self, out: &mut dyn BufMut) {
+        self.chain_id.encode(out);
+        self.nonce.encode(out);
+        self.max_priority_fee_per_gas.encode(out);
+        self.max_fee_per_gas.encode(out);
+        self.gas_limit.encode(out);
+        self.to.encode(out);
+        self.value.encode(out);
+        self.input.0.encode(out);
+        self.access_list.encode(out);
+        self.keyring.encode(out);
+    }
+
+    /// Decodes the unsigned fields (positions 0..=9) from RLP bytes, without a
+    /// list header.
+    pub fn rlp_decode_fields(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        Ok(Self {
+            chain_id: Decodable::decode(buf)?,
+            nonce: Decodable::decode(buf)?,
+            max_priority_fee_per_gas: Decodable::decode(buf)?,
+            max_fee_per_gas: Decodable::decode(buf)?,
+            gas_limit: Decodable::decode(buf)?,
+            to: Decodable::decode(buf)?,
+            value: Decodable::decode(buf)?,
+            input: Decodable::decode(buf)?,
+            access_list: Decodable::decode(buf)?,
+            keyring: Decodable::decode(buf)?,
+        })
+    }
+
+    /// RLP list header for the *unsigned* transaction.
+    fn rlp_header(&self) -> Header {
+        Header {
+            list: true,
+            payload_length: self.rlp_encoded_fields_length(),
+        }
+    }
+
+    /// RLP-encoded length of the *unsigned* transaction (list header + fields).
+    fn rlp_encoded_length(&self) -> usize {
+        self.rlp_header().length_with_payload()
+    }
+
+    /// RLP-encodes the *unsigned* transaction (list of fields 0..=9).
+    fn rlp_encode(&self, out: &mut dyn BufMut) {
+        self.rlp_header().encode(out);
+        self.rlp_encode_fields(out);
+    }
+
+    /// Length of the signed payload (list header + fields + signature_type + signature_payload).
+    fn signed_payload_length(&self, sig: &Wip1001Signature) -> usize {
+        let payload_bytes_len = sig.payload_encoded_len();
+        let payload_header = Header {
+            list: false,
+            payload_length: payload_bytes_len,
+        };
+        self.rlp_encoded_fields_length()
+            + sig.signature_type().length()
+            + payload_header.length_with_payload()
+    }
+
+    /// RLP list header for the *signed* transaction.
+    fn rlp_header_signed(&self, sig: &Wip1001Signature) -> Header {
+        Header {
+            list: true,
+            payload_length: self.signed_payload_length(sig),
+        }
+    }
+
+    /// RLP-encoded length of the *signed* transaction (list header + fields + signature).
+    pub fn rlp_encoded_length_with_signature(&self, sig: &Wip1001Signature) -> usize {
+        self.rlp_header_signed(sig).length_with_payload()
+    }
+
+    /// RLP-encodes the *signed* transaction.
+    pub fn rlp_encode_signed(&self, sig: &Wip1001Signature, out: &mut dyn BufMut) {
+        self.rlp_header_signed(sig).encode(out);
+        self.rlp_encode_fields(out);
+        sig.signature_type().encode(out);
+
+        // Encode signature_payload as an RLP byte-string wrapping `rlp([...])`.
+        let payload_bytes_len = sig.payload_encoded_len();
+        Header {
+            list: false,
+            payload_length: payload_bytes_len,
+        }
+        .encode(out);
+        sig.encode_payload_raw(out);
+    }
+
+    /// Decodes the *signed* transaction including the signature.
+    pub fn rlp_decode_with_signature(
+        buf: &mut &[u8],
+    ) -> alloy_rlp::Result<(Self, Wip1001Signature)> {
+        let header = Header::decode(buf)?;
+        if !header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+        let remaining = buf.len();
+        let tx = Self::rlp_decode_fields(buf)?;
+        let sig_type: u8 = Decodable::decode(buf)?;
+
+        // `signature_payload` is stored as an RLP byte-string whose contents are
+        // themselves an RLP encoding (`rlp([...])`).
+        let payload_header = Header::decode(buf)?;
+        if payload_header.list {
+            return Err(alloy_rlp::Error::UnexpectedList);
+        }
+        if payload_header.payload_length > buf.len() {
+            return Err(alloy_rlp::Error::InputTooShort);
+        }
+        let (mut payload_slice, rest) = buf.split_at(payload_header.payload_length);
+        *buf = rest;
+        let sig = Wip1001Signature::decode_payload_raw(sig_type, &mut payload_slice)?;
+        if !payload_slice.is_empty() {
+            return Err(alloy_rlp::Error::Custom(
+                "trailing bytes in signature_payload",
+            ));
+        }
+
+        if buf.len() + header.payload_length != remaining {
+            return Err(alloy_rlp::Error::ListLengthMismatch {
+                expected: header.payload_length,
+                got: remaining - buf.len(),
+            });
+        }
+        Ok((tx, sig))
+    }
+
+    /// Decodes the signed transaction into a [`Signed<TxWip1001, Wip1001Signature>`].
+    pub fn rlp_decode_signed(buf: &mut &[u8]) -> alloy_rlp::Result<Signed<Self, Wip1001Signature>> {
+        let (tx, sig) = Self::rlp_decode_with_signature(buf)?;
+        let hash = tx.tx_hash(&sig);
+        Ok(Signed::new_unchecked(tx, sig, hash))
+    }
+
+    /// Length of the EIP-2718 encoding (`type_byte || rlp_encode_signed`).
+    pub fn eip2718_encoded_length(&self, sig: &Wip1001Signature) -> usize {
+        1 + self.rlp_encoded_length_with_signature(sig)
+    }
+
+    /// EIP-2718 encodes the transaction with `type_byte = 0x1D`.
+    pub fn eip2718_encode(&self, sig: &Wip1001Signature, out: &mut dyn BufMut) {
+        out.put_u8(WIP_1001_TX_TYPE);
+        self.rlp_encode_signed(sig, out);
+    }
+
+    /// EIP-2718 decodes a signed transaction, asserting the leading type byte
+    /// equals `0x1D`.
+    pub fn eip2718_decode(buf: &mut &[u8]) -> Eip2718Result<Signed<Self, Wip1001Signature>> {
+        if buf.is_empty() {
+            return Err(alloy_rlp::Error::InputTooShort.into());
+        }
+        let ty = buf[0];
+        if ty != WIP_1001_TX_TYPE {
+            return Err(Eip2718Error::UnexpectedType(ty));
+        }
+        *buf = &buf[1..];
+        // OPT: compute the hash from the original buffer to avoid re-serializing.
+        let original = *buf;
+        let (tx, sig) = Self::rlp_decode_with_signature(buf)?;
+        let consumed = original.len() - buf.len();
+        let mut hash_buf = Vec::with_capacity(1 + consumed);
+        hash_buf.push(WIP_1001_TX_TYPE);
+        hash_buf.extend_from_slice(&original[..consumed]);
+        let hash = keccak256(&hash_buf);
+        Ok(Signed::new_unchecked(tx, sig, hash))
+    }
+
+    /// EIP-2718 decodes with an expected `type_byte`.
+    pub fn eip2718_decode_with_type(
+        buf: &mut &[u8],
+        ty: u8,
+    ) -> Eip2718Result<Signed<Self, Wip1001Signature>> {
+        if ty != WIP_1001_TX_TYPE {
+            return Err(Eip2718Error::UnexpectedType(ty));
+        }
+        let mut full = Vec::with_capacity(1 + buf.len());
+        full.push(ty);
+        full.extend_from_slice(buf);
+        let mut slice = full.as_slice();
+        let res = Self::eip2718_decode(&mut slice)?;
+        // Advance the caller's buffer by the number of bytes consumed.
+        let consumed = full.len() - slice.len() - 1; // subtract leading type byte
+        *buf = &buf[consumed..];
+        Ok(res)
+    }
+
+    /// Computes the transaction hash: `keccak256(0x1D || rlp_encode_signed)`.
+    pub fn tx_hash(&self, sig: &Wip1001Signature) -> TxHash {
+        let mut buf = Vec::with_capacity(self.eip2718_encoded_length(sig));
+        self.eip2718_encode(sig, &mut buf);
+        keccak256(&buf)
+    }
+
+    /// Computes the signing hash: `keccak256(0x1D || rlp([fields 0..=9]))`.
+    pub fn signing_hash(&self) -> B256 {
+        let mut buf = Vec::with_capacity(1 + self.rlp_encoded_length());
+        buf.put_u8(WIP_1001_TX_TYPE);
+        self.rlp_encode(&mut buf);
+        keccak256(&buf)
+    }
+}
+
+impl Typed2718 for TxWip1001 {
+    fn ty(&self) -> u8 {
+        WIP_1001_TX_TYPE
+    }
+}
+
+impl IsTyped2718 for TxWip1001 {
+    fn is_type(type_id: u8) -> bool {
+        type_id == WIP_1001_TX_TYPE
+    }
+}
+
+impl Transaction for TxWip1001 {
+    #[inline]
+    fn chain_id(&self) -> Option<u64> {
+        Some(self.chain_id)
+    }
+
+    #[inline]
+    fn nonce(&self) -> u64 {
+        self.nonce
+    }
+
+    #[inline]
+    fn gas_limit(&self) -> u64 {
+        self.gas_limit
+    }
+
+    #[inline]
+    fn gas_price(&self) -> Option<u128> {
+        None
+    }
+
+    #[inline]
+    fn max_fee_per_gas(&self) -> u128 {
+        self.max_fee_per_gas
+    }
+
+    #[inline]
+    fn max_priority_fee_per_gas(&self) -> Option<u128> {
+        Some(self.max_priority_fee_per_gas)
+    }
+
+    #[inline]
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        None
+    }
+
+    #[inline]
+    fn priority_fee_or_price(&self) -> u128 {
+        self.max_priority_fee_per_gas
+    }
+
+    fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
+        alloy_eips::eip1559::calc_effective_gas_price(
+            self.max_fee_per_gas,
+            self.max_priority_fee_per_gas,
+            base_fee,
+        )
+    }
+
+    #[inline]
+    fn is_dynamic_fee(&self) -> bool {
+        true
+    }
+
+    #[inline]
+    fn kind(&self) -> TxKind {
+        self.to
+    }
+
+    #[inline]
+    fn is_create(&self) -> bool {
+        self.to.is_create()
+    }
+
+    #[inline]
+    fn value(&self) -> U256 {
+        self.value
+    }
+
+    #[inline]
+    fn input(&self) -> &Bytes {
+        &self.input
+    }
+
+    #[inline]
+    fn access_list(&self) -> Option<&AccessList> {
+        Some(&self.access_list)
+    }
+
+    #[inline]
+    fn blob_versioned_hashes(&self) -> Option<&[B256]> {
+        None
+    }
+
+    #[inline]
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
+        None
+    }
+}
+
+impl SignableTransaction<Wip1001Signature> for TxWip1001 {
+    fn set_chain_id(&mut self, chain_id: ChainId) {
+        self.chain_id = chain_id;
+    }
+
+    fn encode_for_signing(&self, out: &mut dyn BufMut) {
+        out.put_u8(WIP_1001_TX_TYPE);
+        self.rlp_encode(out);
+    }
+
+    fn payload_len_for_signature(&self) -> usize {
+        1 + self.rlp_encoded_length()
+    }
+
+    fn into_signed(self, signature: Wip1001Signature) -> Signed<Self, Wip1001Signature> {
+        let hash = self.tx_hash(&signature);
+        Signed::new_unchecked(self, signature, hash)
+    }
+}
+
+/// Bridge impl so that `WorldChainTypedTransaction: SignableTransaction<Signature>`
+/// (which wraps all variants with the default alloy [`Signature`]) still works
+/// for [`TxWip1001`]. The secp256k1 signature is wrapped in
+/// [`Wip1001Signature::Secp256k1`] when the envelope is later projected.
+impl SignableTransaction<Signature> for TxWip1001 {
+    fn set_chain_id(&mut self, chain_id: ChainId) {
+        self.chain_id = chain_id;
+    }
+
+    fn encode_for_signing(&self, out: &mut dyn BufMut) {
+        <Self as SignableTransaction<Wip1001Signature>>::encode_for_signing(self, out);
+    }
+
+    fn payload_len_for_signature(&self) -> usize {
+        <Self as SignableTransaction<Wip1001Signature>>::payload_len_for_signature(self)
+    }
+
+    fn into_signed(self, signature: Signature) -> Signed<Self, Signature> {
+        let wip_sig = Wip1001Signature::Secp256k1(signature);
+        let hash = self.tx_hash(&wip_sig);
+        Signed::new_unchecked(self, signature, hash)
+    }
+}
+
+impl TxHashable<Wip1001Signature> for TxWip1001 {
+    fn tx_hash_with_type(&self, signature: &Wip1001Signature, _ty: u8) -> TxHash {
+        self.tx_hash(signature)
+    }
+}
+
+impl Encodable for TxWip1001 {
+    fn encode(&self, out: &mut dyn BufMut) {
+        self.rlp_encode(out);
+    }
+
+    fn length(&self) -> usize {
+        self.rlp_encoded_length()
+    }
+}
+
+impl Decodable for TxWip1001 {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let header = Header::decode(buf)?;
+        if !header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+        let remaining = buf.len();
+        let this = Self::rlp_decode_fields(buf)?;
+        if buf.len() + header.payload_length != remaining {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+        Ok(this)
+    }
+}
+
+/// Newtype wrapper around [`Signed<TxWip1001, Wip1001Signature>`].
+///
+/// `Signed` lives in `alloy-consensus` and so does not satisfy Rust's orphan
+/// rule for `impl Encodable2718`/`impl Decodable2718` when specialized over a
+/// non-default `Sig` type. [`SignedWip1001`] is a transparent, local wrapper
+/// carrying only the type-system discriminator needed for those impls; it
+/// [`Deref`](core::ops::Deref)s back to the inner [`Signed`] and converts
+/// losslessly in both directions.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
+pub struct SignedWip1001 {
+    inner: Signed<TxWip1001, Wip1001Signature>,
+}
+
+impl SignedWip1001 {
+    /// Wraps the given [`Signed`].
+    pub const fn new(inner: Signed<TxWip1001, Wip1001Signature>) -> Self {
+        Self { inner }
+    }
+
+    /// Signs a [`TxWip1001`] with the given [`Wip1001Signature`] and wraps the result.
+    pub fn new_signed(tx: TxWip1001, signature: Wip1001Signature) -> Self {
+        Self::new(tx.into_signed(signature))
+    }
+
+    /// Returns the inner [`Signed`].
+    pub const fn inner(&self) -> &Signed<TxWip1001, Wip1001Signature> {
+        &self.inner
+    }
+
+    /// Unwraps to the inner [`Signed`].
+    pub fn into_inner(self) -> Signed<TxWip1001, Wip1001Signature> {
+        self.inner
+    }
+
+    /// Reference to the transaction body.
+    pub const fn tx(&self) -> &TxWip1001 {
+        self.inner.tx()
+    }
+
+    /// Mutable reference to the transaction body.
+    ///
+    /// # Warning
+    ///
+    /// Modifying the transaction structurally invalidates the signature and
+    /// cached hash.
+    #[doc(hidden)]
+    pub const fn tx_mut(&mut self) -> &mut TxWip1001 {
+        self.inner.tx_mut()
+    }
+
+    /// Reference to the signature.
+    pub const fn signature(&self) -> &Wip1001Signature {
+        self.inner.signature()
+    }
+
+    /// The cached transaction hash.
+    pub fn hash(&self) -> &B256 {
+        self.inner.hash()
+    }
+
+    /// EIP-2718 decode a signed WIP-1001 transaction.
+    pub fn eip2718_decode(buf: &mut &[u8]) -> Eip2718Result<Self> {
+        TxWip1001::eip2718_decode(buf).map(Self::new)
+    }
+}
+
+impl core::ops::Deref for SignedWip1001 {
+    type Target = Signed<TxWip1001, Wip1001Signature>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl From<Signed<TxWip1001, Wip1001Signature>> for SignedWip1001 {
+    fn from(inner: Signed<TxWip1001, Wip1001Signature>) -> Self {
+        Self::new(inner)
+    }
+}
+
+impl From<SignedWip1001> for Signed<TxWip1001, Wip1001Signature> {
+    fn from(value: SignedWip1001) -> Self {
+        value.inner
+    }
+}
+
+impl Typed2718 for SignedWip1001 {
+    fn ty(&self) -> u8 {
+        WIP_1001_TX_TYPE
+    }
+}
+
+impl IsTyped2718 for SignedWip1001 {
+    fn is_type(type_id: u8) -> bool {
+        type_id == WIP_1001_TX_TYPE
+    }
+}
+
+impl Transaction for SignedWip1001 {
+    #[inline]
+    fn chain_id(&self) -> Option<u64> {
+        self.tx().chain_id()
+    }
+    #[inline]
+    fn nonce(&self) -> u64 {
+        self.tx().nonce()
+    }
+    #[inline]
+    fn gas_limit(&self) -> u64 {
+        self.tx().gas_limit()
+    }
+    #[inline]
+    fn gas_price(&self) -> Option<u128> {
+        self.tx().gas_price()
+    }
+    #[inline]
+    fn max_fee_per_gas(&self) -> u128 {
+        self.tx().max_fee_per_gas()
+    }
+    #[inline]
+    fn max_priority_fee_per_gas(&self) -> Option<u128> {
+        self.tx().max_priority_fee_per_gas()
+    }
+    #[inline]
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        self.tx().max_fee_per_blob_gas()
+    }
+    #[inline]
+    fn priority_fee_or_price(&self) -> u128 {
+        self.tx().priority_fee_or_price()
+    }
+    fn effective_gas_price(&self, base_fee: Option<u64>) -> u128 {
+        self.tx().effective_gas_price(base_fee)
+    }
+    #[inline]
+    fn is_dynamic_fee(&self) -> bool {
+        self.tx().is_dynamic_fee()
+    }
+    #[inline]
+    fn kind(&self) -> TxKind {
+        self.tx().kind()
+    }
+    #[inline]
+    fn is_create(&self) -> bool {
+        self.tx().is_create()
+    }
+    #[inline]
+    fn value(&self) -> U256 {
+        self.tx().value()
+    }
+    #[inline]
+    fn input(&self) -> &Bytes {
+        self.tx().input()
+    }
+    #[inline]
+    fn access_list(&self) -> Option<&AccessList> {
+        self.tx().access_list()
+    }
+    #[inline]
+    fn blob_versioned_hashes(&self) -> Option<&[B256]> {
+        self.tx().blob_versioned_hashes()
+    }
+    #[inline]
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
+        self.tx().authorization_list()
+    }
+}
+
+impl Encodable2718 for SignedWip1001 {
+    fn encode_2718_len(&self) -> usize {
+        self.tx().eip2718_encoded_length(self.signature())
+    }
+
+    fn encode_2718(&self, out: &mut dyn BufMut) {
+        self.tx().eip2718_encode(self.signature(), out);
+    }
+
+    fn trie_hash(&self) -> B256 {
+        *self.hash()
+    }
+}
+
+impl Decodable2718 for SignedWip1001 {
+    fn typed_decode(ty: u8, buf: &mut &[u8]) -> Eip2718Result<Self> {
+        if ty != WIP_1001_TX_TYPE {
+            return Err(Eip2718Error::UnexpectedType(ty));
+        }
+        TxWip1001::rlp_decode_signed(buf)
+            .map(Self::new)
+            .map_err(Into::into)
+    }
+
+    fn fallback_decode(_buf: &mut &[u8]) -> Eip2718Result<Self> {
+        // WIP-1001 transactions are always typed; there is no legacy fallback.
+        Err(Eip2718Error::UnexpectedType(0))
+    }
+}
+
+impl Encodable for SignedWip1001 {
+    fn encode(&self, out: &mut dyn BufMut) {
+        <Self as Encodable2718>::network_encode(self, out)
+    }
+
+    fn length(&self) -> usize {
+        <Self as Encodable2718>::network_len(self)
+    }
+}
+
+impl Decodable for SignedWip1001 {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        Ok(<Self as Decodable2718>::network_decode(buf)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{address, b256, hex};
+
+    fn sample_tx() -> TxWip1001 {
+        TxWip1001 {
+            chain_id: 480,
+            nonce: 0x42,
+            max_priority_fee_per_gas: 0x3b9aca00,
+            max_fee_per_gas: 0x4a817c800,
+            gas_limit: 44386,
+            to: address!("6069a6c32cf691f5982febae4faf8a6f3ab2f0f6").into(),
+            value: U256::from(1u64),
+            input: hex!("a22cb465").into(),
+            access_list: AccessList::default(),
+            keyring: address!("000000000000000000000000000000000000001d"),
+        }
+    }
+
+    fn sample_sig() -> Wip1001Signature {
+        Wip1001Signature::Secp256k1(Signature::new(
+            U256::from_be_slice(
+                &b256!("840cfc572845f5786e702984c2a582528cad4b49b2a10b9db1be7fca90058565")[..],
+            ),
+            U256::from_be_slice(
+                &b256!("25e7109ceb98168d95b09b18bbf6b685130e0562f233877d492b94eee0c5b6d1")[..],
+            ),
+            false,
+        ))
+    }
+
+    #[test]
+    fn wip1001_signature_payload_round_trip() {
+        let sig = sample_sig();
+        let mut buf = Vec::new();
+        sig.encode_payload_raw(&mut buf);
+        assert_eq!(buf.len(), sig.payload_encoded_len());
+
+        let mut slice = buf.as_slice();
+        let decoded = Wip1001Signature::decode_payload_raw(sig.signature_type(), &mut slice)
+            .expect("decode payload");
+        assert!(slice.is_empty());
+        assert_eq!(decoded, sig);
+    }
+
+    #[test]
+    fn wip1001_signed_rlp_round_trip() {
+        let tx = sample_tx();
+        let sig = sample_sig();
+
+        let mut buf = Vec::new();
+        tx.rlp_encode_signed(&sig, &mut buf);
+        assert_eq!(buf.len(), tx.rlp_encoded_length_with_signature(&sig));
+
+        let mut slice = buf.as_slice();
+        let (decoded_tx, decoded_sig) =
+            TxWip1001::rlp_decode_with_signature(&mut slice).expect("decode");
+        assert!(slice.is_empty());
+        assert_eq!(decoded_tx, tx);
+        assert_eq!(decoded_sig, sig);
+    }
+
+    #[test]
+    fn wip1001_eip2718_round_trip() {
+        let tx = sample_tx();
+        let sig = sample_sig();
+
+        let mut buf = Vec::new();
+        tx.eip2718_encode(&sig, &mut buf);
+        assert_eq!(buf[0], WIP_1001_TX_TYPE);
+        assert_eq!(buf.len(), tx.eip2718_encoded_length(&sig));
+
+        let mut slice = buf.as_slice();
+        let signed = TxWip1001::eip2718_decode(&mut slice).expect("decode 2718");
+        assert!(slice.is_empty());
+        assert_eq!(signed.tx(), &tx);
+        assert_eq!(signed.signature(), &sig);
+        assert_eq!(*signed.hash(), tx.tx_hash(&sig));
+    }
+
+    #[test]
+    fn wip1001_signed_encode_2718_matches_tx_helper() {
+        let tx = sample_tx();
+        let sig = sample_sig();
+        let signed = SignedWip1001::new_signed(tx.clone(), sig.clone());
+
+        let mut via_signed = Vec::new();
+        signed.encode_2718(&mut via_signed);
+
+        let mut via_tx = Vec::new();
+        tx.eip2718_encode(&sig, &mut via_tx);
+
+        assert_eq!(via_signed, via_tx);
+        assert_eq!(signed.encode_2718_len(), via_tx.len());
+    }
+
+    #[test]
+    fn wip1001_typed_decode_rejects_wrong_type() {
+        let tx = sample_tx();
+        let sig = sample_sig();
+        let mut buf = Vec::new();
+        tx.rlp_encode_signed(&sig, &mut buf);
+
+        let mut slice = buf.as_slice();
+        let err = <SignedWip1001 as Decodable2718>::typed_decode(0x02, &mut slice).unwrap_err();
+        assert!(matches!(err, Eip2718Error::UnexpectedType(0x02)));
+    }
+
+    #[test]
+    fn wip1001_signed_newtype_round_trip() {
+        let tx = sample_tx();
+        let sig = sample_sig();
+        let signed = SignedWip1001::new_signed(tx.clone(), sig.clone());
+
+        // EIP-2718 round-trip through the newtype.
+        let mut buf = Vec::new();
+        signed.encode_2718(&mut buf);
+        let decoded = SignedWip1001::eip2718_decode(&mut buf.as_slice()).expect("decode");
+        assert_eq!(decoded.tx(), &tx);
+        assert_eq!(decoded.signature(), &sig);
+        assert_eq!(*decoded.hash(), *signed.hash());
+
+        // `Signed` <-> `SignedWip1001` conversions are lossless.
+        let inner: Signed<TxWip1001, Wip1001Signature> = signed.clone().into_inner();
+        assert_eq!(inner.tx(), &tx);
+        let back = SignedWip1001::from(inner);
+        assert_eq!(*back.hash(), *signed.hash());
+    }
+
+    #[test]
+    fn wip1001_signing_hash_excludes_signature() {
+        let tx = sample_tx();
+        let sig1 = sample_sig();
+        let sig2 =
+            Wip1001Signature::Secp256k1(Signature::new(U256::from(7u64), U256::from(9u64), true));
+        assert_eq!(tx.signing_hash(), tx.signing_hash());
+        let h1 = tx.tx_hash(&sig1);
+        let h2 = tx.tx_hash(&sig2);
+        assert_ne!(h1, h2, "tx hash depends on signature");
+        // Signing hash excludes signature fields.
+        let signing = tx.signing_hash();
+        assert_ne!(signing, h1);
+        assert_ne!(signing, h2);
+    }
+
+    #[test]
+    fn wip1001_tx_type_byte() {
+        let tx = sample_tx();
+        assert_eq!(<TxWip1001 as Typed2718>::ty(&tx), 0x1D);
+        assert!(<TxWip1001 as IsTyped2718>::is_type(0x1D));
+        assert!(!<TxWip1001 as IsTyped2718>::is_type(0x02));
+    }
+
+    #[test]
+    fn wip1001_into_signed_sets_hash() {
+        let tx = sample_tx();
+        let sig = sample_sig();
+        let signed: Signed<TxWip1001, Wip1001Signature> = tx.clone().into_signed(sig.clone());
+        assert_eq!(signed.tx(), &tx);
+        assert_eq!(signed.signature(), &sig);
+        assert_eq!(*signed.hash(), tx.tx_hash(&sig));
+    }
+}

--- a/crates/primitives/src/transaction/wip_1001.rs
+++ b/crates/primitives/src/transaction/wip_1001.rs
@@ -514,9 +514,6 @@ impl SignableTransaction<Wip1001Signature> for TxWip1001 {
 }
 
 /// Bridge impl so that `WorldChainTypedTransaction: SignableTransaction<Signature>`
-/// (which wraps all variants with the default alloy [`Signature`]) still works
-/// for [`TxWip1001`]. The secp256k1 signature is wrapped in
-/// [`Wip1001Signature::Secp256k1`] when the envelope is later projected.
 impl SignableTransaction<Signature> for TxWip1001 {
     fn set_chain_id(&mut self, chain_id: ChainId) {
         self.chain_id = chain_id;


### PR DESCRIPTION
This PR is stacked on #549.

It implements the EIP-2718 Typed transaction structure for a WIP-1001 compliant transaction `0x1D`. Including RLP roundtrip, serde round trip, and typed signature payload. 

The `Wip1001Signature` has been scoped to only ECDSA, and will be extended in additional PR's

Scope #527

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new transaction type and custom RLP/EIP-2718 encoding/decoding plus signer recovery paths, which can affect transaction hashing and wire compatibility if incorrect.
> 
> **Overview**
> Adds a new `transaction` module to `crates/primitives` that introduces `WorldChainTxEnvelope`, extending the existing typed envelope set with a **WIP-1001 (0x1D)** variant alongside legacy/EIP-2930/EIP-1559/EIP-7702 and Optimism `Deposit`.
> 
> Implements `TxWip1001` plus a `Wip1001Signature` wrapper (currently **secp256k1-only**) with full RLP and EIP-2718 encode/decode, hashing/signing-hash helpers, and a `SignedWip1001` newtype to satisfy orphan-rule constraints.
> 
> Updates envelope conversions and `SignerRecoverable` so WIP-1001 transactions can be encoded/decoded and signer-recovered (secp256k1 only), while explicitly rejecting conversion of WIP-1001 envelopes into Ethereum/Optimism envelopes; includes targeted round-trip and regression tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b898cc2b1de5a483d50c1ff65ea177e44f58197. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->