### PR TITLE
docs: rename WIP-1002 to Subsidy Accounting, switch to ETH-denominated budget

### DIFF
--- a/wips/README.md
+++ b/wips/README.md
@@ -26,7 +26,7 @@ WIPs are modeled after [Ethereum Improvement Proposals (EIPs)](https://github.co
 | WIP    | Title                              | Status | Category | Created    |
 | ------ | ---------------------------------- | ------ | -------- | ---------- |
 | [1001](./wip-1001.md) | WorldID Native Account Abstraction | Draft  | Core     | 2026-03-27 |
-| [1002](./wip-1002.md) | WorldID Gas Accounting             | Draft  | Core     | 2026-04-21 |
+| [1002](./wip-1002.md) | WorldID Subsidy Accounting         | Draft  | Core     | 2026-04-21 |
 
 ---
 

--- a/wips/wip-1002.md
+++ b/wips/wip-1002.md
@@ -1,7 +1,7 @@
 ---
 wip: 1002
-title: WorldID Gas Accounting
-description: A per-credential gas subsidy system for verified World ID holders on World Chain, implemented as a precompile or predeploy with per-period nullifier-keyed budgets, a claimed-credentials bitmap for replay protection, and a configurable authorization map over arbitrary account types.
+title: WorldID Subsidy Accounting
+description: A per-credential, ETH-denominated transaction-fee subsidy system for verified World ID holders on World Chain, implemented as a precompile or predeploy with per-period nullifier-keyed budgets, a claimed-credentials bitmap for replay protection, and a configurable authorization map over arbitrary account types.
 author: Kilian Glas (@kilianglas), 0xOsiris (@0xOsiris), Eric Woolsey (@0xforerunner)
 status: Draft
 type: Standards Track
@@ -12,13 +12,13 @@ requires: WIP-1001, EIP-1559
 
 ## Abstract
 
-A **WorldID Gas Accounting** system enables per-credential gas subsidies for verified humans on World Chain. A [World ID](https://worldcoin.org/world-id) opens a per-period subsidy record whose `nullifier` — derived from a [World ID 4.0](https://github.com/worldcoin/world-id-protocol) Uniqueness Proof — is the record's primary key for budget, authorization, and replay state. The initial claim is driven by a multi-item proof request authorized by a World-Chain-operated WIP-101 relying party contract (an [ERC-1271](https://eips.ethereum.org/EIPS/eip-1271)-style smart-contract signer); the authenticator lists one `RequestItem` per credential the WorldID holds and emits one Uniqueness Proof per item, all sharing the same `nullifier`. Each proof's signal carries the initial set of authorized accounts permitted to spend the budget. The first on-chain call also binds a World ID `sessionId` to the `nullifier` record; subsequent Session Proofs against that `sessionId` may claim credentials acquired later in the period or add / remove authorized addresses. Budgets are governance-configurable per `issuerSchemaId`, and subsidy records expire at period boundaries.
+A **WorldID Subsidy Accounting** system enables per-credential, ETH-denominated transaction-fee subsidies for verified humans on World Chain. A [World ID](https://worldcoin.org/world-id) opens a per-period subsidy record whose `nullifier` — derived from a [World ID 4.0](https://github.com/worldcoin/world-id-protocol) Uniqueness Proof — is the record's primary key for budget, authorization, and replay state. The initial claim is driven by a multi-item proof request authorized by a World-Chain-operated WIP-101 relying party contract (an [ERC-1271](https://eips.ethereum.org/EIPS/eip-1271)-style smart-contract signer); the authenticator lists one `RequestItem` per credential the WorldID holds and emits one Uniqueness Proof per item, all sharing the same `nullifier`. Each proof's signal carries the initial set of authorized accounts permitted to spend the budget. The first on-chain call also binds a World ID `sessionId` to the `nullifier` record; subsequent Session Proofs against that `sessionId` may claim credentials acquired later in the period or add / remove authorized addresses. Budgets are governance-configurable per `issuerSchemaId`, and subsidy records expire at period boundaries.
 
 Authorized addresses may be legacy EOAs, smart contract accounts, or [WIP-1001](./wip-1001.md) *World ID Accounts* — the subsidy system is orthogonal to the account type it funds.
 
 ## Motivation
 
-World ID holders are currently already being subsidized for their gas usage on World Chain. Natively issued gas subsidies allow for a more fluid fee market, and enshrine gas allowances for World ID holders at the protocol (or builder) level rather than relying on off-chain paymasters.
+World ID holders are currently already being subsidized for their transaction fees on World Chain. Native, ETH-denominated subsidies allow for a more fluid fee market, and enshrine fee allowances for World ID holders at the protocol (or builder) level rather than relying on off-chain paymasters. Denominating in ETH (rather than gas units) gives governance more flexibility to fold in factors like the L1 blob-fee price or DeFi congestion when sizing budgets.
 
 Per-credential budgeting lets subsidy weight reflect credential strength — a Proof-of-Human (Orb) credential carries more weight than a Phone credential, and governance can tune each independently via `issuerSchemaId`.
 
@@ -28,16 +28,16 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Deployment Model
 
-The Gas Accounting component can be deployed as either:
+The Subsidy Accounting component can be deployed as either:
 
-- **A precompile**, enabling the protocol to natively read gas accounting state during transaction validation and execution. This is required if gas subsidies are enforced at the protocol level (e.g., the EVM itself checks and deducts budget).
+- **A precompile**, enabling the protocol to natively read subsidy accounting state during transaction validation and execution. This is required if subsidies are enforced at the protocol level (e.g., the EVM itself checks and deducts budget).
 - **A standard contract** (e.g., a predeploy), where the builder reads contract state via `eth_call` during block construction to determine subsidy eligibility and track budget consumption. This avoids protocol-level changes and allows iterating on subsidy logic without hard forks.
 
 The interface is identical in both cases. The choice of deployment model determines where enforcement happens (protocol vs. builder) but does not affect the accounting logic itself.
 
 ### Relying Party Signer
 
-For `rpId = WORLD_CHAIN_RP_ID` the registered RP `signer` in the World ID `RpRegistry` is a stateless [WIP-101](https://github.com/worldcoin/world-id-protocol)-style smart contract deployed on World Chain, rather than an off-chain EOA signer service. OPRF nodes detect the contract via [ERC-165](https://eips.ethereum.org/EIPS/eip-165) `supportsInterface` at registry ingest and validate every incoming `ProofRequest` by performing a read-only `eth_call` to its `verifyRpRequest(...)` entry point before contributing their OPRF share. Framing the RP as an on-chain primitive removes the trusted off-chain key-holder dependency; all economic policy (authorised addresses, budget, replay) remains in the Gas Accounting component, not the signer.
+For `rpId = WORLD_CHAIN_RP_ID` the registered RP `signer` in the World ID `RpRegistry` is a stateless [WIP-101](https://github.com/worldcoin/world-id-protocol)-style smart contract deployed on World Chain, rather than an off-chain EOA signer service. OPRF nodes detect the contract via [ERC-165](https://eips.ethereum.org/EIPS/eip-165) `supportsInterface` at registry ingest and validate every incoming `ProofRequest` by performing a read-only `eth_call` to its `verifyRpRequest(...)` entry point before contributing their OPRF share. Framing the RP as an on-chain primitive removes the trusted off-chain key-holder dependency; all economic policy (authorised addresses, budget, replay) remains in the Subsidy Accounting component, not the signer.
 
 The signer conforms to the [WIP-101](https://github.com/worldcoin/world-id-protocol) interface — an [ERC-1271](https://eips.ethereum.org/EIPS/eip-1271)-style magic-value check specialised for proof-request approval:
 
@@ -77,17 +77,17 @@ Deployment preconditions:
 - OPRF DKG ceremony run for this `rpId` so nodes can contribute shares.
 - Participating OPRF nodes' RPC configuration updated to point at World Chain.
 
-### Gas Accounting Interface
+### Subsidy Accounting Interface
 
-Manages all gas accounting state:
+Manages all subsidy accounting state:
 
 - **Authorization map:** reverse index from authorized account address to the set of `nullifier` records the address may draw budget from. Used at transaction-execution time to select which record's budget is charged; one address MAY be authorized under multiple records simultaneously.
-- **Gas budget map:** maps `nullifier` values to remaining budget in Gwei. Budget accumulates as additional credential proofs are submitted under that `nullifier`.
+- **Subsidy budget map:** maps `nullifier` values to the remaining ETH-denominated budget (in Wei). Budget accumulates as additional credential proofs are submitted under that `nullifier`.
 - **Claimed-credentials map:** for each `nullifier`, tracks which `issuerSchemaId` values have already been claimed (e.g., as a bitmap or set). Prevents double-claiming a credential under the same `nullifier`.
 - **Session bridge map:** maps each `nullifier` to the `sessionId` established at initial claim, so Session Proofs for subsequent operations on that `nullifier` can be verified.
-- **Credential budget configuration:** maps `issuerSchemaId` to claimable budget amount (governance-configurable per credential type).
+- **Credential budget configuration:** maps `issuerSchemaId` to claimable budget amount in Wei (governance-configurable per credential type).
 
-Existence of a record in the gas budget map is itself the per-period replay guard: a Uniqueness Proof carrying a `nullifier` that already has a record in the current period is rejected as a replay.
+Existence of a record in the subsidy budget map is itself the per-period replay guard: a Uniqueness Proof carrying a `nullifier` that already has a record in the current period is rejected as a replay.
 
 Exposes methods for:
 
@@ -98,7 +98,7 @@ Exposes methods for:
 - Budget consumption (called by the protocol or builder during transaction execution)
 
 ```solidity
-interface IGasAccounting {
+interface ISubsidyAccounting {
     /// @notice One per-credential Uniqueness Proof emitted by a single multi-item `ProofRequest`.
     ///         All items of a `claimSubsidy` call MUST share the same `nullifier` and the same
     ///         `signal_hash` public input (achieved by setting the same `signal` on every `RequestItem`).
@@ -151,13 +151,13 @@ interface IGasAccounting {
         bytes calldata proof
     ) external;
 
-    /// @notice Get remaining gas budget for a subsidy record in the current period.
-    function getBudget(uint256 nullifier) external view returns (uint256 remainingGwei);
+    /// @notice Get remaining subsidy budget (in Wei) for a subsidy record in the current period.
+    function getBudget(uint256 nullifier) external view returns (uint256 remainingWei);
 
-    /// @notice Get remaining gas budget available to an address in the current period.
+    /// @notice Get remaining subsidy budget (in Wei) available to an address in the current period.
     ///         If the address maps to multiple nullifiers, the same deterministic selection rule
-    ///         used during gas consumption applies here.
-    function getBudget(address account) external view returns (uint256 remainingGwei);
+    ///         used during budget consumption applies here.
+    function getBudget(address account) external view returns (uint256 remainingWei);
 
     /// @notice Check whether an address is authorized under a given subsidy record.
     function isAuthorized(address account, uint256 nullifier) external view returns (bool);
@@ -171,8 +171,8 @@ interface IGasAccounting {
     /// @notice Consume budget for a subsidy record. Called during tx execution (by protocol or builder).
     function consumeBudget(uint256 nullifier, uint256 gasUsed, uint256 baseFee) external;
 
-    /// @notice Set the claimable budget amount for a credential type. Governance only.
-    function setCredentialBudget(uint256 issuerSchemaId, uint256 budgetGwei) external;
+    /// @notice Set the claimable budget amount (in Wei) for a credential type. Governance only.
+    function setCredentialBudget(uint256 issuerSchemaId, uint256 budgetWei) external;
 }
 ```
 
@@ -180,9 +180,9 @@ interface IGasAccounting {
 
 Reverse index from authorized account address to the set of `nullifier` records the address may draw budget from. Populated on `claimSubsidy` from the `addAddresses` list; mutated throughout the period by `updateAddresses`. Authorized addresses MAY be EOAs, smart contract accounts, or [WIP-1001](./wip-1001.md) *World ID Accounts*.
 
-#### Gas Budget Map
+#### Subsidy Budget Map
 
-Maps `nullifier` values to the per-period subsidy record — remaining budget in Gwei, the `sessionId` used to verify subsequent Session Proofs, the bitmap of claimed `issuerSchemaId` values, the authorized-address set, and a monotonic update nonce incremented on each successful `updateAddresses` (prevents Session Proof replay). Budget accumulates as the initial multi-item `claimSubsidy` and later `claimAdditionalCredential` calls add credentials. A helper lookup by authorized address MAY resolve the budget through the same deterministic nullifier-selection rule used during transaction execution.
+Maps `nullifier` values to the per-period subsidy record — remaining ETH-denominated budget (in Wei), the `sessionId` used to verify subsequent Session Proofs, the bitmap of claimed `issuerSchemaId` values, the authorized-address set, and a monotonic update nonce incremented on each successful `updateAddresses` (prevents Session Proof replay). Budget accumulates as the initial multi-item `claimSubsidy` and later `claimAdditionalCredential` calls add credentials. A helper lookup by authorized address MAY resolve the budget through the same deterministic nullifier-selection rule used during transaction execution.
 
 #### Claimed-Credentials Map
 
@@ -257,7 +257,7 @@ For `claimSubsidy` (atomic over all `items`):
 2. Require `nullifier` to have no record in the current period.
 3. Recompute `signalHash` from a populated `ClaimSubsidySignal`.
 4. Verify every `items[i].proof` as a Uniqueness Proof for `"period_proof" || periodNumber` against the recomputed `signalHash`; all proofs MUST share the same `nullifier` public input.
-5. Create the record: store `sessionId`, set the authorized-address set to `addAddresses`, mark every `items[i].issuerSchemaId` as claimed, sum their configured budgets into `remainingGwei`, set the update nonce to `0`.
+5. Create the record: store `sessionId`, set the authorized-address set to `addAddresses`, mark every `items[i].issuerSchemaId` as claimed, sum their configured budgets into `remainingWei`, set the update nonce to `0`.
 
 For `claimAdditionalCredential`:
 
@@ -278,7 +278,7 @@ A previously-claimed credential in the same period under the same `nullifier` MU
 
 #### Example: Authorization and Budget Claim Flow
 
-Assume governance has configured the following credential budgets:
+Assume governance has configured the following credential budgets (Wei amounts shown in Gwei for readability; 1 Gwei = 10⁹ Wei):
 
 | Credential           | `issuerSchemaId` | Budget      |
 | -------------------- | ---------------- | ----------- |
@@ -344,13 +344,13 @@ To prevent congestion from all accounts submitting refresh proofs at the start o
 
 Note that the claim nullifiers of the same World ID across different periods cannot be linked. A user that wants a new on-chain pseudonym can simply authorize different addresses under the next period's `nullifier`; if a World ID authorizes independent addresses in each period, it remains fully anonymous across periods.
 
-### Gas Accounting Flow
+### Subsidy Accounting Flow
 
 For an incoming transaction:
 
 1. The protocol (or builder) looks up whether the sender address has an associated subsidy `nullifier` in the authorization map.
-2. If the address maps to more than one `nullifier`, a deterministic rule selects which record's budget to use. A [WIP-1001](./wip-1001.md) `0x1D` transaction MAY extend its envelope with an OPTIONAL `gas_nullifier` field; if present and the `world_id_account` is authorized under that `nullifier`, the declared budget is consumed.
-3. The budget is updated based on `gasUsed * baseFee` of the transaction.
+2. If the address maps to more than one `nullifier`, a deterministic rule selects which record's budget to use. A [WIP-1001](./wip-1001.md) `0x1D` transaction MAY extend its envelope with an OPTIONAL `subsidy_nullifier` field; if present and the `world_id_account` is authorized under that `nullifier`, the declared budget is consumed.
+3. The remaining ETH-denominated budget (`remainingWei`) is decremented by `gasUsed * baseFee` (Wei) of the transaction.
 
 `getBudget(address)` SHOULD apply the same deterministic nullifier-selection rule so off-chain callers observe the same effective budget that transaction execution would consume.
 
@@ -358,18 +358,18 @@ A `0x1D` transaction MAY also explicitly opt out of budget consumption via the s
 
 ### Claim Transaction Subsidy
 
-The claim-side mutations (`claimSubsidy`, `claimAdditionalCredential`, `updateAddresses`) themselves cost gas, and a user who has no native ETH on World Chain cannot pay for the very transaction that would mint their subsidy budget. The Gas Accounting component does not prescribe how this bootstrap gas is paid; deployments MAY adopt any of the following, or combine them:
+The claim-side mutations (`claimSubsidy`, `claimAdditionalCredential`, `updateAddresses`) themselves cost gas, and a user who has no native ETH on World Chain cannot pay for the very transaction that would mint their subsidy budget. The Subsidy Accounting component does not prescribe how this bootstrap gas is paid; deployments MAY adopt any of the following, or combine them:
 
 - **User-paid.** The claim transaction is paid in ETH by the caller like any ordinary transaction. Simplest; degenerates for users with zero ETH, which is the target population this system is designed to serve.
 - **Self-subsidized.** The protocol or builder simulates the claim, observes the resulting budget, and charges the claim transaction's own gas against it. Most aligned with the "no native ETH required" goal; requires execution-layer support for speculative simulation or a predictable upper bound on the claim's gas so the subsidy can be pre-deducted.
 - **Protocol-funded bootstrap allowance.** A small fixed allowance per `(rpId, nullifier, period)`, drawn from a protocol pool, covers just the claim transaction independently of the budget it ultimately mints. No simulation required; pool sizing and top-ups are a governance question.
 - **Relayer-paid.** An off-chain relayer (e.g. WorldApp infrastructure) submits and pays for the claim transaction and is reimbursed out of band. Orthogonal to on-chain accounting; decouples bootstrap from the protocol at the cost of a trusted or economically-incentivised relayer.
 
-Non-claim transactions consume budget through the [Gas Accounting Flow](#gas-accounting-flow) above; for the virtual base-fee discount mechanism consumed by those transactions see the sibling [WIP-1003](./wip-1003.md).
+Non-claim transactions consume budget through the [Subsidy Accounting Flow](#subsidy-accounting-flow) above; for the virtual base-fee discount mechanism consumed by those transactions see the sibling [WIP-1003](./wip-1003.md).
 
 ## Rationale
 
-**Gas accounting deployment flexibility.** The component is designed with an identical interface whether deployed as a precompile or a standard contract (e.g., predeploy). As a contract with builder-level enforcement, it avoids protocol changes and allows faster iteration. As a precompile, it enables in-protocol enforcement. Starting with a contract is a pragmatic first step; migration to a precompile is straightforward if needed.
+**Subsidy accounting deployment flexibility.** The component is designed with an identical interface whether deployed as a precompile or a standard contract (e.g., predeploy). As a contract with builder-level enforcement, it avoids protocol changes and allows faster iteration. As a precompile, it enables in-protocol enforcement. Starting with a contract is a pragmatic first step; migration to a precompile is straightforward if needed.
 
 **Nullifier-keyed budget records.** Keying budget, authorization, and claimed-credentials state by the per-period `nullifier` collapses what would otherwise be two independent state objects (a budget record and a nullifier-used set) into a single map whose existence is itself the per-period replay guard. `(nullifier, issuerSchemaId)` in the claimed-credentials map prevents double-claiming a specific credential; nullifier-record existence prevents re-opening a record under the same `nullifier`.
 
@@ -383,11 +383,11 @@ Non-claim transactions consume budget through the [Gas Accounting Flow](#gas-acc
 
 **Periodic refresh with early submission.** Fixed periods with expiring subsidies provide a clean budget lifecycle. Allowing early refresh prevents a thundering herd at period boundaries.
 
-**Orthogonality to World ID Accounts.** [WIP-1001](./wip-1001.md) *World ID Accounts* are authorized here like any other address — no special coupling is required. Legacy EOAs can opt in to gas subsidies without migrating account types, and World ID Accounts can sign `0x1D` transactions that either do or do not consume subsidized gas.
+**Orthogonality to World ID Accounts.** [WIP-1001](./wip-1001.md) *World ID Accounts* are authorized here like any other address — no special coupling is required. Legacy EOAs can opt in to fee subsidies without migrating account types, and World ID Accounts can sign `0x1D` transactions that either do or do not consume subsidy budget.
 
 ## Backwards Compatibility
 
-This WIP introduces a new protocol/builder-level accounting system. It does not modify the semantics of any existing transaction type. Any account type — legacy EOA, smart contract, or [WIP-1001](./wip-1001.md) World ID Account — may be authorized under a subsidy `nullifier` and thereby consume subsidized gas. Whether [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) transactions from authorized accounts can consume gas budgets is an open question (see optional requirements).
+This WIP introduces a new protocol/builder-level accounting system. It does not modify the semantics of any existing transaction type. Any account type — legacy EOA, smart contract, or [WIP-1001](./wip-1001.md) World ID Account — may be authorized under a subsidy `nullifier` and thereby have its transaction fees subsidized. Whether [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) transactions from authorized accounts can consume subsidy budgets is an open question (see optional requirements).
 
 ## Test Cases
 
@@ -403,7 +403,7 @@ This WIP introduces a new protocol/builder-level accounting system. It does not 
 
 **Refresh congestion.** Even with early refresh support, a significant fraction of users may refresh near period boundaries. Sub-period slots with proportional sub-budgets can mitigate traffic spikes.
 
-**Gas accounting trust boundary.** The `consumeBudget` method must be access-controlled. As a precompile, it must only be callable by the protocol during transaction execution. As a contract, it must be restricted to the builder's designated caller (e.g., via `onlyOwner` or a builder-specific access control mechanism).
+**Subsidy accounting trust boundary.** The `consumeBudget` method must be access-controlled. As a precompile, it must only be callable by the protocol during transaction execution. As a contract, it must be restricted to the builder's designated caller (e.g., via `onlyOwner` or a builder-specific access control mechanism).
 
 **Replay protection.** Per-period replay is enforced by two layers: existence of a `nullifier` record blocks re-opening under the same `nullifier`, and the per-record claimed-credentials map blocks double-claiming any specific `issuerSchemaId`. No separate "used nullifiers" set is needed.
 


### PR DESCRIPTION
Renames WIP-1002 from *WorldID Gas Accounting* to *WorldID Subsidy Accounting* and switches the budget denomination from gas units (Gwei) to ETH (Wei). The function-level interface signature for `consumeBudget(nullifier, gasUsed, baseFee)` is unchanged — only the budget unit it decrements (`remainingWei` instead of `remainingGwei`) and the configuration parameter (`budgetWei` instead of `budgetGwei`) move from gas to Wei.

## Why

- "Gas accounting" implied a gas-unit-denominated budget, which constrains how a budget can be sized and refreshed. Denominating in ETH gives governance more flexibility to fold in factors like L1 blob-fee price or DeFi congestion when sizing budgets.
- "Subsidy accounting" is a more accurate name for what the component does — it accounts for an ETH-denominated subsidy that happens to be spent on transaction fees.

## Scope of changes

- `wips/wip-1002.md`
  - Front-matter `title` and `description`.
  - Abstract and Motivation paragraphs.
  - Section headings: \`Gas Accounting Interface\` → \`Subsidy Accounting Interface\`, \`Gas Budget Map\` → \`Subsidy Budget Map\`, \`Gas Accounting Flow\` → \`Subsidy Accounting Flow\`, plus internal anchor links updated.
  - Solidity interface: \`IGasAccounting\` → \`ISubsidyAccounting\`; \`remainingGwei\` → \`remainingWei\`; \`budgetGwei\` → \`budgetWei\`; NatSpec comments updated.
  - Subsidy Accounting Flow: \`gas_nullifier\` envelope hint → \`subsidy_nullifier\`.
  - Example budget table now clarifies that values are Wei, shown in Gwei for readability (1 Gwei = 10⁹ Wei).
  - Rationale, Backwards Compatibility, and Security Considerations headings/prose updated for consistency.
- \`wips/README.md\`: index entry retitled.
