### PR TITLE
fix: cast

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ FROM base AS builder
 WORKDIR /app
 
 RUN curl -L https://foundry.paradigm.xyz | bash && \
-  /root/.foundry/bin/foundryup --install 1.5.1-stable
+  /root/.foundry/bin/foundryup --install 1.5.1
 
 
 ARG WORLD_CHAIN_BUILDER_BIN="world-chain"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk build-only change that only alters which Foundry release tag is installed in the Docker build; primary risk is pulling a slightly different binary than before.
> 
> **Overview**
> Updates the Docker build to install Foundry via `foundryup --install 1.5.1` instead of `1.5.1-stable`, changing which `cast` binary ends up in the final image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad7c09347223aede9bc2e15708816aeb3b37ea67. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->