### PR TITLE
feat: WIP-1001 - Issue 532: Session Key Update Timelocks

### DIFF
--- a/pkg/contracts/src/WorldIDAccountManagerImplV1.sol
+++ b/pkg/contracts/src/WorldIDAccountManagerImplV1.sol
@@ -112,10 +112,12 @@ contract WorldIDAccountManagerImplV1 is IWorldIDAccountManager, Base, Reentrancy
         worldIDAccountNullifier[worldIDAccount_] = worldIDAccountNullifier_;
         sessionIdOf[worldIDAccount_] = sessionId_;
 
-        _addKeys(worldIDAccount_, createUpdate_.keys);
+        if (createUpdate_.removeKeys.length != 0) revert InvalidOperation();
+
+        _addKeys(worldIDAccount_, createUpdate_.addKeys);
 
         emit WorldIDAccountCreated(worldIDAccount_, worldIDAccountNullifier_, sessionId_);
-        emit SessionKeysAdded(worldIDAccount_, createUpdate_.keys);
+        emit SessionKeysAdded(worldIDAccount_, createUpdate_.addKeys);
 
         worldIDVerifier.verify(
             worldIDAccountNullifier_,
@@ -141,11 +143,14 @@ contract WorldIDAccountManagerImplV1 is IWorldIDAccountManager, Base, Reentrancy
         uint256[5] calldata proof_,
         WorldIDAccountUpdate calldata accountUpdate_
     ) external virtual onlyProxy nonReentrant {
-        if (accountUpdate_.operation == Operation.Create) {
+        if (accountUpdate_.operation != Operation.Update) {
             revert InvalidOperation();
         }
         if (worldIDAccountNullifier[worldIDAccount_] == 0) {
             revert WorldIDAccountDoesNotExist();
+        }
+        if (accountUpdate_.addKeys.length == 0 && accountUpdate_.removeKeys.length == 0) {
+            revert EmptyKeySet();
         }
 
         // Snapshot signal hash with the pre-bump generation so the verifier still validates
@@ -154,12 +159,15 @@ contract WorldIDAccountManagerImplV1 is IWorldIDAccountManager, Base, Reentrancy
 
         ++generationOf[worldIDAccount_];
 
-        if (accountUpdate_.operation == Operation.Add) {
-            _addKeys(worldIDAccount_, accountUpdate_.keys);
-            emit SessionKeysAdded(worldIDAccount_, accountUpdate_.keys);
-        } else {
-            _removeKeys(worldIDAccount_, accountUpdate_.keys);
-            emit SessionKeysRemoved(worldIDAccount_, accountUpdate_.keys);
+        _revertIfOverlappingKey(accountUpdate_.addKeys, accountUpdate_.removeKeys);
+
+        if (accountUpdate_.removeKeys.length != 0) {
+            _removeKeys(worldIDAccount_, accountUpdate_.removeKeys);
+            emit SessionKeysRemoved(worldIDAccount_, accountUpdate_.removeKeys);
+        }
+        if (accountUpdate_.addKeys.length != 0) {
+            _addKeys(worldIDAccount_, accountUpdate_.addKeys);
+            emit SessionKeysAdded(worldIDAccount_, accountUpdate_.addKeys);
         }
 
         _dispatchSessionProof(
@@ -222,6 +230,19 @@ contract WorldIDAccountManagerImplV1 is IWorldIDAccountManager, Base, Reentrancy
             sessionNullifier_,
             proof_
         );
+    }
+
+    /// @dev Rejects a unified update that mentions the same key in both `addKeys_` and
+    ///      `removeKeys_`. Overlap is treated as a malformed payload rather than a billed no-op.
+    function _revertIfOverlappingKey(bytes[] calldata addKeys_, bytes[] calldata removeKeys_) internal pure {
+        for (uint256 i = 0; i < addKeys_.length; ++i) {
+            bytes32 addHash = keccak256(addKeys_[i]);
+            for (uint256 j = 0; j < removeKeys_.length; ++j) {
+                if (addHash == keccak256(removeKeys_[j])) {
+                    revert OverlappingUpdateKey(addHash);
+                }
+            }
+        }
     }
 
     /// @dev Validates and appends each key in `keys_` to the authorized set for `worldIDAccount_`.

--- a/pkg/contracts/src/WorldIDAccountManagerImplV1.sol
+++ b/pkg/contracts/src/WorldIDAccountManagerImplV1.sol
@@ -25,6 +25,9 @@ contract WorldIDAccountManagerImplV1 is IWorldIDAccountManager, Base, Reentrancy
     /// @notice Domain tag folded into the action for World ID Account Uniqueness Proofs.
     bytes16 public constant WORLD_ID_ACCOUNT_TAG = "WORLD_ID_ACCOUNT";
 
+    /// @notice Domain tag used to separate revert proofs from key-set update proofs.
+    bytes16 public constant WORLD_ID_ACCOUNT_REVERT_TAG = "WORLD_ID_REVERT";
+
     /// @notice Maximum authorized authenticator keys per World ID Account.
     uint256 public constant MAX_SESSION_KEYS = 20;
 
@@ -38,21 +41,32 @@ contract WorldIDAccountManagerImplV1 is IWorldIDAccountManager, Base, Reentrancy
     /// @notice The World ID verifier proxy address.
     IWorldIDVerifier public worldIDVerifier;
 
+    /// @inheritdoc IWorldIDAccountManager
+    uint256 public sessionKeyUpdateCooldown;
+
     /// @notice A map from World ID accounts to their single use creation nullifier.
     mapping(address worldIDAccount => uint256 nullifier) public worldIDAccountNullifier;
 
     /// @notice The session identifier installed at creation, used to scope subsequent Session Proofs.
     mapping(address worldIDAccount => uint256 sessionId) public sessionIdOf;
 
-    /// @notice Per-account monotonic counter folded into update signal hashes so identical
-    ///         payloads still yield distinct signals across updates.
+    /// @notice Per-account monotonic counter folded into update and revert signal hashes.
     mapping(address worldIDAccount => uint256 generation) public generationOf;
 
-    /// @notice Hashes of the currently authorized authenticator keys for each account.
+    /// @notice Hashes of the post-cooldown authenticator keys for each account.
     mapping(address worldIDAccount => bytes32[] keyHashes) public sessionKeyHashes;
 
     /// @notice 1-indexed position in `sessionKeyHashes[acct]` of each key hash. `0` means absent.
     mapping(address worldIDAccount => mapping(bytes32 keyHash => uint256 indexPlusOne)) public keyHashIndex;
+
+    /// @notice Hashes of the effective pre-update authenticator keys during an active pending window.
+    mapping(address worldIDAccount => bytes32[] keyHashes) public previousSessionKeyHashes;
+
+    /// @notice 1-indexed position in `previousSessionKeyHashes[acct]` of each key hash.
+    mapping(address worldIDAccount => mapping(bytes32 keyHash => uint256 indexPlusOne)) public previousKeyHashIndex;
+
+    /// @notice Timestamp at which the stored key set becomes effective. `0` means no pending update.
+    mapping(address worldIDAccount => uint256 validAfter) public pendingValidAfter;
 
     ///////////////////////////////////////////////////////////////////////////////
     ///                              CONSTRUCTION                               ///
@@ -66,14 +80,21 @@ contract WorldIDAccountManagerImplV1 is IWorldIDAccountManager, Base, Reentrancy
     /// @notice Initializes the proxy.
     /// @param worldIDVerifier_ The World ID 4.0 verifier address. Must not be zero.
     /// @param owner_ The owner that will gain admin privileges via `Ownable2Step`.
-    function initialize(IWorldIDVerifier worldIDVerifier_, address owner_) external reinitializer(1) {
+    /// @param sessionKeyUpdateCooldown_ The delay applied to future key-set updates. Must be non-zero.
+    function initialize(IWorldIDVerifier worldIDVerifier_, address owner_, uint256 sessionKeyUpdateCooldown_)
+        external
+        reinitializer(1)
+    {
         if (address(worldIDVerifier_) == address(0)) revert AddressZero();
         if (owner_ == address(0)) revert AddressZero();
+        if (sessionKeyUpdateCooldown_ == 0) revert ZeroCooldown();
 
         __Base_init(owner_);
         worldIDVerifier = worldIDVerifier_;
+        sessionKeyUpdateCooldown = sessionKeyUpdateCooldown_;
 
         emit WorldIDAccountManagerImplInitialized(worldIDVerifier_, owner_);
+        emit SessionKeyUpdateCooldownSet(sessionKeyUpdateCooldown_);
     }
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -92,32 +113,17 @@ contract WorldIDAccountManagerImplV1 is IWorldIDAccountManager, Base, Reentrancy
         uint256[5] calldata proof_,
         WorldIDAccountUpdate calldata createUpdate_
     ) external virtual onlyProxy nonReentrant returns (address worldIDAccount_) {
-        if (createUpdate_.operation != Operation.Create) {
-            revert InvalidOperation();
-        }
+        if (createUpdate_.operation != Operation.Create) revert InvalidOperation();
         // A zero nullifier would be indistinguishable from "absent" in `worldIDAccountNullifier`,
-        // letting the same account be re-created and permanently bricking `update`.
-        if (worldIDAccountNullifier_ == 0) {
-            revert ZeroNullifier();
-        }
+        // letting the same account be re-created and permanently bricking future updates.
+        if (worldIDAccountNullifier_ == 0) revert ZeroNullifier();
 
         worldIDAccount_ = address(uint160(uint256(keccak256(abi.encodePacked(worldIDAccountNullifier_)))));
-        if (worldIDAccountNullifier[worldIDAccount_] != 0) {
-            revert WorldIDAccountAlreadyExists();
-        }
+        if (worldIDAccountNullifier[worldIDAccount_] != 0) revert WorldIDAccountAlreadyExists();
+        if (createUpdate_.removeKeys.length != 0) revert InvalidOperation();
 
         uint256 action = uint256(keccak256(abi.encodePacked(WORLD_ID_ACCOUNT_TAG, worldIDAccountNonce_))) >> 8;
         uint256 signalHash = uint256(keccak256(abi.encode(createUpdate_))) >> 8;
-
-        worldIDAccountNullifier[worldIDAccount_] = worldIDAccountNullifier_;
-        sessionIdOf[worldIDAccount_] = sessionId_;
-
-        if (createUpdate_.removeKeys.length != 0) revert InvalidOperation();
-
-        _addKeys(worldIDAccount_, createUpdate_.addKeys);
-
-        emit WorldIDAccountCreated(worldIDAccount_, worldIDAccountNullifier_, sessionId_);
-        emit SessionKeysAdded(worldIDAccount_, createUpdate_.addKeys);
 
         worldIDVerifier.verify(
             worldIDAccountNullifier_,
@@ -130,6 +136,14 @@ contract WorldIDAccountManagerImplV1 is IWorldIDAccountManager, Base, Reentrancy
             credentialGenesisIssuedAtMin_,
             proof_
         );
+
+        worldIDAccountNullifier[worldIDAccount_] = worldIDAccountNullifier_;
+        sessionIdOf[worldIDAccount_] = sessionId_;
+
+        _addKeys(worldIDAccount_, createUpdate_.addKeys);
+
+        emit WorldIDAccountCreated(worldIDAccount_, worldIDAccountNullifier_, sessionId_);
+        emit SessionKeysAdded(worldIDAccount_, createUpdate_.addKeys);
     }
 
     /// @inheritdoc IWorldIDAccountManager
@@ -146,29 +160,14 @@ contract WorldIDAccountManagerImplV1 is IWorldIDAccountManager, Base, Reentrancy
         if (accountUpdate_.operation != Operation.Update) {
             revert InvalidOperation();
         }
-        if (worldIDAccountNullifier[worldIDAccount_] == 0) {
-            revert WorldIDAccountDoesNotExist();
-        }
-        if (accountUpdate_.addKeys.length == 0 && accountUpdate_.removeKeys.length == 0) {
-            revert EmptyKeySet();
-        }
+        if (worldIDAccountNullifier[worldIDAccount_] == 0) revert WorldIDAccountDoesNotExist();
+        if (accountUpdate_.addKeys.length == 0 && accountUpdate_.removeKeys.length == 0) revert EmptyKeySet();
 
-        // Snapshot signal hash with the pre-bump generation so the verifier still validates
-        // the proof against the generation the caller signed over.
-        uint256 signalHash = uint256(keccak256(abi.encode(accountUpdate_, generationOf[worldIDAccount_]))) >> 8;
+        uint256 activeValidAfter = _activePendingValidAfter(worldIDAccount_);
+        if (activeValidAfter != 0) revert PendingSessionKeyUpdate(activeValidAfter);
 
-        ++generationOf[worldIDAccount_];
-
-        _revertIfOverlappingKey(accountUpdate_.addKeys, accountUpdate_.removeKeys);
-
-        if (accountUpdate_.removeKeys.length != 0) {
-            _removeKeys(worldIDAccount_, accountUpdate_.removeKeys);
-            emit SessionKeysRemoved(worldIDAccount_, accountUpdate_.removeKeys);
-        }
-        if (accountUpdate_.addKeys.length != 0) {
-            _addKeys(worldIDAccount_, accountUpdate_.addKeys);
-            emit SessionKeysAdded(worldIDAccount_, accountUpdate_.addKeys);
-        }
+        uint256 generation_ = generationOf[worldIDAccount_];
+        uint256 signalHash = uint256(keccak256(abi.encode(accountUpdate_, generation_))) >> 8;
 
         _dispatchSessionProof(
             SessionProofScalars({
@@ -183,17 +182,110 @@ contract WorldIDAccountManagerImplV1 is IWorldIDAccountManager, Base, Reentrancy
             sessionNullifier_,
             proof_
         );
+
+        _revertIfOverlappingKey(accountUpdate_.addKeys, accountUpdate_.removeKeys);
+        _snapshotCurrentKeys(worldIDAccount_);
+
+        if (accountUpdate_.removeKeys.length != 0) _removeKeys(worldIDAccount_, accountUpdate_.removeKeys);
+        if (accountUpdate_.addKeys.length != 0) _addKeys(worldIDAccount_, accountUpdate_.addKeys);
+
+        uint256 validAfter_ = block.timestamp + sessionKeyUpdateCooldown;
+        pendingValidAfter[worldIDAccount_] = validAfter_;
+        generationOf[worldIDAccount_] = generation_ + 1;
+
+        emit SessionKeyUpdateScheduled(worldIDAccount_, accountUpdate_.addKeys, accountUpdate_.removeKeys, validAfter_);
+    }
+
+    /// @inheritdoc IWorldIDAccountManager
+    function revertUpdate(
+        address worldIDAccount_,
+        uint256 proofNonce_,
+        uint64 issuerSchemaId_,
+        uint64 expiresAtMin_,
+        uint256 credentialGenesisIssuedAtMin_,
+        uint256[2] calldata sessionNullifier_,
+        uint256[5] calldata proof_
+    ) external virtual onlyProxy nonReentrant {
+        if (worldIDAccountNullifier[worldIDAccount_] == 0) {
+            revert WorldIDAccountDoesNotExist();
+        }
+
+        uint256 validAfter_ = pendingValidAfter[worldIDAccount_];
+        if (validAfter_ == 0) revert NoPendingSessionKeyUpdate();
+        if (block.timestamp >= validAfter_) revert PendingSessionKeyUpdateExpired(validAfter_);
+
+        uint256 generation_ = generationOf[worldIDAccount_];
+        uint256 signalHash =
+            uint256(keccak256(abi.encode(WORLD_ID_ACCOUNT_REVERT_TAG, worldIDAccount_, validAfter_, generation_))) >> 8;
+
+        _dispatchSessionProof(
+            SessionProofScalars({
+                rpId: WORLD_CHAIN_RP_ID,
+                proofNonce: proofNonce_,
+                signalHash: signalHash,
+                expiresAtMin: expiresAtMin_,
+                issuerSchemaId: issuerSchemaId_,
+                credentialGenesisIssuedAtMin: credentialGenesisIssuedAtMin_,
+                sessionId: sessionIdOf[worldIDAccount_]
+            }),
+            sessionNullifier_,
+            proof_
+        );
+
+        _restorePreviousKeys(worldIDAccount_);
+        delete pendingValidAfter[worldIDAccount_];
+        generationOf[worldIDAccount_] = generation_ + 1;
+
+        emit SessionKeyUpdateReverted(worldIDAccount_);
     }
 
     /// @inheritdoc IWorldIDAccountManager
     function getSessionKeyHashes(address worldIDAccount_) external view virtual onlyProxy returns (bytes32[] memory) {
+        if (_activePendingValidAfter(worldIDAccount_) != 0) {
+            return previousSessionKeyHashes[worldIDAccount_];
+        }
         return sessionKeyHashes[worldIDAccount_];
+    }
+
+    /// @inheritdoc IWorldIDAccountManager
+    function getStoredSessionKeyHashes(address worldIDAccount_)
+        external
+        view
+        virtual
+        onlyProxy
+        returns (bytes32[] memory)
+    {
+        return sessionKeyHashes[worldIDAccount_];
+    }
+
+    /// @inheritdoc IWorldIDAccountManager
+    function getPreviousSessionKeyHashes(address worldIDAccount_)
+        external
+        view
+        virtual
+        onlyProxy
+        returns (bytes32[] memory)
+    {
+        if (_activePendingValidAfter(worldIDAccount_) == 0) {
+            return new bytes32[](0);
+        }
+        return previousSessionKeyHashes[worldIDAccount_];
+    }
+
+    /// @inheritdoc IWorldIDAccountManager
+    function getPendingValidAfter(address worldIDAccount_) external view virtual onlyProxy returns (uint256) {
+        return _activePendingValidAfter(worldIDAccount_);
     }
 
     /// @inheritdoc IWorldIDAccountManager
     function isAuthorized(address worldIDAccount_, bytes calldata key_) external view virtual onlyProxy returns (bool) {
         if (key_.length == 0 || key_.length > MAX_KEY_BYTES) return false;
-        return keyHashIndex[worldIDAccount_][keccak256(key_)] != 0;
+
+        bytes32 keyHash = keccak256(key_);
+        if (_activePendingValidAfter(worldIDAccount_) != 0) {
+            return previousKeyHashIndex[worldIDAccount_][keyHash] != 0;
+        }
+        return keyHashIndex[worldIDAccount_][keyHash] != 0;
     }
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -208,12 +300,26 @@ contract WorldIDAccountManagerImplV1 is IWorldIDAccountManager, Base, Reentrancy
         emit WorldIDVerifierSet(address(worldIDVerifier_));
     }
 
+    /// @inheritdoc IWorldIDAccountManager
+    function setSessionKeyUpdateCooldown(uint256 sessionKeyUpdateCooldown_) external virtual onlyProxy onlyOwner {
+        if (sessionKeyUpdateCooldown_ == 0) revert ZeroCooldown();
+        sessionKeyUpdateCooldown = sessionKeyUpdateCooldown_;
+        emit SessionKeyUpdateCooldownSet(sessionKeyUpdateCooldown_);
+    }
+
     ///////////////////////////////////////////////////////////////////////////////
     ///                                INTERNAL                                 ///
     ///////////////////////////////////////////////////////////////////////////////
 
+    /// @dev Returns `pendingValidAfter[worldIDAccount_]` while the pending update is active.
+    function _activePendingValidAfter(address worldIDAccount_) internal view returns (uint256) {
+        uint256 validAfter_ = pendingValidAfter[worldIDAccount_];
+        if (validAfter_ == 0 || block.timestamp >= validAfter_) return 0;
+        return validAfter_;
+    }
+
     /// @dev Dispatches the session-proof verifier call. Inputs are bundled into a memory struct
-    ///      to keep `update`'s frame small enough to compile without `via_ir`.
+    ///      to keep call sites small enough to compile without `via_ir`.
     function _dispatchSessionProof(
         SessionProofScalars memory s_,
         uint256[2] calldata sessionNullifier_,
@@ -245,8 +351,7 @@ contract WorldIDAccountManagerImplV1 is IWorldIDAccountManager, Base, Reentrancy
         }
     }
 
-    /// @dev Validates and appends each key in `keys_` to the authorized set for `worldIDAccount_`.
-    ///      Reverts on length violations, payload duplicates, or set-size overflow.
+    /// @dev Validates and appends each key in `keys_` to the stored set for `worldIDAccount_`.
     function _addKeys(address worldIDAccount_, bytes[] calldata keys_) internal {
         uint256 keysLen = keys_.length;
         if (keysLen == 0) revert EmptyKeySet();
@@ -255,9 +360,7 @@ contract WorldIDAccountManagerImplV1 is IWorldIDAccountManager, Base, Reentrancy
         mapping(bytes32 => uint256) storage idxMap = keyHashIndex[worldIDAccount_];
 
         uint256 newTotal = hashArr.length + keysLen;
-        if (newTotal > MAX_SESSION_KEYS) {
-            revert TooManyKeys(newTotal, MAX_SESSION_KEYS);
-        }
+        if (newTotal > MAX_SESSION_KEYS) revert TooManyKeys(newTotal, MAX_SESSION_KEYS);
 
         for (uint256 i = 0; i < keysLen; ++i) {
             bytes calldata key = keys_[i];
@@ -270,8 +373,7 @@ contract WorldIDAccountManagerImplV1 is IWorldIDAccountManager, Base, Reentrancy
         }
     }
 
-    /// @dev Removes each key in `keys_` from the authorized set via swap-and-pop.
-    ///      Reverts on length violations, in-payload duplicates, or unknown keys.
+    /// @dev Removes each key in `keys_` from the stored set via swap-and-pop.
     function _removeKeys(address worldIDAccount_, bytes[] calldata keys_) internal {
         uint256 keysLen = keys_.length;
         if (keysLen == 0) revert EmptyKeySet();
@@ -298,11 +400,64 @@ contract WorldIDAccountManagerImplV1 is IWorldIDAccountManager, Base, Reentrancy
         }
     }
 
+    /// @dev Copies the currently stored key set into the previous-key snapshot, replacing any
+    ///      stale snapshot from an expired or reverted update window.
+    function _snapshotCurrentKeys(address worldIDAccount_) internal {
+        _clearPreviousKeys(worldIDAccount_);
+
+        bytes32[] storage current = sessionKeyHashes[worldIDAccount_];
+        bytes32[] storage previous = previousSessionKeyHashes[worldIDAccount_];
+        mapping(bytes32 => uint256) storage previousIdx = previousKeyHashIndex[worldIDAccount_];
+
+        for (uint256 i = 0; i < current.length; ++i) {
+            bytes32 hash = current[i];
+            previous.push(hash);
+            previousIdx[hash] = previous.length;
+        }
+    }
+
+    /// @dev Restores the previous-key snapshot into primary storage, then clears the snapshot.
+    function _restorePreviousKeys(address worldIDAccount_) internal {
+        _clearCurrentKeys(worldIDAccount_);
+
+        bytes32[] storage previous = previousSessionKeyHashes[worldIDAccount_];
+        bytes32[] storage current = sessionKeyHashes[worldIDAccount_];
+        mapping(bytes32 => uint256) storage currentIdx = keyHashIndex[worldIDAccount_];
+
+        for (uint256 i = 0; i < previous.length; ++i) {
+            bytes32 hash = previous[i];
+            current.push(hash);
+            currentIdx[hash] = current.length;
+        }
+
+        _clearPreviousKeys(worldIDAccount_);
+    }
+
+    /// @dev Clears the primary stored key set and its index map.
+    function _clearCurrentKeys(address worldIDAccount_) internal {
+        bytes32[] storage current = sessionKeyHashes[worldIDAccount_];
+        mapping(bytes32 => uint256) storage currentIdx = keyHashIndex[worldIDAccount_];
+
+        for (uint256 i = 0; i < current.length; ++i) {
+            delete currentIdx[current[i]];
+        }
+        delete sessionKeyHashes[worldIDAccount_];
+    }
+
+    /// @dev Clears the previous-key snapshot and its index map.
+    function _clearPreviousKeys(address worldIDAccount_) internal {
+        bytes32[] storage previous = previousSessionKeyHashes[worldIDAccount_];
+        mapping(bytes32 => uint256) storage previousIdx = previousKeyHashIndex[worldIDAccount_];
+
+        for (uint256 i = 0; i < previous.length; ++i) {
+            delete previousIdx[previous[i]];
+        }
+        delete previousSessionKeyHashes[worldIDAccount_];
+    }
+
     /// @dev Reverts if `key_` violates the per-key length bounds.
     function _validateKey(bytes calldata key_) internal pure {
         if (key_.length == 0) revert EmptyKey();
-        if (key_.length > MAX_KEY_BYTES) {
-            revert KeyTooLarge(key_.length, MAX_KEY_BYTES);
-        }
+        if (key_.length > MAX_KEY_BYTES) revert KeyTooLarge(key_.length, MAX_KEY_BYTES);
     }
 }

--- a/pkg/contracts/src/interfaces/IWorldIDAccountManager.sol
+++ b/pkg/contracts/src/interfaces/IWorldIDAccountManager.sol
@@ -26,16 +26,17 @@ interface IWorldIDAccountManager {
     /// @notice The mutation operation a `WorldIDAccountUpdate` payload requests.
     enum Operation {
         Create,
-        Add,
-        Remove
+        Update
     }
 
     /// @notice The signal payload bound into a World ID proof for an account action.
-    /// @param operation Mutation kind. `Create` is only valid in `create`; `Add`/`Remove` only in `update`.
-    /// @param keys Authenticator keys to install or remove. Each key MUST be 1..MAX_KEY_BYTES bytes.
+    /// @param operation Mutation kind. `Create` is only valid in `create`; `Update` only in `update`.
+    /// @param addKeys Authenticator keys to install. Each key MUST be 1..MAX_KEY_BYTES bytes.
+    /// @param removeKeys Authenticator keys to remove. Each key MUST be 1..MAX_KEY_BYTES bytes.
     struct WorldIDAccountUpdate {
         Operation operation;
-        bytes[] keys;
+        bytes[] addKeys;
+        bytes[] removeKeys;
     }
 
     /// @notice Memory-resident scalar inputs for the verifier's `verifySession` call.
@@ -92,7 +93,7 @@ interface IWorldIDAccountManager {
     /// @notice Thrown when `update` targets a World ID Account that has not been created.
     error WorldIDAccountDoesNotExist();
 
-    /// @notice Thrown when a payload contains zero keys.
+    /// @notice Thrown when a payload contains no keys.
     error EmptyKeySet();
 
     /// @notice Thrown when a payload would result in more than `MAX_SESSION_KEYS` authorized keys.
@@ -104,11 +105,14 @@ interface IWorldIDAccountManager {
     /// @notice Thrown when a key exceeds `MAX_KEY_BYTES`.
     error KeyTooLarge(uint256 actual, uint256 max);
 
-    /// @notice Thrown when an `Add` payload includes a key already authorized for the account.
+    /// @notice Thrown when an add payload includes a key already authorized for the account.
     error DuplicateSessionKey(bytes32 keyHash);
 
-    /// @notice Thrown when a `Remove` payload includes a key not authorized for the account.
+    /// @notice Thrown when a remove payload includes a key not authorized for the account.
     error UnknownSessionKey(bytes32 keyHash);
+
+    /// @notice Thrown when the same key appears in both `addKeys` and `removeKeys`.
+    error OverlappingUpdateKey(bytes32 keyHash);
 
     /// @notice Thrown when a required address parameter is the zero address.
     error AddressZero();
@@ -126,7 +130,7 @@ interface IWorldIDAccountManager {
     /// @param expiresAtMin_ Minimum credential expiration constraint.
     /// @param credentialGenesisIssuedAtMin_ Minimum credential `genesis_issued_at`.
     /// @param proof_ Compressed Groth16 proof `[a, b0, b1, c, merkle_root]`.
-    /// @param createUpdate_ Initial set of authenticator keys to install.
+    /// @param createUpdate_ Initial set of authenticator keys to install. `removeKeys` MUST be empty.
     /// @return worldIDAccount_ The deterministic address of the newly created account.
     function create(
         uint256 worldIDAccountNullifier_,
@@ -140,7 +144,7 @@ interface IWorldIDAccountManager {
         WorldIDAccountUpdate calldata createUpdate_
     ) external returns (address worldIDAccount_);
 
-    /// @notice Apply an `Add` or `Remove` update authorized by a World ID 4.0 Session Proof.
+    /// @notice Apply an update authorized by a World ID 4.0 Session Proof.
     /// @param worldIDAccount_ The address of the World ID Account being updated.
     /// @param proofNonce_ Verifier request nonce for the Session Proof.
     /// @param issuerSchemaId_ Credential schema/issuer identifier.
@@ -148,7 +152,8 @@ interface IWorldIDAccountManager {
     /// @param credentialGenesisIssuedAtMin_ Minimum credential `genesis_issued_at`.
     /// @param sessionNullifier_ Per-update verifier input `[nullifier, randomAction]`. Ephemeral.
     /// @param proof_ Compressed Groth16 proof `[a, b0, b1, c, merkle_root]`.
-    /// @param accountUpdate_ The Add/Remove payload.
+    /// @param accountUpdate_ The add/remove payload. At least one of `addKeys` or `removeKeys`
+    ///        MUST be non-empty.
     function update(
         address worldIDAccount_,
         uint256 proofNonce_,

--- a/pkg/contracts/src/interfaces/IWorldIDAccountManager.sol
+++ b/pkg/contracts/src/interfaces/IWorldIDAccountManager.sol
@@ -67,13 +67,22 @@ interface IWorldIDAccountManager {
         address indexed worldIDAccount, uint256 indexed worldIDAccountNullifier, uint256 indexed sessionId
     );
 
-    /// @notice Emitted when one or more authenticator keys are added to a World ID Account.
+    /// @notice Emitted when a World ID Account is created with its initial authenticator keys.
     /// @dev `keys` carries the raw authenticator bytes — on-chain state stores only their hashes.
     event SessionKeysAdded(address indexed worldIDAccount, bytes[] keys);
 
-    /// @notice Emitted when one or more authenticator keys are removed from a World ID Account.
-    /// @dev `keys` carries the raw authenticator bytes — on-chain state stores only their hashes.
-    event SessionKeysRemoved(address indexed worldIDAccount, bytes[] keys);
+    /// @notice Emitted when an authenticated key-set update is scheduled behind the cooldown.
+    /// @dev The post-update key hashes are written into primary storage immediately, but these raw
+    ///      keys are not yet effective until `validAfter`.
+    event SessionKeyUpdateScheduled(
+        address indexed worldIDAccount, bytes[] addKeys, bytes[] removeKeys, uint256 validAfter
+    );
+
+    /// @notice Emitted when a pending key-set update is reverted before it becomes effective.
+    event SessionKeyUpdateReverted(address indexed worldIDAccount);
+
+    /// @notice Emitted when the session-key update cooldown is set or replaced.
+    event SessionKeyUpdateCooldownSet(uint256 cooldown);
 
     ///////////////////////////////////////////////////////////////////////////////
     ///                                 ERRORS                                  ///
@@ -117,9 +126,24 @@ interface IWorldIDAccountManager {
     /// @notice Thrown when a required address parameter is the zero address.
     error AddressZero();
 
+    /// @notice Thrown when the configured session-key update cooldown is zero.
+    error ZeroCooldown();
+
+    /// @notice Thrown when `update` is attempted while another update is still pending.
+    error PendingSessionKeyUpdate(uint256 validAfter);
+
+    /// @notice Thrown when `revertUpdate` is called but no pending update exists.
+    error NoPendingSessionKeyUpdate();
+
+    /// @notice Thrown when `revertUpdate` is called after the pending update's window elapsed.
+    error PendingSessionKeyUpdateExpired(uint256 validAfter);
+
     ///////////////////////////////////////////////////////////////////////////////
     ///                              EXTERNAL API                               ///
     ///////////////////////////////////////////////////////////////////////////////
+
+    /// @notice Returns the configured cooldown for pending key-set updates.
+    function sessionKeyUpdateCooldown() external view returns (uint256);
 
     /// @notice Create a World ID Account authorized by a World ID 4.0 Uniqueness Proof.
     /// @param worldIDAccountNullifier_ The creation nullifier `ν_k`.
@@ -165,12 +189,41 @@ interface IWorldIDAccountManager {
         WorldIDAccountUpdate calldata accountUpdate_
     ) external;
 
-    /// @notice Returns the hashes of all currently authorized authenticator keys for `worldIDAccount_`.
-    /// @dev Raw key bytes are not stored on-chain; reconstruct from `SessionKeysAdded` /
-    ///      `SessionKeysRemoved` events if needed.
+    /// @notice Revert a pending key-set update authorized by a World ID 4.0 Session Proof.
+    /// @dev Reverts the pending window and restores the previous effective key set into primary
+    ///      storage. Reverts if no pending update exists or if the pending window already elapsed.
+    function revertUpdate(
+        address worldIDAccount_,
+        uint256 proofNonce_,
+        uint64 issuerSchemaId_,
+        uint64 expiresAtMin_,
+        uint256 credentialGenesisIssuedAtMin_,
+        uint256[2] calldata sessionNullifier_,
+        uint256[5] calldata proof_
+    ) external;
+
+    /// @notice Returns the hashes of the currently effective authenticator keys for `worldIDAccount_`.
+    /// @dev During an active pending update this returns the previous key set, not the newly stored
+    ///      one. Raw key bytes are not stored on-chain.
     function getSessionKeyHashes(address worldIDAccount_) external view returns (bytes32[] memory);
+
+    /// @notice Returns the hashes written into primary storage for `worldIDAccount_`.
+    /// @dev During an active pending update this is the future post-cooldown key set.
+    function getStoredSessionKeyHashes(address worldIDAccount_) external view returns (bytes32[] memory);
+
+    /// @notice Returns the previous key-set snapshot for an active pending update.
+    /// @dev Returns an empty array once the pending update is no longer active.
+    function getPreviousSessionKeyHashes(address worldIDAccount_) external view returns (bytes32[] memory);
+
+    /// @notice Returns the timestamp at which a pending update becomes effective.
+    /// @dev Returns `0` when there is no active pending update.
+    function getPendingValidAfter(address worldIDAccount_) external view returns (uint256);
 
     /// @notice Returns whether `key_` is currently authorized for `worldIDAccount_`.
     /// @dev Returns `false` (not revert) for malformed key lengths.
     function isAuthorized(address worldIDAccount_, bytes calldata key_) external view returns (bool);
+
+    /// @notice Updates the cooldown used for future key-set updates.
+    /// @param sessionKeyUpdateCooldown_ The new cooldown in seconds. Must be non-zero.
+    function setSessionKeyUpdateCooldown(uint256 sessionKeyUpdateCooldown_) external;
 }

--- a/pkg/contracts/test/WorldIDAccountManagerImplV1.t.sol
+++ b/pkg/contracts/test/WorldIDAccountManagerImplV1.t.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.28;
 
 import {Test} from "forge-std/Test.sol";
-import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 import {WorldIDAccountManager} from "../src/WorldIDAccountManager.sol";
@@ -12,8 +11,7 @@ import {IWorldIDVerifier} from "../src/interfaces/IWorldIDVerifier.sol";
 import {MockWorldIDVerifier} from "./mocks/MockWorldIDVerifier.sol";
 
 /// @title WorldIDAccountManagerImplV1 tests
-/// @notice Exercises every state transition, error path, and signal-hash binding rule of the
-///         WIP-1001 Solidity stand-in.
+/// @notice Exercises the delayed-activation key-update flow, including the effective/stored split.
 contract WorldIDAccountManagerImplV1Test is Test {
     WorldIDAccountManagerImplV1 internal manager;
     WorldIDAccountManagerImplV1 internal impl;
@@ -21,21 +19,27 @@ contract WorldIDAccountManagerImplV1Test is Test {
 
     address internal constant OWNER = address(0xC0FFEE);
     address internal constant ATTACKER = address(0xBAD);
+    uint256 internal constant COOLDOWN = 3 days;
 
     bytes16 internal constant WORLD_ID_ACCOUNT_TAG = "WORLD_ID_ACCOUNT";
+    bytes16 internal constant WORLD_ID_ACCOUNT_REVERT_TAG = "WORLD_ID_REVERT";
     uint64 internal constant WORLD_CHAIN_RP_ID = 480;
 
     event WorldIDAccountCreated(
         address indexed worldIDAccount, uint256 indexed worldIDAccountNullifier, uint256 indexed sessionId
     );
     event SessionKeysAdded(address indexed worldIDAccount, bytes[] keys);
-    event SessionKeysRemoved(address indexed worldIDAccount, bytes[] keys);
+    event SessionKeyUpdateScheduled(
+        address indexed worldIDAccount, bytes[] addKeys, bytes[] removeKeys, uint256 validAfter
+    );
+    event SessionKeyUpdateReverted(address indexed worldIDAccount);
     event WorldIDVerifierSet(address indexed worldIDVerifier);
+    event SessionKeyUpdateCooldownSet(uint256 cooldown);
 
     function setUp() public {
         verifier = new MockWorldIDVerifier(true);
         impl = new WorldIDAccountManagerImplV1();
-        bytes memory initCall = abi.encodeCall(WorldIDAccountManagerImplV1.initialize, (verifier, OWNER));
+        bytes memory initCall = abi.encodeCall(WorldIDAccountManagerImplV1.initialize, (verifier, OWNER, COOLDOWN));
         manager = WorldIDAccountManagerImplV1(address(new WorldIDAccountManager(address(impl), initCall)));
     }
 
@@ -61,6 +65,14 @@ contract WorldIDAccountManagerImplV1Test is Test {
         returns (uint256)
     {
         return uint256(keccak256(abi.encode(u_, generation_))) >> 8;
+    }
+
+    function _signalHashRevert(address account_, uint256 validAfter_, uint256 generation_)
+        internal
+        pure
+        returns (uint256)
+    {
+        return uint256(keccak256(abi.encode(WORLD_ID_ACCOUNT_REVERT_TAG, account_, validAfter_, generation_))) >> 8;
     }
 
     function _key(uint8 seed_, uint256 len_) internal pure returns (bytes memory k) {
@@ -151,8 +163,14 @@ contract WorldIDAccountManagerImplV1Test is Test {
 
     function _newAccountWithKey(bytes memory firstKey_) internal returns (address acct, CreateArgs memory a) {
         a = _defaultCreateArgs();
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _createUpdate(_singleKey(firstKey_));
-        acct = _doCreate(a, u);
+        acct = _doCreate(a, _createUpdate(_singleKey(firstKey_)));
+    }
+
+    function _assertHashesEq(bytes32[] memory actual_, bytes32[] memory expected_) internal pure {
+        assertEq(actual_.length, expected_.length, "hash array length mismatch");
+        for (uint256 i = 0; i < actual_.length; ++i) {
+            assertEq(actual_[i], expected_[i], "hash mismatch");
+        }
     }
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -189,25 +207,20 @@ contract WorldIDAccountManagerImplV1Test is Test {
         emit SessionKeysAdded(expectedAcct, u.addKeys);
 
         address acct = _doCreate(a, u);
-        assertEq(acct, expectedAcct, "derived address mismatch");
-        assertEq(manager.worldIDAccountNullifier(acct), a.nullifier, "nullifier persisted");
-        assertEq(manager.sessionIdOf(acct), a.sessionId, "sessionId persisted");
-        assertEq(manager.generationOf(acct), 0, "generation starts at 0");
 
-        bytes32[] memory hashes = manager.getSessionKeyHashes(acct);
-        assertEq(hashes.length, 1);
-        assertEq(hashes[0], keccak256(k));
+        assertEq(acct, expectedAcct);
+        assertEq(manager.worldIDAccountNullifier(acct), a.nullifier);
+        assertEq(manager.sessionIdOf(acct), a.sessionId);
+        assertEq(manager.generationOf(acct), 0);
+        assertEq(manager.sessionKeyUpdateCooldown(), COOLDOWN);
+
+        bytes32[] memory expected = new bytes32[](1);
+        expected[0] = keccak256(k);
+        _assertHashesEq(manager.getSessionKeyHashes(acct), expected);
+        _assertHashesEq(manager.getStoredSessionKeyHashes(acct), expected);
+        assertEq(manager.getPreviousSessionKeyHashes(acct).length, 0);
+        assertEq(manager.getPendingValidAfter(acct), 0);
         assertTrue(manager.isAuthorized(acct, k));
-    }
-
-    function test_create_action_topByteIsZero() public {
-        CreateArgs memory a = _defaultCreateArgs();
-        for (uint256 nonce = 0; nonce < 32; ++nonce) {
-            assertEq(_action(nonce) >> 248, 0, "top byte must be zero for V2-verifier compat");
-        }
-        a.nonce = 1;
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _createUpdate(_singleKey(_key(0x01, 33)));
-        _doCreate(a, u);
     }
 
     function test_create_revertIf_wrongOperation() public {
@@ -217,108 +230,26 @@ contract WorldIDAccountManagerImplV1Test is Test {
         _doCreate(a, u);
     }
 
-    function test_create_revertIf_removeKeysProvided() public {
-        CreateArgs memory a = _defaultCreateArgs();
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = IWorldIDAccountManager.WorldIDAccountUpdate({
-            operation: IWorldIDAccountManager.Operation.Create,
-            addKeys: _singleKey(_key(0x01, 33)),
-            removeKeys: _singleKey(_key(0x02, 33))
-        });
-        vm.expectRevert(IWorldIDAccountManager.InvalidOperation.selector);
-        _doCreate(a, u);
-    }
-
-    function test_create_revertIf_emptyKeySet() public {
-        CreateArgs memory a = _defaultCreateArgs();
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _createUpdate(_emptyKeys());
-        vm.expectRevert(IWorldIDAccountManager.EmptyKeySet.selector);
-        _doCreate(a, u);
-    }
-
-    function test_create_revertIf_tooManyKeys() public {
-        CreateArgs memory a = _defaultCreateArgs();
-        bytes[] memory keys = new bytes[](21);
-        for (uint256 i = 0; i < 21; ++i) {
-            keys[i] = _key(uint8(i), 33);
-        }
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _createUpdate(keys);
-        vm.expectRevert(abi.encodeWithSelector(IWorldIDAccountManager.TooManyKeys.selector, uint256(21), uint256(20)));
-        _doCreate(a, u);
-    }
-
-    function test_create_revertIf_emptyKey() public {
-        CreateArgs memory a = _defaultCreateArgs();
-        bytes[] memory keys = new bytes[](1);
-        keys[0] = "";
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _createUpdate(keys);
-        vm.expectRevert(IWorldIDAccountManager.EmptyKey.selector);
-        _doCreate(a, u);
-    }
-
-    function test_create_revertIf_keyTooLarge() public {
-        CreateArgs memory a = _defaultCreateArgs();
-        bytes memory big = _key(0x01, 129);
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _createUpdate(_singleKey(big));
-        vm.expectRevert(abi.encodeWithSelector(IWorldIDAccountManager.KeyTooLarge.selector, uint256(129), uint256(128)));
-        _doCreate(a, u);
-    }
-
-    function test_create_acceptsKeyAtExactBound() public {
-        CreateArgs memory a = _defaultCreateArgs();
-        bytes memory exactlyMax = _key(0x01, 128);
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _createUpdate(_singleKey(exactlyMax));
-        _doCreate(a, u);
-    }
-
-    function test_create_revertIf_duplicateKeyInPayload() public {
-        CreateArgs memory a = _defaultCreateArgs();
-        bytes memory k = _key(0xAA, 33);
-        bytes[] memory keys = new bytes[](2);
-        keys[0] = k;
-        keys[1] = k;
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _createUpdate(keys);
-        vm.expectRevert(abi.encodeWithSelector(IWorldIDAccountManager.DuplicateSessionKey.selector, keccak256(k)));
-        _doCreate(a, u);
-    }
-
-    function test_create_revertIf_alreadyExists() public {
-        (address acct,) = _newAccountWithKey(_key(0xAA, 33));
-        CreateArgs memory a = _defaultCreateArgs();
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _createUpdate(_singleKey(_key(0xBB, 33)));
-        vm.expectRevert(IWorldIDAccountManager.WorldIDAccountAlreadyExists.selector);
-        _doCreate(a, u);
-        // sanity: prior account is intact
-        assertTrue(manager.isAuthorized(acct, _key(0xAA, 33)));
-    }
-
-    function test_create_revertIf_zeroNullifier() public {
-        CreateArgs memory a = _defaultCreateArgs();
-        a.nullifier = 0;
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _createUpdate(_singleKey(_key(0x01, 33)));
-        vm.expectRevert(IWorldIDAccountManager.ZeroNullifier.selector);
-        _doCreate(a, u);
-    }
-
     function test_create_revertIf_verifierRejects() public {
         verifier.setShouldAccept(false);
         CreateArgs memory a = _defaultCreateArgs();
         IWorldIDAccountManager.WorldIDAccountUpdate memory u = _createUpdate(_singleKey(_key(0x01, 33)));
         vm.expectRevert(MockWorldIDVerifier.MockVerifierRejected.selector);
         _doCreate(a, u);
-        // No state should be persisted on revert.
-        address expected = _accountAddress(a.nullifier);
-        assertEq(manager.worldIDAccountNullifier(expected), 0);
+        assertEq(manager.worldIDAccountNullifier(_accountAddress(a.nullifier)), 0);
     }
 
     ///////////////////////////////////////////////////////////////////////////////
     ///                                 UPDATE                                  ///
     ///////////////////////////////////////////////////////////////////////////////
 
-    function test_update_add_happyPath_andGenerationBumps() public {
-        (address acct,) = _newAccountWithKey(_key(0x01, 33));
+    function test_update_schedulesStoredKeysButEffectiveRemainsOld() public {
+        bytes memory k1 = _key(0x01, 33);
         bytes memory k2 = _key(0x02, 33);
+        (address acct,) = _newAccountWithKey(k1);
 
         IWorldIDAccountManager.WorldIDAccountUpdate memory u = _updatePayload(_singleKey(k2), _emptyKeys());
+        uint256 validAfter = block.timestamp + COOLDOWN;
 
         vm.expectCall(
             address(verifier),
@@ -338,182 +269,136 @@ contract WorldIDAccountManagerImplV1Test is Test {
             )
         );
         vm.expectEmit(true, true, true, true, address(manager));
-        emit SessionKeysAdded(acct, u.addKeys);
+        emit SessionKeyUpdateScheduled(acct, u.addKeys, u.removeKeys, validAfter);
 
         manager.update(acct, 777, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), u);
 
-        assertEq(manager.generationOf(acct), 1, "generation bumps on update");
-        assertEq(manager.getSessionKeyHashes(acct).length, 2);
+        bytes32[] memory effective = new bytes32[](1);
+        effective[0] = keccak256(k1);
+        bytes32[] memory stored = new bytes32[](2);
+        stored[0] = keccak256(k1);
+        stored[1] = keccak256(k2);
+
+        assertEq(manager.generationOf(acct), 1);
+        _assertHashesEq(manager.getSessionKeyHashes(acct), effective);
+        _assertHashesEq(manager.getStoredSessionKeyHashes(acct), stored);
+        _assertHashesEq(manager.getPreviousSessionKeyHashes(acct), effective);
+        assertEq(manager.getPendingValidAfter(acct), validAfter);
+        assertTrue(manager.isAuthorized(acct, k1));
+        assertFalse(manager.isAuthorized(acct, k2));
+    }
+
+    function test_update_afterCooldown_newKeysBecomeEffective() public {
+        bytes memory k1 = _key(0x01, 33);
+        bytes memory k2 = _key(0x02, 33);
+        bytes memory k3 = _key(0x03, 33);
+
+        CreateArgs memory a = _defaultCreateArgs();
+        bytes[] memory initial = new bytes[](2);
+        initial[0] = k1;
+        initial[1] = k2;
+        address acct = _doCreate(a, _createUpdate(initial));
+
+        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _updatePayload(_singleKey(k3), _singleKey(k1));
+        manager.update(acct, 1, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), u);
+
+        assertTrue(manager.isAuthorized(acct, k1));
         assertTrue(manager.isAuthorized(acct, k2));
-    }
+        assertFalse(manager.isAuthorized(acct, k3));
 
-    function test_update_add_revertIf_duplicate() public {
-        bytes memory k1 = _key(0x01, 33);
-        (address acct,) = _newAccountWithKey(k1);
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _updatePayload(_singleKey(k1), _emptyKeys());
-        vm.expectRevert(abi.encodeWithSelector(IWorldIDAccountManager.DuplicateSessionKey.selector, keccak256(k1)));
-        manager.update(acct, 1, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), u);
-    }
+        vm.warp(block.timestamp + COOLDOWN);
 
-    function test_update_add_revertIf_overflowsMax() public {
-        // Create with 20 keys (max), then attempt to add one more.
-        CreateArgs memory a = _defaultCreateArgs();
-        bytes[] memory initialKeys = new bytes[](20);
-        for (uint256 i = 0; i < 20; ++i) {
-            initialKeys[i] = _key(uint8(i), 33);
-        }
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _createUpdate(initialKeys);
-        address acct = _doCreate(a, u);
+        bytes32[] memory expected = new bytes32[](2);
+        expected[0] = keccak256(k2);
+        expected[1] = keccak256(k3);
 
-        IWorldIDAccountManager.WorldIDAccountUpdate memory addOne =
-            _updatePayload(_singleKey(_key(0xFF, 33)), _emptyKeys());
-        vm.expectRevert(abi.encodeWithSelector(IWorldIDAccountManager.TooManyKeys.selector, uint256(21), uint256(20)));
-        manager.update(acct, 1, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), addOne);
-    }
-
-    function test_update_revertIf_accountDoesNotExist() public {
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _updatePayload(_singleKey(_key(0x01, 33)), _emptyKeys());
-        vm.expectRevert(IWorldIDAccountManager.WorldIDAccountDoesNotExist.selector);
-        manager.update(address(0xCAFE), 1, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), u);
-    }
-
-    function test_update_revertIf_operationCreate() public {
-        (address acct,) = _newAccountWithKey(_key(0x01, 33));
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _createUpdate(_singleKey(_key(0x02, 33)));
-        vm.expectRevert(IWorldIDAccountManager.InvalidOperation.selector);
-        manager.update(acct, 1, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), u);
-    }
-
-    function test_update_remove_happyPath_swapAndPop() public {
-        // Create with 3 keys, remove the middle, verify the remaining set is intact.
-        bytes memory k1 = _key(0x01, 33);
-        bytes memory k2 = _key(0x02, 33);
-        bytes memory k3 = _key(0x03, 33);
-
-        CreateArgs memory a = _defaultCreateArgs();
-        bytes[] memory initialKeys = new bytes[](3);
-        initialKeys[0] = k1;
-        initialKeys[1] = k2;
-        initialKeys[2] = k3;
-        IWorldIDAccountManager.WorldIDAccountUpdate memory createPayload = _createUpdate(initialKeys);
-        address acct = _doCreate(a, createPayload);
-
-        IWorldIDAccountManager.WorldIDAccountUpdate memory rm = _updatePayload(_emptyKeys(), _singleKey(k2));
-        vm.expectEmit(true, true, true, true, address(manager));
-        emit SessionKeysRemoved(acct, rm.removeKeys);
-        manager.update(acct, 1, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), rm);
-
-        bytes32[] memory hashes = manager.getSessionKeyHashes(acct);
-        assertEq(hashes.length, 2);
-        assertTrue(manager.isAuthorized(acct, k1));
-        assertFalse(manager.isAuthorized(acct, k2));
-        assertTrue(manager.isAuthorized(acct, k3));
-        // index for swapped-in element is correct (1-indexed)
-        assertEq(manager.keyHashIndex(acct, keccak256(k3)), 2, "k3 should now sit at index 1 (1-indexed: 2)");
-    }
-
-    function test_update_addAndRemove_happyPath_removeFirstThenAdd() public {
-        bytes memory k1 = _key(0x01, 33);
-        bytes memory k2 = _key(0x02, 33);
-        bytes memory k3 = _key(0x03, 33);
-        bytes memory k4 = _key(0x04, 33);
-
-        CreateArgs memory a = _defaultCreateArgs();
-        bytes[] memory initialKeys = new bytes[](3);
-        initialKeys[0] = k1;
-        initialKeys[1] = k2;
-        initialKeys[2] = k3;
-        address acct = _doCreate(a, _createUpdate(initialKeys));
-
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _updatePayload(_singleKey(k4), _singleKey(k2));
-
-        vm.expectEmit(true, true, true, true, address(manager));
-        emit SessionKeysRemoved(acct, u.removeKeys);
-        vm.expectEmit(true, true, true, true, address(manager));
-        emit SessionKeysAdded(acct, u.addKeys);
-
-        manager.update(acct, 1, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), u);
-
-        bytes32[] memory hashes = manager.getSessionKeyHashes(acct);
-        assertEq(hashes.length, 3);
-        assertTrue(manager.isAuthorized(acct, k1));
-        assertFalse(manager.isAuthorized(acct, k2));
-        assertTrue(manager.isAuthorized(acct, k3));
-        assertTrue(manager.isAuthorized(acct, k4));
-    }
-
-    function test_update_revertIf_addAndRemoveSameExistingKey() public {
-        bytes memory k1 = _key(0x01, 33);
-        (address acct,) = _newAccountWithKey(k1);
-
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _updatePayload(_singleKey(k1), _singleKey(k1));
-
-        vm.expectRevert(abi.encodeWithSelector(IWorldIDAccountManager.OverlappingUpdateKey.selector, keccak256(k1)));
-        manager.update(acct, 1, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), u);
-    }
-
-    function test_update_revertIf_addAndRemoveSameMissingKey() public {
-        bytes memory k1 = _key(0x01, 33);
-        bytes memory k2 = _key(0x02, 33);
-        (address acct,) = _newAccountWithKey(k1);
-
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _updatePayload(_singleKey(k2), _singleKey(k2));
-
-        vm.expectRevert(abi.encodeWithSelector(IWorldIDAccountManager.OverlappingUpdateKey.selector, keccak256(k2)));
-        manager.update(acct, 1, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), u);
-    }
-
-    function test_update_remove_revertIf_unknownKey() public {
-        (address acct,) = _newAccountWithKey(_key(0x01, 33));
-        bytes memory k2 = _key(0x02, 33);
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _updatePayload(_emptyKeys(), _singleKey(k2));
-        vm.expectRevert(abi.encodeWithSelector(IWorldIDAccountManager.UnknownSessionKey.selector, keccak256(k2)));
-        manager.update(acct, 1, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), u);
-    }
-
-    function test_update_remove_canDrainSetAndReadd() public {
-        bytes memory k1 = _key(0x01, 33);
-        (address acct,) = _newAccountWithKey(k1);
-
-        IWorldIDAccountManager.WorldIDAccountUpdate memory rm = _updatePayload(_emptyKeys(), _singleKey(k1));
-        manager.update(acct, 1, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), rm);
-        assertEq(manager.getSessionKeyHashes(acct).length, 0);
+        _assertHashesEq(manager.getSessionKeyHashes(acct), expected);
+        _assertHashesEq(manager.getStoredSessionKeyHashes(acct), expected);
+        assertEq(manager.getPreviousSessionKeyHashes(acct).length, 0);
+        assertEq(manager.getPendingValidAfter(acct), 0);
         assertFalse(manager.isAuthorized(acct, k1));
-
-        // Account still exists.
-        assertEq(manager.worldIDAccountNullifier(acct), 0x1234567890ABCDEF);
-
-        IWorldIDAccountManager.WorldIDAccountUpdate memory addBack = _updatePayload(_singleKey(k1), _emptyKeys());
-        manager.update(acct, 2, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), addBack);
-        assertTrue(manager.isAuthorized(acct, k1));
+        assertTrue(manager.isAuthorized(acct, k2));
+        assertTrue(manager.isAuthorized(acct, k3));
     }
 
-    function test_update_signalHashChangesWithGeneration() public {
-        // Identical payloads at generation 0 and generation 2 must produce different signal hashes.
+    function test_update_revertIf_activePendingExists() public {
         bytes memory k1 = _key(0x01, 33);
         bytes memory k2 = _key(0x02, 33);
+        bytes memory k3 = _key(0x03, 33);
         (address acct,) = _newAccountWithKey(k1);
 
-        IWorldIDAccountManager.WorldIDAccountUpdate memory addK2 = _updatePayload(_singleKey(k2), _emptyKeys());
-        IWorldIDAccountManager.WorldIDAccountUpdate memory removeK2 = _updatePayload(_emptyKeys(), _singleKey(k2));
+        manager.update(
+            acct,
+            1,
+            1,
+            uint64(block.timestamp + 1 days),
+            0,
+            _sessionNullifier(),
+            _proof(),
+            _updatePayload(_singleKey(k2), _emptyKeys())
+        );
 
-        uint256 firstHash = _signalHashUpdate(addK2, 0);
-        uint256 secondHash = _signalHashUpdate(addK2, 2);
-        assertTrue(firstHash != secondHash, "signal hash must change with generation");
+        vm.expectRevert(
+            abi.encodeWithSelector(IWorldIDAccountManager.PendingSessionKeyUpdate.selector, block.timestamp + COOLDOWN)
+        );
+        manager.update(
+            acct,
+            2,
+            1,
+            uint64(block.timestamp + 1 days),
+            0,
+            _sessionNullifier(),
+            _proof(),
+            _updatePayload(_singleKey(k3), _emptyKeys())
+        );
+    }
 
-        manager.update(acct, 1, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), addK2);
-        manager.update(acct, 2, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), removeK2);
-        assertEq(manager.generationOf(acct), 2);
+    function test_update_removeAllKeys_oldKeyRemainsEffectiveUntilCooldown() public {
+        bytes memory k1 = _key(0x01, 33);
+        (address acct,) = _newAccountWithKey(k1);
 
-        // Now the addK2 payload would bind to generation = 2, and the verifier should see secondHash.
+        manager.update(
+            acct,
+            1,
+            1,
+            uint64(block.timestamp + 1 days),
+            0,
+            _sessionNullifier(),
+            _proof(),
+            _updatePayload(_emptyKeys(), _singleKey(k1))
+        );
+
+        assertTrue(manager.isAuthorized(acct, k1));
+        assertEq(manager.getSessionKeyHashes(acct).length, 1);
+        assertEq(manager.getStoredSessionKeyHashes(acct).length, 0);
+
+        vm.warp(block.timestamp + COOLDOWN);
+
+        assertFalse(manager.isAuthorized(acct, k1));
+        assertEq(manager.getSessionKeyHashes(acct).length, 0);
+    }
+
+    function test_update_signalHashUsesGenerationAndExpiredWindowCanBeRescheduled() public {
+        bytes memory k1 = _key(0x01, 33);
+        bytes memory k2 = _key(0x02, 33);
+        bytes memory k3 = _key(0x03, 33);
+        (address acct,) = _newAccountWithKey(k1);
+
+        IWorldIDAccountManager.WorldIDAccountUpdate memory first = _updatePayload(_singleKey(k2), _emptyKeys());
+        manager.update(acct, 1, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), first);
+        assertEq(manager.generationOf(acct), 1);
+
+        vm.warp(block.timestamp + COOLDOWN + 1);
+
+        IWorldIDAccountManager.WorldIDAccountUpdate memory second = _updatePayload(_singleKey(k3), _singleKey(k1));
         vm.expectCall(
             address(verifier),
             abi.encodeCall(
                 IWorldIDVerifier.verifySession,
                 (
                     WORLD_CHAIN_RP_ID,
-                    3,
-                    secondHash,
+                    2,
+                    _signalHashUpdate(second, 1),
                     uint64(block.timestamp + 1 days),
                     uint64(1),
                     0,
@@ -523,18 +408,98 @@ contract WorldIDAccountManagerImplV1Test is Test {
                 )
             )
         );
-        manager.update(acct, 3, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), addK2);
-    }
-
-    function test_update_revertIf_emptyDelta() public {
-        (address acct,) = _newAccountWithKey(_key(0x01, 33));
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _updatePayload(_emptyKeys(), _emptyKeys());
-        vm.expectRevert(IWorldIDAccountManager.EmptyKeySet.selector);
-        manager.update(acct, 1, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), u);
+        manager.update(acct, 2, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), second);
+        assertEq(manager.generationOf(acct), 2);
     }
 
     ///////////////////////////////////////////////////////////////////////////////
-    ///                              isAuthorized                               ///
+    ///                                 REVERT                                  ///
+    ///////////////////////////////////////////////////////////////////////////////
+
+    function test_revert_restoresPreviousStoredAndEffectiveKeys() public {
+        bytes memory k1 = _key(0x01, 33);
+        bytes memory k2 = _key(0x02, 33);
+        bytes memory k3 = _key(0x03, 33);
+
+        CreateArgs memory a = _defaultCreateArgs();
+        bytes[] memory initial = new bytes[](2);
+        initial[0] = k1;
+        initial[1] = k2;
+        address acct = _doCreate(a, _createUpdate(initial));
+
+        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _updatePayload(_singleKey(k3), _singleKey(k1));
+        manager.update(acct, 1, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), u);
+        uint256 validAfter = block.timestamp + COOLDOWN;
+
+        vm.expectCall(
+            address(verifier),
+            abi.encodeCall(
+                IWorldIDVerifier.verifySession,
+                (
+                    WORLD_CHAIN_RP_ID,
+                    2,
+                    _signalHashRevert(acct, validAfter, 1),
+                    uint64(block.timestamp + 1 days),
+                    uint64(1),
+                    0,
+                    0xDEADBEEF,
+                    _sessionNullifier(),
+                    _proof()
+                )
+            )
+        );
+        vm.expectEmit(true, true, true, true, address(manager));
+        emit SessionKeyUpdateReverted(acct);
+
+        manager.revertUpdate(acct, 2, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof());
+
+        bytes32[] memory expected = new bytes32[](2);
+        expected[0] = keccak256(k1);
+        expected[1] = keccak256(k2);
+
+        assertEq(manager.generationOf(acct), 2);
+        _assertHashesEq(manager.getSessionKeyHashes(acct), expected);
+        _assertHashesEq(manager.getStoredSessionKeyHashes(acct), expected);
+        assertEq(manager.getPreviousSessionKeyHashes(acct).length, 0);
+        assertEq(manager.getPendingValidAfter(acct), 0);
+        assertTrue(manager.isAuthorized(acct, k1));
+        assertTrue(manager.isAuthorized(acct, k2));
+        assertFalse(manager.isAuthorized(acct, k3));
+    }
+
+    function test_revert_revertIf_noPending() public {
+        (address acct,) = _newAccountWithKey(_key(0x01, 33));
+        vm.expectRevert(IWorldIDAccountManager.NoPendingSessionKeyUpdate.selector);
+        manager.revertUpdate(acct, 1, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof());
+    }
+
+    function test_revert_revertIf_windowExpired() public {
+        bytes memory k1 = _key(0x01, 33);
+        bytes memory k2 = _key(0x02, 33);
+        (address acct,) = _newAccountWithKey(k1);
+
+        manager.update(
+            acct,
+            1,
+            1,
+            uint64(block.timestamp + 1 days),
+            0,
+            _sessionNullifier(),
+            _proof(),
+            _updatePayload(_singleKey(k2), _emptyKeys())
+        );
+        uint256 validAfter = block.timestamp + COOLDOWN;
+
+        vm.warp(validAfter);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IWorldIDAccountManager.PendingSessionKeyUpdateExpired.selector, validAfter)
+        );
+        manager.revertUpdate(acct, 2, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof());
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    ///                                 VIEWS                                   ///
     ///////////////////////////////////////////////////////////////////////////////
 
     function test_isAuthorized_falseForBadLengths_andUnknownAccount() public {
@@ -545,7 +510,7 @@ contract WorldIDAccountManagerImplV1Test is Test {
         bytes memory tooLong = _key(0x01, 129);
         assertFalse(manager.isAuthorized(acct, zero));
         assertFalse(manager.isAuthorized(acct, tooLong));
-        assertFalse(manager.isAuthorized(address(0xDEAD), k), "no entries for nonexistent acct");
+        assertFalse(manager.isAuthorized(address(0xDEAD), k));
     }
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -563,60 +528,83 @@ contract WorldIDAccountManagerImplV1Test is Test {
         vm.expectEmit(true, true, true, true, address(manager));
         emit WorldIDVerifierSet(address(newVerifier));
         manager.setWorldIDVerifier(newVerifier);
+
         assertEq(address(manager.worldIDVerifier()), address(newVerifier));
     }
 
-    function test_setWorldIDVerifier_revertIf_zeroAddress() public {
+    function test_setSessionKeyUpdateCooldown_onlyOwner_andNonZero() public {
+        vm.prank(ATTACKER);
+        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, ATTACKER));
+        manager.setSessionKeyUpdateCooldown(7 days);
+
         vm.prank(OWNER);
-        vm.expectRevert(IWorldIDAccountManager.AddressZero.selector);
-        manager.setWorldIDVerifier(IWorldIDVerifier(address(0)));
+        vm.expectRevert(IWorldIDAccountManager.ZeroCooldown.selector);
+        manager.setSessionKeyUpdateCooldown(0);
+
+        vm.prank(OWNER);
+        vm.expectEmit(false, false, false, true, address(manager));
+        emit SessionKeyUpdateCooldownSet(7 days);
+        manager.setSessionKeyUpdateCooldown(7 days);
+
+        assertEq(manager.sessionKeyUpdateCooldown(), 7 days);
     }
 
-    function test_initialize_revertIf_zeroVerifier() public {
+    function test_initialize_revertIf_zeroVerifier_zeroOwner_orZeroCooldown() public {
         WorldIDAccountManagerImplV1 freshImpl = new WorldIDAccountManagerImplV1();
-        bytes memory initCall =
-            abi.encodeCall(WorldIDAccountManagerImplV1.initialize, (IWorldIDVerifier(address(0)), OWNER));
-        vm.expectRevert(IWorldIDAccountManager.AddressZero.selector);
-        new WorldIDAccountManager(address(freshImpl), initCall);
-    }
 
-    function test_initialize_revertIf_zeroOwner() public {
-        WorldIDAccountManagerImplV1 freshImpl = new WorldIDAccountManagerImplV1();
-        bytes memory initCall =
-            abi.encodeCall(WorldIDAccountManagerImplV1.initialize, (IWorldIDVerifier(address(verifier)), address(0)));
+        bytes memory zeroVerifier =
+            abi.encodeCall(WorldIDAccountManagerImplV1.initialize, (IWorldIDVerifier(address(0)), OWNER, COOLDOWN));
         vm.expectRevert(IWorldIDAccountManager.AddressZero.selector);
-        new WorldIDAccountManager(address(freshImpl), initCall);
+        new WorldIDAccountManager(address(freshImpl), zeroVerifier);
+
+        freshImpl = new WorldIDAccountManagerImplV1();
+        bytes memory zeroOwner = abi.encodeCall(
+            WorldIDAccountManagerImplV1.initialize, (IWorldIDVerifier(address(verifier)), address(0), COOLDOWN)
+        );
+        vm.expectRevert(IWorldIDAccountManager.AddressZero.selector);
+        new WorldIDAccountManager(address(freshImpl), zeroOwner);
+
+        freshImpl = new WorldIDAccountManagerImplV1();
+        bytes memory zeroCooldown =
+            abi.encodeCall(WorldIDAccountManagerImplV1.initialize, (IWorldIDVerifier(address(verifier)), OWNER, 0));
+        vm.expectRevert(IWorldIDAccountManager.ZeroCooldown.selector);
+        new WorldIDAccountManager(address(freshImpl), zeroCooldown);
     }
 
     function test_implementation_cannotBeInitializedDirectly() public {
         WorldIDAccountManagerImplV1 freshImpl = new WorldIDAccountManagerImplV1();
-        // Initializable.InvalidInitialization() selector
         vm.expectRevert(bytes4(0xf92ee8a9));
-        freshImpl.initialize(verifier, OWNER);
+        freshImpl.initialize(verifier, OWNER, COOLDOWN);
     }
 
     ///////////////////////////////////////////////////////////////////////////////
     ///                              UUPS UPGRADE                               ///
     ///////////////////////////////////////////////////////////////////////////////
 
-    function test_uupsUpgrade_preservesState() public {
-        bytes memory k = _key(0xAA, 33);
-        (address acct,) = _newAccountWithKey(k);
-        uint256 sid = manager.sessionIdOf(acct);
+    function test_uupsUpgrade_preservesPendingState() public {
+        bytes memory k1 = _key(0x01, 33);
+        bytes memory k2 = _key(0x02, 33);
+        (address acct,) = _newAccountWithKey(k1);
+
+        manager.update(
+            acct,
+            1,
+            1,
+            uint64(block.timestamp + 1 days),
+            0,
+            _sessionNullifier(),
+            _proof(),
+            _updatePayload(_singleKey(k2), _emptyKeys())
+        );
+        uint256 validAfter = manager.getPendingValidAfter(acct);
 
         WorldIDAccountManagerImplV1 newImpl = new WorldIDAccountManagerImplV1();
         vm.prank(OWNER);
         manager.upgradeToAndCall(address(newImpl), bytes(""));
 
-        assertEq(manager.sessionIdOf(acct), sid, "sessionId preserved");
-        assertTrue(manager.isAuthorized(acct, k), "key set preserved");
-    }
-
-    function test_uupsUpgrade_onlyOwner() public {
-        WorldIDAccountManagerImplV1 newImpl = new WorldIDAccountManagerImplV1();
-        vm.prank(ATTACKER);
-        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, ATTACKER));
-        manager.upgradeToAndCall(address(newImpl), bytes(""));
+        assertEq(manager.getPendingValidAfter(acct), validAfter);
+        assertTrue(manager.isAuthorized(acct, k1));
+        assertFalse(manager.isAuthorized(acct, k2));
     }
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -630,18 +618,13 @@ contract WorldIDAccountManagerImplV1Test is Test {
         CreateArgs memory a = _defaultCreateArgs();
         a.nullifier = nullifier_;
         a.nonce = nonce_;
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _createUpdate(_singleKey(rawKey_));
 
         address expected = _accountAddress(nullifier_);
-        vm.assume(manager.worldIDAccountNullifier(expected) == 0); // collision guard for fuzz
+        vm.assume(manager.worldIDAccountNullifier(expected) == 0);
 
-        address acct = _doCreate(a, u);
+        address acct = _doCreate(a, _createUpdate(_singleKey(rawKey_)));
         assertEq(acct, expected);
         assertTrue(manager.isAuthorized(acct, rawKey_));
-        assertEq(_action(nonce_) >> 248, 0);
-    }
-
-    function testFuzz_action_alwaysFitsBelowTopByte(uint256 nonce_) public pure {
         assertEq(_action(nonce_) >> 248, 0);
     }
 }

--- a/pkg/contracts/test/WorldIDAccountManagerImplV1.t.sol
+++ b/pkg/contracts/test/WorldIDAccountManagerImplV1.t.sol
@@ -75,6 +75,30 @@ contract WorldIDAccountManagerImplV1Test is Test {
         arr[0] = k_;
     }
 
+    function _emptyKeys() internal pure returns (bytes[] memory arr) {
+        arr = new bytes[](0);
+    }
+
+    function _createUpdate(bytes[] memory addKeys_) internal pure returns (IWorldIDAccountManager.WorldIDAccountUpdate memory u) {
+        u = IWorldIDAccountManager.WorldIDAccountUpdate({
+            operation: IWorldIDAccountManager.Operation.Create,
+            addKeys: addKeys_,
+            removeKeys: _emptyKeys()
+        });
+    }
+
+    function _updatePayload(bytes[] memory addKeys_, bytes[] memory removeKeys_)
+        internal
+        pure
+        returns (IWorldIDAccountManager.WorldIDAccountUpdate memory u)
+    {
+        u = IWorldIDAccountManager.WorldIDAccountUpdate({
+            operation: IWorldIDAccountManager.Operation.Update,
+            addKeys: addKeys_,
+            removeKeys: removeKeys_
+        });
+    }
+
     function _proof() internal pure returns (uint256[5] memory p) {
         p[0] = 1;
         p[1] = 2;
@@ -127,9 +151,7 @@ contract WorldIDAccountManagerImplV1Test is Test {
 
     function _newAccountWithKey(bytes memory firstKey_) internal returns (address acct, CreateArgs memory a) {
         a = _defaultCreateArgs();
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = IWorldIDAccountManager.WorldIDAccountUpdate({
-            operation: IWorldIDAccountManager.Operation.Create, keys: _singleKey(firstKey_)
-        });
+        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _createUpdate(_singleKey(firstKey_));
         acct = _doCreate(a, u);
     }
 
@@ -140,9 +162,7 @@ contract WorldIDAccountManagerImplV1Test is Test {
     function test_create_happyPath_storage_events_andVerifierCall() public {
         CreateArgs memory a = _defaultCreateArgs();
         bytes memory k = _key(0xAA, 33);
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = IWorldIDAccountManager.WorldIDAccountUpdate({
-            operation: IWorldIDAccountManager.Operation.Create, keys: _singleKey(k)
-        });
+        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _createUpdate(_singleKey(k));
         address expectedAcct = _accountAddress(a.nullifier);
 
         vm.expectCall(
@@ -166,7 +186,7 @@ contract WorldIDAccountManagerImplV1Test is Test {
         vm.expectEmit(true, true, true, true, address(manager));
         emit WorldIDAccountCreated(expectedAcct, a.nullifier, a.sessionId);
         vm.expectEmit(true, true, true, true, address(manager));
-        emit SessionKeysAdded(expectedAcct, u.keys);
+        emit SessionKeysAdded(expectedAcct, u.addKeys);
 
         address acct = _doCreate(a, u);
         assertEq(acct, expectedAcct, "derived address mismatch");
@@ -186,16 +206,24 @@ contract WorldIDAccountManagerImplV1Test is Test {
             assertEq(_action(nonce) >> 248, 0, "top byte must be zero for V2-verifier compat");
         }
         a.nonce = 1;
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = IWorldIDAccountManager.WorldIDAccountUpdate({
-            operation: IWorldIDAccountManager.Operation.Create, keys: _singleKey(_key(0x01, 33))
-        });
+        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _createUpdate(_singleKey(_key(0x01, 33)));
         _doCreate(a, u);
     }
 
     function test_create_revertIf_wrongOperation() public {
         CreateArgs memory a = _defaultCreateArgs();
+        IWorldIDAccountManager.WorldIDAccountUpdate memory u =
+            _updatePayload(_singleKey(_key(0x01, 33)), _emptyKeys());
+        vm.expectRevert(IWorldIDAccountManager.InvalidOperation.selector);
+        _doCreate(a, u);
+    }
+
+    function test_create_revertIf_removeKeysProvided() public {
+        CreateArgs memory a = _defaultCreateArgs();
         IWorldIDAccountManager.WorldIDAccountUpdate memory u = IWorldIDAccountManager.WorldIDAccountUpdate({
-            operation: IWorldIDAccountManager.Operation.Add, keys: _singleKey(_key(0x01, 33))
+            operation: IWorldIDAccountManager.Operation.Create,
+            addKeys: _singleKey(_key(0x01, 33)),
+            removeKeys: _singleKey(_key(0x02, 33))
         });
         vm.expectRevert(IWorldIDAccountManager.InvalidOperation.selector);
         _doCreate(a, u);
@@ -203,9 +231,7 @@ contract WorldIDAccountManagerImplV1Test is Test {
 
     function test_create_revertIf_emptyKeySet() public {
         CreateArgs memory a = _defaultCreateArgs();
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = IWorldIDAccountManager.WorldIDAccountUpdate({
-            operation: IWorldIDAccountManager.Operation.Create, keys: new bytes[](0)
-        });
+        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _createUpdate(_emptyKeys());
         vm.expectRevert(IWorldIDAccountManager.EmptyKeySet.selector);
         _doCreate(a, u);
     }
@@ -216,9 +242,7 @@ contract WorldIDAccountManagerImplV1Test is Test {
         for (uint256 i = 0; i < 21; ++i) {
             keys[i] = _key(uint8(i), 33);
         }
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = IWorldIDAccountManager.WorldIDAccountUpdate({
-            operation: IWorldIDAccountManager.Operation.Create, keys: keys
-        });
+        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _createUpdate(keys);
         vm.expectRevert(abi.encodeWithSelector(IWorldIDAccountManager.TooManyKeys.selector, uint256(21), uint256(20)));
         _doCreate(a, u);
     }
@@ -227,9 +251,7 @@ contract WorldIDAccountManagerImplV1Test is Test {
         CreateArgs memory a = _defaultCreateArgs();
         bytes[] memory keys = new bytes[](1);
         keys[0] = "";
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = IWorldIDAccountManager.WorldIDAccountUpdate({
-            operation: IWorldIDAccountManager.Operation.Create, keys: keys
-        });
+        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _createUpdate(keys);
         vm.expectRevert(IWorldIDAccountManager.EmptyKey.selector);
         _doCreate(a, u);
     }
@@ -237,9 +259,7 @@ contract WorldIDAccountManagerImplV1Test is Test {
     function test_create_revertIf_keyTooLarge() public {
         CreateArgs memory a = _defaultCreateArgs();
         bytes memory big = _key(0x01, 129);
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = IWorldIDAccountManager.WorldIDAccountUpdate({
-            operation: IWorldIDAccountManager.Operation.Create, keys: _singleKey(big)
-        });
+        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _createUpdate(_singleKey(big));
         vm.expectRevert(abi.encodeWithSelector(IWorldIDAccountManager.KeyTooLarge.selector, uint256(129), uint256(128)));
         _doCreate(a, u);
     }
@@ -247,9 +267,7 @@ contract WorldIDAccountManagerImplV1Test is Test {
     function test_create_acceptsKeyAtExactBound() public {
         CreateArgs memory a = _defaultCreateArgs();
         bytes memory exactlyMax = _key(0x01, 128);
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = IWorldIDAccountManager.WorldIDAccountUpdate({
-            operation: IWorldIDAccountManager.Operation.Create, keys: _singleKey(exactlyMax)
-        });
+        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _createUpdate(_singleKey(exactlyMax));
         _doCreate(a, u);
     }
 
@@ -259,9 +277,7 @@ contract WorldIDAccountManagerImplV1Test is Test {
         bytes[] memory keys = new bytes[](2);
         keys[0] = k;
         keys[1] = k;
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = IWorldIDAccountManager.WorldIDAccountUpdate({
-            operation: IWorldIDAccountManager.Operation.Create, keys: keys
-        });
+        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _createUpdate(keys);
         vm.expectRevert(abi.encodeWithSelector(IWorldIDAccountManager.DuplicateSessionKey.selector, keccak256(k)));
         _doCreate(a, u);
     }
@@ -269,9 +285,7 @@ contract WorldIDAccountManagerImplV1Test is Test {
     function test_create_revertIf_alreadyExists() public {
         (address acct,) = _newAccountWithKey(_key(0xAA, 33));
         CreateArgs memory a = _defaultCreateArgs();
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = IWorldIDAccountManager.WorldIDAccountUpdate({
-            operation: IWorldIDAccountManager.Operation.Create, keys: _singleKey(_key(0xBB, 33))
-        });
+        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _createUpdate(_singleKey(_key(0xBB, 33)));
         vm.expectRevert(IWorldIDAccountManager.WorldIDAccountAlreadyExists.selector);
         _doCreate(a, u);
         // sanity: prior account is intact
@@ -281,9 +295,7 @@ contract WorldIDAccountManagerImplV1Test is Test {
     function test_create_revertIf_zeroNullifier() public {
         CreateArgs memory a = _defaultCreateArgs();
         a.nullifier = 0;
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = IWorldIDAccountManager.WorldIDAccountUpdate({
-            operation: IWorldIDAccountManager.Operation.Create, keys: _singleKey(_key(0x01, 33))
-        });
+        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _createUpdate(_singleKey(_key(0x01, 33)));
         vm.expectRevert(IWorldIDAccountManager.ZeroNullifier.selector);
         _doCreate(a, u);
     }
@@ -291,9 +303,7 @@ contract WorldIDAccountManagerImplV1Test is Test {
     function test_create_revertIf_verifierRejects() public {
         verifier.setShouldAccept(false);
         CreateArgs memory a = _defaultCreateArgs();
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = IWorldIDAccountManager.WorldIDAccountUpdate({
-            operation: IWorldIDAccountManager.Operation.Create, keys: _singleKey(_key(0x01, 33))
-        });
+        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _createUpdate(_singleKey(_key(0x01, 33)));
         vm.expectRevert(MockWorldIDVerifier.MockVerifierRejected.selector);
         _doCreate(a, u);
         // No state should be persisted on revert.
@@ -309,9 +319,7 @@ contract WorldIDAccountManagerImplV1Test is Test {
         (address acct,) = _newAccountWithKey(_key(0x01, 33));
         bytes memory k2 = _key(0x02, 33);
 
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = IWorldIDAccountManager.WorldIDAccountUpdate({
-            operation: IWorldIDAccountManager.Operation.Add, keys: _singleKey(k2)
-        });
+        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _updatePayload(_singleKey(k2), _emptyKeys());
 
         vm.expectCall(
             address(verifier),
@@ -331,7 +339,7 @@ contract WorldIDAccountManagerImplV1Test is Test {
             )
         );
         vm.expectEmit(true, true, true, true, address(manager));
-        emit SessionKeysAdded(acct, u.keys);
+        emit SessionKeysAdded(acct, u.addKeys);
 
         manager.update(acct, 777, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), u);
 
@@ -343,9 +351,7 @@ contract WorldIDAccountManagerImplV1Test is Test {
     function test_update_add_revertIf_duplicate() public {
         bytes memory k1 = _key(0x01, 33);
         (address acct,) = _newAccountWithKey(k1);
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = IWorldIDAccountManager.WorldIDAccountUpdate({
-            operation: IWorldIDAccountManager.Operation.Add, keys: _singleKey(k1)
-        });
+        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _updatePayload(_singleKey(k1), _emptyKeys());
         vm.expectRevert(abi.encodeWithSelector(IWorldIDAccountManager.DuplicateSessionKey.selector, keccak256(k1)));
         manager.update(acct, 1, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), u);
     }
@@ -357,31 +363,25 @@ contract WorldIDAccountManagerImplV1Test is Test {
         for (uint256 i = 0; i < 20; ++i) {
             initialKeys[i] = _key(uint8(i), 33);
         }
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = IWorldIDAccountManager.WorldIDAccountUpdate({
-            operation: IWorldIDAccountManager.Operation.Create, keys: initialKeys
-        });
+        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _createUpdate(initialKeys);
         address acct = _doCreate(a, u);
 
-        IWorldIDAccountManager.WorldIDAccountUpdate memory addOne = IWorldIDAccountManager.WorldIDAccountUpdate({
-            operation: IWorldIDAccountManager.Operation.Add, keys: _singleKey(_key(0xFF, 33))
-        });
+        IWorldIDAccountManager.WorldIDAccountUpdate memory addOne =
+            _updatePayload(_singleKey(_key(0xFF, 33)), _emptyKeys());
         vm.expectRevert(abi.encodeWithSelector(IWorldIDAccountManager.TooManyKeys.selector, uint256(21), uint256(20)));
         manager.update(acct, 1, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), addOne);
     }
 
     function test_update_revertIf_accountDoesNotExist() public {
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = IWorldIDAccountManager.WorldIDAccountUpdate({
-            operation: IWorldIDAccountManager.Operation.Add, keys: _singleKey(_key(0x01, 33))
-        });
+        IWorldIDAccountManager.WorldIDAccountUpdate memory u =
+            _updatePayload(_singleKey(_key(0x01, 33)), _emptyKeys());
         vm.expectRevert(IWorldIDAccountManager.WorldIDAccountDoesNotExist.selector);
         manager.update(address(0xCAFE), 1, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), u);
     }
 
     function test_update_revertIf_operationCreate() public {
         (address acct,) = _newAccountWithKey(_key(0x01, 33));
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = IWorldIDAccountManager.WorldIDAccountUpdate({
-            operation: IWorldIDAccountManager.Operation.Create, keys: _singleKey(_key(0x02, 33))
-        });
+        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _createUpdate(_singleKey(_key(0x02, 33)));
         vm.expectRevert(IWorldIDAccountManager.InvalidOperation.selector);
         manager.update(acct, 1, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), u);
     }
@@ -397,16 +397,12 @@ contract WorldIDAccountManagerImplV1Test is Test {
         initialKeys[0] = k1;
         initialKeys[1] = k2;
         initialKeys[2] = k3;
-        IWorldIDAccountManager.WorldIDAccountUpdate memory createPayload = IWorldIDAccountManager.WorldIDAccountUpdate({
-            operation: IWorldIDAccountManager.Operation.Create, keys: initialKeys
-        });
+        IWorldIDAccountManager.WorldIDAccountUpdate memory createPayload = _createUpdate(initialKeys);
         address acct = _doCreate(a, createPayload);
 
-        IWorldIDAccountManager.WorldIDAccountUpdate memory rm = IWorldIDAccountManager.WorldIDAccountUpdate({
-            operation: IWorldIDAccountManager.Operation.Remove, keys: _singleKey(k2)
-        });
+        IWorldIDAccountManager.WorldIDAccountUpdate memory rm = _updatePayload(_emptyKeys(), _singleKey(k2));
         vm.expectEmit(true, true, true, true, address(manager));
-        emit SessionKeysRemoved(acct, rm.keys);
+        emit SessionKeysRemoved(acct, rm.removeKeys);
         manager.update(acct, 1, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), rm);
 
         bytes32[] memory hashes = manager.getSessionKeyHashes(acct);
@@ -418,12 +414,61 @@ contract WorldIDAccountManagerImplV1Test is Test {
         assertEq(manager.keyHashIndex(acct, keccak256(k3)), 2, "k3 should now sit at index 1 (1-indexed: 2)");
     }
 
+    function test_update_addAndRemove_happyPath_removeFirstThenAdd() public {
+        bytes memory k1 = _key(0x01, 33);
+        bytes memory k2 = _key(0x02, 33);
+        bytes memory k3 = _key(0x03, 33);
+        bytes memory k4 = _key(0x04, 33);
+
+        CreateArgs memory a = _defaultCreateArgs();
+        bytes[] memory initialKeys = new bytes[](3);
+        initialKeys[0] = k1;
+        initialKeys[1] = k2;
+        initialKeys[2] = k3;
+        address acct = _doCreate(a, _createUpdate(initialKeys));
+
+        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _updatePayload(_singleKey(k4), _singleKey(k2));
+
+        vm.expectEmit(true, true, true, true, address(manager));
+        emit SessionKeysRemoved(acct, u.removeKeys);
+        vm.expectEmit(true, true, true, true, address(manager));
+        emit SessionKeysAdded(acct, u.addKeys);
+
+        manager.update(acct, 1, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), u);
+
+        bytes32[] memory hashes = manager.getSessionKeyHashes(acct);
+        assertEq(hashes.length, 3);
+        assertTrue(manager.isAuthorized(acct, k1));
+        assertFalse(manager.isAuthorized(acct, k2));
+        assertTrue(manager.isAuthorized(acct, k3));
+        assertTrue(manager.isAuthorized(acct, k4));
+    }
+
+    function test_update_revertIf_addAndRemoveSameExistingKey() public {
+        bytes memory k1 = _key(0x01, 33);
+        (address acct,) = _newAccountWithKey(k1);
+
+        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _updatePayload(_singleKey(k1), _singleKey(k1));
+
+        vm.expectRevert(abi.encodeWithSelector(IWorldIDAccountManager.OverlappingUpdateKey.selector, keccak256(k1)));
+        manager.update(acct, 1, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), u);
+    }
+
+    function test_update_revertIf_addAndRemoveSameMissingKey() public {
+        bytes memory k1 = _key(0x01, 33);
+        bytes memory k2 = _key(0x02, 33);
+        (address acct,) = _newAccountWithKey(k1);
+
+        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _updatePayload(_singleKey(k2), _singleKey(k2));
+
+        vm.expectRevert(abi.encodeWithSelector(IWorldIDAccountManager.OverlappingUpdateKey.selector, keccak256(k2)));
+        manager.update(acct, 1, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), u);
+    }
+
     function test_update_remove_revertIf_unknownKey() public {
         (address acct,) = _newAccountWithKey(_key(0x01, 33));
         bytes memory k2 = _key(0x02, 33);
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = IWorldIDAccountManager.WorldIDAccountUpdate({
-            operation: IWorldIDAccountManager.Operation.Remove, keys: _singleKey(k2)
-        });
+        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _updatePayload(_emptyKeys(), _singleKey(k2));
         vm.expectRevert(abi.encodeWithSelector(IWorldIDAccountManager.UnknownSessionKey.selector, keccak256(k2)));
         manager.update(acct, 1, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), u);
     }
@@ -432,9 +477,7 @@ contract WorldIDAccountManagerImplV1Test is Test {
         bytes memory k1 = _key(0x01, 33);
         (address acct,) = _newAccountWithKey(k1);
 
-        IWorldIDAccountManager.WorldIDAccountUpdate memory rm = IWorldIDAccountManager.WorldIDAccountUpdate({
-            operation: IWorldIDAccountManager.Operation.Remove, keys: _singleKey(k1)
-        });
+        IWorldIDAccountManager.WorldIDAccountUpdate memory rm = _updatePayload(_emptyKeys(), _singleKey(k1));
         manager.update(acct, 1, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), rm);
         assertEq(manager.getSessionKeyHashes(acct).length, 0);
         assertFalse(manager.isAuthorized(acct, k1));
@@ -442,9 +485,7 @@ contract WorldIDAccountManagerImplV1Test is Test {
         // Account still exists.
         assertEq(manager.worldIDAccountNullifier(acct), 0x1234567890ABCDEF);
 
-        IWorldIDAccountManager.WorldIDAccountUpdate memory addBack = IWorldIDAccountManager.WorldIDAccountUpdate({
-            operation: IWorldIDAccountManager.Operation.Add, keys: _singleKey(k1)
-        });
+        IWorldIDAccountManager.WorldIDAccountUpdate memory addBack = _updatePayload(_singleKey(k1), _emptyKeys());
         manager.update(acct, 2, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), addBack);
         assertTrue(manager.isAuthorized(acct, k1));
     }
@@ -455,12 +496,8 @@ contract WorldIDAccountManagerImplV1Test is Test {
         bytes memory k2 = _key(0x02, 33);
         (address acct,) = _newAccountWithKey(k1);
 
-        IWorldIDAccountManager.WorldIDAccountUpdate memory addK2 = IWorldIDAccountManager.WorldIDAccountUpdate({
-            operation: IWorldIDAccountManager.Operation.Add, keys: _singleKey(k2)
-        });
-        IWorldIDAccountManager.WorldIDAccountUpdate memory removeK2 = IWorldIDAccountManager.WorldIDAccountUpdate({
-            operation: IWorldIDAccountManager.Operation.Remove, keys: _singleKey(k2)
-        });
+        IWorldIDAccountManager.WorldIDAccountUpdate memory addK2 = _updatePayload(_singleKey(k2), _emptyKeys());
+        IWorldIDAccountManager.WorldIDAccountUpdate memory removeK2 = _updatePayload(_emptyKeys(), _singleKey(k2));
 
         uint256 firstHash = _signalHashUpdate(addK2, 0);
         uint256 secondHash = _signalHashUpdate(addK2, 2);
@@ -489,6 +526,13 @@ contract WorldIDAccountManagerImplV1Test is Test {
             )
         );
         manager.update(acct, 3, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), addK2);
+    }
+
+    function test_update_revertIf_emptyDelta() public {
+        (address acct,) = _newAccountWithKey(_key(0x01, 33));
+        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _updatePayload(_emptyKeys(), _emptyKeys());
+        vm.expectRevert(IWorldIDAccountManager.EmptyKeySet.selector);
+        manager.update(acct, 1, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), u);
     }
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -588,9 +632,7 @@ contract WorldIDAccountManagerImplV1Test is Test {
         CreateArgs memory a = _defaultCreateArgs();
         a.nullifier = nullifier_;
         a.nonce = nonce_;
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u = IWorldIDAccountManager.WorldIDAccountUpdate({
-            operation: IWorldIDAccountManager.Operation.Create, keys: _singleKey(rawKey_)
-        });
+        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _createUpdate(_singleKey(rawKey_));
 
         address expected = _accountAddress(nullifier_);
         vm.assume(manager.worldIDAccountNullifier(expected) == 0); // collision guard for fuzz

--- a/pkg/contracts/test/WorldIDAccountManagerImplV1.t.sol
+++ b/pkg/contracts/test/WorldIDAccountManagerImplV1.t.sol
@@ -79,11 +79,13 @@ contract WorldIDAccountManagerImplV1Test is Test {
         arr = new bytes[](0);
     }
 
-    function _createUpdate(bytes[] memory addKeys_) internal pure returns (IWorldIDAccountManager.WorldIDAccountUpdate memory u) {
+    function _createUpdate(bytes[] memory addKeys_)
+        internal
+        pure
+        returns (IWorldIDAccountManager.WorldIDAccountUpdate memory u)
+    {
         u = IWorldIDAccountManager.WorldIDAccountUpdate({
-            operation: IWorldIDAccountManager.Operation.Create,
-            addKeys: addKeys_,
-            removeKeys: _emptyKeys()
+            operation: IWorldIDAccountManager.Operation.Create, addKeys: addKeys_, removeKeys: _emptyKeys()
         });
     }
 
@@ -93,9 +95,7 @@ contract WorldIDAccountManagerImplV1Test is Test {
         returns (IWorldIDAccountManager.WorldIDAccountUpdate memory u)
     {
         u = IWorldIDAccountManager.WorldIDAccountUpdate({
-            operation: IWorldIDAccountManager.Operation.Update,
-            addKeys: addKeys_,
-            removeKeys: removeKeys_
+            operation: IWorldIDAccountManager.Operation.Update, addKeys: addKeys_, removeKeys: removeKeys_
         });
     }
 
@@ -212,8 +212,7 @@ contract WorldIDAccountManagerImplV1Test is Test {
 
     function test_create_revertIf_wrongOperation() public {
         CreateArgs memory a = _defaultCreateArgs();
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u =
-            _updatePayload(_singleKey(_key(0x01, 33)), _emptyKeys());
+        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _updatePayload(_singleKey(_key(0x01, 33)), _emptyKeys());
         vm.expectRevert(IWorldIDAccountManager.InvalidOperation.selector);
         _doCreate(a, u);
     }
@@ -373,8 +372,7 @@ contract WorldIDAccountManagerImplV1Test is Test {
     }
 
     function test_update_revertIf_accountDoesNotExist() public {
-        IWorldIDAccountManager.WorldIDAccountUpdate memory u =
-            _updatePayload(_singleKey(_key(0x01, 33)), _emptyKeys());
+        IWorldIDAccountManager.WorldIDAccountUpdate memory u = _updatePayload(_singleKey(_key(0x01, 33)), _emptyKeys());
         vm.expectRevert(IWorldIDAccountManager.WorldIDAccountDoesNotExist.selector);
         manager.update(address(0xCAFE), 1, 1, uint64(block.timestamp + 1 days), 0, _sessionNullifier(), _proof(), u);
     }

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -40,6 +40,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 | `WORLD_CHAIN_RP_ID`           | `480`                                        | World Chain's registered RP ID                                    |
 | `WORLD_ID_ACCOUNT_PRECOMPILE` | `0x000000000000000000000000000000000000001D` | Stateful precompile managing the World ID Account registry        |
 | `WORLD_ID_ACCOUNT_TAG`        | `"WORLD_ID_ACCOUNT"` (UTF-8, 16 bytes)       | Domain tag for World ID Account Uniqueness Proof actions          |
+| `WORLD_ID_ACCOUNT_REVERT_TAG` | `"WORLD_ID_REVERT"` (UTF-8, 16 bytes)        | Domain tag for reverting a pending key-ring update                |
 | `WORLD_ID_ACCOUNT_NONCE`      | U256                                         | The generational nonce of the World ID Account. Not necessarily monotonic |
 | `MAX_SESSION_KEYS`            | `20`                                         | Maximum authorized session keys per World ID Account              |
 
@@ -70,6 +71,14 @@ Subsequent update mutations are authorized by World ID 4.0 Session Proofs parame
 > **Note:** `signalHash` must be unique for any given update to the World ID Account.
 
 where `update` is a `KeyringUpdate` with `mode = Update`. Session Proofs are verified with `verifySession`, supplying a fresh `sessionNullifier` for each update. That `sessionNullifier` is consumed only for verification of the current update; only `sessionId` is retained across updates.
+
+Reverting a pending key-ring update is likewise authorized by a fresh Session Proof bound to the same stored `sessionId`, with:
+
+- `rpId = WORLD_CHAIN_RP_ID`
+- `sessionId = sessionId(worldIDAccount)`
+- `signalHash = uint256(keccak256(abi.encode(WORLD_ID_ACCOUNT_REVERT_TAG, worldIDAccount, validAfter, generation))) >> 8`
+
+The revert proof MUST therefore be bound to the exact account and pending update window being reverted.
 
 A World ID Account therefore accepts one Uniqueness Proof at creation and any number of Session Proofs over its lifetime.
 
@@ -137,9 +146,9 @@ struct KeyringUpdate {
 ```
 
 - **`Create`** — installs `addKeys` as the full session key set at $\mathrm{addr}(\nu_k)$ and associates a fresh `sessionId` with the World ID Account. Does **NOT** store any `sessionNullifier`. MUST revert if the World ID Account already exists, if `addKeys.length == 0`, if `addKeys.length > MAX_SESSION_KEYS`, or if `removeKeys.length != 0`.
-- **`Update`** — applies a single atomic key-ring delta. At least one of `addKeys` or `removeKeys` MUST be non-empty. The same key MUST NOT appear in both arrays. Every key in `addKeys` MUST be absent from the existing set. Every key in `removeKeys` MUST be present in the existing set. The resulting set size after applying the full delta MUST NOT exceed `MAX_SESSION_KEYS`. The set MAY become empty; a World ID Account with zero session keys exists but cannot sign transactions until the next `Update` that adds a key.
+- **`Update`** — schedules a single atomic key-ring delta. At least one of `addKeys` or `removeKeys` MUST be non-empty. The same key MUST NOT appear in both arrays. Every key in `addKeys` MUST be absent from the existing set. Every key in `removeKeys` MUST be present in the existing set. The resulting set size after applying the full delta MUST NOT exceed `MAX_SESSION_KEYS`. The set MAY become empty; a World ID Account with zero session keys exists but cannot sign transactions once the update becomes effective unless a later `Update` adds a key.
 
-For `Update`, implementations MUST apply `removeKeys` before `addKeys`. This preserves valid one-for-one rotations at the `MAX_SESSION_KEYS` boundary by avoiding a transient overflow.
+For `Update`, implementations MUST apply `removeKeys` before `addKeys` when computing the future stored set. This preserves valid one-for-one rotations at the `MAX_SESSION_KEYS` boundary by avoiding a transient overflow.
 
 #### Precompile Interface
 
@@ -170,7 +179,21 @@ interface IWorldIDAccount {
         KeyringUpdate calldata keyringUpdate
     ) external;
 
+    /// @notice Revert a pending key-ring update authorized by a World ID 4.0 Session Proof.
+    function revertUpdate(
+        address worldIDAccount,
+        uint256 proofNonce,
+        uint64  issuerSchemaId,
+        uint64  expiresAtMin,
+        uint256 credentialGenesisIssuedAtMin,
+        uint256[2] calldata sessionNullifier,
+        uint256[5] calldata proof
+    ) external;
+
     function getSessionKeys(address worldIDAccount) external view returns (SessionKey[] memory);
+    function getStoredSessionKeys(address worldIDAccount) external view returns (SessionKey[] memory);
+    function getPreviousSessionKeys(address worldIDAccount) external view returns (SessionKey[] memory);
+    function getPendingValidAfter(address worldIDAccount) external view returns (uint256);
     function isAuthorized(address worldIDAccount, SessionKey calldata key) external view returns (bool);
     function getWorldAccountNullifier(address worldIDAccount) external view returns (uint256);
 }
@@ -191,11 +214,25 @@ For `update`, the precompile MUST:
 3. Recompute `signalHash = uint256(keccak256(abi.encode(update))) >> 8`.
 4. Invoke `WorldID.verifySession(WORLD_CHAIN_RP_ID, proofNonce, signalHash, …, sessionId, sessionNullifier, proof)`.
 5. Discard `sessionNullifier` after verification; it MUST NOT be persisted in World ID Account state.
-6. Apply `update`, queued behind the timelock as a single atomic delta over `addKeys` and `removeKeys` (see [Timelock](#timelock)).
+6. Snapshot the currently effective key set as `previousSessionKeys`.
+7. Apply `update` immediately to the stored key set, record `validAfter = block.timestamp + cooldown`, and treat the new stored set as pending until `validAfter` (see [Timelock](#timelock)).
+8. Reject any new `update` while another pending update remains active.
+
+For `revertUpdate`, the precompile MUST:
+
+1. Require an active pending update for `worldIDAccount`.
+2. Require `block.timestamp < validAfter`.
+3. Load the stored `sessionId` for `worldIDAccount`.
+4. Recompute `signalHash = uint256(keccak256(abi.encode(WORLD_ID_ACCOUNT_REVERT_TAG, worldIDAccount, validAfter, generation))) >> 8`.
+5. Invoke `WorldID.verifySession(WORLD_CHAIN_RP_ID, proofNonce, signalHash, …, sessionId, sessionNullifier, proof)`.
+6. Discard `sessionNullifier` after verification; it MUST NOT be persisted in World ID Account state.
+7. Restore `previousSessionKeys` as the stored key set and clear the pending update metadata.
 
 The precompile DOES NOT enforce a one-account-per-WorldID constraint; distinct World ID Accounts remain indexed by distinct `worldIDAccountNonce` values.
 
-> **Note — Precompile gas accounting out of scope.** The specific gas pricing schedule for interacting with `WORLD_ID_ACCOUNT_PRECOMPILE` — covering Groth16 verification cost, per-session-key storage mutation, timelock queue/cancel/execute operations, and the amortized cost of `isAuthorized` reads during `0x1D` validation — is **NOT** defined here. A follow-on revision MUST specify gas costs per operation.
+`getSessionKeys` MUST return the currently effective key set. During an active pending update this is `previousSessionKeys`, not the newly stored key set. `isAuthorized` MUST likewise evaluate against the currently effective key set.
+
+> **Note — Precompile gas accounting out of scope.** The specific gas pricing schedule for interacting with `WORLD_ID_ACCOUNT_PRECOMPILE` — covering Groth16 verification cost, per-session-key storage mutation, pending-update snapshot storage, `revertUpdate`, and the amortized cost of effective-set reads during `0x1D` validation — is **NOT** defined here. A follow-on revision MUST specify gas costs per operation.
 
 ### Recovery
 
@@ -205,14 +242,14 @@ A single WorldID MAY enable recovery for any number of World ID Accounts; World 
 
 ### Timelock
 
-A compromised WorldID authenticator could otherwise rotate session keys in a single block and drain a World ID Account. World ID Account updates are subject to a configurable delay:
+A compromised WorldID authenticator could otherwise rotate session keys in a single block and drain a World ID Account. World ID Account updates are therefore subject to a configurable delayed-activation window:
 
-- `Create` executes immediately (no prior session keys exist to cancel).
-- `Update` deltas are pending until the delay elapses.
-- Existing session keys MAY cancel a pending update during the delay window.
-- The revocation-then-add attack (a Session Proof removes all keys, then later submits an `Update` that adds malicious keys with no incumbents left to cancel) MUST be mitigated — e.g., by delaying removals, or by allowing recently-removed keys to cancel pending updates.
-
-Queue / cancel / execute interface additions are TBD.
+- `Create` executes immediately (no prior session keys exist to protect).
+- `Update` writes the future key set immediately, but it MUST NOT become effective until `validAfter`.
+- During the delay window, `isAuthorized` and `getSessionKeys` MUST continue to use the previous key set.
+- `revertUpdate` MAY restore the previous key set during the delay window, but only with a fresh Session Proof bound to the account's stored `sessionId`.
+- A World ID Account MUST NOT have more than one active pending update at a time.
+- The revocation-then-add attack is mitigated because added keys are not effective until `validAfter`, while removed keys remain effective until `validAfter`.
 
 ### Transaction Type `0x1D`
 
@@ -285,7 +322,7 @@ The envelope is extensible to 2D nonces, batched transactions, and native paymas
 
 **No sybil constraint on World ID Accounts.** Unlinkability across `worldIDAccountNonce` values is a stronger property than one-account-per-identity, and sybil resistance at the account layer is not the right locus — it belongs to whatever system consumes World ID Account addresses (e.g., gas subsidy accounting, application-layer rate limits), which can bind its own per-WorldID limits via independent nullifier domains.
 
-**Recovery timelock.** Without a delay, a compromised WorldID authenticator could instantly replace all session keys and drain the account. The timelock gives existing session key holders a window to detect and cancel malicious changes.
+**Recovery timelock.** Without a delay, a compromised WorldID authenticator could instantly replace all session keys and drain the account. Delayed activation prevents newly-added malicious keys from becoming usable immediately, while `revertUpdate` provides a proof-authorized path to restore the previous key set during the pending window.
 
 ## Backwards Compatibility
 
@@ -307,7 +344,9 @@ Two World ID Accounts owned by the same WorldID are unlinkable across distinct c
 
 ### Timelock Attacks
 
-The revocation-then-add attack vector (a Session Proof removes all session keys, then later submits an `Update` that adds malicious keys with no keys left to cancel) MUST be addressed in the timelock policy design. Possible mitigations include timelocking removals or allowing recently-removed keys to cancel pending updates.
+The revocation-then-add attack vector (a Session Proof removes all session keys, then later submits an `Update` that adds malicious keys with no keys left to cancel) is mitigated by delayed activation: until `validAfter`, removed keys remain effective and added keys remain ineffective. A malicious authenticator can still schedule a harmful future set, but cannot use newly-added keys before the delay elapses.
+
+Because `revertUpdate` is also Session-Proof-authorized, incumbent session keys do **NOT** have unilateral veto power over their own removal. This avoids giving a leaked session key the ability to cancel a legitimate removal on its own, at the cost of not providing a session-key-only emergency stop.
 
 ### Session Key Deanonymization
 

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -61,7 +61,7 @@ where `create` is a `KeyringUpdate` with `mode = Create` (see [Signal Semantics]
 
 The creation nullifier $\nu_k$ is used once to instantiate the World ID Account. Because World ID authenticators do not issue the same `(rpId, action)` nullifier twice, a later mutation MUST NOT attempt to reuse the creation action. On successful `Create`, the caller MUST also provide a fresh `sessionId` for `WORLD_CHAIN_RP_ID`, and the precompile MUST associate it with the World ID Account.
 
-Subsequent `Add` and `Remove` mutations are authorized by World ID 4.0 Session Proofs parameterized by:
+Subsequent update mutations are authorized by World ID 4.0 Session Proofs parameterized by:
 
 - `rpId = WORLD_CHAIN_RP_ID`
 - `sessionId = sessionId(worldIDAccount)`
@@ -69,7 +69,7 @@ Subsequent `Add` and `Remove` mutations are authorized by World ID 4.0 Session P
 
 > **Note:** `signalHash` must be unique for any given update to the World ID Account.
 
-where `update` is a `KeyringUpdate` with `mode != Create`. Session Proofs are verified with `verifySession`, supplying a fresh `sessionNullifier` for each update. That `sessionNullifier` is consumed only for verification of the current update; only `sessionId` is retained across updates.
+where `update` is a `KeyringUpdate` with `mode = Update`. Session Proofs are verified with `verifySession`, supplying a fresh `sessionNullifier` for each update. That `sessionNullifier` is consumed only for verification of the current update; only `sessionId` is retained across updates.
 
 A World ID Account therefore accepts one Uniqueness Proof at creation and any number of Session Proofs over its lifetime.
 
@@ -127,17 +127,19 @@ struct SessionKey {
 #### Signal Semantics
 
 ```solidity
-enum UpdateMode { Create, Add, Remove }
+enum UpdateMode { Create, Update }
 
 struct KeyringUpdate {
     UpdateMode   mode;
-    SessionKey[] keys;
+    SessionKey[] addKeys;
+    SessionKey[] removeKeys;
 }
 ```
 
-- **`Create`** — installs `keys` as the full session key set at $\mathrm{addr}(\nu_k)$ and associates a fresh `sessionId` with the World ID Account. Does **NOT** store any `sessionNullifier`. MUST revert if the World ID Account already exists, if `keys.length == 0`, or if `keys.length > MAX_SESSION_KEYS`.
-- **`Add`** — appends `keys` to the existing set. MUST revert if the World ID Account does not exist, if any key is already present, or if the resulting set exceeds `MAX_SESSION_KEYS`.
-- **`Remove`** — removes each entry in `keys` from the existing set. MUST revert if the World ID Account does not exist or if any key is absent. The set MAY become empty; a World ID Account with zero session keys exists but cannot sign transactions until the next `Add`.
+- **`Create`** — installs `addKeys` as the full session key set at $\mathrm{addr}(\nu_k)$ and associates a fresh `sessionId` with the World ID Account. Does **NOT** store any `sessionNullifier`. MUST revert if the World ID Account already exists, if `addKeys.length == 0`, if `addKeys.length > MAX_SESSION_KEYS`, or if `removeKeys.length != 0`.
+- **`Update`** — applies a single atomic key-ring delta. At least one of `addKeys` or `removeKeys` MUST be non-empty. The same key MUST NOT appear in both arrays. Every key in `addKeys` MUST be absent from the existing set. Every key in `removeKeys` MUST be present in the existing set. The resulting set size after applying the full delta MUST NOT exceed `MAX_SESSION_KEYS`. The set MAY become empty; a World ID Account with zero session keys exists but cannot sign transactions until the next `Update` that adds a key.
+
+For `Update`, implementations MUST apply `removeKeys` before `addKeys`. This preserves valid one-for-one rotations at the `MAX_SESSION_KEYS` boundary by avoiding a transient overflow.
 
 #### Precompile Interface
 
@@ -156,7 +158,7 @@ interface IWorldIDAccount {
         KeyringUpdate calldata createUpdate
     ) external returns (address worldIDAccountAddress);
 
-    /// @notice Apply an Add/Remove update authorized by a World ID 4.0 Session Proof.
+    /// @notice Apply an update authorized by a World ID 4.0 Session Proof.
     function update(
         address worldIDAccount,
         uint256 proofNonce,                  // verifier request nonce
@@ -184,12 +186,12 @@ For `create`, the precompile MUST:
 
 For `update`, the precompile MUST:
 
-1. Require `update.mode != Create`.
+1. Require `update.mode == Update`.
 2. Load the stored `sessionId` for `worldIDAccount`.
 3. Recompute `signalHash = uint256(keccak256(abi.encode(update))) >> 8`.
 4. Invoke `WorldID.verifySession(WORLD_CHAIN_RP_ID, proofNonce, signalHash, …, sessionId, sessionNullifier, proof)`.
 5. Discard `sessionNullifier` after verification; it MUST NOT be persisted in World ID Account state.
-6. Apply `update`, queued behind the timelock for `Add` / `Remove` (see [Timelock](#timelock)).
+6. Apply `update`, queued behind the timelock as a single atomic delta over `addKeys` and `removeKeys` (see [Timelock](#timelock)).
 
 The precompile DOES NOT enforce a one-account-per-WorldID constraint; distinct World ID Accounts remain indexed by distinct `worldIDAccountNonce` values.
 
@@ -197,7 +199,7 @@ The precompile DOES NOT enforce a one-account-per-WorldID constraint; distinct W
 
 ### Recovery
 
-Recovery is the degenerate case of an `Add` or `Remove` submitted after session keys are lost or compromised. Because post-creation authorization is a World ID 4.0 Session Proof bound to the World ID Account's stored `sessionId`, recovery requires only a fresh Session Proof — the full session-key surface is reachable via the same mutation path. No separate recovery flow or state is introduced.
+Recovery is the degenerate case of an `Update` submitted after session keys are lost or compromised. Because post-creation authorization is a World ID 4.0 Session Proof bound to the World ID Account's stored `sessionId`, recovery requires only a fresh Session Proof — the full session-key surface is reachable via the same mutation path. No separate recovery flow or state is introduced.
 
 A single WorldID MAY enable recovery for any number of World ID Accounts; World ID Accounts at distinct `worldIDAccountNonce` values remain unlinkable across the recovery event.
 
@@ -206,9 +208,9 @@ A single WorldID MAY enable recovery for any number of World ID Accounts; World 
 A compromised WorldID authenticator could otherwise rotate session keys in a single block and drain a World ID Account. World ID Account updates are subject to a configurable delay:
 
 - `Create` executes immediately (no prior session keys exist to cancel).
-- `Add` and `Remove` are pending until the delay elapses.
+- `Update` deltas are pending until the delay elapses.
 - Existing session keys MAY cancel a pending update during the delay window.
-- The revocation-then-add attack (a Session Proof removes all keys, then adds malicious ones with no incumbents left to cancel) MUST be mitigated — e.g., by delaying removals, or by allowing recently-removed keys to cancel pending adds.
+- The revocation-then-add attack (a Session Proof removes all keys, then later submits an `Update` that adds malicious keys with no incumbents left to cancel) MUST be mitigated — e.g., by delaying removals, or by allowing recently-removed keys to cancel pending updates.
 
 Queue / cancel / execute interface additions are TBD.
 
@@ -305,7 +307,7 @@ Two World ID Accounts owned by the same WorldID are unlinkable across distinct c
 
 ### Timelock Attacks
 
-The revocation-then-add attack vector (a Session Proof removes all session keys, then adds malicious ones with no keys left to cancel) MUST be addressed in the timelock policy design. Possible mitigations include timelocking removals or allowing recently-removed keys to cancel pending adds.
+The revocation-then-add attack vector (a Session Proof removes all session keys, then later submits an `Update` that adds malicious keys with no keys left to cancel) MUST be addressed in the timelock policy design. Possible mitigations include timelocking removals or allowing recently-removed keys to cancel pending updates.
 
 ### Session Key Deanonymization
 
@@ -326,4 +328,3 @@ The `WorldIDRegistry` accepts roots within a validity window. An attacker whose 
 ### OPRF Key Rotation
 
 If the OPRF key in `OprfKeyRegistry[480]` is rotated, both creation nullifier derivations and session re-derivations change. Existing $\nu_k$ values become unreachable for new creation proofs, and existing `sessionId` values can no longer be used to derive valid Session Proofs; the World ID Account becomes frozen at its current session key set. The protocol MUST define migration semantics across OPRF key epochs.
-


### PR DESCRIPTION
For https://github.com/worldcoin/world-chain/issues/532 , I think it's more user friendly if we unify Adding and Removing of Session Keys to avoid having to wait the timelock period twice in case of a rolling change.

