### PR TITLE
fix: isolate normalization of the payload id to the RPC boundary

### DIFF
--- a/crates/payload/src/generator.rs
+++ b/crates/payload/src/generator.rs
@@ -28,7 +28,6 @@ use world_chain_p2p::protocol::handler::FlashblocksHandle;
 use world_chain_primitives::{
     access_list::FlashblockAccessList, ed25519_dalek::SigningKey,
     flashblocks::recovered_block_from_flashblocks, p2p::Authorization,
-    payload_id::force_op_payload_id_v3,
 };
 
 use crate::job::{CommittedPayloadState, FlashblocksPayloadJob};
@@ -153,8 +152,6 @@ where
         input: BuildNewPayload<Builder::Attributes>,
         id: PayloadId,
     ) -> Result<Self::Job, PayloadBuilderError> {
-        let id = force_op_payload_id_v3(id);
-
         let parent_header = if input.parent_hash.is_zero() {
             // Use latest header for genesis block case
             self.client


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes payload ID handling for payload build jobs by removing internal normalization, which could affect downstream matching/authorization if callers still rely on the old transformed IDs.
> 
> **Overview**
> Removes the internal call to `force_op_payload_id_v3` when creating new payload build jobs, so `FlashblocksPayloadJobGenerator::new_payload_job` now uses the `PayloadId` as provided rather than rewriting it.
> 
> This isolates payload ID normalization away from the payload builder internals, impacting how IDs propagate into `PayloadConfig` and subsequent authorization/publishing flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e5e0e886fd9bf753a57375dca364b47ec026360. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->