### PR TITLE
fix: add jovian upgrade timestamp defaults to named chains

### DIFF
--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -2,12 +2,13 @@ use crate::config::FlashblocksPayloadBuilderConfig;
 use ::eyre::eyre::bail;
 use alloy_chains::NamedChain;
 use alloy_primitives::{Address, address};
-use reth_chainspec::EthChainSpec;
+use reth_chainspec::{EthChainSpec, ForkCondition};
 use reth_network_peers::PeerId;
 use reth_node_builder::NodeConfig;
-use reth_optimism_chainspec::OpChainSpec;
+use reth_optimism_chainspec::{OpChainSpec, OpHardfork};
 use reth_optimism_node::args::RollupArgs;
 use reth_optimism_payload_builder::config::{OpBuilderConfig, OpGasLimitConfig};
+use std::sync::Arc;
 use tracing::{debug, info, warn};
 
 pub mod builder;
@@ -17,6 +18,10 @@ pub mod pbh;
 pub use builder::*;
 pub use p2p::*;
 pub use pbh::*;
+
+const JOVIAN_UPGRADE_TIMESTAMP_SEPOLIA: u64 = 1777161600;
+
+const JOVIAN_UPGRADE_TIMESTAMP_MAINNET: u64 = 1777593600;
 
 pub const DEFAULT_FLASHBLOCKS_BOOTNODES: &str = "enode://78ca7daeb63956cbc3985853d5699a6404d976a2612575563f46876968fdca2383a195ee7db40de348757b2256195996933708f351169ca3f3fe93ab2a774608@16.62.98.53:30303,enode://c96dcadf4cdea4c39ec3fd775637d9e67d455b856b1514cfcf55b72f873a34b96d69e47ccea9fc797a446d4e6948aa80f6b9d479a1727ca166758a900b08f422@16.63.14.166:30303,enode://15688a7b281c32a4da633252dcc5019d60f037ee9eb46d05093dd3023bdd688b9b207d10a39e054a5ed87db666b2cb75696f6537de74d1e1f8dcabc53dc8d2ab@16.63.123.160:30303";
 
@@ -108,6 +113,17 @@ impl WorldChainArgs {
                     self.pbh.signature_aggregator =
                         address!("d21306C75C956142c73c0C3BAb282Be68595081E");
                 }
+
+                let chain_spec = Arc::make_mut(&mut config.chain);
+                chain_spec.inner.hardforks.insert(
+                    OpHardfork::Jovian,
+                    ForkCondition::Timestamp(JOVIAN_UPGRADE_TIMESTAMP_MAINNET),
+                );
+                info!(
+                    target: "reth::cli",
+                    timestamp = JOVIAN_UPGRADE_TIMESTAMP_MAINNET,
+                    "Overriding Jovian activation timestamp for World mainnet"
+                );
             }
             Some(NamedChain::WorldSepolia) => {
                 if let Some(flashblocks) = &mut self.flashblocks
@@ -136,6 +152,17 @@ impl WorldChainArgs {
                     self.pbh.signature_aggregator =
                         address!("0x8af27Ee9AF538C48C7D2a2c8BD6a40eF830e2489");
                 }
+
+                let chain_spec = Arc::make_mut(&mut config.chain);
+                chain_spec.inner.hardforks.insert(
+                    OpHardfork::Jovian,
+                    ForkCondition::Timestamp(JOVIAN_UPGRADE_TIMESTAMP_SEPOLIA),
+                );
+                info!(
+                    target: "reth::cli",
+                    timestamp = JOVIAN_UPGRADE_TIMESTAMP_SEPOLIA,
+                    "Overriding Jovian activation timestamp for World Sepolia"
+                );
             }
             _ => {
                 if let Some(flashblocks) = &mut self.flashblocks


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes chain spec hardfork activation for `NamedChain::World` and `NamedChain::WorldSepolia`, which can affect fork rules and node compatibility if the timestamps are incorrect.
> 
> **Overview**
> Sets explicit default activation timestamps for the `OpHardfork::Jovian` upgrade when running on `NamedChain::World` and `NamedChain::WorldSepolia`.
> 
> `WorldChainArgs::into_config` now mutates the loaded chain spec (via `Arc::make_mut`) to insert a `ForkCondition::Timestamp(...)` for Jovian and logs the override for each network.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f0fb8e5e4309f05e0575a195214acb86a154e6b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->