### PR TITLE
fix(ci): repair sync workflow and target World Chain mainnet

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -20,7 +20,7 @@ jobs:
   sync:
     if: github.repository == 'worldcoin/world-chain'
     name: sync (${{ matrix.chain.bin }})
-    runs-on: arc-public-8xlarge-amd64-runner
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     env:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -5,11 +5,8 @@ name: sync test
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * 1"
-  push:
-    tags:
-      - v*
-  pull_request:
+    - cron: "0 */6 * * *"
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -17,10 +14,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   sync:
+    if: github.repository == 'worldcoin/world-chain'
     name: sync (${{ matrix.chain.bin }})
-    runs-on: ubuntu-latest
+    runs-on: arc-public-8xlarge-amd64-runner
+    permissions:
+      contents: read
     env:
       RUST_LOG: info,sync=error
       RUST_BACKTRACE: 1
@@ -31,13 +33,14 @@ jobs:
           - build: install
             bin: world-chain
             features: jemalloc
-            chain: base
-            tip: "0xbb9b85352c7ebca6ba8efc63bd66cecd038c92ec8ebd02e153a3e0b197e672b7"
+            chain: worldchain
+            tip: "0x836c22335a115e76cb023f53de6fa7e17fc1c5bf3c207bae288084dba5343913"
             block: 10000
-            unwind-target: "0x118a6e922a8c6cab221fc5adfe5056d2b72d58c6580e9c5629de55299e2cf8de"
-        # TODO: Add World Chain Mainnet
+            unwind-target: "0x7aed50a2b92d45a1a24904eee202e283276ed486fb110cfbf3ad6e26a7ef5867"
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@just
       - uses: Swatinem/rust-cache@v2
@@ -47,12 +50,11 @@ jobs:
         run: just ${{ matrix.chain.build }} --features ${{ matrix.chain.features }}
       - name: Run sync
         run: |
-          ~/.cargo/bin/${{ matrix.chain.bin }} node \
+          ${{ matrix.chain.bin }} node \
             --chain ${{ matrix.chain.chain }} \
             --debug.tip ${{ matrix.chain.tip }} \
             --debug.max-block ${{ matrix.chain.block }} \
             --debug.terminate
-
       - name: Verify the target block hash
         run: |
           ${{ matrix.chain.bin }} db --chain ${{ matrix.chain.chain }} get static-file headers ${{ matrix.chain.block }} \

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -20,6 +20,8 @@ jobs:
   sync:
     if: github.repository == 'worldcoin/world-chain'
     name: sync (${{ matrix.chain.bin }})
+    # we use ubuntu-latest and not our self-hosted runners because with our runners the node is not
+    # able to reach external peers therefore it cannot sync at all and the job fails after 1 hour.
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
### Problem

The `sync test` workflow was a bit broken:

- It targeted Base mainnet instead of World Chain.
- It ran on every `pull_request` and on every `v*` tag push, making a full chain sync part of regular PR CI. Far too expensive.
- The `Run sync` step invoked the binary as `~/.cargo/bin/world-chain` while the verify and unwind steps used `world-chain` directly, so the steps disagreed about how the binary was on `PATH`.
- It was missing the hardening (scoped `permissions`, repo guard, `persist-credentials: false`) that Reth's reference workflow uses.

### Solution

- Switch the matrix to World Chain mainnet with tip `0x836c2233…5343913` (block 10000) and unwind target `0x7aed50a2…a7ef5867` (block 9800).
- Trigger only on `workflow_dispatch` and a 6-hour cron, so we still catch chain-breaking regressions quickly without running a sync per PR.
- Adopt Reth's hardening: top-level `permissions: {}`, job-level`permissions: contents: read`, `if: github.repository == 'worldcoin/world-chain'`, and `persist-credentials: false` on checkout.
- Drop the `~/.cargo/bin/` prefix so all `world-chain` invocations consistently rely on `PATH` after `just install`.

### Notes

This PR will make CI in every PR much more faster and more reliable. Most of the times the `sync test` CI job was not working at all, so it wasn't actually giving much information. With this change it can work:

- when manually triggered
- automatically every 6 hours so that we catch potential issues


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only workflow changes that adjust triggers and execution; main risk is reduced coverage (no PR/tag runs) or a misconfigured chain tip/hash causing scheduled sync failures.
> 
> **Overview**
> Updates the `sync test` GitHub Actions workflow to run only on manual dispatch and a 6-hour cron (removing PR and tag triggers) and to guard execution to `worldcoin/world-chain`.
> 
> Retargets the sync matrix from Base to **World Chain mainnet** (new `tip`/`unwind-target` hashes) and makes the job more secure/reliable by scoping `permissions`, disabling checkout credential persistence, running on `ubuntu-latest`, and invoking the built binary consistently via `PATH` (no `~/.cargo/bin` prefix).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dbfc23b9e1ebe4951be99e6833c61f112cb589f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->