### PR TITLE
fix: jovian payload attributes

### DIFF
--- a/crates/builder/src/execution_context.rs
+++ b/crates/builder/src/execution_context.rs
@@ -33,6 +33,7 @@ use reth_optimism_payload_builder::{
     config::OpBuilderConfig,
 };
 use reth_optimism_primitives::OpTransactionSigned;
+use reth_payload_primitives::BuildNextEnv;
 use reth_payload_util::PayloadTransactions;
 use reth_primitives_traits::{Recovered, SealedHeader, TxTy};
 use reth_provider::{BlockReaderIdExt, ChainSpecProvider, StateProviderFactory};
@@ -165,32 +166,11 @@ where
         DB::Error: Send + Sync + 'static,
         DB: Database + 'a,
     {
-        // Prepare attributes for next block environment.
-        let gas_limit = self
-            .inner
-            .attributes()
-            .gas_limit
-            .unwrap_or(self.inner.parent().gas_limit);
-        let attributes = OpNextBlockEnvAttributes {
-            timestamp: self.inner.attributes().timestamp(),
-            suggested_fee_recipient: self.inner.attributes().suggested_fee_recipient(),
-            prev_randao: self.inner.attributes().prev_randao(),
-            gas_limit,
-            parent_beacon_block_root: self.inner.attributes().parent_beacon_block_root(),
-            extra_data: if self
-                .spec()
-                .is_holocene_active_at_timestamp(self.attributes().timestamp())
-            {
-                self.attributes()
-                    .get_holocene_extra_data(
-                        self.spec()
-                            .base_fee_params_at_timestamp(self.attributes().timestamp()),
-                    )
-                    .map_err(PayloadBuilderError::other)?
-            } else {
-                Default::default()
-            }, // TODO: FIXME: Double check this against op-reth
-        };
+        let attributes = OpNextBlockEnvAttributes::build_next_env(
+            self.inner.attributes(),
+            self.inner.parent(),
+            self.spec(),
+        )?;
 
         // Prepare EVM environment.
         let evm_env = self

--- a/crates/builder/src/execution_context.rs
+++ b/crates/builder/src/execution_context.rs
@@ -15,7 +15,6 @@ use op_alloy_rpc_types::OpTransactionRequest;
 use alloy_rpc_types_engine::PayloadId;
 use op_revm::OpSpecId;
 use reth_basic_payload_builder::PayloadConfig;
-use reth_chainspec::EthChainSpec;
 use reth_evm::{
     ConfigureEvm, Database, Evm, EvmEnv,
     block::{BlockExecutionError, BlockValidationError},

--- a/crates/builder/src/payload_builder.rs
+++ b/crates/builder/src/payload_builder.rs
@@ -45,7 +45,6 @@ use tracing::trace;
 use world_chain_primitives::access_list::FlashblockAccessList;
 
 use reth_optimism_chainspec::OpChainSpec;
-use reth_optimism_forks::OpHardforks;
 use reth_optimism_node::{
     OpEvmConfig, OpNextBlockEnvAttributes, OpRethReceiptBuilder, txpool::OpPooledTx,
 };
@@ -358,7 +357,7 @@ where
 
     let execution_conext = ctx
         .evm_config()
-        .context_for_next_block(ctx.parent(), attributes)
+        .context_for_next_block(ctx.parent(), attributes.clone())
         .map_err(PayloadBuilderError::other)?;
 
     let committed_state = CommittedState::<OpRethReceiptBuilder>::try_from(committed_payload)

--- a/crates/builder/src/payload_builder.rs
+++ b/crates/builder/src/payload_builder.rs
@@ -38,6 +38,7 @@ use reth_evm::{
     ConfigureEvm, Database, EvmEnv, execute::BlockBuilderOutcome, precompiles::PrecompilesMap,
 };
 use reth_node_api::{BuiltPayloadExecutedBlock, NodePrimitives, PayloadBuilderError};
+use reth_payload_primitives::BuildNextEnv;
 use reth_revm::database::StateProviderDatabase;
 use revm_database::State;
 use tracing::trace;
@@ -345,28 +346,9 @@ where
     );
 
     let _enter = span.enter();
-    let gas_limit = ctx.attributes().gas_limit.unwrap_or(ctx.parent().gas_limit);
 
-    let attributes = OpNextBlockEnvAttributes {
-        timestamp: ctx.attributes().timestamp(),
-        suggested_fee_recipient: ctx.attributes().suggested_fee_recipient(),
-        prev_randao: ctx.attributes().prev_randao(),
-        gas_limit,
-        parent_beacon_block_root: ctx.attributes().parent_beacon_block_root(),
-        extra_data: if ctx
-            .spec()
-            .is_holocene_active_at_timestamp(ctx.attributes().timestamp())
-        {
-            ctx.attributes()
-                .get_holocene_extra_data(
-                    ctx.spec()
-                        .base_fee_params_at_timestamp(ctx.attributes().timestamp()),
-                )
-                .map_err(PayloadBuilderError::other)?
-        } else {
-            Default::default()
-        },
-    };
+    let attributes =
+        OpNextBlockEnvAttributes::build_next_env(ctx.attributes(), ctx.parent(), ctx.spec())?;
 
     // Prepare EVM environment.
     let evm_env = ctx
@@ -388,7 +370,7 @@ where
 
     trace!(
         target: "flashblocks::payload_builder",
-        gas_limit,
+        gas_limit = attributes.gas_limit,
         effective_gas_limit,
         committed_gas_used = committed_state.gas_used,
         timestamp = ctx.attributes().timestamp(),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how next-block environment attributes (including `gas_limit` and fork-specific `extra_data`) are derived for payload building, which can affect block validity if the helper’s logic differs from the previous inline computation. Scope is small but touches consensus-critical payload construction paths.
> 
> **Overview**
> Refactors payload building to derive `OpNextBlockEnvAttributes` via `OpNextBlockEnvAttributes::build_next_env(...)` (from `reth_payload_primitives::BuildNextEnv`) instead of duplicating inline attribute construction in both `execution_context` and `payload_builder`.
> 
> Also updates tracing to log `gas_limit` from the computed `attributes` to match the new flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 246320224ce7e2242ea13243fbddd8bd6a23ef12. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->