### PR TITLE
chore: bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13416,7 +13416,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain"
-version = "2.0.0"
+version = "2.2.0"
 dependencies = [
  "clap",
  "color-eyre",
@@ -13435,7 +13435,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-builder"
-version = "2.0.0"
+version = "2.2.0"
 dependencies = [
  "alloy-consensus 2.0.4",
  "alloy-eips 2.0.4",
@@ -13498,7 +13498,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-cli"
-version = "2.0.0"
+version = "2.2.0"
 dependencies = [
  "alloy-chains",
  "alloy-genesis",
@@ -13521,7 +13521,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-node"
-version = "2.0.0"
+version = "2.2.0"
 dependencies = [
  "alloy-consensus 2.0.4",
  "alloy-eips 2.0.4",
@@ -13572,7 +13572,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-p2p"
-version = "2.0.0"
+version = "2.2.0"
 dependencies = [
  "alloy-eips 2.0.4",
  "alloy-primitives",
@@ -13605,7 +13605,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-payload"
-version = "2.0.0"
+version = "2.2.0"
 dependencies = [
  "alloy-consensus 2.0.4",
  "alloy-eips 2.0.4",
@@ -13635,7 +13635,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-pbh"
-version = "2.0.0"
+version = "2.2.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -13652,7 +13652,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-pool"
-version = "2.0.0"
+version = "2.2.0"
 dependencies = [
  "alloy-consensus 2.0.4",
  "alloy-eips 2.0.4",
@@ -13688,7 +13688,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-primitives"
-version = "2.0.0"
+version = "2.2.0"
 dependencies = [
  "alloy-consensus 2.0.4",
  "alloy-eip7928",
@@ -13731,7 +13731,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-rpc"
-version = "2.0.0"
+version = "2.2.0"
 dependencies = [
  "alloy",
  "alloy-consensus 2.0.4",
@@ -13786,7 +13786,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-test-utils"
-version = "2.0.0"
+version = "2.2.0"
 dependencies = [
  "alloy-consensus 2.0.4",
  "alloy-contract",
@@ -13868,7 +13868,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-tests"
-version = "2.0.0"
+version = "2.2.0"
 dependencies = [
  "alloy-consensus 2.0.4",
  "alloy-eips 2.0.4",
@@ -13969,7 +13969,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "2.0.0"
+version = "2.2.0"
 dependencies = [
  "alloy-consensus 2.0.4",
  "alloy-contract",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "2.0.0"
+version = "2.2.0"
 edition = "2024"
 rust-version = "1.95.0"
 license = "MIT"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk version-only bump: updates workspace crate versions in `Cargo.toml` and synchronizes `Cargo.lock`, with no functional code changes.
> 
> **Overview**
> Bumps the workspace/package version from `2.0.0` to `2.2.0` in `Cargo.toml`.
> 
> Updates `Cargo.lock` accordingly, advancing all `world-chain*` workspace crates (including `xtask`) to `2.2.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9713fa406dd05b122d0c686cde913a5712eedfd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->