### PR TITLE
refactor: WIP-1001 abstract account model with pluggable admin authorities

### DIFF
--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -136,7 +136,7 @@ The `signalHash` an admin authority binds to is uniform across instantiations.
 
 ```solidity
 struct CreateSignal {
-    bytes32       tag;             // == keccak256("WIP-1001/create")
+    bytes32       tag;             // == keccak256("WORLD_CHAIN_ACCOUNT_CREATE")
     address       msgSender;
     KeyringUpdate keyringUpdate;
 }

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -142,7 +142,7 @@ struct CreateSignal {
 }
 
 struct UpdateSignal {
-    bytes32       tag;             // == keccak256("WIP-1001/update")
+    bytes32       tag;             // == keccak256("WORLD_CHAIN_ACCOUNT_UPDATE")
     address       accountAddress;
     uint64        adminNonce;
     address       msgSender;

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -7,7 +7,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2026-03-27
-requires: EIP-2718, EIP-1559
+requires: EIP-2718, EIP-1559, ERC-4337
 ---
 
 ## Abstract

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -12,7 +12,7 @@ requires: EIP-2718, EIP-1559, ERC-4337
 
 ## Abstract
 
-A *World Chain Account* is a precompile-managed account whose 20-byte address is deterministic and lifetime-stable. Each account has a single *admin authority* fixed at creation, which gates mutation of the account's *Keyring* — the set of session keys authorized to sign on its behalf, held natively in the precompile and read by the protocol during transaction validation. We extend [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) with a typed transaction envelope (`0x1D`) signed by any session key in a *World Chain Account*'s keyring.
+A *World Chain Account* is a precompile-managed account whose 20-byte address is deterministic and lifetime-stable. Each account has a single *admin authority* fixed at creation, which gates mutation of the account's *Keyring* — the set of session keys authorized to sign on its behalf. We extend [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) with a typed transaction envelope (`0x1D`) signed by any session key in a *World Chain Account*'s keyring.
 
 This WIP specifies three admin authority instantiations:
 

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -1,22 +1,26 @@
 ---
 wip: 1001
-title: WorldID Native Account Abstraction
-description: A precompile-managed World ID Account whose creation is gated by a World ID 4.0 Uniqueness Proof, whose subsequent mutations are gated by Session Proofs, and which is authenticated via a new EIP-2718 typed transaction (type `0x1D`).
+title: World Chain Native Account Abstraction
+description: A precompile-managed account model with a single admin authority pinned at creation, supporting WorldID, Secp256k1, and P256 admins. Session keys sign EIP-2718 typed transactions (`0x1D`) on the account; admin authorities gate session-key set mutations.
 author: Kilian Glas (@kilianglas), 0xOsiris (@0xOsiris), Eric Woolsey (@0xforerunner)
 status: Draft
 type: Standards Track
 category: Core
 created: 2026-03-27
-requires: EIP-2718, EIP-1559, ERC-4337
+requires: EIP-2718, EIP-1559
 ---
 
 ## Abstract
 
-A *World ID Account* is a precompile-managed account whose 20-byte address is deterministic and lifetime-stable, derived from its creation nullifier $\mathrm{addr}(\nu_k) = \mathrm{bytes20}(\mathrm{keccak256}(\nu_k))$. Each World ID Account owns a *Key Ring* — the set of session keys authorized to sign on its behalf — held natively in the precompile and read by the protocol during transaction validation. Because the World ID Account is a first-class account on World Chain and its Key Ring is read natively by the protocol, World ID Accounts achieve native account abstraction. We extend [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) with a typed transaction envelope (`0x1D`) signed by any session key in the Key Ring of a *World ID Account*.
+A *World Chain Account* is a precompile-managed account whose 20-byte address is deterministic and lifetime-stable. Each account has a single *admin authority* fixed at creation, which gates mutation of the account's *Keyring* — the set of session keys authorized to sign on its behalf, held natively in the precompile and read by the protocol during transaction validation. We extend [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) with a typed transaction envelope (`0x1D`) signed by any session key in a *World Chain Account*'s keyring.
 
-A single WorldID `MAY` manage any number of World ID Accounts indexed by a user-chosen `worldIDAccountNonce`; World ID Accounts owned by the same WorldID are unlinkable across distinct `worldIDAccountNonce` values. A World ID Account is created by a Uniqueness Proof over its `worldIDAccountNonce`; creation also installs a fresh `sessionId` bound to that account. Session keys are then added, removed, and rotated via fresh Session Proofs over the stored `sessionId`. Recovery from lost or compromised session keys is the degenerate case of the same upgrade path, protected by a configurable timelock.
+This WIP specifies three admin authority instantiations:
 
-World ID Account state lives natively in the `WORLD_ID_ACCOUNT_PRECOMPILE`. There is no per-WorldID uniqueness constraint, no generation counter, and no account recycling — a *World ID Account* is a public identifier for a *World ID* managed set of session keys; it is not an identity anchor.
+- **WorldID admin.** Creation gated by a [World ID 4.0](https://github.com/worldcoin/world-id-protocol) Uniqueness Proof; subsequent keyring mutations gated by Session Proofs against a stored `sessionId`. Recovery from lost or compromised session keys is the degenerate case of the same upgrade path, protected by a configurable timelock. A single WorldID `MAY` manage any number of WorldID-admin accounts indexed by a user-chosen `worldIDAccountNonce`; accounts owned by the same WorldID are unlinkable across distinct values.
+- **Secp256k1 admin.** Creation and keyring mutations gated by ECDSA signatures over a uniform `signalHash` from a single secp256k1 admin key fixed at creation. No recovery — admin-key loss is terminal.
+- **P256 admin.** Same shape as Secp256k1 with a P256 (`secp256r1`) admin key.
+
+Account state lives natively in the `WORLD_CHAIN_ACCOUNT_PRECOMPILE`. The account address is a public identifier for an admin-authority-managed set of session keys, not an identity anchor; per-instantiation rules govern how many accounts a given admin authority may own.
 
 ## Motivation
 
@@ -24,9 +28,11 @@ World ID Account state lives natively in the `WORLD_ID_ACCOUNT_PRECOMPILE`. Ther
 
 Enshrining smart-account authenticators as protocol-level signature verification algorithms lets us jointly optimize transaction gas, expose a simple multi-auth API over familiar authenticators ([Passkey](https://www.w3.org/TR/webauthn-3/) / [WebAuthn](https://www.w3.org/TR/webauthn-3/), [P256](https://neuromancer.sk/std/nist/P-256), [ECDSA](https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm), [EdDSA](https://en.wikipedia.org/wiki/EdDSA)), minimize confirmation time, and remove the need for bundler infrastructure.
 
-### World ID 4.0 Proofs as Authorization
+### Pluggable Admin Authorities
 
-Authorizing World ID Account creation with a World ID 4.0 Uniqueness Proof and subsequent mutations with Session Proofs — rather than a signing key — converges key rotation and recovery onto a single proof-verification path after enrollment: a fresh session proof. No "super key" is ever stored on-device. A `worldIDAccountNonce`-indexed action lets a single WorldID own unlinkably many World ID Accounts.
+A pluggable admin model lets a single account abstraction serve multiple user populations from one precompile. **WorldID admin** converges key rotation and recovery onto a single proof-verification path after enrollment: a fresh Session Proof. No "super key" is ever stored on-device; recovery is the degenerate case of the same upgrade path. **Key admin** (Secp256k1 / P256) lets accounts be owned by users without a WorldID, by hot/cold-separated wallets, or by integrations driven by existing key-management infrastructure; the trade-off is that admin-key loss is terminal.
+
+Sharing a single keyring + transaction surface (`0x1D`, session keys, signal binding, timelock) across instantiations means session-key UX and integration surface are uniform regardless of admin type. A new admin instantiation reduces to specifying one verification primitive and one address-derivation rule.
 
 ## Specification
 
@@ -34,48 +40,293 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Constants
 
-| Name                          | Value                                        | Description                                                       |
-| ----------------------------- | -------------------------------------------- | ----------------------------------------------------------------- |
-| `WORLD_TX_TYPE`               | `0x1D`                                       | [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) tx type       |
-| `WORLD_CHAIN_RP_ID`           | `480`                                        | World Chain's registered RP ID                                    |
-| `WORLD_ID_ACCOUNT_PRECOMPILE` | `0x000000000000000000000000000000000000001D` | Stateful precompile managing the World ID Account registry        |
-| `WORLD_ID_ACCOUNT_TAG`        | `"WORLD_ID_ACCOUNT"` (UTF-8, 16 bytes)       | Domain tag for World ID Account Uniqueness Proof actions          |
-| `WORLD_ID_ACCOUNT_NONCE`      | U256                                         | The generational nonce of the World ID Account. Not necessarily monotonic |
-| `MAX_SESSION_KEYS`            | `20`                                         | Maximum authorized session keys per World ID Account              |
+| Name                              | Value                                        | Description                                                 |
+| --------------------------------- | -------------------------------------------- | ----------------------------------------------------------- |
+| `WORLD_TX_TYPE`                   | `0x1D`                                       | [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) tx type |
+| `WORLD_CHAIN_ACCOUNT_PRECOMPILE`  | `0x000000000000000000000000000000000000001D` | Stateful precompile managing the World Chain Account registry |
+| `MAX_SESSION_KEYS`                | `20`                                         | Maximum authorized session keys per account                 |
+| `ADMIN_TYPE_WORLD_ID`             | `0x00`                                       | Admin type discriminator: WorldID admin                     |
+| `ADMIN_TYPE_SECP256K1`            | `0x01`                                       | Admin type discriminator: Secp256k1 admin                   |
+| `ADMIN_TYPE_P256`                 | `0x02`                                       | Admin type discriminator: P256 admin                        |
 
-### World ID Account Model
+Per-instantiation constants are defined in their respective sections.
 
-A *World ID Account* is an account whose creation `MUST` be gated by a World ID 4.0 Uniqueness Proof. Its address derives from the World ID Account nullifier $\nu_k$ of the initial creation proof, itself a deterministic function of the owning WorldID identity and a user-chosen `worldIDAccountNonce`. A single WorldID `MAY` manage any number of World ID Accounts by variation over the `worldIDAccountNonce`. Each World ID Account `MUST` also store a `sessionId` created at enrollment; subsequent mutations are authorized against that stored session. The per-proof `sessionNullifier` used by `verifySession` is transient proof material and `MUST NOT` be persisted as World ID Account state.
+### Abstract Account Model
 
-*Session keys* are abstract signatories authorized to sign `0x1D` transactions on behalf of the World ID Account; they carry no intrinsic privileges beyond signing. Per-key permissions (expiry, spend limits, call scopes) are out of scope for this WIP (see [Extensions](#extensions)).
+An *account* is created by an admin-authorized `Create` operation that fixes an *admin type* `T` and an *admin authority* `A` of type `T`. After creation, `T` and `A` are immutable for the lifetime of the account. The keyring is mutated by admin-authorized `Add` or `Remove` operations. All admin authorizations bind the operation to a uniform `signalHash` defined below; replay protection across operations is provided by a per-account monotonic `adminNonce`.
 
-#### Proof Authorization
+#### Account State
 
-World ID Account creation is authorized by a World ID 4.0 Uniqueness Proof parameterized by:
+Per-account state stored in the precompile:
+
+```
+struct Account {
+    uint8        adminType;             // ADMIN_TYPE_*
+    bytes        verificationPublicId;  // variable length per admin type
+    SessionKey[] sessionKeys;           // see Session Keys
+    uint64       adminNonce;            // monotonic; replay protection
+    // pendingUpdates: see Timelock
+}
+```
+
+`verificationPublicId` is the persistent public material the admin authority uses to verify subsequent updates. Its encoding is per-instantiation (e.g., `sessionId` for WorldID admin, a compressed pubkey for Secp256k1 admin). It is set at creation and is not directly mutable by this WIP — see [Extensions](#extensions) for admin rotation.
+
+#### Admin Authority Interface
+
+The abstract operation each admin authority provides is:
+
+```
+verifyAdmin(signalHash, signature, verificationPublicId) → bool
+```
+
+`signature` and `verificationPublicId` are byte strings whose encoding is per-instantiation. The precompile invokes this operation during `update`. Each instantiation specifies how the operation is realized — see [Admin Instantiations](#admin-instantiations).
+
+Admin authorization at creation is also instantiation-specific. Some instantiations (key admins) take the address-defining material directly as a creation input that coincides with `verificationPublicId`; others (WorldID admin) take additional address-defining material (a creation nullifier `ν_k`) that is bound by the verifier to `verificationPublicId` (`sessionId`) but stored only as the address — `ν_k` is not retained as account state.
+
+#### Address Derivation
+
+```
+addr = bytes20(keccak256(abi.encodePacked(adminTypeTag, addressDefiningMaterial)))
+```
+
+`adminTypeTag` is the one-byte `ADMIN_TYPE_*` discriminator. `addressDefiningMaterial` is per-instantiation:
+
+- WorldID admin: `ν_k`, the creation Uniqueness Proof's nullifier (32 bytes).
+- Secp256k1 admin: the 33-byte compressed admin pubkey (= `verificationPublicId`).
+- P256 admin: the 64-byte uncompressed admin pubkey (= `verificationPublicId`).
+
+The address is fixed for the lifetime of the account; session-key rotation does **NOT** change the address.
+
+#### Session Keys
+
+```solidity
+enum KeyType { Secp256k1, P256, WebAuthn, EdDSA }
+
+struct SessionKey {
+    KeyType keyType;
+    bytes   keyData;
+}
+```
+
+| `KeyType`   | Value  | Elliptic Curve                                                                          | `keyData`                                                                                   |
+| ----------- | ------ | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `Secp256k1` | `0x00` | [secp256k1](https://en.bitcoin.it/wiki/Secp256k1)                                       | 33 bytes — compressed public key                                                            |
+| `P256`      | `0x01` | [secp256r1](https://neuromancer.sk/std/nist/P-256) (NIST P-256)                         | 64 bytes — uncompressed `(x, y)`                                                            |
+| `WebAuthn`  | `0x02` | [secp256r1](https://neuromancer.sk/std/nist/P-256) (NIST P-256)                         | 64 bytes — uncompressed `(x, y)` (P256 under [WebAuthn](https://www.w3.org/TR/webauthn-3/)) |
+| `EdDSA`     | `0x03` | [edwards25519](https://datatracker.ietf.org/doc/html/rfc8032#section-5.1)               | 32 bytes — compressed public key (Ed25519)                                                  |
+
+`KeyType` and `adminType` occupy disjoint domains: their numeric values are defined in different enums and MUST NOT be used interchangeably in the precompile interface or the address-derivation preimage. Session keys carry no intrinsic privileges beyond signing `0x1D` transactions; per-key permissions (expiry, spend limits, call scopes) are out of scope for this WIP (see [Extensions](#extensions)).
+
+#### Signal Semantics
+
+```solidity
+enum UpdateMode { Create, Add, Remove }
+
+struct KeyringUpdate {
+    UpdateMode   mode;
+    SessionKey[] keys;
+}
+```
+
+- **`Create`** — installs `keys` as the full keyring at the account's address and initializes the account with the supplied admin authority. MUST revert if the account already exists, if `keys.length == 0`, or if `keys.length > MAX_SESSION_KEYS`.
+- **`Add`** — appends `keys` to the existing keyring. MUST revert if the account does not exist, if any key is already present, or if the resulting keyring would exceed `MAX_SESSION_KEYS`.
+- **`Remove`** — removes each entry in `keys` from the existing keyring. MUST revert if the account does not exist or if any key is absent. The keyring MAY become empty; an account with zero session keys exists but cannot sign transactions until the next `Add`.
+
+The `signalHash` an admin authority binds to is uniform across instantiations.
+
+```solidity
+struct CreateSignal {
+    bytes32       tag;             // == keccak256("WIP-1001/create")
+    address       msgSender;
+    KeyringUpdate keyringUpdate;
+}
+
+struct UpdateSignal {
+    bytes32       tag;             // == keccak256("WIP-1001/update")
+    address       accountAddress;
+    uint64        adminNonce;
+    address       msgSender;
+    KeyringUpdate keyringUpdate;
+}
+```
+
+```
+signalHash = uint256(keccak256(abi.encode(signal))) >> 8
+```
+
+where `signal` is a populated `CreateSignal` for `Create` and an `UpdateSignal` for `Add` / `Remove`.
+
+`msgSender` is the EVM `msg.sender` of the precompile call — binding it prevents an in-flight admin authorization observed in the mempool from being replayed by a different submitter. For `Create`, `accountAddress` is omitted because it is not knowable to the admin authority at the time the authorization is produced (it is derived from `Create`'s outputs); the domain tag, `msgSender`, and the keyring payload together suffice to bind the authorization to its intended creation. For updates, `accountAddress` distinguishes admin authorizations across accounts the same admin might control on different domains.
+
+The `>> 8` truncation reduces the digest to 248 bits so it fits within the BN254 scalar field (matching the WorldID 4.0 proof system's signal field width). Truncation is uniform across instantiations even when the verification primitive does not require the BN254 fit, so the same `signalHash` value is canonical across all admin types.
+
+#### Replay Protection
+
+The precompile stores a per-account monotonic `adminNonce`, initialized to `0` at creation and incremented by `1` on every successful `Add` or `Remove`. Admin authorizations for updates are verified against `signalHash` containing the current value of `adminNonce`; an admin authorization that was valid for `adminNonce = n` is no longer valid once the precompile has incremented past `n`.
+
+For `Create`, replay is precluded by account-existence: the precompile MUST revert if the account address is already occupied. A creation authorization can only be applied once because the post-condition (account exists at `addr`) blocks any subsequent attempt at the same address.
+
+This is the abstract replay-protection contract; each instantiation realizes it via its own verification primitive. Instantiations MUST NOT introduce additional bespoke replay machinery — `adminNonce` + account-existence is sufficient and uniform.
+
+#### Timelock
+
+A compromised admin authority could otherwise rotate session keys in a single block and drain an account. Account updates are subject to a configurable delay:
+
+- `Create` executes immediately (no prior session keys exist to cancel).
+- `Add` and `Remove` are pending until the delay elapses.
+- Existing session keys MAY cancel a pending update during the delay window.
+- The revocation-then-add attack (an admin-authorized update removes all keys, then adds malicious ones with no incumbents left to cancel) MUST be mitigated — e.g., by delaying removals, or by allowing recently-removed keys to cancel pending adds.
+
+Queue / cancel / execute interface additions are TBD. Timelock semantics apply uniformly across admin instantiations.
+
+#### Precompile Interface
+
+```solidity
+interface IWorldChainAccount {
+    /// @notice Create an account. `adminCreationData` layout is admin-type-specific.
+    function create(
+        uint8 adminType,
+        bytes calldata adminCreationData,
+        KeyringUpdate calldata keyringUpdate          // mode == Create
+    ) external returns (address account);
+
+    /// @notice Apply an Add/Remove update. `adminAuthorization` layout is admin-type-specific.
+    function update(
+        address account,
+        KeyringUpdate calldata keyringUpdate,         // mode != Create
+        bytes calldata adminAuthorization
+    ) external;
+
+    // Reads
+    function getAdminType(address account) external view returns (uint8);
+    function getVerificationPublicId(address account) external view returns (bytes memory);
+    function getAdminNonce(address account) external view returns (uint64);
+    function getSessionKeys(address account) external view returns (SessionKey[] memory);
+    function isAuthorized(address account, SessionKey calldata key) external view returns (bool);
+}
+```
+
+`adminCreationData` and `adminAuthorization` are opaque bytes blobs; each admin instantiation specifies the ABI-encoded tuple they decode to.
+
+For `create`, the precompile MUST:
+
+1. Require `keyringUpdate.mode == Create`.
+2. Decode `adminCreationData` per the instantiation specified by `adminType`.
+3. Recompute the `Create` `signalHash` over `(msg.sender, keyringUpdate)`.
+4. Verify the admin authorization per the instantiation, against `signalHash` and the instantiation's `verificationPublicId` (or, for WorldID admin, the equivalent verifier public-input set).
+5. Determine `addressDefiningMaterial` per the instantiation (directly from `adminCreationData` for key admins; from the proof's `ν_k` public input for WorldID admin).
+6. Derive `accountAddress = bytes20(keccak256(abi.encodePacked(adminTypeTag, addressDefiningMaterial)))`.
+7. Require the account does not already exist at `accountAddress`.
+8. Initialize the account: store `adminType`, `verificationPublicId`, `sessionKeys = keyringUpdate.keys`, `adminNonce = 0`.
+
+For `update`, the precompile MUST:
+
+1. Require `keyringUpdate.mode != Create`.
+2. Load the account's stored `adminType`, `verificationPublicId`, and `adminNonce`.
+3. Recompute the `Update` `signalHash` over `(accountAddress, adminNonce, msg.sender, keyringUpdate)`.
+4. Verify `adminAuthorization` per `adminType` against `signalHash` and `verificationPublicId`.
+5. Increment `adminNonce`.
+6. Apply `keyringUpdate`, queued behind the timelock.
+
+> **Note — Precompile gas accounting out of scope.** The specific gas pricing schedule for interacting with `WORLD_CHAIN_ACCOUNT_PRECOMPILE` — covering admin verification cost (Groth16 / ECDSA / P256), per-session-key storage mutation, timelock queue/cancel/execute operations, and the amortized cost of `isAuthorized` reads during `0x1D` validation — is **NOT** defined here. A follow-on revision MUST specify gas costs per operation per admin type.
+
+### Admin Instantiations
+
+Each instantiation specifies:
+
+1. The `verificationPublicId` encoding.
+2. The address-defining material.
+3. The `adminCreationData` layout for `create()`.
+4. The creation flow.
+5. The `adminAuthorization` layout for `update()`.
+6. The verification primitive.
+7. Recovery semantics.
+
+Future instantiations (EdDSA, WebAuthn-as-admin, EIP-1271 contract admins, multi-sig) slot in as additional sub-sections without changing the abstract account model.
+
+#### WorldID Admin
+
+`adminType = ADMIN_TYPE_WORLD_ID = 0x00`.
+
+Per-instantiation constants:
+
+| Name                          | Value                                        | Description                                                    |
+| ----------------------------- | -------------------------------------------- | -------------------------------------------------------------- |
+| `WORLD_CHAIN_RP_ID`           | `480`                                        | World Chain's registered RP ID                                 |
+| `WORLD_ID_ACCOUNT_TAG`        | `"WORLD_ID_ACCOUNT"` (UTF-8, 16 bytes)       | Domain tag for WorldID-admin account creation actions          |
+
+`verificationPublicId` is `sessionId` (uint256), provisioned by the caller at creation and supplied by the WorldID authenticator via OPRF.
+
+Address-defining material is `ν_k`, the creation Uniqueness Proof's nullifier:
+
+```
+addr = bytes20(keccak256(abi.encodePacked(ADMIN_TYPE_WORLD_ID, ν_k)))
+```
+
+A single WorldID `MAY` manage any number of WorldID-admin accounts by variation over a user-chosen `worldIDAccountNonce`; accounts owned by the same WorldID are unlinkable across distinct values by the ZK property of the OPRF proof.
+
+##### Creation
+
+`adminCreationData` layout (conceptual; ABI-encoded as a tuple):
+
+```
+WorldIDAdminCreationData {
+    uint256       worldIDAccountNullifier;      // ν_k (public input to verify)
+    uint256       worldIDAccountNonce;          // recomputed into action
+    uint256       sessionId;                    // freshly provisioned by authenticator
+    uint256       proofNonce;                   // verifier request nonce
+    uint64        issuerSchemaId;
+    uint64        expiresAtMin;
+    uint256       credentialGenesisIssuedAtMin;
+    uint256[5]    proof;                        // compressed Groth16 proof
+}
+```
+
+The Uniqueness Proof is parameterized by:
 
 - `rpId = WORLD_CHAIN_RP_ID`
 - `action = keccak256(abi.encodePacked(WORLD_ID_ACCOUNT_TAG, uint256(worldIDAccountNonce)))`
-- `signalHash = uint256(keccak256(abi.encode(create))) >> 8`
+- `signalHash` per the abstract `Create` formula
 
-where `create` is a `KeyringUpdate` with `mode = Create` (see [Signal Semantics](#signal-semantics)).
+Creation flow:
 
-The creation nullifier $\nu_k$ is used once to instantiate the World ID Account. Because World ID authenticators do not issue the same `(rpId, action)` nullifier twice, a later mutation MUST NOT attempt to reuse the creation action. On successful `Create`, the caller MUST also provide a fresh `sessionId` for `WORLD_CHAIN_RP_ID`, and the precompile MUST associate it with the World ID Account.
+1. Decode `adminCreationData`.
+2. Compute `action`.
+3. Recompute the `Create` `signalHash` over `(msg.sender, keyringUpdate)`.
+4. Invoke `WorldID.verify(worldIDAccountNullifier, action, WORLD_CHAIN_RP_ID, proofNonce, signalHash, issuerSchemaId, expiresAtMin, credentialGenesisIssuedAtMin, proof)`. The verifier asserts the proof commits to the supplied `(ν_k, action, signalHash)` tuple under the relying party's public inputs.
+5. Set `addressDefiningMaterial = worldIDAccountNullifier` and derive `addr` per the abstract address formula.
+6. Require account does not exist at `addr`.
+7. Store `adminType = ADMIN_TYPE_WORLD_ID`, `verificationPublicId = abi.encode(sessionId)`, `sessionKeys = keyringUpdate.keys`, `adminNonce = 0`.
 
-Subsequent `Add` and `Remove` mutations are authorized by World ID 4.0 Session Proofs parameterized by:
+The creation nullifier `ν_k` is consumed once to instantiate the account. Because WorldID authenticators do not issue the same `(rpId, action)` nullifier twice, a later mutation MUST NOT attempt to reuse the creation action. `ν_k` is not retained as account state after creation — its only role is address derivation, which is reproducible from any subsequent update's calldata via the precompile's stored `addr`.
 
-- `rpId = WORLD_CHAIN_RP_ID`
-- `sessionId = sessionId(worldIDAccount)`
-- `signalHash = uint256(keccak256(abi.encode(update || WORLD_ID_ACCOUNT_NONCE)) >> 8`
+##### Updates
 
-> **Note:** `signalHash` must be unique for any given update to the World ID Account.
+`adminAuthorization` layout (conceptual; ABI-encoded as a tuple):
 
-where `update` is a `KeyringUpdate` with `mode != Create`. Session Proofs are verified with `verifySession`, supplying a fresh `sessionNullifier` for each update. That `sessionNullifier` is consumed only for verification of the current update; only `sessionId` is retained across updates.
+```
+WorldIDAdminAuth {
+    uint256    proofNonce;
+    uint64     issuerSchemaId;
+    uint64     expiresAtMin;
+    uint256    credentialGenesisIssuedAtMin;
+    uint256[2] sessionNullifier;                // ephemeral per-update verifier input
+    uint256[5] proof;                           // compressed Groth16 proof
+}
+```
 
-A World ID Account therefore accepts one Uniqueness Proof at creation and any number of Session Proofs over its lifetime.
+Update flow (realizes the abstract `update` MUST list):
+
+1. Decode `verificationPublicId` to recover `sessionId`.
+2. Recompute the `Update` `signalHash` over `(accountAddress, adminNonce, msg.sender, keyringUpdate)`.
+3. Invoke `WorldID.verifySession(WORLD_CHAIN_RP_ID, proofNonce, signalHash, issuerSchemaId, expiresAtMin, credentialGenesisIssuedAtMin, sessionId, sessionNullifier, proof)`.
+4. Discard `sessionNullifier` after verification; it MUST NOT be persisted in account state.
+5. Increment `adminNonce`.
+6. Apply `keyringUpdate`, queued behind the timelock.
 
 ##### Session Proof Primer
 
-A Session Proof proves that the caller controls the same World ID that previously established a stored `sessionId`, without reusing the World ID Account creation action. The `sessionId` is the long-lived identifier retained on the World ID Account across updates. The `sessionNullifier` is fresh per proof, passed only to `verifySession`, and discarded after verification.
+A Session Proof proves that the caller controls the same WorldID that previously established the stored `sessionId`, without reusing the account creation action. The `sessionId` is the long-lived verification public identifier retained for the account across updates. The `sessionNullifier` is fresh per proof, passed only to `verifySession`, and discarded after verification.
 
 ##### OPRF Nullifier Proof Primer
 
@@ -96,125 +347,123 @@ $$\nu = \mathrm{Poseidon2}(\text{"World ID Proof"}, \; q, \; R_{\mathrm{oprf}}.x
 
 - **(G5) Signal binding.** The `signalHash` is "dummy-squared" in the circuit (constrained to $h \cdot h = h^2$), preventing a proof from being reused with a different signal.
 
-An accepting proof guarantees the prover holds a valid credential for a leaf in the tree, the OPRF evaluation is correct, and $\nu$ is deterministically bound to $(i, \mathrm{rpId}, a)$. Distinct action values yield distinct nullifier domains.
+For account creation, **(G4)** binds $\nu_k$ to the triple (owner leaf, `WORLD_CHAIN_RP_ID`, `action(worldIDAccountNonce)`) — making `worldIDAccountNonce` the sole account selector per identity — and **(G5)** binds the Uniqueness Proof to the exact `Create` payload it authorizes. For later updates, `verifySession` binds the proof to the account's stored `sessionId`; the accompanying `sessionNullifier` is a per-proof verifier input rather than persistent account state.
 
-For World ID Account creation, **(G4)** binds $\nu_k$ to the triple (owner leaf, `WORLD_CHAIN_RP_ID`, `action(worldIDAccountNonce)`) — making `worldIDAccountNonce` the sole World ID Account selector per identity — and **(G5)** binds the Uniqueness Proof to the exact `Create` payload it authorizes. For later updates, `verifySession` binds the proof to the World ID Account's stored `sessionId`; the accompanying `sessionNullifier` is a per-proof verifier input rather than persistent World ID Account state.
+##### Recovery
 
-#### World ID Account Address
+Recovery is the degenerate case of an `Add` or `Remove` submitted after session keys are lost or compromised. Because post-creation authorization is a Session Proof bound to the account's stored `sessionId`, recovery requires only a fresh Session Proof — the full session-key surface is reachable via the same mutation path. No separate recovery flow or state is introduced.
 
-$$\mathrm{addr}(\nu_k) = \mathrm{bytes20}(\mathrm{keccak256}(\nu_k))$$
+A single WorldID MAY enable recovery for any number of WorldID-admin accounts; accounts at distinct `worldIDAccountNonce` values remain unlinkable across the recovery event.
 
-The address is fixed for the lifetime of the World ID Account. Session key rotation does **NOT** change the address.
+#### Secp256k1 Admin
 
-#### Session Keys
+`adminType = ADMIN_TYPE_SECP256K1 = 0x01`.
 
-```solidity
-enum KeyType { Secp256k1, P256, WebAuthn, EdDSA }
+`verificationPublicId` is the 33-byte compressed secp256k1 admin public key. Address-defining material is the same key:
 
-struct SessionKey {
-    KeyType keyType;
-    bytes   keyData;
+```
+addr = bytes20(keccak256(abi.encodePacked(ADMIN_TYPE_SECP256K1, adminPubkey)))
+```
+
+One admin key controls exactly one Secp256k1-admin account address.
+
+##### Creation
+
+`adminCreationData` layout (conceptual):
+
+```
+Secp256k1AdminCreationData {
+    bytes adminPubkey;    // 33 bytes — compressed secp256k1 pubkey
+    bytes ecdsaSig;       // (r, s, v) over signalHash
 }
 ```
 
-| `KeyType`   | Value  | Elliptic Curve                                                                          | `keyData`                                                                                   |
-| ----------- | ------ | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| `Secp256k1` | `0x00` | [secp256k1](https://en.bitcoin.it/wiki/Secp256k1)                                       | 33 bytes — compressed public key                                                            |
-| `P256`      | `0x01` | [secp256r1](https://neuromancer.sk/std/nist/P-256) (NIST P-256)                         | 64 bytes — uncompressed `(x, y)`                                                            |
-| `WebAuthn`  | `0x02` | [secp256r1](https://neuromancer.sk/std/nist/P-256) (NIST P-256)                         | 64 bytes — uncompressed `(x, y)` (P256 under [WebAuthn](https://www.w3.org/TR/webauthn-3/)) |
-| `EdDSA`     | `0x03` | [edwards25519](https://datatracker.ietf.org/doc/html/rfc8032#section-5.1)               | 32 bytes — compressed public key (Ed25519)                                                  |
+Creation flow:
 
-#### Signal Semantics
+1. Decode `adminPubkey` and `ecdsaSig`.
+2. Recompute the `Create` `signalHash` over `(msg.sender, keyringUpdate)`.
+3. Verify `ecdsaSig` is a valid secp256k1 ECDSA signature over `signalHash` for the public key `adminPubkey`. Implementations MUST enforce low-`s` to reject malleable signatures.
+4. Set `addressDefiningMaterial = adminPubkey` and derive `addr` per the abstract address formula.
+5. Require account does not exist at `addr`.
+6. Store `adminType = ADMIN_TYPE_SECP256K1`, `verificationPublicId = adminPubkey`, `sessionKeys = keyringUpdate.keys`, `adminNonce = 0`.
 
-```solidity
-enum UpdateMode { Create, Add, Remove }
+##### Updates
 
-struct KeyringUpdate {
-    UpdateMode   mode;
-    SessionKey[] keys;
+`adminAuthorization` is the byte-encoding of a single secp256k1 ECDSA signature `(r, s, v)` over the `Update` `signalHash`.
+
+Update flow:
+
+1. Load `adminPubkey` from `verificationPublicId` and `adminNonce`.
+2. Recompute the `Update` `signalHash` over `(accountAddress, adminNonce, msg.sender, keyringUpdate)`.
+3. Verify the signature is valid for `(signalHash, adminPubkey)`; enforce low-`s`.
+4. Increment `adminNonce`.
+5. Apply `keyringUpdate`, queued behind the timelock.
+
+##### Recovery
+
+**Not supported.** Loss of the admin key is terminal — the account's keyring can no longer be mutated. Users who require recoverability MUST choose a WorldID-admin account.
+
+#### P256 Admin
+
+`adminType = ADMIN_TYPE_P256 = 0x02`.
+
+`verificationPublicId` is the 64-byte uncompressed P256 (`secp256r1`) admin public key, encoding `(x, y)` as 32-byte big-endian coordinates concatenated. Address-defining material is the same key:
+
+```
+addr = bytes20(keccak256(abi.encodePacked(ADMIN_TYPE_P256, adminPubkey)))
+```
+
+One admin key controls exactly one P256-admin account address.
+
+##### Creation
+
+`adminCreationData` layout (conceptual):
+
+```
+P256AdminCreationData {
+    bytes adminPubkey;    // 64 bytes — uncompressed P256 pubkey (x || y)
+    bytes p256Sig;        // (r, s) over signalHash
 }
 ```
 
-- **`Create`** — installs `keys` as the full session key set at $\mathrm{addr}(\nu_k)$ and associates a fresh `sessionId` with the World ID Account. Does **NOT** store any `sessionNullifier`. MUST revert if the World ID Account already exists, if `keys.length == 0`, or if `keys.length > MAX_SESSION_KEYS`.
-- **`Add`** — appends `keys` to the existing set. MUST revert if the World ID Account does not exist, if any key is already present, or if the resulting set exceeds `MAX_SESSION_KEYS`.
-- **`Remove`** — removes each entry in `keys` from the existing set. MUST revert if the World ID Account does not exist or if any key is absent. The set MAY become empty; a World ID Account with zero session keys exists but cannot sign transactions until the next `Add`.
+Creation flow:
 
-#### Precompile Interface
+1. Decode `adminPubkey` and `p256Sig`.
+2. Recompute the `Create` `signalHash`.
+3. Verify `p256Sig` is a valid P256 ECDSA signature over `signalHash` for the public key `adminPubkey`, via the [RIP-7212](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md) precompile or equivalent host function. Implementations MUST reject off-curve points and enforce low-`s`.
+4. Set `addressDefiningMaterial = adminPubkey` and derive `addr` per the abstract address formula.
+5. Require account does not exist at `addr`.
+6. Store `adminType = ADMIN_TYPE_P256`, `verificationPublicId = adminPubkey`, `sessionKeys = keyringUpdate.keys`, `adminNonce = 0`.
 
-```solidity
-interface IWorldIDAccount {
-    /// @notice Create a World ID Account authorized by a World ID 4.0 Uniqueness Proof.
-    function create(
-        uint256 worldIDAccountNullifier,       // ν_k
-        uint256 worldIDAccountNonce,           // World ID Account selector; recomputed into `action`
-        uint256 proofNonce,                  // verifier request nonce
-        uint256 sessionId,                   // fresh session for subsequent updates
-        uint64  issuerSchemaId,
-        uint64  expiresAtMin,
-        uint256 credentialGenesisIssuedAtMin,
-        uint256[5] calldata proof,           // compressed Groth16 proof
-        KeyringUpdate calldata createUpdate
-    ) external returns (address worldIDAccountAddress);
+##### Updates
 
-    /// @notice Apply an Add/Remove update authorized by a World ID 4.0 Session Proof.
-    function update(
-        address worldIDAccount,
-        uint256 proofNonce,                  // verifier request nonce
-        uint64  issuerSchemaId,
-        uint64  expiresAtMin,
-        uint256 credentialGenesisIssuedAtMin,
-        uint256[2] calldata sessionNullifier, // ephemeral per-update verifier input; MUST NOT be stored
-        uint256[5] calldata proof,           // compressed Groth16 proof
-        KeyringUpdate calldata keyringUpdate
-    ) external;
+`adminAuthorization` is the byte-encoding of a P256 ECDSA signature `(r, s)` over the `Update` `signalHash`.
 
-    function getSessionKeys(address worldIDAccount) external view returns (SessionKey[] memory);
-    function isAuthorized(address worldIDAccount, SessionKey calldata key) external view returns (bool);
-    function getWorldAccountNullifier(address worldIDAccount) external view returns (uint256);
-}
-```
+Update flow:
 
-For `create`, the precompile MUST:
+1. Load `adminPubkey` from `verificationPublicId` and `adminNonce`.
+2. Recompute the `Update` `signalHash`.
+3. Verify the signature is valid for `(signalHash, adminPubkey)`; enforce low-`s`.
+4. Increment `adminNonce`.
+5. Apply `keyringUpdate`, queued behind the timelock.
 
-1. Require `createUpdate.mode == Create`.
-2. Recompute `action = keccak256(abi.encodePacked(WORLD_ID_ACCOUNT_TAG, uint256(worldIDAccountNonce)))`.
-3. Recompute `signalHash = uint256(keccak256(abi.encode(createUpdate))) >> 8`.
-4. Invoke `WorldID.verify(worldIDAccountNullifier, action, WORLD_CHAIN_RP_ID, proofNonce, signalHash, …, proof)`.
-5. Derive `worldIDAccountAddress = bytes20(keccak256(worldIDAccountNullifier))`, associate the supplied `sessionId` with `worldIDAccountAddress`, and apply `createUpdate` immediately.
+##### Recovery
 
-For `update`, the precompile MUST:
-
-1. Require `update.mode != Create`.
-2. Load the stored `sessionId` for `worldIDAccount`.
-3. Recompute `signalHash = uint256(keccak256(abi.encode(update))) >> 8`.
-4. Invoke `WorldID.verifySession(WORLD_CHAIN_RP_ID, proofNonce, signalHash, …, sessionId, sessionNullifier, proof)`.
-5. Discard `sessionNullifier` after verification; it MUST NOT be persisted in World ID Account state.
-6. Apply `update`, queued behind the timelock for `Add` / `Remove` (see [Timelock](#timelock)).
-
-The precompile DOES NOT enforce a one-account-per-WorldID constraint; distinct World ID Accounts remain indexed by distinct `worldIDAccountNonce` values.
-
-> **Note — Precompile gas accounting out of scope.** The specific gas pricing schedule for interacting with `WORLD_ID_ACCOUNT_PRECOMPILE` — covering Groth16 verification cost, per-session-key storage mutation, timelock queue/cancel/execute operations, and the amortized cost of `isAuthorized` reads during `0x1D` validation — is **NOT** defined here. A follow-on revision MUST specify gas costs per operation.
+**Not supported.** Same warning as Secp256k1 admin.
 
 ### Recovery
 
-Recovery is the degenerate case of an `Add` or `Remove` submitted after session keys are lost or compromised. Because post-creation authorization is a World ID 4.0 Session Proof bound to the World ID Account's stored `sessionId`, recovery requires only a fresh Session Proof — the full session-key surface is reachable via the same mutation path. No separate recovery flow or state is introduced.
+Recovery semantics are per-instantiation:
 
-A single WorldID MAY enable recovery for any number of World ID Accounts; World ID Accounts at distinct `worldIDAccountNonce` values remain unlinkable across the recovery event.
+- **WorldID admin.** Recovery is the degenerate case of an `Add` or `Remove` submitted via Session Proof — see the WorldID admin instantiation. Lost or compromised session keys are recovered by any fresh Session Proof bound to the account's stored `sessionId`.
+- **Secp256k1 admin.** **NOT supported.** Loss of the admin key is terminal.
+- **P256 admin.** **NOT supported.** Loss of the admin key is terminal.
 
-### Timelock
-
-A compromised WorldID authenticator could otherwise rotate session keys in a single block and drain a World ID Account. World ID Account updates are subject to a configurable delay:
-
-- `Create` executes immediately (no prior session keys exist to cancel).
-- `Add` and `Remove` are pending until the delay elapses.
-- Existing session keys MAY cancel a pending update during the delay window.
-- The revocation-then-add attack (a Session Proof removes all keys, then adds malicious ones with no incumbents left to cancel) MUST be mitigated — e.g., by delaying removals, or by allowing recently-removed keys to cancel pending adds.
-
-Queue / cancel / execute interface additions are TBD.
+Users requiring recoverability MUST choose the WorldID admin instantiation.
 
 ### Transaction Type `0x1D`
 
-A `0x1D` transaction is signed by a session key of a World ID Account and submitted directly to the mempool (no [ERC-4337](https://eips.ethereum.org/EIPS/eip-4337) bundler required).
+A `0x1D` transaction is signed by a session key of a World Chain Account and submitted directly to the mempool (no [ERC-4337](https://eips.ethereum.org/EIPS/eip-4337) bundler required). `0x1D` transactions are admin-type-agnostic: they are signed by session keys regardless of which admin authority controls the account, and the validation path reads only the account's keyring.
 
 #### Envelope
 
@@ -229,7 +478,7 @@ A `0x1D` transaction is signed by a session key of a World ID Account and submit
     value,                       // 6
     data,                        // 7
     access_list,                 // 8
-    world_id_account,               // 9   ← signer's World ID Account address
+    account,                     // 9   ← signer's World Chain Account address
     signature_type,              // 10
     session_key,                 // 11  ← `keyData` of the signing session key (per §Session Keys)
     signature_payload,           // 12
@@ -240,14 +489,9 @@ A `0x1D` transaction is signed by a session key of a World ID Account and submit
 signing_hash = keccak256(0x1D || rlp(fields[0..=11]))
 ```
 
-The `signing_hash` covers every field except `signature_payload` itself, binding the
-declared `signature_type` and `session_key` to the signature and ruling out
-scheme-confusion or pubkey-substitution attacks at the consensus layer.
+The `signing_hash` covers every field except `signature_payload` itself, binding the declared `signature_type` and `session_key` to the signature and ruling out scheme-confusion or pubkey-substitution attacks at the consensus layer.
 
-`session_key` is the `keyData` bytes of the `SessionKey` (§Session Keys) used to
-authenticate the transaction. Its `KeyType` is implied by `signature_type` —
-implementations MUST reject any transaction where the length of `session_key`
-does not match the byte length specified for the corresponding `KeyType`.
+`session_key` is the `keyData` bytes of the `SessionKey` (§Session Keys) used to authenticate the transaction. Its `KeyType` is implied by `signature_type` — implementations MUST reject any transaction where the length of `session_key` does not match the byte length specified for the corresponding `KeyType`.
 
 | `signature_type`                                         | `signature_payload`                                 |
 | -------------------------------------------------------- | --------------------------------------------------- |
@@ -256,74 +500,101 @@ does not match the byte length specified for the corresponding `KeyType`.
 | `0x02` [WebAuthn](https://www.w3.org/TR/webauthn-3/)     | `rlp([authenticator_data, client_data_json, r, s])` |
 | `0x03` [EdDSA](https://en.wikipedia.org/wiki/EdDSA)      | `rlp([R, s])`                                       |
 
-For `Secp256k1`, the `session_key` field is redundant with the recoverable public
-key; implementations MUST verify the recovered key matches the declared
-`session_key` (compressed-form encoding) before accepting the transaction.
+For `Secp256k1`, the `session_key` field is redundant with the recoverable public key; implementations MUST verify the recovered key matches the declared `session_key` (compressed-form encoding) before accepting the transaction.
 
 #### Validation
 
-1. Verify `signature_payload` against `signing_hash` using `session_key` as the
-   verifying key (for `Secp256k1`, equivalently: recover and assert equality
-   with `session_key`).
-2. Assert `IWorldIDAccount.isAuthorized(world_id_account, SessionKey { signature_type, session_key })`.
+1. Verify `signature_payload` against `signing_hash` using `session_key` as the verifying key (for `Secp256k1`, equivalently: recover and assert equality with `session_key`).
+2. Assert `IWorldChainAccount.isAuthorized(account, SessionKey { signature_type, session_key })`.
 
 The envelope is extensible to 2D nonces, batched transactions, and native paymaster support in follow-on WIPs.
 
 ### Extensions
 
-- **Per-key permissions.** Session keys MAY be extended with `(expiry, spendLimit, CallScope[])` metadata enforced by the precompile during `0x1D` validation. This extends `SessionKey` and the `KeyringUpdate` signal; the World ID proof continues to bind the full permission set via **(G5)**.
-- **Session rotation.** Replacing a World ID Account's stored `sessionId` with a newly-created session without re-creating the account is deferred.
+- **Per-key permissions.** Session keys MAY be extended with `(expiry, spendLimit, CallScope[])` metadata enforced by the precompile during `0x1D` validation. This extends `SessionKey` and the `KeyringUpdate` signal; the admin authorization continues to bind the full permission set via `signalHash`.
+- **Admin rotation.** Replacing an account's stored `verificationPublicId` (or `adminType`) under admin authorization, with timelock. Deferred — admin type and authority are pinned at creation in this WIP.
+- **Multi-admin.** M-of-N admin authorization for a single account. Deferred.
+- **Additional admin instantiations.** EdDSA-admin, WebAuthn-as-admin, [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271)-admin (contract-controlled accounts).
+- **WorldID-recovery escape hatch for key-admin accounts.** A Secp256k1 / P256 admin account MAY enroll a WorldID at creation as a recovery-only authority that, after a long timelock, can rotate the admin key.
+- **Session rotation.** Replacing a WorldID-admin account's stored `sessionId` with a newly-provisioned session without re-creating the account.
 - **Bundling, 2D nonces, paymasters.** Reserved for follow-on WIPs on the `0x1D` envelope.
 
 ## Rationale
 
-**World ID Account state as precompile.** The session key set lives in a precompile because `0x1D` signature validation happens at the protocol level and must read the authorized set natively. The same precompile owns the creation Uniqueness Proof and Session Proof verification paths, ensuring the address-to-keyset map is only mutated under valid World ID 4.0 proofs.
+**Account state as precompile.** The keyring lives in a precompile because `0x1D` signature validation happens at the protocol level and must read the authorized set natively. The same precompile owns the admin verification paths, ensuring the address-to-keyset map is only mutated under valid admin authorizations.
 
-**World ID 4.0 Proofs as authorization.** World ID Account creation uses a Uniqueness Proof and provisions a fresh session; subsequent mutations use Session Proofs bound to the stored `sessionId`, so repeated World ID Account updates do not rely on reusing the creation action. No "super key" ever needs to be stored on-device. The `worldIDAccountNonce`-indexed creation action (`keccak256(WORLD_ID_ACCOUNT_TAG || worldIDAccountNonce)`) lets a single WorldID own unlinkably many World ID Accounts, with each account's address pinned for life by $\mathrm{addr}(\nu_k) = \mathrm{bytes20}(\mathrm{keccak256}(\nu_k))$.
+**Pluggable admin authorities.** Decoupling the keyring + transaction surface from the admin verification primitive lets a single account abstraction serve users with a WorldID, users with hardware-secured root keys, and integrations driven by existing key-management infrastructure. Sharing `0x1D`, session keys, signal binding, and timelock across instantiations means session-key UX and integration surface are uniform regardless of admin type. Each new instantiation reduces to one verification primitive plus one address-derivation rule.
 
-**No sybil constraint on World ID Accounts.** Unlinkability across `worldIDAccountNonce` values is a stronger property than one-account-per-identity, and sybil resistance at the account layer is not the right locus — it belongs to whatever system consumes World ID Account addresses (e.g., gas subsidy accounting, application-layer rate limits), which can bind its own per-WorldID limits via independent nullifier domains.
+**Single admin authority.** Each account has exactly one admin authority. M-of-N admin authorization is a useful generalization but is deferred — it adds quorum-management state and protocol surface that this WIP does not require for its initial use cases. Multi-admin can be added as an Extension without changing the abstract account model.
 
-**Recovery timelock.** Without a delay, a compromised WorldID authenticator could instantly replace all session keys and drain the account. The timelock gives existing session key holders a window to detect and cancel malicious changes.
+**Admin type pinned at creation.** Address determinism: `adminType` and the address-defining material are part of the address preimage, so changing either mid-lifetime would change the address. Rotation within the same admin type is also deferred to keep v1 minimal.
+
+**No recovery for key-admin accounts.** Key-admin accounts are owned exclusively by their admin key; there is no underlying identity anchor to bootstrap recovery from. Users requiring recoverability choose the WorldID admin instantiation. This matches existing precedent (Tempo root keys, Ethereum EOAs) and avoids smuggling a second admin tier into the spec.
+
+**Uniform replay protection.** All admin authorizations bind to a `signalHash` containing a per-account monotonic `adminNonce`; the precompile increments `adminNonce` on every successful update and rejects authorizations against stale values. Across instantiations, this gives one replay-protection contract — no instantiation-specific bespoke replay machinery, and no ambiguity around what "fresh" means per instantiation.
+
+**Domain-separated address derivation.** Prefixing the address preimage with `adminTypeTag` prevents accidental cross-type collisions even when the address-defining material from two instantiations might coincidentally produce identical bytes under different encodings. Domain separation costs nothing and is standard practice for keccak-based identifier schemes.
+
+**`msg.sender` binding in `signalHash`.** Including `msg.sender` in both `Create` and `Update` `signalHash` definitions kills cross-submitter replay of in-flight admin authorizations: a witnessed authorization with `msg.sender = X` will not verify if resubmitted by a different account. Self-replay by `X` is a no-op (the resulting state is identical). This subsumes the `MAY bind proofs to msg.sender` mitigation noted in earlier drafts of this WIP.
+
+**WorldID 4.0 Proofs as authorization.** Within the WorldID admin instantiation, account creation uses a Uniqueness Proof and provisions a fresh session; subsequent mutations use Session Proofs bound to the stored `sessionId`, so repeated account updates do not rely on reusing the creation action. No "super key" ever needs to be stored on-device. The `worldIDAccountNonce`-indexed creation action lets a single WorldID own unlinkably many WorldID-admin accounts.
+
+**No sybil constraint on accounts.** Unlinkability across `worldIDAccountNonce` values is a stronger property than one-account-per-identity, and sybil resistance at the account layer is not the right locus — it belongs to whatever system consumes account addresses (e.g., gas subsidy accounting, application-layer rate limits), which can bind its own per-WorldID limits via independent nullifier domains.
+
+**Recovery timelock.** Without a delay, a compromised admin authority could instantly replace all session keys and drain the account. The timelock gives existing session key holders a window to detect and cancel malicious changes. The same timelock applies regardless of admin type — a Secp256k1 admin compromise is no less serious than a WorldID compromise, and the cancellation surface (existing session keys) is the same.
 
 ## Backwards Compatibility
 
-This WIP introduces a new account type and transaction type. Existing EOAs and smart contract accounts are unaffected. Standard [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) transactions continue to work for legacy accounts; the `0x1D` envelope is required only for World-ID-Account-authenticated execution.
+This WIP introduces a new account type and transaction type. Existing EOAs and smart contract accounts are unaffected. Standard [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) transactions continue to work for legacy accounts; the `0x1D` envelope is required only for World-Chain-Account-authenticated execution.
 
-### Existing Safe Accounts
+This WIP is Draft. The address-derivation prefix (`adminTypeTag`) and the unified `signalHash` (now including `msg.sender` and `adminNonce`) are breaking changes relative to earlier drafts of this WIP — implementations targeting prior drafts MUST update address derivation and `signalHash` recomputation accordingly. No production accounts exist.
 
-Existing [Safe](https://safe.global) accounts MAY adopt a World ID Account as an authenticator without migrating assets or changing the Safe address. The integration reduces to installing a module that gates execution on `msg.sender` matching a bound World ID Account address; because a `0x1D` transaction's sender is the World ID Account itself, no additional signature verification is required at the Safe layer — protocol-level validation against `IWorldIDAccount.isAuthorized` already gates execution upstream.
+### Existing Safe Accounts (WorldID admin)
+
+Existing [Safe](https://safe.global) accounts MAY adopt a WorldID-admin account as an authenticator without migrating assets or changing the Safe address. The integration reduces to installing a module that gates execution on `msg.sender` matching a bound WorldID-admin account address; because a `0x1D` transaction's sender is the account itself, no additional signature verification is required at the Safe layer — protocol-level validation against `IWorldChainAccount.isAuthorized` already gates execution upstream. Key-admin accounts (Secp256k1, P256) integrate with Safe via Safe's existing native-key support; no module is required.
 
 ## Security Considerations
 
-### Proof Replay
+### Front-Running Admin Authorizations
 
-Because neither the creation proof nor later Session Proofs are bound to the submitting party, any party observing an in-flight proof in the mempool can re-submit it. Signal binding **(G5)** prevents substituting a different update, but a griefer can front-run the original submitter. Harm is limited to gas and ordering — the resulting state is identical. Implementations MAY bind proofs to `msg.sender` or a session-key-signed commitment if stronger guarantees are required.
-
-### World ID Account Unlinkability
-
-Two World ID Accounts owned by the same WorldID are unlinkable across distinct creation `worldIDAccountNonce` values by the ZK property of the OPRF proof. Subsequent updates no longer reuse the creation action; they are authorized via Session Proofs bound to the World ID Account's stored `sessionId`. Updates to the same World ID Account remain linkable through the World ID Account address and its on-chain state transitions.
+Both `Create` and `Update` `signalHash` definitions bind `msg.sender`, so a witnessed admin authorization observed in the mempool cannot be replayed by a different submitter — its `signalHash` would not match. This applies to all instantiations. A griefer can still re-submit an authorization unchanged from the original `msg.sender`, but the resulting state is identical; harm is limited to gas and ordering.
 
 ### Timelock Attacks
 
-The revocation-then-add attack vector (a Session Proof removes all session keys, then adds malicious ones with no keys left to cancel) MUST be addressed in the timelock policy design. Possible mitigations include timelocking removals or allowing recently-removed keys to cancel pending adds.
+The revocation-then-add attack vector (an admin authorization removes all session keys, then adds malicious ones with no keys left to cancel) MUST be addressed in the timelock policy design. Possible mitigations include timelocking removals or allowing recently-removed keys to cancel pending adds. This applies regardless of admin type.
 
 ### Session Key Deanonymization
 
-A session key that is also used as an EOA or added to another World ID Account trivially links the account to that external identity. Clients SHOULD generate fresh session keys per World ID Account.
+A session key that is also used as an EOA, or added to a different World Chain Account, trivially links the account to that external identity. Clients SHOULD generate fresh session keys per account.
 
 ### Signature-key Ambiguity
 
-A World ID Account may store up to `MAX_SESSION_KEYS` keys of mixed `KeyType`, but a `0x1D` transaction declares a single `signature_type`. The spec should define whether a key index is included in the envelope or whether the first matching key is authoritative.
+A World Chain Account may store up to `MAX_SESSION_KEYS` session keys of mixed `KeyType`, but a `0x1D` transaction declares a single `signature_type`. The spec should define whether a key index is included in the envelope or whether the first matching key is authoritative.
 
 ### WebAuthn Challenge Binding
 
-For `signature_type = 0x02`, the `0x1D` `signing_hash` MUST appear as the `challenge` field inside `client_data_json`; otherwise the signature could be replayed from a different WebAuthn context.
+For session-key `signature_type = 0x02`, the `0x1D` `signing_hash` MUST appear as the `challenge` field inside `client_data_json`; otherwise the signature could be replayed from a different WebAuthn context.
 
-### Stale Merkle Root
+### WorldID-admin: Account Unlinkability
+
+Two WorldID-admin accounts owned by the same WorldID are unlinkable across distinct creation `worldIDAccountNonce` values by the ZK property of the OPRF proof. Subsequent updates no longer reuse the creation action; they are authorized via Session Proofs bound to the account's stored `sessionId`. Updates to the same account remain linkable through the account address and its on-chain state transitions.
+
+### WorldID-admin: Stale Merkle Root
 
 The `WorldIDRegistry` accepts roots within a validity window. An attacker whose credential has been revoked could race to submit `create` or `update` against a still-valid but stale root before expiry. The `expiresAtMin + minExpirationThreshold ≥ block.timestamp` check bounds this window, but its duration is a trust parameter.
 
-### OPRF Key Rotation
+### WorldID-admin: OPRF Key Rotation
 
-If the OPRF key in `OprfKeyRegistry[480]` is rotated, both creation nullifier derivations and session re-derivations change. Existing $\nu_k$ values become unreachable for new creation proofs, and existing `sessionId` values can no longer be used to derive valid Session Proofs; the World ID Account becomes frozen at its current session key set. The protocol MUST define migration semantics across OPRF key epochs.
+If the OPRF key in `OprfKeyRegistry[480]` is rotated, both creation nullifier derivations and session re-derivations change. Existing $\nu_k$ values become unreachable for new creation proofs, and existing `sessionId` values can no longer be used to derive valid Session Proofs; affected accounts become frozen at their current keyring. The protocol MUST define migration semantics across OPRF key epochs.
 
+### Key-admin: Admin Key Loss Is Terminal
+
+For Secp256k1 and P256 admin instantiations, loss of the admin key permanently bricks the account — the keyring cannot be mutated, recovered, or rotated. Wallets implementing key-admin accounts MUST surface this risk to users and SHOULD encourage hardware-backed key custody. Users who require recoverability MUST choose the WorldID admin instantiation.
+
+### Key-admin: Linkability
+
+A Secp256k1 or P256 admin pubkey is recoverable from any creation transaction's calldata. Unlike WorldID-admin accounts, key-admin accounts carry no unlinkability guarantees: anyone observing the admin pubkey can identify the (single) account derived from it. Cross-chain reuse of an admin key is a deanonymization vector.
+
+### Key-admin: No Liveness Check
+
+A key-admin account has no protocol-level liveness check on session-key-signed transactions. Session-key compromise can drain account-controlled value at the rate session keys can sign, bounded only by per-key limits (if any) and the timelock on keyring mutation. Sibling WIPs that require WorldID liveness above a value threshold do NOT apply to key-admin accounts.

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -1,7 +1,7 @@
 ---
 wip: 1001
 title: World Chain Native Account Abstraction
-description: A precompile-managed account model with a single admin authority pinned at creation, supporting WorldID, Secp256k1, and P256 admins. Session keys sign EIP-2718 typed transactions (`0x1D`) on the account; admin authorities gate session-key set mutations.
+description: A smart contract managed account model with a single admin authority pinned at creation, supporting WorldID, Secp256k1, and P256 admins. Session keys sign EIP-2718 typed transactions (`0x1D`) on the account; admin authorities gate session-key set mutations.
 author: Kilian Glas (@kilianglas), 0xOsiris (@0xOsiris), Eric Woolsey (@0xforerunner)
 status: Draft
 type: Standards Track

--- a/wips/wip-1002.md
+++ b/wips/wip-1002.md
@@ -14,7 +14,7 @@ requires: WIP-1001, EIP-1559
 
 A **WorldID Subsidy Accounting** system enables per-credential, ETH-denominated transaction-fee subsidies for verified humans on World Chain. A [World ID](https://worldcoin.org/world-id) opens a per-period subsidy record whose `nullifier` — derived from a [World ID 4.0](https://github.com/worldcoin/world-id-protocol) Uniqueness Proof — is the record's primary key for budget, authorization, and replay state. The initial claim is driven by a multi-item proof request authorized by a World-Chain-operated WIP-101 relying party contract (an [ERC-1271](https://eips.ethereum.org/EIPS/eip-1271)-style smart-contract signer); the authenticator lists one `RequestItem` per credential the WorldID holds and emits one Uniqueness Proof per item, all sharing the same `nullifier`. Each proof's signal carries the initial set of authorized accounts permitted to spend the budget. The first on-chain call also binds a World ID `sessionId` to the `nullifier` record; subsequent Session Proofs against that `sessionId` may claim credentials acquired later in the period or add / remove authorized addresses. Budgets are governance-configurable per `issuerSchemaId`, and subsidy records expire at period boundaries.
 
-Authorized addresses may be legacy EOAs, smart contract accounts, or [WIP-1001](./wip-1001.md) *World ID Accounts* — the subsidy system is orthogonal to the account type it funds.
+Authorized addresses may be legacy EOAs, smart contract accounts, or [WIP-1001](./wip-1001.md) *World Chain Accounts* — the subsidy system is orthogonal to the account type it funds.
 
 ## Motivation
 
@@ -178,7 +178,7 @@ interface ISubsidyAccounting {
 
 #### Authorization Map
 
-Reverse index from authorized account address to the set of `nullifier` records the address may draw budget from. Populated on `claimSubsidy` from the `addAddresses` list; mutated throughout the period by `updateAddresses`. Authorized addresses MAY be EOAs, smart contract accounts, or [WIP-1001](./wip-1001.md) *World ID Accounts*.
+Reverse index from authorized account address to the set of `nullifier` records the address may draw budget from. Populated on `claimSubsidy` from the `addAddresses` list; mutated throughout the period by `updateAddresses`. Authorized addresses MAY be EOAs, smart contract accounts, or [WIP-1001](./wip-1001.md) *World Chain Accounts*.
 
 #### Subsidy Budget Map
 
@@ -349,7 +349,7 @@ Note that the claim nullifiers of the same World ID across different periods can
 For an incoming transaction:
 
 1. The protocol (or builder) looks up whether the sender address has an associated subsidy `nullifier` in the authorization map.
-2. If the address maps to more than one `nullifier`, a deterministic rule selects which record's budget to use. A [WIP-1001](./wip-1001.md) `0x1D` transaction MAY extend its envelope with an OPTIONAL `subsidy_nullifier` field; if present and the `world_id_account` is authorized under that `nullifier`, the declared budget is consumed.
+2. If the address maps to more than one `nullifier`, a deterministic rule selects which record's budget to use. A [WIP-1001](./wip-1001.md) `0x1D` transaction MAY extend its envelope with an OPTIONAL `subsidy_nullifier` field; if present and the `account` is authorized under that `nullifier`, the declared budget is consumed.
 3. The remaining ETH-denominated budget (`remainingWei`) is decremented by `gasUsed * baseFee` (Wei) of the transaction.
 
 `getBudget(address)` SHOULD apply the same deterministic nullifier-selection rule so off-chain callers observe the same effective budget that transaction execution would consume.
@@ -383,11 +383,11 @@ Non-claim transactions consume budget through the [Subsidy Accounting Flow](#sub
 
 **Periodic refresh with early submission.** Fixed periods with expiring subsidies provide a clean budget lifecycle. Allowing early refresh prevents a thundering herd at period boundaries.
 
-**Orthogonality to World ID Accounts.** [WIP-1001](./wip-1001.md) *World ID Accounts* are authorized here like any other address — no special coupling is required. Legacy EOAs can opt in to fee subsidies without migrating account types, and World ID Accounts can sign `0x1D` transactions that either do or do not consume subsidy budget.
+**Orthogonality to World Chain Accounts.** [WIP-1001](./wip-1001.md) *World Chain Accounts* are authorized here like any other address — no special coupling is required, and the subsidy system is agnostic to the account's admin type (WorldID, Secp256k1, P256). Legacy EOAs can opt in to fee subsidies without migrating account types, and World Chain Accounts can sign `0x1D` transactions that either do or do not consume subsidy budget.
 
 ## Backwards Compatibility
 
-This WIP introduces a new protocol/builder-level accounting system. It does not modify the semantics of any existing transaction type. Any account type — legacy EOA, smart contract, or [WIP-1001](./wip-1001.md) World ID Account — may be authorized under a subsidy `nullifier` and thereby have its transaction fees subsidized. Whether [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) transactions from authorized accounts can consume subsidy budgets is an open question (see optional requirements).
+This WIP introduces a new protocol/builder-level accounting system. It does not modify the semantics of any existing transaction type. Any account type — legacy EOA, smart contract, or [WIP-1001](./wip-1001.md) World Chain Account — may be authorized under a subsidy `nullifier` and thereby have its transaction fees subsidized. Whether [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) transactions from authorized accounts can consume subsidy budgets is an open question (see optional requirements).
 
 ## Test Cases
 


### PR DESCRIPTION
## Summary

- Refactor WIP-1001 around an abstract Account Model with pluggable admin authorities. Each account has exactly one admin authority, type pinned at creation, drawn from three initial instantiations: WorldID admin (existing flow), Secp256k1 admin, P256 admin. WorldID-only assumptions are pushed into the WorldID instantiation; the abstract model carries only what is shared across all admin types.
- Unify replay protection. Every admin authorization binds a per-account monotonic `adminNonce` into a uniform `signalHash` (mirrored on WIP-1002's signal-binding pattern, with `bytes32` domain tags and `msg.sender` binding). Resolves the prior nonce-vs-verification ambiguity between the spec's signal definition and the precompile verification step. Address-derivation gains a one-byte `adminTypeTag` for cross-instantiation domain separation.
- Update WIP-1002 cross-references to the new "World Chain Account" terminology (no functional change to WIP-1002).

## Why

WIP-1001 currently scopes the account abstraction to WorldID-anchored accounts only. Generalizing to pluggable admin authorities lets the same account abstraction serve users without a WorldID, hot/cold-separated wallets, and integrations driven by existing key-management infrastructure, while preserving WorldID admin's recovery semantics and unlinkability properties as one (recommended) instantiation. Sharing the keyring + `0x1D` envelope + timelock across instantiations means session-key UX and integration surface are uniform regardless of admin type.

This is the project's `Native Multi-Auth` direction in concrete form, expressed as a refactor of the existing WIP rather than a sibling spec.

## Breaking Changes 

- Address-derivation prefix (`adminTypeTag`) is a breaking change relative to earlier drafts. WorldID-admin addresses now derive as `keccak(0x00 || ν_k)` rather than `keccak(ν_k)`.
- `signalHash` formula now explicitly binds `msg.sender` and `adminNonce`, formalising what was a `MAY bind` mitigation in the prior draft.
- Precompile interface generalized: `IWorldIDAccount` → `IWorldChainAccount`, with `create(adminType, ...)` and `update(...)` taking opaque per-instantiation calldata for the admin authorization.