### PR TITLE
feat: make `WorldChainNodeContext` generic over `ChainSpec` and cleanup trait bounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13535,6 +13535,7 @@ dependencies = [
  "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
  "reth-basic-payload-builder",
+ "reth-chainspec",
  "reth-codecs",
  "reth-db",
  "reth-eth-wire",

--- a/crates/builder/src/execution_context.rs
+++ b/crates/builder/src/execution_context.rs
@@ -21,7 +21,7 @@ use reth_evm::{
     block::{BlockExecutionError, BlockValidationError},
     execute::{BlockBuilder, BlockExecutor},
 };
-use reth_node_api::{NodePrimitives, PayloadBuilderError};
+use reth_node_api::PayloadBuilderError;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_node::{
@@ -35,7 +35,7 @@ use reth_optimism_payload_builder::{
 use reth_optimism_primitives::OpTransactionSigned;
 use reth_payload_primitives::BuildNextEnv;
 use reth_payload_util::PayloadTransactions;
-use reth_primitives_traits::{Recovered, SealedHeader, TxTy};
+use reth_primitives_traits::{HeaderTy, Recovered, SealedHeader, TxTy};
 use reth_provider::{BlockReaderIdExt, ChainSpecProvider, StateProviderFactory};
 use reth_revm::cancelled::CancelOnDrop;
 use reth_transaction_pool::{BestTransactionsAttributes, PoolTransaction, TransactionPool};
@@ -453,10 +453,8 @@ where
         evm_config: OpEvmConfig,
         builder_config: OpBuilderConfig,
         config: PayloadConfig<
-            OpPayloadBuilderAttributes<
-                <<OpEvmConfig as ConfigureEvm>::Primitives as NodePrimitives>::SignedTx,
-            >,
-            <<OpEvmConfig as ConfigureEvm>::Primitives as NodePrimitives>::BlockHeader,
+            OpPayloadBuilderAttributes<TxTy<<OpEvmConfig as ConfigureEvm>::Primitives>>,
+            HeaderTy<<OpEvmConfig as ConfigureEvm>::Primitives>,
         >,
         cancel: &CancelOnDrop,
         best_payload: Option<OpBuiltPayload<<OpEvmConfig as ConfigureEvm>::Primitives>>,

--- a/crates/builder/src/traits/context.rs
+++ b/crates/builder/src/traits/context.rs
@@ -23,7 +23,7 @@ use reth_optimism_payload_builder::{
 };
 use reth_payload_primitives::BuildNextEnv;
 use reth_payload_util::PayloadTransactions;
-use reth_primitives_traits::{SealedHeader, TxTy};
+use reth_primitives_traits::{HeaderTy, SealedHeader, TxTy};
 use reth_provider::ChainSpecProvider;
 use reth_transaction_pool::{BestTransactionsAttributes, PoolTransaction, TransactionPool};
 use revm::{DatabaseCommit, context::BlockEnv};
@@ -202,7 +202,7 @@ where
         builder_config: OpBuilderConfig,
         config: reth_basic_payload_builder::PayloadConfig<
             OpPayloadBuilderAttributes<op_alloy_consensus::OpTxEnvelope>,
-            <<OpEvmConfig as ConfigureEvm>::Primitives as reth_node_api::NodePrimitives>::BlockHeader,
+            HeaderTy<<OpEvmConfig as ConfigureEvm>::Primitives>,
         >,
         cancel: &reth_revm::cancelled::CancelOnDrop,
         best_payload: Option<reth_optimism_node::OpBuiltPayload>,

--- a/crates/builder/src/traits/context_builder.rs
+++ b/crates/builder/src/traits/context_builder.rs
@@ -2,9 +2,9 @@ use crate::traits::context::PayloadBuilderCtx;
 use op_alloy_consensus::OpTxEnvelope;
 use reth_basic_payload_builder::PayloadConfig;
 use reth_evm::ConfigureEvm;
-use reth_node_api::NodePrimitives;
 use reth_optimism_node::{OpBuiltPayload, OpEvmConfig, OpPayloadBuilderAttributes};
 use reth_optimism_payload_builder::config::OpBuilderConfig;
+use reth_primitives_traits::HeaderTy;
 use reth_revm::cancelled::CancelOnDrop;
 
 /// Builder trait for creating [`PayloadBuilderCtx`] instances with specific configurations.
@@ -86,7 +86,7 @@ pub trait PayloadBuilderCtxBuilder<Provider, EvmConfig: ConfigureEvm, ChainSpec>
         builder_config: OpBuilderConfig,
         config: PayloadConfig<
             OpPayloadBuilderAttributes<OpTxEnvelope>,
-            <<OpEvmConfig as ConfigureEvm>::Primitives as NodePrimitives>::BlockHeader,
+            HeaderTy<<OpEvmConfig as ConfigureEvm>::Primitives>,
         >,
         cancel: &CancelOnDrop,
         best_payload: Option<OpBuiltPayload>,

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -20,6 +20,7 @@ world-chain-cli.workspace = true
 world-chain-payload.workspace = true
 
 reth-node-builder.workspace = true
+reth-chainspec.workspace = true
 reth-evm.workspace = true
 reth-optimism-chainspec.workspace = true
 reth-optimism-primitives.workspace = true

--- a/crates/node/src/context.rs
+++ b/crates/node/src/context.rs
@@ -22,10 +22,11 @@ use reth_node_builder::{
     rpc::{BasicEngineValidatorBuilder, RpcAddOns},
 };
 use reth_node_core::primitives::Hardforks;
+use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_evm::OpEvmConfig;
 use reth_optimism_node::{
-    OpAddOns, OpConsensusBuilder, OpEngineValidatorBuilder, OpExecutorBuilder, OpNetworkBuilder,
-    args::RollupArgs,
+    OpAddOns, OpConsensusBuilder, OpEngineTypes, OpEngineValidatorBuilder, OpExecutorBuilder,
+    OpNetworkBuilder, args::RollupArgs,
 };
 use reth_optimism_primitives::OpPrimitives;
 use reth_optimism_rpc::OpEthApiBuilder;
@@ -175,8 +176,8 @@ pub struct WorldChainDefaultContext {
 
 impl WorldChainNodePrimitiveTypes for WorldChainDefaultContext {
     type Primitives = OpPrimitives;
-    type Payload = reth_optimism_node::OpEngineTypes;
-    type ChainSpec = reth_optimism_chainspec::OpChainSpec;
+    type Payload = OpEngineTypes;
+    type ChainSpec = OpChainSpec;
 }
 
 impl<N: FullNodeTypes<Types = WorldChainNode<WorldChainDefaultContext>>> WorldChainNodeContext<N>

--- a/crates/node/src/context.rs
+++ b/crates/node/src/context.rs
@@ -15,7 +15,7 @@ use crate::{
 use ed25519_dalek::VerifyingKey;
 use hex::ToHex;
 use reth_network::protocol::IntoRlpxSubProtocol;
-use reth_node_api::{FullNodeTypes, NodeTypes};
+use reth_node_api::{FullNodeTypes, NodeTypes, TxTy};
 use reth_node_builder::{
     NodeAdapter, NodeComponentsBuilder,
     components::{ComponentsBuilder, PayloadServiceBuilder},
@@ -84,11 +84,8 @@ impl WorldChainNetworkBuilder {
 impl<Node, Pool> NetworkBuilder<Node, Pool> for WorldChainNetworkBuilder
 where
     Node: FullNodeTypes<Types: NodeTypes<ChainSpec: Hardforks>>,
-    Pool: TransactionPool<
-            Transaction: PoolTransaction<
-                Consensus = <<Node::Types as NodeTypes>::Primitives as reth_node_api::NodePrimitives>::SignedTx,
-            >,
-        > + Unpin
+    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
+        + Unpin
         + 'static,
 {
     type Network = <OpNetworkBuilder as NetworkBuilder<Node, Pool>>::Network;
@@ -106,9 +103,10 @@ where
 
         let mut network_config = op_network_builder.network_config(ctx)?;
         let local_peer_id = network_config.hello_message.id;
-        network_config.peers_config.trusted_nodes.retain(|peer| {
-            peer.id != local_peer_id
-        });
+        network_config
+            .peers_config
+            .trusted_nodes
+            .retain(|peer| peer.id != local_peer_id);
 
         let mut trusted_peer_ids: Vec<_> = network_config
             .peers_config
@@ -178,6 +176,7 @@ pub struct WorldChainDefaultContext {
 impl WorldChainNodePrimitiveTypes for WorldChainDefaultContext {
     type Primitives = OpPrimitives;
     type Payload = reth_optimism_node::OpEngineTypes;
+    type ChainSpec = reth_optimism_chainspec::OpChainSpec;
 }
 
 impl<N: FullNodeTypes<Types = WorldChainNode<WorldChainDefaultContext>>> WorldChainNodeContext<N>

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -5,6 +5,7 @@ use alloy_consensus::{Block, BlockBody, Header};
 use alloy_eips::eip1559::BaseFeeParams;
 use op_alloy_consensus::OpTxEnvelope;
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
+use reth_codecs::{Compress, Decompress};
 use reth_evm::ConfigureEvm;
 use reth_node_api::{
     BuiltPayload, FullNodeTypes, NodeAddOns, NodePrimitives, NodeTypes, PayloadAttributesBuilder,
@@ -25,7 +26,7 @@ use reth_optimism_node::{
     payload::OpPayloadAttrs,
 };
 use reth_optimism_primitives::OpPrimitives;
-use reth_primitives_traits::SealedHeader;
+use reth_primitives_traits::{SealedHeader, TxTy};
 use reth_rpc_eth_api::EthApiTypes;
 use reth_transaction_pool::TransactionPool;
 use world_chain_cli::WorldChainNodeConfig;
@@ -41,10 +42,10 @@ pub trait WorldChainNodePrimitiveTypes:
     /// Primitive block, receipt, and signed transaction types used by the node.
     type Primitives: NodePrimitives<
             BlockHeader = Header,
-            Block = Block<<Self::Primitives as NodePrimitives>::SignedTx>,
-            BlockBody = BlockBody<<Self::Primitives as NodePrimitives>::SignedTx>,
-            SignedTx: reth_codecs::Compress + reth_codecs::Decompress,
-            Receipt: reth_codecs::Compress + reth_codecs::Decompress,
+            Block = Block<TxTy<Self::Primitives>>,
+            BlockBody = BlockBody<TxTy<Self::Primitives>>,
+            SignedTx: Compress + Decompress,
+            Receipt: Compress + Decompress,
         >;
 
     /// Engine payload types used by the node.
@@ -228,7 +229,7 @@ where
 impl<T: WorldChainNodePrimitiveTypes> NodeTypes for WorldChainNode<T> {
     type Primitives = T::Primitives;
     type ChainSpec = OpChainSpec;
-    type Storage = OpStorage<<T::Primitives as NodePrimitives>::SignedTx>;
+    type Storage = OpStorage<TxTy<T::Primitives>>;
     type Payload = T::Payload;
 }
 

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1,14 +1,17 @@
 use std::{fmt::Debug, sync::Arc};
 
 use crate::pool::WorldChainPoolBuilder;
-use alloy_consensus::{Block, BlockBody, Header};
+use alloy_consensus::{Block, BlockBody, BlockHeader, Header};
 use alloy_eips::eip1559::BaseFeeParams;
+use alloy_primitives::{Address, B64};
 use op_alloy_consensus::OpTxEnvelope;
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
+use reth_chainspec::EthChainSpec;
 use reth_codecs::{Compress, Decompress};
 use reth_evm::ConfigureEvm;
 use reth_node_api::{
-    BuiltPayload, FullNodeTypes, NodeAddOns, NodePrimitives, NodeTypes, PayloadAttributesBuilder,
+    BlockTy, BuiltPayload, FullNodeTypes, NodeAddOns, NodePrimitives, NodeTypes,
+    PayloadAttributesBuilder,
 };
 use reth_node_builder::{
     DebugNode, FullNodeComponents, Node, NodeAdapter, NodeComponents, NodeComponentsBuilder,
@@ -17,7 +20,6 @@ use reth_node_builder::{
     rpc::{EngineValidatorAddOn, RethRpcAddOns},
 };
 use reth_node_core::primitives::EthereumHardforks;
-use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_evm::OpNextBlockEnvAttributes;
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_node::{
@@ -26,7 +28,7 @@ use reth_optimism_node::{
     payload::OpPayloadAttrs,
 };
 use reth_optimism_primitives::OpPrimitives;
-use reth_primitives_traits::{SealedHeader, TxTy};
+use reth_primitives_traits::{ReceiptTy, SealedHeader, TxTy};
 use reth_rpc_eth_api::EthApiTypes;
 use reth_transaction_pool::TransactionPool;
 use world_chain_cli::WorldChainNodeConfig;
@@ -38,14 +40,15 @@ use world_chain_cli::WorldChainNodeConfig;
 /// while inheriting a unified testing harness generic over `T: WorldChainNodeContext`.
 pub trait WorldChainNodePrimitiveTypes:
     Sized + From<WorldChainNodeConfig> + Clone + Debug + Unpin + Send + Sync + 'static
+where
+    TxTy<Self::Primitives>: Compress + Decompress,
+    ReceiptTy<Self::Primitives>: Compress + Decompress,
 {
     /// Primitive block, receipt, and signed transaction types used by the node.
     type Primitives: NodePrimitives<
             BlockHeader = Header,
             Block = Block<TxTy<Self::Primitives>>,
             BlockBody = BlockBody<TxTy<Self::Primitives>>,
-            SignedTx: Compress + Decompress,
-            Receipt: Compress + Decompress,
         >;
 
     /// Engine payload types used by the node.
@@ -53,6 +56,9 @@ pub trait WorldChainNodePrimitiveTypes:
             PayloadAttributes = OpPayloadAttrs,
             BuiltPayload: BuiltPayload<Primitives = Self::Primitives>,
         >;
+
+    /// Chain specification type used by the node.
+    type ChainSpec: EthChainSpec<Header = Header> + 'static;
 }
 
 /// Context trait for World Chain node implementations.
@@ -209,11 +215,12 @@ impl<N, T> DebugNode<N> for WorldChainNode<T>
 where
     N: FullNodeComponents<Types = Self>,
     T: WorldChainNodeContext<N, Primitives = OpPrimitives> + From<WorldChainNodeConfig>,
+    T::ChainSpec: Clone + EthereumHardforks + OpHardforks,
     WorldChainNodeComponentBuilder<N, T>: NodeComponentsBuilder<N>,
 {
     type RpcBlock = alloy_rpc_types_eth::Block<OpTxEnvelope>;
 
-    fn rpc_to_primitive_block(rpc_block: Self::RpcBlock) -> reth_node_api::BlockTy<Self> {
+    fn rpc_to_primitive_block(rpc_block: Self::RpcBlock) -> BlockTy<Self> {
         rpc_block.into_consensus()
     }
 
@@ -228,7 +235,7 @@ where
 
 impl<T: WorldChainNodePrimitiveTypes> NodeTypes for WorldChainNode<T> {
     type Primitives = T::Primitives;
-    type ChainSpec = OpChainSpec;
+    type ChainSpec = T::ChainSpec;
     type Storage = OpStorage<TxTy<T::Primitives>>;
     type Payload = T::Payload;
 }
@@ -237,15 +244,16 @@ impl<T: WorldChainNodePrimitiveTypes> NodeTypes for WorldChainNode<T> {
 ///
 /// Mirrors `reth_optimism_node::node::OpLocalPayloadAttributesBuilder`, which is
 /// not re-exported by upstream. Used by [`DebugNode`] when running in dev mode.
-struct OpLocalPayloadAttributesBuilder {
-    chain_spec: Arc<OpChainSpec>,
+struct OpLocalPayloadAttributesBuilder<ChainSpec> {
+    chain_spec: Arc<ChainSpec>,
 }
 
-impl PayloadAttributesBuilder<OpPayloadAttrs> for OpLocalPayloadAttributesBuilder {
-    fn build(&self, parent: &SealedHeader<alloy_consensus::Header>) -> OpPayloadAttrs {
-        use alloy_consensus::BlockHeader;
-        use alloy_primitives::{Address, B64};
-
+impl<ChainSpec> PayloadAttributesBuilder<OpPayloadAttrs>
+    for OpLocalPayloadAttributesBuilder<ChainSpec>
+where
+    ChainSpec: EthereumHardforks + OpHardforks + Send + Sync + 'static,
+{
+    fn build(&self, parent: &SealedHeader<Header>) -> OpPayloadAttrs {
         let timestamp = std::cmp::max(
             parent.timestamp().saturating_add(1),
             std::time::SystemTime::now()

--- a/crates/node/src/pool.rs
+++ b/crates/node/src/pool.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use alloy_primitives::Address;
 use reth_evm::ConfigureEvm;
-use reth_node_api::{FullNodeTypes, NodePrimitives, NodeTypes, PrimitivesTy, TxTy};
+use reth_node_api::{BlockTy, FullNodeTypes, NodeTypes, PrimitivesTy, TxTy};
 use reth_node_builder::{
     BuilderContext,
     components::{PoolBuilder, PoolBuilderConfigOverrides},
@@ -66,13 +66,11 @@ impl<T> WorldChainPoolBuilder<T> {
 impl<Node, T, Evm> PoolBuilder<Node, Evm> for WorldChainPoolBuilder<T>
 where
     Node: FullNodeTypes<Types: NodeTypes<ChainSpec: OpHardforks>>,
-    Node::Provider: BlockReaderIdExt<Block = <PrimitivesTy<Node::Types> as NodePrimitives>::Block>,
+    Node::Provider: BlockReaderIdExt<Block = BlockTy<Node::Types>>,
     T: WorldChainPoolTransaction<Consensus = TxTy<Node::Types>>,
     Evm: ConfigureEvm<Primitives = PrimitivesTy<Node::Types>> + Clone + 'static,
-    WorldChainTransactionValidator<Node::Provider, T, Evm>: TransactionValidator<
-            Transaction = T,
-            Block = <PrimitivesTy<Node::Types> as NodePrimitives>::Block,
-        >,
+    WorldChainTransactionValidator<Node::Provider, T, Evm>:
+        TransactionValidator<Transaction = T, Block = BlockTy<Node::Types>>,
 {
     type Pool = WorldChainTransactionPool<Node::Provider, DiskFileBlobStore, T, Evm>;
 

--- a/crates/pool/src/validator.rs
+++ b/crates/pool/src/validator.rs
@@ -18,10 +18,9 @@ use alloy_primitives::Address;
 use alloy_sol_types::{SolCall, SolValue};
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 use reth_evm::ConfigureEvm;
-use reth_node_api::NodePrimitives;
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_node::txpool::OpTransactionValidator;
-use reth_primitives_traits::SealedBlock;
+use reth_primitives_traits::{BlockTy, SealedBlock, TxTy};
 use reth_provider::{BlockReaderIdExt, ChainSpecProvider, StateProviderFactory};
 use reth_transaction_pool::{
     TransactionOrigin, TransactionValidationOutcome, TransactionValidator,
@@ -67,8 +66,8 @@ impl<Client, Tx, Evm> WorldChainTransactionValidator<Client, Tx, Evm>
 where
     Client: ChainSpecProvider<ChainSpec: OpHardforks>
         + StateProviderFactory
-        + BlockReaderIdExt<Block = <Evm::Primitives as NodePrimitives>::Block>,
-    Tx: WorldChainPoolTransaction<Consensus = <Evm::Primitives as NodePrimitives>::SignedTx>,
+        + BlockReaderIdExt<Block = BlockTy<Evm::Primitives>>,
+    Tx: WorldChainPoolTransaction<Consensus = TxTy<Evm::Primitives>>,
     Evm: ConfigureEvm,
 {
     /// Create a new [`WorldChainTransactionValidator`].
@@ -260,13 +259,13 @@ impl<Client, Tx, Evm> TransactionValidator for WorldChainTransactionValidator<Cl
 where
     Client: ChainSpecProvider<ChainSpec: OpHardforks>
         + StateProviderFactory
-        + BlockReaderIdExt<Block = <Evm::Primitives as NodePrimitives>::Block>,
-    Tx: WorldChainPoolTransaction<Consensus = <Evm::Primitives as NodePrimitives>::SignedTx>,
+        + BlockReaderIdExt<Block = BlockTy<Evm::Primitives>>,
+    Tx: WorldChainPoolTransaction<Consensus = TxTy<Evm::Primitives>>,
     Evm: ConfigureEvm,
 {
     type Transaction = Tx;
 
-    type Block = <Evm::Primitives as NodePrimitives>::Block;
+    type Block = BlockTy<Evm::Primitives>;
 
     async fn validate_transaction(
         &self,

--- a/crates/primitives/src/flashblocks.rs
+++ b/crates/primitives/src/flashblocks.rs
@@ -18,7 +18,7 @@ use chrono::Utc;
 use eyre::eyre::{bail, eyre};
 use op_alloy_consensus::OpTxEnvelope;
 use reth_chainspec::EthereumHardforks;
-use reth_primitives_traits::{Block as _, BlockBody as _, NodePrimitives, RecoveredBlock};
+use reth_primitives_traits::{Block as _, BlockBody as _, RecoveredBlock, TxTy};
 
 use reth_basic_payload_builder::PayloadConfig;
 use reth_optimism_chainspec::{OpChainSpec, OpHardforks};
@@ -249,7 +249,7 @@ pub fn recovered_block_from_flashblocks(
     let transactions_encoded = diff
         .transactions
         .iter()
-        .map(|t| <OpPrimitives as NodePrimitives>::SignedTx::decode_2718(&mut t.as_ref()))
+        .map(|t| TxTy::<OpPrimitives>::decode_2718(&mut t.as_ref()))
         .collect::<Result<Vec<_>, _>>()
         .map_err(|e| eyre!("Failed to decode transaction: {:?}", e))?;
 

--- a/crates/test-utils/src/e2e_harness/context.rs
+++ b/crates/test-utils/src/e2e_harness/context.rs
@@ -210,6 +210,7 @@ impl From<WorldChainNodeConfig> for Wip1001NodeContext {
 impl WorldChainNodePrimitiveTypes for Wip1001NodeContext {
     type Primitives = Wip1001Primitives;
     type Payload = Wip1001EngineTypes;
+    type ChainSpec = OpChainSpec;
 }
 
 impl<N> WorldChainNodeContext<N> for Wip1001NodeContext

--- a/crates/test-utils/src/e2e_harness/context.rs
+++ b/crates/test-utils/src/e2e_harness/context.rs
@@ -37,9 +37,9 @@ use reth_optimism_node::{
     OpAddOns, OpBuiltPayload, OpConsensusBuilder, OpEngineValidatorBuilder, node::OpPayloadBuilder,
     rpc::OpEthApiBuilder, txpool::OpPooledTransaction,
 };
-use reth_optimism_payload_builder::OpExecData;
+use reth_optimism_payload_builder::{OpExecData, OpPayloadAttrs};
 use reth_optimism_primitives::OpReceipt;
-use reth_primitives_traits::Block as _;
+use reth_primitives_traits::{Block as _, BlockTy, SealedBlock};
 use reth_rpc_api::eth::RpcTypes;
 use world_chain_cli::{WorldChainArgs, WorldChainNodeConfig};
 use world_chain_node::{
@@ -80,12 +80,10 @@ pub struct Wip1001EngineTypes;
 impl PayloadTypes for Wip1001EngineTypes {
     type ExecutionData = OpExecData;
     type BuiltPayload = OpBuiltPayload<Wip1001Primitives>;
-    type PayloadAttributes = reth_optimism_node::payload::OpPayloadAttrs;
+    type PayloadAttributes = OpPayloadAttrs;
 
     fn block_to_payload(
-        block: reth_primitives_traits::SealedBlock<
-            <<Self::BuiltPayload as BuiltPayload>::Primitives as NodePrimitives>::Block,
-        >,
+        block: SealedBlock<BlockTy<<Self::BuiltPayload as BuiltPayload>::Primitives>>,
     ) -> Self::ExecutionData {
         OpExecData::from(OpExecutionData::from_block_unchecked(
             block.hash(),

--- a/crates/test-utils/src/e2e_harness/setup.rs
+++ b/crates/test-utils/src/e2e_harness/setup.rs
@@ -21,7 +21,7 @@ use op_alloy_consensus::{OpTxEnvelope, TxDeposit, encode_holocene_extra_data};
 use op_alloy_rpc_types_engine::{
     OpExecutionData, OpExecutionPayload, OpExecutionPayloadSidecar, OpExecutionPayloadV4,
 };
-use reth_chainspec::EthChainSpec;
+use reth_chainspec::{EthChainSpec, EthereumHardforks};
 use reth_e2e_test_utils::{
     Adapter, NodeHelperType, TmpDB,
     testsuite::{BlockInfo, Environment, NodeClient, NodeState},
@@ -177,7 +177,7 @@ pub async fn setup<T>(
     TxSpammer<<WorldChainNode<T> as NodeTypes>::Payload>,
 )>
 where
-    T: WorldChainTestContextBounds,
+    T: WorldChainTestContextBounds<ChainSpec = OpChainSpec>,
     WorldChainNode<T>: WorldChainNodeTestBounds<T>,
 {
     setup_inner::<T>(
@@ -206,7 +206,7 @@ pub async fn setup_with_block_uncompressed_size_limit<T>(
     TxSpammer<<WorldChainNode<T> as NodeTypes>::Payload>,
 )>
 where
-    T: WorldChainTestContextBounds,
+    T: WorldChainTestContextBounds<ChainSpec = OpChainSpec>,
     WorldChainNode<T>: WorldChainNodeTestBounds<T>,
 {
     setup_inner::<T>(
@@ -237,7 +237,7 @@ pub async fn setup_with_tx_peers<T>(
     TxSpammer<<WorldChainNode<T> as NodeTypes>::Payload>,
 )>
 where
-    T: WorldChainTestContextBounds,
+    T: WorldChainTestContextBounds<ChainSpec = OpChainSpec>,
     WorldChainNode<T>: WorldChainNodeTestBounds<T>,
 {
     setup_inner::<T>(
@@ -268,7 +268,7 @@ async fn setup_inner<T>(
     TxSpammer<<WorldChainNode<T> as NodeTypes>::Payload>,
 )>
 where
-    T: WorldChainTestContextBounds,
+    T: WorldChainTestContextBounds<ChainSpec = OpChainSpec>,
     WorldChainNode<T>: WorldChainNodeTestBounds<T>,
 {
     unsafe {
@@ -632,7 +632,7 @@ pub fn execution_data_from_from_reduced_flashblock(
 
 /// Consolidated trait bound for a World Chain testing context.
 pub trait WorldChainTestContextBounds:
-    WorldChainNodePrimitiveTypes<Payload: EngineTypes>
+    WorldChainNodePrimitiveTypes<Payload: EngineTypes, ChainSpec: EthereumHardforks>
     + WorldChainNodeContext<
         FullNodeTypesAdapter<
             WorldChainNode<Self>,
@@ -676,7 +676,7 @@ pub trait WorldChainTestContextBounds:
 where
     WorldChainNode<Self>: NodeTypes<
             Primitives = <Self as WorldChainNodePrimitiveTypes>::Primitives,
-            ChainSpec = OpChainSpec,
+            ChainSpec = <Self as WorldChainNodePrimitiveTypes>::ChainSpec,
             Payload = <Self as WorldChainNodePrimitiveTypes>::Payload,
             Storage: ChainStorage<<Self as WorldChainNodePrimitiveTypes>::Primitives>,
         > + Node<
@@ -713,7 +713,7 @@ where
 
 impl<T> WorldChainTestContextBounds for T
 where
-    T: WorldChainNodePrimitiveTypes<Payload: EngineTypes>
+    T: WorldChainNodePrimitiveTypes<Payload: EngineTypes, ChainSpec: EthereumHardforks>
         + WorldChainNodeContext<
             FullNodeTypesAdapter<
                 WorldChainNode<T>,
@@ -754,7 +754,7 @@ where
         >,
     WorldChainNode<T>: NodeTypes<
             Primitives = <T as WorldChainNodePrimitiveTypes>::Primitives,
-            ChainSpec = OpChainSpec,
+            ChainSpec = <T as WorldChainNodePrimitiveTypes>::ChainSpec,
             Payload = <T as WorldChainNodePrimitiveTypes>::Payload,
             Storage: ChainStorage<<T as WorldChainNodePrimitiveTypes>::Primitives>,
         > + Node<
@@ -793,7 +793,7 @@ where
 pub trait WorldChainNodeTestBounds<T>:
     NodeTypes<
         Primitives = <T as WorldChainNodePrimitiveTypes>::Primitives,
-        ChainSpec = OpChainSpec,
+        ChainSpec = <T as WorldChainNodePrimitiveTypes>::ChainSpec,
         Payload = <T as WorldChainNodePrimitiveTypes>::Payload,
         Storage: ChainStorage<<T as WorldChainNodePrimitiveTypes>::Primitives>,
     > + Node<
@@ -810,7 +810,7 @@ impl<T, Ctx> WorldChainNodeTestBounds<Ctx> for T
 where
     T: NodeTypes<
             Primitives = <Ctx as WorldChainNodePrimitiveTypes>::Primitives,
-            ChainSpec = OpChainSpec,
+            ChainSpec = <Ctx as WorldChainNodePrimitiveTypes>::ChainSpec,
             Payload = <Ctx as WorldChainNodePrimitiveTypes>::Payload,
             Storage: ChainStorage<<Ctx as WorldChainNodePrimitiveTypes>::Primitives>,
         > + Node<


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk, mostly type/trait-bound refactors that should be compile-time only, but could surface as integration breakages if upstream reth/optimism type aliases differ.
> 
> **Overview**
> Refactors node and e2e harness type declarations to use upstream primitives type aliases (`TxTy`, `BlockTy`, `SealedBlock`) and shared codec trait imports (`Compress`, `Decompress`) instead of repeating fully-qualified generic types.
> 
> Aligns `WorldChainNode` storage and block/payload conversion signatures to these aliases and switches the WIP-1001 engine `PayloadAttributes` to the `reth_optimism_payload_builder::OpPayloadAttrs` re-export for consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88c3dcb1147c2c3aca3a7885a12b4e4ff87e5ac2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->