### PR TITLE
fix: normalize OP payload IDs to v3

### DIFF
--- a/crates/payload/src/generator.rs
+++ b/crates/payload/src/generator.rs
@@ -28,6 +28,7 @@ use world_chain_p2p::protocol::handler::FlashblocksHandle;
 use world_chain_primitives::{
     access_list::FlashblockAccessList, ed25519_dalek::SigningKey,
     flashblocks::recovered_block_from_flashblocks, p2p::Authorization,
+    payload_id::force_op_payload_id_v3,
 };
 
 use crate::job::{CommittedPayloadState, FlashblocksPayloadJob};
@@ -152,6 +153,8 @@ where
         input: BuildNewPayload<Builder::Attributes>,
         id: PayloadId,
     ) -> Result<Self::Job, PayloadBuilderError> {
+        let id = force_op_payload_id_v3(id);
+
         let parent_header = if input.parent_hash.is_zero() {
             // Use latest header for genesis block case
             self.client

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -4,6 +4,7 @@ pub mod access_list;
 pub mod error;
 pub mod flashblocks;
 pub mod p2p;
+pub mod payload_id;
 pub mod primitives;
 pub mod transaction;
 pub use ed25519_dalek;

--- a/crates/primitives/src/payload_id.rs
+++ b/crates/primitives/src/payload_id.rs
@@ -1,0 +1,63 @@
+use alloy_rpc_types_engine::PayloadId;
+
+const OP_ENGINE_PAYLOAD_ID_V3: u8 = 0x03;
+const OP_ENGINE_PAYLOAD_ID_V4: u8 = 0x04;
+
+/// Temporary compatibility fix for op-reth v2.1.0, which derives OP payload IDs
+/// with `EngineApiMessageVersion::default()` and currently defaults to V4.
+pub fn force_op_payload_id_v3(id: PayloadId) -> PayloadId {
+    payload_id_with_version(id, OP_ENGINE_PAYLOAD_ID_V3)
+}
+
+/// Converts the externally visible V3 payload ID back to the V4 ID currently used
+/// by reth's payload service as the internal job lookup key.
+pub fn op_reth_payload_id_v4_lookup(id: PayloadId) -> PayloadId {
+    let bytes = payload_id_bytes(id);
+    if bytes[0] == OP_ENGINE_PAYLOAD_ID_V3 {
+        payload_id_with_version(id, OP_ENGINE_PAYLOAD_ID_V4)
+    } else {
+        id
+    }
+}
+
+fn payload_id_with_version(id: PayloadId, version: u8) -> PayloadId {
+    let mut bytes = payload_id_bytes(id);
+    bytes[0] = version;
+    PayloadId::new(bytes)
+}
+
+fn payload_id_bytes(id: PayloadId) -> [u8; 8] {
+    id.0.into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn forces_first_byte_to_v3() {
+        let id = PayloadId::new([0x04, 1, 2, 3, 4, 5, 6, 7]);
+
+        assert_eq!(
+            force_op_payload_id_v3(id),
+            PayloadId::new([0x03, 1, 2, 3, 4, 5, 6, 7])
+        );
+    }
+
+    #[test]
+    fn maps_external_v3_id_to_internal_v4_lookup() {
+        let id = PayloadId::new([0x03, 1, 2, 3, 4, 5, 6, 7]);
+
+        assert_eq!(
+            op_reth_payload_id_v4_lookup(id),
+            PayloadId::new([0x04, 1, 2, 3, 4, 5, 6, 7])
+        );
+    }
+
+    #[test]
+    fn leaves_non_v3_lookup_ids_unchanged() {
+        let id = PayloadId::new([0x09, 1, 2, 3, 4, 5, 6, 7]);
+
+        assert_eq!(op_reth_payload_id_v4_lookup(id), id);
+    }
+}

--- a/crates/rpc/src/engine.rs
+++ b/crates/rpc/src/engine.rs
@@ -15,7 +15,10 @@ use reth_provider::{BlockReader, HeaderProvider, StateProviderFactory};
 use reth_rpc_api::IntoEngineApiRpcModule;
 use reth_transaction_pool::TransactionPool;
 use tracing::trace;
-use world_chain_primitives::p2p::Authorization;
+use world_chain_primitives::{
+    p2p::Authorization,
+    payload_id::{force_op_payload_id_v3, op_reth_payload_id_v4_lookup},
+};
 
 #[derive(Debug, Clone)]
 pub struct OpEngineApiExt<Provider, EngineT: EngineTypes, Pool, Validator, ChainSpec> {
@@ -115,9 +118,12 @@ where
             to_jobs_gen.send_modify(|b| *b = None)
         }
 
-        self.inner
+        let mut response = self
+            .inner
             .fork_choice_updated_v3(fork_choice_state, payload_attributes)
-            .await
+            .await?;
+        response.payload_id = response.payload_id.map(force_op_payload_id_v3);
+        Ok(response)
     }
 
     async fn get_payload_v2(
@@ -131,14 +137,20 @@ where
         &self,
         payload_id: PayloadId,
     ) -> RpcResult<EngineT::ExecutionPayloadEnvelopeV3> {
-        Ok(self.inner.get_payload_v3(payload_id).await?)
+        Ok(self
+            .inner
+            .get_payload_v3(op_reth_payload_id_v4_lookup(payload_id))
+            .await?)
     }
 
     async fn get_payload_v4(
         &self,
         payload_id: PayloadId,
     ) -> RpcResult<EngineT::ExecutionPayloadEnvelopeV4> {
-        Ok(self.inner.get_payload_v4(payload_id).await?)
+        Ok(self
+            .inner
+            .get_payload_v4(op_reth_payload_id_v4_lookup(payload_id))
+            .await?)
     }
 
     async fn get_payload_bodies_by_hash_v1(
@@ -245,8 +257,11 @@ where
             to_jobs_gen.send_modify(|b| *b = Some(a))
         }
 
-        self.inner
+        let mut response = self
+            .inner
             .fork_choice_updated_v3(fork_choice_state, payload_attributes)
-            .await
+            .await?;
+        response.payload_id = response.payload_id.map(force_op_payload_id_v3);
+        Ok(response)
     }
 }


### PR DESCRIPTION
### Problem

After upgrading to `reth v2.0.0` and `op-reth v2.1.0`, OP payload IDs are derived with the default engine API version, which is now `V4`. Rollup Boost still sends V3 flashblocks payload IDs, causing authorization IDs like `0x03...` to mismatch node-derived IDs like `0x04...` and preventing block building from starting.

`op-reth` issue: https://github.com/ethereum-optimism/optimism/issues/20226

### Solution

Add a temporary world-chain compatibility fix that exposes and compares OP payload IDs with a `V3` prefix for flashblocks and forkchoice responses, while translating `V3` IDs back to `V4` when calling op-reth `getPayload` internals so existing payload job lookup still works.

### Notes

I've tested this on my local devnet and it works smoothly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches engine RPC responses and payload job ID handling; incorrect mapping could break payload lookup/building or cause clients to request the wrong payload IDs.
> 
> **Overview**
> Normalizes OP `PayloadId` handling to address a V3/V4 prefix mismatch after the op-reth upgrade.
> 
> Adds `world_chain_primitives::payload_id` helpers to **force V3 IDs for external surfaces** and to **map V3 back to V4 for internal op-reth job lookup**, then applies this in the flashblocks payload job generator and in `engine` RPC (`forkchoiceUpdatedV3` responses and `getPayloadV3/V4` requests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d37f470fc56a695eb512b474407444e3714c9bc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->