### PR TITLE
fix: aggregate blob_gas_used across flashblocks on the final payload

### DIFF
--- a/crates/builder/src/bal_executor.rs
+++ b/crates/builder/src/bal_executor.rs
@@ -350,6 +350,10 @@ pub struct CommittedState<R: OpReceiptBuilder + Default = OpRethReceiptBuilder> 
     pub is_first: bool,
     /// The total gas used in previous committed transactions.
     pub gas_used: u64,
+    /// The total DA footprint in previous committed transactions.
+    ///
+    /// Post-Jovian this is stored in the block header's `blob_gas_used` field.
+    pub blob_gas_used: u64,
     /// The total fees accumulated in previous committed transactions.
     pub fees: U256,
     /// The bundle state accumulated so far from the State Transitions
@@ -399,6 +403,10 @@ where
                 .ok_or(BalExecutorError::MissingExecutedBlock)?;
 
             let gas_used = executed_block.recovered_block.gas_used();
+            let blob_gas_used = executed_block
+                .recovered_block
+                .blob_gas_used()
+                .unwrap_or_default();
 
             let bundle = value
                 .executed_block()
@@ -431,6 +439,7 @@ where
                 transactions,
                 receipts,
                 gas_used,
+                blob_gas_used,
                 fees,
                 bundle,
             })
@@ -440,6 +449,7 @@ where
                 transactions: vec![],
                 receipts: vec![],
                 gas_used: 0,
+                blob_gas_used: 0,
                 fees: U256::ZERO,
                 bundle: BundleState::default(),
             })

--- a/crates/builder/src/execution_strategy.rs
+++ b/crates/builder/src/execution_strategy.rs
@@ -147,6 +147,7 @@ impl<S: StateRootStrategy> ExecutionStrategy<OpEvmConfig, S> for FlashblocksBalE
             );
 
         executor.gas_used = committed_state.gas_used;
+        executor.da_footprint_used = committed_state.blob_gas_used;
         executor.receipts = committed_state.receipts_iter().cloned().collect();
 
         let (validator, access_list_receiver) = BalBlockValidator::new(
@@ -319,6 +320,7 @@ impl<S: StateRootStrategy> ExecutionStrategy<OpEvmConfig, S>
         );
 
         executor.gas_used = committed_state.gas_used;
+        executor.da_footprint_used = committed_state.blob_gas_used;
         executor.receipts = committed_state.receipts_iter().cloned().collect();
 
         let mut builder = FlashblocksBlockBuilder::<OpPrimitives, _>::new(

--- a/crates/builder/src/payload_builder.rs
+++ b/crates/builder/src/payload_builder.rs
@@ -687,6 +687,7 @@ where
         R::default(),
     );
     executor.gas_used = committed_state.gas_used;
+    executor.da_footprint_used = committed_state.blob_gas_used;
     executor.receipts = committed_state.receipts_iter().cloned().collect();
 
     let builder = BalBlockBuilder::new(
@@ -739,6 +740,7 @@ where
     );
 
     executor.gas_used = committed_state.gas_used;
+    executor.da_footprint_used = committed_state.blob_gas_used;
     executor.receipts = committed_state.receipts_iter().cloned().collect();
 
     let builder = FlashblocksBlockBuilder::new(

--- a/crates/builder/src/validator.rs
+++ b/crates/builder/src/validator.rs
@@ -198,6 +198,8 @@ pub struct ParallelExecutionResult {
     pub receipts: Vec<OpReceipt>,
     /// Gas consumed by this transaction
     pub gas_used: u64,
+    /// DA footprint consumed by this transaction, stored as blob gas post-Jovian.
+    pub blob_gas_used: u64,
     /// Fees earned from this transaction
     pub fees: u128,
     /// Access list entries from this transaction
@@ -461,6 +463,7 @@ where
         let execution_context = self.inner.ctx.clone();
         let evm_env = self.evm_env.clone();
         let gas_used = self.inner.executor.gas_used;
+        let blob_gas_used = self.inner.executor.da_footprint_used;
 
         let db_factory = self.temporal_db_factory.clone();
         let fallback_bundle_state = self.fallback_bundle_state.clone();
@@ -521,7 +524,7 @@ where
             txs_execution_started.elapsed(),
         );
 
-        let merged_result = merge_transaction_results(results, gas_used);
+        let merged_result = merge_transaction_results(results, gas_used, blob_gas_used);
         let database = self.inner.executor.evm_mut().db_mut();
 
         // merge the aggregated access list into the AsyncBalBuilderDb
@@ -533,6 +536,7 @@ where
             .receipts
             .extend_from_slice(&merged_result.receipts);
         self.inner.executor.gas_used = merged_result.gas_used;
+        self.inner.executor.da_footprint_used = merged_result.blob_gas_used;
 
         // append the _executed_ transactions into the executor
         self.inner.transactions.extend_from_slice(
@@ -556,14 +560,17 @@ where
 fn merge_transaction_results(
     results: Vec<ParallelExecutionResult>,
     initial_gas_used: u64,
+    initial_blob_gas_used: u64,
 ) -> ParallelExecutionResult {
     results.into_iter().fold(
         ParallelExecutionResult {
             gas_used: initial_gas_used,
+            blob_gas_used: initial_blob_gas_used,
             ..Default::default()
         },
         |mut acc, mut res| {
             acc.gas_used += res.gas_used;
+            acc.blob_gas_used += res.blob_gas_used;
             if let Some(mut receipt) = res.receipts.pop() {
                 receipt.as_receipt_mut().cumulative_gas_used = acc.gas_used;
                 acc.receipts.push(receipt);
@@ -639,6 +646,7 @@ where
     Ok(ParallelExecutionResult {
         receipts: result.receipts,
         gas_used: result.gas_used,
+        blob_gas_used: result.blob_gas_used,
         fees,
         access_list,
         index,

--- a/crates/test-utils/src/builder.rs
+++ b/crates/test-utils/src/builder.rs
@@ -600,6 +600,7 @@ where
             prev_outcome.as_ref().map(|(o, state)| CommittedState {
                 is_first: false,
                 gas_used: o.block.gas_used(),
+                blob_gas_used: o.block.blob_gas_used().unwrap_or_default(),
                 fees: U256::ZERO,
                 bundle: state.clone(),
                 receipts: o

--- a/e2e-tests/src/fuzz/proptest.rs
+++ b/e2e-tests/src/fuzz/proptest.rs
@@ -58,6 +58,7 @@ fn unwrap_committed_state(
         receipts: vec![],
         transactions: vec![],
         bundle: BundleState::default(),
+        blob_gas_used: 0
     })
 }
 

--- a/e2e-tests/src/fuzz/proptest.rs
+++ b/e2e-tests/src/fuzz/proptest.rs
@@ -58,7 +58,7 @@ fn unwrap_committed_state(
         receipts: vec![],
         transactions: vec![],
         bundle: BundleState::default(),
-        blob_gas_used: 0
+        blob_gas_used: 0,
     })
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches execution accounting for DA/blob gas across incremental flashblock builds, which can affect final block header fields and validation if mis-aggregated. Changes are localized but impact consensus-relevant block construction.
> 
> **Overview**
> Adds cumulative tracking of DA footprint (*blob gas*) across chained flashblocks.
> 
> `CommittedState` now carries `blob_gas_used` sourced from the prior payload’s header, executors are initialized with this value, and the parallel validator merge path now sums per-tx `blob_gas_used` and writes the aggregated total back into the executor so the final payload reflects total `blob_gas_used` across all flashblocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4cf37728272fa2ac0a439f4f6674539073ea1dd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->