### PR TITLE
fix: lookup payload id v4 or v3

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -8,6 +8,9 @@ build:
     docker buildx build \
         -t world-chain:latest .
 
+devnet-up: build
+    @just ./pkg/devnet/devnet-up
+
 deploy-contracts:
     @just ./pkg/contracts/deploy-contracts
 

--- a/crates/payload/src/generator.rs
+++ b/crates/payload/src/generator.rs
@@ -206,6 +206,7 @@ where
                 *authorization
                     .wait_for(|a| match a {
                         Some(auth) => {
+                            // TODO: FIXME: Change Payload ID to be derived from Engine API Message Version
                             if auth.payload_id == payload_id_with_version(payload_id, 4)
                                 || auth.payload_id == payload_id_with_version(payload_id, 3)
                             {

--- a/crates/payload/src/generator.rs
+++ b/crates/payload/src/generator.rs
@@ -199,12 +199,15 @@ where
                 .await
                 .map_err(PayloadBuilderError::other)?;
 
+            let v3 = force_op_payload_id_v3(payload_id);
+            let v4 = payload_id;
+
             // Wait for either an authorization which matches our payload id or for a negative authorization
             Result::<_, PayloadBuilderError>::Ok(
                 *authorization
                     .wait_for(|a| match a {
                         Some(auth) => {
-                            if auth.payload_id == payload_id {
+                            if auth.payload_id == v3 || auth.payload_id == v4 {
                                 true
                             } else {
                                 warn!(

--- a/crates/payload/src/generator.rs
+++ b/crates/payload/src/generator.rs
@@ -26,9 +26,11 @@ use tokio::runtime::Handle;
 use tracing::{debug, warn};
 use world_chain_p2p::protocol::handler::FlashblocksHandle;
 use world_chain_primitives::{
-    access_list::FlashblockAccessList, ed25519_dalek::SigningKey,
-    flashblocks::recovered_block_from_flashblocks, p2p::Authorization,
-    payload_id::force_op_payload_id_v3,
+    access_list::FlashblockAccessList,
+    ed25519_dalek::SigningKey,
+    flashblocks::recovered_block_from_flashblocks,
+    p2p::Authorization,
+    payload_id::{force_op_payload_id_v3, op_reth_payload_id_v4_lookup, payload_id_with_version},
 };
 
 use crate::job::{CommittedPayloadState, FlashblocksPayloadJob};
@@ -199,15 +201,14 @@ where
                 .await
                 .map_err(PayloadBuilderError::other)?;
 
-            let v3 = force_op_payload_id_v3(payload_id);
-            let v4 = payload_id;
-
             // Wait for either an authorization which matches our payload id or for a negative authorization
             Result::<_, PayloadBuilderError>::Ok(
                 *authorization
                     .wait_for(|a| match a {
                         Some(auth) => {
-                            if auth.payload_id == v3 || auth.payload_id == v4 {
+                            if auth.payload_id == payload_id_with_version(payload_id, 4)
+                                || auth.payload_id == payload_id_with_version(payload_id, 3)
+                            {
                                 true
                             } else {
                                 warn!(

--- a/crates/payload/src/generator.rs
+++ b/crates/payload/src/generator.rs
@@ -30,7 +30,7 @@ use world_chain_primitives::{
     ed25519_dalek::SigningKey,
     flashblocks::recovered_block_from_flashblocks,
     p2p::Authorization,
-    payload_id::{force_op_payload_id_v3, op_reth_payload_id_v4_lookup, payload_id_with_version},
+    payload_id::{force_op_payload_id_v3, payload_id_with_version},
 };
 
 use crate::job::{CommittedPayloadState, FlashblocksPayloadJob};

--- a/crates/primitives/src/payload_id.rs
+++ b/crates/primitives/src/payload_id.rs
@@ -20,7 +20,7 @@ pub fn op_reth_payload_id_v4_lookup(id: PayloadId) -> PayloadId {
     }
 }
 
-fn payload_id_with_version(id: PayloadId, version: u8) -> PayloadId {
+pub fn payload_id_with_version(id: PayloadId, version: u8) -> PayloadId {
     let mut bytes = payload_id_bytes(id);
     bytes[0] = version;
     PayloadId::new(bytes)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the payload-authorization gating logic for publishing, so mistakes could cause payload jobs to wait indefinitely or accept the wrong authorization. Scope is small and limited to ID comparison behavior.
> 
> **Overview**
> Improves payload authorization matching to handle OP Engine payload ID version differences by accepting authorizations whose `payload_id` matches either the original (v4) ID or the v3-forced ID.
> 
> This prevents valid authorizations from being ignored when different components derive payload IDs using different message versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d837a86b9bb4b8e18d2bdd6ac3ad6fc005df7d9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->