### PR TITLE
fix: deprecate eth_sendRawTransactionConditional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13116,7 +13116,6 @@ dependencies = [
  "world-chain-p2p",
  "world-chain-pool",
  "world-chain-primitives",
- "world-chain-rpc",
  "world-chain-test-utils",
 ]
 

--- a/crates/builder/Cargo.toml
+++ b/crates/builder/Cargo.toml
@@ -6,6 +6,11 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
+# internal 
+world-chain-primitives.workspace = true
+world-chain-p2p.workspace = true
+world-chain-pool.workspace = true
+
 # reth
 reth-basic-payload-builder.workspace = true
 reth-chain-state.workspace = true
@@ -39,11 +44,6 @@ op-alloy-consensus.workspace = true
 op-alloy-rpc-types.workspace = true
 alloy-op-evm.workspace = true
 alloy-rpc-types-engine.workspace = true
-
-world-chain-primitives.workspace = true
-world-chain-p2p.workspace = true
-world-chain-pool.workspace = true
-world-chain-rpc.workspace = true
 
 # revm
 revm.workspace = true

--- a/crates/builder/src/execution_context.rs
+++ b/crates/builder/src/execution_context.rs
@@ -308,20 +308,6 @@ where
                 continue;
             }
 
-            if let Some(conditional_options) = pooled_tx.conditional_options()
-                && world_chain_rpc::transactions::validate_conditional_options(
-                    conditional_options,
-                    &self.client,
-                )
-                .is_err()
-            {
-                attempt_metrics
-                    .increment_rejection(PayloadBuildRejectionReason::ConditionalInvalid);
-                best_txs.mark_invalid(tx.signer(), tx.nonce());
-                invalid_txs.push(*pooled_tx.hash());
-                continue;
-            }
-
             // A sequencer's block should never contain blob or deposit transactions from the pool.
             if tx.is_eip4844() || tx.is_deposit() {
                 attempt_metrics.increment_rejection(PayloadBuildRejectionReason::BlobOrDeposit);

--- a/crates/rpc/src/core.rs
+++ b/crates/rpc/src/core.rs
@@ -1,6 +1,5 @@
 use crate::{EthTransactionsExt, sequencer::SequencerClient};
 use alloy_primitives::{B256, Bytes};
-use alloy_rpc_types::erc4337::TransactionConditional;
 use jsonrpsee::{
     core::{RpcResult, async_trait},
     proc_macros::rpc,
@@ -24,14 +23,6 @@ pub trait EthApiExt {
     /// Sends a raw transaction to the pool
     #[method(name = "sendRawTransaction")]
     async fn send_raw_transaction(&self, tx: Bytes) -> RpcResult<B256>;
-
-    /// Sends a raw conditional transaction to the pool
-    #[method(name = "sendRawTransactionConditional")]
-    async fn send_raw_transaction_conditional(
-        &self,
-        tx: Bytes,
-        options: TransactionConditional,
-    ) -> RpcResult<B256>;
 }
 
 #[async_trait]
@@ -42,13 +33,5 @@ where
 {
     async fn send_raw_transaction(&self, tx: Bytes) -> RpcResult<B256> {
         Ok(EthTransactionsExt::send_raw_transaction(self, tx).await?)
-    }
-
-    async fn send_raw_transaction_conditional(
-        &self,
-        tx: Bytes,
-        options: TransactionConditional,
-    ) -> RpcResult<B256> {
-        Ok(EthTransactionsExt::send_raw_transaction_conditional(self, tx, options).await?)
     }
 }

--- a/crates/rpc/src/transactions.rs
+++ b/crates/rpc/src/transactions.rs
@@ -1,20 +1,12 @@
 use std::error::Error;
 
-use alloy_consensus::BlockHeader;
-use alloy_eips::BlockId;
-use alloy_primitives::{StorageKey, map::HashMap};
-use alloy_rpc_types::erc4337::{AccountStorage, TransactionConditional};
-use jsonrpsee::{
-    core::{RpcResult, async_trait},
-    types::{ErrorCode, ErrorObject, ErrorObjectOwned},
-};
+use jsonrpsee::core::async_trait;
 use reth_optimism_node::txpool::OpPooledTransaction;
-use reth_primitives_traits::Block;
 use reth_provider::{BlockReaderIdExt, StateProviderFactory};
 use reth_rpc_eth_api::{AsEthApiError, FromEthApiError};
 use reth_rpc_eth_types::{EthApiError, utils::recover_raw_transaction};
 use reth_transaction_pool::{PoolTransaction, TransactionOrigin, TransactionPool};
-use revm_primitives::{Address, B256, Bytes, FixedBytes, map::FbBuildHasher};
+use revm_primitives::{B256, Bytes};
 use world_chain_pool::tx::WorldChainPooledTransaction;
 
 use crate::{core::WorldChainEthApiExt, sequencer::SequencerClient};
@@ -29,12 +21,6 @@ pub trait EthTransactionsExt {
         + Send
         + Sync;
 
-    async fn send_raw_transaction_conditional(
-        &self,
-        tx: Bytes,
-        options: TransactionConditional,
-    ) -> Result<B256, Self::Error>;
-
     async fn send_raw_transaction(&self, tx: Bytes) -> Result<B256, Self::Error>;
 }
 
@@ -45,34 +31,6 @@ where
     Client: BlockReaderIdExt + StateProviderFactory + 'static,
 {
     type Error = EthApiError;
-
-    async fn send_raw_transaction_conditional(
-        &self,
-        tx: Bytes,
-        options: TransactionConditional,
-    ) -> Result<B256, Self::Error> {
-        validate_conditional_options(&options, self.provider()).map_err(Self::Error::other)?;
-
-        let recovered = recover_raw_transaction(&tx)?;
-        let mut pool_transaction: WorldChainPooledTransaction =
-            OpPooledTransaction::from_pooled(recovered).into();
-        pool_transaction.inner = pool_transaction.inner.with_conditional(options.clone());
-
-        // submit the transaction to the pool with a `Local` origin
-        let outcome = self
-            .pool()
-            .add_transaction(TransactionOrigin::Local, pool_transaction)
-            .await
-            .map_err(Self::Error::from_eth_err)?;
-
-        if let Some(client) = self.raw_tx_forwarder().as_ref() {
-            tracing::debug!( target: "rpc::eth",  "forwarding raw conditional transaction to");
-            let _ = client.forward_raw_transaction_conditional(&tx, options).await.inspect_err(|err| {
-                        tracing::debug!(target: "rpc::eth", %err, hash=?*outcome.hash, "failed to forward raw conditional transaction");
-                    });
-        }
-        Ok(outcome.hash)
-    }
 
     async fn send_raw_transaction(&self, tx: Bytes) -> Result<B256, Self::Error> {
         let recovered = recover_raw_transaction(&tx)?;
@@ -120,108 +78,4 @@ where
     pub fn raw_tx_forwarder(&self) -> Option<&SequencerClient> {
         self.sequencer_client.as_ref()
     }
-}
-
-/// Validates the conditional inclusion options provided by the client.
-///
-/// reference for the implementation <https://notes.ethereum.org/@yoav/SkaX2lS9j#>
-/// See also <https://pkg.go.dev/github.com/aK0nshin/go-ethereum/arbitrum_types#ConditionalOptions>
-pub fn validate_conditional_options<Client>(
-    options: &TransactionConditional,
-    provider: &Client,
-) -> RpcResult<()>
-where
-    Client: BlockReaderIdExt + StateProviderFactory,
-{
-    let latest = provider
-        .block_by_id(BlockId::latest())
-        .map_err(|e| ErrorObject::owned(ErrorCode::InternalError.code(), e.to_string(), Some("")))?
-        .ok_or(ErrorObjectOwned::from(ErrorCode::InternalError))?;
-
-    let block_number = latest.header().number();
-    let block_timestamp = latest.header().timestamp();
-    if let Some(min_block) = options.block_number_min
-        && min_block > block_number
-    {
-        return Err(ErrorCode::from(-32003).into());
-    }
-
-    if let Some(max_block) = options.block_number_max
-        && max_block < block_number
-    {
-        return Err(ErrorCode::from(-32003).into());
-    }
-
-    if let Some(min_timestamp) = options.timestamp_min
-        && min_timestamp > block_timestamp
-    {
-        return Err(ErrorCode::from(-32003).into());
-    }
-
-    if let Some(max_timestamp) = options.timestamp_max
-        && max_timestamp < block_timestamp
-    {
-        return Err(ErrorCode::from(-32003).into());
-    }
-
-    validate_known_accounts(
-        &options.known_accounts,
-        latest.header().number().into(),
-        provider,
-    )?;
-
-    Ok(())
-}
-
-/// Validates the account storage slots/storage root provided by the client
-///
-/// Matches the current state of the account storage slots/storage root.
-pub fn validate_known_accounts<Client>(
-    known_accounts: &HashMap<Address, AccountStorage, FbBuildHasher<20>>,
-    latest: BlockId,
-    provider: &Client,
-) -> RpcResult<()>
-where
-    Client: BlockReaderIdExt + StateProviderFactory,
-{
-    let state = provider.state_by_block_id(latest).map_err(|e| {
-        ErrorObject::owned(ErrorCode::InternalError.code(), e.to_string(), Some(""))
-    })?;
-
-    for (address, storage) in known_accounts.iter() {
-        match storage {
-            AccountStorage::Slots(slots) => {
-                for (slot, value) in slots.iter() {
-                    let current =
-                        state
-                            .storage(*address, StorageKey::from(*slot))
-                            .map_err(|e| {
-                                ErrorObject::owned(
-                                    ErrorCode::InternalError.code(),
-                                    e.to_string(),
-                                    Some(""),
-                                )
-                            })?;
-                    if let Some(current) = current {
-                        if FixedBytes::<32>::from_slice(&current.to_be_bytes::<32>()) != *value {
-                            return Err(ErrorCode::from(-32003).into());
-                        }
-                    } else {
-                        return Err(ErrorCode::from(-32003).into());
-                    }
-                }
-            }
-            AccountStorage::RootHash(expected) => {
-                let root = state
-                    .storage_root(*address, Default::default())
-                    .map_err(|e| {
-                        ErrorObject::owned(ErrorCode::InternalError.code(), e.to_string(), Some(""))
-                    })?;
-                if *expected != root {
-                    return Err(ErrorCode::from(-32003).into());
-                }
-            }
-        }
-    }
-    Ok(())
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes RPC surface area and transaction acceptance rules; clients relying on conditional submission or builders depending on conditional validation may see behavior changes or compatibility issues.
> 
> **Overview**
> This PR **deprecates conditional transaction submission** by removing the `eth_sendRawTransactionConditional` RPC method and the associated `send_raw_transaction_conditional` plumbing, including conditional forwarding to the sequencer.
> 
> It also deletes conditional-option validation from the payload builder (no longer rejecting pooled transactions based on `conditional_options`) and drops the `world-chain-rpc` dependency from `world-chain-builder`/lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb1ad6a5eb81bff726caccd73e63013aeef95f09. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->