### PR TITLE
fix(rpc): set tx chain_id from chainspec instead of TxEnv default

### DIFF
--- a/crates/rpc/src/simulate.rs
+++ b/crates/rpc/src/simulate.rs
@@ -502,7 +502,11 @@ where
         let db = StateProviderDatabase::new(state_provider.as_ref());
         let mut state = State::builder().with_database(db).build();
 
-        // 5. Create the Optimism-aware EVM with our simulation inspector
+        // 5. Create the Optimism-aware EVM with our simulation inspector.
+        //    Capture chain_id first — it'd otherwise be unreachable after
+        //    `evm_env` moves into the EVM, and `TxEnv::default()` hardcodes
+        //    Some(1) which mismatches any non-mainnet chainspec.
+        let chain_id = evm_env.cfg_env.chain_id;
         let mut evm = OpEvmFactory::default().create_evm_with_inspector(
             &mut state,
             evm_env,
@@ -542,6 +546,7 @@ where
                 value: U256::ZERO,
                 gas_limit,
                 gas_price: 0,
+                chain_id: Some(chain_id),
                 ..Default::default()
             },
             ..Default::default()
@@ -1059,6 +1064,9 @@ where
     };
     let db = StateProviderDatabase::new(state_provider.as_ref());
     let mut state = State::builder().with_database(db).build();
+    // Capture chain_id before `evm_env` moves into the EVM — `TxEnv::default()`
+    // hardcodes Some(1), which would mismatch any non-mainnet chainspec.
+    let chain_id = evm_env.cfg_env.chain_id;
     let mut evm = OpEvmFactory::default().create_evm(&mut state, evm_env);
 
     let mut call_view = |to: Address, selector: &[u8; 4]| -> Option<Bytes> {
@@ -1070,6 +1078,7 @@ where
                 value: U256::ZERO,
                 gas_limit: 100_000,
                 gas_price: 0,
+                chain_id: Some(chain_id),
                 ..Default::default()
             },
             ..Default::default()


### PR DESCRIPTION
## Summary

`TxEnv::default()` hardcodes `chain_id: Some(1)` (\"Mainnet chain ID is 1\" per revm's source), so every simulated tx was being rejected on any non-Ethereum-mainnet chainspec with:

\`\`\`
transaction validation error: invalid chain ID
\`\`\`

In production this meant sepolia (4801), devnet, and world-chain mainnet (480) all returned that error before the simulator ever ran the EVM call. Caught while smoke-testing the live sepolia endpoint after #499 merged.

## Fix

Read the configured chain id off \`evm_env.cfg_env.chain_id\` (already populated from the running node's chainspec) and put it on the \`TxEnv\`. Done at both construction sites — the main simulate handler and the metadata view-call helper. \`chain_id\` is captured before \`evm_env\` moves into \`create_evm[_with_inspector]\` so it's reachable when we build the tx.

## Why the fork tests didn't catch it

\`crates/rpc/tests/fork_simulate.rs\` already passes \`chain_id: Some(CHAIN_ID)\` (480) explicitly on every transaction it constructs, so the test path always set the right chain id and masked the production gap. Tests still pass unchanged after this fix.

## Test plan

- [x] \`cargo build -p world-chain-rpc\`
- [x] All 13 fork tests pass: \`WORLDCHAIN_PROVIDER=… cargo test -p world-chain-rpc --test fork_simulate\`
- [ ] After deploy: hit \`worldchain_simulateUnsignedUserOp\` on sepolia and verify it returns a real simulation result instead of \`invalid chain ID\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how all simulated EVM transactions are constructed/validated and could alter behavior across networks, but the change is small and localized to simulation/view-call paths.
> 
> **Overview**
> Simulation transactions now use the configured chainspec `chain_id` instead of relying on `TxEnv::default()` (which hardcodes mainnet `1`).
> 
> This captures `evm_env.cfg_env.chain_id` before `evm_env` is moved into EVM construction and sets `TxEnv.chain_id` in both the main `simulateUnsignedUserOp` execution and the token-metadata view-call helper, preventing `invalid chain ID` failures on non-mainnet deployments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c79d9a00cb09a97f84f5ab12d5bad27ff8d8b99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->