### PR TITLE
Osiris/cleanup documentation

### DIFF
--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -7,7 +7,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2026-03-27
-requires: EIP-2, EIP-1559, EIP-196, EIP-197, EIP-198, EIP-2718, EIP-1271, RIP-7212
+requires: EIP-2, EIP-1559, EIP-196, EIP-197, EIP-198, EIP-2718, EIP-2930, EIP-1271, ERC-7562, RIP-7212
 ---
 
 ## Abstract
@@ -38,7 +38,7 @@ World ID is a reference signer implementation. It verifies an EIP-1271 signature
 
 Accounts need authorization logic that can evolve without protocol changes. EIP-1271 lets admin signers define arbitrary account-management authorization, including World ID, secp256k1, secp256r1, EdDSA, BLS12-381, multisig, programmable recovery, multi factor authentication and application-specific schemes.
 
-Session verifiers extend that programmability to transaction execution. A verifier can authenticate a session key, inspect the canonical execution trace, and decide whether the transaction satisfies its policy. The protocol only provides deterministic inputs and enforces the verifier's boolean result.
+Session verifiers extend that programmability to transaction execution. A verifier can authenticate a session key, inspect the canonical execution trace, and decide whether the transaction satisfies its policy. The protocol only provides deterministic inputs and enforces the verifier's evaluation according to its session signers corresponding policy.
 
 ### Stable Transaction Inclusion
 
@@ -54,34 +54,42 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Protocol Constants
 
-| Name | Value | Meaning |
-| --- | --- | --- |
-| `WORLD_TX_TYPE` | `0x1D` | EIP-2718 transaction type for World Chain account transactions. |
-| `MAX_SESSION_VERIFIERS` | `20` | Maximum active session verifiers per account. |
-| `EIP1271_MAGIC_VALUE` | `0x1626ba7e` | Required return value from `isValidSignature`. |
-| `WORLD_CHAIN_RP_ID` | `480` | World Chain relying-party identifier for WebAuthn challenge binding. |
-| `WORLD_ID_ACCOUNT_TAG` | `"WORLD_ID_ACCOUNT"` | Domain tag for World ID account action derivation. |
-| `WIP1001_ACCOUNT_DOMAIN` | `keccak256("WIP1001_ACCOUNT")` | Domain for account address derivation. |
-| `WIP1001_ADMIN_CREATE_DOMAIN` | `keccak256("WIP1001_ADMIN_CREATE")` | Domain for account creation authorization. |
-| `WIP1001_QUEUE_KEYRING_UPDATE_DOMAIN` | `keccak256("WIP1001_QUEUE_KEYRING_UPDATE")` | Domain for keyring update authorization. |
-| `WIP1001_SIGNER_DOMAIN` | `keccak256("WIP1001_SIGNER")` | Domain for default factory `CREATE2` salts. |
+| Name | Type | Value | Meaning |
+| --- | --- | --- | --- |
+| `WORLD_TX_TYPE` | `uint8` | `0x1D` | EIP-2718 transaction type for World Chain account transactions. |
+| `MAX_SESSION_VERIFIERS` | `uint256` | `20` | Maximum active session verifiers per account. |
+| `EIP1271_MAGIC_VALUE` | `bytes4` | `0x1626ba7e` | Required return value from `isValidSignature`. |
+| `WORLD_CHAIN_RP_ID` | `uint64` | `480` | World Chain relying-party identifier for WebAuthn and World ID challenge binding. |
+| `WORLD_ID_ACCOUNT_TAG` | `bytes` | `"WORLD_ID_ACCOUNT"` | Domain tag for World ID account action derivation. |
+| `WIP1001_ACCOUNT_DOMAIN` | `bytes32` | `keccak256("WIP1001_ACCOUNT")` | Domain for account address derivation. |
+| `WIP1001_ADMIN_CREATE_DOMAIN` | `bytes32` | `keccak256("WIP1001_ADMIN_CREATE")` | Domain for account creation authorization. |
+| `WIP1001_QUEUE_KEYRING_UPDATE_DOMAIN` | `bytes32` | `keccak256("WIP1001_QUEUE_KEYRING_UPDATE")` | Domain for queueing a keyring update authorization. |
+| `WIP1001_CANCEL_KEYRING_UPDATE_DOMAIN` | `bytes32` | `keccak256("WIP1001_CANCEL_KEYRING_UPDATE")` | Domain for cancelling a pending keyring update. |
+| `WIP1001_REVOKE_SESSION_VERIFIER_DOMAIN` | `bytes32` | `keccak256("WIP1001_REVOKE_SESSION_VERIFIER")` | Domain for instant session-verifier revocation. |
+| `WIP1001_SIGNER_DOMAIN` | `bytes32` | `keccak256("WIP1001_SIGNER")` | Domain for default factory `CREATE2` salts. |
 
 ### Activation Parameters
 
 WIP-1001 MUST NOT activate until every parameter below is assigned in the fork configuration.
 
-| Name | Value | Requirement |
-| --- | --- | --- |
-| `WORLD_CHAIN_ACCOUNT_MANAGER` | TBD | Predeploy address for the account manager. |
-| `EIP1271_VALIDATION_GAS_LIMIT` | TBD | Fixed gas forwarded to `isValidSignature`. |
-| `EXECUTION_TRACE_VALIDATION_GAS_LIMIT` | TBD | Fixed gas forwarded to `evaluateSessionPolicy`. |
-| `MAX_EXECUTION_TRACE_BYTES` | TBD | Maximum ABI-encoded trace size passed to a session verifier. |
-| `TXPOOL_TRANSACTION_EXPIRATION_WINDOW` | TBD | Maximum time a valid transaction remains in the pool. |
-| `MIN_KEYRING_UPDATE_DELAY` | TBD | MUST be greater than `TXPOOL_TRANSACTION_EXPIRATION_WINDOW`. |
-| `WORLD_ID_1271_SIGNER_FACTORY` | TBD | Default World ID EIP-1271 signer factory. |
-| `SECP256K1_1271_SIGNER_FACTORY` | TBD | Default secp256k1 EIP-1271 signer factory. |
-| `EDDSA_PRECOMPILE` | TBD | EdDSA verification precompile address and ABI. |
-| `BLS12_381_PRECOMPILE` | TBD | BLS12-381 verification precompile address and ABI. |
+| Name | Type | Value | Requirement |
+| --- | --- | --- | --- |
+| `WORLD_CHAIN_ACCOUNT_MANAGER` | `address` | TBD | Predeploy address for the account manager. |
+| `EIP1271_VALIDATION_GAS_LIMIT` | `uint64` | TBD | Fixed gas forwarded to `isValidSignature`. |
+| `EXECUTION_TRACE_VALIDATION_GAS_LIMIT` | `uint64` | TBD | Fixed gas forwarded to `evaluateSessionPolicy`. |
+| `BLOCK_VALIDATION_GAS_BUDGET` | `uint64` | TBD | Per-block gas budget reserved for `0x1D` validation calls. See "Validation Gas Accounting". |
+| `MIN_VALIDATION_FAILURE_FEE` | `uint256` | TBD | Minimum wei charge to the account on validation failure. Anti-DoS floor. |
+| `MAX_EXECUTION_TRACE_BYTES` | `uint32` | TBD | Maximum ABI-encoded trace size passed to a session verifier. |
+| `MAX_PAYLOAD_DATA_BYTES` | `uint32` | TBD | Maximum length of `data` in the `0x1D` envelope. |
+| `MAX_ACCESS_LIST_ENTRIES` | `uint32` | TBD | Maximum number of EIP-2930 access-list entries in the envelope. |
+| `MAX_SESSION_SIGNATURE_BYTES` | `uint32` | TBD | Maximum length of the session `signature` field. |
+| `MAX_ADMIN_AUTHORIZATION_BYTES` | `uint32` | TBD | Maximum length of `adminAuthorization` calldata. |
+| `TXPOOL_TRANSACTION_EXPIRATION_WINDOW` | `uint64` | TBD | Maximum time (seconds) a valid transaction remains in the pool. |
+| `MIN_KEYRING_UPDATE_DELAY` | `uint64` | TBD | MUST satisfy `MIN_KEYRING_UPDATE_DELAY > TXPOOL_TRANSACTION_EXPIRATION_WINDOW`. |
+| `WORLD_ID_1271_SIGNER_FACTORY` | `address` | TBD | Default World ID EIP-1271 signer factory. |
+| `SECP256K1_1271_SIGNER_FACTORY` | `address` | TBD | Default secp256k1 EIP-1271 signer factory. |
+| `EDDSA_PRECOMPILE` | `address` | TBD | EdDSA verification precompile address and ABI. |
+| `BLS12_381_PRECOMPILE` | `address` | TBD | BLS12-381 verification precompile address and ABI. |
 
 ### Reusable Crypto Precompiles
 
@@ -107,7 +115,7 @@ World Chain clients MUST NOT expose private host validation APIs that are unavai
 
 ### Account Model
 
-World Chain accounts are created and managed by `WORLD_CHAIN_ACCOUNT_MANAGER`.
+World Chain accounts are created and managed by a `WORLD_CHAIN_ACCOUNT_MANAGER`.
 
 An account has:
 
@@ -128,25 +136,77 @@ The manager MUST NOT use the admin signer to authorize `0x1D` transaction execut
 The manager stores account state:
 
 ```solidity
+/// @notice Per-account state held by `WORLD_CHAIN_ACCOUNT_MANAGER`.
 struct Account {
+    /// @notice Immutable EIP-1271 admin signer contract. Bound into the account
+    ///         address derivation; cannot be rotated without changing the address.
     address adminSigner;
+
+    /// @notice Caller-supplied salt used in the account address derivation.
+    ///         Stored for indexing / auditability; not consulted at runtime.
     bytes32 accountSalt;
+
+    /// @notice Ordered list of currently active EIP-1271 session verifiers.
+    ///         Length is in `[1, MAX_SESSION_VERIFIERS]`. Order is significant —
+    ///         `activeKeyringHash` commits to ordering.
     SessionVerifier[] activeSessionVerifiers;
+
+    /// @notice `keccak256(abi.encode(activeSessionVerifiers))`. Re-derivable
+    ///         from `activeSessionVerifiers` but cached for cheap reads in
+    ///         signing-hash construction and admin-operation hashing.
     bytes32 activeKeyringHash;
+
+    /// @notice Slot for the at-most-one pending keyring update. See
+    ///         `PendingKeyringUpdate.exists` for presence semantics.
     PendingKeyringUpdate pendingKeyringUpdate;
+
+    /// @notice Strictly monotonically non-decreasing counter consumed by
+    ///         admin-authorized operations (queue, cancel, revoke). Provides
+    ///         replay protection for admin authorizations.
     uint64 adminNonce;
 }
 
+/// @notice An optional, time-locked queued keyring update. Solidity structs are
+///         not nullable in storage, so the optional nature is encoded by the
+///         explicit `exists` flag.
 struct PendingKeyringUpdate {
-    bool exists;
+    /// @notice The `activeKeyringHash` value that was current when this update
+    ///         was queued. Re-checked at activation as a defense-in-depth guard
+    ///         even though only one pending update may exist at a time.
     bytes32 expectedCurrentKeyringHash;
+
+    /// @notice The verifier set that will replace `activeSessionVerifiers` on
+    ///         successful activation. Subject to the same length and uniqueness
+    ///         constraints as `activeSessionVerifiers`.
     SessionVerifier[] targetSessionVerifiers;
+
+    /// @notice `keccak256(abi.encode(targetSessionVerifiers))`. Cached for the
+    ///         same reason as `activeKeyringHash`.
     bytes32 targetKeyringHash;
+
+    /// @notice Earliest UNIX timestamp at which `activateKeyringUpdate` may
+    ///         succeed. MUST be at least `block.timestamp + MIN_KEYRING_UPDATE_DELAY`
+    ///         at queueing time.
     uint64 activateAfter;
+
+    /// @notice The `adminNonce` value consumed when this update was authorized.
+    ///         Used as a replay-protection cookie by `cancelPendingKeyringUpdate`.
     uint64 queuedAtNonce;
+
+    /// @notice Presence flag. `true` iff a pending update is currently queued.
+    ///         When `false`, all other fields in this struct are meaningless and
+    ///         MUST NOT be read by conforming implementations.
+    bool exists;
 }
 
+/// @notice Single-field wrapper for an active session-verifier entry. The
+///         struct exists (rather than a bare `address`) to allow forward-
+///         compatible extension with per-verifier metadata (e.g., a label,
+///         expiry, or stake reference) without changing `activeKeyringHash`
+///         encoding semantics. New fields, if added, MUST be considered in the
+///         keyring hash.
 struct SessionVerifier {
+    /// @notice EIP-1271 contract that also implements `IWorldChainSessionVerifier`.
     address verifier;
 }
 ```
@@ -156,6 +216,12 @@ struct SessionVerifier {
 The protocol does not inspect signer internals. It assigns semantics by account role: admin signer for account management, session verifier for transaction authorization and policy evaluation.
 
 The active keyring MUST contain at least one session verifier and at most `MAX_SESSION_VERIFIERS` session verifiers. A keyring MUST NOT contain duplicate verifier addresses.
+
+#### Account Address Permanence
+
+The account address derives from `(WIP1001_ACCOUNT_DOMAIN, chainId, WORLD_CHAIN_ACCOUNT_MANAGER, adminSigner, accountSalt)`. `adminSigner` is therefore immutable for the life of the address. WIP-1001 defines no operation that rotates `adminSigner` for an existing account. A bug in the admin signer contract is uncorrectable without migrating assets to a new account.
+
+The account address binds `chainId`, so the same `(adminSigner, accountSalt)` deployed via the same factory on a different chain produces a different account address. This eliminates any future possibility for cross-chain account-address replay.
 
 ### Address Derivation
 
@@ -199,9 +265,7 @@ For every admin authorization, the manager computes a domain-separated `adminOpe
 adminSigner.isValidSignature(adminOperationHash, adminAuthorization)
 ```
 
-`adminOperationHash` is the only protocol-defined hash passed to the admin signer. The protocol does not define a generic `signal` field.
-
-The account-creation admin operation hash is:
+For example the account-creation admin operation hash is:
 
 ```solidity
 adminOperationHash = keccak256(
@@ -217,36 +281,15 @@ adminOperationHash = keccak256(
 );
 ```
 
-The keyring-update admin operation hash is:
-
-```solidity
-adminOperationHash = keccak256(
-    abi.encode(
-        WIP1001_QUEUE_KEYRING_UPDATE_DOMAIN,
-        chainId,
-        WORLD_CHAIN_ACCOUNT_MANAGER,
-        account,
-        expectedCurrentKeyringHash,
-        targetKeyringHash,
-        activateAfter,
-        adminNonce
-    )
-);
-```
-
-The manager increments `adminNonce` when it queues a keyring update. Activating a queued update MUST NOT increment `adminNonce`.
-
-### Replay Protection
-
-The account address derivation, operation domains, chain ID, manager address, and admin nonce together provide replay protection for account creation and admin operations.
-
-Session transactions use the transaction nonce in the `0x1D` envelope. This nonce is the EVM transaction nonce for `account`, is consumed by included `0x1D` transactions, and is separate from `adminNonce`.
-
 ### EIP-1271 Admin Signer Hierarchy
 
 The admin signer is an EIP-1271 contract that authorizes account-management operations. It has no protocol ABI beyond EIP-1271:
 
 ```solidity
+/// @notice Marker interface for an EIP-1271 admin signer. Carries no methods
+///         beyond `IERC1271.isValidSignature(bytes32 hash, bytes signature)`.
+///         The protocol identifies admin signers by role (assignment as
+///         `Account.adminSigner`), not by interface.
 interface IWorldChainAdminSigner is IERC1271 {}
 ```
 
@@ -269,10 +312,29 @@ A World ID admin signer is an EIP-1271 contract whose authorization is a World I
 The default World ID admin signer MUST expose immutable account-binding state:
 
 ```solidity
+/// @notice Default World ID EIP-1271 admin signer interface.
+/// @dev    All four view methods MUST return values that are fixed at signer
+///         deployment time and that match the values committed to in the
+///         CREATE2 salt of the deploying factory.
 interface IWorldIDAdminSigner is IWorldChainAdminSigner {
+    /// @notice The `accountSalt` used to derive the bound account address.
+    /// @return The salt value committed to in the factory `configHash`.
     function accountSalt() external view returns (bytes32);
+
+    /// @notice The account address this admin signer is bound to.
+    /// @return Equal to the address that `WORLD_CHAIN_ACCOUNT_MANAGER` derives
+    ///         from `(address(this), accountSalt())` per "Address Derivation".
     function account() external view returns (address);
+
+    /// @notice The World ID relying-party identifier used in proof verification.
+    /// @return MUST equal `WORLD_CHAIN_RP_ID`.
     function worldIdRpId() external view returns (uint64);
+
+    /// @notice The World ID `action` field bound into proofs accepted by this
+    ///         signer.
+    /// @return `worldIdField(abi.encode(WORLD_ID_ACCOUNT_TAG, block.chainid,
+    ///         WORLD_CHAIN_RP_ID, WORLD_CHAIN_ACCOUNT_MANAGER, account(),
+    ///         address(this)))`.
     function worldIdAction() external view returns (uint256);
 }
 ```
@@ -280,11 +342,29 @@ interface IWorldIDAdminSigner is IWorldChainAdminSigner {
 The default World ID admin signer uses the World ID v4 uniqueness-proof verifier shape. Its EIP-1271 signature payload is:
 
 ```solidity
+/// @notice ABI-encoded payload passed as the `signature` argument to
+///         `isValidSignature` for a default World ID admin signer.
 struct WorldIDUniquenessProofSignature {
+    /// @notice Public output. Unique-per-(user, rpId, action) one-time identifier
+    ///         derived inside the circuit. Not consumed by the protocol — the
+    ///         admin signer is `view`-only.
     uint256 nullifier;
+
+    /// @notice Public input. Minimum credential expiration the proof was bound
+    ///         to. Subject to the signer's freshness policy.
     uint64 expiresAtMin;
+
+    /// @notice Public input. Identifies the credential schema and issuer pair.
+    ///         MUST equal the signer's configured issuer schema ID.
     uint64 issuerSchemaId;
+
+    /// @notice Public input. Minimum `genesis_issued_at` the proof was bound
+    ///         to. Subject to the signer's freshness policy.
     uint256 credentialGenesisIssuedAtMin;
+
+    /// @notice Encoded World ID v4 proof. Layout:
+    ///         [0..3] compressed Groth16 proof `[a, b₁, b₂, c]`,
+    ///         [4]    Merkle root from the `WorldIDRegistry`.
     uint256[5] zeroKnowledgeProof;
 }
 ```
@@ -299,6 +379,7 @@ struct WorldIDUniquenessProofSignature {
 worldIdField(
     abi.encode(
         WORLD_ID_ACCOUNT_TAG,
+        block.chainid,
         WORLD_CHAIN_RP_ID,
         WORLD_CHAIN_ACCOUNT_MANAGER,
         account(),
@@ -307,7 +388,9 @@ worldIdField(
 )
 ```
 
-where `worldIdField(input) = uint256(keccak256(input)) >> 8`, matching `FieldElement::from_arbitrary_raw_bytes` in the World ID v4 primitives.
+where `worldIdField(input) = uint256(keccak256(input)) >> 8`, matching `FieldElement::from_arbitrary_raw_bytes` in the World ID v4 primitives. A reference implementation of this reduction is in `crates/primitives/src/lib.rs` (function `from_arbitrary_raw_bytes`) of the World ID protocol repository.
+
+The inclusion of `block.chainid` in the `worldIdAction` derivation is required to prevent cross-chain replay of the World ID proof when the same admin signer contract address exists on multiple chains. The default factory's CREATE2 salt also binds chainId, so for default-factory-deployed signers this is defense-in-depth; for custom signers it is the primary safeguard.
 
 `isValidSignature(hash, signature)` MUST:
 
@@ -333,7 +416,11 @@ A secp256k1 admin signer is an EIP-1271 contract whose authorization is a secp25
 The default secp256k1 admin signer MUST expose immutable owner state:
 
 ```solidity
+/// @notice Default secp256k1 EIP-1271 admin signer interface.
 interface ISecp256k1AdminSigner is IWorldChainAdminSigner {
+    /// @notice The secp256k1 owner address authorizing admin operations.
+    /// @return The owner address committed to in the factory `configHash`.
+    ///         MUST be immutable for the life of the signer.
     function owner() external view returns (address);
 }
 ```
@@ -360,70 +447,162 @@ The secp256k1 admin signer verifies the hash passed by the manager directly. Wal
 Session verifier contracts MUST implement this interface in addition to EIP-1271. Admin-only signers only need to implement EIP-1271.
 
 ```solidity
+/// @notice Session verifier interface. Implemented by every contract eligible
+///         to appear in `Account.activeSessionVerifiers`. Combines EIP-1271
+///         signature verification with execution-trace policy evaluation.
 interface IWorldChainSessionVerifier is IERC1271 {
+    /// @notice EIP-2930 access list entry, mirrored into the trace context so
+    ///         that policy evaluation can reason about pre-warmed state.
     struct AccessListEntry {
+        /// @notice Address whose storage is pre-warmed by this entry.
         address account;
+        /// @notice Storage slots pre-warmed at `account`.
         bytes32[] storageKeys;
     }
 
+    /// @notice Canonical, deterministic snapshot of the `0x1D` transaction as
+    ///         seen by the verifier. Built by the protocol from the envelope,
+    ///         the loaded account state, and the computed signing hash.
+    ///         Contains no block-context values other than `chainId`.
     struct WorldChainTransactionContext {
+        /// @notice The EIP-2718 signing hash of the transaction (see "Envelope").
         bytes32 signingHash;
+        /// @notice The chain ID from the envelope.
         uint256 chainId;
+        /// @notice The account this transaction is executed as.
         address account;
+        /// @notice The session verifier that authorized this transaction.
+        ///         Equal to `address(this)` for the verifier reading the context.
         address sessionVerifier;
+        /// @notice The transaction nonce from the envelope.
         uint64 nonce;
+        /// @notice EIP-1559 priority fee.
         uint256 maxPriorityFeePerGas;
+        /// @notice EIP-1559 max fee.
         uint256 maxFeePerGas;
+        /// @notice The envelope `gasLimit` (covers payload only; validation gas
+        ///         is protocol-paid — see "Validation Gas Accounting").
         uint64 gasLimit;
+        /// @notice Derived predicate `to.length == 0` from the envelope.
         bool isCreate;
+        /// @notice For calls, equal to `to`. For creates, `address(0)`.
+        ///         The deployed address of a CREATE transaction is NOT exposed
+        ///         here; verifiers needing it MUST inspect `trace.calls` (note
+        ///         that the root call is not represented in `trace.calls`).
         address target;
+        /// @notice The envelope `value` (wei transferred).
         uint256 value;
+        /// @notice The envelope `data`. Calldata for calls; init code for creates.
         bytes data;
+        /// @notice First 4 bytes of `data` for non-create transactions when
+        ///         `data.length >= 4`; `0x00000000` otherwise (including all
+        ///         create transactions, regardless of `data.length`).
         bytes4 selector;
+        /// @notice The envelope `accessList`, EIP-2930 shape.
         AccessListEntry[] accessList;
+        /// @notice `activeKeyringHash` of `account` at the time the transaction
+        ///         was admitted to the pool. Provided here because the verifier
+        ///         cannot read manager state from a restricted validation frame.
         bytes32 activeKeyringHash;
     }
 
+    /// @notice Discriminator for `CallTrace.kind`. Mirrors EVM call opcodes.
     enum TraceCallKind {
-        Call,
-        StaticCall,
-        DelegateCall,
-        Create,
-        Create2
+        Call,         // CALL
+        StaticCall,   // STATICCALL
+        DelegateCall, // DELEGATECALL
+        Create,       // CREATE
+        Create2       // CREATE2
     }
 
+    /// @notice Single internal call within the execution trace. Hashes are used
+    ///         in place of full payloads to keep trace size bounded.
     struct CallTrace {
+        /// @notice Depth in the call tree. Root transaction call has depth 0
+        ///         and is NOT represented in `WorldChainExecutionTrace.calls`;
+        ///         the first internal call is depth 1.
         uint32 depth;
+        /// @notice Which call opcode initiated this frame.
         TraceCallKind kind;
+        /// @notice Address that executed the call/create opcode (the parent
+        ///         frame's address). For DelegateCall, the address performing
+        ///         the DELEGATECALL — NOT the inherited original sender.
         address caller;
+        /// @notice For Call/StaticCall/DelegateCall: the callee address.
+        ///         For Create/Create2: the deployed contract address (or the
+        ///         address that would have been deployed, if the create reverted).
         address target;
+        /// @notice Wei transferred by this call. MUST be 0 for StaticCall and
+        ///         DelegateCall.
         uint256 value;
+        /// @notice First 4 bytes of input calldata when `inputHash` covers
+        ///         `>= 4` bytes; `0x00000000` for create kinds and short inputs.
         bytes4 selector;
+        /// @notice `keccak256(input)` where `input` is calldata for calls and
+        ///         init code for creates. `keccak256("")` for empty input.
+        ///         Never the zero sentinel.
         bytes32 inputHash;
+        /// @notice `keccak256(output)` where `output` is return data on success
+        ///         and revert data on failure. `keccak256("")` for empty output.
+        ///         Never the zero sentinel.
         bytes32 outputHash;
+        /// @notice True iff the call returned without reverting.
         bool success;
+        /// @notice Gas consumed by this call, measured at the EVM level.
         uint64 gasUsed;
     }
 
+    /// @notice Single log emission within the execution trace.
     struct LogTrace {
+        /// @notice Address that emitted the log.
         address emitter;
+        /// @notice Up to four indexed topics.
         bytes32[] topics;
+        /// @notice `keccak256(data)`. `keccak256("")` for empty log data.
         bytes32 dataHash;
+        /// @notice Index into `WorldChainExecutionTrace.calls` of the call that
+        ///         emitted this log. `type(uint32).max` indicates emission by
+        ///         the root transaction call (which has no `CallTrace` entry).
+        uint32 callIndex;
     }
 
+    /// @notice The execution trace for a single `0x1D` transaction's payload.
+    ///         Full calldata, return data, and log data are NOT included; only
+    ///         their hashes. Logs from reverted sub-call frames are excluded
+    ///         per EVM revert semantics.
     struct WorldChainExecutionTrace {
+        /// @notice Final success flag of the root transaction call.
         bool success;
+        /// @notice Total gas consumed by payload execution. Excludes validation
+        ///         gas (which is protocol-paid).
         uint64 gasUsed;
+        /// @notice `keccak256` of the root call's return / revert data, with
+        ///         the same empty-data convention as `CallTrace.outputHash`.
         bytes32 outputHash;
+        /// @notice Internal calls in execution order. Length-bounded indirectly
+        ///         by `MAX_EXECUTION_TRACE_BYTES`.
         CallTrace[] calls;
+        /// @notice Emitted logs in emission order. Each annotated with the
+        ///         emitting call's `callIndex` for log↔call correlation.
         LogTrace[] logs;
     }
 
+    /// @notice The full input to `evaluateSessionPolicy`.
     struct ExecutionTraceContext {
         WorldChainTransactionContext transaction;
         WorldChainExecutionTrace trace;
     }
 
+    /// @notice Evaluate whether the executed transaction is acceptable under
+    ///         this session verifier's policy.
+    /// @dev    Called by `WORLD_CHAIN_ACCOUNT_MANAGER` via STATICCALL inside a
+    ///         restricted validation frame after tentative payload execution
+    ///         and before committing payload state. MUST be `view`. MUST NOT
+    ///         attempt state mutation. MUST NOT call out to non-allowlisted
+    ///         addresses (see `WIP1001-VR-8`).
+    /// @param  context Canonical execution snapshot built from the envelope and
+    ///         the post-execution trace.
+    /// @return allowed `true` if policy accepts the trace; `false` rejects.
     function evaluateSessionPolicy(
         ExecutionTraceContext calldata context
     ) external view returns (bool allowed);
@@ -438,8 +617,9 @@ For this context:
 
 - `target` equals `to` when `isCreate == false`;
 - `target` equals `address(0)` when `isCreate == true`;
-- `selector` equals the first four bytes of `data` when `data.length >= 4`;
-- `selector` equals `0x00000000` when `data.length < 4`.
+- `selector` equals the first four bytes of `data` when `isCreate == false` and `data.length >= 4`;
+- `selector` equals `0x00000000` when `isCreate == true`, regardless of `data.length`. Constructor bytecode is not a function selector and MUST NOT be interpreted as one.
+- `selector` equals `0x00000000` when `isCreate == false` and `data.length < 4`.
 
 `ExecutionTraceContext.trace` is canonical and MUST include:
 
@@ -447,9 +627,27 @@ For this context:
 - total gas used by payload execution;
 - `keccak256` of payload return data;
 - all internal calls, ordered by execution order and annotated with call depth;
-- all logs emitted by payload execution, ordered by emission order.
+- all logs emitted by payload execution, ordered by emission order, each annotated with the index of the emitting call.
 
 The root transaction call is represented by `ExecutionTraceContext.transaction`, not by a `CallTrace` entry.
+
+For each `CallTrace` entry:
+
+- When `kind == Create` or `kind == Create2`, `target` MUST be the deployed contract address. If the create call reverted, `target` MUST be the address that *would have been* deployed (computed per EIP-1014 for `Create2` and `keccak256(rlp([sender, nonce]))[12:]` for `Create`).
+- When `kind == DelegateCall`, `value` MUST be `0` (the trace records the value transferred by the call itself, not the inherited callvalue), and `caller` MUST be the address that executed the `DELEGATECALL` opcode (the parent context address, not the original transaction sender).
+- When `success == false`, `outputHash` MUST equal `keccak256(revertData)`. When the call returned successfully but with empty return data, `outputHash` MUST equal `keccak256("")` (i.e., `0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`). `outputHash` MUST NOT be the zero sentinel `bytes32(0)` for empty data.
+- `inputHash` follows the same convention: empty calldata hashes to `keccak256("")`, never `bytes32(0)`.
+
+For each `LogTrace` entry:
+
+- `callIndex` MUST equal the index into `WorldChainExecutionTrace.calls` of the `CallTrace` whose execution emitted the log. The sentinel value `type(uint32).max` indicates the log was emitted by the root transaction call (which has no `CallTrace` entry).
+- Logs emitted within reverted sub-call frames MUST NOT appear in `logs`, consistent with EVM revert semantics.
+
+For `WorldChainExecutionTrace.outputHash`:
+
+- When the root call returned successfully with non-empty return data: `keccak256(returnData)`.
+- When the root call returned successfully with empty return data: `keccak256("")`.
+- When the root call reverted: `keccak256(revertData)`.
 
 Full internal calldata, return data, and log data are not copied into the trace. The trace includes hashes. A verifier that needs exact bytes MUST bind those bytes through the session signature, transaction calldata, or an application-level commitment.
 
@@ -460,7 +658,18 @@ The ABI-encoded trace MUST be no larger than `MAX_EXECUTION_TRACE_BYTES`. If the
 `WORLD_CHAIN_ACCOUNT_MANAGER` exposes:
 
 ```solidity
+/// @notice Public interface of `WORLD_CHAIN_ACCOUNT_MANAGER`. All admin-mutating
+///         methods require an `adminAuthorization` validated through EIP-1271
+///         against the account's admin signer in a restricted validation frame.
 interface IWorldChainAccountManager {
+    /// @notice Create a new World Chain account.
+    /// @param  adminSigner Already-deployed EIP-1271 admin signer contract.
+    /// @param  accountSalt Caller-supplied salt, mixed into address derivation.
+    /// @param  initialSessionVerifiers Initial keyring; length in
+    ///         `[1, MAX_SESSION_VERIFIERS]`, no duplicates, all with deployed code.
+    /// @param  adminAuthorization Bytes interpreted by `adminSigner`. Bound to
+    ///         the account-creation `adminOperationHash` (see "Admin Operation Hashes").
+    /// @return account The address derived per "Address Derivation".
     function create(
         address adminSigner,
         bytes32 accountSalt,
@@ -468,6 +677,19 @@ interface IWorldChainAccountManager {
         bytes calldata adminAuthorization
     ) external returns (address account);
 
+    /// @notice Queue a timelocked keyring replacement.
+    /// @param  account Existing account.
+    /// @param  expectedCurrentKeyringHash Replay/race guard; MUST equal the
+    ///         account's current `activeKeyringHash`.
+    /// @param  targetSessionVerifiers Replacement keyring; same length and
+    ///         uniqueness rules as `initialSessionVerifiers`.
+    /// @param  activateAfter Earliest UNIX timestamp at which
+    ///         `activateKeyringUpdate` may succeed. MUST be at least
+    ///         `block.timestamp + MIN_KEYRING_UPDATE_DELAY`.
+    /// @param  adminAuthorization Bound to the queue `adminOperationHash`.
+    /// @dev    Replaces any existing pending update; emits
+    ///         `PendingKeyringUpdateReplaced` in that case, otherwise
+    ///         `KeyringUpdateQueued`. Increments `adminNonce` by one.
     function queueKeyringUpdate(
         address account,
         bytes32 expectedCurrentKeyringHash,
@@ -476,14 +698,71 @@ interface IWorldChainAccountManager {
         bytes calldata adminAuthorization
     ) external;
 
+    /// @notice Activate a previously queued keyring update once its
+    ///         `activateAfter` has passed. Permissionless — any address may
+    ///         call. Does NOT consume `adminNonce`.
+    /// @param  account Account whose pending update should be activated.
     function activateKeyringUpdate(address account) external;
 
+    /// @notice Cancel a pending keyring update.
+    /// @param  account Account whose pending update should be cancelled.
+    /// @param  expectedQueuedAtNonce Replay guard; MUST equal the pending
+    ///         update's `queuedAtNonce`.
+    /// @param  adminAuthorization Bound to the cancel `adminOperationHash`.
+    /// @dev    Increments `adminNonce` by one. No timelock; admin authorization
+    ///         alone is sufficient.
+    function cancelPendingKeyringUpdate(
+        address account,
+        uint64 expectedQueuedAtNonce,
+        bytes calldata adminAuthorization
+    ) external;
+
+    /// @notice Instantly remove a session verifier from the active keyring.
+    /// @param  account Account whose verifier should be revoked.
+    /// @param  sessionVerifier Verifier address to remove. MUST currently be a
+    ///         keyring member.
+    /// @param  expectedCurrentKeyringHash Race guard; MUST equal the account's
+    ///         current `activeKeyringHash`.
+    /// @param  adminAuthorization Bound to the revoke `adminOperationHash`.
+    /// @dev    No timelock. Increments `adminNonce`. Pool entries from the
+    ///         revoked verifier are evicted; pool entries from other verifiers
+    ///         retain stable inclusion (see "Mempool Revalidation").
+    ///         Reverts if removal would leave the keyring empty — use
+    ///         `queueKeyringUpdate` for full keyring replacement instead.
+    function revokeSessionVerifier(
+        address account,
+        address sessionVerifier,
+        bytes32 expectedCurrentKeyringHash,
+        bytes calldata adminAuthorization
+    ) external;
+
+    /// @return The immutable admin signer of `account`. `address(0)` if account
+    ///         does not exist.
     function getAdminSigner(address account) external view returns (address);
+
+    /// @return The current `adminNonce` of `account`. `0` if account does not
+    ///         exist.
     function getAdminNonce(address account) external view returns (uint64);
+
+    /// @return The `activeKeyringHash` of `account`. `bytes32(0)` if account
+    ///         does not exist.
     function getActiveKeyringHash(address account) external view returns (bytes32);
+
+    /// @return A copy of `account`'s active session verifier list. Empty array
+    ///         if account does not exist.
     function getActiveSessionVerifiers(address account) external view returns (SessionVerifier[] memory);
+
+    /// @return A copy of `account`'s pending keyring update. Check `.exists`
+    ///         before reading other fields.
     function getPendingKeyringUpdate(address account) external view returns (PendingKeyringUpdate memory);
+
+    /// @return `true` iff `sessionVerifier` is currently a member of `account`'s
+    ///         active keyring. Does NOT consider mempool retention windows for
+    ///         recently-revoked verifiers (see "Mempool Revalidation").
     function isAuthorizedSessionVerifier(address account, address sessionVerifier) external view returns (bool);
+
+    /// @return The `SessionVerifier` struct for `sessionVerifier` if it is a
+    ///         current member of `account`'s keyring. Reverts otherwise.
     function getAuthorizedSessionVerifier(address account, address sessionVerifier) external view returns (SessionVerifier memory);
 }
 ```
@@ -501,7 +780,9 @@ interface IWorldChainAccountManager {
 7. Compute `activeKeyringHash = keccak256(abi.encode(initialSessionVerifiers))`.
 8. Compute the account-creation `adminOperationHash`.
 9. Verify `adminAuthorization` through `adminSigner.isValidSignature(adminOperationHash, adminAuthorization)` in a restricted validation frame.
-10. Initialize account state with `adminNonce = 0`, no pending keyring update, and `activeSessionVerifiers = initialSessionVerifiers`.
+10. If `adminSigner` was deployed by `WORLD_ID_1271_SIGNER_FACTORY` (detected via `factory.isFactorySigner(adminSigner)`), the manager MUST also verify `IWorldIDAdminSigner(adminSigner).account() == account` to ensure the signer's self-reported account binding matches the derived address. This step MUST execute in a restricted validation frame and is REQUIRED only for default-factory-deployed admin signers; custom admin signers MAY but are not required to expose `IWorldIDAdminSigner.account()`.
+11. Initialize account state with `adminNonce = 0`, no pending keyring update, and `activeSessionVerifiers = initialSessionVerifiers`.
+12. Emit `AccountCreated(account, adminSigner, accountSalt, activeKeyringHash)`.
 
 If any step fails, account state MUST remain unchanged.
 
@@ -519,7 +800,7 @@ If any step fails, account state MUST remain unchanged.
 8. Let `authorizationNonce = adminNonce`.
 9. Compute the keyring-update `adminOperationHash` using `authorizationNonce` as `adminNonce`.
 10. Verify `adminAuthorization` through `adminSigner.isValidSignature(adminOperationHash, adminAuthorization)`.
-11. Replace any existing pending update with the new pending update.
+11. Replace any existing pending update with the new pending update. If a prior pending update existed and was replaced, emit `PendingKeyringUpdateReplaced` with the prior `targetKeyringHash` and the new pending fields. If no prior pending update existed, emit `KeyringUpdateQueued`.
 12. Store `queuedAtNonce = authorizationNonce`.
 13. Increment `adminNonce` by one.
 
@@ -530,15 +811,53 @@ If any step fails, account state MUST remain unchanged and `adminNonce` MUST NOT
 `activateKeyringUpdate` MAY be called by any address and MUST execute atomically:
 
 1. Require `account` to exist.
-2. Require a pending keyring update.
+2. Require `pendingKeyringUpdate.exists == true`.
 3. Require `block.timestamp >= activateAfter`.
 4. Require `expectedCurrentKeyringHash == activeKeyringHash`.
 5. Require every target session verifier to still have deployed code.
 6. Replace `activeSessionVerifiers` with `targetSessionVerifiers`.
 7. Set `activeKeyringHash = targetKeyringHash`.
-8. Clear the pending update.
+8. Clear the pending update by setting `pendingKeyringUpdate.exists = false`. Other fields of `pendingKeyringUpdate` SHOULD be zeroed for storage hygiene but MUST NOT be relied upon by readers, per the `exists` semantics.
+9. Emit `KeyringUpdateActivated`.
 
 Activation MUST NOT increment `adminNonce`. If activation fails, account state MUST remain unchanged.
+
+#### Pending Keyring Update Cancellation Semantics
+
+`cancelPendingKeyringUpdate` MUST execute atomically:
+
+1. Require `account` to exist.
+2. Require `pendingKeyringUpdate.exists == true`.
+3. Require `pendingKeyringUpdate.queuedAtNonce == expectedQueuedAtNonce` (replay guard against cancelling a different pending update than the admin authorized).
+4. Let `authorizationNonce = adminNonce`.
+5. Compute the cancel-pending-keyring-update `adminOperationHash` using `authorizationNonce` as `adminNonce`.
+6. Verify `adminAuthorization` through `adminSigner.isValidSignature(adminOperationHash, adminAuthorization)` in a restricted validation frame.
+7. Clear the pending keyring update by setting `pendingKeyringUpdate.exists = false`. Other fields SHOULD be zeroed for storage hygiene.
+8. Increment `adminNonce` by one.
+9. Emit `KeyringUpdateCancelled(account, expectedQueuedAtNonce, adminNonce)`.
+
+If any step fails, account state MUST remain unchanged and `adminNonce` MUST NOT change.
+
+#### Session Verifier Revoke Semantics
+
+`revokeSessionVerifier` MUST execute atomically:
+
+1. Require `account` to exist.
+2. Require `sessionVerifier` to be a member of `activeSessionVerifiers`.
+3. Require `expectedCurrentKeyringHash == activeKeyringHash`.
+4. Reject the call if removing `sessionVerifier` would make `activeSessionVerifiers` empty (an empty keyring would brick the account; the admin MUST use `queueKeyringUpdate` to migrate to a different keyring instead).
+5. Let `authorizationNonce = adminNonce`.
+6. Compute the session-verifier-revoke `adminOperationHash` using `authorizationNonce` as `adminNonce`.
+7. Verify `adminAuthorization` through `adminSigner.isValidSignature(adminOperationHash, adminAuthorization)` in a restricted validation frame.
+8. Remove `sessionVerifier` from `activeSessionVerifiers`, preserving the relative order of remaining entries.
+9. Set `activeKeyringHash = keccak256(abi.encode(activeSessionVerifiers))`.
+10. Record `(sessionVerifier, block.number)` in the per-account exit set used by mempool revalidation. This entry MAY be pruned after `TXPOOL_TRANSACTION_EXPIRATION_WINDOW` has elapsed.
+11. Increment `adminNonce` by one.
+12. Emit `SessionVerifierRevoked(account, sessionVerifier, activeKeyringHash, adminNonce)`.
+
+Revocation does NOT affect any pending keyring update; the admin MAY independently cancel a pending update via `cancelPendingKeyringUpdate`. Revocation is the only admin operation that does not preserve stable inclusion: pool entries from the revoked verifier MUST be evicted (see "Mempool Revalidation"). Pool entries from other verifiers retain stable inclusion through the membership-based check.
+
+If any step fails, account state MUST remain unchanged and `adminNonce` MUST NOT change.
 
 ### Restricted Validation Frames
 
@@ -548,7 +867,15 @@ The protocol uses restricted validation frames for:
 - session signature verification;
 - session policy evaluation.
 
-Restricted frames make validation deterministic and independent of mutable external contract state.
+Restricted frames make validation deterministic and independent of mutable external contract state, mutable transaction context, and mutable block context.
+
+#### Enforcement Model
+
+Restricted validation frames are enforced via a runtime opcode-and-target rule tracer derived from [ERC-7562](https://eips.ethereum.org/EIPS/eip-7562). World Chain clients MUST implement this tracer for every validation-frame call (`isValidSignature` and `evaluateSessionPolicy`). The tracer monitors EVM execution at every opcode and rejects the call when any rule below is violated.
+
+Static bytecode analysis at signer registration time is RECOMMENDED as a fast-path admission check but does NOT replace runtime enforcement. Runtime enforcement is authoritative because forbidden opcodes can be hidden behind unreachable static branches.
+
+On any tracer rule violation during validation, the protocol MUST treat the call as if the EIP-1271 magic value was not returned (for signature checks) or as if `false` was returned (for policy evaluation). This is the same handling as malformed return data.
 
 #### EIP-1271 Signature Call
 
@@ -560,9 +887,9 @@ For each EIP-1271 signature check, the protocol MUST perform:
 - call value: `0`;
 - gas: exactly `EIP1271_VALIDATION_GAS_LIMIT`;
 - calldata: `IERC1271.isValidSignature.selector || abi.encode(hash, signature)`;
-- success condition: call succeeds and returns `EIP1271_MAGIC_VALUE`.
+- success condition: call succeeds, returns `EIP1271_MAGIC_VALUE`, and triggers no tracer rule violation.
 
-Failure, revert, out-of-gas, malformed return data, or forbidden validation behavior MUST be treated as signature failure.
+Failure, revert, out-of-gas, malformed return data, or any tracer rule violation MUST be treated as signature failure.
 
 #### Session Policy Evaluation Call
 
@@ -574,43 +901,78 @@ After tentative payload execution, the protocol MUST perform:
 - call value: `0`;
 - gas: exactly `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`;
 - calldata: `IWorldChainSessionVerifier.evaluateSessionPolicy.selector || abi.encode(context)`;
-- success condition: call succeeds and returns `true`.
+- success condition: call succeeds, returns `true`, and triggers no tracer rule violation.
 
-Failure, revert, out-of-gas, malformed return data, forbidden validation behavior, or `false` MUST reject the trace and revert tentative payload execution.
+Failure, revert, out-of-gas, malformed return data, any tracer rule violation, or a return value of `false` MUST reject the trace and revert tentative payload execution.
 
-#### Call Rules
+#### Tracer Rule Taxonomy
 
-Inside a restricted validation frame:
+The tracer enforces the following rules. Where a rule has a direct counterpart in ERC-7562, the ERC-7562 reference is cited; rules without a counterpart are WIP-1001-specific.
 
-- `STATICCALL` to an allowlisted precompile is permitted;
-- `STATICCALL` to any other address is forbidden;
-- `CALL`, `CALLCODE`, `DELEGATECALL`, `CREATE`, and `CREATE2` are forbidden;
-- precompile execution does not create an additional EVM code frame.
+| Rule ID | ERC-7562 ref | Description |
+| --- | --- | --- |
+| `WIP1001-VR-1` | OP-011 | Forbid block-context opcodes: `BLOCKHASH`, `COINBASE`, `TIMESTAMP`, `NUMBER`, `PREVRANDAO`/`DIFFICULTY`, `GASLIMIT`, `BASEFEE`, `BLOBHASH`, `BLOBBASEFEE`. |
+| `WIP1001-VR-2` | OP-011 | Forbid transaction-context opcodes: `GASPRICE`, `ORIGIN`. |
+| `WIP1001-VR-3` | OP-020 | Forbid external account inspection: `BALANCE`, `SELFBALANCE`, `EXTCODESIZE`, `EXTCODECOPY`, `EXTCODEHASH`. |
+| `WIP1001-VR-4` | OP-031, OP-032 | Forbid persistent and transient state mutation: `SSTORE`, `TLOAD`, `TSTORE`. |
+| `WIP1001-VR-5` | OP-031 | Forbid log emission: `LOG0`, `LOG1`, `LOG2`, `LOG3`, `LOG4`. |
+| `WIP1001-VR-6` | OP-031, OP-040 | Forbid `CALL`, `CALLCODE`, `CREATE`, `CREATE2`. |
+| `WIP1001-VR-7` | OP-051 | Forbid `SELFDESTRUCT`. |
+| `WIP1001-VR-8` | OP-061 | `STATICCALL` permitted only to addresses on the allowlisted precompile set; all other `STATICCALL` targets are forbidden. |
+| `WIP1001-VR-9` | OP-052 | `DELEGATECALL` permitted only when the delegatee bytecode itself satisfies every rule in this table (recursive conformance). The tracer MUST validate the delegatee under the same rule set; otherwise the call MUST be rejected. This permits proxy-style signers without compromising determinism. |
+| `WIP1001-VR-10` | — | Precompile execution does not create an additional EVM code frame and is not subject to the rules above. |
+| `WIP1001-VR-11` | — | Reads of the signer contract's own bytecode (via `CODECOPY`/`CODESIZE`) are permitted. |
+| `WIP1001-VR-12` | — | Reads of the signer contract's own storage (via `SLOAD`) are permitted. |
+| `WIP1001-VR-13` | — | `KECCAK256`, `CHAINID`, `GAS`, all stack/memory/calldata opcodes, and all deterministic arithmetic opcodes are permitted. |
 
-#### Opcode Policy
-
-The following opcodes are forbidden inside restricted validation frames:
-
-- block context: `BLOCKHASH`, `COINBASE`, `TIMESTAMP`, `NUMBER`, `PREVRANDAO`/`DIFFICULTY`, `GASLIMIT`, `BASEFEE`, `BLOBHASH`, `BLOBBASEFEE`;
-- transaction context: `GASPRICE`, `ORIGIN`;
-- external account inspection: `BALANCE`, `SELFBALANCE`, `EXTCODESIZE`, `EXTCODECOPY`, `EXTCODEHASH`;
-- mutable state and transient state: `SSTORE`, `TLOAD`, `TSTORE`;
-- logs: `LOG0`, `LOG1`, `LOG2`, `LOG3`, `LOG4`;
-- external execution and creation: `CALL`, `CALLCODE`, `DELEGATECALL`, `CREATE`, `CREATE2`;
-- destruction: `SELFDESTRUCT`.
-
-The following operations are permitted:
+The following primitive operations are permitted inside a restricted validation frame:
 
 - deterministic computation;
 - calldata and memory access;
-- reads of the signer contract's own bytecode;
-- reads of the signer contract's own storage;
+- reads of the signer contract's own bytecode (`WIP1001-VR-11`);
+- reads of the signer contract's own storage (`WIP1001-VR-12`);
 - `KECCAK256`;
 - `CHAINID`;
 - `GAS`;
-- `STATICCALL` to allowlisted precompiles.
+- `STATICCALL` to allowlisted precompiles (`WIP1001-VR-8`);
+- `DELEGATECALL` to a delegatee whose bytecode satisfies the same rule set (`WIP1001-VR-9`).
 
-An implementation MUST reject the validation call if a forbidden opcode or forbidden call target is reached.
+Implementations MAY assume that any address on the allowlisted precompile set has stable input/output behavior across blocks. Adding a new precompile to the allowlist is a hard-fork change.
+
+### Validation Gas Accounting
+
+Validation gas is supplied by the protocol from a per-block budget. It is NOT deducted from the envelope `gasLimit`. The envelope `gasLimit` covers payload execution only.
+
+Per block, the cumulative gas consumed by all `0x1D` validation calls (signature checks via `isValidSignature` plus policy evaluation calls via `evaluateSessionPolicy`) MUST NOT exceed `BLOCK_VALIDATION_GAS_BUDGET`. Block builders MUST account for validation gas when sequencing; a `0x1D` transaction whose worst-case validation cost (`EIP1271_VALIDATION_GAS_LIMIT + EXECUTION_TRACE_VALIDATION_GAS_LIMIT`) exceeds the remaining block validation budget MUST be deferred to a subsequent block.
+
+When a `0x1D` transaction's validation fails (signature failure, policy rejection, or any tracer rule violation):
+
+1. The transaction's nonce on `account` MUST be incremented (preventing replay of the failed transaction).
+2. The protocol MUST charge the account a fee of `max(MIN_VALIDATION_FAILURE_FEE, baseFee * EIP1271_VALIDATION_GAS_LIMIT)` denominated in the transaction's fee token.
+3. The transaction MUST NOT execute its payload.
+4. The validation gas consumed MUST count against `BLOCK_VALIDATION_GAS_BUDGET`.
+
+This makes spam-validation pay-to-play and prevents an attacker with no balance from exhausting the per-block validation budget for free.
+
+Mempool admission MUST refuse any transaction whose `account` does not hold sufficient balance to pay `MIN_VALIDATION_FAILURE_FEE` at the current `baseFee`.
+
+### Mempool Revalidation
+
+World Chain clients MUST revalidate every pooled `0x1D` transaction at least once per block until the transaction is included, expires, or is evicted.
+
+Pool admission and revalidation use a membership-based check rather than a strict keyring-hash equality check, in order to preserve stable inclusion across keyring updates and revocations:
+
+1. On pool entry, the pool MUST record `entryBlock = block.number` for the transaction.
+2. A pooled transaction is considered valid at block `B` iff:
+   - `sessionVerifier` was a member of the account's keyring at every block in the range `[entryBlock, B]`, OR
+   - `sessionVerifier` was a member at `entryBlock` and remained a member until at least `entryBlock + TXPOOL_TRANSACTION_EXPIRATION_WINDOW` (membership persists through transaction lifetime).
+3. The pool MUST evict a pooled transaction immediately when:
+   - `revokeSessionVerifier` is called for its `sessionVerifier`, regardless of `entryBlock` (instant revoke supersedes stable inclusion);
+   - the account's balance falls below `MIN_VALIDATION_FAILURE_FEE` at the current `baseFee`;
+   - `block.timestamp - entryBlock_timestamp >= TXPOOL_TRANSACTION_EXPIRATION_WINDOW`.
+4. The pool MUST retain a pooled transaction across `activateKeyringUpdate` even if the new active keyring no longer includes its `sessionVerifier`, provided the verifier was a member of the keyring active at `entryBlock`. The retention window terminates at `entryBlock_timestamp + TXPOOL_TRANSACTION_EXPIRATION_WINDOW`. This is the stable-inclusion guarantee.
+
+The manager MUST expose sufficient state for the pool to perform these checks. A reference approach is to retain, per account, the set of `(sessionVerifier, exitedAtBlock)` pairs for verifiers removed within the past `TXPOOL_TRANSACTION_EXPIRATION_WINDOW`. State older than this window MAY be pruned.
 
 ### Timelocked Signer-State Updates
 
@@ -641,7 +1003,6 @@ rlp([
     gasLimit,
     account,
     sessionVerifier,
-    isCreate,
     to,
     value,
     data,
@@ -650,9 +1011,17 @@ rlp([
 ])
 ```
 
-If `isCreate == false`, `to` MUST be nonzero and `data` is call data for `to`.
+The `to` field follows EIP-2718 / EIP-1559 conventions: it is RLP-encoded as a 20-byte address for a call, or as the empty byte string for a contract creation. The derived predicate `isCreate := (to.length == 0)` is used throughout this specification but is NOT a separate envelope field. Implementations MUST reject envelopes whose `to` is neither empty nor exactly 20 bytes.
 
-If `isCreate == true`, `to` MUST be `address(0)` and `data` is contract init code.
+When `isCreate == false`, `data` is call data for `to`.
+
+When `isCreate == true`, `data` is contract init code; the deployed address is computed per EIP-1014 (`CREATE` from the account, with the post-increment `nonce` value).
+
+`accessList` MUST be encoded per [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) as `[[address, [storageKey, ...]], ...]`. Implementations MUST reject envelopes where:
+
+- `accessList.length > MAX_ACCESS_LIST_ENTRIES`,
+- `data.length > MAX_PAYLOAD_DATA_BYTES`, or
+- `signature.length > MAX_SESSION_SIGNATURE_BYTES`.
 
 The signing hash is:
 
@@ -667,7 +1036,6 @@ keccak256(
         gasLimit,
         account,
         sessionVerifier,
-        isCreate,
         to,
         value,
         data,
@@ -682,15 +1050,16 @@ To validate and execute a `0x1D` transaction, the protocol MUST:
 
 1. Compute the signing hash.
 2. Load the account from `WORLD_CHAIN_ACCOUNT_MANAGER`.
-3. Reject the transaction if `sessionVerifier` is not in the active keyring.
-4. Verify `signature` by calling `sessionVerifier.isValidSignature(signingHash, signature)` in a restricted validation frame.
-5. Reject the transaction unless the session verifier returns `EIP1271_MAGIC_VALUE`.
-6. Execute the payload tentatively with `account` as the EVM transaction sender and collect the canonical execution trace.
-7. Build `ExecutionTraceContext` from the envelope, signing hash, active keyring hash, and canonical execution trace.
-8. Reject the transaction if `abi.encode(context.trace).length > MAX_EXECUTION_TRACE_BYTES`.
-9. Call `sessionVerifier.evaluateSessionPolicy(context)` in a restricted validation frame.
-10. If session policy evaluation fails, discard tentative payload state and logs, consume nonce and gas according to normal failed-transaction semantics, and mark the transaction failed.
-11. If session policy evaluation succeeds, commit the payload result. If payload execution itself failed, commit the normal failed-call result.
+3. Reject the transaction if `sessionVerifier` is not authorized for `account` per the membership rules in "Mempool Revalidation".
+4. Reserve `EIP1271_VALIDATION_GAS_LIMIT + EXECUTION_TRACE_VALIDATION_GAS_LIMIT` from the remaining `BLOCK_VALIDATION_GAS_BUDGET`. If the budget is exhausted, defer the transaction to a subsequent block; this is not a validation failure.
+5. Verify `signature` by calling `sessionVerifier.isValidSignature(signingHash, signature)` in a restricted validation frame, consuming up to `EIP1271_VALIDATION_GAS_LIMIT` from the block validation budget.
+6. If the signature check does not return `EIP1271_MAGIC_VALUE` (or violates a tracer rule), apply validation failure semantics from "Validation Gas Accounting": charge the account `max(MIN_VALIDATION_FAILURE_FEE, baseFee * EIP1271_VALIDATION_GAS_LIMIT)`, consume the transaction nonce, do not execute the payload, and finalize the transaction as failed.
+7. Execute the payload tentatively with `account` as the EVM transaction sender, charging gas against the envelope `gasLimit`, and collect the canonical execution trace.
+8. Build `ExecutionTraceContext` from the envelope, signing hash, active keyring hash, and canonical execution trace.
+9. Reject the transaction with a payload-execution failure if `abi.encode(context.trace).length > MAX_EXECUTION_TRACE_BYTES`. The validation budget reservation in step 4 MUST still be released (this is a payload failure, not a validation failure).
+10. Call `sessionVerifier.evaluateSessionPolicy(context)` in a restricted validation frame, consuming up to `EXECUTION_TRACE_VALIDATION_GAS_LIMIT` from the block validation budget.
+11. If session policy evaluation does not return `true` (or violates a tracer rule), discard tentative payload state and logs and apply validation failure semantics: charge the account `max(MIN_VALIDATION_FAILURE_FEE, baseFee * EIP1271_VALIDATION_GAS_LIMIT)`, consume the transaction nonce, and finalize the transaction as failed. Payload-execution gas is NOT additionally charged in this branch — validation failure supersedes the payload's normal gas accounting.
+12. If session policy evaluation succeeds, commit the payload result. If payload execution itself failed in step 7, commit the normal failed-call result with payload-execution gas charged from `gasLimit`.
 
 ### EIP-1271 Signer Factory Pattern
 
@@ -705,19 +1074,46 @@ Accounts MAY use any EIP-1271 admin signer or session verifier that satisfies th
 Default factories MUST implement:
 
 ```solidity
+/// @notice Role assignment for a factory-deployed signer. Determines which
+///         interface(s) the deployed contract implements and which slot of an
+///         account's state it is eligible to occupy.
 enum WorldChainSignerRole {
-    AdminSigner,
-    SessionVerifier
+    AdminSigner,     // Eligible as `Account.adminSigner`. Implements EIP-1271 only.
+    SessionVerifier  // Eligible as a member of `Account.activeSessionVerifiers`.
+                     // Implements EIP-1271 + `IWorldChainSessionVerifier`.
 }
 
+/// @notice Self-introspection interface implemented by every contract deployed
+///         by a default `IWorldChain1271SignerFactory`. Allows off-chain tools
+///         and the manager itself to identify factory provenance and variant
+///         without parsing bytecode.
 interface IWorldChainFactoryDeployedSigner {
+    /// @return The factory address that deployed this signer.
     function signerFactory() external view returns (address);
+
+    /// @return Role under which this signer was deployed.
     function signerRole() external view returns (WorldChainSignerRole);
+
+    /// @return Variant identifier (e.g., `WORLD_ID_ADMIN_SIGNER_V1`) selected
+    ///         at deployment.
     function signerVariantId() external view returns (bytes32);
+
+    /// @return `keccak256(config)` where `config` is the variant-specific
+    ///         deployment configuration. Used to verify the signer's bound
+    ///         configuration without re-supplying it.
     function signerConfigHash() external view returns (bytes32);
 }
 
+/// @notice Default factory interface for deploying EIP-1271 signers (admin or
+///         session) under deterministic CREATE2 addresses.
 interface IWorldChain1271SignerFactory {
+    /// @notice Emitted when a new signer is deployed.
+    /// @param  signer Deployed signer address (= return of `createSigner`).
+    /// @param  role The role under which the signer was deployed.
+    /// @param  variantId The variant of `role` deployed.
+    /// @param  configHash `keccak256(config)`. Stored on the deployed signer
+    ///         and returned by `signerConfigHash()`.
+    /// @param  salt The caller-supplied salt (NOT the derived CREATE2 salt).
     event SignerCreated(
         address indexed signer,
         WorldChainSignerRole indexed role,
@@ -726,8 +1122,13 @@ interface IWorldChain1271SignerFactory {
         bytes32 salt
     );
 
+    /// @return The account manager this factory is bound to. MUST equal
+    ///         `WORLD_CHAIN_ACCOUNT_MANAGER`.
     function worldChainAccountManager() external view returns (address);
 
+    /// @notice Pure / view computation of the address `createSigner` would
+    ///         deploy for the same inputs. Used by relayers and indexers to
+    ///         predict signer addresses without writing.
     function computeAddress(
         WorldChainSignerRole role,
         bytes32 variantId,
@@ -735,6 +1136,12 @@ interface IWorldChain1271SignerFactory {
         bytes32 salt
     ) external view returns (address signer);
 
+    /// @notice Deploy a new signer.
+    /// @dev    Idempotent: if a contract already exists at the deterministic
+    ///         address with matching factory metadata, MUST return that
+    ///         address. MUST revert if the address is occupied by an
+    ///         incompatible contract.
+    /// @return signer The deployed (or existing) signer address.
     function createSigner(
         WorldChainSignerRole role,
         bytes32 variantId,
@@ -742,6 +1149,8 @@ interface IWorldChain1271SignerFactory {
         bytes32 salt
     ) external returns (address signer);
 
+    /// @return `true` iff `signer` was deployed by this factory and exposes
+    ///         matching metadata via `IWorldChainFactoryDeployedSigner`.
     function isFactorySigner(address signer) external view returns (bool);
 }
 ```
@@ -791,20 +1200,35 @@ Every default session verifier MUST reject `evaluateSessionPolicy` unless:
 `SECP256K1_1271_SIGNER_FACTORY` MUST support:
 
 ```solidity
+/// @notice Variant ID for the v1 secp256k1 admin signer.
 bytes32 constant SECP256K1_ADMIN_SIGNER_V1 =
     keccak256("world-chain.secp256k1.admin.v1");
 
+/// @notice Variant ID for the v1 secp256k1 session verifier.
 bytes32 constant SECP256K1_SESSION_VERIFIER_V1 =
     keccak256("world-chain.secp256k1.session-verifier.v1");
 
+/// @notice Deployment configuration for `SECP256K1_ADMIN_SIGNER_V1`.
 struct Secp256k1AdminSignerConfig {
+    /// @notice Immutable secp256k1 owner address. ECDSA signatures by this
+    ///         address authorize admin operations.
     address owner;
 }
 
+/// @notice Deployment configuration for `SECP256K1_SESSION_VERIFIER_V1`.
 struct Secp256k1SessionVerifierConfig {
+    /// @notice The account this session verifier is bound to. The verifier
+    ///         rejects `evaluateSessionPolicy` for any other account.
     address account;
+    /// @notice Immutable secp256k1 owner address. ECDSA signatures by this
+    ///         address authorize `0x1D` transactions for `account`.
     address owner;
+    /// @notice Identifies the policy module compiled into the verifier.
+    ///         Variant-specific; the factory MUST reject unknown policies.
     bytes32 policyVariantId;
+    /// @notice ABI-encoded configuration for the selected policy variant.
+    ///         Stored on the verifier; never re-fetched from external state
+    ///         during validation.
     bytes policyConfig;
 }
 ```
@@ -823,27 +1247,60 @@ The secp256k1 session verifier variant MUST:
 `WORLD_ID_1271_SIGNER_FACTORY` MUST support:
 
 ```solidity
+/// @notice Variant ID for the v1 World ID admin signer.
 bytes32 constant WORLD_ID_ADMIN_SIGNER_V1 =
     keccak256("world-chain.world-id.admin.v1");
 
+/// @notice Variant ID for the v1 World ID session verifier.
 bytes32 constant WORLD_ID_SESSION_VERIFIER_V1 =
     keccak256("world-chain.world-id.session-verifier.v1");
 
+/// @notice Deployment configuration for `WORLD_ID_ADMIN_SIGNER_V1`. All fields
+///         are committed to in the factory `configHash` and become immutable
+///         on deployment except where `stateUpdater` is permitted to mutate
+///         them (see "Signer Update Semantics" + "Timelocked Signer-State
+///         Updates").
 struct WorldIDAdminSignerConfig {
+    /// @notice Salt mixed into the bound account address derivation.
     bytes32 accountSalt;
+    /// @notice Address authorized to queue verifier-state updates on the
+    ///         deployed signer. `address(0)` makes the verifier state fully
+    ///         immutable. Updates that can invalidate previously valid
+    ///         signatures MUST be timelocked.
     address stateUpdater;
+    /// @notice World ID Merkle tree depth. Pinned to the depth used by the
+    ///         circuit at deployment.
     uint256 treeDepth;
+    /// @notice Identifies the credential schema and issuer pair this signer
+    ///         accepts.
     uint64 issuerSchemaId;
+    /// @notice X-coordinate of the credential issuer's public key.
     uint256 credentialIssuerPubkeyX;
+    /// @notice Y-coordinate of the credential issuer's public key.
     uint256 credentialIssuerPubkeyY;
+    /// @notice X-coordinate of the OPRF service public key.
     uint256 oprfPubkeyX;
+    /// @notice Y-coordinate of the OPRF service public key.
     uint256 oprfPubkeyY;
+    /// @notice Floor for `expiresAtMin` of accepted credentials, as a UNIX
+    ///         timestamp. Proofs whose `expiresAtMin` is below this value
+    ///         MUST be rejected.
     uint64 minExpiresAt;
+    /// @notice Floor for `credentialGenesisIssuedAtMin`. `0` disables.
     uint256 minCredentialGenesisIssuedAt;
+    /// @notice Initial Merkle roots accepted at deployment. The runtime
+    ///         valid-root set is mutable via `stateUpdater` (see above).
     uint256[] initialValidRoots;
 }
 
+/// @notice Deployment configuration for `WORLD_ID_SESSION_VERIFIER_V1`.
+///         Fields shared with `WorldIDAdminSignerConfig` carry the same
+///         semantics; only the differences are documented here.
 struct WorldIDSessionVerifierConfig {
+    /// @notice The account this session verifier is bound to. Distinct from
+    ///         `WorldIDAdminSignerConfig.accountSalt`: the session verifier is
+    ///         not address-bound the same way an admin signer is, but it
+    ///         pinned-binds to its target account at config time.
     address account;
     address stateUpdater;
     uint256 treeDepth;
@@ -855,22 +1312,180 @@ struct WorldIDSessionVerifierConfig {
     uint64 minExpiresAt;
     uint256 minCredentialGenesisIssuedAt;
     uint256[] initialValidRoots;
+    /// @notice Identifies the policy module compiled into the verifier.
     bytes32 policyVariantId;
+    /// @notice ABI-encoded policy configuration; stored on the verifier.
     bytes policyConfig;
 }
 ```
 
 The World ID admin signer variant MUST implement `IWorldIDAdminSigner`. It derives its account from `address(this)` and `accountSalt`.
 
-The World ID session verifier variant MUST:
+The World ID session verifier variant MUST implement `IWorldChainSessionVerifier` and verify `isValidSignature(signingHash, signature)` as a World ID v4 *session* proof bound to the transaction signing hash. The variant MUST expose immutable account binding state:
 
-- implement `IWorldChainSessionVerifier`;
-- verify `isValidSignature(signingHash, signature)` as a World ID v4 session proof over `signingHash`;
-- bind proof verification to `WORLD_CHAIN_RP_ID`, `WORLD_CHAIN_ACCOUNT_MANAGER`, `account`, `address(this)`, and the configured World ID verifier state;
-- bind `evaluateSessionPolicy` to `account` and `address(this)`;
-- evaluate the configured session policy internally.
+```solidity
+/// @notice Default World ID EIP-1271 session verifier interface. Exposes
+///         immutable account binding state for off-chain verification and
+///         the manager's optional self-consistency check.
+interface IWorldIDSessionVerifier is IWorldChainSessionVerifier {
+    /// @return The account this session verifier authorizes transactions for.
+    ///         Pinned at deployment via `WorldIDSessionVerifierConfig.account`.
+    function account() external view returns (address);
+
+    /// @return MUST equal `WORLD_CHAIN_RP_ID`.
+    function worldIdRpId() external view returns (uint64);
+}
+```
+
+The EIP-1271 signature payload uses the World ID v4 session-proof verifier shape:
+
+```solidity
+/// @notice ABI-encoded payload passed as the `signature` argument to
+///         `isValidSignature` for a default World ID session verifier.
+struct WorldIDSessionProofSignature {
+    /// @notice Minimum credential expiration the proof was bound to.
+    uint64 expiresAtMin;
+    /// @notice Identifies the credential schema and issuer pair.
+    uint64 issuerSchemaId;
+    /// @notice Minimum `genesis_issued_at` the proof was bound to.
+    uint256 credentialGenesisIssuedAtMin;
+    /// @notice Session identifier connecting proofs for the same user+RP
+    ///         across requests. MUST be non-zero (zero is the uniqueness-proof
+    ///         shape used by the admin signer).
+    uint256 sessionId;
+    /// @notice Session nullifier tuple. `[0]` is the nullifier; `[1]` is a
+    ///         randomly generated action.
+    uint256[2] sessionNullifier;
+    /// @notice Encoded World ID v4 proof: `[0..3]` compressed Groth16,
+    ///         `[4]` Merkle root from the `WorldIDRegistry`.
+    uint256[5] zeroKnowledgeProof;
+}
+```
+
+`isValidSignature(hash, signature)` MUST:
+
+- decode `signature` as `WorldIDSessionProofSignature`;
+- compute `signalHash = worldIdField(abi.encode(hash))`;
+- compute `nonce = worldIdField(abi.encode("WIP1001_WORLD_ID_SESSION_NONCE", block.chainid, WORLD_CHAIN_ACCOUNT_MANAGER, account(), address(this), hash))`;
+- require `sessionId != 0` (distinguishing session proofs from uniqueness proofs; a zero sessionId is the uniqueness-proof shape used by the admin signer);
+- require `issuerSchemaId` to equal the verifier's configured issuer schema ID;
+- require `zeroKnowledgeProof[4]` to be an accepted World ID registry root in the verifier's state;
+- require `expiresAtMin` and `credentialGenesisIssuedAtMin` to satisfy the verifier's configured credential freshness policy;
+- verify the proof as a World ID v4 session proof equivalent to `IWorldIDVerifier.verifySession(WORLD_CHAIN_RP_ID, nonce, signalHash, expiresAtMin, issuerSchemaId, credentialGenesisIssuedAtMin, sessionId, sessionNullifier, zeroKnowledgeProof)`;
+- return `EIP1271_MAGIC_VALUE` only if verification succeeds.
+
+`evaluateSessionPolicy(context)` MUST reject unless:
+
+- `context.transaction.account == account()`;
+- `context.transaction.sessionVerifier == address(this)`;
+- the verifier's internal policy accepts `context`.
+
+The verifier MUST verify the same public inputs as the World ID v4 session verifier: issuer schema, credential issuer public key, credential expiration minimum, credential genesis minimum, Merkle root, tree depth, RP ID, OPRF public key, signal hash, nonce, sessionId, and sessionNullifier.
+
+The verifier MUST NOT consume nullifiers as part of `isValidSignature`, because EIP-1271 validation is a `view` operation. Per-session-proof uniqueness (replay protection across multiple transactions reusing the same session proof) is NOT enforced at the protocol level; each `0x1D` transaction's signing hash already commits to its `nonce`, so the same proof cannot authorize two transactions with the same envelope nonce.
+
+The verifier MUST NOT call an external World ID verifier from a restricted validation frame. Verifier state requirements match the admin signer (see "World ID Admin Signer").
 
 World ID verifier state MUST be stored in the signer contract itself. If `stateUpdater == address(0)`, the initial verifier state is immutable. Otherwise, only `stateUpdater` may queue verifier-state updates, and updates that can invalidate accepted transactions MUST follow the signer update semantics above.
+
+### Manager Events
+
+`WORLD_CHAIN_ACCOUNT_MANAGER` MUST emit the following events on the corresponding state transitions. Indexers, recovery tooling, and explorers depend on these; the manager MUST NOT mutate account state without emitting the matching event.
+
+```solidity
+/// @notice Events emitted by `WORLD_CHAIN_ACCOUNT_MANAGER`. Each event
+///         corresponds 1:1 with a state transition; conforming implementations
+///         MUST NOT mutate account state without emitting the matching event.
+interface IWorldChainAccountManagerEvents {
+    /// @notice Emitted exactly once per account, atomically with `create`.
+    /// @param  account Newly created account address.
+    /// @param  adminSigner Immutable admin signer of `account`.
+    /// @param  accountSalt The salt used in address derivation.
+    /// @param  activeKeyringHash Initial `activeKeyringHash`.
+    event AccountCreated(
+        address indexed account,
+        address indexed adminSigner,
+        bytes32 accountSalt,
+        bytes32 activeKeyringHash
+    );
+
+    /// @notice Emitted on a `queueKeyringUpdate` that does NOT replace an
+    ///         existing pending update.
+    /// @param  account Account whose keyring update was queued.
+    /// @param  targetKeyringHash Hash of the queued target verifier set.
+    /// @param  expectedCurrentKeyringHash Active keyring hash at queue time.
+    /// @param  activateAfter Earliest activation timestamp.
+    /// @param  queuedAtNonce `adminNonce` consumed by this queue.
+    event KeyringUpdateQueued(
+        address indexed account,
+        bytes32 indexed targetKeyringHash,
+        bytes32 expectedCurrentKeyringHash,
+        uint64 activateAfter,
+        uint64 queuedAtNonce
+    );
+
+    /// @notice Emitted atomically with `activateKeyringUpdate`.
+    /// @param  account Account whose keyring was activated.
+    /// @param  previousKeyringHash The keyring hash before activation.
+    /// @param  newKeyringHash The keyring hash after activation (= prior
+    ///         pending `targetKeyringHash`).
+    event KeyringUpdateActivated(
+        address indexed account,
+        bytes32 previousKeyringHash,
+        bytes32 indexed newKeyringHash
+    );
+
+    /// @notice Emitted atomically with `cancelPendingKeyringUpdate`.
+    /// @param  account Account whose pending update was cancelled.
+    /// @param  cancelledQueuedAtNonce The `queuedAtNonce` of the cancelled
+    ///         pending update.
+    /// @param  adminNonce New `adminNonce` after the cancellation increment.
+    event KeyringUpdateCancelled(
+        address indexed account,
+        uint64 cancelledQueuedAtNonce,
+        uint64 adminNonce
+    );
+
+    /// @notice Emitted atomically with `revokeSessionVerifier`.
+    /// @param  account Account whose verifier was revoked.
+    /// @param  sessionVerifier Address that was removed from the keyring.
+    /// @param  newKeyringHash `activeKeyringHash` after the removal.
+    /// @param  adminNonce New `adminNonce` after the revocation increment.
+    event SessionVerifierRevoked(
+        address indexed account,
+        address indexed sessionVerifier,
+        bytes32 newKeyringHash,
+        uint64 adminNonce
+    );
+
+    /// @notice Emitted in place of `KeyringUpdateQueued` when a successful
+    ///         `queueKeyringUpdate` replaces a previously queued update.
+    /// @param  account Account whose pending update was replaced.
+    /// @param  previousTargetKeyringHash Target hash of the prior pending update.
+    /// @param  newTargetKeyringHash Target hash of the new pending update.
+    /// @param  newActivateAfter Activation timestamp of the new pending update.
+    /// @param  newQueuedAtNonce `adminNonce` consumed by the new queue.
+    event PendingKeyringUpdateReplaced(
+        address indexed account,
+        bytes32 previousTargetKeyringHash,
+        bytes32 indexed newTargetKeyringHash,
+        uint64 newActivateAfter,
+        uint64 newQueuedAtNonce
+    );
+}
+```
+
+`AccountCreated` MUST be emitted exactly once per account, atomically with `create`.
+
+`KeyringUpdateQueued` MUST be emitted on every successful `queueKeyringUpdate` that does not replace an existing pending update.
+
+`PendingKeyringUpdateReplaced` MUST be emitted instead of `KeyringUpdateQueued` when a successful `queueKeyringUpdate` replaces an existing pending update.
+
+`KeyringUpdateActivated` MUST be emitted atomically with `activateKeyringUpdate`.
+
+`KeyringUpdateCancelled` MUST be emitted atomically with `cancelPendingKeyringUpdate` (see "Pending Keyring Update Cancellation Semantics").
+
+`SessionVerifierRevoked` MUST be emitted atomically with `revokeSessionVerifier` (see "Session Verifier Revoke Semantics").
 
 ### Visual Flow
 
@@ -907,7 +1522,31 @@ sequenceDiagram
     Manager-->>User: Pending until activateAfter
     User->>Manager: activateKeyringUpdate()
     Manager-->>User: Active keyring replaced
+
+    User->>Manager: cancelPendingKeyringUpdate(...)
+    Manager-->>User: Pending update cleared
+
+    User->>Manager: revokeSessionVerifier(...)
+    Manager-->>User: Verifier removed instantly
+    Manager-->>Pool: Evict pooled txns from revoked verifier
 ```
+
+### Invariants
+
+The following invariants are normative consequences of the rules in this specification. Each is traceable to one or more MUST clauses above and SHOULD be enforced by conforming implementations and exercised by the test cases (see "Test Cases").
+
+| ID | Invariant |
+| --- | --- |
+| `INV-1` | The account address is a deterministic function of `(WIP1001_ACCOUNT_DOMAIN, chainId, WORLD_CHAIN_ACCOUNT_MANAGER, adminSigner, accountSalt)`. No operation rotates `adminSigner` for an existing account. |
+| `INV-2` | `adminNonce` is strictly monotonically non-decreasing. It increments by exactly one on every successful `queueKeyringUpdate`, `cancelPendingKeyringUpdate`, and `revokeSessionVerifier`. It MUST NOT change on `activateKeyringUpdate`. |
+| `INV-3` | `1 <= activeSessionVerifiers.length <= MAX_SESSION_VERIFIERS`. The active keyring is never empty for an existing account. |
+| `INV-4` | `activeKeyringHash == keccak256(abi.encode(activeSessionVerifiers))` after every state-changing operation. |
+| `INV-5` | If `pendingKeyringUpdate.exists` is true, then `pendingKeyringUpdate.activateAfter` is at least `block.timestamp + MIN_KEYRING_UPDATE_DELAY` measured at the queueing block. |
+| `INV-6` | At most one pending keyring update per account exists at any time. Re-queueing replaces the prior pending update and emits `PendingKeyringUpdateReplaced`. |
+| `INV-7` | For any included `0x1D` transaction, `sessionVerifier` was a member of the account's keyring at the block of pool entry (see "Mempool Revalidation"). |
+| `INV-8` | For every default factory-deployed signer, `signerFactory()` returns the deploying factory address and `factory.isFactorySigner(signer)` returns `true`. |
+| `INV-9` | Validation calls (`isValidSignature`, `evaluateSessionPolicy`) forward exactly `EIP1271_VALIDATION_GAS_LIMIT` and `EXECUTION_TRACE_VALIDATION_GAS_LIMIT` respectively. Signers MUST NOT observe non-deterministic gas. |
+| `INV-10` | Manager state mutations are atomic with their corresponding events from "Manager Events". A successful state transition without its event is non-conforming. |
 
 ### Extensions
 
@@ -937,9 +1576,29 @@ Execution policy belongs inside the session verifier. The protocol does not need
 
 Validation gas limits are protocol constants, not signer-selected values. This prevents signers from increasing validation cost per transaction and gives clients a fixed resource bound for mempool validation and block execution.
 
+### Block-Budget Validation Gas
+
+Validation gas is supplied by the protocol from a per-block budget rather than charged to the envelope's `gasLimit`. ERC-4337 takes the opposite approach with a per-userop `verificationGasLimit`. The block-budget choice is motivated by:
+
+1. **Unified mempool admission.** Mempools admit transactions when the account can pay payload gas plus `MIN_VALIDATION_FAILURE_FEE`, without modeling per-transaction validation gas.
+2. **Predictable resource bound.** Validation cost per block is bounded a priori by `BLOCK_VALIDATION_GAS_BUDGET`, regardless of how many transactions are included.
+3. **Simpler envelope.** A single `gasLimit` field preserves familiarity with EIP-1559 / EIP-2718 transactions.
+
+The price of this choice is a new validation fee market: validation budget is a scarce per-block resource, and `MIN_VALIDATION_FAILURE_FEE` must be tuned to keep the cost-per-byte of consumed budget above attacker value. See "Validation Budget Exhaustion" in Security Considerations.
+
 ### Timelocked Keyring Updates
 
-A keyring update can invalidate transactions that already passed mempool validation. Requiring `MIN_KEYRING_UPDATE_DELAY > TXPOOL_TRANSACTION_EXPIRATION_WINDOW` guarantees that a transaction cannot be invalidated by a keyring update while it is still eligible for inclusion.
+A keyring update can invalidate transactions that already passed mempool validation. The combination of `MIN_KEYRING_UPDATE_DELAY > TXPOOL_TRANSACTION_EXPIRATION_WINDOW` and the membership-based pool revalidation rule (see "Mempool Revalidation") guarantees that a transaction cannot be invalidated by a keyring update while it is still eligible for inclusion. The membership rule preserves stable inclusion across keyring rotations *and* across `revokeSessionVerifier` calls for unrelated verifiers — only transactions whose own verifier was revoked lose stable inclusion, which is the intended semantics of revocation.
+
+### Instant Revocation vs. Timelocked Updates
+
+Routine keyring updates are timelocked because most updates are not urgent and stable inclusion is more valuable than instantaneous propagation. Instant revocation is reserved for compromise — a leaked session-key, a malicious verifier — where waiting `MIN_KEYRING_UPDATE_DELAY` is unacceptable. The split design:
+
+1. Limits the blast radius: instant revoke only affects pool entries from the revoked verifier; other verifiers' pool entries retain stable inclusion via the membership-based revalidation rule.
+2. Limits the trust required: instant revoke requires admin authorization with replay protection (`adminNonce`) and binding to `expectedCurrentKeyringHash`.
+3. Avoids re-introducing per-keyring timelocks for the common case of removing one verifier from many.
+
+The remaining attack window is the time between leak and detection-plus-revoke (one block once the admin acts). This is documented in "Session Verifier Revocation Race".
 
 ### Restricted Validation Frames
 
@@ -951,6 +1610,34 @@ WIP-1001 introduces a new EIP-2718 transaction type and a new account manager pr
 
 Existing Safe accounts MAY deploy or delegate to EIP-1271 signer contracts that satisfy this specification, but WIP-1001 does not require Safe migration.
 
+## Test Cases
+
+This section is intentionally a scope outline; the full vector set is required before this WIP advances past Draft. Conforming implementations MUST pass every category below; reference vectors will be published alongside the reference implementation.
+
+Required vector categories:
+
+- **Address derivation** — golden vectors for `account = keccak256(abi.encode(WIP1001_ACCOUNT_DOMAIN, chainId, manager, adminSigner, accountSalt))[12:]` across at least three `(chainId, adminSigner, accountSalt)` triples.
+- **`adminOperationHash` derivation** — one positive and one negative vector for each domain: `WIP1001_ADMIN_CREATE_DOMAIN`, `WIP1001_QUEUE_KEYRING_UPDATE_DOMAIN`, `WIP1001_CANCEL_KEYRING_UPDATE_DOMAIN`, `WIP1001_REVOKE_SESSION_VERIFIER_DOMAIN`.
+- **Signing hash** — RLP-encoding vectors for the `0x1D` envelope covering call vs create, empty-vs-populated `accessList`, and `data` lengths near `MAX_PAYLOAD_DATA_BYTES`.
+- **`worldIdAction` derivation** — vectors covering both default and non-default factories, with `chainId` binding (see "World ID Admin Signer").
+- **`worldIdField` reduction** — vectors that exercise the `keccak256 >> 8` field reduction, cross-checked against the `FieldElement::from_arbitrary_raw_bytes` reference implementation in the World ID primitives crate.
+- **Keyring hash and ordering** — vectors that prove `activeKeyringHash` is sensitive to verifier ordering.
+- **Trace ABI encoding** — round-trip vectors for `WorldChainExecutionTrace` covering: deeply nested calls, empty return data, reverted sub-calls, mixed CREATE/CREATE2/Call/StaticCall/DelegateCall.
+- **Restricted frame conformance** — positive vectors (allowed precompiles, own-storage reads) and negative vectors (every forbidden opcode in the policy) drawn from the ERC-7562 conformance suite plus `WIP1001-VR-*` rules.
+- **Mempool revalidation transitions** — vectors covering keyring queue, activate, cancel, and revoke; verifying eviction vs retention rules.
+- **Validation gas accounting** — block-level scenarios: budget exhaustion, validation failure fee charging, mempool admission floor.
+
+## Reference Implementation
+
+A partial reference implementation is in progress in this repository on the `osiris/wip-1001-*` branch series. As of this draft, the following components exist; none are conformant with the full specification yet:
+
+- Solidity manager skeleton: `pkg/contracts/src/WorldIDAccountManagerImplV1.sol` (session-key stub; does not yet implement the keyring/admin/timelock state machine).
+- Manager interface: `pkg/contracts/src/interfaces/IWorldIDAccountManager.sol`.
+- Rust `0x1D` envelope primitives: `crates/primitives/src/transaction/wip_1001.rs`.
+- Trace-collection inspector: `crates/rpc/src/simulate.rs` (covers CREATE/CREATE2 deployed-address capture but does not yet populate `LogTrace.callIndex`).
+
+A complete reference implementation, golden vectors, and a Foundry conformance test suite MUST be published before this WIP advances to Review.
+
 ## Security Considerations
 
 ### Admin Authorization Front-Running
@@ -961,13 +1648,43 @@ Admin authorization signatures MUST bind the admin operation domain, account add
 
 The admin signer can queue keyring changes. Applications SHOULD support recovery or multisig admin signers where appropriate.
 
+### Admin Signer Lock-In
+
+The account address binds the admin signer immutably (see "Account Address Permanence"). A bug in the admin signer contract is uncorrectable without migrating to a new account address. This is a deliberate tradeoff against ERC-4337's owner-rotation model: address derivation is unambiguous and indexers do not need to track admin rotation events, but loss of the admin signer's authentication factor (e.g., the secp256k1 owner key) permanently locks the account.
+
+Mitigations:
+
+- Choose admin signer factory variants that include internal recovery mechanisms (social recovery, multisig with member rotation, time-delayed recovery oracles).
+- Treat secp256k1 admin signers without recovery as equivalent to externally owned accounts: the owner key MUST be backed up.
+- Where corporate / institutional use is intended, prefer multisig admin signers from the start; migration after asset accumulation is expensive.
+
+### Session Verifier Revocation Race
+
+`revokeSessionVerifier` is instant on-chain (one block from admin transaction inclusion to verifier removal) but cannot recover keys before they are detected. The window of risk is the time between key compromise and detection-plus-revocation. This window is bounded by the admin's monitoring latency, not by the protocol. Applications SHOULD instrument session-key usage and trigger automated revocation on anomaly detection.
+
 ### Signer Validation DoS
 
 Fixed validation gas limits bound signer execution. Signers that exceed the limit fail validation.
 
+### Validation Budget Exhaustion
+
+The per-block validation budget (`BLOCK_VALIDATION_GAS_BUDGET`) is a scarce resource. An attacker holding sufficient balance to pay `MIN_VALIDATION_FAILURE_FEE` per failed transaction can spam validation failures, consuming budget at the rate of `BLOCK_VALIDATION_GAS_BUDGET / (EIP1271_VALIDATION_GAS_LIMIT + EXECUTION_TRACE_VALIDATION_GAS_LIMIT)` failures per block. Mitigations:
+
+- Tune `MIN_VALIDATION_FAILURE_FEE` so that the cost of consuming the entire block budget exceeds the marginal value the attacker derives from delaying other users' transactions.
+- Mempool admission MUST refuse transactions whose account balance cannot cover `MIN_VALIDATION_FAILURE_FEE` at the current `baseFee`.
+- Block builders MAY apply additional anti-DoS heuristics (e.g., per-account validation-failure rate limits) without violating the specification.
+
+### Block-Inclusion Bias
+
+Validation budget is fixed per block. Builders may prefer transactions with cheaper validation profiles, biasing inclusion against admin signers / session verifiers with high cryptographic cost (e.g., World ID Groth16 proofs). This is an accepted tradeoff: fixed validation gas limits also bound the worst-case validation cost so that the bias is bounded.
+
 ### Trace Size DoS
 
 `MAX_EXECUTION_TRACE_BYTES` bounds memory and encoding cost for session policy evaluation. Transactions that exceed the bound fail before the context is passed to the signer.
+
+### Calldata Bounds
+
+The activation parameters `MAX_PAYLOAD_DATA_BYTES`, `MAX_ACCESS_LIST_ENTRIES`, `MAX_SESSION_SIGNATURE_BYTES`, and `MAX_ADMIN_AUTHORIZATION_BYTES` bound calldata-driven costs that are not otherwise covered by gas accounting (mempool-admission cost, RLP-decode cost, ABI-encode cost). Implementations MUST enforce all four limits at envelope decode time.
 
 ### External-State Invalidation
 
@@ -1000,3 +1717,23 @@ WebAuthn-based signers MUST bind challenges to the `0x1D` signing hash and `WORL
 ### World ID Stale Verifier State
 
 World ID signers MUST define freshness rules for verifier state, including roots, credential issuer public keys, OPRF public keys, verifier keys, tree depth, and credential freshness policy. Updates that can invalidate previously accepted transactions MUST follow the signer-state timelock requirement.
+
+### Cross-Chain `worldIdAction` Replay
+
+The `worldIdAction` derivation binds `block.chainid` (see "World ID Admin Signer"). Without this binding, a custom (non-default-factory) admin signer deployed at the same address on two chains could accept a World ID proof from one chain on the other. The default factory's CREATE2 salt also binds chainId, so for default-factory signers this is defense-in-depth.
+
+### Self-Inconsistent Admin Signer
+
+The default `IWorldIDAdminSigner.account()` view function returns the admin signer's self-reported account binding. A buggy or malicious signer could return an inconsistent value. The manager protects against this for default-factory-deployed admin signers by checking `IWorldIDAdminSigner(adminSigner).account() == account` during `create` (see "Account Creation Semantics" step 10). For custom admin signers, the manager makes no such check, so self-consistency is the implementor's responsibility.
+
+### Front-Running of `create`
+
+The account-creation `adminOperationHash` does not bind `msg.sender`. Anyone observing a `create` call in the mempool can copy `(adminSigner, accountSalt, initialSessionVerifiers, adminAuthorization)` and front-run it. The resulting account state is identical to the user's intent (because the authorization commits to all state-determining parameters), so the front-runner gains no authority over the account; griefing is limited to gas attribution. ETH or token balances pre-funded to the derived account address before `create` are unaffected: address derivation is independent of who calls `create`.
+
+### DELEGATECALL Conformance
+
+`DELEGATECALL` is permitted inside restricted validation frames only when the delegatee's bytecode itself satisfies every rule in the tracer rule taxonomy (see `WIP1001-VR-9`). Implementations MUST validate the delegatee under the same rule set, recursively if necessary. A non-conforming delegatee MUST cause the validation call to fail. This rule allows proxy-style signers (transparent proxy, UUPS, Safe-style modules) without compromising determinism, but proxies whose implementation contracts call out to mutable external state MUST NOT be used as admin signers or session verifiers.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -48,17 +48,23 @@ Default factories that support mutable signer or verifier state must apply the s
 
 ## Specification
 
-The keywords "MUST", "MUST NOT", "SHOULD", and "MAY" are to be interpreted as described in RFC 2119.
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) and [RFC 8174](https://www.rfc-editor.org/rfc/rfc8174).
+
 
 ### Protocol Constants
 
 | Name | Value | Meaning |
 | --- | --- | --- |
 | `WORLD_TX_TYPE` | `0x1D` | EIP-2718 transaction type for World Chain account transactions. |
-| `MAX_SESSION_SIGNERS` | `20` | Maximum active session verifiers per account. |
+| `MAX_SESSION_VERIFIERS` | `20` | Maximum active session verifiers per account. |
 | `EIP1271_MAGIC_VALUE` | `0x1626ba7e` | Required return value from `isValidSignature`. |
 | `WORLD_CHAIN_RP_ID` | `480` | World Chain relying-party identifier for WebAuthn challenge binding. |
-| `WORLD_ID_ACCOUNT_TAG` | `"WORLD_ID_ACCOUNT"` | Domain tag for World ID account signals. |
+| `WORLD_ID_ACCOUNT_TAG` | `"WORLD_ID_ACCOUNT"` | Domain tag for World ID account action derivation. |
+| `WIP1001_ACCOUNT_DOMAIN` | `keccak256("WIP1001_ACCOUNT")` | Domain for account address derivation. |
+| `WIP1001_ADMIN_CREATE_DOMAIN` | `keccak256("WIP1001_ADMIN_CREATE")` | Domain for account creation authorization. |
+| `WIP1001_QUEUE_KEYRING_UPDATE_DOMAIN` | `keccak256("WIP1001_QUEUE_KEYRING_UPDATE")` | Domain for keyring update authorization. |
+| `WIP1001_SIGNER_DOMAIN` | `keccak256("WIP1001_SIGNER")` | Domain for default factory `CREATE2` salts. |
 
 ### Activation Parameters
 
@@ -125,7 +131,7 @@ The manager stores account state:
 struct Account {
     address adminSigner;
     bytes32 accountSalt;
-    SessionSigner[] activeSessionSigners;
+    SessionVerifier[] activeSessionVerifiers;
     bytes32 activeKeyringHash;
     PendingKeyringUpdate pendingKeyringUpdate;
     uint64 adminNonce;
@@ -134,31 +140,44 @@ struct Account {
 struct PendingKeyringUpdate {
     bool exists;
     bytes32 expectedCurrentKeyringHash;
-    SessionSigner[] targetSessionSigners;
+    SessionVerifier[] targetSessionVerifiers;
     bytes32 targetKeyringHash;
     uint64 activateAfter;
     uint64 queuedAtNonce;
 }
 
-struct SessionSigner {
-    address signer;
+struct SessionVerifier {
+    address verifier;
 }
 ```
 
-`Account.adminSigner` is an EIP-1271 contract. `SessionSigner.signer` is an EIP-1271 contract that also implements `IWorldChainSessionVerifier`.
+`Account.adminSigner` is an EIP-1271 contract. `SessionVerifier.verifier` is an EIP-1271 contract that also implements `IWorldChainSessionVerifier`.
 
 The protocol does not inspect signer internals. It assigns semantics by account role: admin signer for account management, session verifier for transaction authorization and policy evaluation.
 
-The active keyring MUST contain at least one session verifier and at most `MAX_SESSION_SIGNERS` session verifiers. A keyring MUST NOT contain duplicate signer addresses.
+The active keyring MUST contain at least one session verifier and at most `MAX_SESSION_VERIFIERS` session verifiers. A keyring MUST NOT contain duplicate verifier addresses.
 
 ### Address Derivation
 
-The manager derives an account address from:
+The manager derives an account address as:
 
-- `adminSigner`;
-- `accountSalt`;
-- the manager address;
-- the World Chain chain ID.
+```solidity
+account = address(
+    uint160(
+        uint256(
+            keccak256(
+                abi.encode(
+                    WIP1001_ACCOUNT_DOMAIN,
+                    chainId,
+                    WORLD_CHAIN_ACCOUNT_MANAGER,
+                    adminSigner,
+                    accountSalt
+                )
+            )
+        )
+    )
+);
+```
 
 This binds the account address to the admin signer, salt, chain, and manager instance.
 
@@ -167,24 +186,30 @@ This binds the account address to the admin signer, salt, chain, and manager ins
 The manager computes:
 
 ```solidity
-activeKeyringHash = keccak256(abi.encode(activeSessionSigners));
+activeKeyringHash = keccak256(abi.encode(activeSessionVerifiers));
 ```
 
-The hash commits to signer addresses and ordering. Clients SHOULD preserve ordering when displaying, exporting, or signing over a keyring.
+The hash commits to verifier addresses and ordering. Clients SHOULD preserve ordering when displaying, exporting, or signing over a keyring.
 
-### Signal Semantics
+### Admin Operation Hashes
 
-Account creation and admin authorization signatures MUST use domain-separated signals.
-
-The signal for account creation is:
+For every admin authorization, the manager computes a domain-separated `adminOperationHash` and passes it to:
 
 ```solidity
-signal = keccak256(
+adminSigner.isValidSignature(adminOperationHash, adminAuthorization)
+```
+
+`adminOperationHash` is the only protocol-defined hash passed to the admin signer. The protocol does not define a generic `signal` field.
+
+The account-creation admin operation hash is:
+
+```solidity
+adminOperationHash = keccak256(
     abi.encode(
-        WORLD_ID_ACCOUNT_TAG,
+        WIP1001_ADMIN_CREATE_DOMAIN,
         chainId,
         WORLD_CHAIN_ACCOUNT_MANAGER,
-        accountAddress,
+        account,
         adminSigner,
         accountSalt,
         activeKeyringHash
@@ -192,22 +217,30 @@ signal = keccak256(
 );
 ```
 
-Admin operations MUST include:
+The keyring-update admin operation hash is:
 
-- `chainId`;
-- `WORLD_CHAIN_ACCOUNT_MANAGER`;
-- `account`;
-- operation selector;
-- operation parameters;
-- `adminNonce`.
+```solidity
+adminOperationHash = keccak256(
+    abi.encode(
+        WIP1001_QUEUE_KEYRING_UPDATE_DOMAIN,
+        chainId,
+        WORLD_CHAIN_ACCOUNT_MANAGER,
+        account,
+        expectedCurrentKeyringHash,
+        targetKeyringHash,
+        activateAfter,
+        adminNonce
+    )
+);
+```
 
 The manager increments `adminNonce` when it queues a keyring update. Activating a queued update MUST NOT increment `adminNonce`.
 
 ### Replay Protection
 
-The account address derivation, signal domain, chain ID, manager address, and admin nonce together provide replay protection for account creation and admin operations.
+The account address derivation, operation domains, chain ID, manager address, and admin nonce together provide replay protection for account creation and admin operations.
 
-Session transactions use the transaction nonce in the `0x1D` envelope. This nonce is separate from `adminNonce`.
+Session transactions use the transaction nonce in the `0x1D` envelope. This nonce is the EVM transaction nonce for `account`, is consumed by included `0x1D` transactions, and is separate from `adminNonce`.
 
 ### EIP-1271 Admin Signer Hierarchy
 
@@ -237,31 +270,61 @@ The default World ID admin signer MUST expose immutable account-binding state:
 
 ```solidity
 interface IWorldIDAdminSigner is IWorldChainAdminSigner {
+    function accountSalt() external view returns (bytes32);
     function account() external view returns (address);
-    function externalNullifierHash() external view returns (uint256);
+    function worldIdRpId() external view returns (uint64);
+    function worldIdAction() external view returns (uint256);
 }
 ```
 
-The EIP-1271 signature payload is:
+The default World ID admin signer uses the World ID v4 uniqueness-proof verifier shape. Its EIP-1271 signature payload is:
 
 ```solidity
-struct WorldIDAdminSignature {
-    uint256 root;
-    uint256 nullifierHash;
-    uint256[8] proof;
+struct WorldIDUniquenessProofSignature {
+    uint256 nullifier;
+    uint64 expiresAtMin;
+    uint64 issuerSchemaId;
+    uint256 credentialGenesisIssuedAtMin;
+    uint256[5] zeroKnowledgeProof;
 }
 ```
 
-The default factory MUST derive `externalNullifierHash()` from `WORLD_ID_ACCOUNT_TAG`, `WORLD_CHAIN_RP_ID`, and `account()`.
+`account()` MUST return the account address derived by `WORLD_CHAIN_ACCOUNT_MANAGER` using `address(this)` as `adminSigner` and `accountSalt()` as `accountSalt`.
+
+`worldIdRpId()` MUST return `WORLD_CHAIN_RP_ID`.
+
+`worldIdAction()` MUST return:
+
+```solidity
+worldIdField(
+    abi.encode(
+        WORLD_ID_ACCOUNT_TAG,
+        WORLD_CHAIN_RP_ID,
+        WORLD_CHAIN_ACCOUNT_MANAGER,
+        account(),
+        address(this)
+    )
+)
+```
+
+where `worldIdField(input) = uint256(keccak256(input)) >> 8`, matching `FieldElement::from_arbitrary_raw_bytes` in the World ID v4 primitives.
 
 `isValidSignature(hash, signature)` MUST:
 
-- decode `signature` as `WorldIDAdminSignature`;
-- require `root` to be accepted by the signer;
-- verify the World ID proof using `hash` as the operation signal and `externalNullifierHash()` as the external nullifier;
+- decode `signature` as `WorldIDUniquenessProofSignature`;
+- compute `signalHash = worldIdField(abi.encode(hash))`;
+- compute `nonce = worldIdField(abi.encode("WIP1001_WORLD_ID_ADMIN_NONCE", hash))`;
+- require `issuerSchemaId` to equal the signer's configured issuer schema ID;
+- require `zeroKnowledgeProof[4]` to be an accepted World ID registry root in the signer's verifier state;
+- require `expiresAtMin` and `credentialGenesisIssuedAtMin` to satisfy the signer's configured credential freshness policy;
+- verify the proof as a World ID v4 uniqueness proof equivalent to `IWorldIDVerifier.verify(nullifier, worldIdAction(), WORLD_CHAIN_RP_ID, nonce, signalHash, expiresAtMin, issuerSchemaId, credentialGenesisIssuedAtMin, zeroKnowledgeProof)`;
 - return `EIP1271_MAGIC_VALUE` only if verification succeeds.
 
+The signer MUST verify the same public inputs as the World ID v4 verifier: nullifier, issuer schema, credential issuer public key, credential expiration minimum, credential genesis minimum, Merkle root, tree depth, RP ID, action, OPRF public key, signal hash, nonce, and `sessionId = 0`.
+
 The signer MUST NOT consume nullifiers as part of `isValidSignature`, because EIP-1271 validation is a `view` operation. Replay protection comes from the manager-defined operation hash, including `adminNonce`.
+
+The signer MUST NOT call an external World ID verifier from a restricted validation frame. Any World ID registry roots, credential issuer public keys, OPRF public keys, verifier keys, tree depth, and credential freshness policy needed for verification MUST be available from the signer's own code, own storage, or allowlisted precompiles.
 
 #### Secp256k1 Admin Signer
 
@@ -307,7 +370,7 @@ interface IWorldChainSessionVerifier is IERC1271 {
         bytes32 signingHash;
         uint256 chainId;
         address account;
-        address signer;
+        address sessionVerifier;
         uint64 nonce;
         uint256 maxPriorityFeePerGas;
         uint256 maxFeePerGas;
@@ -371,6 +434,13 @@ The protocol MUST call `evaluateSessionPolicy` after tentative payload execution
 
 `ExecutionTraceContext.transaction` is derived from the `0x1D` envelope, the active account state, and the computed signing hash. It does not include block-context values other than `chainId`.
 
+For this context:
+
+- `target` equals `to` when `isCreate == false`;
+- `target` equals `address(0)` when `isCreate == true`;
+- `selector` equals the first four bytes of `data` when `data.length >= 4`;
+- `selector` equals `0x00000000` when `data.length < 4`.
+
 `ExecutionTraceContext.trace` is canonical and MUST include:
 
 - the final payload success flag;
@@ -394,14 +464,14 @@ interface IWorldChainAccountManager {
     function create(
         address adminSigner,
         bytes32 accountSalt,
-        SessionSigner[] calldata initialSessionSigners,
+        SessionVerifier[] calldata initialSessionVerifiers,
         bytes calldata adminAuthorization
     ) external returns (address account);
 
     function queueKeyringUpdate(
         address account,
         bytes32 expectedCurrentKeyringHash,
-        SessionSigner[] calldata targetSessionSigners,
+        SessionVerifier[] calldata targetSessionVerifiers,
         uint64 activateAfter,
         bytes calldata adminAuthorization
     ) external;
@@ -411,43 +481,64 @@ interface IWorldChainAccountManager {
     function getAdminSigner(address account) external view returns (address);
     function getAdminNonce(address account) external view returns (uint64);
     function getActiveKeyringHash(address account) external view returns (bytes32);
-    function getActiveSessionSigners(address account) external view returns (SessionSigner[] memory);
+    function getActiveSessionVerifiers(address account) external view returns (SessionVerifier[] memory);
     function getPendingKeyringUpdate(address account) external view returns (PendingKeyringUpdate memory);
-    function isAuthorized(address account, address signer) external view returns (bool);
-    function getAuthorizedSigner(address account, address signer) external view returns (SessionSigner memory);
+    function isAuthorizedSessionVerifier(address account, address sessionVerifier) external view returns (bool);
+    function getAuthorizedSessionVerifier(address account, address sessionVerifier) external view returns (SessionVerifier memory);
 }
 ```
 
-`create` MUST:
+#### Account Creation Semantics
 
-- derive the account address;
-- require `initialSessionSigners.length` to be in `[1, MAX_SESSION_SIGNERS]`;
-- reject duplicate session verifiers;
-- verify `adminAuthorization` by calling `adminSigner.isValidSignature(signal, adminAuthorization)`;
-- reject the call if the account already exists;
-- initialize account state.
+`create` MUST execute atomically:
 
-`queueKeyringUpdate` MUST:
+1. Reject `adminSigner == address(0)` and any zero session verifier address.
+2. Require `adminSigner` and every initial session verifier to have deployed code.
+3. Require `initialSessionVerifiers.length` to be in `[1, MAX_SESSION_VERIFIERS]`.
+4. Reject duplicate session verifier addresses.
+5. Derive `account` from `adminSigner`, `accountSalt`, `WORLD_CHAIN_ACCOUNT_MANAGER`, and `chainId`.
+6. Reject the call if `account` already exists.
+7. Compute `activeKeyringHash = keccak256(abi.encode(initialSessionVerifiers))`.
+8. Compute the account-creation `adminOperationHash`.
+9. Verify `adminAuthorization` through `adminSigner.isValidSignature(adminOperationHash, adminAuthorization)` in a restricted validation frame.
+10. Initialize account state with `adminNonce = 0`, no pending keyring update, and `activeSessionVerifiers = initialSessionVerifiers`.
 
-- require the account to exist;
-- require `expectedCurrentKeyringHash == activeKeyringHash`;
-- require `targetSessionSigners.length` to be in `[1, MAX_SESSION_SIGNERS]`;
-- reject duplicate target signers;
-- require `activateAfter >= block.timestamp + MIN_KEYRING_UPDATE_DELAY`;
-- verify the admin operation through `adminSigner.isValidSignature`;
-- replace any existing pending update with the new pending update;
-- increment `adminNonce`.
+If any step fails, account state MUST remain unchanged.
 
-`activateKeyringUpdate` MUST:
+#### Keyring Update Queue Semantics
 
-- require a pending update;
-- require `block.timestamp >= activateAfter`;
-- require `expectedCurrentKeyringHash == activeKeyringHash`;
-- replace `activeSessionSigners`;
-- update `activeKeyringHash`;
-- clear the pending update.
+`queueKeyringUpdate` MUST execute atomically:
 
-`activateKeyringUpdate` MAY be called by any address.
+1. Require `account` to exist.
+2. Require `expectedCurrentKeyringHash == activeKeyringHash`.
+3. Require `targetSessionVerifiers.length` to be in `[1, MAX_SESSION_VERIFIERS]`.
+4. Reject zero, duplicate, or undeployed target session verifier addresses.
+5. Compute `targetKeyringHash = keccak256(abi.encode(targetSessionVerifiers))`.
+6. Reject the update if `targetKeyringHash == activeKeyringHash`.
+7. Require `activateAfter >= block.timestamp + MIN_KEYRING_UPDATE_DELAY`.
+8. Let `authorizationNonce = adminNonce`.
+9. Compute the keyring-update `adminOperationHash` using `authorizationNonce` as `adminNonce`.
+10. Verify `adminAuthorization` through `adminSigner.isValidSignature(adminOperationHash, adminAuthorization)`.
+11. Replace any existing pending update with the new pending update.
+12. Store `queuedAtNonce = authorizationNonce`.
+13. Increment `adminNonce` by one.
+
+If any step fails, account state MUST remain unchanged and `adminNonce` MUST NOT change.
+
+#### Keyring Update Activation Semantics
+
+`activateKeyringUpdate` MAY be called by any address and MUST execute atomically:
+
+1. Require `account` to exist.
+2. Require a pending keyring update.
+3. Require `block.timestamp >= activateAfter`.
+4. Require `expectedCurrentKeyringHash == activeKeyringHash`.
+5. Require every target session verifier to still have deployed code.
+6. Replace `activeSessionVerifiers` with `targetSessionVerifiers`.
+7. Set `activeKeyringHash = targetKeyringHash`.
+8. Clear the pending update.
+
+Activation MUST NOT increment `adminNonce`. If activation fails, account state MUST remain unchanged.
 
 ### Restricted Validation Frames
 
@@ -549,7 +640,7 @@ rlp([
     maxFeePerGas,
     gasLimit,
     account,
-    signer,
+    sessionVerifier,
     isCreate,
     to,
     value,
@@ -558,6 +649,10 @@ rlp([
     signature
 ])
 ```
+
+If `isCreate == false`, `to` MUST be nonzero and `data` is call data for `to`.
+
+If `isCreate == true`, `to` MUST be `address(0)` and `data` is contract init code.
 
 The signing hash is:
 
@@ -571,7 +666,7 @@ keccak256(
         maxFeePerGas,
         gasLimit,
         account,
-        signer,
+        sessionVerifier,
         isCreate,
         to,
         value,
@@ -587,33 +682,195 @@ To validate and execute a `0x1D` transaction, the protocol MUST:
 
 1. Compute the signing hash.
 2. Load the account from `WORLD_CHAIN_ACCOUNT_MANAGER`.
-3. Reject the transaction if `signer` is not in the active keyring.
-4. Verify `signature` by calling `signer.isValidSignature(signingHash, signature)` in a restricted validation frame.
-5. Reject the transaction unless the signer returns `EIP1271_MAGIC_VALUE`.
+3. Reject the transaction if `sessionVerifier` is not in the active keyring.
+4. Verify `signature` by calling `sessionVerifier.isValidSignature(signingHash, signature)` in a restricted validation frame.
+5. Reject the transaction unless the session verifier returns `EIP1271_MAGIC_VALUE`.
 6. Execute the payload tentatively with `account` as the EVM transaction sender and collect the canonical execution trace.
 7. Build `ExecutionTraceContext` from the envelope, signing hash, active keyring hash, and canonical execution trace.
 8. Reject the transaction if `abi.encode(context.trace).length > MAX_EXECUTION_TRACE_BYTES`.
-9. Call `signer.evaluateSessionPolicy(context)` in a restricted validation frame.
+9. Call `sessionVerifier.evaluateSessionPolicy(context)` in a restricted validation frame.
 10. If session policy evaluation fails, discard tentative payload state and logs, consume nonce and gas according to normal failed-transaction semantics, and mark the transaction failed.
 11. If session policy evaluation succeeds, commit the payload result. If payload execution itself failed, commit the normal failed-call result.
 
-### Default Signer Factories
+### EIP-1271 Signer Factory Pattern
 
 World Chain provides default EIP-1271 signer factories through predeploy addresses assigned at activation.
 
-Default factories are reference implementations. Accounts MAY use any EIP-1271 admin signer or session verifier that satisfies this specification.
+Factories are deployment helpers, not authorization registries. A factory-created signer has no account authority until it is used as the admin signer during `create` or added to an account keyring through `queueKeyringUpdate`.
 
-#### Secp256k1 Signer
+Accounts MAY use any EIP-1271 admin signer or session verifier that satisfies this specification. They are not required to use a default factory.
 
-`SECP256K1_1271_SIGNER_FACTORY` deploys the secp256k1 admin signer defined in this specification and MAY deploy session verifier variants that use the same secp256k1 authentication core.
+#### Factory Interface
 
-The admin signer variant implements EIP-1271 only. A session verifier variant MUST also implement `IWorldChainSessionVerifier`.
+Default factories MUST implement:
 
-#### World ID Signer
+```solidity
+enum WorldChainSignerRole {
+    AdminSigner,
+    SessionVerifier
+}
 
-`WORLD_ID_1271_SIGNER_FACTORY` deploys the World ID admin signer defined in this specification and MAY deploy session verifier variants that use the same World ID authentication core.
+interface IWorldChainFactoryDeployedSigner {
+    function signerFactory() external view returns (address);
+    function signerRole() external view returns (WorldChainSignerRole);
+    function signerVariantId() external view returns (bytes32);
+    function signerConfigHash() external view returns (bytes32);
+}
 
-The admin signer variant implements EIP-1271 only. A session verifier variant MUST also implement `IWorldChainSessionVerifier` and MUST bind its World ID proof to the `0x1D` signing hash.
+interface IWorldChain1271SignerFactory {
+    event SignerCreated(
+        address indexed signer,
+        WorldChainSignerRole indexed role,
+        bytes32 indexed variantId,
+        bytes32 configHash,
+        bytes32 salt
+    );
+
+    function worldChainAccountManager() external view returns (address);
+
+    function computeAddress(
+        WorldChainSignerRole role,
+        bytes32 variantId,
+        bytes calldata config,
+        bytes32 salt
+    ) external view returns (address signer);
+
+    function createSigner(
+        WorldChainSignerRole role,
+        bytes32 variantId,
+        bytes calldata config,
+        bytes32 salt
+    ) external returns (address signer);
+
+    function isFactorySigner(address signer) external view returns (bool);
+}
+```
+
+#### Factory Creation Semantics
+
+`createSigner` MUST:
+
+1. Reject unknown `role` or `variantId`.
+2. Decode and validate `config` for the selected variant.
+3. Compute `configHash = keccak256(config)`.
+4. Deploy the signer with `CREATE2` using `keccak256(abi.encode(WIP1001_SIGNER_DOMAIN, chainId, WORLD_CHAIN_ACCOUNT_MANAGER, role, variantId, configHash, salt))` as the `CREATE2` salt.
+5. Initialize immutable signer metadata: `signerFactory`, `signerRole`, `signerVariantId`, and `signerConfigHash`.
+6. Return the deployed signer address.
+7. Emit `SignerCreated`.
+
+`computeAddress` MUST return the same address that `createSigner` would deploy for the same inputs.
+
+The `SignerCreated.salt` event field MUST be the caller-supplied `salt`, not the derived `CREATE2` salt.
+
+`createSigner` MUST be idempotent: if the expected signer is already deployed with matching metadata, it MUST return the existing address. It MUST revert if the expected address is occupied by a contract with different metadata.
+
+`isFactorySigner(signer)` MUST return `true` only if `signer` was deployed by the factory and exposes matching factory metadata.
+
+Factory deployment MUST NOT mutate `WORLD_CHAIN_ACCOUNT_MANAGER` state.
+
+#### Signer Update Semantics
+
+Factory-created signers MAY expose signer-specific update functions. Any update that can change the result of `isValidSignature` or `evaluateSessionPolicy` for an already accepted transaction MUST be timelocked by at least `MIN_KEYRING_UPDATE_DELAY`.
+
+Examples include World ID root updates, owner rotations, recovery configuration changes, and policy configuration changes.
+
+#### Session Policy Configuration
+
+Session verifier variants MAY take `policyVariantId` and `policyConfig` in their factory config. These values are verifier configuration, not protocol fields.
+
+A factory MUST reject unknown policy variants. A deployed session verifier MUST evaluate policy internally from its own code and storage. It MUST NOT depend on an external policy contract during restricted validation.
+
+Every default session verifier MUST reject `evaluateSessionPolicy` unless:
+
+- `context.transaction.account` equals the verifier's configured account;
+- `context.transaction.sessionVerifier == address(this)`;
+- the verifier's internal policy accepts `context`.
+
+#### Secp256k1 Factory
+
+`SECP256K1_1271_SIGNER_FACTORY` MUST support:
+
+```solidity
+bytes32 constant SECP256K1_ADMIN_SIGNER_V1 =
+    keccak256("world-chain.secp256k1.admin.v1");
+
+bytes32 constant SECP256K1_SESSION_VERIFIER_V1 =
+    keccak256("world-chain.secp256k1.session-verifier.v1");
+
+struct Secp256k1AdminSignerConfig {
+    address owner;
+}
+
+struct Secp256k1SessionVerifierConfig {
+    address account;
+    address owner;
+    bytes32 policyVariantId;
+    bytes policyConfig;
+}
+```
+
+The secp256k1 admin signer variant MUST implement `ISecp256k1AdminSigner` and verify EIP-1271 signatures against `owner`.
+
+The secp256k1 session verifier variant MUST:
+
+- implement `IWorldChainSessionVerifier`;
+- verify `isValidSignature(signingHash, signature)` against `owner`;
+- bind `evaluateSessionPolicy` to `account` and `address(this)`;
+- evaluate the configured session policy internally.
+
+#### World ID Factory
+
+`WORLD_ID_1271_SIGNER_FACTORY` MUST support:
+
+```solidity
+bytes32 constant WORLD_ID_ADMIN_SIGNER_V1 =
+    keccak256("world-chain.world-id.admin.v1");
+
+bytes32 constant WORLD_ID_SESSION_VERIFIER_V1 =
+    keccak256("world-chain.world-id.session-verifier.v1");
+
+struct WorldIDAdminSignerConfig {
+    bytes32 accountSalt;
+    address stateUpdater;
+    uint256 treeDepth;
+    uint64 issuerSchemaId;
+    uint256 credentialIssuerPubkeyX;
+    uint256 credentialIssuerPubkeyY;
+    uint256 oprfPubkeyX;
+    uint256 oprfPubkeyY;
+    uint64 minExpiresAt;
+    uint256 minCredentialGenesisIssuedAt;
+    uint256[] initialValidRoots;
+}
+
+struct WorldIDSessionVerifierConfig {
+    address account;
+    address stateUpdater;
+    uint256 treeDepth;
+    uint64 issuerSchemaId;
+    uint256 credentialIssuerPubkeyX;
+    uint256 credentialIssuerPubkeyY;
+    uint256 oprfPubkeyX;
+    uint256 oprfPubkeyY;
+    uint64 minExpiresAt;
+    uint256 minCredentialGenesisIssuedAt;
+    uint256[] initialValidRoots;
+    bytes32 policyVariantId;
+    bytes policyConfig;
+}
+```
+
+The World ID admin signer variant MUST implement `IWorldIDAdminSigner`. It derives its account from `address(this)` and `accountSalt`.
+
+The World ID session verifier variant MUST:
+
+- implement `IWorldChainSessionVerifier`;
+- verify `isValidSignature(signingHash, signature)` as a World ID v4 session proof over `signingHash`;
+- bind proof verification to `WORLD_CHAIN_RP_ID`, `WORLD_CHAIN_ACCOUNT_MANAGER`, `account`, `address(this)`, and the configured World ID verifier state;
+- bind `evaluateSessionPolicy` to `account` and `address(this)`;
+- evaluate the configured session policy internally.
+
+World ID verifier state MUST be stored in the signer contract itself. If `stateUpdater == address(0)`, the initial verifier state is immutable. Otherwise, only `stateUpdater` may queue verifier-state updates, and updates that can invalidate accepted transactions MUST follow the signer update semantics above.
 
 ### Visual Flow
 
@@ -630,7 +887,7 @@ sequenceDiagram
     User->>Pool: Submit 0x1D transaction
     Pool->>Protocol: Validate transaction
     Protocol->>Manager: Load active keyring
-    Manager-->>Protocol: signer authorized, activeKeyringHash
+    Manager-->>Protocol: sessionVerifier authorized, activeKeyringHash
     Protocol->>Signer: isValidSignature(signingHash, signature)
     Signer-->>Protocol: EIP1271_MAGIC_VALUE
     Protocol-->>Pool: Valid while keyring is active
@@ -698,7 +955,7 @@ Existing Safe accounts MAY deploy or delegate to EIP-1271 signer contracts that 
 
 ### Admin Authorization Front-Running
 
-Admin authorization signatures MUST bind account address, manager address, chain ID, operation selector, operation parameters, and nonce. A signature valid for one admin operation MUST NOT be valid for another.
+Admin authorization signatures MUST bind the admin operation domain, account address, manager address, chain ID, operation parameters, and nonce where applicable. A signature valid for one admin operation MUST NOT be valid for another.
 
 ### Admin Signer Compromise
 
@@ -732,14 +989,14 @@ Upgradeable signer contracts can change validation behavior. Signer factories SH
 
 The `0x1D` envelope exposes the selected session verifier. Applications that need stronger privacy should use verifier contracts that aggregate or rotate credentials.
 
-### Signature-Signer Ambiguity
+### Signature-Verifier Ambiguity
 
-The transaction envelope includes both `account` and `signer`. The protocol MUST verify that `signer` is active for `account` before calling EIP-1271.
+The transaction envelope includes both `account` and `sessionVerifier`. The protocol MUST verify that `sessionVerifier` is active for `account` before calling EIP-1271.
 
 ### WebAuthn Challenge Binding
 
 WebAuthn-based signers MUST bind challenges to the `0x1D` signing hash and `WORLD_CHAIN_RP_ID`.
 
-### World ID Stale Roots
+### World ID Stale Verifier State
 
-World ID signers MUST define root freshness rules. Root updates that can invalidate previously accepted transactions MUST follow the signer-state timelock requirement.
+World ID signers MUST define freshness rules for verifier state, including roots, credential issuer public keys, OPRF public keys, verifier keys, tree depth, and credential freshness policy. Updates that can invalidate previously accepted transactions MUST follow the signer-state timelock requirement.

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -36,7 +36,7 @@ World ID is a reference signer implementation. It verifies an EIP-1271 signature
 
 ### Programmability
 
-Accounts need authorization logic that can evolve without protocol changes. EIP-1271 lets admin signers define arbitrary account-management authorization, including World ID, secp256k1, multisig, recovery, and application-specific schemes.
+Accounts need authorization logic that can evolve without protocol changes. EIP-1271 lets admin signers define arbitrary account-management authorization, including World ID, secp256k1, secp256r1, EdDSA, BLS12-381, multisig, programmable recovery, multi factor authentication and application-specific schemes.
 
 Session verifiers extend that programmability to transaction execution. A verifier can authenticate a session key, inspect the canonical execution trace, and decide whether the transaction satisfies its policy. The protocol only provides deterministic inputs and enforces the verifier's boolean result.
 

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -12,137 +12,289 @@ requires: EIP-2, EIP-1559, EIP-196, EIP-197, EIP-198, EIP-2718, EIP-1271, RIP-72
 
 ## Abstract
 
-A *World Chain Account* is a predeploy-managed account whose 20-byte address is deterministic and lifetime-stable. Each account has one admin signer fixed at creation and an active **keyring** of session signers authorized to sign transactions on the account's behalf. Both admin authorization and session-key transaction authorization are verified exclusively through [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) smart contract signers.
+WIP-1001 defines a native World Chain account type managed by the `WORLD_CHAIN_ACCOUNT_MANAGER` predeploy.
 
-This WIP extends [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) with a typed transaction envelope (`0x1D`) whose signature payload is passed to an authorized session signer's `isValidSignature(bytes32,bytes)` implementation under a restricted, metered validation frame. The protocol does not natively dispatch over secp256k1, P256, WebAuthn, EdDSA, BLS, World ID, or any other signature scheme. Those schemes are implemented by EIP-1271 signer contracts using reusable EVM precompiles.
+Each account has one EIP-1271 admin signer and an active keyring of EIP-1271 session verifiers. The admin signer is the root authority for account management. Session verifiers are delegated authorities for `0x1D` transaction execution.
 
-Session signers also define programmable execution policy. The protocol does not store or interpret that policy. After signature verification and tentative transaction execution, the protocol supplies the resulting execution trace to the same session verifier contract. The verifier evaluates its internal policy as `f(transactionContext, executionTrace) -> bool`; if it returns false or fails, the transaction reverts.
+The protocol does not implement signature schemes directly. Instead, the protocol calls EIP-1271 signers in restricted validation frames. Signature schemes, proof systems, recovery policies, and execution policies are implemented by signer contracts. The protocol provides reusable cryptographic precompiles for common primitives.
 
-Account state and keyring management live in the `WORLD_CHAIN_ACCOUNT_MANAGER` predeploy. The manager exposes default signer factories for common strategies, including a World ID signer that verifies World ID proofs encoded in EIP-1271 signature bytes, and a secp256k1 signer that wraps EOA-style signatures. These default signers are reference implementations, not privileged protocol paths.
-
-Keyring updates are timelocked. An admin-authorized update first queues a full replacement keyring, and that keyring can only become active after a protocol-defined delay longer than the public transaction-pool expiration window. Default signer factories MUST apply the same delay discipline to signer authorization state so that EIP-1271 verification cannot fail between public transaction-pool validation and inclusion due to keyring or signer-state mutation.
+Session verifiers also own their execution policy. After tentative transaction execution, the protocol asks the verifier whether the observed execution trace is valid. If the verifier rejects the trace, the tentative execution is reverted.
 
 ## Motivation
 
-### One Signature Abstraction
+### One Authorization Path
 
-Ethereum already standardizes contract-based signature validation through EIP-1271. WIP-1001 makes EIP-1271 the only native authorization abstraction for World Chain Accounts. This keeps the transaction envelope small and scheme-agnostic while allowing wallets, applications, and future protocol features to introduce new signing policies without changing the transaction type.
+World Chain accounts need programmable authentication without adding a protocol branch for every signature scheme or proof system. EIP-1271 gives the protocol one authorization path: call a signer contract and require the standard magic value.
 
-An EOA wrapper, a passkey signer, a World ID proof verifier, a threshold signer, an EdDSA signer, or a BLS aggregate signer is simply a contract that returns the EIP-1271 magic value for a given hash and opaque signature bytes. The same signer can also own the session policy for what that session key may do.
+Admin signers and session verifiers both use EIP-1271, but they have different protocol roles. An admin signer authorizes account-management operations. A session verifier authorizes transaction signatures and evaluates the resulting execution trace.
 
 ### Reusable Cryptography
 
-Cryptographic accelerators used for account validation should not be host-private. If WIP-1001 signers depend on an elliptic-curve, hash, pairing, EdDSA, or BLS primitive, the primitive MUST be exposed as a normal EVM precompile with the same behavior for contracts and protocol validation. This makes signer contracts the compatibility layer over public VM functionality.
+Signer contracts need efficient cryptographic primitives, but those primitives should not define account semantics. WIP-1001 exposes reusable precompiles for supported curves and proof systems, while keeping account policy in contracts.
 
-### Programmable Keyrings
+World ID is a reference signer implementation. It verifies an EIP-1271 signature that encodes a World ID proof. It is not a privileged protocol path.
 
-The keyring should be an elegant authorization registry, not a catalogue of native signature algorithms or call-scope rules. A World Chain Account stores signer contracts. The signer contract owns the verification strategy, recovery strategy, quorum rules, proof format, authenticator-specific state, and programmable execution policy. This gives the protocol one validation path while preserving a programmable account surface.
+### Programmability
 
-### Pool-Stable Validation
+Accounts need authorization logic that can evolve without protocol changes. EIP-1271 lets admin signers define arbitrary account-management authorization, including World ID, secp256k1, multisig, recovery, and application-specific schemes.
 
-Public transaction pools validate transactions before inclusion. If a keyring or signer can invalidate a signature immediately after validation, a transaction can be accepted by the pool and then fail during block construction. WIP-1001 therefore requires keyring replacements and default signer authorization-state changes to be delayed by more than the public pool expiration window. A transaction that is pool-valid against the active keyring and a compliant default signer remains valid until it either expires from the pool or is included, assuming no other transaction fields become invalid.
+Session verifiers extend that programmability to transaction execution. A verifier can authenticate a session key, inspect the canonical execution trace, and decide whether the transaction satisfies its policy. The protocol only provides deterministic inputs and enforces the verifier's boolean result.
+
+### Stable Transaction Inclusion
+
+Mempool validation and block inclusion must agree on which keyring is active. Keyring updates are therefore timelocked for longer than the transaction pool expiration window. A transaction that validates against an active keyring cannot become invalid before it expires from the pool because of a keyring update.
+
+Default factories that support mutable signer or verifier state must apply the same rule to state that can invalidate already accepted transactions.
 
 ## Specification
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) and [RFC 8174](https://www.rfc-editor.org/rfc/rfc8174).
+The keywords "MUST", "MUST NOT", "SHOULD", and "MAY" are to be interpreted as described in RFC 2119.
 
-### Constants
+### Protocol Constants
 
-| Name | Value | Description |
-| ---- | ----- | ----------- |
-| `WORLD_TX_TYPE` | `0x1D` | EIP-2718 transaction type |
-| `WORLD_CHAIN_ACCOUNT_MANAGER` | `TBD` | World Chain Account Manager predeploy address |
-| `MAX_SESSION_SIGNERS` | `20` | Maximum active session signers per account |
-| `EIP1271_MAGIC_VALUE` | `0x1626ba7e` | `bytes4(keccak256("isValidSignature(bytes32,bytes)"))` |
-| `EIP1271_VALIDATION_GAS_LIMIT` | `TBD` | Fixed gas supplied to every protocol EIP-1271 validation frame |
-| `EXECUTION_TRACE_VALIDATION_GAS_LIMIT` | `TBD` | Fixed gas supplied to every protocol execution-trace policy validation frame |
-| `MAX_EXECUTION_TRACE_BYTES` | `TBD` | Maximum ABI-encoded execution trace size supplied to a verifier |
-| `TXPOOL_TRANSACTION_EXPIRATION_WINDOW` | `TBD` | Maximum public transaction-pool lifetime for a `0x1D` transaction |
-| `MIN_KEYRING_UPDATE_DELAY` | `> TXPOOL_TRANSACTION_EXPIRATION_WINDOW` | Minimum delay before a queued keyring can activate |
-| `WORLD_ID_1271_SIGNER_FACTORY` | `TBD` | Default World ID EIP-1271 signer factory |
-| `SECP256K1_1271_SIGNER_FACTORY` | `TBD` | Default secp256k1 EIP-1271 signer factory |
-| `WORLD_CHAIN_RP_ID` | `480` | World Chain's registered World ID relying-party ID |
-| `WORLD_ID_ACCOUNT_TAG` | `"WORLD_ID_ACCOUNT"` | Domain tag for World ID account/signer creation actions |
+| Name | Value | Meaning |
+| --- | --- | --- |
+| `WORLD_TX_TYPE` | `0x1D` | EIP-2718 transaction type for World Chain account transactions. |
+| `MAX_SESSION_SIGNERS` | `20` | Maximum active session verifiers per account. |
+| `EIP1271_MAGIC_VALUE` | `0x1626ba7e` | Required return value from `isValidSignature`. |
+| `WORLD_CHAIN_RP_ID` | `480` | World Chain relying-party identifier for WebAuthn challenge binding. |
+| `WORLD_ID_ACCOUNT_TAG` | `"WORLD_ID_ACCOUNT"` | Domain tag for World ID account signals. |
 
-`EIP1271_VALIDATION_GAS_LIMIT`, `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`, and `MAX_EXECUTION_TRACE_BYTES` are protocol constants. They are not selected by the transaction, account, signer, keyring entry, admin authorization, or factory.
+### Activation Parameters
 
-`MIN_KEYRING_UPDATE_DELAY` MUST be strictly greater than the maximum configured public transaction-pool expiration window for `0x1D` transactions. If a client or network changes the public pool expiration window, this constant MUST remain larger than the new window before WIP-1001 public-pool admission is enabled under that configuration.
+WIP-1001 MUST NOT activate until every parameter below is assigned in the fork configuration.
+
+| Name | Value | Requirement |
+| --- | --- | --- |
+| `WORLD_CHAIN_ACCOUNT_MANAGER` | TBD | Predeploy address for the account manager. |
+| `EIP1271_VALIDATION_GAS_LIMIT` | TBD | Fixed gas forwarded to `isValidSignature`. |
+| `EXECUTION_TRACE_VALIDATION_GAS_LIMIT` | TBD | Fixed gas forwarded to `evaluateSessionPolicy`. |
+| `MAX_EXECUTION_TRACE_BYTES` | TBD | Maximum ABI-encoded trace size passed to a session verifier. |
+| `TXPOOL_TRANSACTION_EXPIRATION_WINDOW` | TBD | Maximum time a valid transaction remains in the pool. |
+| `MIN_KEYRING_UPDATE_DELAY` | TBD | MUST be greater than `TXPOOL_TRANSACTION_EXPIRATION_WINDOW`. |
+| `WORLD_ID_1271_SIGNER_FACTORY` | TBD | Default World ID EIP-1271 signer factory. |
+| `SECP256K1_1271_SIGNER_FACTORY` | TBD | Default secp256k1 EIP-1271 signer factory. |
+| `EDDSA_PRECOMPILE` | TBD | EdDSA verification precompile address and ABI. |
+| `BLS12_381_PRECOMPILE` | TBD | BLS12-381 verification precompile address and ABI. |
 
 ### Reusable Crypto Precompiles
 
-Any accelerated cryptographic primitive used by protocol-valid EIP-1271 signers MUST be available through an EVM precompile with the same behavior for smart contracts and protocol/system callers. Implementations MUST NOT validate WIP-1001 signers with private host functions unavailable to contracts.
+Signer contracts MAY call protocol-supported cryptographic precompiles from restricted validation frames.
 
-The restricted validation-frame precompile allowlist initially contains:
+The validation-frame precompile allowlist is:
 
-| Name | Address | Purpose |
-| ---- | ------- | ------- |
-| `ECRECOVER` | `0x0000000000000000000000000000000000000001` | Ethereum secp256k1 recovery |
-| `SHA256` | `0x0000000000000000000000000000000000000002` | WebAuthn and other hash-based verification |
-| `MODEXP` | `0x0000000000000000000000000000000000000005` | Modular exponentiation ([EIP-198](https://eips.ethereum.org/EIPS/eip-198)) |
-| `BN254_ADD` | `0x0000000000000000000000000000000000000006` | BN254 G1 addition ([EIP-196](https://eips.ethereum.org/EIPS/eip-196)) |
-| `BN254_MUL` | `0x0000000000000000000000000000000000000007` | BN254 G1 scalar multiplication ([EIP-196](https://eips.ethereum.org/EIPS/eip-196)) |
-| `BN254_PAIRING` | `0x0000000000000000000000000000000000000008` | BN254 pairing check ([EIP-197](https://eips.ethereum.org/EIPS/eip-197)) |
-| `P256VERIFY` | `0x0000000000000000000000000000000000000100` | P256/secp256r1 verification ([RIP-7212](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md)) |
-| `EDDSA_VERIFY` | `TBD` | EdDSA signature verification; specified by a separate WIP |
-| `BLS12_381_VERIFY` | `TBD` | BLS12-381 verification or pairing suite; specified by a separate WIP |
+| Primitive | Source |
+| --- | --- |
+| `ecrecover` | Ethereum precompile |
+| `sha256` | Ethereum precompile |
+| `ripemd160` | Ethereum precompile |
+| `identity` | Ethereum precompile |
+| `modexp` | Ethereum precompile |
+| `bn254 add` | Ethereum precompile |
+| `bn254 scalar multiplication` | Ethereum precompile |
+| `bn254 pairing` | Ethereum precompile |
+| `secp256r1 verify` | RIP-7212 |
+| `EdDSA verify` | Activation parameter |
+| `BLS12-381 verify` | Activation parameter |
 
-The concrete address, supported curve(s), input/output encoding, malleability rules, failure behavior, and gas schedule for `EDDSA_VERIFY` and `BLS12_381_VERIFY` are out of scope for this WIP and MUST be specified before activation. Future curve, pairing, or proof-system precompiles MAY be added by a follow-on fork.
+World Chain clients MUST NOT expose private host validation APIs that are unavailable to contracts. Any primitive used by a default signer MUST be available through an allowlisted precompile.
 
-### Abstract Account Model
+### Account Model
 
-An account is created by an EIP-1271-admin-authorized `create` operation. Creation fixes:
+World Chain accounts are created and managed by `WORLD_CHAIN_ACCOUNT_MANAGER`.
 
-- `adminSigner`, the EIP-1271 contract that authorizes future keyring updates;
-- `accountSalt`, the admin-selected salt used for deterministic address derivation;
-- the initial active keyring of session signers.
+An account has:
 
-After creation, `adminSigner` and `accountSalt` are immutable for the lifetime of the account. Keyring mutation is performed by queueing a full replacement keyring, then activating it after the timelock delay has elapsed.
+- one immutable account address;
+- one EIP-1271 admin signer;
+- one active keyring of EIP-1271 session verifiers;
+- at most one pending keyring update;
+- one admin nonce.
 
-#### Account State
+Account authority is hierarchical:
 
-Per-account state stored by the `WORLD_CHAIN_ACCOUNT_MANAGER` predeploy:
+1. The account manager owns account state and enforces account-management rules.
+2. The admin signer is the root account authority. It authorizes account creation and keyring updates through EIP-1271.
+3. Session verifiers are delegated transaction authorities. They authorize `0x1D` transactions through EIP-1271 and approve or reject the observed execution trace through `evaluateSessionPolicy`.
+
+The manager MUST NOT use the admin signer to authorize `0x1D` transaction execution unless the same address is also present in the active session keyring. The manager MUST NOT use a session verifier to authorize account-management operations unless the same address is also configured as the admin signer.
+
+The manager stores account state:
 
 ```solidity
 struct Account {
-    address         adminSigner;
-    bytes32         accountSalt;
+    address adminSigner;
+    bytes32 accountSalt;
     SessionSigner[] activeSessionSigners;
-    bytes32         activeKeyringHash;
+    bytes32 activeKeyringHash;
     PendingKeyringUpdate pendingKeyringUpdate;
-    uint64          adminNonce;
+    uint64 adminNonce;
 }
 
 struct PendingKeyringUpdate {
-    bool            exists;
-    bytes32         expectedCurrentKeyringHash;
+    bool exists;
+    bytes32 expectedCurrentKeyringHash;
     SessionSigner[] targetSessionSigners;
-    bytes32         targetKeyringHash;
-    uint64          activateAfter;
-    uint64          queuedAtNonce;
+    bytes32 targetKeyringHash;
+    uint64 activateAfter;
+    uint64 queuedAtNonce;
 }
-```
 
-`adminNonce` is initialized to `0` at creation and incremented by `1` whenever a keyring update is successfully queued. `activateKeyringUpdate` does not require a new admin authorization and does not increment `adminNonce`.
-
-#### Session Signers
-
-```solidity
 struct SessionSigner {
     address signer;
 }
 ```
 
-`signer` MUST NOT be the zero address and MUST have non-empty code when it is added to a keyring. The signer MUST implement `IERC1271.isValidSignature(bytes32,bytes)` and `IWorldChainSessionVerifier.isValidExecutionTrace(WorldChainTransactionContext,WorldChainExecutionTrace)`.
+`Account.adminSigner` is an EIP-1271 contract. `SessionSigner.signer` is an EIP-1271 contract that also implements `IWorldChainSessionVerifier`.
 
-Protocol native EIP-1271 signature verification is constrained to `EIP1271_VALIDATION_GAS_LIMIT`.
+The protocol does not inspect signer internals. It assigns semantics by account role: admin signer for account management, session verifier for transaction authorization and policy evaluation.
 
-A keyring MUST contain at least one session signer and MUST NOT contain more than `MAX_SESSION_SIGNERS`.
+The active keyring MUST contain at least one session verifier and at most `MAX_SESSION_SIGNERS` session verifiers. A keyring MUST NOT contain duplicate signer addresses.
 
-Session signers carry no intrinsic privileges beyond signing `0x1D` transactions whose execution traces are accepted by their verifier policy.
+### Address Derivation
 
-#### Session Verifier Execution Policy Interface
+The manager derives an account address from:
 
-Session signers MUST implement:
+- `adminSigner`;
+- `accountSalt`;
+- the manager address;
+- the World Chain chain ID.
+
+This binds the account address to the admin signer, salt, chain, and manager instance.
+
+### Keyring Hash
+
+The manager computes:
+
+```solidity
+activeKeyringHash = keccak256(abi.encode(activeSessionSigners));
+```
+
+The hash commits to signer addresses and ordering. Clients SHOULD preserve ordering when displaying, exporting, or signing over a keyring.
+
+### Signal Semantics
+
+Account creation and admin authorization signatures MUST use domain-separated signals.
+
+The signal for account creation is:
+
+```solidity
+signal = keccak256(
+    abi.encode(
+        WORLD_ID_ACCOUNT_TAG,
+        chainId,
+        WORLD_CHAIN_ACCOUNT_MANAGER,
+        accountAddress,
+        adminSigner,
+        accountSalt,
+        activeKeyringHash
+    )
+);
+```
+
+Admin operations MUST include:
+
+- `chainId`;
+- `WORLD_CHAIN_ACCOUNT_MANAGER`;
+- `account`;
+- operation selector;
+- operation parameters;
+- `adminNonce`.
+
+The manager increments `adminNonce` when it queues a keyring update. Activating a queued update MUST NOT increment `adminNonce`.
+
+### Replay Protection
+
+The account address derivation, signal domain, chain ID, manager address, and admin nonce together provide replay protection for account creation and admin operations.
+
+Session transactions use the transaction nonce in the `0x1D` envelope. This nonce is separate from `adminNonce`.
+
+### EIP-1271 Admin Signer Hierarchy
+
+The admin signer is an EIP-1271 contract that authorizes account-management operations. It has no protocol ABI beyond EIP-1271:
+
+```solidity
+interface IWorldChainAdminSigner is IERC1271 {}
+```
+
+The protocol calls the admin signer with a manager-defined operation hash. The signer returns `EIP1271_MAGIC_VALUE` if the operation is authorized.
+
+Admin signer implementations include:
+
+- World ID admin signers;
+- secp256k1 admin signers;
+- multisig admin signers;
+- recovery admin signers;
+- custom application admin signers.
+
+Only the EIP-1271 boundary is protocol-significant. The implementation class is signer contract state, not account manager state.
+
+#### World ID Admin Signer
+
+A World ID admin signer is an EIP-1271 contract whose authorization is a World ID proof bound to the manager-defined operation hash.
+
+The default World ID admin signer MUST expose immutable account-binding state:
+
+```solidity
+interface IWorldIDAdminSigner is IWorldChainAdminSigner {
+    function account() external view returns (address);
+    function externalNullifierHash() external view returns (uint256);
+}
+```
+
+The EIP-1271 signature payload is:
+
+```solidity
+struct WorldIDAdminSignature {
+    uint256 root;
+    uint256 nullifierHash;
+    uint256[8] proof;
+}
+```
+
+The default factory MUST derive `externalNullifierHash()` from `WORLD_ID_ACCOUNT_TAG`, `WORLD_CHAIN_RP_ID`, and `account()`.
+
+`isValidSignature(hash, signature)` MUST:
+
+- decode `signature` as `WorldIDAdminSignature`;
+- require `root` to be accepted by the signer;
+- verify the World ID proof using `hash` as the operation signal and `externalNullifierHash()` as the external nullifier;
+- return `EIP1271_MAGIC_VALUE` only if verification succeeds.
+
+The signer MUST NOT consume nullifiers as part of `isValidSignature`, because EIP-1271 validation is a `view` operation. Replay protection comes from the manager-defined operation hash, including `adminNonce`.
+
+#### Secp256k1 Admin Signer
+
+A secp256k1 admin signer is an EIP-1271 contract whose authorization is a secp256k1 signature by a configured owner.
+
+The default secp256k1 admin signer MUST expose immutable owner state:
+
+```solidity
+interface ISecp256k1AdminSigner is IWorldChainAdminSigner {
+    function owner() external view returns (address);
+}
+```
+
+The EIP-1271 signature payload is the standard 65-byte payload:
+
+```text
+r || s || v
+```
+
+`isValidSignature(hash, signature)` MUST:
+
+- require `signature.length == 65`;
+- decode `r`, `s`, and `v`;
+- require `s` to be in the lower half order as specified by EIP-2;
+- require `v` to be `27` or `28`;
+- recover the signer with `ecrecover(hash, v, r, s)`;
+- return `EIP1271_MAGIC_VALUE` only if the recovered address equals `owner()`.
+
+The secp256k1 admin signer verifies the hash passed by the manager directly. Wallets that need EIP-191, EIP-712, or WebAuthn wrapping MUST implement that wrapping inside a different EIP-1271 signer contract.
+
+### Session Verifier Interface
+
+Session verifier contracts MUST implement this interface in addition to EIP-1271. Admin-only signers only need to implement EIP-1271.
 
 ```solidity
 interface IWorldChainSessionVerifier is IERC1271 {
@@ -156,15 +308,15 @@ interface IWorldChainSessionVerifier is IERC1271 {
         uint256 chainId;
         address account;
         address signer;
-        uint64  nonce;
+        uint64 nonce;
         uint256 maxPriorityFeePerGas;
         uint256 maxFeePerGas;
-        uint64  gasLimit;
-        bool    isCreate;
+        uint64 gasLimit;
+        bool isCreate;
         address target;
         uint256 value;
-        bytes   data;
-        bytes4  selector;
+        bytes data;
+        bytes4 selector;
         AccessListEntry[] accessList;
         bytes32 activeKeyringHash;
     }
@@ -178,135 +330,64 @@ interface IWorldChainSessionVerifier is IERC1271 {
     }
 
     struct CallTrace {
-        uint32        depth;
+        uint32 depth;
         TraceCallKind kind;
-        address       caller;
-        address       target;
-        uint256       value;
-        bytes4        selector;
-        bytes32       inputHash;
-        bytes32       outputHash;
-        bool          success;
-        uint64        gasUsed;
+        address caller;
+        address target;
+        uint256 value;
+        bytes4 selector;
+        bytes32 inputHash;
+        bytes32 outputHash;
+        bool success;
+        uint64 gasUsed;
     }
 
     struct LogTrace {
-        address   emitter;
+        address emitter;
         bytes32[] topics;
-        bytes32   dataHash;
+        bytes32 dataHash;
     }
 
     struct WorldChainExecutionTrace {
-        bool        success;
-        uint64      gasUsed;
-        bytes32     outputHash;
+        bool success;
+        uint64 gasUsed;
+        bytes32 outputHash;
         CallTrace[] calls;
-        LogTrace[]  logs;
+        LogTrace[] logs;
     }
 
-    function isValidExecutionTrace(
-        WorldChainTransactionContext calldata context,
-        WorldChainExecutionTrace calldata trace
+    struct ExecutionTraceContext {
+        WorldChainTransactionContext transaction;
+        WorldChainExecutionTrace trace;
+    }
+
+    function evaluateSessionPolicy(
+        ExecutionTraceContext calldata context
     ) external view returns (bool allowed);
 }
 ```
 
-The protocol constructs `WorldChainTransactionContext` from the `0x1D` transaction after computing `signingHash` and loading the active keyring entry:
+The protocol MUST call `evaluateSessionPolicy` after tentative payload execution and before committing payload state.
 
-- `signingHash` is the canonical `0x1D` signing hash.
-- `chainId`, `nonce`, fee fields, `gasLimit`, `value`, `data`, and `accessList` are copied from the transaction.
-- `account` is the World Chain Account sender.
-- `signer` is the declared session signer.
-- For a call transaction, `isCreate == false` and `target == to`.
-- For a contract-creation transaction, `isCreate == true`, `target == address(0)`, and `data` is init code.
-- `selector` is the first four bytes of `data`; if `data.length < 4`, `selector == 0x00000000`.
-- `activeKeyringHash` is the account's active keyring hash at validation time.
+`ExecutionTraceContext.transaction` is derived from the `0x1D` envelope, the active account state, and the computed signing hash. It does not include block-context values other than `chainId`.
 
-The protocol constructs `WorldChainExecutionTrace` from the tentative execution of the `0x1D` payload:
+`ExecutionTraceContext.trace` is canonical and MUST include:
 
-- `success` is the success status of the root transaction payload execution.
-- `gasUsed` is the gas consumed by the root transaction payload execution before trace validation.
-- `outputHash` is `keccak256(returnData)` for the root transaction payload execution.
-- `calls` is the ordered, depth-annotated call/create trace emitted by the root execution. The root call itself is excluded because it is already represented by `WorldChainTransactionContext`.
-- `logs` is the ordered log summary emitted by the root execution.
+- the final payload success flag;
+- total gas used by payload execution;
+- `keccak256` of payload return data;
+- all internal calls, ordered by execution order and annotated with call depth;
+- all logs emitted by payload execution, ordered by emission order.
 
-Full internal calldata, return data, and log data are not copied into the trace by default; their hashes are supplied to keep trace validation bounded. A verifier that needs to authorize exact internal calldata SHOULD require the caller to include the relevant commitments in the session signature or in root transaction calldata. The ABI-encoded trace supplied to the verifier MUST NOT exceed `MAX_EXECUTION_TRACE_BYTES`.
+The root transaction call is represented by `ExecutionTraceContext.transaction`, not by a `CallTrace` entry.
 
-No block-context fields other than `chainId` are supplied. If a verifier policy depends on time, block number, or other context, it MUST bind that data through its own signature/proof payload rather than reading block opcodes during trace validation.
+Full internal calldata, return data, and log data are not copied into the trace. The trace includes hashes. A verifier that needs exact bytes MUST bind those bytes through the session signature, transaction calldata, or an application-level commitment.
 
-The execution-trace policy check is evaluated after tentative execution and before state commit, under the same call-target and opcode restrictions as EIP-1271 signature validation, with gas exactly `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`. If the call reverts, runs out of gas, executes a forbidden opcode, calls a forbidden address, returns malformed data, or returns `false`, the transaction-level authorization fails and the tentative payload execution is reverted.
-
-The policy function is intentionally `f(transactionContext, executionTrace) -> bool`: the protocol supplies what happened, while the verifier defines whether that execution is allowed. Examples include target/selector allowlists, method-argument commitments, value-flow limits, internal-call restrictions, log emission requirements, proof-bound permissions, per-session spending state, or app-specific invariants over the call trace.
-
-#### Address Derivation
-
-```text
-account = bytes20(keccak256(abi.encodePacked(
-    bytes32("WORLD_CHAIN_ACCOUNT"),
-    block.chainid,
-    WORLD_CHAIN_ACCOUNT_MANAGER,
-    adminSigner,
-    accountSalt
-)))
-```
-
-The address is fixed for the lifetime of the account. Keyring updates, signer state changes, and admin-signer internal recovery do not change the account address.
-
-The default World ID signer factory SHOULD derive different signer addresses for different World ID account nonces. A World ID holder who wants unlinkability across accounts SHOULD use distinct World ID signer instances and distinct `accountSalt` values.
-
-#### Keyring Hash
-
-The canonical keyring hash is:
-
-```text
-keyringHash = keccak256(abi.encode(sessionSigners))
-```
-
-where `sessionSigners` is the full ABI-encoded `SessionSigner[]` in its stored order. The order is admin-selected and consensus-significant. Clients SHOULD sort signers lexicographically by `signer` before submitting updates to avoid accidental duplicate representations.
-
-#### Signal Semantics
-
-Admin authorizations bind to a uniform `signalHash`. The hash supplied to an admin signer is always the 248-bit truncated keccak value:
-
-```text
-signalHash = bytes32(uint256(keccak256(abi.encode(signal))) >> 8)
-```
-
-The truncation keeps the value within the BN254 scalar field for World ID proof-backed EIP-1271 signers. It is uniform for all admin signers so that the signed value is independent of the signer implementation.
-
-```solidity
-struct CreateSignal {
-    bytes32         tag;               // keccak256("WORLD_CHAIN_ACCOUNT_CREATE")
-    address         adminSigner;
-    bytes32         accountSalt;
-    address         msgSender;
-    SessionSigner[] initialSessionSigners;
-}
-
-struct QueueKeyringUpdateSignal {
-    bytes32         tag;               // keccak256("WORLD_CHAIN_ACCOUNT_QUEUE_KEYRING_UPDATE")
-    address         account;
-    address         adminSigner;
-    uint64          adminNonce;
-    address         msgSender;
-    bytes32         expectedCurrentKeyringHash;
-    SessionSigner[] targetSessionSigners;
-    bytes32         targetKeyringHash;
-    uint64          activateAfter;
-}
-```
-
-`msgSender` is the EVM `msg.sender` of the manager call. Binding it prevents an in-flight admin authorization observed in the mempool from being replayed by a different submitter. A public factory, relayer, or forwarding contract that calls the manager for multiple users MUST enforce its own caller/request binding before forwarding; otherwise those users share the same `msg.sender` for WIP-1001 authorization purposes.
-
-#### Replay Protection
-
-For `create`, replay is precluded by account existence: the manager MUST revert if the derived account already exists.
-
-For `queueKeyringUpdate`, replay is prevented by `adminNonce`. The signal contains the current `adminNonce`; after a successful queue operation the manager increments `adminNonce`. An authorization for nonce `n` is invalid after the account advances to nonce `n + 1`.
-
-Queueing a new keyring update while another update is pending is permitted. The new queue operation MUST be independently admin-authorized, MUST satisfy the same delay rules, and replaces the previous pending update.
+The ABI-encoded trace MUST be no larger than `MAX_EXECUTION_TRACE_BYTES`. If the trace exceeds this limit, the transaction MUST fail.
 
 ### Manager Interface
+
+`WORLD_CHAIN_ACCOUNT_MANAGER` exposes:
 
 ```solidity
 interface IWorldChainAccountManager {
@@ -337,386 +418,328 @@ interface IWorldChainAccountManager {
 }
 ```
 
-For `create`, the manager MUST:
+`create` MUST:
 
-1. Require `adminSigner` has non-empty code.
-2. Validate all `initialSessionSigners` and keyring-size constraints.
-3. Compute the deterministic account address from `(adminSigner, accountSalt)`.
-4. Require the account does not already exist.
-5. Recompute the `CreateSignal` `signalHash`.
-6. Run the restricted EIP-1271 validation frame against `adminSigner` with `(hash = signalHash, signature = adminAuthorization)`.
-7. Store `adminSigner`, `accountSalt`, `activeSessionSigners = initialSessionSigners`, `activeKeyringHash`, no pending update, and `adminNonce = 0`.
+- derive the account address;
+- require `initialSessionSigners.length` to be in `[1, MAX_SESSION_SIGNERS]`;
+- reject duplicate session verifiers;
+- verify `adminAuthorization` by calling `adminSigner.isValidSignature(signal, adminAuthorization)`;
+- reject the call if the account already exists;
+- initialize account state.
 
-For `queueKeyringUpdate`, the manager MUST:
+`queueKeyringUpdate` MUST:
 
-1. Require the account exists.
-2. Validate all `targetSessionSigners` and keyring-size constraints.
-3. Require `expectedCurrentKeyringHash == activeKeyringHash`.
-4. Require `activateAfter >= block.timestamp + MIN_KEYRING_UPDATE_DELAY`.
-5. Compute `targetKeyringHash = keccak256(abi.encode(targetSessionSigners))`.
-6. Recompute the `QueueKeyringUpdateSignal` `signalHash` using the current `adminNonce`.
-7. Run the restricted EIP-1271 validation frame against the account's `adminSigner` with `(hash = signalHash, signature = adminAuthorization)`.
-8. Store the pending update, replacing any previous pending update.
-9. Increment `adminNonce`.
+- require the account to exist;
+- require `expectedCurrentKeyringHash == activeKeyringHash`;
+- require `targetSessionSigners.length` to be in `[1, MAX_SESSION_SIGNERS]`;
+- reject duplicate target signers;
+- require `activateAfter >= block.timestamp + MIN_KEYRING_UPDATE_DELAY`;
+- verify the admin operation through `adminSigner.isValidSignature`;
+- replace any existing pending update with the new pending update;
+- increment `adminNonce`.
 
-For `activateKeyringUpdate`, the manager MUST:
+`activateKeyringUpdate` MUST:
 
-1. Require the account exists.
-2. Require a pending update exists.
-3. Require `block.timestamp >= pending.activateAfter`.
-4. Require `pending.expectedCurrentKeyringHash == activeKeyringHash`.
-5. Replace `activeSessionSigners` with `pending.targetSessionSigners`.
-6. Store `activeKeyringHash = pending.targetKeyringHash`.
-7. Clear the pending update.
+- require a pending update;
+- require `block.timestamp >= activateAfter`;
+- require `expectedCurrentKeyringHash == activeKeyringHash`;
+- replace `activeSessionSigners`;
+- update `activeKeyringHash`;
+- clear the pending update.
 
-`activateKeyringUpdate` is permissionless. It applies only a previously admin-authorized update after the required delay.
+`activateKeyringUpdate` MAY be called by any address.
 
 ### Restricted Validation Frames
 
-Protocol signer validation is intentionally narrower than an ordinary EVM `STATICCALL`. Normal smart contracts MAY call any EIP-1271 or policy implementation according to Ethereum rules, but WIP-1001 protocol validation of an admin signer, session signer, or session policy MUST execute in a restricted validation frame.
+The protocol uses restricted validation frames for:
 
-The goal is:
+- admin authorization;
+- session signature verification;
+- session policy evaluation.
 
-```text
-protocol -> WORLD_CHAIN_ACCOUNT_MANAGER -> signer validation hook -> allowlisted crypto precompiles only
-```
+Restricted frames make validation deterministic and independent of mutable external contract state.
 
-There MUST NOT be an arbitrary EVM-to-EVM call graph during protocol signature or policy validation.
+#### EIP-1271 Signature Call
 
-#### Signature Entry Call
+For each EIP-1271 signature check, the protocol MUST perform:
 
-For a signer contract `signer`, hash `hash`, and signature bytes `signature`, the protocol invokes:
-
-```solidity
-IERC1271(signer).isValidSignature(hash, signature)
-```
-
-with:
-
-- call type: `STATICCALL` semantics;
-- `CALLER`: `WORLD_CHAIN_ACCOUNT_MANAGER`;
-- `ADDRESS`: `signer`;
-- `CALLVALUE`: `0`;
+- opcode: `STATICCALL`;
+- caller: `WORLD_CHAIN_ACCOUNT_MANAGER`;
+- callee: the signer contract;
+- call value: `0`;
 - gas: exactly `EIP1271_VALIDATION_GAS_LIMIT`;
 - calldata: `IERC1271.isValidSignature.selector || abi.encode(hash, signature)`;
-- success condition: the call succeeds and returns ABI-encoded `bytes4(EIP1271_MAGIC_VALUE)`.
+- success condition: call succeeds and returns `EIP1271_MAGIC_VALUE`.
 
-If the call reverts, runs out of gas, executes a forbidden opcode, calls a forbidden address, returns malformed data, or returns any value other than `EIP1271_MAGIC_VALUE`, the signature is invalid.
+Failure, revert, out-of-gas, malformed return data, or forbidden validation behavior MUST be treated as signature failure.
 
-A `0x1D` transaction, account, keyring entry, admin signer, and session signer MUST NOT choose or override the signature-validation gas. The gas consumed by session-signer validation MUST be metered against the transaction's gas limit before execution of the transaction payload. Admin validation gas is metered against the EVM call to the manager.
+#### Session Policy Evaluation Call
 
-#### Execution Trace Policy Entry Call
+After tentative payload execution, the protocol MUST perform:
 
-After tentative transaction payload execution, for a session signer `signer`, transaction context `context`, and execution trace `trace`, the protocol invokes:
-
-```solidity
-IWorldChainSessionVerifier(signer).isValidExecutionTrace(context, trace)
-```
-
-with:
-
-- call type: `STATICCALL` semantics;
-- `CALLER`: `WORLD_CHAIN_ACCOUNT_MANAGER`;
-- `ADDRESS`: `signer`;
-- `CALLVALUE`: `0`;
+- opcode: `STATICCALL`;
+- caller: `WORLD_CHAIN_ACCOUNT_MANAGER`;
+- callee: the session verifier used for the transaction;
+- call value: `0`;
 - gas: exactly `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`;
-- calldata: `IWorldChainSessionVerifier.isValidExecutionTrace.selector || abi.encode(context, trace)`;
-- success condition: the call succeeds and returns ABI-encoded `bool(true)`.
+- calldata: `IWorldChainSessionVerifier.evaluateSessionPolicy.selector || abi.encode(context)`;
+- success condition: call succeeds and returns `true`.
 
-If the call reverts, runs out of gas, executes a forbidden opcode, calls a forbidden address, returns malformed data, or returns `false`, trace validation fails and the tentative transaction payload execution MUST be reverted.
+Failure, revert, out-of-gas, malformed return data, forbidden validation behavior, or `false` MUST reject the trace and revert tentative payload execution.
 
-A `0x1D` transaction, account, keyring entry, admin signer, and session signer MUST NOT choose or override the trace-validation gas. The gas consumed by execution-trace policy validation MUST be metered against the transaction's gas limit after payload execution and before transaction finalization.
+#### Call Rules
 
-#### Call-Depth and Call-Target Rules
+Inside a restricted validation frame:
 
-During the restricted validation frame:
-
-- `STATICCALL` to an address in the validation precompile allowlist is permitted.
-- `STATICCALL` to any non-allowlisted address is forbidden.
-- `CALL`, `CALLCODE`, `DELEGATECALL`, `CREATE`, and `CREATE2` are forbidden.
-- Precompile execution does not introduce an additional EVM-code frame for purposes of this rule.
-
-Therefore a protocol-valid EIP-1271 signer contract MUST be self-contained except for direct calls to allowed precompiles. Proxy patterns, module systems, and library dispatch through `DELEGATECALL` are invalid in the restricted frame unless a future WIP relaxes this rule.
+- `STATICCALL` to an allowlisted precompile is permitted;
+- `STATICCALL` to any other address is forbidden;
+- `CALL`, `CALLCODE`, `DELEGATECALL`, `CREATE`, and `CREATE2` are forbidden;
+- precompile execution does not create an additional EVM code frame.
 
 #### Opcode Policy
 
-The restricted validation frame permits deterministic computation, calldata/memory access, own-code access, own-storage reads, `KECCAK256`, `CHAINID`, `GAS`, and `STATICCALL` to allowed precompiles. `GAS` is permitted because each frame starts with a fixed protocol gas limit rather than transaction-selected gas.
+The following opcodes are forbidden inside restricted validation frames:
 
-The following opcodes are forbidden if executed in the restricted validation frame:
+- block context: `BLOCKHASH`, `COINBASE`, `TIMESTAMP`, `NUMBER`, `PREVRANDAO`/`DIFFICULTY`, `GASLIMIT`, `BASEFEE`, `BLOBHASH`, `BLOBBASEFEE`;
+- transaction context: `GASPRICE`, `ORIGIN`;
+- external account inspection: `BALANCE`, `SELFBALANCE`, `EXTCODESIZE`, `EXTCODECOPY`, `EXTCODEHASH`;
+- mutable state and transient state: `SSTORE`, `TLOAD`, `TSTORE`;
+- logs: `LOG0`, `LOG1`, `LOG2`, `LOG3`, `LOG4`;
+- external execution and creation: `CALL`, `CALLCODE`, `DELEGATECALL`, `CREATE`, `CREATE2`;
+- destruction: `SELFDESTRUCT`.
 
-```text
-BLOCKHASH
-COINBASE
-TIMESTAMP
-NUMBER
-PREVRANDAO / DIFFICULTY
-GASLIMIT
-BASEFEE
-BLOBHASH
-BLOBBASEFEE
-GASPRICE
-ORIGIN
-BALANCE
-SELFBALANCE
-EXTCODESIZE
-EXTCODECOPY
-EXTCODEHASH
-SSTORE
-TLOAD
-TSTORE
-LOG0
-LOG1
-LOG2
-LOG3
-LOG4
-CALL
-CALLCODE
-DELEGATECALL
-CREATE
-CREATE2
-SELFDESTRUCT
-```
+The following operations are permitted:
 
-This list removes block-context, transaction-context, external-state, transient-state, logging, mutation, and arbitrary call-depth dependencies from protocol signature and execution-trace policy validation. EIP-1271 validity and trace-policy validity MAY depend on the signer's own persistent storage via `SLOAD`, subject to the signer-state timelock requirements below.
+- deterministic computation;
+- calldata and memory access;
+- reads of the signer contract's own bytecode;
+- reads of the signer contract's own storage;
+- `KECCAK256`;
+- `CHAINID`;
+- `GAS`;
+- `STATICCALL` to allowlisted precompiles.
 
-### Signer-State Timelock Requirements
+An implementation MUST reject the validation call if a forbidden opcode or forbidden call target is reached.
 
-To make public-pool validation stable, any signer state that can cause a previously valid signature or previously accepted execution trace to become invalid MUST transition through a delay of at least `MIN_KEYRING_UPDATE_DELAY` before it becomes effective.
+### Timelocked Signer-State Updates
 
-For default manager-supported signer factories, this is mandatory:
+Default factories that expose mutable signer or verifier state capable of invalidating a previously valid signature MUST timelock those updates by at least `MIN_KEYRING_UPDATE_DELAY`.
 
-- owner rotation in a secp256k1 signer MUST be queued before activation;
-- World ID session verifier state that changes accepted session material MUST be queued before activation;
-- threshold, key, revocation, recovery, or trace-policy state in any default signer MUST be queued before activation.
+Examples include:
 
-Custom EIP-1271 signers are protocol-compatible only if all storage values read during signature or trace-policy restricted frames obey the same delay discipline. Public transaction-pool implementations MUST NOT advertise full validation-stability guarantees for custom signers unless the signer bytecode or deployment is known to satisfy this property. Consensus validation still executes the signature and trace-policy calls at inclusion time; the timelock requirement defines WIP-1001-compliant signer behavior and public-pool admission policy.
+- root rotations;
+- verification-key rotations;
+- signer recovery changes;
+- signer revocation lists;
+- account binding changes.
 
-### Default Signer Factories
-
-Default signer factories are ordinary contracts, exposed by or discoverable from `WORLD_CHAIN_ACCOUNT_MANAGER`, that deploy deterministic EIP-1271 signer contracts with WIP-1001-compliant restricted-frame behavior and signer-state timelocks.
-
-The default factories are not special validation paths. A signer produced by a default factory is authorized only if it appears in the active keyring or is fixed as an account's admin signer.
-
-Default signer implementations MUST implement `isValidExecutionTrace`. A signer with no additional execution policy MAY return `true` for every well-formed trace after signature validation succeeds, but any configurable execution policy it exposes MUST be stored and updated inside the signer under the signer-state timelock rules.
-
-#### Secp256k1 EIP-1271 Signer
-
-The secp256k1 signer factory deploys signer contracts that store an Ethereum address `owner`.
-
-`isValidSignature(hash, signature)` MUST:
-
-1. Decode `signature` as an Ethereum secp256k1 ECDSA signature.
-2. Enforce the Ethereum low-`s` rule from [EIP-2](https://eips.ethereum.org/EIPS/eip-2).
-3. Recover the signer address over `hash` using `ECRECOVER`.
-4. Return `EIP1271_MAGIC_VALUE` iff the recovered address equals the active `owner`.
-
-Owner rotation, owner revocation, or any trace-policy update that can invalidate a previously valid signature or accepted execution trace MUST be timelocked by at least `MIN_KEYRING_UPDATE_DELAY`.
-
-#### World ID EIP-1271 Signer
-
-The World ID signer factory deploys signer contracts that verify World ID proofs encoded inside EIP-1271 signature bytes. World ID is a reference EIP-1271 verification strategy, not a native WIP-1001 admin or session-key type.
-
-A World ID signer stores the public verifier state required to validate future proofs, including at minimum the relevant `sessionId` or equivalent World ID session-verification material.
-
-For transaction or admin validation, `isValidSignature(hash, signature)` MUST:
-
-1. Decode `signature` as a World ID proof payload.
-2. Derive the World ID proof `signalHash` from `hash`, using `uint256(hash) >> 8` when the proof system requires a BN254-field signal.
-3. Verify the World ID proof against the stored session-verification material and the decoded public inputs.
-4. Return `EIP1271_MAGIC_VALUE` iff verification succeeds.
-
-A conceptual session-proof signature payload is:
-
-```solidity
-struct WorldID1271Signature {
-    uint256    proofNonce;
-    uint64     issuerSchemaId;
-    uint64     expiresAtMin;
-    uint256    credentialGenesisIssuedAtMin;
-    uint256[2] sessionNullifier;
-    uint256[5] proof;
-}
-```
-
-The signer MUST NOT persist `sessionNullifier` as account-manager state. Replay prevention for manager operations comes from account existence and `adminNonce`; replay prevention or nullifier tracking internal to a World ID signer is signer-policy-specific and MUST preserve the signer-state timelock guarantee if it can invalidate pooled transactions.
-
-World ID signer creation MAY be gated by a World ID Uniqueness Proof. The creation proof, account nonce, signer salt, and initial session-verification material are factory-level concerns. Once deployed, the signer is just an EIP-1271 contract from the manager's perspective.
+Signer state that cannot affect validation of already accepted transactions MAY update without this delay.
 
 ### Transaction Type `0x1D`
 
-A `0x1D` transaction is signed by a session signer of a World Chain Account and submitted directly to the public transaction pool. `0x1D` transactions are signer-strategy-agnostic: transaction validation reads the active keyring, invokes EIP-1271 on the declared signer, tentatively executes the payload, then asks the same signer whether the resulting execution trace satisfies its internal policy.
-
 #### Envelope
 
-```text
-0x1D || rlp([
-    chain_id,                    // 0
-    nonce,                       // 1
-    max_priority_fee_per_gas,    // 2
-    max_fee_per_gas,             // 3
-    gas_limit,                   // 4
-    to,                          // 5
-    value,                       // 6
-    data,                        // 7
-    access_list,                 // 8
-    account,                     // 9   -- sender's World Chain Account address
-    signer,                      // 10  -- authorized EIP-1271 session signer
-    signature,                   // 11  -- opaque bytes passed to isValidSignature
+`WORLD_TX_TYPE` transactions use the following payload:
+
+```solidity
+rlp([
+    chainId,
+    nonce,
+    maxPriorityFeePerGas,
+    maxFeePerGas,
+    gasLimit,
+    account,
+    signer,
+    isCreate,
+    to,
+    value,
+    data,
+    accessList,
+    signature
 ])
 ```
 
-```text
-signing_hash = keccak256(0x1D || rlp(fields[0..=10]))
-```
-
-The `signing_hash` covers every field except `signature` itself, binding the declared session signer to the transaction and ruling out signer-substitution attacks at the consensus layer.
-
-The protocol does not interpret `signature`. It is passed unchanged to:
+The signing hash is:
 
 ```solidity
-IERC1271(signer).isValidSignature(signing_hash, signature)
+keccak256(
+    0x1D ||
+    rlp([
+        chainId,
+        nonce,
+        maxPriorityFeePerGas,
+        maxFeePerGas,
+        gasLimit,
+        account,
+        signer,
+        isCreate,
+        to,
+        value,
+        data,
+        accessList
+    ])
+)
 ```
 
 #### Validation and Execution
 
-The protocol MUST validate and execute a `0x1D` transaction as follows:
+To validate and execute a `0x1D` transaction, the protocol MUST:
 
-1. Compute `signing_hash`.
-2. Load the active keyring entry for `(account, signer)`.
-3. Reject if no matching active session signer exists.
-4. Run the restricted EIP-1271 validation frame against `signer` with `(hash = signing_hash, signature = signature)`.
-5. Reject if the frame does not return `EIP1271_MAGIC_VALUE`.
-6. Tentatively execute the transaction payload under normal EVM rules, collecting the canonical `WorldChainExecutionTrace`.
-7. Construct `WorldChainTransactionContext` from the transaction and active keyring state.
-8. Require `abi.encode(trace).length <= MAX_EXECUTION_TRACE_BYTES`.
-9. Run the restricted execution-trace policy validation frame against `signer` with `(context, trace)`.
-10. If the frame does not return `true`, revert the tentative payload execution and mark the transaction as failed by policy.
-11. If the frame returns `true`, finalize the transaction according to the tentative payload execution result.
+1. Compute the signing hash.
+2. Load the account from `WORLD_CHAIN_ACCOUNT_MANAGER`.
+3. Reject the transaction if `signer` is not in the active keyring.
+4. Verify `signature` by calling `signer.isValidSignature(signingHash, signature)` in a restricted validation frame.
+5. Reject the transaction unless the signer returns `EIP1271_MAGIC_VALUE`.
+6. Execute the payload tentatively with `account` as the EVM transaction sender and collect the canonical execution trace.
+7. Build `ExecutionTraceContext` from the envelope, signing hash, active keyring hash, and canonical execution trace.
+8. Reject the transaction if `abi.encode(context.trace).length > MAX_EXECUTION_TRACE_BYTES`.
+9. Call `signer.evaluateSessionPolicy(context)` in a restricted validation frame.
+10. If session policy evaluation fails, discard tentative payload state and logs, consume nonce and gas according to normal failed-transaction semantics, and mark the transaction failed.
+11. If session policy evaluation succeeds, commit the payload result. If payload execution itself failed, commit the normal failed-call result.
 
-Authorization is checked before any signer call so an attacker cannot use an unauthorized `0x1D` transaction to force arbitrary signature or trace-policy validation work.
+### Default Signer Factories
 
-The envelope is extensible to 2D nonces, batched transactions, and native paymaster support in follow-on WIPs.
+World Chain provides default EIP-1271 signer factories through predeploy addresses assigned at activation.
+
+Default factories are reference implementations. Accounts MAY use any EIP-1271 admin signer or session verifier that satisfies this specification.
+
+#### Secp256k1 Signer
+
+`SECP256K1_1271_SIGNER_FACTORY` deploys the secp256k1 admin signer defined in this specification and MAY deploy session verifier variants that use the same secp256k1 authentication core.
+
+The admin signer variant implements EIP-1271 only. A session verifier variant MUST also implement `IWorldChainSessionVerifier`.
+
+#### World ID Signer
+
+`WORLD_ID_1271_SIGNER_FACTORY` deploys the World ID admin signer defined in this specification and MAY deploy session verifier variants that use the same World ID authentication core.
+
+The admin signer variant implements EIP-1271 only. A session verifier variant MUST also implement `IWorldChainSessionVerifier` and MUST bind its World ID proof to the `0x1D` signing hash.
 
 ### Visual Flow
 
 ```mermaid
-flowchart TD
-    Wallet[Wallet or App] --> Tx[0x1D Transaction]
-    Tx --> Pool[Public Tx Pool Validation]
-    Pool --> Manager[WORLD_CHAIN_ACCOUNT_MANAGER Predeploy]
-    Manager --> Active[Active Session Signer Set]
-    Active --> Signer[Authorized EIP-1271 Session Signer]
-    Signer --> Frame[Restricted Signature Frame]
-    Frame --> SigResult{Returns magic value?}
-    SigResult -->|no| Reject[Reject Transaction]
-    SigResult -->|yes| Exec[Tentative EVM Execution]
-    Exec --> Trace[Canonical Execution Trace]
-    Trace --> Policy[Verifier Trace Policy]
-    Policy --> PolicyResult{Trace allowed?}
-    PolicyResult -->|yes| Include[Finalize Transaction]
-    PolicyResult -->|no| Revert[Revert Tentative Execution]
-    Frame --> Crypto[Allowlisted Crypto Precompiles]
-    Policy --> Crypto
+sequenceDiagram
+    autonumber
+    participant User
+    participant Pool as Tx Pool
+    participant Protocol
+    participant Manager as WORLD_CHAIN_ACCOUNT_MANAGER
+    participant Signer as EIP-1271 Session Verifier
+    participant App as Target Contracts
 
-    Admin[Admin EIP-1271 Signer] --> Queue[queueKeyringUpdate]
-    Queue --> Pending[Pending Keyring + activateAfter]
-    Pending -->|delay > txpool expiration| Activate[activateKeyringUpdate]
-    Activate --> Active
+    User->>Pool: Submit 0x1D transaction
+    Pool->>Protocol: Validate transaction
+    Protocol->>Manager: Load active keyring
+    Manager-->>Protocol: signer authorized, activeKeyringHash
+    Protocol->>Signer: isValidSignature(signingHash, signature)
+    Signer-->>Protocol: EIP1271_MAGIC_VALUE
+    Protocol-->>Pool: Valid while keyring is active
 
-    WorldID[World ID Proof in Signature Bytes] --> WIDSigner[WorldID1271Signer]
-    WIDSigner --> Frame
-    EOA[EOA Signature Bytes] --> EOASigner[Secp256k1 1271 Signer]
-    EOASigner --> Frame
+    Protocol->>App: Tentative execution as account
+    App-->>Protocol: Result, calls, logs
+    Protocol->>Signer: evaluateSessionPolicy(context)
+    alt trace accepted
+        Signer-->>Protocol: true
+        Protocol-->>User: Commit payload result
+    else trace rejected
+        Signer-->>Protocol: false or failure
+        Protocol-->>User: Revert tentative payload
+    end
+
+    User->>Manager: queueKeyringUpdate(...)
+    Manager-->>User: Pending until activateAfter
+    User->>Manager: activateKeyringUpdate()
+    Manager-->>User: Active keyring replaced
 ```
 
 ### Extensions
 
-- **Trace schema extensions.** The execution trace schema MAY be extended with additional bounded summaries such as storage-write commitments, balance-delta commitments, or transient-storage summaries. The verifier remains the policy owner; the protocol only defines the trace data it supplies.
-- **Admin rotation.** Replacing an account's fixed `adminSigner` under a separate timelocked admin-rotation flow. Deferred in this WIP.
-- **Multi-admin.** M-of-N admin authorization for a single account. Deferred as native manager state; near-term policies SHOULD be represented inside an EIP-1271 admin signer.
-- **Additional crypto precompiles.** BLS12-381, EdDSA variants, secp256k1 verification without recovery, or other primitives MAY be added as VM precompiles. Once allowlisted for the restricted validation frame, EIP-1271 signer contracts can use them without changing the `0x1D` envelope.
-- **Bundling, 2D nonces, paymasters.** Reserved for follow-on WIPs on the `0x1D` envelope.
+WIP-1001 is designed to support future signer contracts without protocol changes, including:
+
+- multisig signers;
+- social recovery signers;
+- passkey signers;
+- threshold signers;
+- proof-system signers;
+- enterprise policy signers;
+- application-specific session verifiers.
+
+New cryptographic primitives SHOULD be added as reusable precompiles, not as account-specific protocol branches.
 
 ## Rationale
 
-**Account state as predeploy.** The keyring lives in the `WORLD_CHAIN_ACCOUNT_MANAGER` predeploy because `0x1D` validation must read the active signer set natively while preserving an ordinary Solidity/EVM-bytecode implementation surface for account management and default factories.
+### EIP-1271 as the Signer Boundary
 
-**EIP-1271-only verification.** A single contract-signature abstraction avoids protocol branches for every authenticator or cryptographic scheme. New signer strategies can be deployed as contracts and audited independently without changing the transaction type.
+EIP-1271 gives World Chain one protocol boundary for all authorization schemes. The protocol verifies a signer contract; the signer contract decides how to authenticate.
 
-**Fixed validation gas.** Per-signer gas limits make keyring entries harder to reason about, expand the admin-authorized state surface, and let signer deployment choices affect transaction validation economics. A single `EIP1271_VALIDATION_GAS_LIMIT` gives every protocol 1271 validation frame the same execution budget.
+### Verifier-Owned Execution Policy
 
-**Verifier-owned programmable policy.** Static `(target, selector)` allowlists are too narrow for account-native sessions, and the manager should not store a policy language. Passing the post-execution trace to the same verifier that authenticated the session lets policy be expressed as `f(transactionContext, executionTrace) -> bool`, so the verifier can decide whether what actually happened is allowed.
+Execution policy belongs inside the session verifier. The protocol does not need to understand spending limits, method allowlists, intents, or application-specific policy. It only supplies the canonical transaction context and execution trace, then asks the verifier for a boolean decision.
 
-**Reusable precompiles instead of host-only cryptography.** P256, EdDSA, BLS, pairing checks, and future curves are useful outside account validation. Exposing them as normal precompiles ensures the protocol and contracts agree on inputs, outputs, gas, and edge cases.
+### Fixed Validation Gas
 
-**Restricted validation frames.** Unrestricted contract signature or policy validation would allow an arbitrary read-only call graph before transaction execution. The restricted frame bounds gas, fixes the caller, forbids arbitrary call depth, and removes block-, transaction-, and external-state-sensitive opcodes while preserving own-storage policy and direct precompile calls.
+Validation gas limits are protocol constants, not signer-selected values. This prevents signers from increasing validation cost per transaction and gives clients a fixed resource bound for mempool validation and block execution.
 
-**Full-keyring replacement.** Updates carry the complete target keyring rather than add/remove deltas. This makes every admin authorization commit to the exact post-update authorization set, avoids ordering-dependent delta semantics, and removes edge cases where separately authorized removals and additions compose into an unintended intermediate keyring.
+### Timelocked Keyring Updates
 
-**Timelocked activation.** Delaying keyring activation by more than the transaction-pool expiration window prevents manager-owned keyring changes from invalidating transactions that were already admitted to the public pool. Applying the same discipline to default signer authorization and policy state extends that guarantee through signer validation.
+A keyring update can invalidate transactions that already passed mempool validation. Requiring `MIN_KEYRING_UPDATE_DELAY > TXPOOL_TRANSACTION_EXPIRATION_WINDOW` guarantees that a transaction cannot be invalidated by a keyring update while it is still eligible for inclusion.
 
-**World ID as reference signer.** World ID proofs are powerful authorization material, but they do not need a native WIP-1001 admin type. Encoding World ID proof payloads in EIP-1271 signatures makes World ID one programmable signer implementation among many and keeps the manager's account model uniform.
+### Restricted Validation Frames
+
+Restricted validation frames prevent validation results from depending on mutable external state, block metadata, or external contract calls. Signers remain programmable, but validation stays reproducible across pool validation and block execution.
 
 ## Backwards Compatibility
 
-This WIP introduces a new account type and transaction type. Existing EOAs and smart contract accounts are unaffected. Standard [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) transactions continue to work for legacy accounts; the `0x1D` envelope is required only for World-Chain-Account-authenticated execution.
+WIP-1001 introduces a new EIP-2718 transaction type and a new account manager predeploy. Existing Ethereum transaction types, EOAs, contracts, and Safe accounts are unchanged.
 
-This WIP is Draft. The move to EIP-1271-only session and admin verification, the replacement of native account-manager language with a manager predeploy, the removal of native signature-type dispatch, and timelocked keyring activation are breaking changes relative to earlier drafts. No production accounts exist.
-
-Existing draft implementations or libraries that expose native P256, WebAuthn, EdDSA, or secp256k1 WIP-1001 transaction signature variants are obsolete relative to this specification. Those strategies SHOULD migrate to EIP-1271 signer contracts or default signer factories.
-
-### Existing Safe Accounts
-
-Existing [Safe](https://safe.global) accounts MAY integrate with World Chain Accounts without migrating assets or changing the Safe address by installing modules or guards that recognize a World Chain Account as an authorized caller. Existing Safe contracts are not automatically valid WIP-1001 protocol signers: the restricted validation frames forbid arbitrary call depth, `DELEGATECALL`, and external contract state reads. A Safe-style policy can be used as a protocol signer only through bytecode that satisfies the signature interface, execution-trace policy interface, restricted-frame rules, and signer-state timelock rules, or through ordinary application-level calls outside WIP-1001 protocol validation.
+Existing Safe accounts MAY deploy or delegate to EIP-1271 signer contracts that satisfy this specification, but WIP-1001 does not require Safe migration.
 
 ## Security Considerations
 
-### Front-Running Admin Authorizations
+### Admin Authorization Front-Running
 
-Both `CreateSignal` and `QueueKeyringUpdateSignal` bind `msg.sender`, so a witnessed admin authorization observed in the mempool cannot be replayed by a different submitter. A griefer can still re-submit an authorization unchanged from the original `msg.sender`, but the resulting state is either identical or supersedes the same pending update under the same admin intent.
-
-The binding is to the direct EVM caller of `WORLD_CHAIN_ACCOUNT_MANAGER`. A public factory, relayer, or forwarding contract that calls the manager on behalf of multiple users MUST enforce its own caller/request binding before forwarding.
+Admin authorization signatures MUST bind account address, manager address, chain ID, operation selector, operation parameters, and nonce. A signature valid for one admin operation MUST NOT be valid for another.
 
 ### Admin Signer Compromise
 
-An admin signer can queue a full keyring replacement, but the replacement cannot activate until `MIN_KEYRING_UPDATE_DELAY` has elapsed. The delay gives wallets and monitoring systems time to warn users or move funds using still-active session signers. If the admin signer remains compromised until activation, the attacker can eventually replace the keyring.
+The admin signer can queue keyring changes. Applications SHOULD support recovery or multisig admin signers where appropriate.
 
 ### Signer Validation DoS
 
-Protocol signature validation is bounded by the fixed `EIP1271_VALIDATION_GAS_LIMIT`, execution-trace policy validation is bounded by the fixed `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`, and trace size is bounded by `MAX_EXECUTION_TRACE_BYTES`. Transactions cannot select a higher gas budget for either validation frame, and keyring authorization is checked before signer calls. This prevents unauthorized transactions from using arbitrary signer contracts as validation gas sinks.
+Fixed validation gas limits bound signer execution. Signers that exceed the limit fail validation.
 
-### Call-Graph and External-State Invalidation
+### Trace Size DoS
 
-Restricted validation frames forbid EVM-to-EVM calls except direct `STATICCALL`s to allowlisted precompiles. They also forbid external-code and external-balance inspection opcodes. As a result, protocol signature and trace-policy validity cannot depend on another contract's code, storage, or balance changing before inclusion.
+`MAX_EXECUTION_TRACE_BYTES` bounds memory and encoding cost for session policy evaluation. Transactions that exceed the bound fail before the context is passed to the signer.
 
-### Context-Sensitive Opcode Invalidation
+### External-State Invalidation
 
-Block-context and transaction-context opcodes such as `TIMESTAMP`, `NUMBER`, `BASEFEE`, `GASPRICE`, `ORIGIN`, and blob context are forbidden in restricted validation frames. Signatures and trace-policy decisions therefore cannot become valid or invalid solely because a block producer selected a different block context.
+Restricted frames forbid external contract reads and calls except allowlisted precompiles. This prevents unrelated contract state from changing signature or session policy outcomes.
+
+### Block-Context Invalidation
+
+Restricted frames forbid block-context opcodes. Signers that need time or block constraints MUST bind them into the signature or proof input.
 
 ### Own-Storage Invalidation
 
-Signer validity and execution-trace policy validity MAY depend on the signer's own storage. This is the intentional programmable policy surface. To preserve public-pool stability, any own-storage change that can invalidate a previously valid signature or previously accepted execution trace MUST be timelocked by at least `MIN_KEYRING_UPDATE_DELAY` for WIP-1001-compliant signers.
+Signers and verifiers may read their own storage. Default factories that expose mutable state affecting validation MUST timelock those updates by at least `MIN_KEYRING_UPDATE_DELAY`.
 
-### Custom Signer Safety
+### Upgradeable Signers
 
-The manager can verify any signer that satisfies the signature and execution-trace policy restricted frames at inclusion time, but public transaction pools should distinguish default or otherwise known-safe signers from arbitrary custom signers. If a custom signer can immediately change own-storage validation or trace-policy state, it can invalidate pooled transactions before inclusion and should not receive the full WIP-1001 pool-stability guarantee.
+Upgradeable signer contracts can change validation behavior. Signer factories SHOULD make upgradeability explicit, and upgrades that affect validation SHOULD be timelocked.
 
-### Contract Upgradeability
+### Session Verifier Deanonymization
 
-Upgradeable signer contracts can change account authorization policy without changing the World Chain Account keyring. Proxy patterns that require `DELEGATECALL` during validation are invalid under the restricted frame. Upgrade paths that can invalidate signatures MUST themselves obey the signer-state timelock discipline.
-
-### Session Signer Deanonymization
-
-A signer contract reused across accounts links those accounts. Clients SHOULD deploy fresh signer instances per account when unlinkability matters. World ID users who require unlinkability SHOULD use distinct World ID account nonces and signer instances.
+The `0x1D` envelope exposes the selected session verifier. Applications that need stronger privacy should use verifier contracts that aggregate or rotate credentials.
 
 ### Signature-Signer Ambiguity
 
-A World Chain Account may store up to `MAX_SESSION_SIGNERS`, but a `0x1D` transaction declares exactly one `signer`. The keyring lookup is by signer address and MUST be unique. There is no "first matching signer" ambiguity.
+The transaction envelope includes both `account` and `signer`. The protocol MUST verify that `signer` is active for `account` before calling EIP-1271.
 
 ### WebAuthn Challenge Binding
 
-For WebAuthn-based EIP-1271 signer contracts, the `0x1D` `signing_hash` SHOULD appear as the WebAuthn challenge, or be bound by an equivalent domain-separated digest inside the contract's validation logic. WIP-1001 does not prescribe the internal EIP-1271 signature format.
+WebAuthn-based signers MUST bind challenges to the `0x1D` signing hash and `WORLD_CHAIN_RP_ID`.
 
 ### World ID Stale Roots
 
-World ID signer implementations that accept roots within a validity window inherit the stale-root risks of the underlying World ID verifier. A credential revoked shortly before root expiry may still authorize a signature until the verifier's root-validity and credential-expiration checks reject it. The signer implementation MUST surface and document those verifier trust parameters.
+World ID signers MUST define root freshness rules. Root updates that can invalidate previously accepted transactions MUST follow the signer-state timelock requirement.

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -14,15 +14,15 @@ requires: EIP-1271, EIP-2718, EIP-1559, EIP-2930, ERC-7562, RIP-7212
 
 WIP-1001 defines a native World Chain account type managed by the `WORLD_CHAIN_ACCOUNT_MANAGER` predeploy. Each account has one immutable [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) admin signer and one active keyring of EIP-1271 session verifiers.
 
-`0x1D` transactions are [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) typed transactions executed with the World Chain account as the EVM sender. A session verifier first authorizes the transaction signature through EIP-1271. After tentative execution, the same verifier evaluates the canonical execution trace and decides whether the payload result may be committed.
+We extend [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) with a new typed transaction envelope with type flag `0x1D`. `0x1D` transactions executed with the World Chain account **Framed** as the sender. Session verifiers act as the transaction level signatories via programmable [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271). Session verifiers dually function as signature verifiers, and session key policy evaluators.
 
-The protocol does not implement signer-specific authentication. Signature schemes, proof systems, recovery policy, and spending policy live in signer contracts. The protocol supplies deterministic inputs, restricted validation frames, and reusable precompiles for common cryptographic primitives.
+We design with the principal of not having signer-specific authentication as a native execution path in the protocol. Signature schemes, proof systems, recovery policies, and spending policies are fully programmable. The protocol only prescribes deterministic context, validation frames, and reusable precompiles for cryptographic operations.
 
 ## Motivation
 
-World Chain accounts need programmable authentication without adding a protocol branch for every signature scheme or proof system. EIP-1271 gives the protocol one authorization boundary: call a signer contract with a hash and require the standard magic value.
+World Chain accounts need programmable authentication without adding a protocol branch for every signature scheme, or session key policy. [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) gives the protocol one authorization boundary: a fully programmable smart contract.
 
-Admin signers and session verifiers use the same EIP-1271 boundary but have different roles. The admin signer authorizes account-management operations. Session verifiers authorize `0x1D` transactions and evaluate the resulting execution trace.
+Admin signers and session verifiers use the same [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) boundary but have different roles. The admin signer authorizes account-management operations. Session verifiers authorize `0x1D` transactions and evaluate the resulting execution trace.
 
 Stable transaction inclusion requires mempool validation and block execution to agree on which verifier may authorize a transaction. Keyring replacement is therefore timelocked for longer than pool transaction expiration, while emergency revocation can evict only transactions from the revoked verifier.
 

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -7,50 +7,28 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2026-03-27
-requires: EIP-2, EIP-1559, EIP-196, EIP-197, EIP-198, EIP-2718, EIP-2930, EIP-1271, ERC-7562, RIP-7212
+requires: EIP-1271, EIP-2718, EIP-1559, EIP-2930, ERC-7562, RIP-7212
 ---
 
 ## Abstract
 
-WIP-1001 defines a native World Chain account type managed by the `WORLD_CHAIN_ACCOUNT_MANAGER` predeploy.
+WIP-1001 defines a native World Chain account type managed by the `WORLD_CHAIN_ACCOUNT_MANAGER` predeploy. Each account has one immutable [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) admin signer and one active keyring of EIP-1271 session verifiers.
 
-Each account has one EIP-1271 admin signer and an active keyring of EIP-1271 session verifiers. The admin signer is the root authority for account management. Session verifiers are delegated authorities for `0x1D` transaction execution.
+`0x1D` transactions are [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) typed transactions executed with the World Chain account as the EVM sender. A session verifier first authorizes the transaction signature through EIP-1271. After tentative execution, the same verifier evaluates the canonical execution trace and decides whether the payload result may be committed.
 
-The protocol does not implement signature schemes directly. Instead, the protocol calls EIP-1271 signers in restricted validation frames. Signature schemes, proof systems, recovery policies, and execution policies are implemented by signer contracts. The protocol provides reusable cryptographic precompiles for common primitives.
-
-Session verifiers also own their execution policy. After tentative transaction execution, the protocol asks the verifier whether the observed execution trace is valid. If the verifier rejects the trace, the tentative execution is reverted.
+The protocol does not implement signer-specific authentication. Signature schemes, proof systems, recovery policy, and spending policy live in signer contracts. The protocol supplies deterministic inputs, restricted validation frames, and reusable precompiles for common cryptographic primitives.
 
 ## Motivation
 
-### One Authorization Path
+World Chain accounts need programmable authentication without adding a protocol branch for every signature scheme or proof system. EIP-1271 gives the protocol one authorization boundary: call a signer contract with a hash and require the standard magic value.
 
-World Chain accounts need programmable authentication without adding a protocol branch for every signature scheme or proof system. EIP-1271 gives the protocol one authorization path: call a signer contract and require the standard magic value.
+Admin signers and session verifiers use the same EIP-1271 boundary but have different roles. The admin signer authorizes account-management operations. Session verifiers authorize `0x1D` transactions and evaluate the resulting execution trace.
 
-Admin signers and session verifiers both use EIP-1271, but they have different protocol roles. An admin signer authorizes account-management operations. A session verifier authorizes transaction signatures and evaluates the resulting execution trace.
-
-### Reusable Cryptography
-
-Signer contracts need efficient cryptographic primitives, but those primitives should not define account semantics. WIP-1001 exposes reusable precompiles for supported curves and proof systems, while keeping account policy in contracts.
-
-World ID is a reference signer implementation. It verifies an EIP-1271 signature that encodes a World ID proof. It is not a privileged protocol path.
-
-### Programmability
-
-Accounts need authorization logic that can evolve without protocol changes. EIP-1271 lets admin signers define arbitrary account-management authorization, including World ID, secp256k1, secp256r1, EdDSA, BLS12-381, multisig, programmable recovery, multi factor authentication and application-specific schemes.
-
-Session verifiers extend that programmability to transaction execution. A verifier can authenticate a session key, inspect the canonical execution trace, and decide whether the transaction satisfies its policy. The protocol only provides deterministic inputs and enforces the verifier's evaluation according to its session signers corresponding policy.
-
-### Stable Transaction Inclusion
-
-Mempool validation and block inclusion must agree on which keyring is active. Keyring updates are therefore timelocked for longer than the transaction pool expiration window. A transaction that validates against an active keyring cannot become invalid before it expires from the pool because of a keyring update.
-
-Default factories that support mutable signer or verifier state must apply the same rule to state that can invalidate already accepted transactions.
+Stable transaction inclusion requires mempool validation and block execution to agree on which verifier may authorize a transaction. Keyring replacement is therefore timelocked for longer than pool transaction expiration, while emergency revocation can evict only transactions from the revoked verifier.
 
 ## Specification
 
-
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) and [RFC 8174](https://www.rfc-editor.org/rfc/rfc8174).
-
 
 ### Protocol Constants
 
@@ -70,21 +48,21 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Activation Parameters
 
-WIP-1001 MUST NOT activate until every parameter below is assigned in the fork configuration.
+WIP-1001 MUST NOT activate until every parameter below is assigned in fork configuration.
 
 | Name | Type | Value | Requirement |
 | --- | --- | --- | --- |
 | `WORLD_CHAIN_ACCOUNT_MANAGER` | `address` | TBD | Predeploy address for the account manager. |
 | `EIP1271_VALIDATION_GAS_LIMIT` | `uint64` | TBD | Fixed gas forwarded to `isValidSignature`. |
 | `EXECUTION_TRACE_VALIDATION_GAS_LIMIT` | `uint64` | TBD | Fixed gas forwarded to `evaluateSessionPolicy`. |
-| `BLOCK_VALIDATION_GAS_BUDGET` | `uint64` | TBD | Per-block gas budget reserved for `0x1D` validation calls. See "Validation Gas Accounting". |
-| `MIN_VALIDATION_FAILURE_FEE` | `uint256` | TBD | Minimum wei charge to the account on validation failure. Anti-DoS floor. |
+| `BLOCK_VALIDATION_GAS_BUDGET` | `uint64` | TBD | Per-block gas budget reserved for `0x1D` validation calls. |
+| `MIN_VALIDATION_FAILURE_FEE` | `uint256` | TBD | Minimum wei charged to the account on validation failure. |
 | `MAX_EXECUTION_TRACE_BYTES` | `uint32` | TBD | Maximum ABI-encoded trace size passed to a session verifier. |
-| `MAX_PAYLOAD_DATA_BYTES` | `uint32` | TBD | Maximum length of `data` in the `0x1D` envelope. |
-| `MAX_ACCESS_LIST_ENTRIES` | `uint32` | TBD | Maximum number of EIP-2930 access-list entries in the envelope. |
+| `MAX_PAYLOAD_DATA_BYTES` | `uint32` | TBD | Maximum length of `data` in a `0x1D` envelope. |
+| `MAX_ACCESS_LIST_ENTRIES` | `uint32` | TBD | Maximum number of [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) access-list entries in a `0x1D` envelope. |
 | `MAX_SESSION_SIGNATURE_BYTES` | `uint32` | TBD | Maximum length of the session `signature` field. |
 | `MAX_ADMIN_AUTHORIZATION_BYTES` | `uint32` | TBD | Maximum length of `adminAuthorization` calldata. |
-| `TXPOOL_TRANSACTION_EXPIRATION_WINDOW` | `uint64` | TBD | Maximum time (seconds) a valid transaction remains in the pool. |
+| `TXPOOL_TRANSACTION_EXPIRATION_WINDOW` | `uint64` | TBD | Maximum time in seconds that a valid transaction remains in the pool. |
 | `MIN_KEYRING_UPDATE_DELAY` | `uint64` | TBD | MUST satisfy `MIN_KEYRING_UPDATE_DELAY > TXPOOL_TRANSACTION_EXPIRATION_WINDOW`. |
 | `WORLD_ID_1271_SIGNER_FACTORY` | `address` | TBD | Default World ID EIP-1271 signer factory. |
 | `SECP256K1_1271_SIGNER_FACTORY` | `address` | TBD | Default secp256k1 EIP-1271 signer factory. |
@@ -94,8 +72,6 @@ WIP-1001 MUST NOT activate until every parameter below is assigned in the fork c
 ### Reusable Crypto Precompiles
 
 Signer contracts MAY call protocol-supported cryptographic precompiles from restricted validation frames.
-
-The validation-frame precompile allowlist is:
 
 | Primitive | Source |
 | --- | --- |
@@ -107,568 +83,241 @@ The validation-frame precompile allowlist is:
 | `bn254 add` | Ethereum precompile |
 | `bn254 scalar multiplication` | Ethereum precompile |
 | `bn254 pairing` | Ethereum precompile |
-| `secp256r1 verify` | RIP-7212 |
+| `secp256r1 verify` | [RIP-7212](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md) |
 | `EdDSA verify` | Activation parameter |
 | `BLS12-381 verify` | Activation parameter |
 
 World Chain clients MUST NOT expose private host validation APIs that are unavailable to contracts. Any primitive used by a default signer MUST be available through an allowlisted precompile.
 
-### Account Model
+### Account State
 
-World Chain accounts are created and managed by a `WORLD_CHAIN_ACCOUNT_MANAGER`.
-
-An account has:
-
-- one immutable account address;
-- one EIP-1271 admin signer;
-- one active keyring of EIP-1271 session verifiers;
-- at most one pending keyring update;
-- one admin nonce.
-
-Account authority is hierarchical:
-
-1. The account manager owns account state and enforces account-management rules.
-2. The admin signer is the root account authority. It authorizes account creation and keyring updates through EIP-1271.
-3. Session verifiers are delegated transaction authorities. They authorize `0x1D` transactions through EIP-1271 and approve or reject the observed execution trace through `evaluateSessionPolicy`.
-
-The manager MUST NOT use the admin signer to authorize `0x1D` transaction execution unless the same address is also present in the active session keyring. The manager MUST NOT use a session verifier to authorize account-management operations unless the same address is also configured as the admin signer.
-
-The manager stores account state:
+World Chain accounts are created and managed by `WORLD_CHAIN_ACCOUNT_MANAGER`.
 
 ```solidity
-/// @notice Per-account state held by `WORLD_CHAIN_ACCOUNT_MANAGER`.
 struct Account {
-    /// @notice Immutable EIP-1271 admin signer contract. Bound into the account
-    ///         address derivation; cannot be rotated without changing the address.
     address adminSigner;
-
-    /// @notice Caller-supplied salt used in the account address derivation.
-    ///         Stored for indexing / auditability; not consulted at runtime.
     bytes32 accountSalt;
-
-    /// @notice Ordered list of currently active EIP-1271 session verifiers.
-    ///         Length is in `[1, MAX_SESSION_VERIFIERS]`. Order is significant —
-    ///         `activeKeyringHash` commits to ordering.
     SessionVerifier[] activeSessionVerifiers;
-
-    /// @notice `keccak256(abi.encode(activeSessionVerifiers))`. Re-derivable
-    ///         from `activeSessionVerifiers` but cached for cheap reads in
-    ///         signing-hash construction and admin-operation hashing.
     bytes32 activeKeyringHash;
-
-    /// @notice Slot for the at-most-one pending keyring update. See
-    ///         `PendingKeyringUpdate.exists` for presence semantics.
     PendingKeyringUpdate pendingKeyringUpdate;
-
-    /// @notice Strictly monotonically non-decreasing counter consumed by
-    ///         admin-authorized operations (queue, cancel, revoke). Provides
-    ///         replay protection for admin authorizations.
     uint64 adminNonce;
+    uint64 transactionNonce;
 }
 
-/// @notice An optional, time-locked queued keyring update. Solidity structs are
-///         not nullable in storage, so the optional nature is encoded by the
-///         explicit `exists` flag.
 struct PendingKeyringUpdate {
-    /// @notice The `activeKeyringHash` value that was current when this update
-    ///         was queued. Re-checked at activation as a defense-in-depth guard
-    ///         even though only one pending update may exist at a time.
     bytes32 expectedCurrentKeyringHash;
-
-    /// @notice The verifier set that will replace `activeSessionVerifiers` on
-    ///         successful activation. Subject to the same length and uniqueness
-    ///         constraints as `activeSessionVerifiers`.
     SessionVerifier[] targetSessionVerifiers;
-
-    /// @notice `keccak256(abi.encode(targetSessionVerifiers))`. Cached for the
-    ///         same reason as `activeKeyringHash`.
     bytes32 targetKeyringHash;
-
-    /// @notice Earliest UNIX timestamp at which `activateKeyringUpdate` may
-    ///         succeed. MUST be at least `block.timestamp + MIN_KEYRING_UPDATE_DELAY`
-    ///         at queueing time.
     uint64 activateAfter;
-
-    /// @notice The `adminNonce` value consumed when this update was authorized.
-    ///         Used as a replay-protection cookie by `cancelPendingKeyringUpdate`.
     uint64 queuedAtNonce;
-
-    /// @notice Presence flag. `true` iff a pending update is currently queued.
-    ///         When `false`, all other fields in this struct are meaningless and
-    ///         MUST NOT be read by conforming implementations.
     bool exists;
 }
 
-/// @notice Single-field wrapper for an active session-verifier entry. The
-///         struct exists (rather than a bare `address`) to allow forward-
-///         compatible extension with per-verifier metadata (e.g., a label,
-///         expiry, or stake reference) without changing `activeKeyringHash`
-///         encoding semantics. New fields, if added, MUST be considered in the
-///         keyring hash.
 struct SessionVerifier {
-    /// @notice EIP-1271 contract that also implements `IWorldChainSessionVerifier`.
     address verifier;
 }
+```
 
-`Account.adminSigner` is an EIP-1271 contract. `SessionVerifier.verifier` is an EIP-1271 contract that also implements `IWorldChainSessionVerifier`.
+For every existing account:
 
-The protocol does not inspect signer internals. It assigns semantics by account role: admin signer for account management, session verifier for transaction authorization and policy evaluation.
+- `adminSigner` MUST be a deployed EIP-1271 contract and is immutable for the life of the account address.
+- `activeSessionVerifiers.length` MUST be in `[1, MAX_SESSION_VERIFIERS]`.
+- each `SessionVerifier.verifier` MUST be a deployed contract implementing EIP-1271 and `IWorldChainSessionVerifier`;
+- `activeSessionVerifiers` MUST NOT contain duplicate verifier addresses;
+- `activeKeyringHash == keccak256(abi.encode(activeSessionVerifiers))`;
+- `adminNonce` is consumed only by admin operations;
+- `transactionNonce` is consumed only by included `0x1D` transactions.
 
-The active keyring MUST contain at least one session verifier and at most `MAX_SESSION_VERIFIERS` session verifiers. A keyring MUST NOT contain duplicate verifier addresses.
+The manager MUST NOT use the admin signer to authorize `0x1D` execution unless the admin signer is also in the active session keyring. The manager MUST NOT use a session verifier to authorize account-management operations unless that verifier is also the account's admin signer.
 
-#### Account Address Permanence
-
-The account address derives from `(WIP1001_ACCOUNT_DOMAIN, chainId, WORLD_CHAIN_ACCOUNT_MANAGER, adminSigner, accountSalt)`. `adminSigner` is therefore immutable for the life of the address. WIP-1001 defines no operation that rotates `adminSigner` for an existing account. A bug in the admin signer contract is uncorrectable without migrating assets to a new account.
-
-The account address binds `chainId`, so the same `(adminSigner, accountSalt)` deployed via the same factory on a different chain produces a different account address. This eliminates any future possibility for cross-chain account-address replay.
-
-### Address Derivation
+#### Address Derivation
 
 The manager derives an account address as:
 
 ```solidity
-account = address(
-    uint160(
-        uint256(
-            keccak256(
-                abi.encode(
-                    WIP1001_ACCOUNT_DOMAIN,
-                    chainId,
-                    WORLD_CHAIN_ACCOUNT_MANAGER,
-                    adminSigner,
-                    accountSalt
-                )
-            )
-        )
-    )
-);
+account = address(uint160(uint256(keccak256(abi.encode(
+    WIP1001_ACCOUNT_DOMAIN,
+    chainId,
+    WORLD_CHAIN_ACCOUNT_MANAGER,
+    adminSigner,
+    accountSalt
+)))));
 ```
 
-This binds the account address to the admin signer, salt, chain, and manager instance.
+The address binds the account to the manager instance, chain, admin signer, and salt. WIP-1001 defines no operation that rotates `adminSigner` for an existing account.
 
-### Keyring Hash
+#### Admin Operation Hashes
 
-The manager computes:
-
-```solidity
-activeKeyringHash = keccak256(abi.encode(activeSessionVerifiers));
-```
-
-The hash commits to verifier addresses and ordering. Clients SHOULD preserve ordering when displaying, exporting, or signing over a keyring.
-
-### Admin Operation Hashes
-
-For every admin authorization, the manager computes a domain-separated `adminOperationHash` and passes it to:
+For every admin authorization, the manager computes a domain-separated `adminOperationHash` and calls:
 
 ```solidity
 adminSigner.isValidSignature(adminOperationHash, adminAuthorization)
 ```
 
-For example the account-creation admin operation hash is:
+The hash for each operation is:
 
 ```solidity
-adminOperationHash = keccak256(
-    abi.encode(
-        WIP1001_ADMIN_CREATE_DOMAIN,
-        chainId,
-        WORLD_CHAIN_ACCOUNT_MANAGER,
-        account,
-        adminSigner,
-        accountSalt,
-        activeKeyringHash
-    )
-);
+createHash = keccak256(abi.encode(
+    WIP1001_ADMIN_CREATE_DOMAIN,
+    chainId,
+    WORLD_CHAIN_ACCOUNT_MANAGER,
+    account,
+    adminSigner,
+    accountSalt,
+    activeKeyringHash
+));
+
+queueHash = keccak256(abi.encode(
+    WIP1001_QUEUE_KEYRING_UPDATE_DOMAIN,
+    chainId,
+    WORLD_CHAIN_ACCOUNT_MANAGER,
+    account,
+    adminNonce,
+    expectedCurrentKeyringHash,
+    targetKeyringHash,
+    activateAfter
+));
+
+cancelHash = keccak256(abi.encode(
+    WIP1001_CANCEL_KEYRING_UPDATE_DOMAIN,
+    chainId,
+    WORLD_CHAIN_ACCOUNT_MANAGER,
+    account,
+    adminNonce,
+    expectedQueuedAtNonce
+));
+
+revokeHash = keccak256(abi.encode(
+    WIP1001_REVOKE_SESSION_VERIFIER_DOMAIN,
+    chainId,
+    WORLD_CHAIN_ACCOUNT_MANAGER,
+    account,
+    adminNonce,
+    sessionVerifier,
+    expectedCurrentKeyringHash
+));
 ```
 
-### EIP-1271 Admin Signer Hierarchy
+### Signer Interfaces
 
-The admin signer is an EIP-1271 contract that authorizes account-management operations. It has no protocol ABI beyond EIP-1271:
+The admin signer has no protocol ABI beyond EIP-1271:
 
 ```solidity
-/// @notice Marker interface for an EIP-1271 admin signer. Carries no methods
-///         beyond `IERC1271.isValidSignature(bytes32 hash, bytes signature)`.
-///         The protocol identifies admin signers by role (assignment as
-///         `Account.adminSigner`), not by interface.
 interface IWorldChainAdminSigner is IERC1271 {}
 ```
 
-The protocol calls the admin signer with a manager-defined operation hash. The signer returns `EIP1271_MAGIC_VALUE` if the operation is authorized.
-
-Admin signer implementations include:
-
-- World ID admin signers;
-- secp256k1 admin signers;
-- multisig admin signers;
-- recovery admin signers;
-- custom application admin signers.
-
-Only the EIP-1271 boundary is protocol-significant. The implementation class is signer contract state, not account manager state.
-
-#### World ID Admin Signer
-
-A World ID admin signer is an EIP-1271 contract whose authorization is a World ID proof bound to the manager-defined operation hash.
-
-The default World ID admin signer MUST expose immutable account-binding state:
+Session verifier contracts MUST implement EIP-1271 and:
 
 ```solidity
-/// @notice Default World ID EIP-1271 admin signer interface.
-/// @dev    All four view methods MUST return values that are fixed at signer
-///         deployment time and that match the values committed to in the
-///         CREATE2 salt of the deploying factory.
-interface IWorldIDAdminSigner is IWorldChainAdminSigner {
-    /// @notice The `accountSalt` used to derive the bound account address.
-    /// @return The salt value committed to in the factory `configHash`.
-    function accountSalt() external view returns (bytes32);
-
-    /// @notice The account address this admin signer is bound to.
-    /// @return Equal to the address that `WORLD_CHAIN_ACCOUNT_MANAGER` derives
-    ///         from `(address(this), accountSalt())` per "Address Derivation".
-    function account() external view returns (address);
-
-    /// @notice The World ID relying-party identifier used in proof verification.
-    /// @return MUST equal `WORLD_CHAIN_RP_ID`.
-    function worldIdRpId() external view returns (uint64);
-
-    /// @notice The World ID `action` field bound into proofs accepted by this
-    ///         signer.
-    /// @return `worldIdField(abi.encode(WORLD_ID_ACCOUNT_TAG, block.chainid,
-    ///         WORLD_CHAIN_RP_ID, WORLD_CHAIN_ACCOUNT_MANAGER, account(),
-    ///         address(this)))`.
-    function worldIdAction() external view returns (uint256);
-}
-```
-
-The default World ID admin signer uses the World ID v4 uniqueness-proof verifier shape. Its EIP-1271 signature payload is:
-
-```solidity
-/// @notice ABI-encoded payload passed as the `signature` argument to
-///         `isValidSignature` for a default World ID admin signer.
-struct WorldIDUniquenessProofSignature {
-    /// @notice Public output. Unique-per-(user, rpId, action) one-time identifier
-    ///         derived inside the circuit. Not consumed by the protocol — the
-    ///         admin signer is `view`-only.
-    uint256 nullifier;
-
-    /// @notice Public input. Minimum credential expiration the proof was bound
-    ///         to. Subject to the signer's freshness policy.
-    uint64 expiresAtMin;
-
-    /// @notice Public input. Identifies the credential schema and issuer pair.
-    ///         MUST equal the signer's configured issuer schema ID.
-    uint64 issuerSchemaId;
-
-    /// @notice Public input. Minimum `genesis_issued_at` the proof was bound
-    ///         to. Subject to the signer's freshness policy.
-    uint256 credentialGenesisIssuedAtMin;
-
-    /// @notice Encoded World ID v4 proof. Layout:
-    ///         [0..3] compressed Groth16 proof `[a, b₁, b₂, c]`,
-    ///         [4]    Merkle root from the `WorldIDRegistry`.
-    uint256[5] zeroKnowledgeProof;
-}
-```
-
-`account()` MUST return the account address derived by `WORLD_CHAIN_ACCOUNT_MANAGER` using `address(this)` as `adminSigner` and `accountSalt()` as `accountSalt`.
-
-`worldIdRpId()` MUST return `WORLD_CHAIN_RP_ID`.
-
-`worldIdAction()` MUST return:
-
-```solidity
-worldIdField(
-    abi.encode(
-        WORLD_ID_ACCOUNT_TAG,
-        block.chainid,
-        WORLD_CHAIN_RP_ID,
-        WORLD_CHAIN_ACCOUNT_MANAGER,
-        account(),
-        address(this)
-    )
-)
-```
-
-where `worldIdField(input) = uint256(keccak256(input)) >> 8`, matching `FieldElement::from_arbitrary_raw_bytes` in the World ID v4 primitives. A reference implementation of this reduction is in `crates/primitives/src/lib.rs` (function `from_arbitrary_raw_bytes`) of the World ID protocol repository.
-
-The inclusion of `block.chainid` in the `worldIdAction` derivation is required to prevent cross-chain replay of the World ID proof when the same admin signer contract address exists on multiple chains. The default factory's CREATE2 salt also binds chainId, so for default-factory-deployed signers this is defense-in-depth; for custom signers it is the primary safeguard.
-
-`isValidSignature(hash, signature)` MUST:
-
-- decode `signature` as `WorldIDUniquenessProofSignature`;
-- compute `signalHash = worldIdField(abi.encode(hash))`;
-- compute `nonce = worldIdField(abi.encode("WIP1001_WORLD_ID_ADMIN_NONCE", hash))`;
-- require `issuerSchemaId` to equal the signer's configured issuer schema ID;
-- require `zeroKnowledgeProof[4]` to be an accepted World ID registry root in the signer's verifier state;
-- require `expiresAtMin` and `credentialGenesisIssuedAtMin` to satisfy the signer's configured credential freshness policy;
-- verify the proof as a World ID v4 uniqueness proof equivalent to `IWorldIDVerifier.verify(nullifier, worldIdAction(), WORLD_CHAIN_RP_ID, nonce, signalHash, expiresAtMin, issuerSchemaId, credentialGenesisIssuedAtMin, zeroKnowledgeProof)`;
-- return `EIP1271_MAGIC_VALUE` only if verification succeeds.
-
-The signer MUST verify the same public inputs as the World ID v4 verifier: nullifier, issuer schema, credential issuer public key, credential expiration minimum, credential genesis minimum, Merkle root, tree depth, RP ID, action, OPRF public key, signal hash, nonce, and `sessionId = 0`.
-
-The signer MUST NOT consume nullifiers as part of `isValidSignature`, because EIP-1271 validation is a `view` operation. Replay protection comes from the manager-defined operation hash, including `adminNonce`.
-
-The signer MUST NOT call an external World ID verifier from a restricted validation frame. Any World ID registry roots, credential issuer public keys, OPRF public keys, verifier keys, tree depth, and credential freshness policy needed for verification MUST be available from the signer's own code, own storage, or allowlisted precompiles.
-
-#### Secp256k1 Admin Signer
-
-A secp256k1 admin signer is an EIP-1271 contract whose authorization is a secp256k1 signature by a configured owner.
-
-The default secp256k1 admin signer MUST expose immutable owner state:
-
-```solidity
-/// @notice Default secp256k1 EIP-1271 admin signer interface.
-interface ISecp256k1AdminSigner is IWorldChainAdminSigner {
-    /// @notice The secp256k1 owner address authorizing admin operations.
-    /// @return The owner address committed to in the factory `configHash`.
-    ///         MUST be immutable for the life of the signer.
-    function owner() external view returns (address);
-}
-```
-
-The EIP-1271 signature payload is the standard 65-byte payload:
-
-```text
-r || s || v
-```
-
-`isValidSignature(hash, signature)` MUST:
-
-- require `signature.length == 65`;
-- decode `r`, `s`, and `v`;
-- require `s` to be in the lower half order as specified by EIP-2;
-- require `v` to be `27` or `28`;
-- recover the signer with `ecrecover(hash, v, r, s)`;
-- return `EIP1271_MAGIC_VALUE` only if the recovered address equals `owner()`.
-
-The secp256k1 admin signer verifies the hash passed by the manager directly. Wallets that need EIP-191, EIP-712, or WebAuthn wrapping MUST implement that wrapping inside a different EIP-1271 signer contract.
-
-### Session Verifier Interface
-
-Session verifier contracts MUST implement this interface in addition to EIP-1271. Admin-only signers only need to implement EIP-1271.
-
-```solidity
-/// @notice Session verifier interface. Implemented by every contract eligible
-///         to appear in `Account.activeSessionVerifiers`. Combines EIP-1271
-///         signature verification with execution-trace policy evaluation.
 interface IWorldChainSessionVerifier is IERC1271 {
-    /// @notice EIP-2930 access list entry, mirrored into the trace context so
-    ///         that policy evaluation can reason about pre-warmed state.
     struct AccessListEntry {
-        /// @notice Address whose storage is pre-warmed by this entry.
         address account;
-        /// @notice Storage slots pre-warmed at `account`.
         bytes32[] storageKeys;
     }
 
-    /// @notice Canonical, deterministic snapshot of the `0x1D` transaction as
-    ///         seen by the verifier. Built by the protocol from the envelope,
-    ///         the loaded account state, and the computed signing hash.
-    ///         Contains no block-context values other than `chainId`.
     struct WorldChainTransactionContext {
-        /// @notice The EIP-2718 signing hash of the transaction (see "Envelope").
         bytes32 signingHash;
-        /// @notice The chain ID from the envelope.
         uint256 chainId;
-        /// @notice The account this transaction is executed as.
         address account;
-        /// @notice The session verifier that authorized this transaction.
-        ///         Equal to `address(this)` for the verifier reading the context.
         address sessionVerifier;
-        /// @notice The transaction nonce from the envelope.
         uint64 nonce;
-        /// @notice EIP-1559 priority fee.
         uint256 maxPriorityFeePerGas;
-        /// @notice EIP-1559 max fee.
         uint256 maxFeePerGas;
-        /// @notice The envelope `gasLimit` (covers payload only; validation gas
-        ///         is protocol-paid — see "Validation Gas Accounting").
         uint64 gasLimit;
-        /// @notice Derived predicate `to.length == 0` from the envelope.
         bool isCreate;
-        /// @notice For calls, equal to `to`. For creates, `address(0)`.
-        ///         The deployed address of a CREATE transaction is NOT exposed
-        ///         here; verifiers needing it MUST inspect `trace.calls` (note
-        ///         that the root call is not represented in `trace.calls`).
         address target;
-        /// @notice The envelope `value` (wei transferred).
         uint256 value;
-        /// @notice The envelope `data`. Calldata for calls; init code for creates.
         bytes data;
-        /// @notice First 4 bytes of `data` for non-create transactions when
-        ///         `data.length >= 4`; `0x00000000` otherwise (including all
-        ///         create transactions, regardless of `data.length`).
         bytes4 selector;
-        /// @notice The envelope `accessList`, EIP-2930 shape.
         AccessListEntry[] accessList;
-        /// @notice `activeKeyringHash` of `account` at the time the transaction
-        ///         was admitted to the pool. Provided here because the verifier
-        ///         cannot read manager state from a restricted validation frame.
         bytes32 activeKeyringHash;
     }
 
-    /// @notice Discriminator for `CallTrace.kind`. Mirrors EVM call opcodes.
     enum TraceCallKind {
-        Call,         // CALL
-        StaticCall,   // STATICCALL
-        DelegateCall, // DELEGATECALL
-        Create,       // CREATE
-        Create2       // CREATE2
+        Call,
+        StaticCall,
+        DelegateCall,
+        Create,
+        Create2
     }
 
-    /// @notice Single internal call within the execution trace. Hashes are used
-    ///         in place of full payloads to keep trace size bounded.
     struct CallTrace {
-        /// @notice Depth in the call tree. Root transaction call has depth 0
-        ///         and is NOT represented in `WorldChainExecutionTrace.calls`;
-        ///         the first internal call is depth 1.
         uint32 depth;
-        /// @notice Which call opcode initiated this frame.
         TraceCallKind kind;
-        /// @notice Address that executed the call/create opcode (the parent
-        ///         frame's address). For DelegateCall, the address performing
-        ///         the DELEGATECALL — NOT the inherited original sender.
         address caller;
-        /// @notice For Call/StaticCall/DelegateCall: the callee address.
-        ///         For Create/Create2: the deployed contract address (or the
-        ///         address that would have been deployed, if the create reverted).
         address target;
-        /// @notice Wei transferred by this call. MUST be 0 for StaticCall and
-        ///         DelegateCall.
         uint256 value;
-        /// @notice First 4 bytes of input calldata when `inputHash` covers
-        ///         `>= 4` bytes; `0x00000000` for create kinds and short inputs.
         bytes4 selector;
-        /// @notice `keccak256(input)` where `input` is calldata for calls and
-        ///         init code for creates. `keccak256("")` for empty input.
-        ///         Never the zero sentinel.
         bytes32 inputHash;
-        /// @notice `keccak256(output)` where `output` is return data on success
-        ///         and revert data on failure. `keccak256("")` for empty output.
-        ///         Never the zero sentinel.
         bytes32 outputHash;
-        /// @notice True iff the call returned without reverting.
         bool success;
-        /// @notice Gas consumed by this call, measured at the EVM level.
         uint64 gasUsed;
     }
 
-    /// @notice Single log emission within the execution trace.
     struct LogTrace {
-        /// @notice Address that emitted the log.
         address emitter;
-        /// @notice Up to four indexed topics.
         bytes32[] topics;
-        /// @notice `keccak256(data)`. `keccak256("")` for empty log data.
         bytes32 dataHash;
-        /// @notice Index into `WorldChainExecutionTrace.calls` of the call that
-        ///         emitted this log. `type(uint32).max` indicates emission by
-        ///         the root transaction call (which has no `CallTrace` entry).
         uint32 callIndex;
     }
 
-    /// @notice The execution trace for a single `0x1D` transaction's payload.
-    ///         Full calldata, return data, and log data are NOT included; only
-    ///         their hashes. Logs from reverted sub-call frames are excluded
-    ///         per EVM revert semantics.
     struct WorldChainExecutionTrace {
-        /// @notice Final success flag of the root transaction call.
         bool success;
-        /// @notice Total gas consumed by payload execution. Excludes validation
-        ///         gas (which is protocol-paid).
         uint64 gasUsed;
-        /// @notice `keccak256` of the root call's return / revert data, with
-        ///         the same empty-data convention as `CallTrace.outputHash`.
         bytes32 outputHash;
-        /// @notice Internal calls in execution order. Length-bounded indirectly
-        ///         by `MAX_EXECUTION_TRACE_BYTES`.
         CallTrace[] calls;
-        /// @notice Emitted logs in emission order. Each annotated with the
-        ///         emitting call's `callIndex` for log↔call correlation.
         LogTrace[] logs;
     }
 
-    /// @notice The full input to `evaluateSessionPolicy`.
     struct ExecutionTraceContext {
         WorldChainTransactionContext transaction;
         WorldChainExecutionTrace trace;
     }
 
-    /// @notice Evaluate whether the executed transaction is acceptable under
-    ///         this session verifier's policy.
-    /// @dev    Called by `WORLD_CHAIN_ACCOUNT_MANAGER` via STATICCALL inside a
-    ///         restricted validation frame after tentative payload execution
-    ///         and before committing payload state. MUST be `view`. MUST NOT
-    ///         attempt state mutation. MUST NOT call out to non-allowlisted
-    ///         addresses (see `WIP1001-VR-8`).
-    /// @param  context Canonical execution snapshot built from the envelope and
-    ///         the post-execution trace.
-    /// @return allowed `true` if policy accepts the trace; `false` rejects.
     function evaluateSessionPolicy(
         ExecutionTraceContext calldata context
     ) external view returns (bool allowed);
 }
 ```
 
-The protocol MUST call `evaluateSessionPolicy` after tentative payload execution and before committing payload state.
+`WorldChainTransactionContext` MUST be derived from the envelope, loaded account state, and computed signing hash. It MUST NOT include block-context values other than `chainId`.
 
-`ExecutionTraceContext.transaction` is derived from the `0x1D` envelope, the active account state, and the computed signing hash. It does not include block-context values other than `chainId`.
+For `WorldChainTransactionContext`:
 
-For this context:
+- `target == to` when `isCreate == false`;
+- `target == address(0)` when `isCreate == true`;
+- `selector == bytes4(data[:4])` when `isCreate == false && data.length >= 4`;
+- `selector == 0x00000000` otherwise;
+- `activeKeyringHash` is the account's active keyring hash observed during transaction validation.
 
-- `target` equals `to` when `isCreate == false`;
-- `target` equals `address(0)` when `isCreate == true`;
-- `selector` equals the first four bytes of `data` when `isCreate == false` and `data.length >= 4`;
-- `selector` equals `0x00000000` when `isCreate == true`, regardless of `data.length`. Constructor bytecode is not a function selector and MUST NOT be interpreted as one.
-- `selector` equals `0x00000000` when `isCreate == false` and `data.length < 4`.
+For `WorldChainExecutionTrace`:
 
-`ExecutionTraceContext.trace` is canonical and MUST include:
+- the root transaction call is represented by `transaction`, not by a `CallTrace`;
+- `calls` MUST include every internal call in execution order;
+- `logs` MUST include emitted logs in emission order, excluding logs reverted by EVM revert semantics;
+- `outputHash`, `CallTrace.inputHash`, `CallTrace.outputHash`, and `LogTrace.dataHash` MUST use `keccak256(bytes)`, including `keccak256("")` for empty bytes; `bytes32(0)` MUST NOT be used as an empty-data sentinel;
+- a reverted call's `outputHash` MUST hash revert data;
+- `LogTrace.callIndex == type(uint32).max` identifies a root-call log.
 
-- the final payload success flag;
-- total gas used by payload execution;
-- `keccak256` of payload return data;
-- all internal calls, ordered by execution order and annotated with call depth;
-- all logs emitted by payload execution, ordered by emission order, each annotated with the index of the emitting call.
+For each `CallTrace`:
 
-The root transaction call is represented by `ExecutionTraceContext.transaction`, not by a `CallTrace` entry.
+- `depth` is the EVM call depth; the first internal call has depth `1`;
+- `caller` is the address that executed the call opcode;
+- for `Create` and `Create2`, `target` is the deployed address or the address that would have been deployed if the create reverted;
+- `Create2` target addresses are computed per EIP-1014;
+- `Create` target addresses are computed as `keccak256(rlp([sender, nonce]))[12:]`;
+- `DelegateCall.value == 0`, and `DelegateCall.caller` is the address that executed `DELEGATECALL`.
 
-For each `CallTrace` entry:
+Full internal calldata, return data, and log data are not copied into the trace. A verifier that needs exact bytes MUST bind those bytes through the session signature, transaction calldata, or an application-level commitment.
 
-- When `kind == Create` or `kind == Create2`, `target` MUST be the deployed contract address. If the create call reverted, `target` MUST be the address that *would have been* deployed (computed per EIP-1014 for `Create2` and `keccak256(rlp([sender, nonce]))[12:]` for `Create`).
-- When `kind == DelegateCall`, `value` MUST be `0` (the trace records the value transferred by the call itself, not the inherited callvalue), and `caller` MUST be the address that executed the `DELEGATECALL` opcode (the parent context address, not the original transaction sender).
-- When `success == false`, `outputHash` MUST equal `keccak256(revertData)`. When the call returned successfully but with empty return data, `outputHash` MUST equal `keccak256("")` (i.e., `0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`). `outputHash` MUST NOT be the zero sentinel `bytes32(0)` for empty data.
-- `inputHash` follows the same convention: empty calldata hashes to `keccak256("")`, never `bytes32(0)`.
-
-For each `LogTrace` entry:
-
-- `callIndex` MUST equal the index into `WorldChainExecutionTrace.calls` of the `CallTrace` whose execution emitted the log. The sentinel value `type(uint32).max` indicates the log was emitted by the root transaction call (which has no `CallTrace` entry).
-- Logs emitted within reverted sub-call frames MUST NOT appear in `logs`, consistent with EVM revert semantics.
-
-For `WorldChainExecutionTrace.outputHash`:
-
-- When the root call returned successfully with non-empty return data: `keccak256(returnData)`.
-- When the root call returned successfully with empty return data: `keccak256("")`.
-- When the root call reverted: `keccak256(revertData)`.
-
-Full internal calldata, return data, and log data are not copied into the trace. The trace includes hashes. A verifier that needs exact bytes MUST bind those bytes through the session signature, transaction calldata, or an application-level commitment.
-
-The ABI-encoded trace MUST be no larger than `MAX_EXECUTION_TRACE_BYTES`. If the trace exceeds this limit, the transaction MUST fail.
+The ABI encoding of `ExecutionTraceContext.trace` MUST NOT exceed `MAX_EXECUTION_TRACE_BYTES`.
 
 ### Manager Interface
 
 `WORLD_CHAIN_ACCOUNT_MANAGER` exposes:
 
 ```solidity
-/// @notice Public interface of `WORLD_CHAIN_ACCOUNT_MANAGER`. All admin-mutating
-///         methods require an `adminAuthorization` validated through EIP-1271
-///         against the account's admin signer in a restricted validation frame.
 interface IWorldChainAccountManager {
-    /// @notice Create a new World Chain account.
-    /// @param  adminSigner Already-deployed EIP-1271 admin signer contract.
-    /// @param  accountSalt Caller-supplied salt, mixed into address derivation.
-    /// @param  initialSessionVerifiers Initial keyring; length in
-    ///         `[1, MAX_SESSION_VERIFIERS]`, no duplicates, all with deployed code.
-    /// @param  adminAuthorization Bytes interpreted by `adminSigner`. Bound to
-    ///         the account-creation `adminOperationHash` (see "Admin Operation Hashes").
-    /// @return account The address derived per "Address Derivation".
     function create(
         address adminSigner,
         bytes32 accountSalt,
@@ -676,19 +325,6 @@ interface IWorldChainAccountManager {
         bytes calldata adminAuthorization
     ) external returns (address account);
 
-    /// @notice Queue a timelocked keyring replacement.
-    /// @param  account Existing account.
-    /// @param  expectedCurrentKeyringHash Replay/race guard; MUST equal the
-    ///         account's current `activeKeyringHash`.
-    /// @param  targetSessionVerifiers Replacement keyring; same length and
-    ///         uniqueness rules as `initialSessionVerifiers`.
-    /// @param  activateAfter Earliest UNIX timestamp at which
-    ///         `activateKeyringUpdate` may succeed. MUST be at least
-    ///         `block.timestamp + MIN_KEYRING_UPDATE_DELAY`.
-    /// @param  adminAuthorization Bound to the queue `adminOperationHash`.
-    /// @dev    Replaces any existing pending update; emits
-    ///         `PendingKeyringUpdateReplaced` in that case, otherwise
-    ///         `KeyringUpdateQueued`. Increments `adminNonce` by one.
     function queueKeyringUpdate(
         address account,
         bytes32 expectedCurrentKeyringHash,
@@ -697,37 +333,14 @@ interface IWorldChainAccountManager {
         bytes calldata adminAuthorization
     ) external;
 
-    /// @notice Activate a previously queued keyring update once its
-    ///         `activateAfter` has passed. Permissionless — any address may
-    ///         call. Does NOT consume `adminNonce`.
-    /// @param  account Account whose pending update should be activated.
     function activateKeyringUpdate(address account) external;
 
-    /// @notice Cancel a pending keyring update.
-    /// @param  account Account whose pending update should be cancelled.
-    /// @param  expectedQueuedAtNonce Replay guard; MUST equal the pending
-    ///         update's `queuedAtNonce`.
-    /// @param  adminAuthorization Bound to the cancel `adminOperationHash`.
-    /// @dev    Increments `adminNonce` by one. No timelock; admin authorization
-    ///         alone is sufficient.
     function cancelPendingKeyringUpdate(
         address account,
         uint64 expectedQueuedAtNonce,
         bytes calldata adminAuthorization
     ) external;
 
-    /// @notice Instantly remove a session verifier from the active keyring.
-    /// @param  account Account whose verifier should be revoked.
-    /// @param  sessionVerifier Verifier address to remove. MUST currently be a
-    ///         keyring member.
-    /// @param  expectedCurrentKeyringHash Race guard; MUST equal the account's
-    ///         current `activeKeyringHash`.
-    /// @param  adminAuthorization Bound to the revoke `adminOperationHash`.
-    /// @dev    No timelock. Increments `adminNonce`. Pool entries from the
-    ///         revoked verifier are evicted; pool entries from other verifiers
-    ///         retain stable inclusion (see "Mempool Revalidation").
-    ///         Reverts if removal would leave the keyring empty — use
-    ///         `queueKeyringUpdate` for full keyring replacement instead.
     function revokeSessionVerifier(
         address account,
         address sessionVerifier,
@@ -735,178 +348,167 @@ interface IWorldChainAccountManager {
         bytes calldata adminAuthorization
     ) external;
 
-    /// @return The immutable admin signer of `account`. `address(0)` if account
-    ///         does not exist.
     function getAdminSigner(address account) external view returns (address);
-
-    /// @return The current `adminNonce` of `account`. `0` if account does not
-    ///         exist.
     function getAdminNonce(address account) external view returns (uint64);
-
-    /// @return The `activeKeyringHash` of `account`. `bytes32(0)` if account
-    ///         does not exist.
+    function getTransactionNonce(address account) external view returns (uint64);
     function getActiveKeyringHash(address account) external view returns (bytes32);
-
-    /// @return A copy of `account`'s active session verifier list. Empty array
-    ///         if account does not exist.
     function getActiveSessionVerifiers(address account) external view returns (SessionVerifier[] memory);
-
-    /// @return A copy of `account`'s pending keyring update. Check `.exists`
-    ///         before reading other fields.
     function getPendingKeyringUpdate(address account) external view returns (PendingKeyringUpdate memory);
-
-    /// @return `true` iff `sessionVerifier` is currently a member of `account`'s
-    ///         active keyring. Does NOT consider mempool retention windows for
-    ///         recently-revoked verifiers (see "Mempool Revalidation").
     function isAuthorizedSessionVerifier(address account, address sessionVerifier) external view returns (bool);
-
-    /// @return The `SessionVerifier` struct for `sessionVerifier` if it is a
-    ///         current member of `account`'s keyring. Reverts otherwise.
     function getAuthorizedSessionVerifier(address account, address sessionVerifier) external view returns (SessionVerifier memory);
 }
 ```
 
-#### Account Creation Semantics
+The manager MUST expose enough state for txpool revalidation: current active verifier membership, account balance, account transaction nonce, and recent session-verifier revocations that have not aged past `TXPOOL_TRANSACTION_EXPIRATION_WINDOW`.
 
-`create` MUST execute atomically:
+### Manager Events
 
-1. Reject `adminSigner == address(0)` and any zero session verifier address.
-2. Require `adminSigner` and every initial session verifier to have deployed code.
-3. Require `initialSessionVerifiers.length` to be in `[1, MAX_SESSION_VERIFIERS]`.
-4. Reject duplicate session verifier addresses.
-5. Derive `account` from `adminSigner`, `accountSalt`, `WORLD_CHAIN_ACCOUNT_MANAGER`, and `chainId`.
-6. Reject the call if `account` already exists.
-7. Compute `activeKeyringHash = keccak256(abi.encode(initialSessionVerifiers))`.
-8. Compute the account-creation `adminOperationHash`.
-9. Verify `adminAuthorization` through `adminSigner.isValidSignature(adminOperationHash, adminAuthorization)` in a restricted validation frame.
-10. If `adminSigner` was deployed by `WORLD_ID_1271_SIGNER_FACTORY` (detected via `factory.isFactorySigner(adminSigner)`), the manager MUST also verify `IWorldIDAdminSigner(adminSigner).account() == account` to ensure the signer's self-reported account binding matches the derived address. This step MUST execute in a restricted validation frame and is REQUIRED only for default-factory-deployed admin signers; custom admin signers MAY but are not required to expose `IWorldIDAdminSigner.account()`.
-11. Initialize account state with `adminNonce = 0`, no pending keyring update, and `activeSessionVerifiers = initialSessionVerifiers`.
-12. Emit `AccountCreated(account, adminSigner, accountSalt, activeKeyringHash)`.
+Each successful state transition MUST emit exactly one matching event in the same transaction that mutates state.
 
-If any step fails, account state MUST remain unchanged.
+```solidity
+interface IWorldChainAccountManagerEvents {
+    event AccountCreated(
+        address indexed account,
+        address indexed adminSigner,
+        bytes32 accountSalt,
+        bytes32 activeKeyringHash
+    );
 
-#### Keyring Update Queue Semantics
+    event KeyringUpdateQueued(
+        address indexed account,
+        bytes32 indexed targetKeyringHash,
+        bytes32 expectedCurrentKeyringHash,
+        uint64 activateAfter,
+        uint64 queuedAtNonce
+    );
 
-`queueKeyringUpdate` MUST execute atomically:
+    event PendingKeyringUpdateReplaced(
+        address indexed account,
+        bytes32 previousTargetKeyringHash,
+        bytes32 indexed newTargetKeyringHash,
+        uint64 newActivateAfter,
+        uint64 newQueuedAtNonce
+    );
 
-1. Require `account` to exist.
-2. Require `expectedCurrentKeyringHash == activeKeyringHash`.
-3. Require `targetSessionVerifiers.length` to be in `[1, MAX_SESSION_VERIFIERS]`.
-4. Reject zero, duplicate, or undeployed target session verifier addresses.
-5. Compute `targetKeyringHash = keccak256(abi.encode(targetSessionVerifiers))`.
-6. Reject the update if `targetKeyringHash == activeKeyringHash`.
-7. Require `activateAfter >= block.timestamp + MIN_KEYRING_UPDATE_DELAY`.
-8. Let `authorizationNonce = adminNonce`.
-9. Compute the keyring-update `adminOperationHash` using `authorizationNonce` as `adminNonce`.
-10. Verify `adminAuthorization` through `adminSigner.isValidSignature(adminOperationHash, adminAuthorization)`.
-11. Replace any existing pending update with the new pending update. If a prior pending update existed and was replaced, emit `PendingKeyringUpdateReplaced` with the prior `targetKeyringHash` and the new pending fields. If no prior pending update existed, emit `KeyringUpdateQueued`.
-12. Store `queuedAtNonce = authorizationNonce`.
-13. Increment `adminNonce` by one.
+    event KeyringUpdateActivated(
+        address indexed account,
+        bytes32 previousKeyringHash,
+        bytes32 indexed newKeyringHash
+    );
 
-If any step fails, account state MUST remain unchanged and `adminNonce` MUST NOT change.
+    event KeyringUpdateCancelled(
+        address indexed account,
+        uint64 cancelledQueuedAtNonce,
+        uint64 adminNonce
+    );
 
-#### Keyring Update Activation Semantics
+    event SessionVerifierRevoked(
+        address indexed account,
+        address indexed sessionVerifier,
+        bytes32 newKeyringHash,
+        uint64 adminNonce
+    );
+}
+```
 
-`activateKeyringUpdate` MAY be called by any address and MUST execute atomically:
+### Manager State Transitions
 
-1. Require `account` to exist.
-2. Require `pendingKeyringUpdate.exists == true`.
-3. Require `block.timestamp >= activateAfter`.
-4. Require `expectedCurrentKeyringHash == activeKeyringHash`.
-5. Require every target session verifier to still have deployed code.
-6. Replace `activeSessionVerifiers` with `targetSessionVerifiers`.
-7. Set `activeKeyringHash = targetKeyringHash`.
-8. Clear the pending update by setting `pendingKeyringUpdate.exists = false`. Other fields of `pendingKeyringUpdate` SHOULD be zeroed for storage hygiene but MUST NOT be relied upon by readers, per the `exists` semantics.
-9. Emit `KeyringUpdateActivated`.
+Every admin-mutating method MUST reject `adminAuthorization.length > MAX_ADMIN_AUTHORIZATION_BYTES`. If any requirement in a manager state transition fails, the method MUST revert without changing account state, incrementing `adminNonce`, or emitting its state-transition event.
 
-Activation MUST NOT increment `adminNonce`. If activation fails, account state MUST remain unchanged.
+Admin authorization is valid only when `adminSigner.isValidSignature(adminOperationHash, adminAuthorization)` succeeds in a restricted validation frame and returns `EIP1271_MAGIC_VALUE`.
 
-#### Pending Keyring Update Cancellation Semantics
+#### `create`
 
-`cancelPendingKeyringUpdate` MUST execute atomically:
+`create` MUST:
 
-1. Require `account` to exist.
-2. Require `pendingKeyringUpdate.exists == true`.
-3. Require `pendingKeyringUpdate.queuedAtNonce == expectedQueuedAtNonce` (replay guard against cancelling a different pending update than the admin authorized).
-4. Let `authorizationNonce = adminNonce`.
-5. Compute the cancel-pending-keyring-update `adminOperationHash` using `authorizationNonce` as `adminNonce`.
-6. Verify `adminAuthorization` through `adminSigner.isValidSignature(adminOperationHash, adminAuthorization)` in a restricted validation frame.
-7. Clear the pending keyring update by setting `pendingKeyringUpdate.exists = false`. Other fields SHOULD be zeroed for storage hygiene.
-8. Increment `adminNonce` by one.
-9. Emit `KeyringUpdateCancelled(account, expectedQueuedAtNonce, adminNonce)`.
+1. reject `adminSigner == address(0)`;
+2. require `adminSigner` and each initial session verifier to have deployed code;
+3. require `initialSessionVerifiers.length` to be in `[1, MAX_SESSION_VERIFIERS]`;
+4. reject duplicate or zero session verifier addresses;
+5. derive `account`;
+6. reject if `account` already exists;
+7. compute `activeKeyringHash`;
+8. verify `createHash` through `adminSigner`;
+9. if `WORLD_ID_1271_SIGNER_FACTORY.isFactorySigner(adminSigner) == true`, require `IWorldIDAdminSigner(adminSigner).account() == account`;
+10. initialize account state with `adminNonce = 0`, `transactionNonce = 0`, no pending keyring update, and `activeSessionVerifiers = initialSessionVerifiers`;
+11. emit `AccountCreated(account, adminSigner, accountSalt, activeKeyringHash)`.
 
-If any step fails, account state MUST remain unchanged and `adminNonce` MUST NOT change.
+#### `queueKeyringUpdate`
 
-#### Session Verifier Revoke Semantics
+`queueKeyringUpdate` MUST:
 
-`revokeSessionVerifier` MUST execute atomically:
+1. require `account` to exist;
+2. require `expectedCurrentKeyringHash == activeKeyringHash`;
+3. require `targetSessionVerifiers.length` to be in `[1, MAX_SESSION_VERIFIERS]`;
+4. reject duplicate, zero, or undeployed target session verifier addresses;
+5. compute `targetKeyringHash = keccak256(abi.encode(targetSessionVerifiers))`;
+6. reject `targetKeyringHash == activeKeyringHash`;
+7. require `activateAfter >= block.timestamp + MIN_KEYRING_UPDATE_DELAY`;
+8. compute `queueHash` using the current `adminNonce`;
+9. verify `queueHash` through `adminSigner`;
+10. replace any existing pending update with the new pending update;
+11. store `queuedAtNonce = adminNonce`;
+12. increment `adminNonce` by one;
+13. emit `PendingKeyringUpdateReplaced` if an update was replaced, otherwise emit `KeyringUpdateQueued`.
 
-1. Require `account` to exist.
-2. Require `sessionVerifier` to be a member of `activeSessionVerifiers`.
-3. Require `expectedCurrentKeyringHash == activeKeyringHash`.
-4. Reject the call if removing `sessionVerifier` would make `activeSessionVerifiers` empty (an empty keyring would brick the account; the admin MUST use `queueKeyringUpdate` to migrate to a different keyring instead).
-5. Let `authorizationNonce = adminNonce`.
-6. Compute the session-verifier-revoke `adminOperationHash` using `authorizationNonce` as `adminNonce`.
-7. Verify `adminAuthorization` through `adminSigner.isValidSignature(adminOperationHash, adminAuthorization)` in a restricted validation frame.
-8. Remove `sessionVerifier` from `activeSessionVerifiers`, preserving the relative order of remaining entries.
-9. Set `activeKeyringHash = keccak256(abi.encode(activeSessionVerifiers))`.
-10. Record `(sessionVerifier, block.number)` in the per-account exit set used by mempool revalidation. This entry MAY be pruned after `TXPOOL_TRANSACTION_EXPIRATION_WINDOW` has elapsed.
-11. Increment `adminNonce` by one.
-12. Emit `SessionVerifierRevoked(account, sessionVerifier, activeKeyringHash, adminNonce)`.
+#### `activateKeyringUpdate`
 
-Revocation does NOT affect any pending keyring update; the admin MAY independently cancel a pending update via `cancelPendingKeyringUpdate`. Revocation is the only admin operation that does not preserve stable inclusion: pool entries from the revoked verifier MUST be evicted (see "Mempool Revalidation"). Pool entries from other verifiers retain stable inclusion through the membership-based check.
+`activateKeyringUpdate` MAY be called by any address and MUST:
 
-If any step fails, account state MUST remain unchanged and `adminNonce` MUST NOT change.
+1. require `account` to exist;
+2. require `pendingKeyringUpdate.exists == true`;
+3. require `block.timestamp >= pendingKeyringUpdate.activateAfter`;
+4. require `pendingKeyringUpdate.expectedCurrentKeyringHash == activeKeyringHash`;
+5. require every target session verifier to still have deployed code;
+6. replace `activeSessionVerifiers` with `targetSessionVerifiers`;
+7. set `activeKeyringHash = targetKeyringHash`;
+8. clear the pending update by setting `pendingKeyringUpdate.exists = false`;
+9. emit `KeyringUpdateActivated`.
+
+Activation MUST NOT change `adminNonce`.
+
+#### `cancelPendingKeyringUpdate`
+
+`cancelPendingKeyringUpdate` MUST:
+
+1. require `account` to exist;
+2. require `pendingKeyringUpdate.exists == true`;
+3. require `pendingKeyringUpdate.queuedAtNonce == expectedQueuedAtNonce`;
+4. compute `cancelHash` using the current `adminNonce`;
+5. verify `cancelHash` through `adminSigner`;
+6. clear the pending update by setting `pendingKeyringUpdate.exists = false`;
+7. increment `adminNonce` by one;
+8. emit `KeyringUpdateCancelled(account, expectedQueuedAtNonce, adminNonce)`.
+
+#### `revokeSessionVerifier`
+
+`revokeSessionVerifier` MUST:
+
+1. require `account` to exist;
+2. require `sessionVerifier` to be a current member of `activeSessionVerifiers`;
+3. require `expectedCurrentKeyringHash == activeKeyringHash`;
+4. reject if removal would make the active keyring empty;
+5. compute `revokeHash` using the current `adminNonce`;
+6. verify `revokeHash` through `adminSigner`;
+7. remove `sessionVerifier` while preserving the relative order of all remaining verifiers;
+8. set `activeKeyringHash = keccak256(abi.encode(activeSessionVerifiers))`;
+9. record the revocation for txpool revalidation until `TXPOOL_TRANSACTION_EXPIRATION_WINDOW` has elapsed;
+10. increment `adminNonce` by one;
+11. emit `SessionVerifierRevoked(account, sessionVerifier, activeKeyringHash, adminNonce)`.
+
+Revocation MUST NOT change any pending keyring update.
 
 ### Restricted Validation Frames
 
-The protocol uses restricted validation frames for:
+The protocol uses restricted validation frames for admin authorization, session signature verification, and session policy evaluation.
 
-- admin authorization;
-- session signature verification;
-- session policy evaluation.
+For each EIP-1271 signature check, the protocol MUST perform a `STATICCALL` from `WORLD_CHAIN_ACCOUNT_MANAGER` to the signer with value `0`, gas exactly `EIP1271_VALIDATION_GAS_LIMIT`, and calldata `IERC1271.isValidSignature.selector || abi.encode(hash, signature)`. The call succeeds only if it returns `EIP1271_MAGIC_VALUE` and triggers no tracer rule violation.
 
-Restricted frames make validation deterministic and independent of mutable external contract state, mutable transaction context, and mutable block context.
+For each session policy check, the protocol MUST perform a `STATICCALL` from `WORLD_CHAIN_ACCOUNT_MANAGER` to the session verifier with value `0`, gas exactly `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`, and calldata `IWorldChainSessionVerifier.evaluateSessionPolicy.selector || abi.encode(context)`. The call succeeds only if it returns `true` and triggers no tracer rule violation.
 
-#### Enforcement Model
+Failure, revert, out-of-gas, malformed return data, or a tracer violation MUST be treated as signature or policy failure.
 
-Restricted validation frames are enforced via a runtime opcode-and-target rule tracer derived from [ERC-7562](https://eips.ethereum.org/EIPS/eip-7562). World Chain clients MUST implement this tracer for every validation-frame call (`isValidSignature` and `evaluateSessionPolicy`). The tracer monitors EVM execution at every opcode and rejects the call when any rule below is violated.
-
-Static bytecode analysis at signer registration time is RECOMMENDED as a fast-path admission check but does NOT replace runtime enforcement. Runtime enforcement is authoritative because forbidden opcodes can be hidden behind unreachable static branches.
-
-On any tracer rule violation during validation, the protocol MUST treat the call as if the EIP-1271 magic value was not returned (for signature checks) or as if `false` was returned (for policy evaluation). This is the same handling as malformed return data.
-
-#### EIP-1271 Signature Call
-
-For each EIP-1271 signature check, the protocol MUST perform:
-
-- opcode: `STATICCALL`;
-- caller: `WORLD_CHAIN_ACCOUNT_MANAGER`;
-- callee: the signer contract;
-- call value: `0`;
-- gas: exactly `EIP1271_VALIDATION_GAS_LIMIT`;
-- calldata: `IERC1271.isValidSignature.selector || abi.encode(hash, signature)`;
-- success condition: call succeeds, returns `EIP1271_MAGIC_VALUE`, and triggers no tracer rule violation.
-
-Failure, revert, out-of-gas, malformed return data, or any tracer rule violation MUST be treated as signature failure.
-
-#### Session Policy Evaluation Call
-
-After tentative payload execution, the protocol MUST perform:
-
-- opcode: `STATICCALL`;
-- caller: `WORLD_CHAIN_ACCOUNT_MANAGER`;
-- callee: the session verifier used for the transaction;
-- call value: `0`;
-- gas: exactly `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`;
-- calldata: `IWorldChainSessionVerifier.evaluateSessionPolicy.selector || abi.encode(context)`;
-- success condition: call succeeds, returns `true`, and triggers no tracer rule violation.
-
-Failure, revert, out-of-gas, malformed return data, any tracer rule violation, or a return value of `false` MUST reject the trace and revert tentative payload execution.
-
-#### Tracer Rule Taxonomy
-
-The tracer enforces the following rules. Where a rule has a direct counterpart in ERC-7562, the ERC-7562 reference is cited; rules without a counterpart are WIP-1001-specific.
+Restricted frames are enforced by a runtime opcode-and-target tracer derived from [ERC-7562](https://eips.ethereum.org/EIPS/eip-7562). Runtime enforcement is authoritative.
 
 | Rule ID | ERC-7562 ref | Description |
 | --- | --- | --- |
@@ -917,84 +519,21 @@ The tracer enforces the following rules. Where a rule has a direct counterpart i
 | `WIP1001-VR-5` | OP-031 | Forbid log emission: `LOG0`, `LOG1`, `LOG2`, `LOG3`, `LOG4`. |
 | `WIP1001-VR-6` | OP-031, OP-040 | Forbid `CALL`, `CALLCODE`, `CREATE`, `CREATE2`. |
 | `WIP1001-VR-7` | OP-051 | Forbid `SELFDESTRUCT`. |
-| `WIP1001-VR-8` | OP-061 | `STATICCALL` permitted only to addresses on the allowlisted precompile set; all other `STATICCALL` targets are forbidden. |
-| `WIP1001-VR-9` | OP-052 | `DELEGATECALL` permitted only when the delegatee bytecode itself satisfies every rule in this table (recursive conformance). The tracer MUST validate the delegatee under the same rule set; otherwise the call MUST be rejected. This permits proxy-style signers without compromising determinism. |
-| `WIP1001-VR-10` | — | Precompile execution does not create an additional EVM code frame and is not subject to the rules above. |
-| `WIP1001-VR-11` | — | Reads of the signer contract's own bytecode (via `CODECOPY`/`CODESIZE`) are permitted. |
-| `WIP1001-VR-12` | — | Reads of the signer contract's own storage (via `SLOAD`) are permitted. |
-| `WIP1001-VR-13` | — | `KECCAK256`, `CHAINID`, `GAS`, all stack/memory/calldata opcodes, and all deterministic arithmetic opcodes are permitted. |
+| `WIP1001-VR-8` | OP-061 | Permit `STATICCALL` only to allowlisted precompiles. |
+| `WIP1001-VR-9` | OP-052 | Permit `DELEGATECALL` only when the delegatee bytecode satisfies the same rule set. The tracer MUST validate delegatees recursively. |
+| `WIP1001-VR-10` | - | Precompile execution does not create an additional EVM code frame. |
+| `WIP1001-VR-11` | - | Permit reads of the signer contract's own bytecode via `CODECOPY` and `CODESIZE`. |
+| `WIP1001-VR-12` | - | Permit reads of the signer contract's own storage via `SLOAD`. |
+| `WIP1001-VR-13` | - | Permit `KECCAK256`, `CHAINID`, `GAS`, stack, memory, calldata, and deterministic arithmetic opcodes. |
 
-The following primitive operations are permitted inside a restricted validation frame:
-
-- deterministic computation;
-- calldata and memory access;
-- reads of the signer contract's own bytecode (`WIP1001-VR-11`);
-- reads of the signer contract's own storage (`WIP1001-VR-12`);
-- `KECCAK256`;
-- `CHAINID`;
-- `GAS`;
-- `STATICCALL` to allowlisted precompiles (`WIP1001-VR-8`);
-- `DELEGATECALL` to a delegatee whose bytecode satisfies the same rule set (`WIP1001-VR-9`).
-
-Implementations MAY assume that any address on the allowlisted precompile set has stable input/output behavior across blocks. Adding a new precompile to the allowlist is a hard-fork change.
-
-### Validation Gas Accounting
-
-Validation gas is supplied by the protocol from a per-block budget. It is NOT deducted from the envelope `gasLimit`. The envelope `gasLimit` covers payload execution only.
-
-Per block, the cumulative gas consumed by all `0x1D` validation calls (signature checks via `isValidSignature` plus policy evaluation calls via `evaluateSessionPolicy`) MUST NOT exceed `BLOCK_VALIDATION_GAS_BUDGET`. Block builders MUST account for validation gas when sequencing; a `0x1D` transaction whose worst-case validation cost (`EIP1271_VALIDATION_GAS_LIMIT + EXECUTION_TRACE_VALIDATION_GAS_LIMIT`) exceeds the remaining block validation budget MUST be deferred to a subsequent block.
-
-When a `0x1D` transaction's validation fails (signature failure, policy rejection, or any tracer rule violation):
-
-1. The transaction's nonce on `account` MUST be incremented (preventing replay of the failed transaction).
-2. The protocol MUST charge the account a fee of `max(MIN_VALIDATION_FAILURE_FEE, baseFee * EIP1271_VALIDATION_GAS_LIMIT)` denominated in the transaction's fee token.
-3. The transaction MUST NOT execute its payload.
-4. The validation gas consumed MUST count against `BLOCK_VALIDATION_GAS_BUDGET`.
-
-This makes spam-validation pay-to-play and prevents an attacker with no balance from exhausting the per-block validation budget for free.
-
-Mempool admission MUST refuse any transaction whose `account` does not hold sufficient balance to pay `MIN_VALIDATION_FAILURE_FEE` at the current `baseFee`.
-
-### Mempool Revalidation
-
-World Chain clients MUST revalidate every pooled `0x1D` transaction at least once per block until the transaction is included, expires, or is evicted.
-
-Pool admission and revalidation use a membership-based check rather than a strict keyring-hash equality check, in order to preserve stable inclusion across keyring updates and revocations:
-
-1. On pool entry, the pool MUST record `entryBlock = block.number` for the transaction.
-2. A pooled transaction is considered valid at block `B` iff:
-   - `sessionVerifier` was a member of the account's keyring at every block in the range `[entryBlock, B]`, OR
-   - `sessionVerifier` was a member at `entryBlock` and remained a member until at least `entryBlock + TXPOOL_TRANSACTION_EXPIRATION_WINDOW` (membership persists through transaction lifetime).
-3. The pool MUST evict a pooled transaction immediately when:
-   - `revokeSessionVerifier` is called for its `sessionVerifier`, regardless of `entryBlock` (instant revoke supersedes stable inclusion);
-   - the account's balance falls below `MIN_VALIDATION_FAILURE_FEE` at the current `baseFee`;
-   - `block.timestamp - entryBlock_timestamp >= TXPOOL_TRANSACTION_EXPIRATION_WINDOW`.
-4. The pool MUST retain a pooled transaction across `activateKeyringUpdate` even if the new active keyring no longer includes its `sessionVerifier`, provided the verifier was a member of the keyring active at `entryBlock`. The retention window terminates at `entryBlock_timestamp + TXPOOL_TRANSACTION_EXPIRATION_WINDOW`. This is the stable-inclusion guarantee.
-
-The manager MUST expose sufficient state for the pool to perform these checks. A reference approach is to retain, per account, the set of `(sessionVerifier, exitedAtBlock)` pairs for verifiers removed within the past `TXPOOL_TRANSACTION_EXPIRATION_WINDOW`. State older than this window MAY be pruned.
-
-### Timelocked Signer-State Updates
-
-Default factories that expose mutable signer or verifier state capable of invalidating a previously valid signature MUST timelock those updates by at least `MIN_KEYRING_UPDATE_DELAY`.
-
-Examples include:
-
-- root rotations;
-- verification-key rotations;
-- signer recovery changes;
-- signer revocation lists;
-- account binding changes.
-
-Signer state that cannot affect validation of already accepted transactions MAY update without this delay.
+Adding a new precompile to the validation allowlist is a hard-fork change.
 
 ### Transaction Type `0x1D`
 
-#### Envelope
-
-`WORLD_TX_TYPE` transactions use the following payload:
+The wire encoding is:
 
 ```solidity
-rlp([
+0x1D || rlp([
     chainId,
     nonce,
     maxPriorityFeePerGas,
@@ -1010,22 +549,10 @@ rlp([
 ])
 ```
 
-The `to` field follows EIP-2718 / EIP-1559 conventions: it is RLP-encoded as a 20-byte address for a call, or as the empty byte string for a contract creation. The derived predicate `isCreate := (to.length == 0)` is used throughout this specification but is NOT a separate envelope field. Implementations MUST reject envelopes whose `to` is neither empty nor exactly 20 bytes.
-
-When `isCreate == false`, `data` is call data for `to`.
-
-When `isCreate == true`, `data` is contract init code; the deployed address is computed per EIP-1014 (`CREATE` from the account, with the post-increment `nonce` value).
-
-`accessList` MUST be encoded per [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) as `[[address, [storageKey, ...]], ...]`. Implementations MUST reject envelopes where:
-
-- `accessList.length > MAX_ACCESS_LIST_ENTRIES`,
-- `data.length > MAX_PAYLOAD_DATA_BYTES`, or
-- `signature.length > MAX_SESSION_SIGNATURE_BYTES`.
-
 The signing hash is:
 
 ```solidity
-keccak256(
+signingHash = keccak256(
     0x1D ||
     rlp([
         chainId,
@@ -1040,79 +567,114 @@ keccak256(
         data,
         accessList
     ])
-)
+);
 ```
 
-#### Validation and Execution
-
-To validate and execute a `0x1D` transaction, the protocol MUST:
-
-1. Compute the signing hash.
-2. Load the account from `WORLD_CHAIN_ACCOUNT_MANAGER`.
-3. Reject the transaction if `sessionVerifier` is not authorized for `account` per the membership rules in "Mempool Revalidation".
-4. Reserve `EIP1271_VALIDATION_GAS_LIMIT + EXECUTION_TRACE_VALIDATION_GAS_LIMIT` from the remaining `BLOCK_VALIDATION_GAS_BUDGET`. If the budget is exhausted, defer the transaction to a subsequent block; this is not a validation failure.
-5. Verify `signature` by calling `sessionVerifier.isValidSignature(signingHash, signature)` in a restricted validation frame, consuming up to `EIP1271_VALIDATION_GAS_LIMIT` from the block validation budget.
-6. If the signature check does not return `EIP1271_MAGIC_VALUE` (or violates a tracer rule), apply validation failure semantics from "Validation Gas Accounting": charge the account `max(MIN_VALIDATION_FAILURE_FEE, baseFee * EIP1271_VALIDATION_GAS_LIMIT)`, consume the transaction nonce, do not execute the payload, and finalize the transaction as failed.
-7. Execute the payload tentatively with `account` as the EVM transaction sender, charging gas against the envelope `gasLimit`, and collect the canonical execution trace.
-8. Build `ExecutionTraceContext` from the envelope, signing hash, active keyring hash, and canonical execution trace.
-9. Reject the transaction with a payload-execution failure if `abi.encode(context.trace).length > MAX_EXECUTION_TRACE_BYTES`. The validation budget reservation in step 4 MUST still be released (this is a payload failure, not a validation failure).
-10. Call `sessionVerifier.evaluateSessionPolicy(context)` in a restricted validation frame, consuming up to `EXECUTION_TRACE_VALIDATION_GAS_LIMIT` from the block validation budget.
-11. If session policy evaluation does not return `true` (or violates a tracer rule), discard tentative payload state and logs and apply validation failure semantics: charge the account `max(MIN_VALIDATION_FAILURE_FEE, baseFee * EIP1271_VALIDATION_GAS_LIMIT)`, consume the transaction nonce, and finalize the transaction as failed. Payload-execution gas is NOT additionally charged in this branch — validation failure supersedes the payload's normal gas accounting.
-12. If session policy evaluation succeeds, commit the payload result. If payload execution itself failed in step 7, commit the normal failed-call result with payload-execution gas charged from `gasLimit`.
-
-### EIP-1271 Signer Factory Pattern
-
-World Chain provides default EIP-1271 signer factories through predeploy addresses assigned at activation.
-
-Factories are deployment helpers, not authorization registries. A factory-created signer has no account authority until it is used as the admin signer during `create` or added to an account keyring through `queueKeyringUpdate`.
-
-Accounts MAY use any EIP-1271 admin signer or session verifier that satisfies this specification. They are not required to use a default factory.
-
-#### Factory Interface
-
-Default factories MUST implement:
+The transaction hash is:
 
 ```solidity
-/// @notice Role assignment for a factory-deployed signer. Determines which
-///         interface(s) the deployed contract implements and which slot of an
-///         account's state it is eligible to occupy.
+txHash = keccak256(
+    0x1D ||
+    rlp([
+        chainId,
+        nonce,
+        maxPriorityFeePerGas,
+        maxFeePerGas,
+        gasLimit,
+        account,
+        sessionVerifier,
+        to,
+        value,
+        data,
+        accessList,
+        signature
+    ])
+);
+```
+
+Envelope validity requirements:
+
+- `chainId` MUST equal the executing chain ID;
+- `nonce` MUST equal `Account.transactionNonce`;
+- `to` MUST be the empty byte string for contract creation or exactly 20 bytes for a call;
+- `data.length <= MAX_PAYLOAD_DATA_BYTES`;
+- `accessList.length <= MAX_ACCESS_LIST_ENTRIES`;
+- `signature.length <= MAX_SESSION_SIGNATURE_BYTES`;
+- `accessList` MUST use EIP-2930 encoding;
+- `maxFeePerGas` and `maxPriorityFeePerGas` follow [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) validity rules.
+
+### Validation, Execution, and Failure Semantics
+
+Block builders MUST reserve `EIP1271_VALIDATION_GAS_LIMIT + EXECUTION_TRACE_VALIDATION_GAS_LIMIT` from `BLOCK_VALIDATION_GAS_BUDGET` before including a `0x1D` transaction. If the remaining budget is insufficient, the transaction MUST be deferred; deferral is not a validation failure and MUST NOT mutate account state.
+
+To include a `0x1D` transaction, the protocol MUST:
+
+1. decode and validate the envelope;
+2. load `account` from `WORLD_CHAIN_ACCOUNT_MANAGER`;
+3. require `sessionVerifier` to be authorized for `account` under the txpool membership rules;
+4. require the account balance to cover the worst-case payload gas charge and `MIN_VALIDATION_FAILURE_FEE`;
+5. compute `signingHash`;
+6. call `sessionVerifier.isValidSignature(signingHash, signature)` in a restricted validation frame;
+7. if signature validation fails, apply validation-failure semantics and stop;
+8. increment `Account.transactionNonce` by one;
+9. execute the payload tentatively with `account` as the EVM sender and gas charged against envelope `gasLimit`;
+10. construct `ExecutionTraceContext`;
+11. if `abi.encode(context.trace).length > MAX_EXECUTION_TRACE_BYTES`, discard tentative payload state, apply trace-overflow semantics, and stop;
+12. call `sessionVerifier.evaluateSessionPolicy(context)` in a restricted validation frame;
+13. if policy validation fails, discard tentative payload state, apply validation-failure semantics, and stop;
+14. otherwise commit the normal payload result, including a reverted payload result if the target call reverted.
+
+Failure classes are:
+
+| Failure | Nonce | Payload state/logs | Fee behavior |
+| --- | --- | --- | --- |
+| Envelope, account, balance, nonce, or authorization precheck failure | unchanged | none | transaction is invalid and not included |
+| Validation budget exhausted | unchanged | none | transaction is deferred |
+| Signature validation failure | incremented | none | charge `max(MIN_VALIDATION_FAILURE_FEE, baseFee * EIP1271_VALIDATION_GAS_LIMIT)` |
+| Trace exceeds `MAX_EXECUTION_TRACE_BYTES` | incremented | discarded | charge as a failed payload execution under the envelope gas rules |
+| Session policy failure | incremented | discarded | charge `max(MIN_VALIDATION_FAILURE_FEE, baseFee * EIP1271_VALIDATION_GAS_LIMIT)`; payload gas is not additionally charged |
+| Payload execution revert with accepted policy | incremented | EVM revert result committed | charge normal payload gas |
+
+All validation gas consumed by signature and policy checks MUST count against `BLOCK_VALIDATION_GAS_BUDGET`. Validation gas is not deducted from the envelope `gasLimit`.
+
+### Txpool Revalidation
+
+World Chain clients MUST revalidate every pooled `0x1D` transaction at least once per block until inclusion, expiration, or eviction.
+
+On pool admission, the client MUST record `entryTimestamp`, `account`, `sessionVerifier`, `nonce`, and the account's active keyring membership at admission. A transaction is eligible to remain pooled only while all conditions hold:
+
+- `block.timestamp < entryTimestamp + TXPOOL_TRANSACTION_EXPIRATION_WINDOW`;
+- `account` exists;
+- the account balance can cover `MIN_VALIDATION_FAILURE_FEE` at the current `baseFee`;
+- the transaction nonce can still become executable under the account nonce ordering rules;
+- `sessionVerifier` has not been revoked after admission.
+
+Activation of a queued keyring update MUST NOT evict already pooled transactions whose verifier was active at admission. `revokeSessionVerifier` MUST immediately evict pooled transactions from the revoked verifier.
+
+### Timelocked Signer-State Updates
+
+Default factory signers with mutable state that can change `isValidSignature` or `evaluateSessionPolicy` for already accepted transactions MUST timelock those updates by at least `MIN_KEYRING_UPDATE_DELAY`.
+
+This applies to root rotations, verification-key rotations, signer recovery changes, signer revocation lists, account binding changes, and policy configuration changes. State that cannot affect validation MAY update without this delay.
+
+### Default Signer Factories
+
+Accounts MAY use any EIP-1271 admin signer or session verifier that satisfies this specification. Default factories are deployment helpers, not authorization registries. A factory-created signer has no account authority until it is used as an admin signer during `create` or added to an account keyring.
+
+```solidity
 enum WorldChainSignerRole {
-    AdminSigner,     // Eligible as `Account.adminSigner`. Implements EIP-1271 only.
-    SessionVerifier  // Eligible as a member of `Account.activeSessionVerifiers`.
-                     // Implements EIP-1271 + `IWorldChainSessionVerifier`.
+    AdminSigner,
+    SessionVerifier
 }
 
-/// @notice Self-introspection interface implemented by every contract deployed
-///         by a default `IWorldChain1271SignerFactory`. Allows off-chain tools
-///         and the manager itself to identify factory provenance and variant
-///         without parsing bytecode.
 interface IWorldChainFactoryDeployedSigner {
-    /// @return The factory address that deployed this signer.
     function signerFactory() external view returns (address);
-
-    /// @return Role under which this signer was deployed.
     function signerRole() external view returns (WorldChainSignerRole);
-
-    /// @return Variant identifier (e.g., `WORLD_ID_ADMIN_SIGNER_V1`) selected
-    ///         at deployment.
     function signerVariantId() external view returns (bytes32);
-
-    /// @return `keccak256(config)` where `config` is the variant-specific
-    ///         deployment configuration. Used to verify the signer's bound
-    ///         configuration without re-supplying it.
     function signerConfigHash() external view returns (bytes32);
 }
 
-/// @notice Default factory interface for deploying EIP-1271 signers (admin or
-///         session) under deterministic CREATE2 addresses.
 interface IWorldChain1271SignerFactory {
-    /// @notice Emitted when a new signer is deployed.
-    /// @param  signer Deployed signer address (= return of `createSigner`).
-    /// @param  role The role under which the signer was deployed.
-    /// @param  variantId The variant of `role` deployed.
-    /// @param  configHash `keccak256(config)`. Stored on the deployed signer
-    ///         and returned by `signerConfigHash()`.
-    /// @param  salt The caller-supplied salt (NOT the derived CREATE2 salt).
     event SignerCreated(
         address indexed signer,
         WorldChainSignerRole indexed role,
@@ -1121,185 +683,92 @@ interface IWorldChain1271SignerFactory {
         bytes32 salt
     );
 
-    /// @return The account manager this factory is bound to. MUST equal
-    ///         `WORLD_CHAIN_ACCOUNT_MANAGER`.
     function worldChainAccountManager() external view returns (address);
-
-    /// @notice Pure / view computation of the address `createSigner` would
-    ///         deploy for the same inputs. Used by relayers and indexers to
-    ///         predict signer addresses without writing.
     function computeAddress(
         WorldChainSignerRole role,
         bytes32 variantId,
         bytes calldata config,
         bytes32 salt
     ) external view returns (address signer);
-
-    /// @notice Deploy a new signer.
-    /// @dev    Idempotent: if a contract already exists at the deterministic
-    ///         address with matching factory metadata, MUST return that
-    ///         address. MUST revert if the address is occupied by an
-    ///         incompatible contract.
-    /// @return signer The deployed (or existing) signer address.
     function createSigner(
         WorldChainSignerRole role,
         bytes32 variantId,
         bytes calldata config,
         bytes32 salt
     ) external returns (address signer);
-
-    /// @return `true` iff `signer` was deployed by this factory and exposes
-    ///         matching metadata via `IWorldChainFactoryDeployedSigner`.
     function isFactorySigner(address signer) external view returns (bool);
 }
 ```
 
-#### Factory Creation Semantics
-
 `createSigner` MUST:
 
-1. Reject unknown `role` or `variantId`.
-2. Decode and validate `config` for the selected variant.
-3. Compute `configHash = keccak256(config)`.
-4. Deploy the signer with `CREATE2` using `keccak256(abi.encode(WIP1001_SIGNER_DOMAIN, chainId, WORLD_CHAIN_ACCOUNT_MANAGER, role, variantId, configHash, salt))` as the `CREATE2` salt.
-5. Initialize immutable signer metadata: `signerFactory`, `signerRole`, `signerVariantId`, and `signerConfigHash`.
-6. Return the deployed signer address.
-7. Emit `SignerCreated`.
+1. reject unknown `role` or `variantId`;
+2. decode and validate `config`;
+3. compute `configHash = keccak256(config)`;
+4. deploy with `CREATE2` using `keccak256(abi.encode(WIP1001_SIGNER_DOMAIN, chainId, WORLD_CHAIN_ACCOUNT_MANAGER, role, variantId, configHash, salt))` as the salt;
+5. initialize signer metadata;
+6. return the deployed signer address;
+7. emit `SignerCreated`.
 
-`computeAddress` MUST return the same address that `createSigner` would deploy for the same inputs.
+`computeAddress` MUST return the address that `createSigner` would deploy. `createSigner` MUST be idempotent when the expected signer already exists with matching metadata and MUST revert when the expected address is occupied by incompatible code. Factory deployment MUST NOT mutate manager state.
 
-The `SignerCreated.salt` event field MUST be the caller-supplied `salt`, not the derived `CREATE2` salt.
-
-`createSigner` MUST be idempotent: if the expected signer is already deployed with matching metadata, it MUST return the existing address. It MUST revert if the expected address is occupied by a contract with different metadata.
-
-`isFactorySigner(signer)` MUST return `true` only if `signer` was deployed by the factory and exposes matching factory metadata.
-
-Factory deployment MUST NOT mutate `WORLD_CHAIN_ACCOUNT_MANAGER` state.
-
-#### Signer Update Semantics
-
-Factory-created signers MAY expose signer-specific update functions. Any update that can change the result of `isValidSignature` or `evaluateSessionPolicy` for an already accepted transaction MUST be timelocked by at least `MIN_KEYRING_UPDATE_DELAY`.
-
-Examples include World ID root updates, owner rotations, recovery configuration changes, and policy configuration changes.
-
-#### Session Policy Configuration
-
-Session verifier variants MAY take `policyVariantId` and `policyConfig` in their factory config. These values are verifier configuration, not protocol fields.
-
-A factory MUST reject unknown policy variants. A deployed session verifier MUST evaluate policy internally from its own code and storage. It MUST NOT depend on an external policy contract during restricted validation.
-
-Every default session verifier MUST reject `evaluateSessionPolicy` unless:
-
-- `context.transaction.account` equals the verifier's configured account;
-- `context.transaction.sessionVerifier == address(this)`;
-- the verifier's internal policy accepts `context`.
-
-#### Secp256k1 Factory
+### Default Secp256k1 Signers
 
 `SECP256K1_1271_SIGNER_FACTORY` MUST support:
 
 ```solidity
-/// @notice Variant ID for the v1 secp256k1 admin signer.
 bytes32 constant SECP256K1_ADMIN_SIGNER_V1 =
     keccak256("world-chain.secp256k1.admin.v1");
 
-/// @notice Variant ID for the v1 secp256k1 session verifier.
 bytes32 constant SECP256K1_SESSION_VERIFIER_V1 =
     keccak256("world-chain.secp256k1.session-verifier.v1");
 
-/// @notice Deployment configuration for `SECP256K1_ADMIN_SIGNER_V1`.
 struct Secp256k1AdminSignerConfig {
-    /// @notice Immutable secp256k1 owner address. ECDSA signatures by this
-    ///         address authorize admin operations.
     address owner;
 }
 
-/// @notice Deployment configuration for `SECP256K1_SESSION_VERIFIER_V1`.
 struct Secp256k1SessionVerifierConfig {
-    /// @notice The account this session verifier is bound to. The verifier
-    ///         rejects `evaluateSessionPolicy` for any other account.
     address account;
-    /// @notice Immutable secp256k1 owner address. ECDSA signatures by this
-    ///         address authorize `0x1D` transactions for `account`.
     address owner;
-    /// @notice Identifies the policy module compiled into the verifier.
-    ///         Variant-specific; the factory MUST reject unknown policies.
     bytes32 policyVariantId;
-    /// @notice ABI-encoded configuration for the selected policy variant.
-    ///         Stored on the verifier; never re-fetched from external state
-    ///         during validation.
     bytes policyConfig;
+}
+
+interface ISecp256k1AdminSigner is IWorldChainAdminSigner {
+    function owner() external view returns (address);
 }
 ```
 
-The secp256k1 admin signer variant MUST implement `ISecp256k1AdminSigner` and verify EIP-1271 signatures against `owner`.
+The EIP-1271 signature payload is `r || s || v`. `isValidSignature(hash, signature)` MUST require `signature.length == 65`, lower-half-order `s`, `v` equal to `27` or `28`, and `ecrecover(hash, v, r, s) == owner()`.
 
-The secp256k1 session verifier variant MUST:
+The secp256k1 session verifier variant MUST verify the same payload against its configured `owner`, reject `evaluateSessionPolicy` unless `context.transaction.account == account` and `context.transaction.sessionVerifier == address(this)`, and evaluate policy internally from its own code and storage.
 
-- implement `IWorldChainSessionVerifier`;
-- verify `isValidSignature(signingHash, signature)` against `owner`;
-- bind `evaluateSessionPolicy` to `account` and `address(this)`;
-- evaluate the configured session policy internally.
-
-#### World ID Factory
+### Default World ID Signers
 
 `WORLD_ID_1271_SIGNER_FACTORY` MUST support:
 
 ```solidity
-/// @notice Variant ID for the v1 World ID admin signer.
 bytes32 constant WORLD_ID_ADMIN_SIGNER_V1 =
     keccak256("world-chain.world-id.admin.v1");
 
-/// @notice Variant ID for the v1 World ID session verifier.
 bytes32 constant WORLD_ID_SESSION_VERIFIER_V1 =
     keccak256("world-chain.world-id.session-verifier.v1");
 
-/// @notice Deployment configuration for `WORLD_ID_ADMIN_SIGNER_V1`. All fields
-///         are committed to in the factory `configHash` and become immutable
-///         on deployment except where `stateUpdater` is permitted to mutate
-///         them (see "Signer Update Semantics" + "Timelocked Signer-State
-///         Updates").
 struct WorldIDAdminSignerConfig {
-    /// @notice Salt mixed into the bound account address derivation.
     bytes32 accountSalt;
-    /// @notice Address authorized to queue verifier-state updates on the
-    ///         deployed signer. `address(0)` makes the verifier state fully
-    ///         immutable. Updates that can invalidate previously valid
-    ///         signatures MUST be timelocked.
     address stateUpdater;
-    /// @notice World ID Merkle tree depth. Pinned to the depth used by the
-    ///         circuit at deployment.
     uint256 treeDepth;
-    /// @notice Identifies the credential schema and issuer pair this signer
-    ///         accepts.
     uint64 issuerSchemaId;
-    /// @notice X-coordinate of the credential issuer's public key.
     uint256 credentialIssuerPubkeyX;
-    /// @notice Y-coordinate of the credential issuer's public key.
     uint256 credentialIssuerPubkeyY;
-    /// @notice X-coordinate of the OPRF service public key.
     uint256 oprfPubkeyX;
-    /// @notice Y-coordinate of the OPRF service public key.
     uint256 oprfPubkeyY;
-    /// @notice Floor for `expiresAtMin` of accepted credentials, as a UNIX
-    ///         timestamp. Proofs whose `expiresAtMin` is below this value
-    ///         MUST be rejected.
     uint64 minExpiresAt;
-    /// @notice Floor for `credentialGenesisIssuedAtMin`. `0` disables.
     uint256 minCredentialGenesisIssuedAt;
-    /// @notice Initial Merkle roots accepted at deployment. The runtime
-    ///         valid-root set is mutable via `stateUpdater` (see above).
     uint256[] initialValidRoots;
 }
 
-/// @notice Deployment configuration for `WORLD_ID_SESSION_VERIFIER_V1`.
-///         Fields shared with `WorldIDAdminSignerConfig` carry the same
-///         semantics; only the differences are documented here.
 struct WorldIDSessionVerifierConfig {
-    /// @notice The account this session verifier is bound to. Distinct from
-    ///         `WorldIDAdminSignerConfig.accountSalt`: the session verifier is
-    ///         not address-bound the same way an admin signer is, but it
-    ///         pinned-binds to its target account at config time.
     address account;
     address stateUpdater;
     uint256 treeDepth;
@@ -1311,297 +780,86 @@ struct WorldIDSessionVerifierConfig {
     uint64 minExpiresAt;
     uint256 minCredentialGenesisIssuedAt;
     uint256[] initialValidRoots;
-    /// @notice Identifies the policy module compiled into the verifier.
     bytes32 policyVariantId;
-    /// @notice ABI-encoded policy configuration; stored on the verifier.
     bytes policyConfig;
 }
-```
 
-The World ID admin signer variant MUST implement `IWorldIDAdminSigner`. It derives its account from `address(this)` and `accountSalt`.
-
-The World ID session verifier variant MUST implement `IWorldChainSessionVerifier` and verify `isValidSignature(signingHash, signature)` as a World ID v4 *session* proof bound to the transaction signing hash. The variant MUST expose immutable account binding state:
-
-```solidity
-/// @notice Default World ID EIP-1271 session verifier interface. Exposes
-///         immutable account binding state for off-chain verification and
-///         the manager's optional self-consistency check.
-interface IWorldIDSessionVerifier is IWorldChainSessionVerifier {
-    /// @return The account this session verifier authorizes transactions for.
-    ///         Pinned at deployment via `WorldIDSessionVerifierConfig.account`.
+interface IWorldIDAdminSigner is IWorldChainAdminSigner {
+    function accountSalt() external view returns (bytes32);
     function account() external view returns (address);
+    function worldIdRpId() external view returns (uint64);
+    function worldIdAction() external view returns (uint256);
+}
 
-    /// @return MUST equal `WORLD_CHAIN_RP_ID`.
+interface IWorldIDSessionVerifier is IWorldChainSessionVerifier {
+    function account() external view returns (address);
     function worldIdRpId() external view returns (uint64);
 }
 ```
 
-The EIP-1271 signature payload uses the World ID v4 session-proof verifier shape:
+`IWorldIDAdminSigner.account()` MUST equal the manager-derived account using `address(this)` as `adminSigner` and `accountSalt()` as `accountSalt`. `worldIdRpId()` MUST equal `WORLD_CHAIN_RP_ID`.
+
+`worldIdAction()` MUST return:
 
 ```solidity
-/// @notice ABI-encoded payload passed as the `signature` argument to
-///         `isValidSignature` for a default World ID session verifier.
-struct WorldIDSessionProofSignature {
-    /// @notice Minimum credential expiration the proof was bound to.
+worldIdField(abi.encode(
+    WORLD_ID_ACCOUNT_TAG,
+    block.chainid,
+    WORLD_CHAIN_RP_ID,
+    WORLD_CHAIN_ACCOUNT_MANAGER,
+    account(),
+    address(this)
+))
+```
+
+where `worldIdField(input) = uint256(keccak256(input)) >> 8`.
+
+The World ID admin signer signature payload is:
+
+```solidity
+struct WorldIDUniquenessProofSignature {
+    uint256 nullifier;
     uint64 expiresAtMin;
-    /// @notice Identifies the credential schema and issuer pair.
     uint64 issuerSchemaId;
-    /// @notice Minimum `genesis_issued_at` the proof was bound to.
     uint256 credentialGenesisIssuedAtMin;
-    /// @notice Session identifier connecting proofs for the same user+RP
-    ///         across requests. MUST be non-zero (zero is the uniqueness-proof
-    ///         shape used by the admin signer).
-    uint256 sessionId;
-    /// @notice Session nullifier tuple. `[0]` is the nullifier; `[1]` is a
-    ///         randomly generated action.
-    uint256[2] sessionNullifier;
-    /// @notice Encoded World ID v4 proof: `[0..3]` compressed Groth16,
-    ///         `[4]` Merkle root from the `WorldIDRegistry`.
     uint256[5] zeroKnowledgeProof;
 }
 ```
 
-`isValidSignature(hash, signature)` MUST:
+Admin `isValidSignature(hash, signature)` MUST decode `WorldIDUniquenessProofSignature`, compute `signalHash = worldIdField(abi.encode(hash))`, compute `nonce = worldIdField(abi.encode("WIP1001_WORLD_ID_ADMIN_NONCE", hash))`, require configured issuer and freshness parameters, require `zeroKnowledgeProof[4]` to be an accepted root, verify a World ID v4 uniqueness proof with `sessionId = 0`, and return `EIP1271_MAGIC_VALUE` only on success.
 
-- decode `signature` as `WorldIDSessionProofSignature`;
-- compute `signalHash = worldIdField(abi.encode(hash))`;
-- compute `nonce = worldIdField(abi.encode("WIP1001_WORLD_ID_SESSION_NONCE", block.chainid, WORLD_CHAIN_ACCOUNT_MANAGER, account(), address(this), hash))`;
-- require `sessionId != 0` (distinguishing session proofs from uniqueness proofs; a zero sessionId is the uniqueness-proof shape used by the admin signer);
-- require `issuerSchemaId` to equal the verifier's configured issuer schema ID;
-- require `zeroKnowledgeProof[4]` to be an accepted World ID registry root in the verifier's state;
-- require `expiresAtMin` and `credentialGenesisIssuedAtMin` to satisfy the verifier's configured credential freshness policy;
-- verify the proof as a World ID v4 session proof equivalent to `IWorldIDVerifier.verifySession(WORLD_CHAIN_RP_ID, nonce, signalHash, expiresAtMin, issuerSchemaId, credentialGenesisIssuedAtMin, sessionId, sessionNullifier, zeroKnowledgeProof)`;
-- return `EIP1271_MAGIC_VALUE` only if verification succeeds.
-
-`evaluateSessionPolicy(context)` MUST reject unless:
-
-- `context.transaction.account == account()`;
-- `context.transaction.sessionVerifier == address(this)`;
-- the verifier's internal policy accepts `context`.
-
-The verifier MUST verify the same public inputs as the World ID v4 session verifier: issuer schema, credential issuer public key, credential expiration minimum, credential genesis minimum, Merkle root, tree depth, RP ID, OPRF public key, signal hash, nonce, sessionId, and sessionNullifier.
-
-The verifier MUST NOT consume nullifiers as part of `isValidSignature`, because EIP-1271 validation is a `view` operation. Per-session-proof uniqueness (replay protection across multiple transactions reusing the same session proof) is NOT enforced at the protocol level; each `0x1D` transaction's signing hash already commits to its `nonce`, so the same proof cannot authorize two transactions with the same envelope nonce.
-
-The verifier MUST NOT call an external World ID verifier from a restricted validation frame. Verifier state requirements match the admin signer (see "World ID Admin Signer").
-
-World ID verifier state MUST be stored in the signer contract itself. If `stateUpdater == address(0)`, the initial verifier state is immutable. Otherwise, only `stateUpdater` may queue verifier-state updates, and updates that can invalidate accepted transactions MUST follow the signer update semantics above.
-
-### Manager Events
-
-`WORLD_CHAIN_ACCOUNT_MANAGER` MUST emit the following events on the corresponding state transitions. Indexers, recovery tooling, and explorers depend on these; the manager MUST NOT mutate account state without emitting the matching event.
+The World ID session verifier signature payload is:
 
 ```solidity
-/// @notice Events emitted by `WORLD_CHAIN_ACCOUNT_MANAGER`. Each event
-///         corresponds 1:1 with a state transition; conforming implementations
-///         MUST NOT mutate account state without emitting the matching event.
-interface IWorldChainAccountManagerEvents {
-    /// @notice Emitted exactly once per account, atomically with `create`.
-    /// @param  account Newly created account address.
-    /// @param  adminSigner Immutable admin signer of `account`.
-    /// @param  accountSalt The salt used in address derivation.
-    /// @param  activeKeyringHash Initial `activeKeyringHash`.
-    event AccountCreated(
-        address indexed account,
-        address indexed adminSigner,
-        bytes32 accountSalt,
-        bytes32 activeKeyringHash
-    );
-
-    /// @notice Emitted on a `queueKeyringUpdate` that does NOT replace an
-    ///         existing pending update.
-    /// @param  account Account whose keyring update was queued.
-    /// @param  targetKeyringHash Hash of the queued target verifier set.
-    /// @param  expectedCurrentKeyringHash Active keyring hash at queue time.
-    /// @param  activateAfter Earliest activation timestamp.
-    /// @param  queuedAtNonce `adminNonce` consumed by this queue.
-    event KeyringUpdateQueued(
-        address indexed account,
-        bytes32 indexed targetKeyringHash,
-        bytes32 expectedCurrentKeyringHash,
-        uint64 activateAfter,
-        uint64 queuedAtNonce
-    );
-
-    /// @notice Emitted atomically with `activateKeyringUpdate`.
-    /// @param  account Account whose keyring was activated.
-    /// @param  previousKeyringHash The keyring hash before activation.
-    /// @param  newKeyringHash The keyring hash after activation (= prior
-    ///         pending `targetKeyringHash`).
-    event KeyringUpdateActivated(
-        address indexed account,
-        bytes32 previousKeyringHash,
-        bytes32 indexed newKeyringHash
-    );
-
-    /// @notice Emitted atomically with `cancelPendingKeyringUpdate`.
-    /// @param  account Account whose pending update was cancelled.
-    /// @param  cancelledQueuedAtNonce The `queuedAtNonce` of the cancelled
-    ///         pending update.
-    /// @param  adminNonce New `adminNonce` after the cancellation increment.
-    event KeyringUpdateCancelled(
-        address indexed account,
-        uint64 cancelledQueuedAtNonce,
-        uint64 adminNonce
-    );
-
-    /// @notice Emitted atomically with `revokeSessionVerifier`.
-    /// @param  account Account whose verifier was revoked.
-    /// @param  sessionVerifier Address that was removed from the keyring.
-    /// @param  newKeyringHash `activeKeyringHash` after the removal.
-    /// @param  adminNonce New `adminNonce` after the revocation increment.
-    event SessionVerifierRevoked(
-        address indexed account,
-        address indexed sessionVerifier,
-        bytes32 newKeyringHash,
-        uint64 adminNonce
-    );
-
-    /// @notice Emitted in place of `KeyringUpdateQueued` when a successful
-    ///         `queueKeyringUpdate` replaces a previously queued update.
-    /// @param  account Account whose pending update was replaced.
-    /// @param  previousTargetKeyringHash Target hash of the prior pending update.
-    /// @param  newTargetKeyringHash Target hash of the new pending update.
-    /// @param  newActivateAfter Activation timestamp of the new pending update.
-    /// @param  newQueuedAtNonce `adminNonce` consumed by the new queue.
-    event PendingKeyringUpdateReplaced(
-        address indexed account,
-        bytes32 previousTargetKeyringHash,
-        bytes32 indexed newTargetKeyringHash,
-        uint64 newActivateAfter,
-        uint64 newQueuedAtNonce
-    );
+struct WorldIDSessionProofSignature {
+    uint64 expiresAtMin;
+    uint64 issuerSchemaId;
+    uint256 credentialGenesisIssuedAtMin;
+    uint256 sessionId;
+    uint256[2] sessionNullifier;
+    uint256[5] zeroKnowledgeProof;
 }
 ```
 
-`AccountCreated` MUST be emitted exactly once per account, atomically with `create`.
+Session `isValidSignature(hash, signature)` MUST decode `WorldIDSessionProofSignature`, compute `signalHash = worldIdField(abi.encode(hash))`, compute `nonce = worldIdField(abi.encode("WIP1001_WORLD_ID_SESSION_NONCE", block.chainid, WORLD_CHAIN_ACCOUNT_MANAGER, account(), address(this), hash))`, require `sessionId != 0`, require configured issuer and freshness parameters, require `zeroKnowledgeProof[4]` to be an accepted root, verify a World ID v4 session proof, and return `EIP1271_MAGIC_VALUE` only on success.
 
-`KeyringUpdateQueued` MUST be emitted on every successful `queueKeyringUpdate` that does not replace an existing pending update.
+World ID signers MUST verify the configured public inputs for issuer schema, credential issuer public key, credential expiration minimum, credential genesis minimum, Merkle root, tree depth, RP ID, OPRF public key, signal hash, nonce, and proof type. They MUST NOT consume nullifiers in `isValidSignature` and MUST NOT call an external World ID verifier from a restricted validation frame.
 
-`PendingKeyringUpdateReplaced` MUST be emitted instead of `KeyringUpdateQueued` when a successful `queueKeyringUpdate` replaces an existing pending update.
-
-`KeyringUpdateActivated` MUST be emitted atomically with `activateKeyringUpdate`.
-
-`KeyringUpdateCancelled` MUST be emitted atomically with `cancelPendingKeyringUpdate` (see "Pending Keyring Update Cancellation Semantics").
-
-`SessionVerifierRevoked` MUST be emitted atomically with `revokeSessionVerifier` (see "Session Verifier Revoke Semantics").
-
-### Visual Flow
-
-```mermaid
-sequenceDiagram
-    autonumber
-    participant User
-    participant Pool as Tx Pool
-    participant Protocol
-    participant Manager as WORLD_CHAIN_ACCOUNT_MANAGER
-    participant Signer as EIP-1271 Session Verifier
-    participant App as Target Contracts
-
-    User->>Pool: Submit 0x1D transaction
-    Pool->>Protocol: Validate transaction
-    Protocol->>Manager: Load active keyring
-    Manager-->>Protocol: sessionVerifier authorized, activeKeyringHash
-    Protocol->>Signer: isValidSignature(signingHash, signature)
-    Signer-->>Protocol: EIP1271_MAGIC_VALUE
-    Protocol-->>Pool: Valid while keyring is active
-
-    Protocol->>App: Tentative execution as account
-    App-->>Protocol: Result, calls, logs
-    Protocol->>Signer: evaluateSessionPolicy(context)
-    alt trace accepted
-        Signer-->>Protocol: true
-        Protocol-->>User: Commit payload result
-    else trace rejected
-        Signer-->>Protocol: false or failure
-        Protocol-->>User: Revert tentative payload
-    end
-
-    User->>Manager: queueKeyringUpdate(...)
-    Manager-->>User: Pending until activateAfter
-    User->>Manager: activateKeyringUpdate()
-    Manager-->>User: Active keyring replaced
-
-    User->>Manager: cancelPendingKeyringUpdate(...)
-    Manager-->>User: Pending update cleared
-
-    User->>Manager: revokeSessionVerifier(...)
-    Manager-->>User: Verifier removed instantly
-    Manager-->>Pool: Evict pooled txns from revoked verifier
-```
-
-### Invariants
-
-The following invariants are normative consequences of the rules in this specification. Each is traceable to one or more MUST clauses above and SHOULD be enforced by conforming implementations and exercised by the test cases (see "Test Cases").
-
-| ID | Invariant |
-| --- | --- |
-| `INV-1` | The account address is a deterministic function of `(WIP1001_ACCOUNT_DOMAIN, chainId, WORLD_CHAIN_ACCOUNT_MANAGER, adminSigner, accountSalt)`. No operation rotates `adminSigner` for an existing account. |
-| `INV-2` | `adminNonce` is strictly monotonically non-decreasing. It increments by exactly one on every successful `queueKeyringUpdate`, `cancelPendingKeyringUpdate`, and `revokeSessionVerifier`. It MUST NOT change on `activateKeyringUpdate`. |
-| `INV-3` | `1 <= activeSessionVerifiers.length <= MAX_SESSION_VERIFIERS`. The active keyring is never empty for an existing account. |
-| `INV-4` | `activeKeyringHash == keccak256(abi.encode(activeSessionVerifiers))` after every state-changing operation. |
-| `INV-5` | If `pendingKeyringUpdate.exists` is true, then `pendingKeyringUpdate.activateAfter` is at least `block.timestamp + MIN_KEYRING_UPDATE_DELAY` measured at the queueing block. |
-| `INV-6` | At most one pending keyring update per account exists at any time. Re-queueing replaces the prior pending update and emits `PendingKeyringUpdateReplaced`. |
-| `INV-7` | For any included `0x1D` transaction, `sessionVerifier` was a member of the account's keyring at the block of pool entry (see "Mempool Revalidation"). |
-| `INV-8` | For every default factory-deployed signer, `signerFactory()` returns the deploying factory address and `factory.isFactorySigner(signer)` returns `true`. |
-| `INV-9` | Validation calls (`isValidSignature`, `evaluateSessionPolicy`) forward exactly `EIP1271_VALIDATION_GAS_LIMIT` and `EXECUTION_TRACE_VALIDATION_GAS_LIMIT` respectively. Signers MUST NOT observe non-deterministic gas. |
-| `INV-10` | Manager state mutations are atomic with their corresponding events from "Manager Events". A successful state transition without its event is non-conforming. |
-
-### Extensions
-
-WIP-1001 is designed to support future signer contracts without protocol changes, including:
-
-- multisig signers;
-- social recovery signers;
-- passkey signers;
-- threshold signers;
-- proof-system signers;
-- enterprise policy signers;
-- application-specific session verifiers.
-
-New cryptographic primitives SHOULD be added as reusable precompiles, not as account-specific protocol branches.
+World ID verifier state MUST be stored in the signer contract itself. If `stateUpdater == address(0)`, the verifier state is immutable. Otherwise, updates that can invalidate accepted transactions MUST follow "Timelocked Signer-State Updates".
 
 ## Rationale
 
-### EIP-1271 as the Signer Boundary
-
 EIP-1271 gives World Chain one protocol boundary for all authorization schemes. The protocol verifies a signer contract; the signer contract decides how to authenticate.
 
-### Verifier-Owned Execution Policy
+Execution policy belongs inside the session verifier. The protocol supplies the canonical transaction context and execution trace, then asks the verifier for a boolean decision.
 
-Execution policy belongs inside the session verifier. The protocol does not need to understand spending limits, method allowlists, intents, or application-specific policy. It only supplies the canonical transaction context and execution trace, then asks the verifier for a boolean decision.
+Validation gas limits are protocol constants, not signer-selected values. This gives clients a fixed resource bound for mempool validation and block execution.
 
-### Fixed Validation Gas
+Validation gas is supplied from a per-block budget rather than the envelope `gasLimit`. This keeps the payload gas model close to EIP-1559 transactions while bounding validation work per block.
 
-Validation gas limits are protocol constants, not signer-selected values. This prevents signers from increasing validation cost per transaction and gives clients a fixed resource bound for mempool validation and block execution.
+Timelocked keyring updates preserve stable inclusion for transactions already accepted by the pool. Instant revocation remains available for compromised session verifiers and only evicts transactions from the revoked verifier.
 
-### Block-Budget Validation Gas
-
-Validation gas is supplied by the protocol from a per-block budget rather than charged to the envelope's `gasLimit`. ERC-4337 takes the opposite approach with a per-userop `verificationGasLimit`. The block-budget choice is motivated by:
-
-1. **Unified mempool admission.** Mempools admit transactions when the account can pay payload gas plus `MIN_VALIDATION_FAILURE_FEE`, without modeling per-transaction validation gas.
-2. **Predictable resource bound.** Validation cost per block is bounded a priori by `BLOCK_VALIDATION_GAS_BUDGET`, regardless of how many transactions are included.
-3. **Simpler envelope.** A single `gasLimit` field preserves familiarity with EIP-1559 / EIP-2718 transactions.
-
-The price of this choice is a new validation fee market: validation budget is a scarce per-block resource, and `MIN_VALIDATION_FAILURE_FEE` must be tuned to keep the cost-per-byte of consumed budget above attacker value. See "Validation Budget Exhaustion" in Security Considerations.
-
-### Timelocked Keyring Updates
-
-A keyring update can invalidate transactions that already passed mempool validation. The combination of `MIN_KEYRING_UPDATE_DELAY > TXPOOL_TRANSACTION_EXPIRATION_WINDOW` and the membership-based pool revalidation rule (see "Mempool Revalidation") guarantees that a transaction cannot be invalidated by a keyring update while it is still eligible for inclusion. The membership rule preserves stable inclusion across keyring rotations *and* across `revokeSessionVerifier` calls for unrelated verifiers — only transactions whose own verifier was revoked lose stable inclusion, which is the intended semantics of revocation.
-
-### Instant Revocation vs. Timelocked Updates
-
-Routine keyring updates are timelocked because most updates are not urgent and stable inclusion is more valuable than instantaneous propagation. Instant revocation is reserved for compromise — a leaked session-key, a malicious verifier — where waiting `MIN_KEYRING_UPDATE_DELAY` is unacceptable. The split design:
-
-1. Limits the blast radius: instant revoke only affects pool entries from the revoked verifier; other verifiers' pool entries retain stable inclusion via the membership-based revalidation rule.
-2. Limits the trust required: instant revoke requires admin authorization with replay protection (`adminNonce`) and binding to `expectedCurrentKeyringHash`.
-3. Avoids re-introducing per-keyring timelocks for the common case of removing one verifier from many.
-
-The remaining attack window is the time between leak and detection-plus-revoke (one block once the admin acts). This is documented in "Session Verifier Revocation Race".
-
-### Restricted Validation Frames
-
-Restricted validation frames prevent validation results from depending on mutable external state, block metadata, or external contract calls. Signers remain programmable, but validation stays reproducible across pool validation and block execution.
+Restricted validation frames prevent validation from depending on mutable external state, block metadata, or arbitrary external contract calls.
 
 ## Backwards Compatibility
 
@@ -1611,128 +869,40 @@ Existing Safe accounts MAY deploy or delegate to EIP-1271 signer contracts that 
 
 ## Test Cases
 
-This section is intentionally a scope outline; the full vector set is required before this WIP advances past Draft. Conforming implementations MUST pass every category below; reference vectors will be published alongside the reference implementation.
+Conforming implementations MUST pass vectors for:
 
-Required vector categories:
+- address derivation across multiple `(chainId, manager, adminSigner, accountSalt)` tuples;
+- `activeKeyringHash` ordering and duplicate rejection;
+- each admin operation hash domain, including negative replay cases;
+- `0x1D` RLP encoding, signing hash, and transaction hash;
+- malformed envelope rejection for `to`, `data`, `accessList`, and `signature` bounds;
+- manager state transitions, emitted events, nonce changes, and failure atomicity;
+- transaction validation failures, policy failures, trace overflow, and payload reverts;
+- txpool retention across keyring activation and eviction on revocation;
+- restricted-frame positive cases and each forbidden opcode or call target;
+- World ID `worldIdField`, `worldIdAction`, admin proof, and session proof inputs;
+- default secp256k1 low-s, `v`, owner, and signature-length checks;
+- block validation budget exhaustion and validation-failure fee charging.
 
-- **Address derivation** — golden vectors for `account = keccak256(abi.encode(WIP1001_ACCOUNT_DOMAIN, chainId, manager, adminSigner, accountSalt))[12:]` across at least three `(chainId, adminSigner, accountSalt)` triples.
-- **`adminOperationHash` derivation** — one positive and one negative vector for each domain: `WIP1001_ADMIN_CREATE_DOMAIN`, `WIP1001_QUEUE_KEYRING_UPDATE_DOMAIN`, `WIP1001_CANCEL_KEYRING_UPDATE_DOMAIN`, `WIP1001_REVOKE_SESSION_VERIFIER_DOMAIN`.
-- **Signing hash** — RLP-encoding vectors for the `0x1D` envelope covering call vs create, empty-vs-populated `accessList`, and `data` lengths near `MAX_PAYLOAD_DATA_BYTES`.
-- **`worldIdAction` derivation** — vectors covering both default and non-default factories, with `chainId` binding (see "World ID Admin Signer").
-- **`worldIdField` reduction** — vectors that exercise the `keccak256 >> 8` field reduction, cross-checked against the `FieldElement::from_arbitrary_raw_bytes` reference implementation in the World ID primitives crate.
-- **Keyring hash and ordering** — vectors that prove `activeKeyringHash` is sensitive to verifier ordering.
-- **Trace ABI encoding** — round-trip vectors for `WorldChainExecutionTrace` covering: deeply nested calls, empty return data, reverted sub-calls, mixed CREATE/CREATE2/Call/StaticCall/DelegateCall.
-- **Restricted frame conformance** — positive vectors (allowed precompiles, own-storage reads) and negative vectors (every forbidden opcode in the policy) drawn from the ERC-7562 conformance suite plus `WIP1001-VR-*` rules.
-- **Mempool revalidation transitions** — vectors covering keyring queue, activate, cancel, and revoke; verifying eviction vs retention rules.
-- **Validation gas accounting** — block-level scenarios: budget exhaustion, validation failure fee charging, mempool admission floor.
-
-## Reference Implementation
-
-A partial reference implementation is in progress in this repository on the `osiris/wip-1001-*` branch series. As of this draft, the following components exist; none are conformant with the full specification yet:
-
-- Solidity manager skeleton: `pkg/contracts/src/WorldIDAccountManagerImplV1.sol` (session-key stub; does not yet implement the keyring/admin/timelock state machine).
-- Manager interface: `pkg/contracts/src/interfaces/IWorldIDAccountManager.sol`.
-- Rust `0x1D` envelope primitives: `crates/primitives/src/transaction/wip_1001.rs`.
-- Trace-collection inspector: `crates/rpc/src/simulate.rs` (covers CREATE/CREATE2 deployed-address capture but does not yet populate `LogTrace.callIndex`).
-
-A complete reference implementation, golden vectors, and a Foundry conformance test suite MUST be published before this WIP advances to Review.
+Complete golden vectors and a conformance test suite MUST be published before this WIP advances to Review.
 
 ## Security Considerations
 
-### Admin Authorization Front-Running
-
-Admin authorization signatures MUST bind the admin operation domain, account address, manager address, chain ID, operation parameters, and nonce where applicable. A signature valid for one admin operation MUST NOT be valid for another.
-
-### Admin Signer Compromise
-
-The admin signer can queue keyring changes. Applications SHOULD support recovery or multisig admin signers where appropriate.
-
-### Admin Signer Lock-In
-
-The account address binds the admin signer immutably (see "Account Address Permanence"). A bug in the admin signer contract is uncorrectable without migrating to a new account address. This is a deliberate tradeoff against ERC-4337's owner-rotation model: address derivation is unambiguous and indexers do not need to track admin rotation events, but loss of the admin signer's authentication factor (e.g., the secp256k1 owner key) permanently locks the account.
-
-Mitigations:
-
-- Choose admin signer factory variants that include internal recovery mechanisms (social recovery, multisig with member rotation, time-delayed recovery oracles).
-- Treat secp256k1 admin signers without recovery as equivalent to externally owned accounts: the owner key MUST be backed up.
-- Where corporate / institutional use is intended, prefer multisig admin signers from the start; migration after asset accumulation is expensive.
-
-### Session Verifier Revocation Race
-
-`revokeSessionVerifier` is instant on-chain (one block from admin transaction inclusion to verifier removal) but cannot recover keys before they are detected. The window of risk is the time between key compromise and detection-plus-revocation. This window is bounded by the admin's monitoring latency, not by the protocol. Applications SHOULD instrument session-key usage and trigger automated revocation on anomaly detection.
-
-### Signer Validation DoS
-
-Fixed validation gas limits bound signer execution. Signers that exceed the limit fail validation.
-
-### Validation Budget Exhaustion
-
-The per-block validation budget (`BLOCK_VALIDATION_GAS_BUDGET`) is a scarce resource. An attacker holding sufficient balance to pay `MIN_VALIDATION_FAILURE_FEE` per failed transaction can spam validation failures, consuming budget at the rate of `BLOCK_VALIDATION_GAS_BUDGET / (EIP1271_VALIDATION_GAS_LIMIT + EXECUTION_TRACE_VALIDATION_GAS_LIMIT)` failures per block. Mitigations:
-
-- Tune `MIN_VALIDATION_FAILURE_FEE` so that the cost of consuming the entire block budget exceeds the marginal value the attacker derives from delaying other users' transactions.
-- Mempool admission MUST refuse transactions whose account balance cannot cover `MIN_VALIDATION_FAILURE_FEE` at the current `baseFee`.
-- Block builders MAY apply additional anti-DoS heuristics (e.g., per-account validation-failure rate limits) without violating the specification.
-
-### Block-Inclusion Bias
-
-Validation budget is fixed per block. Builders may prefer transactions with cheaper validation profiles, biasing inclusion against admin signers / session verifiers with high cryptographic cost (e.g., World ID Groth16 proofs). This is an accepted tradeoff: fixed validation gas limits also bound the worst-case validation cost so that the bias is bounded.
-
-### Trace Size DoS
-
-`MAX_EXECUTION_TRACE_BYTES` bounds memory and encoding cost for session policy evaluation. Transactions that exceed the bound fail before the context is passed to the signer.
-
-### Calldata Bounds
-
-The activation parameters `MAX_PAYLOAD_DATA_BYTES`, `MAX_ACCESS_LIST_ENTRIES`, `MAX_SESSION_SIGNATURE_BYTES`, and `MAX_ADMIN_AUTHORIZATION_BYTES` bound calldata-driven costs that are not otherwise covered by gas accounting (mempool-admission cost, RLP-decode cost, ABI-encode cost). Implementations MUST enforce all four limits at envelope decode time.
-
-### External-State Invalidation
-
-Restricted frames forbid external contract reads and calls except allowlisted precompiles. This prevents unrelated contract state from changing signature or session policy outcomes.
-
-### Block-Context Invalidation
-
-Restricted frames forbid block-context opcodes. Signers that need time or block constraints MUST bind them into the signature or proof input.
-
-### Own-Storage Invalidation
-
-Signers and verifiers may read their own storage. Default factories that expose mutable state affecting validation MUST timelock those updates by at least `MIN_KEYRING_UPDATE_DELAY`.
-
-### Upgradeable Signers
-
-Upgradeable signer contracts can change validation behavior. Signer factories SHOULD make upgradeability explicit, and upgrades that affect validation SHOULD be timelocked.
-
-### Session Verifier Deanonymization
-
-The `0x1D` envelope exposes the selected session verifier. Applications that need stronger privacy should use verifier contracts that aggregate or rotate credentials.
-
-### Signature-Verifier Ambiguity
-
-The transaction envelope includes both `account` and `sessionVerifier`. The protocol MUST verify that `sessionVerifier` is active for `account` before calling EIP-1271.
-
-### WebAuthn Challenge Binding
-
-WebAuthn-based signers MUST bind challenges to the `0x1D` signing hash and `WORLD_CHAIN_RP_ID`.
-
-### World ID Stale Verifier State
-
-World ID signers MUST define freshness rules for verifier state, including roots, credential issuer public keys, OPRF public keys, verifier keys, tree depth, and credential freshness policy. Updates that can invalidate previously accepted transactions MUST follow the signer-state timelock requirement.
-
-### Cross-Chain `worldIdAction` Replay
-
-The `worldIdAction` derivation binds `block.chainid` (see "World ID Admin Signer"). Without this binding, a custom (non-default-factory) admin signer deployed at the same address on two chains could accept a World ID proof from one chain on the other. The default factory's CREATE2 salt also binds chainId, so for default-factory signers this is defense-in-depth.
-
-### Self-Inconsistent Admin Signer
-
-The default `IWorldIDAdminSigner.account()` view function returns the admin signer's self-reported account binding. A buggy or malicious signer could return an inconsistent value. The manager protects against this for default-factory-deployed admin signers by checking `IWorldIDAdminSigner(adminSigner).account() == account` during `create` (see "Account Creation Semantics" step 10). For custom admin signers, the manager makes no such check, so self-consistency is the implementor's responsibility.
-
-### Front-Running of `create`
-
-The account-creation `adminOperationHash` does not bind `msg.sender`. Anyone observing a `create` call in the mempool can copy `(adminSigner, accountSalt, initialSessionVerifiers, adminAuthorization)` and front-run it. The resulting account state is identical to the user's intent (because the authorization commits to all state-determining parameters), so the front-runner gains no authority over the account; griefing is limited to gas attribution. ETH or token balances pre-funded to the derived account address before `create` are unaffected: address derivation is independent of who calls `create`.
-
-### DELEGATECALL Conformance
-
-`DELEGATECALL` is permitted inside restricted validation frames only when the delegatee's bytecode itself satisfies every rule in the tracer rule taxonomy (see `WIP1001-VR-9`). Implementations MUST validate the delegatee under the same rule set, recursively if necessary. A non-conforming delegatee MUST cause the validation call to fail. This rule allows proxy-style signers (transparent proxy, UUPS, Safe-style modules) without compromising determinism, but proxies whose implementation contracts call out to mutable external state MUST NOT be used as admin signers or session verifiers.
-
-## Copyright
-
-Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+- Admin authorization hashes bind domain, chain ID, manager, account, parameters, and nonce where applicable. A signature valid for one operation MUST NOT be valid for another.
+- The admin signer is immutable in the account address. A broken or lost admin signer requires migrating assets to a new account.
+- Applications that need recovery SHOULD use admin signers with recovery or multisig logic from account creation.
+- `revokeSessionVerifier` is effective only after compromise is detected and the admin transaction is included. Monitoring and automated revocation reduce this window.
+- Fixed validation gas limits bound signer execution. Signers that exceed the limit fail validation.
+- `BLOCK_VALIDATION_GAS_BUDGET` is scarce. `MIN_VALIDATION_FAILURE_FEE` MUST be tuned so validation spam is costly, and clients MUST reject pooled transactions that cannot pay it.
+- Builders may prefer transactions with cheaper validation profiles. Fixed validation gas bounds the worst-case bias.
+- `MAX_EXECUTION_TRACE_BYTES`, `MAX_PAYLOAD_DATA_BYTES`, `MAX_ACCESS_LIST_ENTRIES`, `MAX_SESSION_SIGNATURE_BYTES`, and `MAX_ADMIN_AUTHORIZATION_BYTES` bound calldata, decoding, memory, and ABI-encoding costs.
+- Restricted frames forbid mutable external-state reads and block-context opcodes. Signers that need time, block, or external-state constraints MUST bind them into the signature or proof input.
+- Signers may read their own storage. Mutable signer state that can affect accepted transactions MUST be timelocked.
+- Upgradeable signers can change validation behavior. Upgrades that affect validation MUST follow the signer-state timelock requirement.
+- The `0x1D` envelope exposes `account` and `sessionVerifier`. Applications that need stronger privacy should use verifier contracts that aggregate or rotate credentials.
+- The protocol MUST verify that `sessionVerifier` is authorized for `account` before calling EIP-1271.
+- WebAuthn-based signers MUST bind challenges to the `0x1D` signing hash and `WORLD_CHAIN_RP_ID`.
+- World ID signers MUST bind `block.chainid` into `worldIdAction` or session nonce inputs to prevent cross-chain proof replay.
+- The default World ID admin signer self-reports `account()`. The manager checks this only for default-factory-deployed World ID admin signers; custom signers are responsible for their own consistency.
+- `create` does not bind `msg.sender`, so a copied call can be front-run. The resulting account state is identical because the authorization commits to all state-determining parameters.
+- `DELEGATECALL` inside restricted validation frames is safe only when the delegatee bytecode satisfies the same tracer rules recursively.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Large, normative rewrite of the WIP-1001 specification (constants, interfaces, and validation semantics) that could change downstream client/contract implementations, though it is documentation-only in this repo.
> 
> **Overview**
> Updates `wips/wip-1001.md` with a major spec rewrite: formalizes the `WORLD_CHAIN_ACCOUNT_MANAGER`-managed account model with **admin signers** vs **session verifiers**, explicit domain-separated hashing, deterministic address derivation, and a canonical execution-trace + `evaluateSessionPolicy` flow for `0x1D` transactions.
> 
> Adds new protocol-level parameters and rules around **restricted validation frames** (ERC-7562-style tracer), **validation gas budgeting/fees**, **mempool revalidation** for stable inclusion, expanded manager APIs (queue/activate/cancel keyring updates, instant verifier revocation) and required manager events, plus detailed default factory patterns and World ID/secp256k1 reference signer variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f4c649393593281147137a81bccc7eed4031e2b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->