### PR TITLE
wip: use only 1271 with programmable policies

### DIFF
--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -1,7 +1,7 @@
 ---
 wip: 1001
 title: World Chain Native Account Abstraction
-description: A smart contract managed account model with a single admin authority pinned at creation. Session keys compose a keyring that delegates transaction authorization for the account.
+description: A predeploy-managed account model whose admin and session authorization are verified through EIP-1271 smart contract signers.
 author: Kilian Glas (@kilianglas), 0xOsiris (@0xOsiris), Eric Woolsey (@0xforerunner)
 status: Draft
 type: Standards Track
@@ -12,42 +12,35 @@ requires: EIP-2, EIP-1559, EIP-196, EIP-197, EIP-198, EIP-2718, EIP-1271, RIP-72
 
 ## Abstract
 
-A *World Chain Account* is a smart contract managed account whose 20-byte address is deterministic and lifetime-stable. Each account has a single *admin authority* fixed at creation, which gates mutation of the account's keyring -- the set of session keys authorized to sign on its behalf. We extend [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) with a typed transaction envelope (`0x1D`) signed by any authorized session key in a World Chain Account's keyring.
+A *World Chain Account* is a predeploy-managed account whose 20-byte address is deterministic and lifetime-stable. Each account has one admin signer fixed at creation and an active **keyring** of session signers authorized to sign transactions on the account's behalf. Both admin authorization and session-key transaction authorization are verified exclusively through [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) smart contract signers.
 
-This WIP deliberately minimizes the diff from Ethereum's existing signature model. The protocol recognizes only two session-key verification modes:
+This WIP extends [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) with a typed transaction envelope (`0x1D`) whose signature payload is passed to an authorized session signer's `isValidSignature(bytes32,bytes)` implementation under a restricted, metered validation frame. The protocol does not natively dispatch over secp256k1, P256, WebAuthn, EdDSA, BLS, World ID, or any other signature scheme. Those schemes are implemented by EIP-1271 signer contracts using reusable EVM precompiles.
 
-- **Secp256k1 EOA key.** The `0x1D` transaction carries an Ethereum-style secp256k1 ECDSA signature. Validation recovers an address from the transaction signing hash and requires that address to be authorized in the account keyring.
-- **EIP-1271 contract key.** The `0x1D` transaction names a contract key. Validation invokes `isValidSignature(bytes32,bytes)` under a restricted, metered validation frame and requires the EIP-1271 magic value.
+Session signers also define programmable execution policy. The protocol does not store or interpret that policy. After signature verification and tentative transaction execution, the protocol supplies the resulting execution trace to the same session verifier contract. The verifier evaluates its internal policy as `f(transactionContext, executionTrace) -> bool`; if it returns false or fails, the transaction reverts.
 
-Non-ECDSA signature algorithms, including P256, WebAuthn, EdDSA, BLS, and pairing-based proof systems, are not native session-key types in this WIP. They are implemented by EIP-1271 key contracts using elliptic-curve and pairing precompiles exposed by the VM. The same precompiles are callable by ordinary smart contracts and by protocol/system validation, avoiding private host-only cryptography.
+Account state and keyring management live in the `WORLD_CHAIN_ACCOUNT_MANAGER` predeploy. The manager exposes default signer factories for common strategies, including a World ID signer that verifies World ID proofs encoded in EIP-1271 signature bytes, and a secp256k1 signer that wraps EOA-style signatures. These default signers are reference implementations, not privileged protocol paths.
 
-This WIP specifies three admin authority instantiations:
-
-- **WorldID admin.** Creation gated by a [World ID 4.0](https://github.com/worldcoin/world-id-protocol) Uniqueness Proof; subsequent keyring mutations gated by Session Proofs against a stored `sessionId`. Recovery from lost or compromised session keys is the degenerate case of the same upgrade path. A single WorldID `MAY` manage any number of WorldID-admin accounts indexed by a user-chosen `worldIDAccountNonce`; accounts owned by the same WorldID are unlinkable across distinct values.
-- **Secp256k1 EOA admin.** Creation and keyring mutations gated by Ethereum-style ECDSA signatures over a uniform `signalHash` from a single admin address fixed at creation. Admin-key loss is terminal.
-- **EIP-1271 contract admin.** Creation and keyring mutations gated by `isValidSignature(bytes32,bytes)` on a single contract signer fixed at creation and evaluated under the restricted validation frame. Recovery, if any, is delegated to the signer contract's own policy.
-
-Account state lives natively in the `WORLD_CHAIN_ACCOUNT_PRECOMPILE`. The account address is a public identifier for an admin-authority-managed set of session keys, not an identity anchor; per-instantiation rules govern how many accounts a given admin authority may own.
+Keyring updates are timelocked. An admin-authorized update first queues a full replacement keyring, and that keyring can only become active after a protocol-defined delay longer than the public transaction-pool expiration window. Default signer factories MUST apply the same delay discipline to signer authorization state so that EIP-1271 verification cannot fail between public transaction-pool validation and inclusion due to keyring or signer-state mutation.
 
 ## Motivation
 
-### Minimal Ethereum Diff
+### One Signature Abstraction
 
-Ethereum already has one native transaction-signature algorithm and one standard contract-signature interface. WIP-1001 follows that split: native secp256k1 address recovery for EOA-like signers, and [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) for contract signers.
+Ethereum already standardizes contract-based signature validation through EIP-1271. WIP-1001 makes EIP-1271 the only native authorization abstraction for World Chain Accounts. This keeps the transaction envelope small and scheme-agnostic while allowing wallets, applications, and future protocol features to introduce new signing policies without changing the transaction type.
 
-This keeps the `0x1D` transaction model close to existing Ethereum validation while still admitting modern authenticators and application-defined signing policies. A passkey, threshold signer, BLS aggregate signer, or Groth16-backed signer is a contract that returns the EIP-1271 magic value after calling public precompiles.
+An EOA wrapper, a passkey signer, a World ID proof verifier, a threshold signer, an EdDSA signer, or a BLS aggregate signer is simply a contract that returns the EIP-1271 magic value for a given hash and opaque signature bytes. The same signer can also own the session policy for what that session key may do.
 
 ### Reusable Cryptography
 
-Cryptographic accelerators used for account validation should not be protocol-private. If the protocol accepts an elliptic-curve or bilinear pairing during EIP-1271 validation, the same primitive MUST be exposed as a normal EVM precompile callable by smart contracts. This lets signer contracts, application contracts, and protocol validation share one compatibility surface.
+Cryptographic accelerators used for account validation should not be host-private. If WIP-1001 signers depend on an elliptic-curve, hash, pairing, EdDSA, or BLS primitive, the primitive MUST be exposed as a normal EVM precompile with the same behavior for contracts and protocol validation. This makes signer contracts the compatibility layer over public VM functionality.
 
-### Pluggable Admin Authorities
+### Programmable Keyrings
 
-TODO: FIXME: Rewrite with new Admin Key Model
+The keyring should be an elegant authorization registry, not a catalogue of native signature algorithms or call-scope rules. A World Chain Account stores signer contracts. The signer contract owns the verification strategy, recovery strategy, quorum rules, proof format, authenticator-specific state, and programmable execution policy. This gives the protocol one validation path while preserving a programmable account surface.
 
-A pluggable admin model lets a single account abstraction serve multiple user populations from one precompile. **WorldID admin** converges key rotation and recovery onto a single proof-verification path after enrollment: a fresh Session Proof. No "super key" is ever stored on-device; recovery is the degenerate case of the same upgrade path. **Secp256k1 EOA admin** lets accounts be owned by existing Ethereum keys. **EIP-1271 contract admin** lets accounts be controlled by multisigs, passkeys, policy engines, or custom recovery contracts without adding new native admin algorithms to this WIP.
+### Pool-Stable Validation
 
-Sharing a single keyring + transaction surface (`0x1D`, session keys, signal binding) across instantiations means session-key UX and integration surface are uniform regardless of admin type. A new non-ECDSA admin scheme reduces to an EIP-1271 contract plus, if needed, a reusable VM precompile.
+Public transaction pools validate transactions before inclusion. If a keyring or signer can invalidate a signature immediately after validation, a transaction can be accepted by the pool and then fail during block construction. WIP-1001 therefore requires keyring replacements and default signer authorization-state changes to be delayed by more than the public pool expiration window. A transaction that is pool-valid against the active keyring and a compliant default signer remains valid until it either expires from the pool or is included, assuming no other transaction fields become invalid.
 
 ## Specification
 
@@ -55,278 +48,346 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Constants
 
-| Name                              | Value                                        | Description                                                  |
-| --------------------------------- | -------------------------------------------- | ------------------------------------------------------------ |
-| `WORLD_TX_TYPE`                   | `0x1D`                                       | [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) tx type  |
-| `WORLD_CHAIN_ACCOUNT_PRECOMPILE`  | `0x000000000000000000000000000000000000001D` | Stateful precompile managing the World Chain Account registry |
-| `MAX_SESSION_KEYS`                | `20`                                         | Maximum authorized session keys per account                  |
-| `ADMIN_TYPE_WORLD_ID`             | `0x00`                                       | Admin type discriminator: WorldID admin                      |
-| `ADMIN_TYPE_SECP256K1_EOA`        | `0x01`                                       | Admin type discriminator: secp256k1 EOA admin                |
-| `ADMIN_TYPE_EIP1271`              | `0x02`                                       | Admin type discriminator: EIP-1271 contract admin            |
-| `KEY_TYPE_SECP256K1_EOA`          | `0x00`                                       | Session key type: Ethereum secp256k1 address                 |
-| `KEY_TYPE_EIP1271`                | `0x01`                                       | Session key type: EIP-1271 contract address                  |
-| `EIP1271_MAGIC_VALUE`             | `0x1626ba7e`                                 | `bytes4(keccak256("isValidSignature(bytes32,bytes)"))`       |
-| `MAX_EIP1271_VALIDATION_GAS`      | `TBD`                                        | Maximum gas for one protocol EIP-1271 validation frame        |
+| Name | Value | Description |
+| ---- | ----- | ----------- |
+| `WORLD_TX_TYPE` | `0x1D` | EIP-2718 transaction type |
+| `WORLD_CHAIN_ACCOUNT_MANAGER` | `TBD` | World Chain Account Manager predeploy address |
+| `MAX_SESSION_SIGNERS` | `20` | Maximum active session signers per account |
+| `EIP1271_MAGIC_VALUE` | `0x1626ba7e` | `bytes4(keccak256("isValidSignature(bytes32,bytes)"))` |
+| `EIP1271_VALIDATION_GAS_LIMIT` | `TBD` | Fixed gas supplied to every protocol EIP-1271 validation frame |
+| `EXECUTION_TRACE_VALIDATION_GAS_LIMIT` | `TBD` | Fixed gas supplied to every protocol execution-trace policy validation frame |
+| `MAX_EXECUTION_TRACE_BYTES` | `TBD` | Maximum ABI-encoded execution trace size supplied to a verifier |
+| `TXPOOL_TRANSACTION_EXPIRATION_WINDOW` | `TBD` | Maximum public transaction-pool lifetime for a `0x1D` transaction |
+| `MIN_KEYRING_UPDATE_DELAY` | `> TXPOOL_TRANSACTION_EXPIRATION_WINDOW` | Minimum delay before a queued keyring can activate |
+| `WORLD_ID_1271_SIGNER_FACTORY` | `TBD` | Default World ID EIP-1271 signer factory |
+| `SECP256K1_1271_SIGNER_FACTORY` | `TBD` | Default secp256k1 EIP-1271 signer factory |
+| `WORLD_CHAIN_RP_ID` | `480` | World Chain's registered World ID relying-party ID |
+| `WORLD_ID_ACCOUNT_TAG` | `"WORLD_ID_ACCOUNT"` | Domain tag for World ID account/signer creation actions |
 
-Per-instantiation constants are defined in their respective sections.
+`EIP1271_VALIDATION_GAS_LIMIT`, `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`, and `MAX_EXECUTION_TRACE_BYTES` are protocol constants. They are not selected by the transaction, account, signer, keyring entry, admin authorization, or factory.
+
+`MIN_KEYRING_UPDATE_DELAY` MUST be strictly greater than the maximum configured public transaction-pool expiration window for `0x1D` transactions. If a client or network changes the public pool expiration window, this constant MUST remain larger than the new window before WIP-1001 public-pool admission is enabled under that configuration.
 
 ### Reusable Crypto Precompiles
 
-Any cryptographic primitive used by WIP-1001 protocol validation MUST be available through an EVM precompile with the same behavior for smart contracts and protocol/system callers. Implementations MUST NOT validate WIP-1001 EIP-1271 signers with private host functions that are unavailable to contracts.
+Any accelerated cryptographic primitive used by protocol-valid EIP-1271 signers MUST be available through an EVM precompile with the same behavior for smart contracts and protocol/system callers. Implementations MUST NOT validate WIP-1001 signers with private host functions unavailable to contracts.
 
-The validation precompile allowlist initially contains:
+The restricted validation-frame precompile allowlist initially contains:
 
-| Name              | Address                                      | Purpose                                      |
-| ----------------- | -------------------------------------------- | -------------------------------------------- |
-| `ECRECOVER`       | `0x0000000000000000000000000000000000000001` | Ethereum secp256k1 recovery                  |
-| `SHA256`          | `0x0000000000000000000000000000000000000002` | WebAuthn and other hash-based verification   |
-| `MODEXP`          | `0x0000000000000000000000000000000000000005` | Modular exponentiation ([EIP-198](https://eips.ethereum.org/EIPS/eip-198)) |
-| `BN254_ADD`       | `0x0000000000000000000000000000000000000006` | BN254 G1 addition ([EIP-196](https://eips.ethereum.org/EIPS/eip-196)) |
-| `BN254_MUL`       | `0x0000000000000000000000000000000000000007` | BN254 G1 scalar multiplication ([EIP-196](https://eips.ethereum.org/EIPS/eip-196)) |
-| `BN254_PAIRING`   | `0x0000000000000000000000000000000000000008` | BN254 pairing check ([EIP-197](https://eips.ethereum.org/EIPS/eip-197)) |
-| `P256VERIFY`      | `0x0000000000000000000000000000000000000100` | P256/secp256r1 verification ([RIP-7212](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md)) |
-| `EDDSA_VERIFY`    | `TBD`                                        | EdDSA signature verification; specified by a separate WIP |
+| Name | Address | Purpose |
+| ---- | ------- | ------- |
+| `ECRECOVER` | `0x0000000000000000000000000000000000000001` | Ethereum secp256k1 recovery |
+| `SHA256` | `0x0000000000000000000000000000000000000002` | WebAuthn and other hash-based verification |
+| `MODEXP` | `0x0000000000000000000000000000000000000005` | Modular exponentiation ([EIP-198](https://eips.ethereum.org/EIPS/eip-198)) |
+| `BN254_ADD` | `0x0000000000000000000000000000000000000006` | BN254 G1 addition ([EIP-196](https://eips.ethereum.org/EIPS/eip-196)) |
+| `BN254_MUL` | `0x0000000000000000000000000000000000000007` | BN254 G1 scalar multiplication ([EIP-196](https://eips.ethereum.org/EIPS/eip-196)) |
+| `BN254_PAIRING` | `0x0000000000000000000000000000000000000008` | BN254 pairing check ([EIP-197](https://eips.ethereum.org/EIPS/eip-197)) |
+| `P256VERIFY` | `0x0000000000000000000000000000000000000100` | P256/secp256r1 verification ([RIP-7212](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md)) |
+| `EDDSA_VERIFY` | `TBD` | EdDSA signature verification; specified by a separate WIP |
+| `BLS12_381_VERIFY` | `TBD` | BLS12-381 verification or pairing suite; specified by a separate WIP |
 
-The concrete address, supported curve(s), input/output encoding, malleability rules, failure behavior, and gas schedule for `EDDSA_VERIFY` are out of scope for WIP-1001 and MUST be specified by a separate WIP before activation.
-
-Future curve or pairing systems MAY be added by extending this allowlist in a follow-on fork. EIP-1271 signer contracts that need a non-allowlisted primitive are invalid for WIP-1001 protocol validation until that primitive is exposed as an allowed precompile.
+The concrete address, supported curve(s), input/output encoding, malleability rules, failure behavior, and gas schedule for `EDDSA_VERIFY` and `BLS12_381_VERIFY` are out of scope for this WIP and MUST be specified before activation. Future curve, pairing, or proof-system precompiles MAY be added by a follow-on fork.
 
 ### Abstract Account Model
 
-An *account* is created by an admin-authorized `Create` operation that fixes an *admin type* `T` and an *admin authority* `A` of type `T`. After creation, `T` and `A` are immutable for the lifetime of the account. The keyring is mutated by admin-authorized full-keyring replacement operations: `SetKeyring`. All admin authorizations bind the operation to a uniform `signalHash` defined below; replay protection across operations is provided by a per-account monotonic `adminNonce`.
+An account is created by an EIP-1271-admin-authorized `create` operation. Creation fixes:
+
+- `adminSigner`, the EIP-1271 contract that authorizes future keyring updates;
+- `accountSalt`, the admin-selected salt used for deterministic address derivation;
+- the initial active keyring of session signers.
+
+After creation, `adminSigner` and `accountSalt` are immutable for the lifetime of the account. Keyring mutation is performed by queueing a full replacement keyring, then activating it after the timelock delay has elapsed.
 
 #### Account State
 
-Per-account state stored in the precompile:
+Per-account state stored by the `WORLD_CHAIN_ACCOUNT_MANAGER` predeploy:
 
 ```solidity
 struct Account {
-    uint8       adminType;             // ADMIN_TYPE_*
-    bytes       verificationPublicId;  // variable length per admin type
-    SessionKey[] sessionKeys;          // see Session Keys
-    bytes32     keyringHash;           // keccak256(abi.encode(sessionKeys))
-    uint64      adminNonce;            // monotonic; replay protection
+    address         adminSigner;
+    bytes32         accountSalt;
+    SessionSigner[] activeSessionSigners;
+    bytes32         activeKeyringHash;
+    PendingKeyringUpdate pendingKeyringUpdate;
+    uint64          adminNonce;
+}
+
+struct PendingKeyringUpdate {
+    bool            exists;
+    bytes32         expectedCurrentKeyringHash;
+    SessionSigner[] targetSessionSigners;
+    bytes32         targetKeyringHash;
+    uint64          activateAfter;
+    uint64          queuedAtNonce;
 }
 ```
 
-`verificationPublicId` is the persistent public material the admin authority uses to verify subsequent updates. Its encoding is per-instantiation (e.g., `sessionId` for WorldID admin, an admin address for Secp256k1 EOA admin, or `(contract, gasLimit)` for EIP-1271 admin). It is set at creation and is not directly mutable by this WIP -- see [Extensions](#extensions) for admin rotation.
+`adminNonce` is initialized to `0` at creation and incremented by `1` whenever a keyring update is successfully queued. `activateKeyringUpdate` does not require a new admin authorization and does not increment `adminNonce`.
 
-#### Session Keys
+#### Session Signers
 
 ```solidity
-enum KeyType {
-    Secp256k1EOA,  // 0x00
-    EIP1271        // 0x01
-}
-
-struct SessionKey {
-    KeyType keyType;
-    address key;
-    uint32  validationGasLimit;
-    SessionPolicy policy;
-}
-
-struct SessionPolicy {
-    uint64      validAfter;
-    uint64      validUntil;
-    uint256     maxValuePerTx;
-    CallScope[] callScopes;
-}
-
-struct CallScope {
-    address target;
-    bytes4  selector;
+struct SessionSigner {
+    address signer;
 }
 ```
 
-| `keyType`          | Value  | `key` meaning                                     | `validationGasLimit`                         |
-| ------------------ | ------ | ------------------------------------------------- | -------------------------------------------- |
-| `Secp256k1EOA`     | `0x00` | Ethereum address recovered from secp256k1 ECDSA   | MUST be `0`                                  |
-| `EIP1271`          | `0x01` | Contract implementing `isValidSignature(bytes32,bytes)` | MUST be `> 0` and `<= MAX_EIP1271_VALIDATION_GAS` |
+`signer` MUST NOT be the zero address and MUST have non-empty code when it is added to a keyring. The signer MUST implement `IERC1271.isValidSignature(bytes32,bytes)` and `IWorldChainSessionVerifier.isValidExecutionTrace(WorldChainTransactionContext,WorldChainExecutionTrace)`.
 
-`key` MUST NOT be the zero address. For `EIP1271`, `key` MUST have non-empty code at the time it is added to a keyring or fixed as an admin authority.
+There is no `validationGasLimit` field. Every protocol EIP-1271 validation uses `EIP1271_VALIDATION_GAS_LIMIT`.
 
-Keyring uniqueness is defined by `(keyType, key)`. A keyring MUST NOT contain two entries with the same `(keyType, key)`, even if their `validationGasLimit` or policy values differ. Changing an EIP-1271 session key's gas limit or a session key's policy requires replacing the full keyring with `SetKeyring`.
+Keyring uniqueness is defined by `signer`. A keyring MUST NOT contain two entries with the same signer address. Changing the authorized signer set requires queueing a full replacement keyring.
 
-Session policies provide the basic scoped-key surface in this WIP:
+A keyring MUST contain at least one session signer and MUST NOT contain more than `MAX_SESSION_SIGNERS`.
 
-- `validAfter` and `validUntil` define the key's validity window in Unix seconds. `validUntil == 0` means no upper bound. If `validUntil != 0`, implementations MUST require `validAfter <= validUntil`.
-- `maxValuePerTx` is the maximum native-token `value` the key may authorize in one `0x1D` transaction. `type(uint256).max` means no value limit.
-- `callScopes` is an allowlist over `(to, selector)`. If empty, no target/selector restriction is applied. `target == address(0)` matches any target. `selector == 0x00000000` matches any selector; otherwise it is matched against the first four bytes of transaction calldata, with empty calldata treated as selector `0x00000000`.
+Session signers carry no intrinsic privileges beyond signing `0x1D` transactions whose execution traces are accepted by their verifier policy.
 
-A `0x1D` transaction satisfies a `SessionPolicy` iff the current block timestamp is within the validity window, `value <= maxValuePerTx`, and either `callScopes` is empty or at least one `CallScope` matches the transaction.
+#### Session Verifier Execution Policy Interface
 
-Session keys carry no intrinsic privileges beyond signing `0x1D` transactions that satisfy their stored policy.
+Session signers MUST implement:
 
-#### Admin Authority Interface
+```solidity
+interface IWorldChainSessionVerifier is IERC1271 {
+    struct AccessListEntry {
+        address account;
+        bytes32[] storageKeys;
+    }
 
-The abstract operation each admin authority provides is:
+    struct WorldChainTransactionContext {
+        bytes32 signingHash;
+        uint256 chainId;
+        address account;
+        address signer;
+        uint64  nonce;
+        uint256 maxPriorityFeePerGas;
+        uint256 maxFeePerGas;
+        uint64  gasLimit;
+        bool    isCreate;
+        address target;
+        uint256 value;
+        bytes   data;
+        bytes4  selector;
+        AccessListEntry[] accessList;
+        bytes32 activeKeyringHash;
+    }
 
-```text
-verifyAdmin(signalHash, authorization, verificationPublicId) -> bool
+    enum TraceCallKind {
+        Call,
+        StaticCall,
+        DelegateCall,
+        Create,
+        Create2
+    }
+
+    struct CallTrace {
+        uint32        depth;
+        TraceCallKind kind;
+        address       caller;
+        address       target;
+        uint256       value;
+        bytes4        selector;
+        bytes32       inputHash;
+        bytes32       outputHash;
+        bool          success;
+        uint64        gasUsed;
+    }
+
+    struct LogTrace {
+        address   emitter;
+        bytes32[] topics;
+        bytes32   dataHash;
+    }
+
+    struct WorldChainExecutionTrace {
+        bool        success;
+        uint64      gasUsed;
+        bytes32     outputHash;
+        CallTrace[] calls;
+        LogTrace[]  logs;
+    }
+
+    function isValidExecutionTrace(
+        WorldChainTransactionContext calldata context,
+        WorldChainExecutionTrace calldata trace
+    ) external view returns (bool allowed);
+}
 ```
 
-`authorization` and `verificationPublicId` are byte strings whose encoding is per-instantiation. The precompile invokes this operation during `update`. Each instantiation specifies how the operation is realized -- see [Admin Instantiations](#admin-instantiations).
+The protocol constructs `WorldChainTransactionContext` from the `0x1D` transaction after computing `signingHash` and loading the active keyring entry:
 
-Admin authorization at creation is also instantiation-specific. Each instantiation defines an `adminCreationContext`: the canonical ABI tuple of creation fields that fix the admin authority, the address-defining material, and any persistent verification state. The first element of this tuple MUST be the `uint8 adminType` discriminator. Authorization payloads, signatures, and proofs are excluded from this context to avoid recursive hashing. `CreateSignal` binds `adminType` and `adminCreationContextHash = keccak256(adminCreationContext)` so the creation authorization cannot be replayed with different permanent admin state.
+- `signingHash` is the canonical `0x1D` signing hash.
+- `chainId`, `nonce`, fee fields, `gasLimit`, `value`, `data`, and `accessList` are copied from the transaction.
+- `account` is the World Chain Account sender.
+- `signer` is the declared session signer.
+- For a call transaction, `isCreate == false` and `target == to`.
+- For a contract-creation transaction, `isCreate == true`, `target == address(0)`, and `data` is init code.
+- `selector` is the first four bytes of `data`; if `data.length < 4`, `selector == 0x00000000`.
+- `activeKeyringHash` is the account's active keyring hash at validation time.
 
-Some instantiations take address-defining material directly as a creation input that coincides with `verificationPublicId`; others retain a different persistent verifier identifier. For WorldID admin, the creation nullifier defines the address while `sessionId` is stored as `verificationPublicId`. For EIP-1271 admin, the signer contract defines the address while `(signer, validationGasLimit)` is stored as `verificationPublicId`.
+The protocol constructs `WorldChainExecutionTrace` from the tentative execution of the `0x1D` payload:
+
+- `success` is the success status of the root transaction payload execution.
+- `gasUsed` is the gas consumed by the root transaction payload execution before trace validation.
+- `outputHash` is `keccak256(returnData)` for the root transaction payload execution.
+- `calls` is the ordered, depth-annotated call/create trace emitted by the root execution. The root call itself is excluded because it is already represented by `WorldChainTransactionContext`.
+- `logs` is the ordered log summary emitted by the root execution.
+
+Full internal calldata, return data, and log data are not copied into the trace by default; their hashes are supplied to keep trace validation bounded. A verifier that needs to authorize exact internal calldata SHOULD require the caller to include the relevant commitments in the session signature or in root transaction calldata. The ABI-encoded trace supplied to the verifier MUST NOT exceed `MAX_EXECUTION_TRACE_BYTES`.
+
+No block-context fields other than `chainId` are supplied. If a verifier policy depends on time, block number, or other context, it MUST bind that data through its own signature/proof payload rather than reading block opcodes during trace validation.
+
+The execution-trace policy check is evaluated after tentative execution and before state commit, under the same call-target and opcode restrictions as EIP-1271 signature validation, with gas exactly `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`. If the call reverts, runs out of gas, executes a forbidden opcode, calls a forbidden address, returns malformed data, or returns `false`, the transaction-level authorization fails and the tentative payload execution is reverted.
+
+The policy function is intentionally `f(transactionContext, executionTrace) -> bool`: the protocol supplies what happened, while the verifier defines whether that execution is allowed. Examples include target/selector allowlists, method-argument commitments, value-flow limits, internal-call restrictions, log emission requirements, proof-bound permissions, per-session spending state, or app-specific invariants over the call trace.
 
 #### Address Derivation
 
 ```text
-addr = bytes20(keccak256(abi.encodePacked(adminTypeTag, addressDefiningMaterial)))
+account = bytes20(keccak256(abi.encodePacked(
+    bytes32("WORLD_CHAIN_ACCOUNT"),
+    block.chainid,
+    WORLD_CHAIN_ACCOUNT_MANAGER,
+    adminSigner,
+    accountSalt
+)))
 ```
 
-`adminTypeTag` is the one-byte `ADMIN_TYPE_*` discriminator. `addressDefiningMaterial` is per-instantiation:
+The address is fixed for the lifetime of the account. Keyring updates, signer state changes, and admin-signer internal recovery do not change the account address.
 
-- WorldID admin: the creation Uniqueness Proof's nullifier (32 bytes).
-- Secp256k1 EOA admin: the 20-byte admin address (= `verificationPublicId`).
-- EIP-1271 contract admin: the 20-byte signer contract address.
+The default World ID signer factory SHOULD derive different signer addresses for different World ID account nonces. A World ID holder who wants unlinkability across accounts SHOULD use distinct World ID signer instances and distinct `accountSalt` values.
 
-The address is fixed for the lifetime of the account; session-key rotation does **NOT** change the address.
-
-#### Signal Semantics
-
-```solidity
-enum UpdateMode {
-    Create,        // 0x00
-    SetKeyring     // 0x01
-}
-
-struct KeyringUpdate {
-    UpdateMode   mode;
-    bytes32      expectedCurrentKeyringHash;
-    SessionKey[] keys;
-}
-```
-
-- **`Create`** -- installs `keys` as the full keyring at the account's address and initializes the account with the supplied admin authority. MUST revert if the account already exists, if `expectedCurrentKeyringHash != 0x00..00`, if `keys.length == 0`, or if `keys.length > MAX_SESSION_KEYS`.
-- **`SetKeyring`** -- proposes replacing the existing keyring with exactly `keys`. MUST revert if the account does not exist, if `expectedCurrentKeyringHash != account.keyringHash`, if `keys.length == 0`, or if `keys.length > MAX_SESSION_KEYS`.
-
-For all modes, every `SessionKey` MUST satisfy the validation rules in [Session Keys](#session-keys). An implementation SHOULD validate key shape, gas limits, zero addresses, duplicate entries, and EIP-1271 code existence before performing expensive admin authorization.
+#### Keyring Hash
 
 The canonical keyring hash is:
 
 ```text
-keyringHash = keccak256(abi.encode(keys))
+keyringHash = keccak256(abi.encode(sessionSigners))
 ```
 
-where `keys` is the full ABI-encoded `SessionKey[]` in its stored order. The order is admin-selected and consensus-significant; clients SHOULD sort keys lexicographically by `(keyType, key)` before submitting updates to avoid accidental duplicate representations.
+where `sessionSigners` is the full ABI-encoded `SessionSigner[]` in its stored order. The order is admin-selected and consensus-significant. Clients SHOULD sort signers lexicographically by `signer` before submitting updates to avoid accidental duplicate representations.
 
-The `signalHash` an admin authority binds to is uniform across instantiations.
+#### Signal Semantics
 
-```solidity
-struct CreateSignal {
-    bytes32       tag;             // == keccak256("WORLD_CHAIN_ACCOUNT_CREATE")
-    uint8         adminType;
-    bytes32       adminCreationContextHash;
-    address       msgSender;
-    KeyringUpdate keyringUpdate;
-}
-
-struct UpdateSignal {
-    bytes32       tag;             // == keccak256("WORLD_CHAIN_ACCOUNT_UPDATE")
-    address       accountAddress;
-    uint64        adminNonce;
-    address       msgSender;
-    KeyringUpdate keyringUpdate;
-}
-```
+Admin authorizations bind to a uniform `signalHash`. The hash supplied to an admin signer is always the 248-bit truncated keccak value:
 
 ```text
 signalHash = bytes32(uint256(keccak256(abi.encode(signal))) >> 8)
 ```
 
-where `signal` is a populated `CreateSignal` for `Create` and an `UpdateSignal` for `SetKeyring`. The resulting value is encoded as a `bytes32` with its high 8 bits set to zero.
-
-`msgSender` is the EVM `msg.sender` of the precompile call -- binding it prevents an in-flight admin authorization observed in the mempool from being replayed by a different submitter. For `Create`, `accountAddress` is omitted because it is not knowable to the admin authority at the time the authorization is produced (it is derived from `Create`'s outputs); the domain tag, `adminType`, `adminCreationContextHash`, `msgSender`, and the keyring payload bind the authorization to its intended creation. For updates, `accountAddress` distinguishes admin authorizations across accounts the same admin might control on different domains.
-
-The `>> 8` truncation reduces the digest to 248 bits so it fits within the BN254 scalar field (matching the WorldID 4.0 proof system's signal field width). Truncation is uniform across instantiations even when the verification primitive does not require the BN254 fit, so the same `signalHash` value is canonical across all admin types.
-
-#### Replay Protection
-
-The precompile stores a per-account monotonic `adminNonce`, initialized to `0` at creation and incremented by `1` on every successful `SetKeyring` update. Admin authorizations for updates are verified against `signalHash` containing the current value of `adminNonce`; an admin authorization that was valid for `adminNonce = n` is no longer valid once the precompile has incremented past `n`.
-
-For `Create`, replay is precluded by account-existence: the precompile MUST revert if the account address is already occupied. A creation authorization can only be applied once because the post-condition (account exists at `addr`) blocks any subsequent attempt at the same address.
-
-This is the abstract replay-protection contract; each instantiation realizes it via its own verification primitive. Instantiations MUST NOT introduce additional bespoke replay machinery -- `adminNonce` + account-existence is sufficient and uniform.
-
-#### Precompile Interface
+The truncation keeps the value within the BN254 scalar field for World ID proof-backed EIP-1271 signers. It is uniform for all admin signers so that the signed value is independent of the signer implementation.
 
 ```solidity
-interface IWorldChainAccount {
-    /// @notice Create an account. `adminCreationData` layout is admin-type-specific.
-    function create(
-        uint8 adminType,
-        bytes calldata adminCreationData,
-        KeyringUpdate calldata keyringUpdate          // mode == Create
-    ) external returns (address account);
+struct CreateSignal {
+    bytes32         tag;               // keccak256("WORLD_CHAIN_ACCOUNT_CREATE")
+    address         adminSigner;
+    bytes32         accountSalt;
+    address         msgSender;
+    SessionSigner[] initialSessionSigners;
+}
 
-    /// @notice Authorize and apply a SetKeyring update.
-    /// `adminAuthorization` layout is admin-type-specific.
-    function update(
-        address account,
-        KeyringUpdate calldata keyringUpdate,         // mode == SetKeyring
-        bytes calldata adminAuthorization
-    ) external;
-
-    // Reads
-    function getAdminType(address account) external view returns (uint8);
-    function getVerificationPublicId(address account) external view returns (bytes memory);
-    function getAdminNonce(address account) external view returns (uint64);
-    function getSessionKeys(address account) external view returns (SessionKey[] memory);
-    function isAuthorized(address account, uint8 keyType, address key) external view returns (bool);
-    function getAuthorizedKey(address account, uint8 keyType, address key)
-        external
-        view
-        returns (SessionKey memory);
+struct QueueKeyringUpdateSignal {
+    bytes32         tag;               // keccak256("WORLD_CHAIN_ACCOUNT_QUEUE_KEYRING_UPDATE")
+    address         account;
+    address         adminSigner;
+    uint64          adminNonce;
+    address         msgSender;
+    bytes32         expectedCurrentKeyringHash;
+    SessionSigner[] targetSessionSigners;
+    bytes32         targetKeyringHash;
+    uint64          activateAfter;
 }
 ```
 
-`adminCreationData` and `adminAuthorization` are opaque bytes blobs; each admin instantiation specifies the ABI-encoded tuple they decode to.
+`msgSender` is the EVM `msg.sender` of the manager call. Binding it prevents an in-flight admin authorization observed in the mempool from being replayed by a different submitter. A public factory, relayer, or forwarding contract that calls the manager for multiple users MUST enforce its own caller/request binding before forwarding; otherwise those users share the same `msg.sender` for WIP-1001 authorization purposes.
 
-For `create`, the precompile MUST:
+#### Replay Protection
 
-1. Require `keyringUpdate.mode == Create`.
-2. Validate all `keyringUpdate.keys` and keyring-size constraints.
-3. Decode `adminCreationData` per the instantiation specified by `adminType`.
-4. Compute the instantiation's `adminCreationContextHash`.
-5. Recompute the `Create` `signalHash` over `(adminType, adminCreationContextHash, msg.sender, keyringUpdate)`.
-6. Verify the admin authorization per the instantiation, against `signalHash` and the instantiation's `verificationPublicId` (or, for WorldID admin, the equivalent verifier public-input set).
-7. Determine `addressDefiningMaterial` per the instantiation.
-8. Derive `accountAddress = bytes20(keccak256(abi.encodePacked(adminTypeTag, addressDefiningMaterial)))`.
-9. Require the account does not already exist at `accountAddress`.
-10. Initialize the account: store `adminType`, `verificationPublicId`, `sessionKeys = keyringUpdate.keys`, `keyringHash = keccak256(abi.encode(keyringUpdate.keys))`, and `adminNonce = 0`.
+For `create`, replay is precluded by account existence: the manager MUST revert if the derived account already exists.
 
-For `update`, the precompile MUST:
+For `queueKeyringUpdate`, replay is prevented by `adminNonce`. The signal contains the current `adminNonce`; after a successful queue operation the manager increments `adminNonce`. An authorization for nonce `n` is invalid after the account advances to nonce `n + 1`.
 
-1. Require `keyringUpdate.mode == SetKeyring`.
-2. Validate all `keyringUpdate.keys` and keyring constraints.
-3. Load the account's stored `adminType`, `verificationPublicId`, `keyringHash`, and `adminNonce`.
-4. Require `keyringUpdate.expectedCurrentKeyringHash == keyringHash`.
-5. Recompute the `Update` `signalHash` over `(accountAddress, adminNonce, msg.sender, keyringUpdate)`.
-6. Verify `adminAuthorization` per `adminType` against `signalHash` and `verificationPublicId`.
-7. Replace `sessionKeys` with `keyringUpdate.keys` and store `keyringHash = keccak256(abi.encode(keyringUpdate.keys))`.
-8. Increment `adminNonce`.
+Queueing a new keyring update while another update is pending is permitted. The new queue operation MUST be independently admin-authorized, MUST satisfy the same delay rules, and replaces the previous pending update.
 
-> **Note -- Precompile gas accounting out of scope.** The full gas pricing schedule for interacting with `WORLD_CHAIN_ACCOUNT_PRECOMPILE` -- covering admin verification cost, per-session-key storage mutation, and the amortized cost of reads during `0x1D` validation -- is **NOT** fully defined here. A follow-on revision MUST specify gas costs per operation. EIP-1271 validation gas is separately constrained by [Restricted EIP-1271 Validation Frame](#restricted-eip-1271-validation-frame).
+### Manager Interface
 
-### Restricted EIP-1271 Validation Frame
+```solidity
+interface IWorldChainAccountManager {
+    function create(
+        address adminSigner,
+        bytes32 accountSalt,
+        SessionSigner[] calldata initialSessionSigners,
+        bytes calldata adminAuthorization
+    ) external returns (address account);
 
-Protocol EIP-1271 validation is intentionally narrower than an ordinary EVM `STATICCALL`. Normal smart contracts MAY call any EIP-1271 implementation according to Ethereum rules, but WIP-1001 protocol validation of an EIP-1271 session key or EIP-1271 admin MUST execute in a restricted validation frame.
+    function queueKeyringUpdate(
+        address account,
+        bytes32 expectedCurrentKeyringHash,
+        SessionSigner[] calldata targetSessionSigners,
+        uint64 activateAfter,
+        bytes calldata adminAuthorization
+    ) external;
+
+    function activateKeyringUpdate(address account) external;
+
+    function getAdminSigner(address account) external view returns (address);
+    function getAdminNonce(address account) external view returns (uint64);
+    function getActiveKeyringHash(address account) external view returns (bytes32);
+    function getActiveSessionSigners(address account) external view returns (SessionSigner[] memory);
+    function getPendingKeyringUpdate(address account) external view returns (PendingKeyringUpdate memory);
+    function isAuthorized(address account, address signer) external view returns (bool);
+    function getAuthorizedSigner(address account, address signer) external view returns (SessionSigner memory);
+}
+```
+
+For `create`, the manager MUST:
+
+1. Require `adminSigner` has non-empty code.
+2. Validate all `initialSessionSigners` and keyring-size constraints.
+3. Compute the deterministic account address from `(adminSigner, accountSalt)`.
+4. Require the account does not already exist.
+5. Recompute the `CreateSignal` `signalHash`.
+6. Run the restricted EIP-1271 validation frame against `adminSigner` with `(hash = signalHash, signature = adminAuthorization)`.
+7. Store `adminSigner`, `accountSalt`, `activeSessionSigners = initialSessionSigners`, `activeKeyringHash`, no pending update, and `adminNonce = 0`.
+
+For `queueKeyringUpdate`, the manager MUST:
+
+1. Require the account exists.
+2. Validate all `targetSessionSigners` and keyring-size constraints.
+3. Require `expectedCurrentKeyringHash == activeKeyringHash`.
+4. Require `activateAfter >= block.timestamp + MIN_KEYRING_UPDATE_DELAY`.
+5. Compute `targetKeyringHash = keccak256(abi.encode(targetSessionSigners))`.
+6. Recompute the `QueueKeyringUpdateSignal` `signalHash` using the current `adminNonce`.
+7. Run the restricted EIP-1271 validation frame against the account's `adminSigner` with `(hash = signalHash, signature = adminAuthorization)`.
+8. Store the pending update, replacing any previous pending update.
+9. Increment `adminNonce`.
+
+For `activateKeyringUpdate`, the manager MUST:
+
+1. Require the account exists.
+2. Require a pending update exists.
+3. Require `block.timestamp >= pending.activateAfter`.
+4. Require `pending.expectedCurrentKeyringHash == activeKeyringHash`.
+5. Replace `activeSessionSigners` with `pending.targetSessionSigners`.
+6. Store `activeKeyringHash = pending.targetKeyringHash`.
+7. Clear the pending update.
+
+`activateKeyringUpdate` is permissionless. It applies only a previously admin-authorized update after the required delay.
+
+### Restricted Validation Frames
+
+Protocol signer validation is intentionally narrower than an ordinary EVM `STATICCALL`. Normal smart contracts MAY call any EIP-1271 or policy implementation according to Ethereum rules, but WIP-1001 protocol validation of an admin signer, session signer, or session policy MUST execute in a restricted validation frame.
 
 The goal is:
 
 ```text
-protocol -> EIP-1271 signer contract -> allowlisted crypto precompiles only
+protocol -> WORLD_CHAIN_ACCOUNT_MANAGER -> signer validation hook -> allowlisted crypto precompiles only
 ```
 
-There MUST NOT be an arbitrary EVM-to-EVM call graph during signature validation.
+There MUST NOT be an arbitrary EVM-to-EVM call graph during protocol signature or policy validation.
 
-#### Entry Call
+#### Signature Entry Call
 
-For a signer contract `signer`, hash `hash`, signature bytes `signature`, and stored gas limit `validationGasLimit`, the protocol invokes:
+For a signer contract `signer`, hash `hash`, and signature bytes `signature`, the protocol invokes:
 
 ```solidity
 IERC1271(signer).isValidSignature(hash, signature)
@@ -335,21 +396,38 @@ IERC1271(signer).isValidSignature(hash, signature)
 with:
 
 - call type: `STATICCALL` semantics;
-- `CALLER`: `WORLD_CHAIN_ACCOUNT_PRECOMPILE`;
+- `CALLER`: `WORLD_CHAIN_ACCOUNT_MANAGER`;
 - `ADDRESS`: `signer`;
 - `CALLVALUE`: `0`;
-- gas: exactly `validationGasLimit`;
+- gas: exactly `EIP1271_VALIDATION_GAS_LIMIT`;
 - calldata: `IERC1271.isValidSignature.selector || abi.encode(hash, signature)`;
 - success condition: the call succeeds and returns ABI-encoded `bytes4(EIP1271_MAGIC_VALUE)`.
 
 If the call reverts, runs out of gas, executes a forbidden opcode, calls a forbidden address, returns malformed data, or returns any value other than `EIP1271_MAGIC_VALUE`, the signature is invalid.
 
-`validationGasLimit` is always loaded from account state:
+A `0x1D` transaction, account, keyring entry, admin signer, and session signer MUST NOT choose or override the signature-validation gas. The gas consumed by session-signer validation MUST be metered against the transaction's gas limit before execution of the transaction payload. Admin validation gas is metered against the EVM call to the manager.
 
-- for EIP-1271 session keys, from the stored `SessionKey`;
-- for EIP-1271 admins, from the stored `verificationPublicId`.
+#### Execution Trace Policy Entry Call
 
-A `0x1D` transaction MUST NOT choose or override EIP-1271 validation gas. The gas consumed by session-key validation MUST be metered against the transaction's gas limit before execution of the transaction payload. Admin validation gas is metered against the EVM call to `create` or `update`.
+After tentative transaction payload execution, for a session signer `signer`, transaction context `context`, and execution trace `trace`, the protocol invokes:
+
+```solidity
+IWorldChainSessionVerifier(signer).isValidExecutionTrace(context, trace)
+```
+
+with:
+
+- call type: `STATICCALL` semantics;
+- `CALLER`: `WORLD_CHAIN_ACCOUNT_MANAGER`;
+- `ADDRESS`: `signer`;
+- `CALLVALUE`: `0`;
+- gas: exactly `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`;
+- calldata: `IWorldChainSessionVerifier.isValidExecutionTrace.selector || abi.encode(context, trace)`;
+- success condition: the call succeeds and returns ABI-encoded `bool(true)`.
+
+If the call reverts, runs out of gas, executes a forbidden opcode, calls a forbidden address, returns malformed data, or returns `false`, trace validation fails and the tentative transaction payload execution MUST be reverted.
+
+A `0x1D` transaction, account, keyring entry, admin signer, and session signer MUST NOT choose or override the trace-validation gas. The gas consumed by execution-trace policy validation MUST be metered against the transaction's gas limit after payload execution and before transaction finalization.
 
 #### Call-Depth and Call-Target Rules
 
@@ -364,7 +442,7 @@ Therefore a protocol-valid EIP-1271 signer contract MUST be self-contained excep
 
 #### Opcode Policy
 
-The restricted validation frame permits deterministic computation, calldata/memory access, own-code access, own-storage reads, `KECCAK256`, `CHAINID`, `GAS`, and `STATICCALL` to allowed precompiles. `GAS` is permitted because the frame starts with a fixed stored `validationGasLimit` rather than transaction-selected gas.
+The restricted validation frame permits deterministic computation, calldata/memory access, own-code access, own-storage reads, `KECCAK256`, `CHAINID`, `GAS`, and `STATICCALL` to allowed precompiles. `GAS` is permitted because each frame starts with a fixed protocol gas limit rather than transaction-selected gas.
 
 The following opcodes are forbidden if executed in the restricted validation frame:
 
@@ -401,244 +479,74 @@ CREATE2
 SELFDESTRUCT
 ```
 
-This list removes block-context, transaction-context, external-state, transient-state, logging, mutation, and arbitrary call-depth dependencies from protocol signature validation. EIP-1271 validity MAY depend on the signer contract's own persistent storage via `SLOAD`; this is the intentional stateful policy surface of contract signatures.
+This list removes block-context, transaction-context, external-state, transient-state, logging, mutation, and arbitrary call-depth dependencies from protocol signature and execution-trace policy validation. EIP-1271 validity and trace-policy validity MAY depend on the signer's own persistent storage via `SLOAD`, subject to the signer-state timelock requirements below.
 
-### Admin Instantiations
+### Signer-State Timelock Requirements
 
-Each instantiation specifies:
+To make public-pool validation stable, any signer state that can cause a previously valid signature or previously accepted execution trace to become invalid MUST transition through a delay of at least `MIN_KEYRING_UPDATE_DELAY` before it becomes effective.
 
-1. The `verificationPublicId` encoding.
-2. The address-defining material.
-3. The `adminCreationData` layout for `create()`.
-4. The creation flow.
-5. The `adminAuthorization` layout for `update()`.
-6. The verification primitive.
-7. Recovery semantics.
+For default manager-supported signer factories, this is mandatory:
 
-Additional non-ECDSA admin schemes SHOULD be implemented as EIP-1271 contract admins backed by reusable precompiles, rather than as new native admin types.
+- owner rotation in a secp256k1 signer MUST be queued before activation;
+- World ID session verifier state that changes accepted session material MUST be queued before activation;
+- threshold, key, revocation, recovery, or trace-policy state in any default signer MUST be queued before activation.
 
-#### WorldID Admin
+Custom EIP-1271 signers are protocol-compatible only if all storage values read during signature or trace-policy restricted frames obey the same delay discipline. Public transaction-pool implementations MUST NOT advertise full validation-stability guarantees for custom signers unless the signer bytecode or deployment is known to satisfy this property. Consensus validation still executes the signature and trace-policy calls at inclusion time; the timelock requirement defines WIP-1001-compliant signer behavior and public-pool admission policy.
 
-`adminType = ADMIN_TYPE_WORLD_ID = 0x00`.
+### Default Signer Factories
 
-Per-instantiation constants:
+Default signer factories are ordinary contracts, exposed by or discoverable from `WORLD_CHAIN_ACCOUNT_MANAGER`, that deploy deterministic EIP-1271 signer contracts with WIP-1001-compliant restricted-frame behavior and signer-state timelocks.
 
-| Name                          | Value                                        | Description                                           |
-| ----------------------------- | -------------------------------------------- | ----------------------------------------------------- |
-| `WORLD_CHAIN_RP_ID`           | `480`                                        | World Chain's registered RP ID                        |
-| `WORLD_ID_ACCOUNT_TAG`        | `"WORLD_ID_ACCOUNT"` (UTF-8, 16 bytes)       | Domain tag for WorldID-admin account creation actions |
+The default factories are not special validation paths. A signer produced by a default factory is authorized only if it appears in the active keyring or is fixed as an account's admin signer.
 
-`verificationPublicId` is `abi.encode(uint256 sessionId)`. `sessionId` is provisioned by the caller at creation and supplied by the WorldID authenticator via OPRF.
+Default signer implementations MUST implement `isValidExecutionTrace`. A signer with no additional execution policy MAY return `true` for every well-formed trace after signature validation succeeds, but any configurable execution policy it exposes MUST be stored and updated inside the signer under the signer-state timelock rules.
 
-Address-defining material is the creation Uniqueness Proof's nullifier:
+#### Secp256k1 EIP-1271 Signer
 
-```text
-addr = bytes20(keccak256(abi.encodePacked(ADMIN_TYPE_WORLD_ID, worldIDAccountNullifier)))
-```
+The secp256k1 signer factory deploys signer contracts that store an Ethereum address `owner`.
 
-A single WorldID `MAY` manage any number of WorldID-admin accounts by variation over a user-chosen `worldIDAccountNonce`; accounts owned by the same WorldID are unlinkable across distinct values by the ZK property of the OPRF proof.
+`isValidSignature(hash, signature)` MUST:
 
-##### Creation
+1. Decode `signature` as an Ethereum secp256k1 ECDSA signature.
+2. Enforce the Ethereum low-`s` rule from [EIP-2](https://eips.ethereum.org/EIPS/eip-2).
+3. Recover the signer address over `hash` using `ECRECOVER`.
+4. Return `EIP1271_MAGIC_VALUE` iff the recovered address equals the active `owner`.
 
-`adminCreationData` layout (conceptual; ABI-encoded as a tuple):
+Owner rotation, owner revocation, or any trace-policy update that can invalidate a previously valid signature or accepted execution trace MUST be timelocked by at least `MIN_KEYRING_UPDATE_DELAY`.
 
-```solidity
-struct WorldIDAdminCreationData {
-    uint256       worldIDAccountNullifier;      // creation nullifier, public verifier input
-    uint256       worldIDAccountNonce;          // recomputed into action
-    uint256       sessionId;                    // freshly provisioned by authenticator
-    uint256       proofNonce;                   // verifier request nonce
-    uint64        issuerSchemaId;
-    uint64        expiresAtMin;
-    uint256       credentialGenesisIssuedAtMin;
-    uint256[5]    proof;                        // compressed Groth16 proof
-}
-```
+#### World ID EIP-1271 Signer
 
-The Uniqueness Proof is parameterized by:
+The World ID signer factory deploys signer contracts that verify World ID proofs encoded inside EIP-1271 signature bytes. World ID is a reference EIP-1271 verification strategy, not a native WIP-1001 admin or session-key type.
 
-- `rpId = WORLD_CHAIN_RP_ID`
-- `action = keccak256(abi.encodePacked(WORLD_ID_ACCOUNT_TAG, uint256(worldIDAccountNonce)))`
-- `adminCreationContext = abi.encode(ADMIN_TYPE_WORLD_ID, worldIDAccountNullifier, worldIDAccountNonce, sessionId)`
-- `signalHash` per the abstract `Create` formula, using `keccak256(adminCreationContext)`
+A World ID signer stores the public verifier state required to validate future proofs, including at minimum the relevant `sessionId` or equivalent World ID session-verification material.
 
-Creation flow:
+For transaction or admin validation, `isValidSignature(hash, signature)` MUST:
 
-1. Decode `adminCreationData`.
-2. Compute `action`.
-3. Compute `adminCreationContextHash = keccak256(abi.encode(ADMIN_TYPE_WORLD_ID, worldIDAccountNullifier, worldIDAccountNonce, sessionId))`.
-4. Recompute the `Create` `signalHash` per the abstract `Create` formula.
-5. Invoke `WorldID.verify(worldIDAccountNullifier, action, WORLD_CHAIN_RP_ID, proofNonce, signalHash, issuerSchemaId, expiresAtMin, credentialGenesisIssuedAtMin, proof)`. The verifier asserts the proof commits to the supplied `(worldIDAccountNullifier, action, signalHash)` tuple under the relying party's public inputs. Because `signalHash` includes `adminCreationContextHash`, the proof is also bound to the stored `sessionId`.
-6. Set `addressDefiningMaterial = worldIDAccountNullifier` and derive `addr` per the abstract address formula.
-7. Require account does not exist at `addr`.
-8. Store `adminType = ADMIN_TYPE_WORLD_ID`, `verificationPublicId = abi.encode(sessionId)`, `sessionKeys = keyringUpdate.keys`, `keyringHash = keccak256(abi.encode(keyringUpdate.keys))`, `adminNonce = 0`.
+1. Decode `signature` as a World ID proof payload.
+2. Derive the World ID proof `signalHash` from `hash`, using `uint256(hash) >> 8` when the proof system requires a BN254-field signal.
+3. Verify the World ID proof against the stored session-verification material and the decoded public inputs.
+4. Return `EIP1271_MAGIC_VALUE` iff verification succeeds.
 
-The creation nullifier is consumed once to instantiate the account. Because WorldID authenticators do not issue the same `(rpId, action)` nullifier twice, a later mutation MUST NOT attempt to reuse the creation action. The nullifier is not retained as account state after creation -- its only role is address derivation, which is reproducible from any subsequent update's calldata via the precompile's stored `addr`.
-
-##### Updates
-
-`adminAuthorization` layout (conceptual; ABI-encoded as a tuple):
+A conceptual session-proof signature payload is:
 
 ```solidity
-struct WorldIDAdminAuth {
+struct WorldID1271Signature {
     uint256    proofNonce;
     uint64     issuerSchemaId;
     uint64     expiresAtMin;
     uint256    credentialGenesisIssuedAtMin;
-    uint256[2] sessionNullifier;                // ephemeral per-update verifier input
-    uint256[5] proof;                           // compressed Groth16 proof
+    uint256[2] sessionNullifier;
+    uint256[5] proof;
 }
 ```
 
-Update flow:
+The signer MUST NOT persist `sessionNullifier` as account-manager state. Replay prevention for manager operations comes from account existence and `adminNonce`; replay prevention or nullifier tracking internal to a World ID signer is signer-policy-specific and MUST preserve the signer-state timelock guarantee if it can invalidate pooled transactions.
 
-1. Decode `verificationPublicId` to recover `sessionId`.
-2. Recompute the `Update` `signalHash` per the abstract `Update` formula.
-3. Invoke `WorldID.verifySession(WORLD_CHAIN_RP_ID, proofNonce, signalHash, issuerSchemaId, expiresAtMin, credentialGenesisIssuedAtMin, sessionId, sessionNullifier, proof)`.
-4. Discard `sessionNullifier` after verification; it MUST NOT be persisted in account state.
-5. Require `keyringUpdate.mode == SetKeyring`.
-6. Return success to the precompile `update` flow, which applies the full keyring replacement and increments `adminNonce`.
-
-##### Session Proof Primer
-
-A Session Proof proves that the caller controls the same WorldID that previously established the stored `sessionId`, without reusing the account creation action. The `sessionId` is the long-lived verification public identifier retained for the account across updates. The `sessionNullifier` is fresh per proof, passed only to `verifySession`, and discarded after verification.
-
-##### OPRF Nullifier Proof Primer
-
-An `OPRFNullifierProof` is a [Groth16](https://eprint.iacr.org/2016/260) proof over [BN254](https://hackmd.io/@jpw/bn254) submitted on-chain as `uint256[5] = [a, b0, b1, c, merkle_root]`. The `WorldIDVerifier` reconstructs the public inputs from calldata and on-chain registry lookups (notably `merkle_root` via `WorldIDRegistry.isValidRoot()` and `oprfPublicKey` via `OprfKeyRegistry[rpId]`) and invokes the Groth16 verifier. The Groth16 verifier MUST ultimately use the same BN254 precompiles exposed to smart contracts.
-
-The circuit proves knowledge of a private witness satisfying:
-
-- **Merkle membership.** The authenticator key is a leaf in the `WorldIDRegistry` tree at the declared root.
-- **Credential validity.** The credential bears a valid EdDSA-Poseidon2 signature over BabyJubJub from the issuer identified by `issuerSchemaId`, and has not expired.
-- **OPRF correctness.** The OPRF response was evaluated under the registered key for `rpId`, with a DLog equality proof binding blinded and unblinded responses.
-- **Deterministic nullifier derivation.** The nullifier is deterministic per `(identity, rpId, action)`, regardless of blinding factor or proof randomness.
-- **Signal binding.** The `signalHash` is constrained in the circuit, preventing a proof from being reused with a different signal.
-
-For account creation, deterministic nullifier derivation binds the creation nullifier to the tuple (owner leaf, `WORLD_CHAIN_RP_ID`, `action(worldIDAccountNonce)`) -- making `worldIDAccountNonce` the sole account selector per identity -- and signal binding binds the Uniqueness Proof to the exact `Create` payload and stored `sessionId` it authorizes. For later updates, `verifySession` binds the proof to the account's stored `sessionId`; the accompanying `sessionNullifier` is a per-proof verifier input rather than persistent account state.
-
-##### Recovery
-
-Recovery is the degenerate case of a `SetKeyring` submitted after session keys are lost or compromised. Because post-creation authorization is a Session Proof bound to the account's stored `sessionId`, recovery requires only a fresh Session Proof -- the full session-key surface is reachable via the same mutation path. No separate recovery flow or state is introduced.
-
-A single WorldID MAY enable recovery for any number of WorldID-admin accounts; accounts at distinct `worldIDAccountNonce` values remain unlinkable across the recovery event.
-
-#### Secp256k1 EOA Admin
-
-`adminType = ADMIN_TYPE_SECP256K1_EOA = 0x01`.
-
-`verificationPublicId` is the 20-byte Ethereum admin address. Address-defining material is the same address:
-
-```text
-addr = bytes20(keccak256(abi.encodePacked(ADMIN_TYPE_SECP256K1_EOA, adminAddress)))
-```
-
-One admin address controls exactly one Secp256k1-EOA-admin account address.
-
-##### Creation
-
-`adminCreationData` layout (conceptual):
-
-```solidity
-struct Secp256k1EOAAdminCreationData {
-    address adminAddress;
-    bytes   ecdsaSig;       // rlp([y_parity, r, s]) over signalHash
-}
-```
-
-Creation flow:
-
-1. Decode `adminAddress` and `ecdsaSig`.
-2. Compute `adminCreationContextHash = keccak256(abi.encode(ADMIN_TYPE_SECP256K1_EOA, adminAddress))`.
-3. Recompute the `Create` `signalHash` per the abstract `Create` formula.
-4. Decode `ecdsaSig` as `rlp([y_parity, r, s])`.
-5. Recover the Ethereum address from `ecdsaSig` over `signalHash`; require it equals `adminAddress`. Implementations MUST enforce Ethereum's [low-`s` rule](https://eips.ethereum.org/EIPS/eip-2) for consensus signatures.
-6. Set `addressDefiningMaterial = adminAddress` and derive `addr` per the abstract address formula.
-7. Require account does not exist at `addr`.
-8. Store `adminType = ADMIN_TYPE_SECP256K1_EOA`, `verificationPublicId = abi.encode(adminAddress)`, `sessionKeys = keyringUpdate.keys`, `keyringHash = keccak256(abi.encode(keyringUpdate.keys))`, `adminNonce = 0`.
-
-##### Updates
-
-`adminAuthorization` is `rlp([y_parity, r, s])` for a single secp256k1 ECDSA signature over the `Update` `signalHash`.
-
-Update flow:
-
-1. Load `adminAddress` from `verificationPublicId` and `adminNonce`.
-2. Recompute the `Update` `signalHash` per the abstract `Update` formula.
-3. Require `keyringUpdate.mode == SetKeyring`.
-4. Decode `adminAuthorization` as `rlp([y_parity, r, s])`.
-5. Recover the Ethereum address from the signature; require it equals `adminAddress`; enforce low-`s`.
-6. Return success to the precompile `update` flow, which applies the full keyring replacement and increments `adminNonce`.
-
-##### Recovery
-
-**Not supported by WIP-1001.** Loss of the admin key is terminal -- the account's keyring can no longer be mutated. Users who require protocol-level recovery SHOULD choose a WorldID-admin account or an EIP-1271 admin whose contract policy includes recovery.
-
-#### EIP-1271 Contract Admin
-
-`adminType = ADMIN_TYPE_EIP1271 = 0x02`.
-
-`verificationPublicId` is `abi.encode(address signer, uint32 validationGasLimit)`. Address-defining material is the 20-byte signer contract address:
-
-```text
-addr = bytes20(keccak256(abi.encodePacked(ADMIN_TYPE_EIP1271, signer)))
-```
-
-One signer contract address controls exactly one EIP-1271-admin account address. The `validationGasLimit` is fixed at creation and used for all future admin validations.
-
-##### Creation
-
-`adminCreationData` layout (conceptual):
-
-```solidity
-struct EIP1271AdminCreationData {
-    address signer;
-    uint32  validationGasLimit;
-    bytes   signature;             // EIP-1271 signature over signalHash
-}
-```
-
-Creation flow:
-
-1. Decode `signer`, `validationGasLimit`, and `signature`.
-2. Require `signer` has non-empty code.
-3. Require `validationGasLimit > 0 && validationGasLimit <= MAX_EIP1271_VALIDATION_GAS`.
-4. Compute `adminCreationContextHash = keccak256(abi.encode(ADMIN_TYPE_EIP1271, signer, validationGasLimit))`.
-5. Recompute the `Create` `signalHash` per the abstract `Create` formula.
-6. Run the restricted EIP-1271 validation frame against `signer` with `(hash = signalHash, signature, validationGasLimit)`.
-7. Set `addressDefiningMaterial = signer` and derive `addr` per the abstract address formula.
-8. Require account does not exist at `addr`.
-9. Store `adminType = ADMIN_TYPE_EIP1271`, `verificationPublicId = abi.encode(signer, validationGasLimit)`, `sessionKeys = keyringUpdate.keys`, `keyringHash = keccak256(abi.encode(keyringUpdate.keys))`, `adminNonce = 0`.
-
-##### Updates
-
-`adminAuthorization` is the opaque EIP-1271 signature bytes passed to the stored signer contract.
-
-Update flow:
-
-1. Decode `(signer, validationGasLimit)` from `verificationPublicId`.
-2. Recompute the `Update` `signalHash` per the abstract `Update` formula.
-3. Require `keyringUpdate.mode == SetKeyring`.
-4. Run the restricted EIP-1271 validation frame against `signer` with `(hash = signalHash, signature = adminAuthorization, validationGasLimit)`.
-5. Return success to the precompile `update` flow, which applies the full keyring replacement and increments `adminNonce`.
-
-##### Recovery
-
-WIP-1001 does not define a separate recovery path for EIP-1271-admin accounts. Recovery, signer rotation, quorum changes, passkey replacement, or social recovery MAY be implemented inside the signer contract's own state and policy. If the signer contract can no longer return the EIP-1271 magic value under the restricted validation frame, the account's keyring can no longer be mutated.
-
-### Recovery
-
-Recovery semantics are per-instantiation:
-
-- **WorldID admin.** Recovery is the degenerate case of `SetKeyring` submitted via Session Proof -- see the WorldID admin instantiation. Lost or compromised session keys are recovered by any fresh Session Proof bound to the account's stored `sessionId`.
-- **Secp256k1 EOA admin.** **NOT supported by WIP-1001.** Loss of the admin key is terminal.
-- **EIP-1271 contract admin.** Delegated to the signer contract's own policy. WIP-1001 only checks whether the fixed signer contract returns the EIP-1271 magic value under the restricted validation frame.
-
-Users requiring protocol-level recovery SHOULD choose the WorldID admin instantiation. Users requiring application-defined recovery MAY choose an EIP-1271 admin, subject to the restricted-frame constraints.
+World ID signer creation MAY be gated by a World ID Uniqueness Proof. The creation proof, account nonce, signer salt, and initial session-verification material are factory-level concerns. Once deployed, the signer is just an EIP-1271 contract from the manager's perspective.
 
 ### Transaction Type `0x1D`
 
-A `0x1D` transaction is signed by a session key of a World Chain Account and submitted directly to the mempool (no [ERC-4337](https://eips.ethereum.org/EIPS/eip-4337) bundler required). `0x1D` transactions are admin-type-agnostic: they are signed by session keys regardless of which admin authority controls the account, and the validation path reads only the account's keyring.
+A `0x1D` transaction is signed by a session signer of a World Chain Account and submitted directly to the public transaction pool. `0x1D` transactions are signer-strategy-agnostic: transaction validation reads the active keyring, invokes EIP-1271 on the declared signer, tentatively executes the payload, then asks the same signer whether the resulting execution trace satisfies its internal policy.
 
 #### Envelope
 
@@ -654,156 +562,163 @@ A `0x1D` transaction is signed by a session key of a World Chain Account and sub
     data,                        // 7
     access_list,                 // 8
     account,                     // 9   -- sender's World Chain Account address
-    key_type,                    // 10  -- KEY_TYPE_*
-    key,                         // 11  -- 20-byte session key address
-    signature_payload,           // 12
+    signer,                      // 10  -- authorized EIP-1271 session signer
+    signature,                   // 11  -- opaque bytes passed to isValidSignature
 ])
 ```
 
 ```text
-signing_hash = keccak256(0x1D || rlp(fields[0..=11]))
+signing_hash = keccak256(0x1D || rlp(fields[0..=10]))
 ```
 
-The `signing_hash` covers every field except `signature_payload` itself, binding the declared `key_type` and `key` to the signature and ruling out scheme-confusion or key-substitution attacks at the consensus layer.
+The `signing_hash` covers every field except `signature` itself, binding the declared session signer to the transaction and ruling out signer-substitution attacks at the consensus layer.
 
-| `key_type`                     | `signature_payload`                                      |
-| ------------------------------ | -------------------------------------------------------- |
-| `0x00` `Secp256k1EOA`          | `rlp([y_parity, r, s])`                                  |
-| `0x01` `EIP1271`               | Opaque bytes passed unchanged as EIP-1271 `_signature`   |
+The protocol does not interpret `signature`. It is passed unchanged to:
 
-For `Secp256k1EOA`, implementations MUST enforce the Ethereum [low-`s` rule](https://eips.ethereum.org/EIPS/eip-2) and MUST reject signatures whose recovered address does not equal the declared `key`.
+```solidity
+IERC1271(signer).isValidSignature(signing_hash, signature)
+```
 
-For `EIP1271`, `signature_payload` is not interpreted by the protocol except as bytes supplied to `isValidSignature(signing_hash, signature_payload)`.
+#### Validation and Execution
 
-#### Validation
-
-The protocol MUST validate a `0x1D` transaction as follows:
+The protocol MUST validate and execute a `0x1D` transaction as follows:
 
 1. Compute `signing_hash`.
-2. Load the account's keyring entry for `(key_type, key)`.
-3. Reject if no matching authorized session key exists.
-4. Reject if the transaction does not satisfy the stored `SessionPolicy`.
-5. If `key_type == KEY_TYPE_SECP256K1_EOA`, verify `signature_payload` by Ethereum secp256k1 recovery over `signing_hash` and require the recovered address equals `key`.
-6. If `key_type == KEY_TYPE_EIP1271`, run the restricted EIP-1271 validation frame against `key` with `(hash = signing_hash, signature = signature_payload, validationGasLimit = stored SessionKey.validationGasLimit)`.
+2. Load the active keyring entry for `(account, signer)`.
+3. Reject if no matching active session signer exists.
+4. Run the restricted EIP-1271 validation frame against `signer` with `(hash = signing_hash, signature = signature)`.
+5. Reject if the frame does not return `EIP1271_MAGIC_VALUE`.
+6. Tentatively execute the transaction payload under normal EVM rules, collecting the canonical `WorldChainExecutionTrace`.
+7. Construct `WorldChainTransactionContext` from the transaction and active keyring state.
+8. Require `abi.encode(trace).length <= MAX_EXECUTION_TRACE_BYTES`.
+9. Run the restricted execution-trace policy validation frame against `signer` with `(context, trace)`.
+10. If the frame does not return `true`, revert the tentative payload execution and mark the transaction as failed by policy.
+11. If the frame returns `true`, finalize the transaction according to the tentative payload execution result.
 
-Authorization is checked before EIP-1271 execution so an attacker cannot use an unauthorized `0x1D` transaction to force arbitrary contract validation work.
+Authorization is checked before any signer call so an attacker cannot use an unauthorized `0x1D` transaction to force arbitrary signature or trace-policy validation work.
 
 The envelope is extensible to 2D nonces, batched transactions, and native paymaster support in follow-on WIPs.
 
+### Visual Flow
+
+```mermaid
+flowchart TD
+    Wallet[Wallet or App] --> Tx[0x1D Transaction]
+    Tx --> Pool[Public Tx Pool Validation]
+    Pool --> Manager[WORLD_CHAIN_ACCOUNT_MANAGER Predeploy]
+    Manager --> Active[Active Session Signer Set]
+    Active --> Signer[Authorized EIP-1271 Session Signer]
+    Signer --> Frame[Restricted Signature Frame]
+    Frame --> SigResult{Returns magic value?}
+    SigResult -->|no| Reject[Reject Transaction]
+    SigResult -->|yes| Exec[Tentative EVM Execution]
+    Exec --> Trace[Canonical Execution Trace]
+    Trace --> Policy[Verifier Trace Policy]
+    Policy --> PolicyResult{Trace allowed?}
+    PolicyResult -->|yes| Include[Finalize Transaction]
+    PolicyResult -->|no| Revert[Revert Tentative Execution]
+    Frame --> Crypto[Allowlisted Crypto Precompiles]
+    Policy --> Crypto
+
+    Admin[Admin EIP-1271 Signer] --> Queue[queueKeyringUpdate]
+    Queue --> Pending[Pending Keyring + activateAfter]
+    Pending -->|delay > txpool expiration| Activate[activateKeyringUpdate]
+    Activate --> Active
+
+    WorldID[World ID Proof in Signature Bytes] --> WIDSigner[WorldID1271Signer]
+    WIDSigner --> Frame
+    EOA[EOA Signature Bytes] --> EOASigner[Secp256k1 1271 Signer]
+    EOASigner --> Frame
+```
+
 ### Extensions
 
-- **Richer key policies.** Session policies MAY be extended with rate limits, aggregate spend limits, paymaster scopes, or more expressive call constraints. Any extension to `SessionPolicy` remains bound by the `KeyringUpdate` `signalHash`.
-- **Admin rotation.** Replacing an account's stored `verificationPublicId` (or `adminType`) under admin authorization. Deferred -- admin type and authority are pinned at creation in this WIP.
-- **Multi-admin.** M-of-N admin authorization for a single account. Deferred. Most near-term multi-admin policies SHOULD be represented as EIP-1271 contract admins.
-- **Additional crypto precompiles.** BLS12-381, secp256k1 verification without recovery, or other primitives MAY be added as VM precompiles. Once allowlisted for the restricted validation frame, EIP-1271 signer contracts can use them without changing the `0x1D` envelope.
-- **WorldID-recovery escape hatch for EOA-admin accounts.** A Secp256k1 EOA admin account MAY enroll a WorldID at creation as a recovery-only authority that can rotate the admin key under a follow-on recovery policy.
-- **Session rotation.** Replacing a WorldID-admin account's stored `sessionId` with a newly-provisioned session without re-creating the account.
+- **Trace schema extensions.** The execution trace schema MAY be extended with additional bounded summaries such as storage-write commitments, balance-delta commitments, or transient-storage summaries. The verifier remains the policy owner; the protocol only defines the trace data it supplies.
+- **Admin rotation.** Replacing an account's fixed `adminSigner` under a separate timelocked admin-rotation flow. Deferred in this WIP.
+- **Multi-admin.** M-of-N admin authorization for a single account. Deferred as native manager state; near-term policies SHOULD be represented inside an EIP-1271 admin signer.
+- **Additional crypto precompiles.** BLS12-381, EdDSA variants, secp256k1 verification without recovery, or other primitives MAY be added as VM precompiles. Once allowlisted for the restricted validation frame, EIP-1271 signer contracts can use them without changing the `0x1D` envelope.
 - **Bundling, 2D nonces, paymasters.** Reserved for follow-on WIPs on the `0x1D` envelope.
 
 ## Rationale
 
-**Account state as precompile.** The keyring lives in a precompile because `0x1D` signature validation happens at the protocol level and must read the authorized set natively. The same precompile owns the admin verification paths, ensuring the address-to-key map is only mutated under valid admin authorizations.
+**Account state as predeploy.** The keyring lives in the `WORLD_CHAIN_ACCOUNT_MANAGER` predeploy because `0x1D` validation must read the active signer set natively while preserving an ordinary Solidity/EVM-bytecode implementation surface for account management and default factories.
 
-**Minimal signature surface.** Secp256k1 address recovery and EIP-1271 contract signatures are the two signature abstractions Ethereum already standardizes. WIP-1001 uses those abstractions directly instead of introducing native P256/WebAuthn/EdDSA/BLS session-key variants. That keeps transaction validation simple and moves signer-specific policy into contracts.
+**EIP-1271-only verification.** A single contract-signature abstraction avoids protocol branches for every authenticator or cryptographic scheme. New signer strategies can be deployed as contracts and audited independently without changing the transaction type.
 
-**Reusable precompiles instead of host-only cryptography.** P256, pairing checks, and future curves are useful outside account validation. Exposing them as normal precompiles ensures the protocol and contracts agree on inputs, outputs, gas, and edge cases. EIP-1271 signer contracts become the abstraction layer over those primitives.
+**Fixed validation gas.** Per-signer gas limits make keyring entries harder to reason about, expand the admin-authorized state surface, and let signer deployment choices affect transaction validation economics. A single `EIP1271_VALIDATION_GAS_LIMIT` gives every protocol 1271 validation frame the same execution budget.
 
-**Restricted EIP-1271 validation.** Unrestricted contract signature validation would let a transaction execute an arbitrary read-only call graph before transaction execution, creating DoS risk and state/context-dependent invalidation. The restricted frame bounds gas, fixes the caller, forbids arbitrary call depth, and removes block-, transaction-, and external-state-sensitive opcodes while preserving own-storage policy and direct precompile calls.
+**Verifier-owned programmable policy.** Static `(target, selector)` allowlists are too narrow for account-native sessions, and the manager should not store a policy language. Passing the post-execution trace to the same verifier that authenticated the session lets policy be expressed as `f(transactionContext, executionTrace) -> bool`, so the verifier can decide whether what actually happened is allowed.
+
+**Reusable precompiles instead of host-only cryptography.** P256, EdDSA, BLS, pairing checks, and future curves are useful outside account validation. Exposing them as normal precompiles ensures the protocol and contracts agree on inputs, outputs, gas, and edge cases.
+
+**Restricted validation frames.** Unrestricted contract signature or policy validation would allow an arbitrary read-only call graph before transaction execution. The restricted frame bounds gas, fixes the caller, forbids arbitrary call depth, and removes block-, transaction-, and external-state-sensitive opcodes while preserving own-storage policy and direct precompile calls.
 
 **Full-keyring replacement.** Updates carry the complete target keyring rather than add/remove deltas. This makes every admin authorization commit to the exact post-update authorization set, avoids ordering-dependent delta semantics, and removes edge cases where separately authorized removals and additions compose into an unintended intermediate keyring.
 
-**Scoped session keys.** The basic `SessionPolicy` fields cover the most common session-key limits -- time bounds, per-transaction value caps, and target/selector allowlists -- without introducing a general-purpose permission language. More expressive policy logic can still live inside EIP-1271 key contracts.
+**Timelocked activation.** Delaying keyring activation by more than the transaction-pool expiration window prevents manager-owned keyring changes from invalidating transactions that were already admitted to the public pool. Applying the same discipline to default signer authorization and policy state extends that guarantee through signer validation.
 
-**Single admin authority.** Each account has exactly one admin authority. M-of-N admin authorization is a useful generalization but is deferred as native protocol state. EIP-1271 contract admins cover most quorum-management use cases without changing the abstract account model.
-
-**Admin type pinned at creation.** Address determinism: `adminType` and the address-defining material are part of the address preimage, so changing either mid-lifetime would change the address. Rotation within the same admin type is also deferred to keep v1 minimal.
-
-**No WIP-level recovery for EOA admins.** EOA-admin accounts are owned exclusively by their admin key; there is no underlying identity anchor to bootstrap recovery from. Users requiring protocol-level recoverability choose the WorldID admin instantiation. Users requiring contract-defined recoverability use EIP-1271 admin contracts.
-
-**Uniform replay protection.** All admin authorizations bind to a `signalHash` containing a per-account monotonic `adminNonce`; the precompile increments `adminNonce` on every successful update and rejects authorizations against stale values. Across instantiations, this gives one replay-protection contract -- no instantiation-specific bespoke replay machinery, and no ambiguity around what "fresh" means per instantiation.
-
-**Creation context binding.** `CreateSignal` includes `adminType` and `adminCreationContextHash` because creation permanently fixes admin state before an account address exists. Binding this context prevents an otherwise valid creation authorization from being reused with a different WorldID `sessionId`, EIP-1271 validation gas limit, or other persistent admin parameter excluded from the signature/proof bytes themselves.
-
-**Domain-separated address derivation.** Prefixing the address preimage with `adminTypeTag` prevents accidental cross-type collisions even when the address-defining material from two instantiations might coincidentally produce identical bytes under different encodings. Domain separation costs nothing and is standard practice for keccak-based identifier schemes.
-
-**`msg.sender` binding in `signalHash`.** Including `msg.sender` in both `Create` and `Update` `signalHash` definitions kills cross-submitter replay of in-flight admin authorizations: a witnessed authorization with `msg.sender = X` will not verify if resubmitted by a different account. Self-replay by `X` is a no-op (the resulting state is identical).
-
-**WorldID 4.0 Proofs as authorization.** Within the WorldID admin instantiation, account creation uses a Uniqueness Proof and provisions a fresh session; subsequent mutations use Session Proofs bound to the stored `sessionId`, so repeated account updates do not rely on reusing the creation action. No "super key" ever needs to be stored on-device. The `worldIDAccountNonce`-indexed creation action lets a single WorldID own unlinkably many WorldID-admin accounts.
-
-**No sybil constraint on accounts.** Unlinkability across `worldIDAccountNonce` values is a stronger property than one-account-per-identity, and sybil resistance at the account layer is not the right locus -- it belongs to whatever system consumes account addresses (e.g., gas subsidy accounting, application-layer rate limits), which can bind its own per-WorldID limits via independent nullifier domains.
-
-**Immediate admin updates.** Delayed update and cancellation policies are deferred to follow-on WIPs. WIP-1001 keeps admin-authorized keyring replacement immediate so the core account model only specifies authorization, replay protection, and transaction validation.
+**World ID as reference signer.** World ID proofs are powerful authorization material, but they do not need a native WIP-1001 admin type. Encoding World ID proof payloads in EIP-1271 signatures makes World ID one programmable signer implementation among many and keeps the manager's account model uniform.
 
 ## Backwards Compatibility
 
 This WIP introduces a new account type and transaction type. Existing EOAs and smart contract accounts are unaffected. Standard [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) transactions continue to work for legacy accounts; the `0x1D` envelope is required only for World-Chain-Account-authenticated execution.
 
-This WIP is Draft. The replacement of native non-ECDSA session-key types with EIP-1271 contract keys, the `SessionKey` keyring shape, scoped session policies, full-keyring replacement updates, the EIP-1271 restricted validation frame, and creation-context binding in `CreateSignal` are breaking changes relative to earlier drafts of this WIP. No production accounts exist.
+This WIP is Draft. The move to EIP-1271-only session and admin verification, the replacement of native account-manager language with a manager predeploy, the removal of native signature-type dispatch, and timelocked keyring activation are breaking changes relative to earlier drafts. No production accounts exist.
+
+Existing draft implementations or libraries that expose native P256, WebAuthn, EdDSA, or secp256k1 WIP-1001 transaction signature variants are obsolete relative to this specification. Those strategies SHOULD migrate to EIP-1271 signer contracts or default signer factories.
 
 ### Existing Safe Accounts
 
-Existing [Safe](https://safe.global) accounts MAY integrate with World Chain Accounts without migrating assets or changing the Safe address by installing modules or guards that recognize a World Chain Account as an authorized caller. Existing Safe contracts are not automatically valid WIP-1001 protocol EIP-1271 session keys: the restricted validation frame forbids arbitrary call depth, `DELEGATECALL`, and external contract state reads. A Safe-style policy can be used as a protocol session key only through bytecode that satisfies the restricted-frame rules, or through ordinary application-level calls outside WIP-1001 protocol validation.
+Existing [Safe](https://safe.global) accounts MAY integrate with World Chain Accounts without migrating assets or changing the Safe address by installing modules or guards that recognize a World Chain Account as an authorized caller. Existing Safe contracts are not automatically valid WIP-1001 protocol signers: the restricted validation frames forbid arbitrary call depth, `DELEGATECALL`, and external contract state reads. A Safe-style policy can be used as a protocol signer only through bytecode that satisfies the signature interface, execution-trace policy interface, restricted-frame rules, and signer-state timelock rules, or through ordinary application-level calls outside WIP-1001 protocol validation.
 
 ## Security Considerations
 
 ### Front-Running Admin Authorizations
 
-Both `Create` and `Update` `signalHash` definitions bind `msg.sender`, so a witnessed admin authorization observed in the mempool cannot be replayed by a different submitter -- its `signalHash` would not match. This applies to all instantiations. A griefer can still re-submit an authorization unchanged from the original `msg.sender`, but the resulting state is identical; harm is limited to gas and ordering.
+Both `CreateSignal` and `QueueKeyringUpdateSignal` bind `msg.sender`, so a witnessed admin authorization observed in the mempool cannot be replayed by a different submitter. A griefer can still re-submit an authorization unchanged from the original `msg.sender`, but the resulting state is either identical or supersedes the same pending update under the same admin intent.
 
-The binding is to the direct EVM caller of `WORLD_CHAIN_ACCOUNT_PRECOMPILE`. A public factory, relayer, or forwarding contract that calls the precompile on behalf of multiple users MUST enforce its own caller/request binding before forwarding; otherwise two users of the same forwarding contract share the same `msg.sender` for WIP-1001 authorization purposes.
+The binding is to the direct EVM caller of `WORLD_CHAIN_ACCOUNT_MANAGER`. A public factory, relayer, or forwarding contract that calls the manager on behalf of multiple users MUST enforce its own caller/request binding before forwarding.
 
-### Admin Authority Compromise
+### Admin Signer Compromise
 
-An admin authority can immediately replace the full session-key set. If the admin authority is compromised, the attacker can rotate the keyring and then authorize `0x1D` transactions with the new keys. This WIP intentionally does not define delayed or cancellable admin updates; wallets and applications that require that behavior should use an EIP-1271 admin contract or a follow-on protocol extension.
+An admin signer can queue a full keyring replacement, but the replacement cannot activate until `MIN_KEYRING_UPDATE_DELAY` has elapsed. The delay gives wallets and monitoring systems time to warn users or move funds using still-active session signers. If the admin signer remains compromised until activation, the attacker can eventually replace the keyring.
 
-### EIP-1271 Validation DoS
+### Signer Validation DoS
 
-Protocol EIP-1271 validation is bounded by stored `validationGasLimit` and `MAX_EIP1271_VALIDATION_GAS`. Transactions cannot select a higher gas budget for validation, and authorization is checked before contract validation. This prevents unauthorized transactions from using arbitrary signer contracts as pre-execution gas sinks.
+Protocol signature validation is bounded by the fixed `EIP1271_VALIDATION_GAS_LIMIT`, execution-trace policy validation is bounded by the fixed `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`, and trace size is bounded by `MAX_EXECUTION_TRACE_BYTES`. Transactions cannot select a higher gas budget for either validation frame, and keyring authorization is checked before signer calls. This prevents unauthorized transactions from using arbitrary signer contracts as validation gas sinks.
 
-### EIP-1271 Call-Graph and External-State Invalidation
+### Call-Graph and External-State Invalidation
 
-The restricted validation frame forbids EVM-to-EVM calls except direct `STATICCALL`s to allowlisted precompiles. It also forbids external-code and external-balance inspection opcodes. As a result, protocol signature validity cannot depend on another contract's code, storage, or balance changing before inclusion.
+Restricted validation frames forbid EVM-to-EVM calls except direct `STATICCALL`s to allowlisted precompiles. They also forbid external-code and external-balance inspection opcodes. As a result, protocol signature and trace-policy validity cannot depend on another contract's code, storage, or balance changing before inclusion.
 
-### EIP-1271 Context-Sensitive Opcode Invalidation
+### Context-Sensitive Opcode Invalidation
 
-Block-context and transaction-context opcodes such as `TIMESTAMP`, `NUMBER`, `BASEFEE`, `GASPRICE`, `ORIGIN`, and blob context are forbidden in the restricted validation frame. Signatures therefore cannot become valid or invalid solely because a block producer selected a different block context.
+Block-context and transaction-context opcodes such as `TIMESTAMP`, `NUMBER`, `BASEFEE`, `GASPRICE`, `ORIGIN`, and blob context are forbidden in restricted validation frames. Signatures and trace-policy decisions therefore cannot become valid or invalid solely because a block producer selected a different block context.
 
-### EIP-1271 Own-Storage Invalidation
+### Own-Storage Invalidation
 
-EIP-1271 signer validity MAY depend on the signer contract's own storage. This is intentional: it permits multisig thresholds, passkey rotation, revocation lists, recovery state, and policy updates. It also means a signature that was valid during mempool simulation can become invalid if the signer contract's own storage changes before inclusion. Wallets and relayers MUST treat EIP-1271 validity as state-dependent.
+Signer validity and execution-trace policy validity MAY depend on the signer's own storage. This is the intentional programmable policy surface. To preserve public-pool stability, any own-storage change that can invalidate a previously valid signature or previously accepted execution trace MUST be timelocked by at least `MIN_KEYRING_UPDATE_DELAY` for WIP-1001-compliant signers.
+
+### Custom Signer Safety
+
+The manager can verify any signer that satisfies the signature and execution-trace policy restricted frames at inclusion time, but public transaction pools should distinguish default or otherwise known-safe signers from arbitrary custom signers. If a custom signer can immediately change own-storage validation or trace-policy state, it can invalidate pooled transactions before inclusion and should not receive the full WIP-1001 pool-stability guarantee.
 
 ### Contract Upgradeability
 
-Upgradeable EIP-1271 signer contracts can change account authorization policy without changing the World Chain Account keyring or admin authority. This is a feature when used intentionally, but it is also a risk. Wallets SHOULD surface whether an EIP-1271 signer is upgradeable, proxy-based, or otherwise able to change behavior. Proxy patterns that require `DELEGATECALL` during validation are invalid under the restricted frame.
+Upgradeable signer contracts can change account authorization policy without changing the World Chain Account keyring. Proxy patterns that require `DELEGATECALL` during validation are invalid under the restricted frame. Upgrade paths that can invalidate signatures MUST themselves obey the signer-state timelock discipline.
 
-### Session Key Deanonymization
+### Session Signer Deanonymization
 
-A Secp256k1 EOA key address reused as an EOA, or authorized on a different World Chain Account, links those accounts. An EIP-1271 key contract reused across contexts likewise links them. Clients SHOULD generate fresh session keys per account when unlinkability matters.
+A signer contract reused across accounts links those accounts. Clients SHOULD deploy fresh signer instances per account when unlinkability matters. World ID users who require unlinkability SHOULD use distinct World ID account nonces and signer instances.
 
-### Signature-Key Ambiguity
+### Signature-Signer Ambiguity
 
-A World Chain Account may store up to `MAX_SESSION_KEYS`, but a `0x1D` transaction declares exactly one `(key_type, key)`. The keyring lookup is by that pair and MUST be unique. There is no "first matching key" ambiguity.
+A World Chain Account may store up to `MAX_SESSION_SIGNERS`, but a `0x1D` transaction declares exactly one `signer`. The keyring lookup is by signer address and MUST be unique. There is no "first matching signer" ambiguity.
 
 ### WebAuthn Challenge Binding
 
 For WebAuthn-based EIP-1271 signer contracts, the `0x1D` `signing_hash` SHOULD appear as the WebAuthn challenge, or be bound by an equivalent domain-separated digest inside the contract's validation logic. WIP-1001 does not prescribe the internal EIP-1271 signature format.
 
-### WorldID-admin: Account Unlinkability
+### World ID Stale Roots
 
-Two WorldID-admin accounts owned by the same WorldID are unlinkable across distinct creation `worldIDAccountNonce` values by the ZK property of the OPRF proof. Subsequent updates no longer reuse the creation action; they are authorized via Session Proofs bound to the account's stored `sessionId`. Updates to the same account remain linkable through the account address and its on-chain state transitions.
-
-### WorldID-admin: Stale Merkle Root
-
-The `WorldIDRegistry` accepts roots within a validity window. An attacker whose credential has been revoked could race to submit `create` or `update` against a still-valid but stale root before expiry. The `expiresAtMin + minExpirationThreshold >= block.timestamp` check bounds this window, but its duration is a trust parameter.
-
-### EOA-admin: Admin Key Loss Is Terminal
-
-For Secp256k1 EOA admin instantiations, loss of the admin key permanently bricks the account -- the keyring cannot be mutated, recovered, or rotated by WIP-1001. Wallets implementing EOA-admin accounts MUST surface this risk to users and SHOULD encourage hardware-backed key custody.
-
-### EOA-admin and EIP-1271-admin: Linkability
-
-An EOA admin address or EIP-1271 admin contract address is recoverable from any creation transaction's calldata and is part of address derivation. Unlike WorldID-admin accounts, these accounts carry no unlinkability guarantees. Cross-chain or cross-application reuse of an admin address is a deanonymization vector.
-
-### No Liveness Check
-
-A non-WorldID-admin account has no protocol-level liveness check on session-key-signed transactions. Session-key compromise can drain account-controlled value at the rate session keys can authorize, bounded only by configured `SessionPolicy` limits and off-protocol controls. Sibling WIPs that require WorldID liveness above a value threshold do NOT apply to non-WorldID-admin accounts.
+World ID signer implementations that accept roots within a validity window inherit the stale-root risks of the underlying World ID verifier. A credential revoked shortly before root expiry may still authorize a signature until the verifier's root-validity and credential-expiration checks reject it. The signer implementation MUST surface and document those verifier trust parameters.

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -134,9 +134,7 @@ struct SessionSigner {
 
 `signer` MUST NOT be the zero address and MUST have non-empty code when it is added to a keyring. The signer MUST implement `IERC1271.isValidSignature(bytes32,bytes)` and `IWorldChainSessionVerifier.isValidExecutionTrace(WorldChainTransactionContext,WorldChainExecutionTrace)`.
 
-There is no `validationGasLimit` field. Every protocol EIP-1271 validation uses `EIP1271_VALIDATION_GAS_LIMIT`.
-
-Keyring uniqueness is defined by `signer`. A keyring MUST NOT contain two entries with the same signer address. Changing the authorized signer set requires queueing a full replacement keyring.
+Protocol native EIP-1271 signature verification is constrained to `EIP1271_VALIDATION_GAS_LIMIT`.
 
 A keyring MUST contain at least one session signer and MUST NOT contain more than `MAX_SESSION_SIGNERS`.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because this is a substantial redesign of a core protocol specification (account model, tx validation flow, and key management), which will ripple into any implementers despite being documentation-only.
> 
> **Overview**
> Updates `wips/wip-1001.md` to **remove native signature-type dispatch** (secp256k1/World ID/etc.) and make *all* admin + session authorization occur via **EIP-1271 signer contracts** with fixed protocol gas limits.
> 
> Replaces the precompile-centric account model with a `WORLD_CHAIN_ACCOUNT_MANAGER` predeploy that manages deterministic account creation and **timelocked keyring replacement** (`queueKeyringUpdate` + permissionless `activateKeyringUpdate`) to keep public-tx-pool validation stable.
> 
> Extends `0x1D` transaction validation to include a second restricted frame: after signature verification, the payload is tentatively executed and the resulting **bounded execution trace** is passed back to the same signer via `isValidExecutionTrace(context, trace)` to enforce programmable session policy; adds requirements for default signer factories and signer-state timelocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 521e68b21131bdfd51af0f0586fe7be6cb740cef. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->