### PR TITLE
Osiris/revert commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13116,7 +13116,6 @@ dependencies = [
  "world-chain-p2p",
  "world-chain-pool",
  "world-chain-primitives",
- "world-chain-rpc",
  "world-chain-test-utils",
 ]
 

--- a/crates/builder/Cargo.toml
+++ b/crates/builder/Cargo.toml
@@ -6,6 +6,11 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
+# internal 
+world-chain-primitives.workspace = true
+world-chain-p2p.workspace = true
+world-chain-pool.workspace = true
+
 # reth
 reth-basic-payload-builder.workspace = true
 reth-chain-state.workspace = true
@@ -39,11 +44,6 @@ op-alloy-consensus.workspace = true
 op-alloy-rpc-types.workspace = true
 alloy-op-evm.workspace = true
 alloy-rpc-types-engine.workspace = true
-
-world-chain-primitives.workspace = true
-world-chain-p2p.workspace = true
-world-chain-pool.workspace = true
-world-chain-rpc.workspace = true
 
 # revm
 revm.workspace = true

--- a/crates/builder/src/execution_context.rs
+++ b/crates/builder/src/execution_context.rs
@@ -308,20 +308,6 @@ where
                 continue;
             }
 
-            if let Some(conditional_options) = pooled_tx.conditional_options()
-                && world_chain_rpc::transactions::validate_conditional_options(
-                    conditional_options,
-                    &self.client,
-                )
-                .is_err()
-            {
-                attempt_metrics
-                    .increment_rejection(PayloadBuildRejectionReason::ConditionalInvalid);
-                best_txs.mark_invalid(tx.signer(), tx.nonce());
-                invalid_txs.push(*pooled_tx.hash());
-                continue;
-            }
-
             // A sequencer's block should never contain blob or deposit transactions from the pool.
             if tx.is_eip4844() || tx.is_deposit() {
                 attempt_metrics.increment_rejection(PayloadBuildRejectionReason::BlobOrDeposit);

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -1028,6 +1028,51 @@ mod tests {
     }
 
     #[test]
+    fn envelope_wip1001_eddsa_round_trip_and_recover() {
+        use ed25519_dalek::Signer;
+
+        let signing_key = ed25519_dalek::SigningKey::from_bytes(&[0xAB; 32]);
+        let verifying_key = signing_key.verifying_key();
+        let session_key_bytes = verifying_key.to_bytes();
+
+        let keyring = address!("000000000000000000000000000000000000001d");
+        let tx = TxWip1001 {
+            chain_id: 480,
+            nonce: 11,
+            max_priority_fee_per_gas: 2_000_000_000,
+            max_fee_per_gas: 4_000_000_000,
+            gas_limit: 100_000,
+            to: address!("6069a6c32cf691f5982febae4faf8a6f3ab2f0f6").into(),
+            value: U256::from(123u64),
+            input: hex!("c0ffee").into(),
+            access_list: AccessList::default(),
+            world_id_account: keyring,
+            signature_type: Wip1001Signature::EDDSA_TYPE,
+            session_key: Bytes::copy_from_slice(&session_key_bytes),
+        };
+
+        let signing_hash = tx.signing_hash();
+        let sig = signing_key.sign(signing_hash.as_slice());
+        let signature = Wip1001Signature::EdDSA(sig);
+
+        let signed = SignedWip1001::new_signed(tx.clone(), signature.clone());
+        let envelope: WorldChainTxEnvelope = signed.into();
+
+        let mut buf = Vec::new();
+        envelope.encode_2718(&mut buf);
+        let decoded = WorldChainTxEnvelope::decode_2718(&mut buf.as_slice()).expect("decode_2718");
+        assert!(decoded.is_wip1001());
+        assert_eq!(decoded.hash(), envelope.hash());
+        let decoded_wip = decoded.as_wip1001().expect("is wip1001");
+        assert_eq!(decoded_wip.tx(), &tx);
+        assert_eq!(decoded_wip.signature(), &signature);
+
+        // recover_signer verifies the EdDSA signature and returns the keyring.
+        let recovered = envelope.recover_signer().expect("recover");
+        assert_eq!(recovered, keyring);
+    }
+
+    #[test]
     fn envelope_wip1001_via_typed_transaction_path() {
         // Exercise the `Signed<WorldChainTypedTransaction>` -> `WorldChainTxEnvelope`
         // conversion for the WIP-1001 variant: the default secp256k1 Signature

--- a/crates/primitives/src/transaction/keyring.rs
+++ b/crates/primitives/src/transaction/keyring.rs
@@ -1,12 +1,10 @@
-//! Authorization lookup against the WIP-1001 Key Ring registry.
+//! Authorization lookup against the WIP-1001 keyring registry.
 //!
-//! A *Key Ring* is the set of session keys authorized to sign on behalf of a
-//! given *World ID Account* address. [`KeyringRegistry`] is the interface between
-//! the [signature verifier](super::verify) and whatever holds the
-//! precompile-managed Key Ring state — the pool's state provider, the
-//! builder, the RPC layer, or a test double. It deliberately mirrors
-//! `IWorldIDAccount.isAuthorized` from the spec so the eventual
-//! precompile-backed implementation is a thin adapter.
+//! [`KeyringRegistry`] is the interface between the [signature
+//! verifier](super::verify) and whatever holds the precompile-managed keyring
+//! state — the pool's state provider, the builder, the RPC layer, or a test
+//! double. It deliberately mirrors `IWorldIDKeyRing.isAuthorized` from the
+//! spec so the eventual precompile-backed implementation is a thin adapter.
 //!
 //! [`validate_wip1001`] is the one-stop entry point that callers (pool,
 //! builder, RPC) should use: it computes the signing hash, runs the per-scheme
@@ -19,8 +17,7 @@ use crate::transaction::{
     SessionKey, TxWip1001, Wip1001Signature, Wip1001VerifyError, verify_wip1001_signature,
 };
 
-/// Read-only view of the precompile-managed Key Ring state, indexed by
-/// World ID Account address.
+/// Read-only view of the precompile-managed keyring state.
 ///
 /// Implementors translate `is_authorized` into a state lookup at the current
 /// block height. The trait is sync because pool/builder admission paths are
@@ -32,11 +29,11 @@ pub trait KeyringRegistry {
     /// pending or rejected accordingly.
     type Error;
 
-    /// Returns `Ok(true)` iff `session_key` is currently in the Key Ring of
-    /// the World ID Account at `world_id_account`.
+    /// Returns `Ok(true)` iff `session_key` is currently in the authorized set
+    /// of `keyring`.
     fn is_authorized(
         &self,
-        world_id_account: Address,
+        keyring: Address,
         session_key: &SessionKey,
     ) -> Result<bool, Self::Error>;
 }
@@ -53,19 +50,18 @@ pub enum Wip1001ValidationError<E> {
     /// rejected or pending.
     #[error("keyring registry lookup failed: {0}")]
     Registry(E),
-    /// Signature is valid but the recovered session key is not in the Key
-    /// Ring of the declared World ID Account at the current state height.
-    #[error("session key is not authorized for world ID account {world_id_account}")]
+    /// Signature is valid but the recovered session key is not in the
+    /// keyring's authorized set at the current state height.
+    #[error("session key is not authorized for keyring {keyring}")]
     NotAuthorized {
-        /// The World ID Account address whose Key Ring did not contain the
-        /// recovered session key.
-        world_id_account: Address,
+        /// The keyring address that the unauthorized key was presented for.
+        keyring: Address,
     },
 }
 
 /// Verify a WIP-1001 transaction's signature against its embedded
 /// `session_key`, then assert that the registry authorizes the key for the
-/// declared World ID Account's Key Ring.
+/// declared keyring.
 ///
 /// On success returns the typed [`SessionKey`] that was bound to the
 /// signature, ready to be passed onward to gas/nonce accounting.
@@ -85,7 +81,7 @@ pub fn validate_wip1001<R: KeyringRegistry>(
     match registry.is_authorized(tx.world_id_account, &session_key) {
         Ok(true) => Ok(session_key),
         Ok(false) => Err(Wip1001ValidationError::NotAuthorized {
-            world_id_account: tx.world_id_account,
+            keyring: tx.world_id_account,
         }),
         Err(e) => Err(Wip1001ValidationError::Registry(e)),
     }
@@ -115,19 +111,15 @@ mod mock {
             Self::default()
         }
 
-        /// Authorizes `key` on the Key Ring of `world_id_account`. Idempotent.
-        pub fn authorize(&mut self, world_id_account: Address, key: SessionKey) {
-            self.authorized
-                .entry(world_id_account)
-                .or_default()
-                .insert(key);
+        /// Authorizes `key` on `keyring`. Idempotent.
+        pub fn authorize(&mut self, keyring: Address, key: SessionKey) {
+            self.authorized.entry(keyring).or_default().insert(key);
         }
 
-        /// Revokes `key` from the Key Ring of `world_id_account`. Returns `true`
-        /// if a removal occurred.
-        pub fn revoke(&mut self, world_id_account: Address, key: &SessionKey) -> bool {
+        /// Revokes `key` on `keyring`. Returns `true` if a removal occurred.
+        pub fn revoke(&mut self, keyring: Address, key: &SessionKey) -> bool {
             self.authorized
-                .get_mut(&world_id_account)
+                .get_mut(&keyring)
                 .map(|set| set.remove(key))
                 .unwrap_or(false)
         }
@@ -138,12 +130,12 @@ mod mock {
 
         fn is_authorized(
             &self,
-            world_id_account: Address,
+            keyring: Address,
             session_key: &SessionKey,
         ) -> Result<bool, Self::Error> {
             Ok(self
                 .authorized
-                .get(&world_id_account)
+                .get(&keyring)
                 .is_some_and(|set| set.contains(session_key)))
         }
     }
@@ -175,7 +167,7 @@ mod tests {
         type Error = LookupFailed;
         fn is_authorized(
             &self,
-            _world_id_account: Address,
+            _keyring: Address,
             _session_key: &SessionKey,
         ) -> Result<bool, Self::Error> {
             Err(LookupFailed)
@@ -244,25 +236,25 @@ mod tests {
     #[test]
     fn validate_rejects_unauthorized_key() {
         let (tx, sig, _key) = signed_p256();
-        // Empty registry — key is not in any Key Ring.
+        // Empty registry — key is not authorized.
         let registry = MockKeyringRegistry::new();
         let err = validate_wip1001(&tx, &sig, &registry).expect_err("must reject");
         assert!(matches!(
             err,
-            Wip1001ValidationError::NotAuthorized { world_id_account } if world_id_account == tx.world_id_account
+            Wip1001ValidationError::NotAuthorized { keyring } if keyring == tx.world_id_account
         ));
     }
 
     #[test]
-    fn validate_rejects_when_authorized_for_different_world_id_account() {
+    fn validate_rejects_when_authorized_for_different_keyring() {
         let (tx, sig, key) = signed_p256();
         let mut registry = MockKeyringRegistry::new();
-        // Authorize the key on a *different* World ID Account's Key Ring.
+        // Authorize the key on a *different* keyring.
         registry.authorize(Address::with_last_byte(0xAA), key);
         let err = validate_wip1001(&tx, &sig, &registry).expect_err("must reject");
         assert!(matches!(
             err,
-            Wip1001ValidationError::NotAuthorized { world_id_account } if world_id_account == tx.world_id_account
+            Wip1001ValidationError::NotAuthorized { keyring } if keyring == tx.world_id_account
         ));
     }
 
@@ -301,14 +293,14 @@ mod tests {
     #[test]
     fn mock_revoke_round_trip() {
         let (_, _, key) = signed_p256();
-        let acct = address!("00000000000000000000000000000000000000aa");
+        let kr = address!("00000000000000000000000000000000000000aa");
         let mut registry = MockKeyringRegistry::new();
-        registry.authorize(acct, key.clone());
-        assert!(registry.is_authorized(acct, &key).unwrap());
-        assert!(registry.revoke(acct, &key));
-        assert!(!registry.is_authorized(acct, &key).unwrap());
+        registry.authorize(kr, key.clone());
+        assert!(registry.is_authorized(kr, &key).unwrap());
+        assert!(registry.revoke(kr, &key));
+        assert!(!registry.is_authorized(kr, &key).unwrap());
         // Idempotent revoke.
-        assert!(!registry.revoke(acct, &key));
+        assert!(!registry.revoke(kr, &key));
     }
 
     use std::convert::Infallible;

--- a/crates/primitives/src/transaction/signature.rs
+++ b/crates/primitives/src/transaction/signature.rs
@@ -1,3 +1,5 @@
+use core::hash::{Hash, Hasher};
+
 use alloy_primitives::{B256, Bytes, Signature, U256, bytes::BufMut};
 use alloy_rlp::{Decodable, Encodable, Header};
 
@@ -18,10 +20,7 @@ pub const ED25519_PUBKEY_LEN: usize = 32;
 /// Ed25519 key. The `signature_type` byte and `session_key` bytes live on
 /// [`TxWip1001`] (covered by `signing_hash`); this enum carries only the
 /// scheme-specific signature payload.
-///
-/// Ed25519 is intentionally not yet implemented — the wire format is reserved
-/// for a follow-on PR.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "signatureType", content = "signaturePayload")]
 #[non_exhaustive]
 pub enum Wip1001Signature {
@@ -40,6 +39,12 @@ pub enum Wip1001Signature {
     /// `signature_payload = rlp([authenticator_data, client_data_json, r, s])`.
     #[serde(rename = "0x2")]
     WebAuthn(WebAuthnSignature),
+    /// Ed25519 EdDSA over edwards25519, `signature_type = 0x03`.
+    ///
+    /// `signature_payload = rlp([R, s])` — where `R || s` is the canonical
+    /// 64-byte [`ed25519_dalek::Signature`].
+    #[serde(rename = "0x3")]
+    EdDSA(ed25519_dalek::Signature),
 }
 
 /// Raw P-256 ECDSA `(r, s)` signature pair.
@@ -75,7 +80,7 @@ impl Wip1001Signature {
     pub const P256_TYPE: u8 = 0x01;
     /// `signature_type` byte for the WebAuthn variant.
     pub const WEBAUTHN_TYPE: u8 = 0x02;
-    /// `signature_type` byte for the EdDSA variant (reserved).
+    /// `signature_type` byte for the EdDSA variant.
     pub const EDDSA_TYPE: u8 = 0x03;
 
     /// Returns the `signature_type` tag byte for this variant.
@@ -85,6 +90,7 @@ impl Wip1001Signature {
             Self::Secp256k1(_) => Self::SECP256K1_TYPE,
             Self::P256(_) => Self::P256_TYPE,
             Self::WebAuthn(_) => Self::WEBAUTHN_TYPE,
+            Self::EdDSA(_) => Self::EDDSA_TYPE,
         }
     }
 
@@ -108,6 +114,14 @@ impl Wip1001Signature {
     pub const fn as_webauthn(&self) -> Option<&WebAuthnSignature> {
         match self {
             Self::WebAuthn(sig) => Some(sig),
+            _ => None,
+        }
+    }
+
+    /// Returns the inner [`ed25519_dalek::Signature`] if this is the `EdDSA` variant.
+    pub const fn as_eddsa(&self) -> Option<&ed25519_dalek::Signature> {
+        match self {
+            Self::EdDSA(sig) => Some(sig),
             _ => None,
         }
     }
@@ -147,6 +161,17 @@ impl Wip1001Signature {
                 }
                 .length_with_payload()
             }
+            Self::EdDSA(sig) => {
+                let bytes = sig.to_bytes();
+                let r = U256::from_be_bytes::<32>(bytes[..32].try_into().expect("32 bytes"));
+                let s = U256::from_be_bytes::<32>(bytes[32..].try_into().expect("32 bytes"));
+                let list_payload_len = r.length() + s.length();
+                Header {
+                    list: true,
+                    payload_length: list_payload_len,
+                }
+                .length_with_payload()
+            }
         }
     }
 
@@ -156,6 +181,7 @@ impl Wip1001Signature {
     /// - secp256k1: `rlp([y_parity, r, s])`
     /// - P256: `rlp([r, s])`
     /// - WebAuthn: `rlp([authenticator_data, client_data_json, r, s])`
+    /// - EdDSA: `rlp([R, s])` where `R || s` is the canonical 64-byte signature
     pub(crate) fn encode_payload_raw(&self, out: &mut dyn BufMut) {
         match self {
             Self::Secp256k1(sig) => {
@@ -196,6 +222,19 @@ impl Wip1001Signature {
                 .encode(out);
                 sig.authenticator_data.0.encode(out);
                 sig.client_data_json.0.encode(out);
+                r.encode(out);
+                s.encode(out);
+            }
+            Self::EdDSA(sig) => {
+                let bytes = sig.to_bytes();
+                let r = U256::from_be_bytes::<32>(bytes[..32].try_into().expect("32 bytes"));
+                let s = U256::from_be_bytes::<32>(bytes[32..].try_into().expect("32 bytes"));
+                let list_payload_len = r.length() + s.length();
+                Header {
+                    list: true,
+                    payload_length: list_payload_len,
+                }
+                .encode(out);
                 r.encode(out);
                 s.encode(out);
             }
@@ -273,9 +312,46 @@ impl Wip1001Signature {
                     s: B256::from(s.to_be_bytes::<32>()),
                 }))
             }
+            Self::EDDSA_TYPE => {
+                let header = Header::decode(buf)?;
+                if !header.list {
+                    return Err(alloy_rlp::Error::UnexpectedString);
+                }
+                let start = buf.len();
+                let r: U256 = Decodable::decode(buf)?;
+                let s: U256 = Decodable::decode(buf)?;
+                let consumed = start - buf.len();
+                if consumed != header.payload_length {
+                    return Err(alloy_rlp::Error::ListLengthMismatch {
+                        expected: header.payload_length,
+                        got: consumed,
+                    });
+                }
+                let mut sig_bytes = [0u8; 64];
+                sig_bytes[..32].copy_from_slice(&r.to_be_bytes::<32>());
+                sig_bytes[32..].copy_from_slice(&s.to_be_bytes::<32>());
+                Ok(Self::EdDSA(ed25519_dalek::Signature::from_bytes(
+                    &sig_bytes,
+                )))
+            }
             _ => Err(alloy_rlp::Error::Custom(
                 "unsupported wip-1001 signature type",
             )),
+        }
+    }
+}
+
+// `ed25519_dalek::Signature` does not implement `Hash`. Hash via the canonical
+// 64-byte representation; tag the variant with `signature_type` so different
+// schemes don't collide.
+impl Hash for Wip1001Signature {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.signature_type().hash(state);
+        match self {
+            Self::Secp256k1(sig) => sig.hash(state),
+            Self::P256(sig) => sig.hash(state),
+            Self::WebAuthn(sig) => sig.hash(state),
+            Self::EdDSA(sig) => sig.to_bytes().hash(state),
         }
     }
 }
@@ -306,6 +382,8 @@ pub enum SessionKey {
         /// Affine y coordinate.
         y: B256,
     },
+    /// Compressed Ed25519 public key (32 bytes), validated on-curve at parse time.
+    EdDSA(ed25519_dalek::VerifyingKey),
 }
 
 /// Parse error for [`SessionKey::from_wire`].
@@ -322,6 +400,10 @@ pub enum SessionKeyError {
         /// Actual length in bytes.
         got: usize,
     },
+    /// `key_data` is the right length but does not decode to a valid public key
+    /// (e.g. Ed25519 point not on the curve).
+    #[error("malformed public key")]
+    MalformedKey,
 }
 
 impl SessionKey {
@@ -347,6 +429,19 @@ impl SessionKey {
                 let (x, y) = parse_p256_key_data(key_data)?;
                 Ok(Self::WebAuthn { x, y })
             }
+            Wip1001Signature::EDDSA_TYPE => {
+                if key_data.len() != ED25519_PUBKEY_LEN {
+                    return Err(SessionKeyError::InvalidLength {
+                        expected: ED25519_PUBKEY_LEN,
+                        got: key_data.len(),
+                    });
+                }
+                let mut buf = [0u8; ED25519_PUBKEY_LEN];
+                buf.copy_from_slice(key_data);
+                let vk = ed25519_dalek::VerifyingKey::from_bytes(&buf)
+                    .map_err(|_| SessionKeyError::MalformedKey)?;
+                Ok(Self::EdDSA(vk))
+            }
             other => Err(SessionKeyError::UnsupportedType(other)),
         }
     }
@@ -358,6 +453,7 @@ impl SessionKey {
             Self::Secp256k1(_) => Wip1001Signature::SECP256K1_TYPE,
             Self::P256 { .. } => Wip1001Signature::P256_TYPE,
             Self::WebAuthn { .. } => Wip1001Signature::WEBAUTHN_TYPE,
+            Self::EdDSA(_) => Wip1001Signature::EDDSA_TYPE,
         }
     }
 }

--- a/crates/primitives/src/transaction/verify.rs
+++ b/crates/primitives/src/transaction/verify.rs
@@ -1,12 +1,12 @@
 //! WIP-1001 signature verification.
 //!
-//! Generalized verification across the schemes defined in the
+//! Generalized verification across all schemes defined in the
 //! [WIP-1001](https://github.com/worldcoin/world-chain/blob/main/wips/wip-1001.md)
-//! envelope: secp256k1, P-256, and WebAuthn.
+//! envelope: secp256k1, P-256, WebAuthn, and Ed25519.
 //!
-//! For non-recoverable schemes (P-256, WebAuthn), the session pubkey is read
-//! from the transaction's `session_key` field; for secp256k1, the recovered
-//! pubkey is checked against `session_key`. EdDSA is reserved for a future PR.
+//! For non-recoverable schemes (P-256, WebAuthn, Ed25519), the session pubkey
+//! is read from the transaction's `session_key` field; for secp256k1, the
+//! recovered pubkey is checked against `session_key`.
 
 use alloy_consensus::crypto::RecoveryError;
 use alloy_primitives::{B256, U256, uint};
@@ -67,6 +67,9 @@ pub enum Wip1001VerifyError {
     /// WebAuthn `authenticatorData` / `clientDataJSON` failed validation.
     #[error("WebAuthn validation failed: {0}")]
     WebAuthnInvalid(&'static str),
+    /// Ed25519 EdDSA signature failed `verify_strict`.
+    #[error("EdDSA verification failed")]
+    EddsaVerificationFailed,
 }
 
 impl From<Wip1001VerifyError> for RecoveryError {
@@ -105,6 +108,9 @@ pub fn verify_wip1001_signature(
         }
         (SessionKey::WebAuthn { x, y }, Wip1001Signature::WebAuthn(sig)) => {
             verify_webauthn(sig, x, y, signing_hash)?;
+        }
+        (SessionKey::EdDSA(verifying_key), Wip1001Signature::EdDSA(sig)) => {
+            verify_eddsa(verifying_key, sig, signing_hash)?;
         }
         // Already covered by the discriminator equality check above.
         _ => unreachable!("signature_type was checked equal to session key type"),
@@ -203,6 +209,22 @@ pub fn verify_webauthn(
 
     let p256_sig = P256Signature { r: sig.r, s: sig.s };
     verify_p256(&p256_sig, pub_key_x, pub_key_y, &message_hash)
+}
+
+/// Verify an Ed25519 EdDSA signature against `signing_hash` using the supplied
+/// `verifying_key`.
+///
+/// Treats `signing_hash` as the *message* (not a prehash) — Ed25519 internally
+/// hashes its input via SHA-512 as part of the signing/verification equation.
+/// `verify_strict` rejects mixed-order public keys and small-subgroup signatures.
+pub fn verify_eddsa(
+    verifying_key: &ed25519_dalek::VerifyingKey,
+    sig: &ed25519_dalek::Signature,
+    signing_hash: &B256,
+) -> Result<(), Wip1001VerifyError> {
+    verifying_key
+        .verify_strict(signing_hash.as_slice(), sig)
+        .map_err(|_| Wip1001VerifyError::EddsaVerificationFailed)
 }
 
 fn compute_webauthn_message_hash(
@@ -439,5 +461,87 @@ mod tests {
         };
         let err = verify_webauthn(&webauthn, &x, &y, &signing_hash).unwrap_err();
         assert!(matches!(err, Wip1001VerifyError::WebAuthnInvalid(_)));
+    }
+
+    /// Deterministic Ed25519 keypair from a fixed seed (no RNG dependency).
+    fn ed25519_keypair() -> (ed25519_dalek::SigningKey, ed25519_dalek::VerifyingKey) {
+        let seed: [u8; 32] = [
+            0x9d, 0x61, 0xb1, 0x9d, 0xef, 0xfd, 0x5a, 0x60, 0xba, 0x84, 0x4a, 0xf4, 0x92, 0xec,
+            0x2c, 0xc4, 0x44, 0x49, 0xc5, 0x69, 0x7b, 0x32, 0x69, 0x19, 0x70, 0x3b, 0xac, 0x03,
+            0x1c, 0xae, 0x7f, 0x60,
+        ];
+        let sk = ed25519_dalek::SigningKey::from_bytes(&seed);
+        let vk = sk.verifying_key();
+        (sk, vk)
+    }
+
+    #[test]
+    fn eddsa_happy_path() {
+        use ed25519_dalek::Signer;
+        let (sk, vk) = ed25519_keypair();
+        let signing_hash = B256::from_slice(&[0x55; 32]);
+        let sig = sk.sign(signing_hash.as_slice());
+        verify_eddsa(&vk, &sig, &signing_hash).expect("valid eddsa signature");
+    }
+
+    #[test]
+    fn eddsa_rejects_tampered_hash() {
+        use ed25519_dalek::Signer;
+        let (sk, vk) = ed25519_keypair();
+        let signing_hash = B256::from_slice(&[0x55; 32]);
+        let other = B256::from_slice(&[0x66; 32]);
+        let sig = sk.sign(signing_hash.as_slice());
+        let err = verify_eddsa(&vk, &sig, &other).unwrap_err();
+        assert!(matches!(err, Wip1001VerifyError::EddsaVerificationFailed));
+    }
+
+    #[test]
+    fn eddsa_rejects_wrong_pubkey() {
+        use ed25519_dalek::Signer;
+        let (sk_a, _vk_a) = ed25519_keypair();
+        // Different seed -> different keypair.
+        let sk_b = ed25519_dalek::SigningKey::from_bytes(&[0xCD; 32]);
+        let vk_b = sk_b.verifying_key();
+        let signing_hash = B256::from_slice(&[0x55; 32]);
+        let sig = sk_a.sign(signing_hash.as_slice());
+        // Verifying with someone else's pubkey must fail.
+        let err = verify_eddsa(&vk_b, &sig, &signing_hash).unwrap_err();
+        assert!(matches!(err, Wip1001VerifyError::EddsaVerificationFailed));
+    }
+
+    #[test]
+    fn session_key_from_wire_rejects_wrong_length_eddsa() {
+        let too_short = [0xAAu8; 31];
+        let err = SessionKey::from_wire(Wip1001Signature::EDDSA_TYPE, &too_short);
+        assert!(matches!(
+            err,
+            Err(SessionKeyError::InvalidLength {
+                expected: 32,
+                got: 31
+            })
+        ));
+    }
+
+    #[test]
+    fn verify_wip1001_signature_eddsa_round_trip() {
+        use ed25519_dalek::Signer;
+        let (sk, vk) = ed25519_keypair();
+        let signing_hash = B256::from_slice(&[0x77; 32]);
+        let sig = sk.sign(signing_hash.as_slice());
+
+        let key_bytes = vk.to_bytes();
+        let signature = Wip1001Signature::EdDSA(sig);
+
+        let session_key = verify_wip1001_signature(
+            Wip1001Signature::EDDSA_TYPE,
+            &key_bytes,
+            &signature,
+            &signing_hash,
+        )
+        .expect("verify");
+        match session_key {
+            SessionKey::EdDSA(recovered_vk) => assert_eq!(recovered_vk, vk),
+            other => panic!("expected EdDSA SessionKey, got {other:?}"),
+        }
     }
 }

--- a/crates/rpc/src/core.rs
+++ b/crates/rpc/src/core.rs
@@ -1,6 +1,5 @@
 use crate::{EthTransactionsExt, sequencer::SequencerClient};
 use alloy_primitives::{B256, Bytes};
-use alloy_rpc_types::erc4337::TransactionConditional;
 use jsonrpsee::{
     core::{RpcResult, async_trait},
     proc_macros::rpc,
@@ -24,14 +23,6 @@ pub trait EthApiExt {
     /// Sends a raw transaction to the pool
     #[method(name = "sendRawTransaction")]
     async fn send_raw_transaction(&self, tx: Bytes) -> RpcResult<B256>;
-
-    /// Sends a raw conditional transaction to the pool
-    #[method(name = "sendRawTransactionConditional")]
-    async fn send_raw_transaction_conditional(
-        &self,
-        tx: Bytes,
-        options: TransactionConditional,
-    ) -> RpcResult<B256>;
 }
 
 #[async_trait]
@@ -42,13 +33,5 @@ where
 {
     async fn send_raw_transaction(&self, tx: Bytes) -> RpcResult<B256> {
         Ok(EthTransactionsExt::send_raw_transaction(self, tx).await?)
-    }
-
-    async fn send_raw_transaction_conditional(
-        &self,
-        tx: Bytes,
-        options: TransactionConditional,
-    ) -> RpcResult<B256> {
-        Ok(EthTransactionsExt::send_raw_transaction_conditional(self, tx, options).await?)
     }
 }

--- a/crates/rpc/src/transactions.rs
+++ b/crates/rpc/src/transactions.rs
@@ -1,20 +1,12 @@
 use std::error::Error;
 
-use alloy_consensus::BlockHeader;
-use alloy_eips::BlockId;
-use alloy_primitives::{StorageKey, map::HashMap};
-use alloy_rpc_types::erc4337::{AccountStorage, TransactionConditional};
-use jsonrpsee::{
-    core::{RpcResult, async_trait},
-    types::{ErrorCode, ErrorObject, ErrorObjectOwned},
-};
+use jsonrpsee::core::async_trait;
 use reth_optimism_node::txpool::OpPooledTransaction;
-use reth_primitives_traits::Block;
 use reth_provider::{BlockReaderIdExt, StateProviderFactory};
 use reth_rpc_eth_api::{AsEthApiError, FromEthApiError};
 use reth_rpc_eth_types::{EthApiError, utils::recover_raw_transaction};
 use reth_transaction_pool::{PoolTransaction, TransactionOrigin, TransactionPool};
-use revm_primitives::{Address, B256, Bytes, FixedBytes, map::FbBuildHasher};
+use revm_primitives::{B256, Bytes};
 use world_chain_pool::tx::WorldChainPooledTransaction;
 
 use crate::{core::WorldChainEthApiExt, sequencer::SequencerClient};
@@ -29,12 +21,6 @@ pub trait EthTransactionsExt {
         + Send
         + Sync;
 
-    async fn send_raw_transaction_conditional(
-        &self,
-        tx: Bytes,
-        options: TransactionConditional,
-    ) -> Result<B256, Self::Error>;
-
     async fn send_raw_transaction(&self, tx: Bytes) -> Result<B256, Self::Error>;
 }
 
@@ -45,34 +31,6 @@ where
     Client: BlockReaderIdExt + StateProviderFactory + 'static,
 {
     type Error = EthApiError;
-
-    async fn send_raw_transaction_conditional(
-        &self,
-        tx: Bytes,
-        options: TransactionConditional,
-    ) -> Result<B256, Self::Error> {
-        validate_conditional_options(&options, self.provider()).map_err(Self::Error::other)?;
-
-        let recovered = recover_raw_transaction(&tx)?;
-        let mut pool_transaction: WorldChainPooledTransaction =
-            OpPooledTransaction::from_pooled(recovered).into();
-        pool_transaction.inner = pool_transaction.inner.with_conditional(options.clone());
-
-        // submit the transaction to the pool with a `Local` origin
-        let outcome = self
-            .pool()
-            .add_transaction(TransactionOrigin::Local, pool_transaction)
-            .await
-            .map_err(Self::Error::from_eth_err)?;
-
-        if let Some(client) = self.raw_tx_forwarder().as_ref() {
-            tracing::debug!( target: "rpc::eth",  "forwarding raw conditional transaction to");
-            let _ = client.forward_raw_transaction_conditional(&tx, options).await.inspect_err(|err| {
-                        tracing::debug!(target: "rpc::eth", %err, hash=?*outcome.hash, "failed to forward raw conditional transaction");
-                    });
-        }
-        Ok(outcome.hash)
-    }
 
     async fn send_raw_transaction(&self, tx: Bytes) -> Result<B256, Self::Error> {
         let recovered = recover_raw_transaction(&tx)?;
@@ -120,108 +78,4 @@ where
     pub fn raw_tx_forwarder(&self) -> Option<&SequencerClient> {
         self.sequencer_client.as_ref()
     }
-}
-
-/// Validates the conditional inclusion options provided by the client.
-///
-/// reference for the implementation <https://notes.ethereum.org/@yoav/SkaX2lS9j#>
-/// See also <https://pkg.go.dev/github.com/aK0nshin/go-ethereum/arbitrum_types#ConditionalOptions>
-pub fn validate_conditional_options<Client>(
-    options: &TransactionConditional,
-    provider: &Client,
-) -> RpcResult<()>
-where
-    Client: BlockReaderIdExt + StateProviderFactory,
-{
-    let latest = provider
-        .block_by_id(BlockId::latest())
-        .map_err(|e| ErrorObject::owned(ErrorCode::InternalError.code(), e.to_string(), Some("")))?
-        .ok_or(ErrorObjectOwned::from(ErrorCode::InternalError))?;
-
-    let block_number = latest.header().number();
-    let block_timestamp = latest.header().timestamp();
-    if let Some(min_block) = options.block_number_min
-        && min_block > block_number
-    {
-        return Err(ErrorCode::from(-32003).into());
-    }
-
-    if let Some(max_block) = options.block_number_max
-        && max_block < block_number
-    {
-        return Err(ErrorCode::from(-32003).into());
-    }
-
-    if let Some(min_timestamp) = options.timestamp_min
-        && min_timestamp > block_timestamp
-    {
-        return Err(ErrorCode::from(-32003).into());
-    }
-
-    if let Some(max_timestamp) = options.timestamp_max
-        && max_timestamp < block_timestamp
-    {
-        return Err(ErrorCode::from(-32003).into());
-    }
-
-    validate_known_accounts(
-        &options.known_accounts,
-        latest.header().number().into(),
-        provider,
-    )?;
-
-    Ok(())
-}
-
-/// Validates the account storage slots/storage root provided by the client
-///
-/// Matches the current state of the account storage slots/storage root.
-pub fn validate_known_accounts<Client>(
-    known_accounts: &HashMap<Address, AccountStorage, FbBuildHasher<20>>,
-    latest: BlockId,
-    provider: &Client,
-) -> RpcResult<()>
-where
-    Client: BlockReaderIdExt + StateProviderFactory,
-{
-    let state = provider.state_by_block_id(latest).map_err(|e| {
-        ErrorObject::owned(ErrorCode::InternalError.code(), e.to_string(), Some(""))
-    })?;
-
-    for (address, storage) in known_accounts.iter() {
-        match storage {
-            AccountStorage::Slots(slots) => {
-                for (slot, value) in slots.iter() {
-                    let current =
-                        state
-                            .storage(*address, StorageKey::from(*slot))
-                            .map_err(|e| {
-                                ErrorObject::owned(
-                                    ErrorCode::InternalError.code(),
-                                    e.to_string(),
-                                    Some(""),
-                                )
-                            })?;
-                    if let Some(current) = current {
-                        if FixedBytes::<32>::from_slice(&current.to_be_bytes::<32>()) != *value {
-                            return Err(ErrorCode::from(-32003).into());
-                        }
-                    } else {
-                        return Err(ErrorCode::from(-32003).into());
-                    }
-                }
-            }
-            AccountStorage::RootHash(expected) => {
-                let root = state
-                    .storage_root(*address, Default::default())
-                    .map_err(|e| {
-                        ErrorObject::owned(ErrorCode::InternalError.code(), e.to_string(), Some(""))
-                    })?;
-                if *expected != root {
-                    return Err(ErrorCode::from(-32003).into());
-                }
-            }
-        }
-    }
-    Ok(())
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches cryptographic signature parsing/verification and transaction admission paths, so bugs could cause invalid WIP-1001 tx acceptance/rejection. Removing the conditional RPC method is a breaking API change for clients relying on conditional inclusion.
> 
> **Overview**
> Adds **Ed25519 (EdDSA) support** to WIP-1001 transactions by extending `Wip1001Signature` and `SessionKey` with an `EdDSA` variant, implementing RLP encode/decode and strict signature verification (`verify_eddsa`), and expanding envelope/verification test coverage for EdDSA round-trips and signer recovery.
> 
> Removes the `eth_sendRawTransactionConditional` RPC method and all conditional-option validation/forwarding logic from `rpc` and the builder’s payload construction path, and drops the `world-chain-rpc` dependency from `world-chain-builder` (plus corresponding lockfile updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d46e8a5ca42e43047bd80988390da52722f9704. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->