### PR TITLE
fix: normalize OP payload IDs to v3

### DIFF
--- a/crates/payload/src/generator.rs
+++ b/crates/payload/src/generator.rs
@@ -28,6 +28,7 @@ use world_chain_p2p::protocol::handler::FlashblocksHandle;
 use world_chain_primitives::{
     access_list::FlashblockAccessList, ed25519_dalek::SigningKey,
     flashblocks::recovered_block_from_flashblocks, p2p::Authorization,
+    payload_id::force_op_payload_id_v3,
 };
 
 use crate::job::{CommittedPayloadState, FlashblocksPayloadJob};
@@ -152,6 +153,8 @@ where
         input: BuildNewPayload<Builder::Attributes>,
         id: PayloadId,
     ) -> Result<Self::Job, PayloadBuilderError> {
+        let id = force_op_payload_id_v3(id);
+
         let parent_header = if input.parent_hash.is_zero() {
             // Use latest header for genesis block case
             self.client

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -4,6 +4,7 @@ pub mod access_list;
 pub mod error;
 pub mod flashblocks;
 pub mod p2p;
+pub mod payload_id;
 pub mod primitives;
 pub mod transaction;
 pub use ed25519_dalek;

--- a/crates/primitives/src/payload_id.rs
+++ b/crates/primitives/src/payload_id.rs
@@ -1,0 +1,63 @@
+use alloy_rpc_types_engine::PayloadId;
+
+const OP_ENGINE_PAYLOAD_ID_V3: u8 = 0x03;
+const OP_ENGINE_PAYLOAD_ID_V4: u8 = 0x04;
+
+/// Temporary compatibility fix for op-reth v2.1.0, which derives OP payload IDs
+/// with `EngineApiMessageVersion::default()` and currently defaults to V4.
+pub fn force_op_payload_id_v3(id: PayloadId) -> PayloadId {
+    payload_id_with_version(id, OP_ENGINE_PAYLOAD_ID_V3)
+}
+
+/// Converts the externally visible V3 payload ID back to the V4 ID currently used
+/// by reth's payload service as the internal job lookup key.
+pub fn op_reth_payload_id_v4_lookup(id: PayloadId) -> PayloadId {
+    let bytes = payload_id_bytes(id);
+    if bytes[0] == OP_ENGINE_PAYLOAD_ID_V3 {
+        payload_id_with_version(id, OP_ENGINE_PAYLOAD_ID_V4)
+    } else {
+        id
+    }
+}
+
+fn payload_id_with_version(id: PayloadId, version: u8) -> PayloadId {
+    let mut bytes = payload_id_bytes(id);
+    bytes[0] = version;
+    PayloadId::new(bytes)
+}
+
+fn payload_id_bytes(id: PayloadId) -> [u8; 8] {
+    id.0.into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn forces_first_byte_to_v3() {
+        let id = PayloadId::new([0x04, 1, 2, 3, 4, 5, 6, 7]);
+
+        assert_eq!(
+            force_op_payload_id_v3(id),
+            PayloadId::new([0x03, 1, 2, 3, 4, 5, 6, 7])
+        );
+    }
+
+    #[test]
+    fn maps_external_v3_id_to_internal_v4_lookup() {
+        let id = PayloadId::new([0x03, 1, 2, 3, 4, 5, 6, 7]);
+
+        assert_eq!(
+            op_reth_payload_id_v4_lookup(id),
+            PayloadId::new([0x04, 1, 2, 3, 4, 5, 6, 7])
+        );
+    }
+
+    #[test]
+    fn leaves_non_v3_lookup_ids_unchanged() {
+        let id = PayloadId::new([0x09, 1, 2, 3, 4, 5, 6, 7]);
+
+        assert_eq!(op_reth_payload_id_v4_lookup(id), id);
+    }
+}

--- a/crates/rpc/src/engine.rs
+++ b/crates/rpc/src/engine.rs
@@ -15,7 +15,10 @@ use reth_provider::{BlockReader, HeaderProvider, StateProviderFactory};
 use reth_rpc_api::IntoEngineApiRpcModule;
 use reth_transaction_pool::TransactionPool;
 use tracing::trace;
-use world_chain_primitives::p2p::Authorization;
+use world_chain_primitives::{
+    p2p::Authorization,
+    payload_id::{force_op_payload_id_v3, op_reth_payload_id_v4_lookup},
+};
 
 #[derive(Debug, Clone)]
 pub struct OpEngineApiExt<Provider, EngineT: EngineTypes, Pool, Validator, ChainSpec> {
@@ -115,9 +118,12 @@ where
             to_jobs_gen.send_modify(|b| *b = None)
         }
 
-        self.inner
+        let mut response = self
+            .inner
             .fork_choice_updated_v3(fork_choice_state, payload_attributes)
-            .await
+            .await?;
+        response.payload_id = response.payload_id.map(force_op_payload_id_v3);
+        Ok(response)
     }
 
     async fn get_payload_v2(
@@ -131,14 +137,20 @@ where
         &self,
         payload_id: PayloadId,
     ) -> RpcResult<EngineT::ExecutionPayloadEnvelopeV3> {
-        Ok(self.inner.get_payload_v3(payload_id).await?)
+        Ok(self
+            .inner
+            .get_payload_v3(op_reth_payload_id_v4_lookup(payload_id))
+            .await?)
     }
 
     async fn get_payload_v4(
         &self,
         payload_id: PayloadId,
     ) -> RpcResult<EngineT::ExecutionPayloadEnvelopeV4> {
-        Ok(self.inner.get_payload_v4(payload_id).await?)
+        Ok(self
+            .inner
+            .get_payload_v4(op_reth_payload_id_v4_lookup(payload_id))
+            .await?)
     }
 
     async fn get_payload_bodies_by_hash_v1(
@@ -245,8 +257,11 @@ where
             to_jobs_gen.send_modify(|b| *b = Some(a))
         }
 
-        self.inner
+        let mut response = self
+            .inner
             .fork_choice_updated_v3(fork_choice_state, payload_attributes)
-            .await
+            .await?;
+        response.payload_id = response.payload_id.map(force_op_payload_id_v3);
+        Ok(response)
     }
 }

--- a/crates/test-utils/src/e2e_harness/setup.rs
+++ b/crates/test-utils/src/e2e_harness/setup.rs
@@ -54,7 +54,9 @@ use world_chain_node::{
     FlashblocksOpApi, OpApiExtServer,
     node::{WorldChainNode, WorldChainNodeContext},
 };
-use world_chain_primitives::{flashblocks::Flashblock, p2p::Authorization};
+use world_chain_primitives::{
+    flashblocks::Flashblock, p2p::Authorization, payload_id::force_op_payload_id_v3,
+};
 
 use world_chain_pool::{
     BasicWorldChainPool,
@@ -432,7 +434,7 @@ pub fn create_authorization_generator(
 ) -> impl Fn(OpPayloadAttrs) -> Authorization + Clone {
     move |attrs: OpPayloadAttrs| {
         let authorizer_sk = SigningKey::from_bytes(&[0; 32]);
-        let payload_id = attrs.payload_id(&block_hash);
+        let payload_id = force_op_payload_id_v3(attrs.payload_id(&block_hash));
         Authorization::new(
             payload_id,
             attrs.payload_attributes.timestamp,

--- a/crates/test-utils/src/mock.rs
+++ b/crates/test-utils/src/mock.rs
@@ -325,7 +325,7 @@ impl TransactionsProvider for MockEthProvider {
     ) -> ProviderResult<Vec<Vec<Self::Transaction>>> {
         // init btreemap so we can return in order
         let mut map = BTreeMap::new();
-        for (_, block) in self.blocks.lock().iter() {
+        for block in self.blocks.lock().values() {
             if range.contains(&block.number) {
                 map.insert(block.number, block.body.transactions.clone());
             }

--- a/e2e-tests/src/it/testsuite.rs
+++ b/e2e-tests/src/it/testsuite.rs
@@ -57,6 +57,7 @@ use world_chain_primitives::{
         Authorization, Authorized, AuthorizedMsg, AuthorizedPayload, FlashblocksP2PMsg,
         StartPublish,
     },
+    payload_id::force_op_payload_id_v3,
     primitives::{ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, FlashblocksPayloadV1},
 };
 use world_chain_test_utils::{
@@ -1281,7 +1282,7 @@ async fn test_engine_driver_pending_block_queries() -> eyre::Result<()> {
     let authorization_gen =
         move |parent_hash: B256, attrs: reth_optimism_payload_builder::OpPayloadAttrs| {
             let authorizer_sk = ed25519_dalek::SigningKey::from_bytes(&[0; 32]);
-            let payload_id = attrs.payload_id(&parent_hash);
+            let payload_id = force_op_payload_id_v3(attrs.payload_id(&parent_hash));
             world_chain_primitives::p2p::Authorization::new(
                 payload_id,
                 attrs.payload_attributes.timestamp,
@@ -1475,7 +1476,7 @@ async fn test_eth_api_assertions() -> eyre::Result<()> {
     let authorization_gen =
         move |parent_hash: B256, attrs: reth_optimism_payload_builder::OpPayloadAttrs| {
             let authorizer_sk = ed25519_dalek::SigningKey::from_bytes(&[0; 32]);
-            let payload_id = attrs.payload_id(&parent_hash);
+            let payload_id = force_op_payload_id_v3(attrs.payload_id(&parent_hash));
             world_chain_primitives::p2p::Authorization::new(
                 payload_id,
                 attrs.payload_attributes.timestamp,
@@ -1709,7 +1710,7 @@ async fn test_assertion_driven_event_stream() -> eyre::Result<()> {
     let authorization_gen =
         move |parent_hash: B256, attrs: reth_optimism_payload_builder::OpPayloadAttrs| {
             let authorizer_sk = ed25519_dalek::SigningKey::from_bytes(&[0; 32]);
-            let payload_id = attrs.payload_id(&parent_hash);
+            let payload_id = force_op_payload_id_v3(attrs.payload_id(&parent_hash));
             world_chain_primitives::p2p::Authorization::new(
                 payload_id,
                 attrs.payload_attributes.timestamp,


### PR DESCRIPTION
This PR adds back the patch added with https://github.com/worldcoin/world-chain/pull/572 and later removed. In particular this PR takes also care of fixing tests so that CI is not broken by this temporary patch of the `op-reth` bug.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts Engine API payload ID handling across RPC and payload building, which can break consensus-engine interoperability if the version mapping is wrong. Scope is limited to payload ID normalization and test harness updates.
> 
> **Overview**
> Normalizes OP Engine API `payload_id` handling to **always expose V3 IDs externally** while maintaining compatibility with op-reth’s current internal V4 job lookup.
> 
> Adds a new `world_chain_primitives::payload_id` module with helpers to force the first byte to V3 (`force_op_payload_id_v3`) and to remap V3 back to V4 for internal lookups (`op_reth_payload_id_v4_lookup`), and applies this mapping in `rpc/engine.rs` (`forkchoiceUpdatedV3` responses, `get_payload_v3/v4` requests) and in the payload job generator (`payload/generator.rs`). Updates e2e/test utilities to generate authorizations using the normalized V3 payload IDs and includes a small mock provider iteration fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98cff84a0f52bd9a6f1abe6b572af3b863c38e2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->