### PR TITLE
fix: cast version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ FROM base AS builder
 WORKDIR /app
 
 RUN curl -L https://foundry.paradigm.xyz | bash && \
-  /root/.foundry/bin/foundryup
+  /root/.foundry/bin/foundryup --install 1.5.1-stable
+
 
 ARG WORLD_CHAIN_BUILDER_BIN="world-chain"
 ARG PROFILE="maxperf"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low-risk Docker build change that pins the Foundry toolchain to a specific version; main risk is CI/build breakage if that version becomes unavailable or incompatible with downstream scripts.
> 
> **Overview**
> Pins the Docker image’s Foundry installation by running `foundryup --install 1.5.1-stable` instead of installing the latest version, making the bundled `cast` tooling reproducible across builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bb38b663ed21f4aaf6801d6144d1201654d05bc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->