### PR TITLE
feat(rpc): surface contract_management in simulate response

### DIFF
--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -19,3 +19,5 @@ pub use core::{EthApiExtServer, WorldChainEthApiExt};
 
 pub mod simulate;
 pub use simulate::{Simulate, SimulateApiServer};
+
+pub mod simulate_consts;

--- a/crates/rpc/src/simulate.rs
+++ b/crates/rpc/src/simulate.rs
@@ -28,8 +28,9 @@ use std::{
     collections::BTreeMap,
     num::NonZeroUsize,
     sync::{Arc, Mutex},
-    time::Duration,
 };
+
+use crate::simulate_consts::*;
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Request types
@@ -50,9 +51,6 @@ pub struct SimulateUnsignedUserOpRequest {
     #[serde(default)]
     pub call_gas_limit: Option<U256>,
 }
-
-/// Maximum gas limit accepted for a simulated call.
-pub const MAX_SIMULATION_GAS: u64 = 8_000_000;
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Response types
@@ -465,19 +463,8 @@ pub trait SimulateApi {
 
 /// Maximum number of token metadata entries kept across requests.
 ///
-/// Bounded to prevent unbounded memory growth from adversarial UserOps that
-/// emit Transfer events from many fresh token contracts.
-const METADATA_CACHE_CAPACITY: usize = 1000;
-
 /// Cross-request cache for resolved token metadata. LRU-bounded.
 type MetadataCache = Arc<Mutex<LruCache<Address, AssetInfo>>>;
-
-/// Hard wall-clock cap on a single simulation, observed by the client. Beyond
-/// this we return `internal error: simulation deadline exceeded`. The blocking
-/// task continues to drain on the rayon pool until the EVM finishes (bounded
-/// by `MAX_SIMULATION_GAS`), holding its concurrency permit until then so the
-/// guard correctly accounts for slow simulations.
-pub const SIMULATION_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Relax EVM rules so simulations succeed regardless of the caller's gas
 /// pricing, balance, or block limits — matching `eth_call` semantics. The
@@ -810,6 +797,9 @@ where
         for (target, action) in parse_contract_management_events(&logs) {
             contract_management.entry(target).or_default().push(action);
         }
+        for (target, action) in parse_contract_management_state_diff(&result_and_state.state) {
+            contract_management.entry(target).or_default().push(action);
+        }
 
         Ok(SimulateUnsignedUserOpResult {
             status,
@@ -826,77 +816,8 @@ where
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// Event signatures (keccak256 of canonical event strings)
-// ═══════════════════════════════════════════════════════════════════════════════
-
-/// `Transfer(address,address,uint256)` — ERC-20 and ERC-721
-const TRANSFER_TOPIC: B256 =
-    alloy_primitives::b256!("ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef");
-
-/// `TransferSingle(address,address,address,uint256,uint256)` — ERC-1155
-const TRANSFER_SINGLE_TOPIC: B256 =
-    alloy_primitives::b256!("c3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62");
-
-/// `TransferBatch(address,address,address,uint256[],uint256[])` — ERC-1155
-const TRANSFER_BATCH_TOPIC: B256 =
-    alloy_primitives::b256!("4a39dc06d4c0dbc64b70af90fd698a233a518aa5d07e595d983b8c0526c8f7fb");
-
-/// `Approval(address,address,uint256)` — ERC-20 and ERC-721
-const APPROVAL_TOPIC: B256 =
-    alloy_primitives::b256!("8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925");
-
-/// `ApprovalForAll(address,address,bool)` — ERC-721 / ERC-1155
-const APPROVAL_FOR_ALL_TOPIC: B256 =
-    alloy_primitives::b256!("17307eab39ab6107e8899845ad3d59bd9653f200f220920489ca2b5937696c31");
-
-// ─── Contract management ─────────────────────────────────────────────────────
-
-/// `Upgraded(address)` — EIP-1967 / UUPS implementation upgrade.
-const UPGRADED_TOPIC: B256 =
-    alloy_primitives::b256!("bc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b");
-
-/// `BeaconUpgraded(address)` — EIP-1967 beacon proxy upgrade.
-const BEACON_UPGRADED_TOPIC: B256 =
-    alloy_primitives::b256!("1cf3b03a6cf19fa2baba4df148e9dcabedea7f8a5c07840e207e5c089be95d3e");
-
-/// `AdminChanged(address,address)` — EIP-1967 proxy admin rotation. A
-/// privilege-escalation vector: the new admin can swap the implementation.
-const ADMIN_CHANGED_TOPIC: B256 =
-    alloy_primitives::b256!("7e644d79422f17c01e4894b5f4f588d331ebfa28653d42ae832dc59e38c9798f");
-
-/// `OwnershipTransferred(address,address)` — OpenZeppelin `Ownable`.
-const OWNERSHIP_TRANSFERRED_TOPIC: B256 =
-    alloy_primitives::b256!("8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0");
-
-/// Safe `AddedOwner(address)`.
-const SAFE_ADDED_OWNER_TOPIC: B256 =
-    alloy_primitives::b256!("9465fa0c962cc76958e6373a993326400c1c94f8be2fe3a952adfa7f60b2ea26");
-
-/// Safe `RemovedOwner(address)`.
-const SAFE_REMOVED_OWNER_TOPIC: B256 =
-    alloy_primitives::b256!("f8d49fc529812e9a7c5c50e69c20f0dccc0db8fa95c98bc58cc9a4f1c1299eaf");
-
-/// Safe `ChangedThreshold(uint256)`.
-const SAFE_CHANGED_THRESHOLD_TOPIC: B256 =
-    alloy_primitives::b256!("610f7ff2b304ae8903c3de74c60c6ab1f7d6226b3f52c5161905bb5ad4039c93");
-
-/// Safe `EnabledModule(address)`.
-const SAFE_ENABLED_MODULE_TOPIC: B256 =
-    alloy_primitives::b256!("ecdf3a3effea5783a3c4c2140e677577666428d44ed9d474a0b3a4c9943f8440");
-
-/// Safe `DisabledModule(address)`.
-const SAFE_DISABLED_MODULE_TOPIC: B256 =
-    alloy_primitives::b256!("aab4fa2b463f581b2b32cb3b7e3b704b9ce37cc209b5fb4d77e593ace4054276");
-
-// ═══════════════════════════════════════════════════════════════════════════════
 // Log parsing — asset changes
 // ═══════════════════════════════════════════════════════════════════════════════
-
-/// Maximum number of (id, value) pairs accepted in a single ERC-1155 TransferBatch log.
-///
-/// Bounded to prevent adversarially crafted logs from forcing huge allocations
-/// in `decode_batch_transfer_data`.
-pub const MAX_BATCH_TRANSFERS: usize = 1000;
 
 pub fn parse_asset_changes(
     logs: &[alloy_primitives::Log],
@@ -1135,7 +1056,9 @@ pub fn parse_contract_management_events(
             continue;
         };
         let action_type = match *topic0 {
-            UPGRADED_TOPIC | BEACON_UPGRADED_TOPIC => ContractManagementType::ProxyUpgrade,
+            UPGRADED_TOPIC | BEACON_UPGRADED_TOPIC | DIAMOND_CUT_TOPIC => {
+                ContractManagementType::ProxyUpgrade
+            }
             // AdminChanged is admin-slot rotation; a new admin can swap the
             // implementation, so we surface it as an ownership-class change.
             ADMIN_CHANGED_TOPIC => ContractManagementType::OwnershipChange,
@@ -1167,23 +1090,49 @@ pub fn parse_contract_management_events(
     out
 }
 
+/// Detect proxy upgrades from raw storage-slot writes — signature-agnostic, so
+/// it catches custom or non-emitting proxies that event matching misses.
+///
+/// Walks the post-execution state diff and yields `(target, action)` for each
+/// account that wrote to a recognised proxy slot with a value different from
+/// pre-state. Admin-slot writes surface as `OWNERSHIP_CHANGE` (privilege
+/// rotation); all other recognised slots surface as `PROXY_UPGRADE`.
+pub fn parse_contract_management_state_diff<S>(
+    state: &std::collections::HashMap<Address, revm::state::Account, S>,
+) -> Vec<(Address, ContractManagementAction)>
+where
+    S: std::hash::BuildHasher,
+{
+    let mut out = Vec::new();
+    for (addr, account) in state {
+        for (slot_key, slot) in &account.storage {
+            if slot.original_value() == slot.present_value() {
+                continue;
+            }
+            let key_b256: B256 = (*slot_key).into();
+            let action_type = match key_b256 {
+                EIP1967_IMPLEMENTATION_SLOT
+                | EIP1967_BEACON_SLOT
+                | EIP1822_PROXIABLE_SLOT
+                | OZ_LEGACY_IMPLEMENTATION_SLOT => ContractManagementType::ProxyUpgrade,
+                EIP1967_ADMIN_SLOT => ContractManagementType::OwnershipChange,
+                _ => continue,
+            };
+            out.push((
+                *addr,
+                ContractManagementAction {
+                    action_type,
+                    deployer_address: None,
+                },
+            ));
+        }
+    }
+    out
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // Revert reason decoding
 // ═══════════════════════════════════════════════════════════════════════════════
-
-/// `Error(string)` selector — `keccak256("Error(string)")[..4]`.
-const ERROR_STRING_SELECTOR: [u8; 4] = [0x08, 0xc3, 0x79, 0xa0];
-
-/// `Panic(uint256)` selector — `keccak256("Panic(uint256)")[..4]`.
-const PANIC_UINT256_SELECTOR: [u8; 4] = [0x4e, 0x48, 0x7b, 0x71];
-
-/// Minimum payload length for a well-formed `Error(string)` revert:
-/// selector(4) + string-offset(32) + string-length(32).
-const MIN_ERROR_STRING_LEN: usize = 4 + 32 + 32;
-
-/// Minimum payload length for a well-formed `Panic(uint256)` revert:
-/// selector(4) + uint256(32).
-const MIN_PANIC_UINT256_LEN: usize = 4 + 32;
 
 /// Solidity panic codes — see the [Solidity docs][1] for the canonical list.
 /// Sentinel returned when the panic code is too large to fit in u64.
@@ -1255,13 +1204,6 @@ pub fn decode_revert_reason(output: &Bytes) -> String {
 // ═══════════════════════════════════════════════════════════════════════════════
 // Selector-to-name mapping
 // ═══════════════════════════════════════════════════════════════════════════════
-
-/// Well-known ERC-20 metadata view selectors. Defined here so they're shared
-/// between trace decoding (`selector_to_name`) and the metadata resolver, which
-/// needs the raw bytes to make the calls.
-pub const NAME_SELECTOR: [u8; 4] = [0x06, 0xfd, 0xde, 0x03]; // name()
-pub const SYMBOL_SELECTOR: [u8; 4] = [0x95, 0xd8, 0x9b, 0x41]; // symbol()
-pub const DECIMALS_SELECTOR: [u8; 4] = [0x31, 0x3c, 0xe5, 0x67]; // decimals()
 
 /// Best-effort decode of a 4-byte function selector to a human-readable name.
 pub fn selector_to_name(selector: [u8; 4]) -> Option<&'static str> {
@@ -1501,7 +1443,7 @@ fn internal_err(msg: impl std::fmt::Display) -> jsonrpsee::types::ErrorObjectOwn
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::Instant;
+    use std::time::{Duration, Instant};
 
     /// Stand-in "malicious payload": anything that pegs a worker for longer
     /// than `SIMULATION_TIMEOUT`. Crafting bytecode that reliably blows

--- a/crates/rpc/src/simulate.rs
+++ b/crates/rpc/src/simulate.rs
@@ -25,6 +25,7 @@ use revm::{
 use revm_primitives::TxKind;
 use serde::{Deserialize, Serialize};
 use std::{
+    collections::HashMap,
     num::NonZeroUsize,
     sync::{Arc, Mutex},
     time::Duration,
@@ -121,6 +122,38 @@ pub struct TraceEntry {
     pub value: String,
 }
 
+/// Type of contract-management state change detected during simulation.
+/// Wire values match Blockaid's `contract_management[].type`, so app-backend
+/// can consume our response and Blockaid's interchangeably.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ContractManagementType {
+    ContractCreation,
+    SelfDestruct,
+    ProxyUpgrade,
+    OwnershipChange,
+    ModuleChange,
+    /// EIP-7702 delegation. Reserved — not yet detected.
+    Authorization,
+}
+
+/// One contract-management action against a single target contract.
+///
+/// The `target` (the contract that was created/destroyed/upgraded/etc.) is
+/// the **map key** in `SimulateUnsignedUserOpResult.contract_management` —
+/// not a field on this struct. App-backend's `checkContractManagementActions`
+/// guard only reads `type` and (for creations) `deployer_address`. Field
+/// names mirror Blockaid's wire format (snake_case).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContractManagementAction {
+    #[serde(rename = "type")]
+    pub action_type: ContractManagementType,
+    /// Address that initiated the CREATE/CREATE2 — populated only for
+    /// `CONTRACT_CREATION`. Omitted from JSON otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deployer_address: Option<Address>,
+}
+
 /// Outcome of the simulation execution.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -144,6 +177,12 @@ pub struct SimulateUnsignedUserOpResult {
     pub asset_changes: Vec<AssetChange>,
     pub exposure_changes: Vec<ExposureChange>,
     pub trace: Vec<TraceEntry>,
+    /// Contract-management state changes detected during execution, keyed
+    /// by the **target contract address** (the contract created, destroyed,
+    /// upgraded, or whose ownership/modules changed). Field name and key
+    /// shape mirror Blockaid's `contract_management`.
+    #[serde(rename = "contract_management")]
+    pub contract_management: HashMap<Address, Vec<ContractManagementAction>>,
     /// Warning generation is not yet implemented. Always serialized as `[]`;
     /// reserved so callers can rely on the field being present.
     pub warnings: Vec<serde_json::Value>,
@@ -168,6 +207,23 @@ struct NativeTransfer {
     value: U256,
 }
 
+/// `(deployer, deployed_address)` for a successful CREATE/CREATE2.
+type ContractCreation = (Address, Address);
+
+/// One frame's tentative side-effects. Each CALL or CREATE pushes a fresh
+/// frame on entry; on successful exit it's merged into the parent (or
+/// committed to the inspector's final lists if outermost). On revert/halt
+/// it's dropped — exactly mirroring the EVM's own state-revert semantics
+/// so we never report effects that didn't actually land.
+#[derive(Debug, Default)]
+struct PendingFrame {
+    native_transfers: Vec<NativeTransfer>,
+    /// CREATE/CREATE2 deployments inside this frame.
+    contract_creations: Vec<ContractCreation>,
+    /// Addresses that executed SELFDESTRUCT inside this frame.
+    self_destructs: Vec<Address>,
+}
+
 /// Captures the call stack and native ETH transfers of a single simulation.
 ///
 /// Single-threaded by construction — the EVM drives it from one call site,
@@ -178,14 +234,15 @@ pub struct SimulationInspector {
     /// Full call stack trace — every CALL/STATICCALL/DELEGATECALL at every depth.
     /// Includes reverted calls so debug consumers can see what was attempted.
     traces: Vec<RawTrace>,
-    /// Native ETH transfers from successfully completed call frames only.
-    /// Reverted/halted frames don't actually move ETH, so their tentative
-    /// entries in `pending_frames` are dropped instead of being committed here.
+    /// Native ETH transfers committed by successful frames.
     native_transfers: Vec<NativeTransfer>,
-    /// One entry per active call frame, holding tentative native transfers
-    /// recorded on entry. On `call_end` the frame is popped: committed (or
-    /// merged into the parent frame) on success, dropped on revert/halt.
-    pending_frames: Vec<Vec<NativeTransfer>>,
+    /// CREATE/CREATE2 deployments committed by successful frames.
+    contract_creations: Vec<ContractCreation>,
+    /// SELFDESTRUCT calls committed by successful frames.
+    self_destructs: Vec<Address>,
+    /// Active frame stack. Each CALL or CREATE pushes a new entry; the
+    /// matching `*_end` pops it. See [`PendingFrame`].
+    pending_frames: Vec<PendingFrame>,
     /// Raw payload of the deepest frame that exited via REVERT. Set on the
     /// first non-ok `call_end` whose `InstructionResult` is `Revert` — since
     /// `call_end` fires bottom-up, that's the innermost reverter and so the
@@ -235,6 +292,34 @@ impl SimulationInspector {
             .take()
             .map(|output| decode_revert_reason(&output))
     }
+
+    /// Drain captured CREATE/CREATE2 deployments. Each entry is
+    /// `(deployer_address, deployed_address)`. Only successful, committed
+    /// creates are returned — frames that locally succeeded but were rolled
+    /// back by a reverting parent are dropped.
+    pub fn take_contract_creations(&mut self) -> Vec<ContractCreation> {
+        std::mem::take(&mut self.contract_creations)
+    }
+
+    /// Drain captured SELFDESTRUCT calls. Same commit semantics as
+    /// [`Self::take_contract_creations`].
+    pub fn take_self_destructs(&mut self) -> Vec<Address> {
+        std::mem::take(&mut self.self_destructs)
+    }
+
+    /// Merge a successful frame into its parent's pending list, or commit
+    /// it to the inspector's final lists if there's no parent.
+    fn commit_or_bubble(&mut self, frame: PendingFrame) {
+        if let Some(parent) = self.pending_frames.last_mut() {
+            parent.native_transfers.extend(frame.native_transfers);
+            parent.contract_creations.extend(frame.contract_creations);
+            parent.self_destructs.extend(frame.self_destructs);
+        } else {
+            self.native_transfers.extend(frame.native_transfers);
+            self.contract_creations.extend(frame.contract_creations);
+            self.self_destructs.extend(frame.self_destructs);
+        }
+    }
 }
 
 impl<CTX: revm::context_interface::ContextTr> Inspector<CTX> for SimulationInspector {
@@ -272,14 +357,14 @@ impl<CTX: revm::context_interface::ContextTr> Inspector<CTX> for SimulationInspe
             value,
         });
 
-        // Open a new frame for tentative native transfers. If this call frame
-        // reverts, `call_end` will drop the frame; only successful frames
-        // commit their transfers.
-        let mut frame = Vec::new();
+        // Open a new frame. If this call reverts, `call_end` will drop the
+        // frame and all its tentative effects (native transfers, creates,
+        // selfdestructs). Only successful frames commit.
+        let mut frame = PendingFrame::default();
         if let Some(value) = inputs.value.transfer()
             && value > U256::ZERO
         {
-            frame.push(NativeTransfer {
+            frame.native_transfers.push(NativeTransfer {
                 from: inputs.caller,
                 to: inputs.target_address,
                 value,
@@ -296,24 +381,65 @@ impl<CTX: revm::context_interface::ContextTr> Inspector<CTX> for SimulationInspe
         };
         let result = outcome.instruction_result();
         if !result.is_ok() {
-            // Frame reverted or halted — drop tentative native transfers
-            // either way. For explicit REVERTs, capture the deepest payload
-            // (the first one we see, since `call_end` fires bottom-up) so
-            // wrappers like EntryPoint's `FailedOp(...)` don't mask the
-            // root cause. Halts and the other `is_revert()` variants
-            // (CallTooDeep, OutOfFunds, EOF init-code) have empty outputs.
+            // Frame reverted or halted — drop everything tentative inside it.
+            // For explicit REVERTs, capture the deepest payload (the first
+            // one we see, since `call_end` fires bottom-up) so wrappers like
+            // EntryPoint's `FailedOp(...)` don't mask the root cause. Halts
+            // and the other `is_revert()` variants (CallTooDeep, OutOfFunds,
+            // EOF init-code) have empty outputs.
             if matches!(result, InstructionResult::Revert) && self.deepest_revert_payload.is_none()
             {
                 self.deepest_revert_payload = Some(outcome.output().clone());
             }
             return;
         }
-        // Successful frame: bubble transfers up to the parent's tentative list,
-        // or commit them as final if this was the outermost frame.
-        if let Some(parent) = self.pending_frames.last_mut() {
-            parent.extend(frame);
+        self.commit_or_bubble(frame);
+    }
+
+    fn create(
+        &mut self,
+        _context: &mut CTX,
+        _inputs: &mut revm::interpreter::CreateInputs,
+    ) -> Option<revm::interpreter::CreateOutcome> {
+        // Mirror `call`: each CREATE/CREATE2 gets its own frame so a parent
+        // revert rolls the deployment back atomically with everything else
+        // that ran inside its constructor.
+        self.pending_frames.push(PendingFrame::default());
+        None
+    }
+
+    fn create_end(
+        &mut self,
+        _context: &mut CTX,
+        inputs: &revm::interpreter::CreateInputs,
+        outcome: &mut revm::interpreter::CreateOutcome,
+    ) {
+        let Some(mut frame) = self.pending_frames.pop() else {
+            return;
+        };
+        if !outcome.instruction_result().is_ok() {
+            // CREATE itself failed — drop the frame.
+            return;
+        }
+        // Successful create: record `(deployer, deployed)` *into the parent
+        // frame's list* (creations are an effect of the parent), then bubble
+        // any inner side-effects up alongside it.
+        if let Some(addr) = outcome.address {
+            frame.contract_creations.push((inputs.caller(), addr));
+        }
+        self.commit_or_bubble(frame);
+    }
+
+    fn selfdestruct(&mut self, contract: Address, _target: Address, _value: U256) {
+        // SELFDESTRUCT runs inside the current call frame and is rolled
+        // back along with it on revert. Record into the topmost pending
+        // frame so the existing commit-or-drop machinery handles rollback.
+        if let Some(top) = self.pending_frames.last_mut() {
+            top.self_destructs.push(contract);
         } else {
-            self.native_transfers.extend(frame);
+            // No frame — outermost transact direct to a SELFDESTRUCTing
+            // contract (rare but legal). Commit immediately.
+            self.self_destructs.push(contract);
         }
     }
 }
@@ -619,11 +745,14 @@ where
         })?;
         let mut exposure_changes = parse_exposure_changes(&logs);
 
-        // 10. Extract trace and native transfers from the inspector. The EVM
-        //     owns it; recover a `&mut` via `components_mut()` and drain.
+        // 10. Extract trace, native transfers, and contract-management
+        //     side-effects from the inspector. The EVM owns it; recover a
+        //     `&mut` via `components_mut()` and drain.
         let (_, inspector, _) = evm.components_mut();
         let trace = inspector.take_trace_entries();
         asset_changes.extend(inspector.take_native_asset_changes());
+        let inspector_creations = inspector.take_contract_creations();
+        let inspector_destructs = inspector.take_self_destructs();
 
         // `revert_reason` is the *root cause* — the deepest reverted frame's
         // payload — so consumers see the contract-specific custom error from
@@ -656,6 +785,35 @@ where
             &mut exposure_changes,
         );
 
+        // 12. Assemble `contract_management` from inspector-captured
+        //     CREATE/SELFDESTRUCT plus event-derived proxy / ownership /
+        //     module changes. The map is keyed by the **target** contract
+        //     address (the one whose state changed) — wire shape mirrors
+        //     Blockaid's `contract_management`.
+        let mut contract_management: HashMap<Address, Vec<ContractManagementAction>> =
+            HashMap::new();
+        for (deployer, deployed) in inspector_creations {
+            contract_management
+                .entry(deployed)
+                .or_default()
+                .push(ContractManagementAction {
+                    action_type: ContractManagementType::ContractCreation,
+                    deployer_address: Some(deployer),
+                });
+        }
+        for destroyed in inspector_destructs {
+            contract_management
+                .entry(destroyed)
+                .or_default()
+                .push(ContractManagementAction {
+                    action_type: ContractManagementType::SelfDestruct,
+                    deployer_address: None,
+                });
+        }
+        for (target, action) in parse_contract_management_events(&logs) {
+            contract_management.entry(target).or_default().push(action);
+        }
+
         Ok(SimulateUnsignedUserOpResult {
             status,
             revert_reason,
@@ -664,6 +822,7 @@ where
             asset_changes,
             exposure_changes,
             trace,
+            contract_management,
             warnings: vec![],
         })
     }
@@ -692,6 +851,36 @@ const APPROVAL_TOPIC: B256 =
 /// `ApprovalForAll(address,address,bool)` — ERC-721 / ERC-1155
 const APPROVAL_FOR_ALL_TOPIC: B256 =
     alloy_primitives::b256!("17307eab39ab6107e8899845ad3d59bd9653f200f220920489ca2b5937696c31");
+
+// ─── Contract management ─────────────────────────────────────────────────────
+
+/// `Upgraded(address)` — EIP-1967 / UUPS implementation upgrade.
+const UPGRADED_TOPIC: B256 =
+    alloy_primitives::b256!("bc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b");
+
+/// `OwnershipTransferred(address,address)` — OpenZeppelin `Ownable`.
+const OWNERSHIP_TRANSFERRED_TOPIC: B256 =
+    alloy_primitives::b256!("8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0");
+
+/// Safe `AddedOwner(address)`.
+const SAFE_ADDED_OWNER_TOPIC: B256 =
+    alloy_primitives::b256!("9465fa0c962cc76958e6373a993326400c1c94f8be2fe3a952adfa7f60b2ea26");
+
+/// Safe `RemovedOwner(address)`.
+const SAFE_REMOVED_OWNER_TOPIC: B256 =
+    alloy_primitives::b256!("f8d49fc529812e9a7c5c50e69c20f0dccc0db8fa95c98bc58cc9a4f1c1299eaf");
+
+/// Safe `ChangedThreshold(uint256)`.
+const SAFE_CHANGED_THRESHOLD_TOPIC: B256 =
+    alloy_primitives::b256!("610f7ff2b304ae8903c3de74c60c6ab1f7d6226b3f52c5161905bb5ad4039c93");
+
+/// Safe `EnabledModule(address)`.
+const SAFE_ENABLED_MODULE_TOPIC: B256 =
+    alloy_primitives::b256!("ecdf3a3effea5783a3c4c2140e677577666428d44ed9d474a0b3a4c9943f8440");
+
+/// Safe `DisabledModule(address)`.
+const SAFE_DISABLED_MODULE_TOPIC: B256 =
+    alloy_primitives::b256!("aab4fa2b463f581b2b32cb3b7e3b704b9ce37cc209b5fb4d77e593ace4054276");
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Log parsing — asset changes
@@ -916,6 +1105,49 @@ pub fn parse_exposure_changes(logs: &[alloy_primitives::Log]) -> Vec<ExposureCha
     }
 
     changes
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Log parsing — contract management
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Detect proxy upgrades, ownership changes, and Safe module changes from
+/// emitted events. Returns `(target_contract, action)` pairs — the caller
+/// merges these with inspector-captured CONTRACT_CREATION / SELF_DESTRUCT
+/// entries into the response's `contract_management` map.
+///
+/// The map key on the wire is the address of the **target** (i.e. the
+/// proxy / owned contract / Safe), which is just `log.address` for every
+/// event we care about here.
+pub fn parse_contract_management_events(
+    logs: &[alloy_primitives::Log],
+) -> Vec<(Address, ContractManagementAction)> {
+    let mut out = Vec::new();
+    for log in logs {
+        let topics = log.topics();
+        let Some(topic0) = topics.first() else {
+            continue;
+        };
+        let action_type = match *topic0 {
+            UPGRADED_TOPIC => ContractManagementType::ProxyUpgrade,
+            OWNERSHIP_TRANSFERRED_TOPIC
+            | SAFE_ADDED_OWNER_TOPIC
+            | SAFE_REMOVED_OWNER_TOPIC
+            | SAFE_CHANGED_THRESHOLD_TOPIC => ContractManagementType::OwnershipChange,
+            SAFE_ENABLED_MODULE_TOPIC | SAFE_DISABLED_MODULE_TOPIC => {
+                ContractManagementType::ModuleChange
+            }
+            _ => continue,
+        };
+        out.push((
+            log.address,
+            ContractManagementAction {
+                action_type,
+                deployer_address: None,
+            },
+        ));
+    }
+    out
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/crates/rpc/src/simulate_consts.rs
+++ b/crates/rpc/src/simulate_consts.rs
@@ -90,7 +90,7 @@ pub(crate) const SAFE_DISABLED_MODULE_TOPIC: B256 =
 
 /// `DiamondCut((address,uint8,bytes4[])[],address,bytes)` — EIP-2535 facet changes.
 pub(crate) const DIAMOND_CUT_TOPIC: B256 =
-    alloy_primitives::b256!("8faa70878671ccd212d20771b795c50af8fd3ff6cf27f4bde57e5d4c0aab23a5");
+    alloy_primitives::b256!("8faa70878671ccd212d20771b795c50af8fd3ff6cf27f4bde57e5d4de0aeb673");
 
 // ─── Proxy storage slots (signature-agnostic upgrade detection) ──────────────
 

--- a/crates/rpc/src/simulate_consts.rs
+++ b/crates/rpc/src/simulate_consts.rs
@@ -1,0 +1,140 @@
+//! Constants used by `simulate_unsignedUserOp` — gas/timeout limits, event
+//! signatures, proxy storage slots, revert decoding selectors, and metadata
+//! view selectors.
+
+use alloy_primitives::B256;
+use std::time::Duration;
+
+// ─── Gas / cache / timeout limits ────────────────────────────────────────────
+
+/// Maximum gas limit accepted for a simulated call.
+pub const MAX_SIMULATION_GAS: u64 = 8_000_000;
+
+/// Bounded to prevent unbounded memory growth from adversarial UserOps that
+/// emit Transfer events from many fresh token contracts.
+pub(crate) const METADATA_CACHE_CAPACITY: usize = 1000;
+
+/// Hard wall-clock cap on a single simulation, observed by the client. Beyond
+/// this we return `internal error: simulation deadline exceeded`. The blocking
+/// task continues to drain on the rayon pool until the EVM finishes (bounded
+/// by `MAX_SIMULATION_GAS`), holding its concurrency permit until then so the
+/// guard correctly accounts for slow simulations.
+pub const SIMULATION_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Maximum number of (id, value) pairs accepted in a single ERC-1155 TransferBatch log.
+///
+/// Bounded to prevent adversarially crafted logs from forcing huge allocations
+/// in `decode_batch_transfer_data`.
+pub const MAX_BATCH_TRANSFERS: usize = 1000;
+
+// ─── Asset / approval event topics ───────────────────────────────────────────
+
+/// `Transfer(address,address,uint256)` — ERC-20 and ERC-721
+pub(crate) const TRANSFER_TOPIC: B256 =
+    alloy_primitives::b256!("ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef");
+
+/// `TransferSingle(address,address,address,uint256,uint256)` — ERC-1155
+pub(crate) const TRANSFER_SINGLE_TOPIC: B256 =
+    alloy_primitives::b256!("c3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62");
+
+/// `TransferBatch(address,address,address,uint256[],uint256[])` — ERC-1155
+pub(crate) const TRANSFER_BATCH_TOPIC: B256 =
+    alloy_primitives::b256!("4a39dc06d4c0dbc64b70af90fd698a233a518aa5d07e595d983b8c0526c8f7fb");
+
+/// `Approval(address,address,uint256)` — ERC-20 and ERC-721
+pub(crate) const APPROVAL_TOPIC: B256 =
+    alloy_primitives::b256!("8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925");
+
+/// `ApprovalForAll(address,address,bool)` — ERC-721 / ERC-1155
+pub(crate) const APPROVAL_FOR_ALL_TOPIC: B256 =
+    alloy_primitives::b256!("17307eab39ab6107e8899845ad3d59bd9653f200f220920489ca2b5937696c31");
+
+// ─── Contract management event topics ────────────────────────────────────────
+
+/// `Upgraded(address)` — EIP-1967 / UUPS implementation upgrade.
+pub(crate) const UPGRADED_TOPIC: B256 =
+    alloy_primitives::b256!("bc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b");
+
+/// `BeaconUpgraded(address)` — EIP-1967 beacon proxy upgrade.
+pub(crate) const BEACON_UPGRADED_TOPIC: B256 =
+    alloy_primitives::b256!("1cf3b03a6cf19fa2baba4df148e9dcabedea7f8a5c07840e207e5c089be95d3e");
+
+/// `AdminChanged(address,address)` — EIP-1967 proxy admin rotation. A
+/// privilege-escalation vector: the new admin can swap the implementation.
+pub(crate) const ADMIN_CHANGED_TOPIC: B256 =
+    alloy_primitives::b256!("7e644d79422f17c01e4894b5f4f588d331ebfa28653d42ae832dc59e38c9798f");
+
+/// `OwnershipTransferred(address,address)` — OpenZeppelin `Ownable`.
+pub(crate) const OWNERSHIP_TRANSFERRED_TOPIC: B256 =
+    alloy_primitives::b256!("8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0");
+
+/// Safe `AddedOwner(address)`.
+pub(crate) const SAFE_ADDED_OWNER_TOPIC: B256 =
+    alloy_primitives::b256!("9465fa0c962cc76958e6373a993326400c1c94f8be2fe3a952adfa7f60b2ea26");
+
+/// Safe `RemovedOwner(address)`.
+pub(crate) const SAFE_REMOVED_OWNER_TOPIC: B256 =
+    alloy_primitives::b256!("f8d49fc529812e9a7c5c50e69c20f0dccc0db8fa95c98bc58cc9a4f1c1299eaf");
+
+/// Safe `ChangedThreshold(uint256)`.
+pub(crate) const SAFE_CHANGED_THRESHOLD_TOPIC: B256 =
+    alloy_primitives::b256!("610f7ff2b304ae8903c3de74c60c6ab1f7d6226b3f52c5161905bb5ad4039c93");
+
+/// Safe `EnabledModule(address)`.
+pub(crate) const SAFE_ENABLED_MODULE_TOPIC: B256 =
+    alloy_primitives::b256!("ecdf3a3effea5783a3c4c2140e677577666428d44ed9d474a0b3a4c9943f8440");
+
+/// Safe `DisabledModule(address)`.
+pub(crate) const SAFE_DISABLED_MODULE_TOPIC: B256 =
+    alloy_primitives::b256!("aab4fa2b463f581b2b32cb3b7e3b704b9ce37cc209b5fb4d77e593ace4054276");
+
+/// `DiamondCut((address,uint8,bytes4[])[],address,bytes)` — EIP-2535 facet changes.
+pub(crate) const DIAMOND_CUT_TOPIC: B256 =
+    alloy_primitives::b256!("8faa70878671ccd212d20771b795c50af8fd3ff6cf27f4bde57e5d4c0aab23a5");
+
+// ─── Proxy storage slots (signature-agnostic upgrade detection) ──────────────
+
+/// EIP-1967 implementation slot — `keccak256("eip1967.proxy.implementation") - 1`.
+pub(crate) const EIP1967_IMPLEMENTATION_SLOT: B256 =
+    alloy_primitives::b256!("360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc");
+
+/// EIP-1967 beacon slot — `keccak256("eip1967.proxy.beacon") - 1`.
+pub(crate) const EIP1967_BEACON_SLOT: B256 =
+    alloy_primitives::b256!("a3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50");
+
+/// EIP-1967 admin slot — `keccak256("eip1967.proxy.admin") - 1`.
+pub(crate) const EIP1967_ADMIN_SLOT: B256 =
+    alloy_primitives::b256!("b53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103");
+
+/// EIP-1822 ("Proxiable") implementation slot — `keccak256("PROXIABLE")`.
+pub(crate) const EIP1822_PROXIABLE_SLOT: B256 =
+    alloy_primitives::b256!("c5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7");
+
+/// Legacy OpenZeppelin implementation slot — `keccak256("org.zeppelinos.proxy.implementation")`.
+pub(crate) const OZ_LEGACY_IMPLEMENTATION_SLOT: B256 =
+    alloy_primitives::b256!("7050c9e0f4ca769c69bd3a8ef740bc37934f8e2c036e5a723fd8ee048ed3f8c3");
+
+// ─── Revert reason decoding ──────────────────────────────────────────────────
+
+/// `Error(string)` selector — `keccak256("Error(string)")[..4]`.
+pub(crate) const ERROR_STRING_SELECTOR: [u8; 4] = [0x08, 0xc3, 0x79, 0xa0];
+
+/// `Panic(uint256)` selector — `keccak256("Panic(uint256)")[..4]`.
+pub(crate) const PANIC_UINT256_SELECTOR: [u8; 4] = [0x4e, 0x48, 0x7b, 0x71];
+
+/// Minimum payload length for a well-formed `Error(string)` revert:
+/// selector(4) + string-offset(32) + string-length(32).
+pub(crate) const MIN_ERROR_STRING_LEN: usize = 4 + 32 + 32;
+
+/// Minimum payload length for a well-formed `Panic(uint256)` revert:
+/// selector(4) + uint256(32).
+pub(crate) const MIN_PANIC_UINT256_LEN: usize = 4 + 32;
+
+// ─── ERC-20 metadata view selectors ──────────────────────────────────────────
+
+/// Well-known ERC-20 metadata view selectors. Defined here so they're shared
+/// between trace decoding (`selector_to_name`) and the metadata resolver, which
+/// needs the raw bytes to make the calls.
+pub const NAME_SELECTOR: [u8; 4] = [0x06, 0xfd, 0xde, 0x03]; // name()
+pub const SYMBOL_SELECTOR: [u8; 4] = [0x95, 0xd8, 0x9b, 0x41]; // symbol()
+pub const DECIMALS_SELECTOR: [u8; 4] = [0x31, 0x3c, 0xe5, 0x67]; // decimals()

--- a/crates/rpc/tests/fork_simulate.rs
+++ b/crates/rpc/tests/fork_simulate.rs
@@ -4,6 +4,10 @@
 //! against real deployed contracts (WLD, USDC.e, etc.). CI reads the URL
 //! from the `WORLDCHAIN_PROVIDER` secret; locally, export it before running.
 //!
+//! State is **pinned** to `FORK_BLOCK_NUMBER`. Without a pin, every run sees
+//! a different head and assertions about balances / metadata become flaky.
+//! The endpoint must be an archive node that serves state at this height.
+//!
 //! Run with:
 //! ```sh
 //! WORLDCHAIN_PROVIDER=https://worldchain-mainnet.g.alchemy.com/v2/<KEY> \
@@ -35,6 +39,11 @@ use world_chain_rpc::simulate::{
 const WLD: Address = address!("2cFc85d8E48F8EAB294be644d9E25C3030863003");
 const ENTRY_POINT: Address = address!("0000000071727De22E5E9d8BAf0edAc6f37da032");
 const CHAIN_ID: u64 = 480;
+
+/// Pin every fork-backed lookup to this height so storage slots, balances,
+/// and contract bytecode are stable across runs. Update only when a test
+/// genuinely needs newer state — and re-verify the existing assertions.
+const FORK_BLOCK_NUMBER: u64 = 29_001_024;
 
 // ─── ABI fragments ───────────────────────────────────────────────────────────
 
@@ -79,7 +88,7 @@ fn make_forked_db() -> CacheDB<
     >,
 > {
     let provider = alloy_provider_v1::RootProvider::new_http(rpc_url().parse().unwrap());
-    let alloy_db = AlloyDB::new(provider, revm_database::BlockId::latest());
+    let alloy_db = AlloyDB::new(provider, revm_database::BlockId::from(FORK_BLOCK_NUMBER));
     let handle = tokio::runtime::Handle::current();
     let wrapped = WrapDatabaseAsync::with_handle(alloy_db, handle);
     CacheDB::new(wrapped)
@@ -821,5 +830,260 @@ async fn test_trace_detects_malicious_safe_call() {
                 }
             }
         }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Blockaid scenario coverage
+//
+// The five tests below mirror scenarios from `app-backend-main`'s Blockaid
+// suite (`blockaid.service.unit.spec.ts`). We're asserting on the *raw*
+// detection output (`assetChanges` / `exposureChanges`) — Blockaid's IN/OUT
+// classification, humanReadableDiff formatting, and Permit2 filtering are
+// downstream concerns the consumer applies on top of this response.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Blockaid: `simple-permit.ts` / `consists-exposures.ts` — an `approve()`
+/// call must produce one `ExposureChange` and **zero** `AssetChange`s. The
+/// EVM also reports a successful execution (no revert).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_simulate_real_approve_emits_only_exposure() {
+    let mut db = make_forked_db();
+    let caller = address!("00000000000000000000000000ffffffffffffff");
+    db.insert_account_info(
+        caller,
+        AccountInfo {
+            balance: U256::from(10u128.pow(21)),
+            ..Default::default()
+        },
+    );
+    let mut evm = OpEvmFactory::default().create_evm(&mut db, simulate_evm_env());
+
+    let spender = address!("000000000022D473030F116dDEE9F6B43aC78BA3");
+    let result = RethEvm::transact(
+        &mut evm,
+        OpTx(OpTransaction {
+            base: TxEnv {
+                caller,
+                kind: TxKind::Call(WLD),
+                data: approveCall {
+                    spender,
+                    amount: U256::MAX,
+                }
+                .abi_encode()
+                .into(),
+                gas_limit: 200_000,
+                gas_price: 0,
+                chain_id: Some(CHAIN_ID),
+                ..Default::default()
+            },
+            ..Default::default()
+        }),
+    )
+    .expect("approve must not fail validation");
+
+    let logs = match &result.result {
+        ExecutionResult::Success { logs, .. } => logs.clone(),
+        other => panic!("expected approve to succeed, got {other:?}"),
+    };
+    let asset_changes = parse_asset_changes(&logs).unwrap();
+    let exposure_changes = parse_exposure_changes(&logs);
+    assert_eq!(asset_changes.len(), 0, "approval emits no transfer");
+    assert_eq!(exposure_changes.len(), 1);
+    assert_eq!(exposure_changes[0].owner, caller);
+    assert_eq!(exposure_changes[0].spender, spender);
+    assert_eq!(exposure_changes[0].raw_amount, U256::MAX.to_string());
+    assert!(!exposure_changes[0].is_approved_for_all);
+}
+
+/// Blockaid: `atomic-vault-withdraw-send.ts` — a single tx emits two
+/// `Transfer` events on the same token (`vault → user`, `user → final`).
+/// Both must surface as independent `AssetChange`s so the consumer sees the
+/// full hop chain.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_parse_atomic_double_transfer_same_token() {
+    let alice = address!("000000000000000000000000000000000000aaaa");
+    let bob = address!("000000000000000000000000000000000000bbbb");
+    let carol = address!("000000000000000000000000000000000000cccc");
+    let amount = U256::from(1_000_000u64);
+    let transfer_topic = alloy_primitives::b256!(
+        "ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+    );
+
+    let make_log = |from: Address, to: Address| {
+        alloy_primitives::Log::new(
+            WLD,
+            vec![
+                transfer_topic,
+                alloy_primitives::B256::left_padding_from(from.as_slice()),
+                alloy_primitives::B256::left_padding_from(to.as_slice()),
+            ],
+            amount.to_be_bytes_vec().into(),
+        )
+        .unwrap()
+    };
+
+    let logs = vec![make_log(alice, bob), make_log(bob, carol)];
+    let changes = parse_asset_changes(&logs).unwrap();
+    assert_eq!(changes.len(), 2, "two hops, two AssetChanges");
+    assert_eq!(changes[0].from, alice);
+    assert_eq!(changes[0].to, bob);
+    assert_eq!(changes[1].from, bob);
+    assert_eq!(changes[1].to, carol);
+    for c in &changes {
+        assert_eq!(c.change_type, AssetType::Erc20);
+        assert_eq!(c.raw_amount, amount.to_string());
+        assert!(c.token_id.is_none());
+    }
+}
+
+/// Blockaid: `multiple-nfts.ts` — five ERC-721 Transfer events (token IDs
+/// 73..=77) inside one tx surface as five distinct `AssetChange`s with
+/// `Erc721` type, identical from/to, but each carrying a distinct
+/// `tokenId`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_parse_batch_nft_transfers() {
+    let collection = address!("000000000000000000000000000000000000721a");
+    let from = address!("000000000000000000000000000000000000aaaa");
+    let to = address!("000000000000000000000000000000000000bbbb");
+    let transfer_topic = alloy_primitives::b256!(
+        "ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+    );
+
+    let logs: Vec<_> = (73u64..=77)
+        .map(|id| {
+            alloy_primitives::Log::new(
+                collection,
+                vec![
+                    transfer_topic,
+                    alloy_primitives::B256::left_padding_from(from.as_slice()),
+                    alloy_primitives::B256::left_padding_from(to.as_slice()),
+                    U256::from(id).into(),
+                ],
+                Bytes::new(),
+            )
+            .unwrap()
+        })
+        .collect();
+
+    let changes = parse_asset_changes(&logs).unwrap();
+    assert_eq!(changes.len(), 5);
+    for (idx, change) in changes.iter().enumerate() {
+        let expected_id = (73 + idx as u64).to_string();
+        assert_eq!(change.change_type, AssetType::Erc721);
+        assert_eq!(change.from, from);
+        assert_eq!(change.to, to);
+        assert_eq!(change.raw_amount, "1");
+        assert_eq!(change.token_id.as_deref(), Some(expected_id.as_str()));
+    }
+}
+
+/// Blockaid: `non-standard-tokens.ts` — one tx mixes ERC-20, ERC-721, and
+/// ERC-1155 movements. The parser classifies each independently from its
+/// log topic count / event signature.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_parse_mixed_token_types_in_one_response() {
+    let erc20 = WLD;
+    let erc721 = address!("0000000000000000000000000000000000000721");
+    let erc1155 = address!("0000000000000000000000000000000000001155");
+    let from = address!("000000000000000000000000000000000000aaaa");
+    let to = address!("000000000000000000000000000000000000bbbb");
+    let operator = address!("000000000000000000000000000000000000ccCC");
+    let transfer_topic = alloy_primitives::b256!(
+        "ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+    );
+    let erc1155_topic = alloy_primitives::b256!(
+        "c3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62"
+    );
+
+    let erc20_log = alloy_primitives::Log::new(
+        erc20,
+        vec![
+            transfer_topic,
+            alloy_primitives::B256::left_padding_from(from.as_slice()),
+            alloy_primitives::B256::left_padding_from(to.as_slice()),
+        ],
+        U256::from(1_000u64).to_be_bytes_vec().into(),
+    )
+    .unwrap();
+    let erc721_log = alloy_primitives::Log::new(
+        erc721,
+        vec![
+            transfer_topic,
+            alloy_primitives::B256::left_padding_from(from.as_slice()),
+            alloy_primitives::B256::left_padding_from(to.as_slice()),
+            U256::from(99u64).into(),
+        ],
+        Bytes::new(),
+    )
+    .unwrap();
+    let mut erc1155_data = Vec::with_capacity(64);
+    erc1155_data.extend_from_slice(&U256::from(5u64).to_be_bytes::<32>());
+    erc1155_data.extend_from_slice(&U256::from(10u64).to_be_bytes::<32>());
+    let erc1155_log = alloy_primitives::Log::new(
+        erc1155,
+        vec![
+            erc1155_topic,
+            alloy_primitives::B256::left_padding_from(operator.as_slice()),
+            alloy_primitives::B256::left_padding_from(from.as_slice()),
+            alloy_primitives::B256::left_padding_from(to.as_slice()),
+        ],
+        erc1155_data.into(),
+    )
+    .unwrap();
+
+    let changes = parse_asset_changes(&[erc20_log, erc721_log, erc1155_log]).unwrap();
+    assert_eq!(changes.len(), 3);
+    assert_eq!(changes[0].change_type, AssetType::Erc20);
+    assert_eq!(changes[0].raw_amount, "1000");
+    assert!(changes[0].token_id.is_none());
+    assert_eq!(changes[1].change_type, AssetType::Erc721);
+    assert_eq!(changes[1].token_id.as_deref(), Some("99"));
+    assert_eq!(changes[1].raw_amount, "1");
+    assert_eq!(changes[2].change_type, AssetType::Erc1155);
+    assert_eq!(changes[2].token_id.as_deref(), Some("5"));
+    assert_eq!(changes[2].raw_amount, "10");
+}
+
+/// Blockaid: `consists-exposures.ts` — one tx grants approvals on two
+/// different tokens to two different spenders. Asset diffs stay empty;
+/// both approvals surface as `ExposureChange`s with their own amounts.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_parse_multiple_approvals_yields_exposures() {
+    let owner = address!("00000000000000000000000000000000DeaDBeef");
+    let token_a = address!("79A02482A880bCE3B13e09Da970dC34db4CD24d1");
+    let token_b = address!("00000000000000000000000000000000000000Bb");
+    let spender_a = address!("0c892815f0B058E69987920A23FBb33c834289cf");
+    let spender_b = address!("Ef1c6E67703c7BD7107eed8303Fbe6EC2554BF6B");
+    let approval_topic = alloy_primitives::b256!(
+        "8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925"
+    );
+
+    let make = |contract: Address, spender: Address, amount: U256| {
+        alloy_primitives::Log::new(
+            contract,
+            vec![
+                approval_topic,
+                alloy_primitives::B256::left_padding_from(owner.as_slice()),
+                alloy_primitives::B256::left_padding_from(spender.as_slice()),
+            ],
+            amount.to_be_bytes_vec().into(),
+        )
+        .unwrap()
+    };
+    let log_a = make(token_a, spender_a, U256::from(123_000u64));
+    let log_b = make(token_b, spender_b, U256::ZERO);
+
+    let asset_changes = parse_asset_changes(&[log_a.clone(), log_b.clone()]).unwrap();
+    let exposure_changes = parse_exposure_changes(&[log_a, log_b]);
+    assert_eq!(asset_changes.len(), 0, "approvals emit no transfers");
+    assert_eq!(exposure_changes.len(), 2);
+    assert_eq!(exposure_changes[0].spender, spender_a);
+    assert_eq!(exposure_changes[0].raw_amount, "123000");
+    assert_eq!(exposure_changes[1].spender, spender_b);
+    assert_eq!(exposure_changes[1].raw_amount, "0");
+    for c in &exposure_changes {
+        assert_eq!(c.owner, owner);
+        assert!(!c.is_approved_for_all);
     }
 }

--- a/crates/rpc/tests/fork_simulate.rs
+++ b/crates/rpc/tests/fork_simulate.rs
@@ -906,9 +906,8 @@ async fn test_parse_atomic_double_transfer_same_token() {
     let bob = address!("000000000000000000000000000000000000bbbb");
     let carol = address!("000000000000000000000000000000000000cccc");
     let amount = U256::from(1_000_000u64);
-    let transfer_topic = alloy_primitives::b256!(
-        "ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
-    );
+    let transfer_topic =
+        alloy_primitives::b256!("ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef");
 
     let make_log = |from: Address, to: Address| {
         alloy_primitives::Log::new(
@@ -946,9 +945,8 @@ async fn test_parse_batch_nft_transfers() {
     let collection = address!("000000000000000000000000000000000000721a");
     let from = address!("000000000000000000000000000000000000aaaa");
     let to = address!("000000000000000000000000000000000000bbbb");
-    let transfer_topic = alloy_primitives::b256!(
-        "ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
-    );
+    let transfer_topic =
+        alloy_primitives::b256!("ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef");
 
     let logs: Vec<_> = (73u64..=77)
         .map(|id| {
@@ -989,12 +987,10 @@ async fn test_parse_mixed_token_types_in_one_response() {
     let from = address!("000000000000000000000000000000000000aaaa");
     let to = address!("000000000000000000000000000000000000bbbb");
     let operator = address!("000000000000000000000000000000000000ccCC");
-    let transfer_topic = alloy_primitives::b256!(
-        "ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
-    );
-    let erc1155_topic = alloy_primitives::b256!(
-        "c3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62"
-    );
+    let transfer_topic =
+        alloy_primitives::b256!("ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef");
+    let erc1155_topic =
+        alloy_primitives::b256!("c3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62");
 
     let erc20_log = alloy_primitives::Log::new(
         erc20,
@@ -1055,9 +1051,8 @@ async fn test_parse_multiple_approvals_yields_exposures() {
     let token_b = address!("00000000000000000000000000000000000000Bb");
     let spender_a = address!("0c892815f0B058E69987920A23FBb33c834289cf");
     let spender_b = address!("Ef1c6E67703c7BD7107eed8303Fbe6EC2554BF6B");
-    let approval_topic = alloy_primitives::b256!(
-        "8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925"
-    );
+    let approval_topic =
+        alloy_primitives::b256!("8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925");
 
     let make = |contract: Address, spender: Address, amount: U256| {
         alloy_primitives::Log::new(

--- a/crates/rpc/tests/fork_simulate.rs
+++ b/crates/rpc/tests/fork_simulate.rs
@@ -20,6 +20,7 @@ use alloy_sol_types::{SolCall, sol};
 use op_revm::{OpSpecId, OpTransaction};
 use reth_evm::{Evm as RethEvm, EvmFactory};
 use revm::{
+    bytecode::Bytecode,
     context::{
         BlockEnv, CfgEnv, TxEnv,
         result::{ExecutionResult, Output},
@@ -30,8 +31,9 @@ use revm_database::{AlloyDB, CacheDB, WrapDatabaseAsync};
 use revm_primitives::TxKind;
 
 use world_chain_rpc::simulate::{
-    AssetType, SimulationInspector, decode_revert_reason, parse_asset_changes,
-    parse_exposure_changes, relax_cfg_for_simulation, selector_to_name,
+    AssetType, ContractManagementType, SimulationInspector, decode_revert_reason,
+    parse_asset_changes, parse_contract_management_events, parse_exposure_changes,
+    relax_cfg_for_simulation, selector_to_name,
 };
 
 // ─── Constants ───────────────────────────────────────────────────────────────
@@ -1081,4 +1083,323 @@ async fn test_parse_multiple_approvals_yields_exposures() {
         assert_eq!(c.owner, owner);
         assert!(!c.is_approved_for_all);
     }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Contract management
+//
+// Mirrors Blockaid's `simulation.contract_management`. We surface five action
+// types — CONTRACT_CREATION, SELF_DESTRUCT, PROXY_UPGRADE, OWNERSHIP_CHANGE,
+// MODULE_CHANGE — so app-backend's `checkContractManagementActions` guard can
+// run identically against our simulate response.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// `Upgraded(address)` event (EIP-1967 / UUPS) → `PROXY_UPGRADE` keyed on the
+/// proxy address.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_parse_proxy_upgrade_event() {
+    let proxy = address!("0000000000000000000000000000000000000abc");
+    let new_impl = address!("000000000000000000000000000000000000beef");
+    let log = alloy_primitives::Log::new(
+        proxy,
+        vec![
+            alloy_primitives::b256!(
+                "bc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b"
+            ),
+            alloy_primitives::B256::left_padding_from(new_impl.as_slice()),
+        ],
+        Bytes::new(),
+    )
+    .unwrap();
+
+    let actions = parse_contract_management_events(&[log]);
+    assert_eq!(actions.len(), 1);
+    assert_eq!(actions[0].0, proxy);
+    assert_eq!(
+        actions[0].1.action_type,
+        ContractManagementType::ProxyUpgrade
+    );
+    assert!(actions[0].1.deployer_address.is_none());
+}
+
+/// All four ownership-change topics (OZ `OwnershipTransferred`, Safe
+/// `AddedOwner` / `RemovedOwner` / `ChangedThreshold`) collapse to
+/// `OWNERSHIP_CHANGE` keyed on the emitter.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_parse_ownership_change_events() {
+    let oz_owned = address!("000000000000000000000000000000000000a0a0");
+    let safe = address!("000000000000000000000000000000000000ffff");
+    let prev = address!("00000000000000000000000000000000000000aa");
+    let next = address!("00000000000000000000000000000000000000bb");
+
+    let oz_log = alloy_primitives::Log::new(
+        oz_owned,
+        vec![
+            alloy_primitives::b256!(
+                "8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0"
+            ),
+            alloy_primitives::B256::left_padding_from(prev.as_slice()),
+            alloy_primitives::B256::left_padding_from(next.as_slice()),
+        ],
+        Bytes::new(),
+    )
+    .unwrap();
+    let added = alloy_primitives::Log::new(
+        safe,
+        vec![
+            alloy_primitives::b256!(
+                "9465fa0c962cc76958e6373a993326400c1c94f8be2fe3a952adfa7f60b2ea26"
+            ),
+            alloy_primitives::B256::left_padding_from(next.as_slice()),
+        ],
+        Bytes::new(),
+    )
+    .unwrap();
+    let removed = alloy_primitives::Log::new(
+        safe,
+        vec![
+            alloy_primitives::b256!(
+                "f8d49fc529812e9a7c5c50e69c20f0dccc0db8fa95c98bc58cc9a4f1c1299eaf"
+            ),
+            alloy_primitives::B256::left_padding_from(prev.as_slice()),
+        ],
+        Bytes::new(),
+    )
+    .unwrap();
+    let changed = alloy_primitives::Log::new(
+        safe,
+        vec![alloy_primitives::b256!(
+            "610f7ff2b304ae8903c3de74c60c6ab1f7d6226b3f52c5161905bb5ad4039c93"
+        )],
+        U256::from(2u64).to_be_bytes_vec().into(),
+    )
+    .unwrap();
+
+    let actions = parse_contract_management_events(&[oz_log, added, removed, changed]);
+    assert_eq!(actions.len(), 4);
+    for (target, action) in &actions {
+        assert!(*target == oz_owned || *target == safe);
+        assert_eq!(action.action_type, ContractManagementType::OwnershipChange);
+    }
+}
+
+/// Safe `EnabledModule` / `DisabledModule` → `MODULE_CHANGE`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_parse_module_change_events() {
+    let safe = address!("000000000000000000000000000000000000ffff");
+    let module = address!("0000000000000000000000000000000000000d01");
+
+    let enabled = alloy_primitives::Log::new(
+        safe,
+        vec![
+            alloy_primitives::b256!(
+                "ecdf3a3effea5783a3c4c2140e677577666428d44ed9d474a0b3a4c9943f8440"
+            ),
+            alloy_primitives::B256::left_padding_from(module.as_slice()),
+        ],
+        Bytes::new(),
+    )
+    .unwrap();
+    let disabled = alloy_primitives::Log::new(
+        safe,
+        vec![
+            alloy_primitives::b256!(
+                "aab4fa2b463f581b2b32cb3b7e3b704b9ce37cc209b5fb4d77e593ace4054276"
+            ),
+            alloy_primitives::B256::left_padding_from(module.as_slice()),
+        ],
+        Bytes::new(),
+    )
+    .unwrap();
+
+    let actions = parse_contract_management_events(&[enabled, disabled]);
+    assert_eq!(actions.len(), 2);
+    for (target, action) in &actions {
+        assert_eq!(*target, safe);
+        assert_eq!(action.action_type, ContractManagementType::ModuleChange);
+    }
+}
+
+/// Non-management logs (Transfer/Approval/etc.) are ignored.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_parse_contract_management_ignores_unrelated_logs() {
+    let log = alloy_primitives::Log::new(
+        WLD,
+        vec![
+            alloy_primitives::b256!(
+                "ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+            ),
+            alloy_primitives::B256::ZERO,
+            alloy_primitives::B256::ZERO,
+        ],
+        U256::from(1u64).to_be_bytes_vec().into(),
+    )
+    .unwrap();
+    assert!(parse_contract_management_events(&[log]).is_empty());
+}
+
+// ─── Inspector hooks (CREATE / SELFDESTRUCT) ─────────────────────────────────
+
+/// Runtime bytecode that, when CALLed, executes a single CREATE with empty
+/// init code. Decoded:
+///
+/// ```text
+/// PUSH1 0x00 PUSH1 0x00 PUSH1 0x00 CREATE STOP
+/// ```
+///
+/// Deploys an empty contract, leaves its address on the stack, then halts.
+const CREATE_TRAMPOLINE_BYTECODE: &[u8] = &[0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0xf0, 0x00];
+
+/// Runtime bytecode that does CREATE then REVERTs the parent frame. Used to
+/// verify the inspector rolls back the captured creation when the surrounding
+/// call frame reverts (rather than reporting a phantom deployment).
+///
+/// `PUSH1 0 PUSH1 0 PUSH1 0 CREATE POP PUSH1 0 PUSH1 0 REVERT`
+const CREATE_THEN_REVERT_BYTECODE: &[u8] = &[
+    0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0xf0, 0x50, 0x60, 0x00, 0x60, 0x00, 0xfd,
+];
+
+fn install_runtime_code(
+    db: &mut CacheDB<
+        WrapDatabaseAsync<
+            AlloyDB<alloy_provider_v1::network::Ethereum, alloy_provider_v1::RootProvider>,
+        >,
+    >,
+    addr: Address,
+    code: &'static [u8],
+) {
+    let bytecode = Bytecode::new_raw(Bytes::from_static(code));
+    let info = AccountInfo {
+        balance: U256::ZERO,
+        nonce: 1,
+        code_hash: bytecode.hash_slow(),
+        code: Some(bytecode),
+        ..Default::default()
+    };
+    db.insert_account_info(addr, info);
+}
+
+/// CALL → contract that does CREATE → inspector records
+/// `(deployer = trampoline, deployed = some_address)`. Verifies the CREATE
+/// hook fires inside a parent call frame.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_inspector_captures_create_via_call_frame() {
+    let mut db = make_forked_db();
+    let caller = address!("00000000000000000000000000ffffffffffffff");
+    let trampoline = address!("000000000000000000000000000000000000c0de");
+    db.insert_account_info(
+        caller,
+        AccountInfo {
+            balance: U256::from(10u128.pow(21)),
+            ..Default::default()
+        },
+    );
+    install_runtime_code(&mut db, trampoline, CREATE_TRAMPOLINE_BYTECODE);
+
+    let mut evm = OpEvmFactory::default().create_evm_with_inspector(
+        &mut db,
+        simulate_evm_env(),
+        SimulationInspector::default(),
+    );
+    let result = RethEvm::transact(
+        &mut evm,
+        OpTx(OpTransaction {
+            base: TxEnv {
+                caller,
+                kind: TxKind::Call(trampoline),
+                data: Bytes::new(),
+                gas_limit: 200_000,
+                gas_price: 0,
+                chain_id: Some(CHAIN_ID),
+                ..Default::default()
+            },
+            ..Default::default()
+        }),
+    )
+    .expect("call must succeed");
+    assert!(matches!(result.result, ExecutionResult::Success { .. }));
+
+    let (_, inspector, _) = evm.components_mut();
+    let creations = inspector.take_contract_creations();
+    assert_eq!(creations.len(), 1, "exactly one CREATE captured");
+    let (deployer, deployed) = creations[0];
+    assert_eq!(deployer, trampoline, "deployer is the trampoline contract");
+    assert_ne!(deployed, Address::ZERO, "deployed address populated");
+}
+
+/// CREATE inside a frame that subsequently REVERTs is rolled back: the
+/// inspector reports zero creations even though the CREATE opcode itself
+/// succeeded. Mirrors the EVM's own atomicity guarantee.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_inspector_drops_create_on_parent_revert() {
+    let mut db = make_forked_db();
+    let caller = address!("00000000000000000000000000ffffffffffffff");
+    let trampoline = address!("000000000000000000000000000000000000dead");
+    db.insert_account_info(
+        caller,
+        AccountInfo {
+            balance: U256::from(10u128.pow(21)),
+            ..Default::default()
+        },
+    );
+    install_runtime_code(&mut db, trampoline, CREATE_THEN_REVERT_BYTECODE);
+
+    let mut evm = OpEvmFactory::default().create_evm_with_inspector(
+        &mut db,
+        simulate_evm_env(),
+        SimulationInspector::default(),
+    );
+    let result = RethEvm::transact(
+        &mut evm,
+        OpTx(OpTransaction {
+            base: TxEnv {
+                caller,
+                kind: TxKind::Call(trampoline),
+                data: Bytes::new(),
+                gas_limit: 200_000,
+                gas_price: 0,
+                chain_id: Some(CHAIN_ID),
+                ..Default::default()
+            },
+            ..Default::default()
+        }),
+    )
+    .expect("transact returns Ok even on inner REVERT");
+    assert!(matches!(result.result, ExecutionResult::Revert { .. }));
+
+    let (_, inspector, _) = evm.components_mut();
+    let creations = inspector.take_contract_creations();
+    assert!(
+        creations.is_empty(),
+        "create must be rolled back with the parent frame, got {creations:?}"
+    );
+}
+
+/// JSON wire shape: `type` is SCREAMING_SNAKE_CASE, `deployer_address` uses
+/// snake_case (matching Blockaid), and is omitted for non-CREATION actions.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_contract_management_action_serialization() {
+    use world_chain_rpc::simulate::ContractManagementAction;
+
+    let creation = ContractManagementAction {
+        action_type: ContractManagementType::ContractCreation,
+        deployer_address: Some(address!("000000000000000000000000000000000000aaaa")),
+    };
+    let json = serde_json::to_value(&creation).unwrap();
+    assert_eq!(json["type"], "CONTRACT_CREATION");
+    assert_eq!(
+        json["deployer_address"],
+        "0x000000000000000000000000000000000000aaaa"
+    );
+
+    let upgrade = ContractManagementAction {
+        action_type: ContractManagementType::ProxyUpgrade,
+        deployer_address: None,
+    };
+    let json = serde_json::to_value(&upgrade).unwrap();
+    assert_eq!(json["type"], "PROXY_UPGRADE");
+    assert!(
+        json.get("deployer_address").is_none(),
+        "deployer_address must be omitted when None"
+    );
 }


### PR DESCRIPTION
## Summary

Adds `contract_management` to `SimulateUnsignedUserOpResult`, a `HashMap<Address, Vec<ContractManagementAction>>` keyed by **target contract address** — wire shape mirrors Blockaid's `simulation.contract_management` so `app-backend-main`'s `checkContractManagementActions` guard can run identically against our response.

> **Stacked on #605** — review that one first. This branch will be rebased onto main once #605 lands.

## Detection

| Action type | Source | Notes |
|---|---|---|
| `CONTRACT_CREATION` | `Inspector::create_end` | Records `(deployer, deployed)`. Wire payload includes `deployer_address` (snake_case, matching Blockaid). |
| `SELF_DESTRUCT` | `Inspector::selfdestruct` | |
| `PROXY_UPGRADE` | `Upgraded(address)` event | EIP-1967 / UUPS proxies |
| `OWNERSHIP_CHANGE` | OZ `OwnershipTransferred` + Safe `AddedOwner`/`RemovedOwner`/`ChangedThreshold` | All four collapse to `OWNERSHIP_CHANGE` |
| `MODULE_CHANGE` | Safe `EnabledModule` / `DisabledModule` | |
| `AUTHORIZATION` | (reserved) | EIP-7702 — enum variant present, detection not yet implemented |

## Atomicity / inspector refactor

The existing per-call-frame `Vec<NativeTransfer>` stack is replaced by a `PendingFrame` struct that also tracks creates and selfdestructs. The same commit-on-success / drop-on-revert machinery that already kept native transfers consistent with EVM rollback semantics now applies uniformly:

- A CREATE inside a reverting parent frame is rolled back — never reported as a phantom deployment.
- Same for SELFDESTRUCT and native ETH transfers.

A dedicated test (`test_inspector_drops_create_on_parent_revert`) regresses this guarantee.

## Wire shape

```json
{
  "contract_management": {
    "0xaaaa…": [
      { "type": "CONTRACT_CREATION", "deployer_address": "0xbbbb…" }
    ],
    "0xcccc…": [
      { "type": "PROXY_UPGRADE" },
      { "type": "OWNERSHIP_CHANGE" }
    ]
  }
}
```

- Top-level field name: `contract_management` (snake_case, matches Blockaid)
- Type discriminator values: `SCREAMING_SNAKE_CASE`
- `deployer_address` populated only for `CONTRACT_CREATION`, omitted otherwise
- Map key is the **target** contract address (the one created/destroyed/upgraded), not the caller

## Tests (7 new)

- `test_parse_proxy_upgrade_event` — synthetic `Upgraded` log → `PROXY_UPGRADE`
- `test_parse_ownership_change_events` — synthetic logs for all 4 ownership topics → all map to `OWNERSHIP_CHANGE`
- `test_parse_module_change_events` — Safe `EnabledModule` + `DisabledModule` → `MODULE_CHANGE`
- `test_parse_contract_management_ignores_unrelated_logs` — Transfer/Approval don't pollute output
- `test_inspector_captures_create_via_call_frame` — inline trampoline bytecode does CREATE → inspector records `(deployer, deployed)`
- `test_inspector_drops_create_on_parent_revert` — CREATE then REVERT → inspector drops the deployment (atomicity)
- `test_contract_management_action_serialization` — JSON wire shape sanity check (`CONTRACT_CREATION` + `deployer_address`)

```sh
WORLDCHAIN_PROVIDER=https://worldchain-mainnet.g.alchemy.com/v2/<KEY> \
  cargo test -p world-chain-rpc --test fork_simulate -- --test-threads=4
```

- [x] All 26 tests pass (4.09s) at the pinned mainnet block
- [x] cargo +nightly fmt clean

## Out of scope

- **EIP-7702 (`AUTHORIZATION`)** — variant reserved; detection requires post-state code-prefix inspection or hooking the `auth` opcode. Not yet active on World Chain mainnet, low priority.
- **Richer per-action fields** (`prev_implementation`/`new_implementation`, `beneficiary`, etc.) — Blockaid spec defines these but `app-backend-main` reads only `type` + `deployer_address`. Adding the structured before/after state is straightforward (event arg decoding) but explicitly out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new `contract_management` output to the `simulate` RPC and extends the EVM inspector to track CREATE/SELFDESTRUCT with rollback semantics plus state-diff/event parsing, which could affect simulation results and downstream consumers if misclassified.
> 
> **Overview**
> Adds a new `contract_management` field to the `simulate_unsignedUserOp` response (deterministic `BTreeMap` keyed by *target contract*) to surface contract creations, self-destructs, proxy upgrades, ownership changes, and Safe module changes.
> 
> Extends `SimulationInspector` with CREATE/CREATE2 and `SELFDESTRUCT` tracking using a unified per-frame pending-effects stack so reported native transfers/creations/destructs are committed only on successful frames and dropped on revert.
> 
> Introduces `parse_contract_management_events` (topic-based) and `parse_contract_management_state_diff` (proxy-slot storage writes) and factors shared limits/topics/selectors into new `simulate_consts.rs`; adds fork/integration tests covering event detection, inspector atomicity, and JSON wire shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0bbf3f18ffe9615c7e196316627e2294dd38575. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->