### PR TITLE
fix: jovian DA limits

### DIFF
--- a/crates/builder/benches/flashblock_building_live_node.rs
+++ b/crates/builder/benches/flashblock_building_live_node.rs
@@ -4,6 +4,7 @@ use alloy_primitives::{Address, B256, Bytes};
 use alloy_rpc_types_engine::PayloadAttributes as RpcPayloadAttributes;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use reth_basic_payload_builder::{BuildArguments, BuildOutcome, PayloadConfig};
+use reth_optimism_forks::OpHardforks;
 use reth_optimism_node::{
     OpPayloadAttributes, payload::OpPayloadAttrs, utils::optimism_payload_attributes,
 };
@@ -51,7 +52,9 @@ fn deterministic_payload_attributes(
         no_tx_pool: Some(true),
         eip_1559_params: Some(eip1559_params),
         gas_limit: Some(CHAIN_SPEC.genesis_header().gas_limit),
-        min_base_fee: Some(0),
+        min_base_fee: CHAIN_SPEC
+            .is_jovian_active_at_timestamp(timestamp)
+            .then_some(0),
     }
 }
 

--- a/crates/builder/src/execution_context.rs
+++ b/crates/builder/src/execution_context.rs
@@ -2,6 +2,7 @@ use crate::{
     payload_builder_metrics::{PayloadBuildRejectionReason, PayloadBuildTaskOutcome},
     state_db::StateDB,
     traits::{context::PayloadBuilderCtx, context_builder::PayloadBuilderCtxBuilder},
+    utils::estimated_da_size_bytes,
 };
 use alloy_consensus::{Block, SignableTransaction, Transaction, transaction::SignerRecoverable};
 use alloy_eips::{Encodable2718, Typed2718};
@@ -13,10 +14,10 @@ use op_alloy_consensus::EIP1559ParamError;
 use op_alloy_rpc_types::OpTransactionRequest;
 
 use alloy_rpc_types_engine::PayloadId;
-use op_revm::OpSpecId;
+use op_revm::{L1BlockInfo, OpSpecId, constants::L1_BLOCK_CONTRACT};
 use reth_basic_payload_builder::PayloadConfig;
 use reth_evm::{
-    ConfigureEvm, Database, Evm, EvmEnv,
+    ConfigureEvm, Database as RethDatabase, Evm, EvmEnv,
     block::{BlockExecutionError, BlockValidationError},
     execute::{BlockBuilder, BlockExecutor},
 };
@@ -38,7 +39,7 @@ use reth_primitives_traits::{Recovered, SealedHeader, TxTy};
 use reth_provider::{BlockReaderIdExt, ChainSpecProvider, StateProviderFactory};
 use reth_revm::cancelled::CancelOnDrop;
 use reth_transaction_pool::{BestTransactionsAttributes, PoolTransaction, TransactionPool};
-use revm::{DatabaseCommit, context::BlockEnv};
+use revm::{Database as RevmDatabase, DatabaseCommit, context::BlockEnv};
 use revm_database::State;
 use semaphore_rs::Field;
 use std::{collections::HashSet, fmt::Debug, sync::Arc, time::Instant};
@@ -82,12 +83,13 @@ where
         info: &mut ExecutionInfo,
         base_fee: u64,
         gas_used: u64,
+        tx_da_size: u64,
         tx: Recovered<OpTransactionSigned>,
     ) {
         // add gas used by the transaction to cumulative gas used, before creating the
         // receipt
         info.cumulative_gas_used += gas_used;
-        info.cumulative_da_bytes_used += tx.network_len() as u64;
+        info.cumulative_da_bytes_used += tx_da_size;
 
         // update add to total fees
         let miner_fee = tx
@@ -163,7 +165,7 @@ where
     >
     where
         DB::Error: Send + Sync + 'static,
-        DB: Database + 'a,
+        DB: RethDatabase + 'a,
     {
         let attributes = OpNextBlockEnvAttributes::build_next_env(
             self.inner.attributes(),
@@ -236,6 +238,20 @@ where
         let block_da_limit = self.inner.builder_config.da_config.max_da_block_size();
         let tx_da_limit = self.inner.builder_config.da_config.max_da_tx_size();
         let base_fee = builder.evm_mut().block().basefee;
+        let da_footprint_gas_scalar = if self
+            .spec()
+            .is_jovian_active_at_timestamp(self.attributes().timestamp)
+        {
+            let db = builder.evm_mut().db_mut();
+            db.basic(L1_BLOCK_CONTRACT)
+                .map_err(PayloadBuilderError::other)?;
+            Some(
+                L1BlockInfo::fetch_da_footprint_gas_scalar(db)
+                    .map_err(PayloadBuilderError::other)?,
+            )
+        } else {
+            None
+        };
         let mut transactions_considered = 0;
         let mut transactions_executed = 0;
         let mut invalid_txs = vec![];
@@ -277,7 +293,7 @@ where
                 tx_da_limit,
                 block_da_limit,
                 tx.gas_limit(),
-                None, // TODO: related to Jovian
+                da_footprint_gas_scalar,
             ) {
                 attempt_metrics.increment_rejection(PayloadBuildRejectionReason::OverLimits);
                 // we can't fit this transaction into the block, so we need to mark it as
@@ -368,7 +384,7 @@ where
 
             attempt_metrics.record_transaction_gas_used(gas_used);
             transactions_executed += 1;
-            self.commit_changes(info, base_fee, gas_used, tx);
+            self.commit_changes(info, base_fee, gas_used, tx_da_size, tx);
         }
 
         if !spent_nullifier_hashes.is_empty() {
@@ -392,7 +408,8 @@ where
             // is not spent rather than sitting in the default execution client's mempool.
             match builder.execute_transaction(tx.clone()) {
                 Ok(gas_used) => {
-                    self.commit_changes(info, base_fee, gas_used, tx);
+                    let tx_da_size = estimated_da_size_bytes(&tx);
+                    self.commit_changes(info, base_fee, gas_used, tx_da_size, tx);
                     attempt_metrics
                         .record_spend_nullifiers_outcome(PayloadBuildTaskOutcome::Success);
                 }

--- a/crates/builder/src/payload_builder.rs
+++ b/crates/builder/src/payload_builder.rs
@@ -13,6 +13,7 @@ use crate::{
         context::PayloadBuilderCtx, context_builder::PayloadBuilderCtxBuilder,
         payload_builder::FlashblockPayloadBuilder,
     },
+    utils::estimated_da_size_bytes,
 };
 use alloy_eips::Encodable2718;
 use alloy_primitives::TxHash;
@@ -35,7 +36,8 @@ use reth_basic_payload_builder::{
     PayloadConfig,
 };
 use reth_evm::{
-    ConfigureEvm, Database, EvmEnv, execute::BlockBuilderOutcome, precompiles::PrecompilesMap,
+    ConfigureEvm, Database, EvmEnv, RecoveredTx, execute::BlockBuilderOutcome,
+    precompiles::PrecompilesMap,
 };
 use reth_node_api::{BuiltPayloadExecutedBlock, NodePrimitives, PayloadBuilderError};
 use reth_payload_primitives::BuildNextEnv;
@@ -53,7 +55,9 @@ use reth_optimism_payload_builder::{
     config::OpBuilderConfig,
     payload::{OpBuiltPayload, OpPayloadAttrs, OpPayloadBuilderAttributes},
 };
-use reth_optimism_primitives::{OpPrimitives, OpReceipt, OpTransactionSigned};
+use reth_optimism_primitives::{
+    OpPrimitives, OpReceipt, OpTransactionSigned, transaction::OpTransaction,
+};
 use reth_payload_util::{NoopPayloadTransactions, PayloadTransactions};
 use reth_provider::{BlockExecutionOutput, ChainSpecProvider, ProviderError, StateProviderFactory};
 
@@ -493,6 +497,7 @@ fn build_inner<'a, Txs, Ctx, Pool, R>(
 >
 where
     R: OpReceiptBuilder + Default,
+    R::Transaction: Encodable2718 + OpTransaction,
     Pool: TransactionPool,
     Txs: PayloadTransactions,
     Txs::Transaction: OpPooledTx,
@@ -534,7 +539,11 @@ where
         committed_payload.map_or(ExecutionInfo::default(), |p| ExecutionInfo {
             total_fees: p.fees(),
             cumulative_gas_used: p.block().gas_used(),
-            ..Default::default()
+            cumulative_da_bytes_used: committed_state
+                .transactions_iter()
+                .filter(|tx| !tx.tx().is_deposit())
+                .map(estimated_da_size_bytes)
+                .sum(),
         })
     };
 

--- a/crates/builder/src/utils.rs
+++ b/crates/builder/src/utils.rs
@@ -1,3 +1,5 @@
+use alloy_eips::Encodable2718;
+use op_revm::estimate_tx_compressed_size;
 use reth_optimism_payload_builder::config::OpBuilderConfig;
 use revm_database::states::reverts::{AccountInfoRevert, Reverts};
 use std::collections::{HashMap, hash_map::Entry};
@@ -60,6 +62,11 @@ pub(crate) fn effective_gas_limit(
         .map_or(protocol_gas_limit, |configured_gas_limit| {
             configured_gas_limit.min(protocol_gas_limit)
         })
+}
+
+/// Returns the Fjord estimated compressed transaction size in DA bytes.
+pub(crate) fn estimated_da_size_bytes(tx: &impl Encodable2718) -> u64 {
+    estimate_tx_compressed_size(tx.encoded_2718().as_ref()).saturating_div(1_000_000)
 }
 
 #[cfg(test)]

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -15,6 +15,7 @@ use reth_node_builder::{
 use reth_node_core::primitives::EthereumHardforks;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_evm::OpNextBlockEnvAttributes;
+use reth_optimism_forks::OpHardforks;
 use reth_optimism_node::{
     OpEngineTypes, OpStorage,
     node::{OpConsensusBuilder, OpExecutorBuilder},
@@ -271,7 +272,10 @@ impl PayloadAttributesBuilder<OpPayloadAttrs> for OpLocalPayloadAttributesBuilde
             no_tx_pool: None,
             gas_limit,
             eip_1559_params: Some(B64::from(eip1559_bytes)),
-            min_base_fee: Some(0),
+            min_base_fee: self
+                .chain_spec
+                .is_jovian_active_at_timestamp(timestamp)
+                .then_some(0),
         })
     }
 }

--- a/crates/test-utils/src/e2e_harness/setup.rs
+++ b/crates/test-utils/src/e2e_harness/setup.rs
@@ -463,7 +463,9 @@ pub fn build_payload_attributes(
         no_tx_pool: Some(false),
         eip_1559_params: Some(eip1559_params),
         gas_limit: Some(200_000_000), // 200MGas
-        min_base_fee: Some(0),
+        min_base_fee: CHAIN_SPEC
+            .is_fork_active_at_timestamp(OpHardfork::Jovian, timestamp)
+            .then_some(0),
     }
     .into()
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes transaction inclusion/limit enforcement during payload construction under the Jovian fork, which can affect block contents and liveness if miscomputed. Risk is limited to fork-gated paths and DA accounting/metrics logic.
> 
> **Overview**
> Fixes Jovian-specific DA limit handling in the flashblocks payload builder by **fetching and applying the on-chain `da_footprint_gas_scalar`** (via `L1BlockInfo`) when evaluating `ExecutionInfo::is_tx_over_limits`, instead of always passing `None`.
> 
> Updates DA accounting to use **estimated compressed DA bytes** (new `estimated_da_size_bytes`) for cumulative tracking, including carried-over precommitted payloads and the builder’s own `spend_nullifiers_tx`, and gates `min_base_fee` injection on *Jovian activation* in node/dev, benches, and e2e test payload attributes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 742264bee0395bb04341ffe2b9d24d763c91b6ab. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->