### PR TITLE
fix: use Rust 1.95.0 for docker image

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 version = "1.11.3"
 edition = "2024"
-rust-version = "1.92.0"
+rust-version = "1.95.0"
 license = "MIT"
 homepage = "https://world.org/world-chain"
 repository = "https://github.com/worldcoin/world-chain/"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.10
-FROM public.ecr.aws/docker/library/rust:1.92.0-bookworm AS base
+FROM public.ecr.aws/docker/library/rust:1.95.0-bookworm AS base
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
   --mount=type=cache,target=/usr/local/cargo/git \


### PR DESCRIPTION
### Problem

We're using rust `1.92.0` to build the docker image of `world-chain`, but reth `v2.0.0` requires at least `1.93.0`.

### Solution

Bump rust to latest version `1.95.0`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version bump affecting build tooling only, but may surface new compiler/lint warnings or CI differences due to the newer toolchain.
> 
> **Overview**
> Updates the project’s required Rust toolchain to `1.95.0` by bumping `rust-version` in `Cargo.toml` and switching the Docker build base image from `rust:1.92.0-bookworm` to `rust:1.95.0-bookworm`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a137e82055f7ed77f2814d253a9cfa76445c5f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->