### PR TITLE
chore: add execution trace construction section to wip-1001

### DIFF
--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -14,7 +14,7 @@ requires: EIP-1271, EIP-2718, EIP-1559, EIP-2930, ERC-7562, RIP-7212
 
 WIP-1001 defines a native World Chain account type managed by the `WORLD_CHAIN_ACCOUNT_MANAGER` predeploy. Each account has one immutable [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) compliant admin signer and one active keyring of EIP-1271 compliant session verifiers.
 
-We extend [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) with a new typed transaction envelope with type flag `0x1D`. `0x1D` transactions executed with the World Chain account **Framed** as the sender. Session verifiers act as the transaction level signatories via programmable [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271). Session verifiers dually function as signature verifiers, and session key policy evaluators.
+We extend [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) with a new typed transaction envelope with type flag `0x1D`. `0x1D` transactions are executed with the World Chain account **Framed** as the sender. Session verifiers act as the transaction level signatories via programmable [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) smart contracts. Session verifiers dually function as signature verifiers, and session key policy evaluators.
 
 We design with the principal of not having signer-specific authentication as a native execution path in the protocol. Signature schemes, proof systems, recovery policies, and spending policies are fully programmable. The protocol only prescribes deterministic context, validation frames, and reusable precompiles for cryptographic operations.
 
@@ -24,7 +24,7 @@ World Chain accounts need programmable authentication without adding a protocol 
 
 Admin signers and session verifiers use the same [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) boundary but have different roles. The admin signer authorizes account-management operations. Session verifiers authorize `0x1D` transactions and evaluate the resulting execution trace.
 
-Stable transaction inclusion requires mempool validation and block execution to agree on which verifier may authorize a transaction. Keyring replacement is therefore timelocked for longer than pool transaction expiration, while emergency revocation can evict only transactions from the revoked verifier.
+Stable transaction inclusion requires transaction validation to be stable from the time a transaction hits the mempool to the time of inclusion in the block. Keyring updates are therefore timelocked for longer than the eviction time of transactions in the transaction pool.
 
 ## Specification
 
@@ -87,8 +87,6 @@ Signer contracts MAY call protocol-supported cryptographic precompiles from rest
 | `EdDSA verify` | Activation parameter |
 | `BLS12-381 verify` | Activation parameter |
 
-World Chain clients MUST NOT expose private host validation APIs that are unavailable to contracts. Any primitive used by a default signer MUST be available through an allowlisted precompile.
-
 ### Account State
 
 World Chain accounts are created and managed by `WORLD_CHAIN_ACCOUNT_MANAGER`.
@@ -101,7 +99,6 @@ struct Account {
     bytes32 activeKeyringHash;
     PendingKeyringUpdate pendingKeyringUpdate;
     uint64 adminNonce;
-    uint64 transactionNonce;
 }
 
 struct PendingKeyringUpdate {
@@ -120,15 +117,12 @@ struct SessionVerifier {
 
 For every existing account:
 
-- `adminSigner` MUST be a deployed EIP-1271 contract and is immutable for the life of the account address.
+- `adminSigner` MUST be a deployed as a EIP-1271 contract and is immutable for the life of the account address.
 - `activeSessionVerifiers.length` MUST be in `[1, MAX_SESSION_VERIFIERS]`.
-- each `SessionVerifier.verifier` MUST be a deployed contract implementing EIP-1271 and `IWorldChainSessionVerifier`;
+- each `SessionVerifier.verifier` MUST be a deployed contract adhering to EIP-1271 and `IWorldChainSessionVerifier`;
 - `activeSessionVerifiers` MUST NOT contain duplicate verifier addresses;
 - `activeKeyringHash == keccak256(abi.encode(activeSessionVerifiers))`;
 - `adminNonce` is consumed only by admin operations;
-- `transactionNonce` is consumed only by included `0x1D` transactions.
-
-The manager MUST NOT use the admin signer to authorize `0x1D` execution unless the admin signer is also in the active session keyring. The manager MUST NOT use a session verifier to authorize account-management operations unless that verifier is also the account's admin signer.
 
 #### Address Derivation
 
@@ -280,38 +274,6 @@ interface IWorldChainSessionVerifier is IERC1271 {
 }
 ```
 
-`WorldChainTransactionContext` MUST be derived from the envelope, loaded account state, and computed signing hash. It MUST NOT include block-context values other than `chainId`.
-
-For `WorldChainTransactionContext`:
-
-- `target == to` when `isCreate == false`;
-- `target == address(0)` when `isCreate == true`;
-- `selector == bytes4(data[:4])` when `isCreate == false && data.length >= 4`;
-- `selector == 0x00000000` otherwise;
-- `activeKeyringHash` is the account's active keyring hash observed during transaction validation.
-
-For `WorldChainExecutionTrace`:
-
-- the root transaction call is represented by `transaction`, not by a `CallTrace`;
-- `calls` MUST include every internal call in execution order;
-- `logs` MUST include emitted logs in emission order, excluding logs reverted by EVM revert semantics;
-- `outputHash`, `CallTrace.inputHash`, `CallTrace.outputHash`, and `LogTrace.dataHash` MUST use `keccak256(bytes)`, including `keccak256("")` for empty bytes; `bytes32(0)` MUST NOT be used as an empty-data sentinel;
-- a reverted call's `outputHash` MUST hash revert data;
-- `LogTrace.callIndex == type(uint32).max` identifies a root-call log.
-
-For each `CallTrace`:
-
-- `depth` is the EVM call depth; the first internal call has depth `1`;
-- `caller` is the address that executed the call opcode;
-- for `Create` and `Create2`, `target` is the deployed address or the address that would have been deployed if the create reverted;
-- `Create2` target addresses are computed per EIP-1014;
-- `Create` target addresses are computed as `keccak256(rlp([sender, nonce]))[12:]`;
-- `DelegateCall.value == 0`, and `DelegateCall.caller` is the address that executed `DELEGATECALL`.
-
-Full internal calldata, return data, and log data are not copied into the trace. A verifier that needs exact bytes MUST bind those bytes through the session signature, transaction calldata, or an application-level commitment.
-
-The ABI encoding of `ExecutionTraceContext.trace` MUST NOT exceed `MAX_EXECUTION_TRACE_BYTES`.
-
 ### Manager Interface
 
 `WORLD_CHAIN_ACCOUNT_MANAGER` exposes:
@@ -358,8 +320,6 @@ interface IWorldChainAccountManager {
     function getAuthorizedSessionVerifier(address account, address sessionVerifier) external view returns (SessionVerifier memory);
 }
 ```
-
-The manager MUST expose enough state for txpool revalidation: current active verifier membership, account balance, account transaction nonce, and recent session-verifier revocations that have not aged past `TXPOOL_TRANSACTION_EXPIRATION_WINDOW`.
 
 ### Manager Events
 

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -48,7 +48,7 @@ Default factories that support mutable signer or verifier state must apply the s
 
 ## Specification
 
-The keywords "MUST", "MUST NOT", "SHOULD", and "MAY" are to be interpreted as described in RFC 2119.
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) and [RFC 8174](https://www.rfc-editor.org/rfc/rfc8174).
 
 ### Protocol Constants
 

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -1,38 +1,51 @@
 ---
 wip: 1001
 title: World Chain Native Account Abstraction
-description: A smart contract managed account model with a single admin authority pinned at creation, supporting WorldID, Secp256k1, and P256 admins. Session keys sign EIP-2718 typed transactions (`0x1D`) on the account; admin authorities gate session-key set mutations.
+description: A smart contract managed account model with a single admin authority pinned at creation. Session signers compose a Key Ring that allows for tightly scoped delegated authorizations over the account.
 author: Kilian Glas (@kilianglas), 0xOsiris (@0xOsiris), Eric Woolsey (@0xforerunner)
 status: Draft
 type: Standards Track
 category: Core
 created: 2026-03-27
-requires: EIP-2718, EIP-1559, ERC-4337
+requires: EIP-2, EIP-1559, EIP-196, EIP-197, EIP-198, EIP-2718, EIP-1271, RIP-7212
 ---
 
 ## Abstract
 
-A *World Chain Account* is a precompile-managed account whose 20-byte address is deterministic and lifetime-stable. Each account has a single *admin authority* fixed at creation, which gates mutation of the account's *Keyring* — the set of session keys authorized to sign on its behalf. We extend [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) with a typed transaction envelope (`0x1D`) signed by any session key in a *World Chain Account*'s keyring.
+A *World Chain Account* is a smart contract managed account whose 20-byte address is deterministic and lifetime-stable. Each account has a single *admin authority* fixed at creation, which gates mutation of the account's *Keyring* -- the set of session signers authorized to sign on its behalf. We extend [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) with a typed transaction envelope (`0x1D`) signed by any authorized session signer in a World Chain Account's keyring.
+
+This WIP deliberately minimizes the diff from Ethereum's existing signature model. The protocol recognizes only two session-signer verification modes:
+
+- **Secp256k1 EOA signer.** The `0x1D` transaction carries an Ethereum-style secp256k1 ECDSA signature. Validation recovers an address from the transaction signing hash and requires that address to be authorized in the account keyring.
+- **EIP-1271 contract signer.** The `0x1D` transaction names a contract signer. Validation invokes `isValidSignature(bytes32,bytes)` under a restricted, metered validation frame and requires the EIP-1271 magic value.
+
+Non-ECDSA signature algorithms, including P256, WebAuthn, EdDSA, BLS, and pairing-based proof systems, are not native session-signer types in this WIP. They are implemented by EIP-1271 signer contracts using elliptic-curve and pairing precompiles exposed by the VM. The same precompiles are callable by ordinary smart contracts and by protocol/system validation, avoiding private host-only cryptography.
 
 This WIP specifies three admin authority instantiations:
 
-- **WorldID admin.** Creation gated by a [World ID 4.0](https://github.com/worldcoin/world-id-protocol) Uniqueness Proof; subsequent keyring mutations gated by Session Proofs against a stored `sessionId`. Recovery from lost or compromised session keys is the degenerate case of the same upgrade path, protected by a configurable timelock. A single WorldID `MAY` manage any number of WorldID-admin accounts indexed by a user-chosen `worldIDAccountNonce`; accounts owned by the same WorldID are unlinkable across distinct values.
-- **Secp256k1 admin.** Creation and keyring mutations gated by ECDSA signatures over a uniform `signalHash` from a single secp256k1 admin key fixed at creation. No recovery — admin-key loss is terminal.
-- **P256 admin.** Same shape as Secp256k1 with a P256 (`secp256r1`) admin key.
+- **WorldID admin.** Creation gated by a [World ID 4.0](https://github.com/worldcoin/world-id-protocol) Uniqueness Proof; subsequent keyring mutations gated by Session Proofs against a stored `sessionId`. Recovery from lost or compromised session signers is the degenerate case of the same upgrade path, protected by a configurable timelock. A single WorldID `MAY` manage any number of WorldID-admin accounts indexed by a user-chosen `worldIDAccountNonce`; accounts owned by the same WorldID are unlinkable across distinct values.
+- **Secp256k1 EOA admin.** Creation and keyring mutations gated by Ethereum-style ECDSA signatures over a uniform `signalHash` from a single admin address fixed at creation. Admin-key loss is terminal.
+- **EIP-1271 contract admin.** Creation and keyring mutations gated by `isValidSignature(bytes32,bytes)` on a single contract signer fixed at creation and evaluated under the restricted validation frame. Recovery, if any, is delegated to the signer contract's own policy.
 
-Account state lives natively in the `WORLD_CHAIN_ACCOUNT_PRECOMPILE`. The account address is a public identifier for an admin-authority-managed set of session keys, not an identity anchor; per-instantiation rules govern how many accounts a given admin authority may own.
+Account state lives natively in the `WORLD_CHAIN_ACCOUNT_PRECOMPILE`. The account address is a public identifier for an admin-authority-managed set of session signers, not an identity anchor; per-instantiation rules govern how many accounts a given admin authority may own.
 
 ## Motivation
 
-### Computational Sustainability & World Chain UX
+### Minimal Ethereum Diff
 
-Enshrining smart-account authenticators as protocol-level signature verification algorithms lets us jointly optimize transaction gas, expose a simple multi-auth API over familiar authenticators ([Passkey](https://www.w3.org/TR/webauthn-3/) / [WebAuthn](https://www.w3.org/TR/webauthn-3/), [P256](https://neuromancer.sk/std/nist/P-256), [ECDSA](https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm), [EdDSA](https://en.wikipedia.org/wiki/EdDSA)), minimize confirmation time, and remove the need for bundler infrastructure.
+Ethereum already has one native transaction-signature algorithm and one standard contract-signature interface. WIP-1001 follows that split: native secp256k1 address recovery for EOA-like signers, and [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) for contract signers. The World Chain Account precompile stores authorization state, but it does not grow a bespoke signature-algorithm registry.
+
+This keeps the `0x1D` transaction model close to existing Ethereum validation while still admitting modern authenticators and application-defined signing policies. A passkey, threshold signer, BLS aggregate signer, or Groth16-backed signer is a contract that returns the EIP-1271 magic value after calling public precompiles.
+
+### Reusable Cryptography
+
+Cryptographic accelerators used for account validation should not be protocol-private. If the protocol accepts an elliptic-curve or pairing primitive during EIP-1271 validation, the same primitive MUST be exposed as a normal EVM precompile callable by smart contracts. This lets signer contracts, application contracts, and protocol validation share one compatibility surface.
 
 ### Pluggable Admin Authorities
 
-A pluggable admin model lets a single account abstraction serve multiple user populations from one precompile. **WorldID admin** converges key rotation and recovery onto a single proof-verification path after enrollment: a fresh Session Proof. No "super key" is ever stored on-device; recovery is the degenerate case of the same upgrade path. **Key admin** (Secp256k1 / P256) lets accounts be owned by users without a WorldID, by hot/cold-separated wallets, or by integrations driven by existing key-management infrastructure; the trade-off is that admin-key loss is terminal.
+A pluggable admin model lets a single account abstraction serve multiple user populations from one precompile. **WorldID admin** converges key rotation and recovery onto a single proof-verification path after enrollment: a fresh Session Proof. No "super key" is ever stored on-device; recovery is the degenerate case of the same upgrade path. **Secp256k1 EOA admin** lets accounts be owned by existing Ethereum keys. **EIP-1271 contract admin** lets accounts be controlled by multisigs, passkeys, policy engines, or custom recovery contracts without adding new native admin algorithms to this WIP.
 
-Sharing a single keyring + transaction surface (`0x1D`, session keys, signal binding, timelock) across instantiations means session-key UX and integration surface are uniform regardless of admin type. A new admin instantiation reduces to specifying one verification primitive and one address-derivation rule.
+Sharing a single keyring + transaction surface (`0x1D`, session signers, signal binding, timelock) across instantiations means session-signer UX and integration surface are uniform regardless of admin type. A new non-ECDSA admin scheme reduces to an EIP-1271 contract plus, if needed, a reusable VM precompile.
 
 ## Specification
 
@@ -40,16 +53,38 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Constants
 
-| Name                              | Value                                        | Description                                                 |
-| --------------------------------- | -------------------------------------------- | ----------------------------------------------------------- |
-| `WORLD_TX_TYPE`                   | `0x1D`                                       | [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) tx type |
+| Name                              | Value                                        | Description                                                  |
+| --------------------------------- | -------------------------------------------- | ------------------------------------------------------------ |
+| `WORLD_TX_TYPE`                   | `0x1D`                                       | [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) tx type  |
 | `WORLD_CHAIN_ACCOUNT_PRECOMPILE`  | `0x000000000000000000000000000000000000001D` | Stateful precompile managing the World Chain Account registry |
-| `MAX_SESSION_KEYS`                | `20`                                         | Maximum authorized session keys per account                 |
-| `ADMIN_TYPE_WORLD_ID`             | `0x00`                                       | Admin type discriminator: WorldID admin                     |
-| `ADMIN_TYPE_SECP256K1`            | `0x01`                                       | Admin type discriminator: Secp256k1 admin                   |
-| `ADMIN_TYPE_P256`                 | `0x02`                                       | Admin type discriminator: P256 admin                        |
+| `MAX_SESSION_SIGNERS`             | `20`                                         | Maximum authorized session signers per account               |
+| `ADMIN_TYPE_WORLD_ID`             | `0x00`                                       | Admin type discriminator: WorldID admin                      |
+| `ADMIN_TYPE_SECP256K1_EOA`        | `0x01`                                       | Admin type discriminator: secp256k1 EOA admin                |
+| `ADMIN_TYPE_EIP1271`              | `0x02`                                       | Admin type discriminator: EIP-1271 contract admin            |
+| `SIGNER_TYPE_SECP256K1_EOA`       | `0x00`                                       | Session signer type: Ethereum secp256k1 address              |
+| `SIGNER_TYPE_EIP1271`             | `0x01`                                       | Session signer type: EIP-1271 contract address               |
+| `EIP1271_MAGIC_VALUE`             | `0x1626ba7e`                                 | `bytes4(keccak256("isValidSignature(bytes32,bytes)"))`       |
+| `MAX_EIP1271_VALIDATION_GAS`      | `TBD`                                        | Maximum gas for one protocol EIP-1271 validation frame        |
 
 Per-instantiation constants are defined in their respective sections.
+
+### Reusable Crypto Precompiles
+
+Any cryptographic primitive used by WIP-1001 protocol validation MUST be available through an EVM precompile with the same behavior for smart contracts and protocol/system callers. Implementations MUST NOT validate WIP-1001 EIP-1271 signers with private host functions that are unavailable to contracts.
+
+The validation precompile allowlist initially contains:
+
+| Name              | Address                                      | Purpose                                      |
+| ----------------- | -------------------------------------------- | -------------------------------------------- |
+| `ECRECOVER`       | `0x0000000000000000000000000000000000000001` | Ethereum secp256k1 recovery                  |
+| `SHA256`          | `0x0000000000000000000000000000000000000002` | WebAuthn and other hash-based verification   |
+| `MODEXP`          | `0x0000000000000000000000000000000000000005` | Modular exponentiation ([EIP-198](https://eips.ethereum.org/EIPS/eip-198)) |
+| `BN254_ADD`       | `0x0000000000000000000000000000000000000006` | BN254 G1 addition ([EIP-196](https://eips.ethereum.org/EIPS/eip-196)) |
+| `BN254_MUL`       | `0x0000000000000000000000000000000000000007` | BN254 G1 scalar multiplication ([EIP-196](https://eips.ethereum.org/EIPS/eip-196)) |
+| `BN254_PAIRING`   | `0x0000000000000000000000000000000000000008` | BN254 pairing check ([EIP-197](https://eips.ethereum.org/EIPS/eip-197)) |
+| `P256VERIFY`      | `0x0000000000000000000000000000000000000100` | P256/secp256r1 verification ([RIP-7212](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md)) |
+
+Future curve or pairing systems MAY be added by extending this allowlist in a follow-on fork. EIP-1271 signer contracts that need a non-allowlisted primitive are invalid for WIP-1001 protocol validation until that primitive is exposed as an allowed precompile.
 
 ### Abstract Account Model
 
@@ -59,63 +94,69 @@ An *account* is created by an admin-authorized `Create` operation that fixes an 
 
 Per-account state stored in the precompile:
 
-```
+```solidity
 struct Account {
-    uint8        adminType;             // ADMIN_TYPE_*
-    bytes        verificationPublicId;  // variable length per admin type
-    SessionKey[] sessionKeys;           // see Session Keys
-    uint64       adminNonce;            // monotonic; replay protection
+    uint8       adminType;             // ADMIN_TYPE_*
+    bytes       verificationPublicId;  // variable length per admin type
+    SignerRef[] sessionSigners;        // see Session Signers
+    uint64      adminNonce;            // monotonic; replay protection
     // pendingUpdates: see Timelock
 }
 ```
 
-`verificationPublicId` is the persistent public material the admin authority uses to verify subsequent updates. Its encoding is per-instantiation (e.g., `sessionId` for WorldID admin, a compressed pubkey for Secp256k1 admin). It is set at creation and is not directly mutable by this WIP — see [Extensions](#extensions) for admin rotation.
+`verificationPublicId` is the persistent public material the admin authority uses to verify subsequent updates. Its encoding is per-instantiation (e.g., `sessionId` for WorldID admin, an admin address for Secp256k1 EOA admin, or `(contract, gasLimit)` for EIP-1271 admin). It is set at creation and is not directly mutable by this WIP -- see [Extensions](#extensions) for admin rotation.
+
+#### Session Signers
+
+```solidity
+enum SignerType {
+    Secp256k1EOA,  // 0x00
+    EIP1271        // 0x01
+}
+
+struct SignerRef {
+    SignerType signerType;
+    address    signer;
+    uint32     validationGasLimit;
+}
+```
+
+| `signerType`       | Value  | `signer` meaning                                  | `validationGasLimit`                         |
+| ------------------ | ------ | ------------------------------------------------- | -------------------------------------------- |
+| `Secp256k1EOA`     | `0x00` | Ethereum address recovered from secp256k1 ECDSA   | MUST be `0`                                  |
+| `EIP1271`          | `0x01` | Contract implementing `isValidSignature(bytes32,bytes)` | MUST be `> 0` and `<= MAX_EIP1271_VALIDATION_GAS` |
+
+`signer` MUST NOT be the zero address. For `EIP1271`, `signer` MUST have non-empty code at the time it is added to a keyring or fixed as an admin authority.
+
+Keyring uniqueness is defined by `(signerType, signer)`. A keyring MUST NOT contain two entries with the same `(signerType, signer)`, even if their `validationGasLimit` values differ. Changing an EIP-1271 session signer's gas limit requires removing and re-adding that signer, or a future signer-update operation. A `Remove` operation MUST supply the exact stored `SignerRef`, including `validationGasLimit`, to avoid multiple valid encodings for the same state transition.
+
+Session signers carry no intrinsic privileges beyond signing `0x1D` transactions. Per-signer permissions (expiry, spend limits, call scopes) are out of scope for this WIP (see [Extensions](#extensions)).
 
 #### Admin Authority Interface
 
 The abstract operation each admin authority provides is:
 
-```
-verifyAdmin(signalHash, signature, verificationPublicId) → bool
+```text
+verifyAdmin(signalHash, authorization, verificationPublicId) -> bool
 ```
 
-`signature` and `verificationPublicId` are byte strings whose encoding is per-instantiation. The precompile invokes this operation during `update`. Each instantiation specifies how the operation is realized — see [Admin Instantiations](#admin-instantiations).
+`authorization` and `verificationPublicId` are byte strings whose encoding is per-instantiation. The precompile invokes this operation during `update`. Each instantiation specifies how the operation is realized -- see [Admin Instantiations](#admin-instantiations).
 
-Admin authorization at creation is also instantiation-specific. Some instantiations (key admins) take the address-defining material directly as a creation input that coincides with `verificationPublicId`; others (WorldID admin) take additional address-defining material (a creation nullifier `ν_k`) that is bound by the verifier to `verificationPublicId` (`sessionId`) but stored only as the address — `ν_k` is not retained as account state.
+Admin authorization at creation is also instantiation-specific. Some instantiations take the address-defining material directly as a creation input that coincides with `verificationPublicId`; others (WorldID admin) take additional address-defining material (a creation nullifier) that is bound by the verifier to `verificationPublicId` (`sessionId`) but stored only as the address. The creation nullifier is not retained as account state.
 
 #### Address Derivation
 
-```
+```text
 addr = bytes20(keccak256(abi.encodePacked(adminTypeTag, addressDefiningMaterial)))
 ```
 
 `adminTypeTag` is the one-byte `ADMIN_TYPE_*` discriminator. `addressDefiningMaterial` is per-instantiation:
 
-- WorldID admin: `ν_k`, the creation Uniqueness Proof's nullifier (32 bytes).
-- Secp256k1 admin: the 33-byte compressed admin pubkey (= `verificationPublicId`).
-- P256 admin: the 64-byte uncompressed admin pubkey (= `verificationPublicId`).
+- WorldID admin: the creation Uniqueness Proof's nullifier (32 bytes).
+- Secp256k1 EOA admin: the 20-byte admin address (= `verificationPublicId`).
+- EIP-1271 contract admin: the 20-byte signer contract address.
 
-The address is fixed for the lifetime of the account; session-key rotation does **NOT** change the address.
-
-#### Session Keys
-
-```solidity
-enum KeyType { Secp256k1, P256, WebAuthn, EdDSA }
-
-struct SessionKey {
-    KeyType keyType;
-    bytes   keyData;
-}
-```
-
-| `KeyType`   | Value  | Elliptic Curve                                                                          | `keyData`                                                                                   |
-| ----------- | ------ | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| `Secp256k1` | `0x00` | [secp256k1](https://en.bitcoin.it/wiki/Secp256k1)                                       | 33 bytes — compressed public key                                                            |
-| `P256`      | `0x01` | [secp256r1](https://neuromancer.sk/std/nist/P-256) (NIST P-256)                         | 64 bytes — uncompressed `(x, y)`                                                            |
-| `WebAuthn`  | `0x02` | [secp256r1](https://neuromancer.sk/std/nist/P-256) (NIST P-256)                         | 64 bytes — uncompressed `(x, y)` (P256 under [WebAuthn](https://www.w3.org/TR/webauthn-3/)) |
-| `EdDSA`     | `0x03` | [edwards25519](https://datatracker.ietf.org/doc/html/rfc8032#section-5.1)               | 32 bytes — compressed public key (Ed25519)                                                  |
-
-`KeyType` and `adminType` occupy disjoint domains: their numeric values are defined in different enums and MUST NOT be used interchangeably in the precompile interface or the address-derivation preimage. Session keys carry no intrinsic privileges beyond signing `0x1D` transactions; per-key permissions (expiry, spend limits, call scopes) are out of scope for this WIP (see [Extensions](#extensions)).
+The address is fixed for the lifetime of the account; session-signer rotation does **NOT** change the address.
 
 #### Signal Semantics
 
@@ -123,14 +164,16 @@ struct SessionKey {
 enum UpdateMode { Create, Add, Remove }
 
 struct KeyringUpdate {
-    UpdateMode   mode;
-    SessionKey[] keys;
+    UpdateMode  mode;
+    SignerRef[] signers;
 }
 ```
 
-- **`Create`** — installs `keys` as the full keyring at the account's address and initializes the account with the supplied admin authority. MUST revert if the account already exists, if `keys.length == 0`, or if `keys.length > MAX_SESSION_KEYS`.
-- **`Add`** — appends `keys` to the existing keyring. MUST revert if the account does not exist, if any key is already present, or if the resulting keyring would exceed `MAX_SESSION_KEYS`.
-- **`Remove`** — removes each entry in `keys` from the existing keyring. MUST revert if the account does not exist or if any key is absent. The keyring MAY become empty; an account with zero session keys exists but cannot sign transactions until the next `Add`.
+- **`Create`** -- installs `signers` as the full keyring at the account's address and initializes the account with the supplied admin authority. MUST revert if the account already exists, if `signers.length == 0`, or if `signers.length > MAX_SESSION_SIGNERS`.
+- **`Add`** -- appends `signers` to the existing keyring. MUST revert if the account does not exist, if any signer is already present by `(signerType, signer)`, or if the resulting keyring would exceed `MAX_SESSION_SIGNERS`.
+- **`Remove`** -- removes each entry in `signers` from the existing keyring. MUST revert if the account does not exist, if any signer is absent by `(signerType, signer)`, or if any supplied `SignerRef` does not exactly match the stored entry. The keyring MAY become empty; an account with zero session signers exists but cannot sign transactions until the next `Add`.
+
+For all modes, every `SignerRef` MUST satisfy the validation rules in [Session Signers](#session-signers). An implementation SHOULD validate signer shape, gas limits, zero addresses, duplicate entries, and EIP-1271 code existence before performing expensive admin authorization.
 
 The `signalHash` an admin authority binds to is uniform across instantiations.
 
@@ -150,13 +193,13 @@ struct UpdateSignal {
 }
 ```
 
-```
-signalHash = uint256(keccak256(abi.encode(signal))) >> 8
+```text
+signalHash = bytes32(uint256(keccak256(abi.encode(signal))) >> 8)
 ```
 
-where `signal` is a populated `CreateSignal` for `Create` and an `UpdateSignal` for `Add` / `Remove`.
+where `signal` is a populated `CreateSignal` for `Create` and an `UpdateSignal` for `Add` / `Remove`. The resulting value is encoded as a `bytes32` with its high 8 bits set to zero.
 
-`msgSender` is the EVM `msg.sender` of the precompile call — binding it prevents an in-flight admin authorization observed in the mempool from being replayed by a different submitter. For `Create`, `accountAddress` is omitted because it is not knowable to the admin authority at the time the authorization is produced (it is derived from `Create`'s outputs); the domain tag, `msgSender`, and the keyring payload together suffice to bind the authorization to its intended creation. For updates, `accountAddress` distinguishes admin authorizations across accounts the same admin might control on different domains.
+`msgSender` is the EVM `msg.sender` of the precompile call -- binding it prevents an in-flight admin authorization observed in the mempool from being replayed by a different submitter. For `Create`, `accountAddress` is omitted because it is not knowable to the admin authority at the time the authorization is produced (it is derived from `Create`'s outputs); the domain tag, `msgSender`, and the keyring payload together suffice to bind the authorization to its intended creation. For updates, `accountAddress` distinguishes admin authorizations across accounts the same admin might control on different domains.
 
 The `>> 8` truncation reduces the digest to 248 bits so it fits within the BN254 scalar field (matching the WorldID 4.0 proof system's signal field width). Truncation is uniform across instantiations even when the verification primitive does not require the BN254 fit, so the same `signalHash` value is canonical across all admin types.
 
@@ -166,16 +209,16 @@ The precompile stores a per-account monotonic `adminNonce`, initialized to `0` a
 
 For `Create`, replay is precluded by account-existence: the precompile MUST revert if the account address is already occupied. A creation authorization can only be applied once because the post-condition (account exists at `addr`) blocks any subsequent attempt at the same address.
 
-This is the abstract replay-protection contract; each instantiation realizes it via its own verification primitive. Instantiations MUST NOT introduce additional bespoke replay machinery — `adminNonce` + account-existence is sufficient and uniform.
+This is the abstract replay-protection contract; each instantiation realizes it via its own verification primitive. Instantiations MUST NOT introduce additional bespoke replay machinery -- `adminNonce` + account-existence is sufficient and uniform.
 
 #### Timelock
 
-A compromised admin authority could otherwise rotate session keys in a single block and drain an account. Account updates are subject to a configurable delay:
+A compromised admin authority could otherwise rotate session signers in a single block and drain an account. Account updates are subject to a configurable delay:
 
-- `Create` executes immediately (no prior session keys exist to cancel).
+- `Create` executes immediately (no prior session signers exist to cancel).
 - `Add` and `Remove` are pending until the delay elapses.
-- Existing session keys MAY cancel a pending update during the delay window.
-- The revocation-then-add attack (an admin-authorized update removes all keys, then adds malicious ones with no incumbents left to cancel) MUST be mitigated — e.g., by delaying removals, or by allowing recently-removed keys to cancel pending adds.
+- Existing session signers MAY cancel a pending update during the delay window.
+- The revocation-then-add attack (an admin-authorized update removes all signers, then adds malicious ones with no incumbents left to cancel) MUST be mitigated -- e.g., by delaying removals, or by allowing recently-removed signers to cancel pending adds.
 
 Queue / cancel / execute interface additions are TBD. Timelock semantics apply uniformly across admin instantiations.
 
@@ -201,8 +244,12 @@ interface IWorldChainAccount {
     function getAdminType(address account) external view returns (uint8);
     function getVerificationPublicId(address account) external view returns (bytes memory);
     function getAdminNonce(address account) external view returns (uint64);
-    function getSessionKeys(address account) external view returns (SessionKey[] memory);
-    function isAuthorized(address account, SessionKey calldata key) external view returns (bool);
+    function getSessionSigners(address account) external view returns (SignerRef[] memory);
+    function isAuthorized(address account, uint8 signerType, address signer) external view returns (bool);
+    function getAuthorizedSigner(address account, uint8 signerType, address signer)
+        external
+        view
+        returns (SignerRef memory);
 }
 ```
 
@@ -211,24 +258,117 @@ interface IWorldChainAccount {
 For `create`, the precompile MUST:
 
 1. Require `keyringUpdate.mode == Create`.
-2. Decode `adminCreationData` per the instantiation specified by `adminType`.
-3. Recompute the `Create` `signalHash` over `(msg.sender, keyringUpdate)`.
-4. Verify the admin authorization per the instantiation, against `signalHash` and the instantiation's `verificationPublicId` (or, for WorldID admin, the equivalent verifier public-input set).
-5. Determine `addressDefiningMaterial` per the instantiation (directly from `adminCreationData` for key admins; from the proof's `ν_k` public input for WorldID admin).
-6. Derive `accountAddress = bytes20(keccak256(abi.encodePacked(adminTypeTag, addressDefiningMaterial)))`.
-7. Require the account does not already exist at `accountAddress`.
-8. Initialize the account: store `adminType`, `verificationPublicId`, `sessionKeys = keyringUpdate.keys`, `adminNonce = 0`.
+2. Validate all `keyringUpdate.signers` and keyring-size constraints.
+3. Decode `adminCreationData` per the instantiation specified by `adminType`.
+4. Recompute the `Create` `signalHash` over `(msg.sender, keyringUpdate)`.
+5. Verify the admin authorization per the instantiation, against `signalHash` and the instantiation's `verificationPublicId` (or, for WorldID admin, the equivalent verifier public-input set).
+6. Determine `addressDefiningMaterial` per the instantiation.
+7. Derive `accountAddress = bytes20(keccak256(abi.encodePacked(adminTypeTag, addressDefiningMaterial)))`.
+8. Require the account does not already exist at `accountAddress`.
+9. Initialize the account: store `adminType`, `verificationPublicId`, `sessionSigners = keyringUpdate.signers`, `adminNonce = 0`.
 
 For `update`, the precompile MUST:
 
 1. Require `keyringUpdate.mode != Create`.
-2. Load the account's stored `adminType`, `verificationPublicId`, and `adminNonce`.
-3. Recompute the `Update` `signalHash` over `(accountAddress, adminNonce, msg.sender, keyringUpdate)`.
-4. Verify `adminAuthorization` per `adminType` against `signalHash` and `verificationPublicId`.
-5. Increment `adminNonce`.
-6. Apply `keyringUpdate`, queued behind the timelock.
+2. Validate all `keyringUpdate.signers` and mode-specific keyring constraints.
+3. Load the account's stored `adminType`, `verificationPublicId`, and `adminNonce`.
+4. Recompute the `Update` `signalHash` over `(accountAddress, adminNonce, msg.sender, keyringUpdate)`.
+5. Verify `adminAuthorization` per `adminType` against `signalHash` and `verificationPublicId`.
+6. Increment `adminNonce`.
+7. Apply `keyringUpdate`, queued behind the timelock.
 
-> **Note — Precompile gas accounting out of scope.** The specific gas pricing schedule for interacting with `WORLD_CHAIN_ACCOUNT_PRECOMPILE` — covering admin verification cost (Groth16 / ECDSA / P256), per-session-key storage mutation, timelock queue/cancel/execute operations, and the amortized cost of `isAuthorized` reads during `0x1D` validation — is **NOT** defined here. A follow-on revision MUST specify gas costs per operation per admin type.
+> **Note -- Precompile gas accounting out of scope.** The full gas pricing schedule for interacting with `WORLD_CHAIN_ACCOUNT_PRECOMPILE` -- covering admin verification cost, per-session-signer storage mutation, timelock queue/cancel/execute operations, and the amortized cost of reads during `0x1D` validation -- is **NOT** fully defined here. A follow-on revision MUST specify gas costs per operation. EIP-1271 validation gas is separately constrained by [Restricted EIP-1271 Validation Frame](#restricted-eip-1271-validation-frame).
+
+### Restricted EIP-1271 Validation Frame
+
+Protocol EIP-1271 validation is intentionally narrower than an ordinary EVM `STATICCALL`. Normal smart contracts MAY call any EIP-1271 implementation according to Ethereum rules, but WIP-1001 protocol validation of an EIP-1271 session signer or EIP-1271 admin MUST execute in a restricted validation frame.
+
+The goal is:
+
+```text
+protocol -> EIP-1271 signer contract -> allowlisted crypto precompiles only
+```
+
+There MUST NOT be an arbitrary EVM-to-EVM call graph during signature validation.
+
+#### Entry Call
+
+For a signer contract `signer`, hash `hash`, signature bytes `signature`, and stored gas limit `validationGasLimit`, the protocol invokes:
+
+```solidity
+IERC1271(signer).isValidSignature(hash, signature)
+```
+
+with:
+
+- call type: `STATICCALL` semantics;
+- `CALLER`: `WORLD_CHAIN_ACCOUNT_PRECOMPILE`;
+- `ADDRESS`: `signer`;
+- `CALLVALUE`: `0`;
+- gas: exactly `validationGasLimit`;
+- calldata: `IERC1271.isValidSignature.selector || abi.encode(hash, signature)`;
+- success condition: the call succeeds and returns ABI-encoded `bytes4(EIP1271_MAGIC_VALUE)`.
+
+If the call reverts, runs out of gas, executes a forbidden opcode, calls a forbidden address, returns malformed data, or returns any value other than `EIP1271_MAGIC_VALUE`, the signature is invalid.
+
+`validationGasLimit` is always loaded from account state:
+
+- for EIP-1271 session signers, from the stored `SignerRef`;
+- for EIP-1271 admins, from the stored `verificationPublicId`.
+
+A `0x1D` transaction MUST NOT choose or override EIP-1271 validation gas. The gas consumed by session-signer validation MUST be metered against the transaction's gas limit before execution of the transaction payload. Admin validation gas is metered against the EVM call to `create` or `update`.
+
+#### Call-Depth and Call-Target Rules
+
+During the restricted validation frame:
+
+- `STATICCALL` to an address in the validation precompile allowlist is permitted.
+- `STATICCALL` to any non-allowlisted address is forbidden.
+- `CALL`, `CALLCODE`, `DELEGATECALL`, `CREATE`, and `CREATE2` are forbidden.
+- Precompile execution does not introduce an additional EVM-code frame for purposes of this rule.
+
+Therefore a protocol-valid EIP-1271 signer contract MUST be self-contained except for direct calls to allowed precompiles. Proxy patterns, module systems, and library dispatch through `DELEGATECALL` are invalid in the restricted frame unless a future WIP relaxes this rule.
+
+#### Opcode Policy
+
+The restricted validation frame permits deterministic computation, calldata/memory access, own-code access, own-storage reads, `KECCAK256`, `CHAINID`, `GAS`, and `STATICCALL` to allowed precompiles. `GAS` is permitted because the frame starts with a fixed stored `validationGasLimit` rather than transaction-selected gas.
+
+The following opcodes are forbidden if executed in the restricted validation frame:
+
+```text
+BLOCKHASH
+COINBASE
+TIMESTAMP
+NUMBER
+PREVRANDAO / DIFFICULTY
+GASLIMIT
+BASEFEE
+BLOBHASH
+BLOBBASEFEE
+GASPRICE
+ORIGIN
+BALANCE
+SELFBALANCE
+EXTCODESIZE
+EXTCODECOPY
+EXTCODEHASH
+SSTORE
+TLOAD
+TSTORE
+LOG0
+LOG1
+LOG2
+LOG3
+LOG4
+CALL
+CALLCODE
+DELEGATECALL
+CREATE
+CREATE2
+SELFDESTRUCT
+```
+
+This list removes block-context, transaction-context, external-state, transient-state, logging, mutation, and arbitrary call-depth dependencies from protocol signature validation. EIP-1271 validity MAY depend on the signer contract's own persistent storage via `SLOAD`; this is the intentional stateful policy surface of contract signatures.
 
 ### Admin Instantiations
 
@@ -242,7 +382,7 @@ Each instantiation specifies:
 6. The verification primitive.
 7. Recovery semantics.
 
-Future instantiations (EdDSA, WebAuthn-as-admin, EIP-1271 contract admins, multi-sig) slot in as additional sub-sections without changing the abstract account model.
+Additional non-ECDSA admin schemes SHOULD be implemented as EIP-1271 contract admins backed by reusable precompiles, rather than as new native admin types.
 
 #### WorldID Admin
 
@@ -250,17 +390,17 @@ Future instantiations (EdDSA, WebAuthn-as-admin, EIP-1271 contract admins, multi
 
 Per-instantiation constants:
 
-| Name                          | Value                                        | Description                                                    |
-| ----------------------------- | -------------------------------------------- | -------------------------------------------------------------- |
-| `WORLD_CHAIN_RP_ID`           | `480`                                        | World Chain's registered RP ID                                 |
-| `WORLD_ID_ACCOUNT_TAG`        | `"WORLD_ID_ACCOUNT"` (UTF-8, 16 bytes)       | Domain tag for WorldID-admin account creation actions          |
+| Name                          | Value                                        | Description                                           |
+| ----------------------------- | -------------------------------------------- | ----------------------------------------------------- |
+| `WORLD_CHAIN_RP_ID`           | `480`                                        | World Chain's registered RP ID                        |
+| `WORLD_ID_ACCOUNT_TAG`        | `"WORLD_ID_ACCOUNT"` (UTF-8, 16 bytes)       | Domain tag for WorldID-admin account creation actions |
 
 `verificationPublicId` is `sessionId` (uint256), provisioned by the caller at creation and supplied by the WorldID authenticator via OPRF.
 
-Address-defining material is `ν_k`, the creation Uniqueness Proof's nullifier:
+Address-defining material is the creation Uniqueness Proof's nullifier:
 
-```
-addr = bytes20(keccak256(abi.encodePacked(ADMIN_TYPE_WORLD_ID, ν_k)))
+```text
+addr = bytes20(keccak256(abi.encodePacked(ADMIN_TYPE_WORLD_ID, worldIDAccountNullifier)))
 ```
 
 A single WorldID `MAY` manage any number of WorldID-admin accounts by variation over a user-chosen `worldIDAccountNonce`; accounts owned by the same WorldID are unlinkable across distinct values by the ZK property of the OPRF proof.
@@ -269,9 +409,9 @@ A single WorldID `MAY` manage any number of WorldID-admin accounts by variation 
 
 `adminCreationData` layout (conceptual; ABI-encoded as a tuple):
 
-```
-WorldIDAdminCreationData {
-    uint256       worldIDAccountNullifier;      // ν_k (public input to verify)
+```solidity
+struct WorldIDAdminCreationData {
+    uint256       worldIDAccountNullifier;      // creation nullifier, public verifier input
     uint256       worldIDAccountNonce;          // recomputed into action
     uint256       sessionId;                    // freshly provisioned by authenticator
     uint256       proofNonce;                   // verifier request nonce
@@ -293,19 +433,19 @@ Creation flow:
 1. Decode `adminCreationData`.
 2. Compute `action`.
 3. Recompute the `Create` `signalHash` over `(msg.sender, keyringUpdate)`.
-4. Invoke `WorldID.verify(worldIDAccountNullifier, action, WORLD_CHAIN_RP_ID, proofNonce, signalHash, issuerSchemaId, expiresAtMin, credentialGenesisIssuedAtMin, proof)`. The verifier asserts the proof commits to the supplied `(ν_k, action, signalHash)` tuple under the relying party's public inputs.
+4. Invoke `WorldID.verify(worldIDAccountNullifier, action, WORLD_CHAIN_RP_ID, proofNonce, signalHash, issuerSchemaId, expiresAtMin, credentialGenesisIssuedAtMin, proof)`. The verifier asserts the proof commits to the supplied `(worldIDAccountNullifier, action, signalHash)` tuple under the relying party's public inputs.
 5. Set `addressDefiningMaterial = worldIDAccountNullifier` and derive `addr` per the abstract address formula.
 6. Require account does not exist at `addr`.
-7. Store `adminType = ADMIN_TYPE_WORLD_ID`, `verificationPublicId = abi.encode(sessionId)`, `sessionKeys = keyringUpdate.keys`, `adminNonce = 0`.
+7. Store `adminType = ADMIN_TYPE_WORLD_ID`, `verificationPublicId = abi.encode(sessionId)`, `sessionSigners = keyringUpdate.signers`, `adminNonce = 0`.
 
-The creation nullifier `ν_k` is consumed once to instantiate the account. Because WorldID authenticators do not issue the same `(rpId, action)` nullifier twice, a later mutation MUST NOT attempt to reuse the creation action. `ν_k` is not retained as account state after creation — its only role is address derivation, which is reproducible from any subsequent update's calldata via the precompile's stored `addr`.
+The creation nullifier is consumed once to instantiate the account. Because WorldID authenticators do not issue the same `(rpId, action)` nullifier twice, a later mutation MUST NOT attempt to reuse the creation action. The nullifier is not retained as account state after creation -- its only role is address derivation, which is reproducible from any subsequent update's calldata via the precompile's stored `addr`.
 
 ##### Updates
 
 `adminAuthorization` layout (conceptual; ABI-encoded as a tuple):
 
-```
-WorldIDAdminAuth {
+```solidity
+struct WorldIDAdminAuth {
     uint256    proofNonce;
     uint64     issuerSchemaId;
     uint64     expiresAtMin;
@@ -315,7 +455,7 @@ WorldIDAdminAuth {
 }
 ```
 
-Update flow (realizes the abstract `update` MUST list):
+Update flow:
 
 1. Decode `verificationPublicId` to recover `sessionId`.
 2. Recompute the `Update` `signalHash` over `(accountAddress, adminNonce, msg.sender, keyringUpdate)`.
@@ -330,144 +470,142 @@ A Session Proof proves that the caller controls the same WorldID that previously
 
 ##### OPRF Nullifier Proof Primer
 
-An `OPRFNullifierProof` is a [Groth16](https://eprint.iacr.org/2016/260) proof over [BN254](https://hackmd.io/@jpw/bn254) submitted on-chain as `uint256[5] = [a, b₀, b₁, c, merkle_root]`. The `WorldIDVerifier` reconstructs the 15 public inputs from calldata and on-chain registry lookups (notably `merkle_root` via `WorldIDRegistry.isValidRoot()` and `oprfPublicKey` via `OprfKeyRegistry[rpId]`) and invokes the Groth16 verifier.
+An `OPRFNullifierProof` is a [Groth16](https://eprint.iacr.org/2016/260) proof over [BN254](https://hackmd.io/@jpw/bn254) submitted on-chain as `uint256[5] = [a, b0, b1, c, merkle_root]`. The `WorldIDVerifier` reconstructs the public inputs from calldata and on-chain registry lookups (notably `merkle_root` via `WorldIDRegistry.isValidRoot()` and `oprfPublicKey` via `OprfKeyRegistry[rpId]`) and invokes the Groth16 verifier. The Groth16 verifier MUST ultimately use the same BN254 precompiles exposed to smart contracts.
 
-The circuit proves knowledge of a private witness $w = (s, k, p, \beta, R_{\mathrm{oprf}}, \mathit{cred}, \sigma_{\mathit{cred}})$ satisfying:
+The circuit proves knowledge of a private witness satisfying:
 
-- **(G1) Merkle membership.** The authenticator key $k$ is a leaf in the `WorldIDRegistry` tree at the declared root.
-- **(G2) Credential validity.** $\mathit{cred}$ bears a valid EdDSA-Poseidon2 signature over [BabyJubJub](https://eips.ethereum.org/EIPS/eip-2494) from the issuer identified by `issuerSchemaId`, and has not expired.
-- **(G3) OPRF correctness.** The OPRF response $R_{\mathrm{oprf}}$ was evaluated under the registered key for `rpId`, with a DLog equality proof binding blinded and unblinded responses.
-- **(G4) Deterministic nullifier derivation.**
+- **Merkle membership.** The authenticator key is a leaf in the `WorldIDRegistry` tree at the declared root.
+- **Credential validity.** The credential bears a valid EdDSA-Poseidon2 signature over BabyJubJub from the issuer identified by `issuerSchemaId`, and has not expired.
+- **OPRF correctness.** The OPRF response was evaluated under the registered key for `rpId`, with a DLog equality proof binding blinded and unblinded responses.
+- **Deterministic nullifier derivation.** The nullifier is deterministic per `(identity, rpId, action)`, regardless of blinding factor or proof randomness.
+- **Signal binding.** The `signalHash` is constrained in the circuit, preventing a proof from being reused with a different signal.
 
-$$q = \mathrm{Poseidon2}(\text{"World ID Query"}, \; i, \; \mathrm{rpId}, \; a)$$
-
-$$\nu = \mathrm{Poseidon2}(\text{"World ID Proof"}, \; q, \; R_{\mathrm{oprf}}.x, \; R_{\mathrm{oprf}}.y)$$
-
-  $\nu$ is deterministic per $(i, \mathrm{rpId}, a)$: the same identity proving under the same $(\mathrm{rpId}, a)$ always yields the same $\nu$, regardless of blinding factor $\beta$ or proof randomness.
-
-- **(G5) Signal binding.** The `signalHash` is "dummy-squared" in the circuit (constrained to $h \cdot h = h^2$), preventing a proof from being reused with a different signal.
-
-For account creation, **(G4)** binds $\nu_k$ to the triple (owner leaf, `WORLD_CHAIN_RP_ID`, `action(worldIDAccountNonce)`) — making `worldIDAccountNonce` the sole account selector per identity — and **(G5)** binds the Uniqueness Proof to the exact `Create` payload it authorizes. For later updates, `verifySession` binds the proof to the account's stored `sessionId`; the accompanying `sessionNullifier` is a per-proof verifier input rather than persistent account state.
+For account creation, deterministic nullifier derivation binds the creation nullifier to the tuple (owner leaf, `WORLD_CHAIN_RP_ID`, `action(worldIDAccountNonce)`) -- making `worldIDAccountNonce` the sole account selector per identity -- and signal binding binds the Uniqueness Proof to the exact `Create` payload it authorizes. For later updates, `verifySession` binds the proof to the account's stored `sessionId`; the accompanying `sessionNullifier` is a per-proof verifier input rather than persistent account state.
 
 ##### Recovery
 
-Recovery is the degenerate case of an `Add` or `Remove` submitted after session keys are lost or compromised. Because post-creation authorization is a Session Proof bound to the account's stored `sessionId`, recovery requires only a fresh Session Proof — the full session-key surface is reachable via the same mutation path. No separate recovery flow or state is introduced.
+Recovery is the degenerate case of an `Add` or `Remove` submitted after session signers are lost or compromised. Because post-creation authorization is a Session Proof bound to the account's stored `sessionId`, recovery requires only a fresh Session Proof -- the full session-signer surface is reachable via the same mutation path. No separate recovery flow or state is introduced.
 
 A single WorldID MAY enable recovery for any number of WorldID-admin accounts; accounts at distinct `worldIDAccountNonce` values remain unlinkable across the recovery event.
 
-#### Secp256k1 Admin
+#### Secp256k1 EOA Admin
 
-`adminType = ADMIN_TYPE_SECP256K1 = 0x01`.
+`adminType = ADMIN_TYPE_SECP256K1_EOA = 0x01`.
 
-`verificationPublicId` is the 33-byte compressed secp256k1 admin public key. Address-defining material is the same key:
+`verificationPublicId` is the 20-byte Ethereum admin address. Address-defining material is the same address:
 
+```text
+addr = bytes20(keccak256(abi.encodePacked(ADMIN_TYPE_SECP256K1_EOA, adminAddress)))
 ```
-addr = bytes20(keccak256(abi.encodePacked(ADMIN_TYPE_SECP256K1, adminPubkey)))
-```
 
-One admin key controls exactly one Secp256k1-admin account address.
+One admin address controls exactly one Secp256k1-EOA-admin account address.
 
 ##### Creation
 
 `adminCreationData` layout (conceptual):
 
-```
-Secp256k1AdminCreationData {
-    bytes adminPubkey;    // 33 bytes — compressed secp256k1 pubkey
-    bytes ecdsaSig;       // (r, s, v) over signalHash
+```solidity
+struct Secp256k1EOAAdminCreationData {
+    address adminAddress;
+    bytes   ecdsaSig;       // rlp([y_parity, r, s]) over signalHash
 }
 ```
 
 Creation flow:
 
-1. Decode `adminPubkey` and `ecdsaSig`.
+1. Decode `adminAddress` and `ecdsaSig`.
 2. Recompute the `Create` `signalHash` over `(msg.sender, keyringUpdate)`.
-3. Verify `ecdsaSig` is a valid secp256k1 ECDSA signature over `signalHash` for the public key `adminPubkey`. Implementations MUST enforce low-`s` to reject malleable signatures.
-4. Set `addressDefiningMaterial = adminPubkey` and derive `addr` per the abstract address formula.
-5. Require account does not exist at `addr`.
-6. Store `adminType = ADMIN_TYPE_SECP256K1`, `verificationPublicId = adminPubkey`, `sessionKeys = keyringUpdate.keys`, `adminNonce = 0`.
+3. Decode `ecdsaSig` as `rlp([y_parity, r, s])`.
+4. Recover the Ethereum address from `ecdsaSig` over `signalHash`; require it equals `adminAddress`. Implementations MUST enforce Ethereum's [low-`s` rule](https://eips.ethereum.org/EIPS/eip-2) for consensus signatures.
+5. Set `addressDefiningMaterial = adminAddress` and derive `addr` per the abstract address formula.
+6. Require account does not exist at `addr`.
+7. Store `adminType = ADMIN_TYPE_SECP256K1_EOA`, `verificationPublicId = abi.encode(adminAddress)`, `sessionSigners = keyringUpdate.signers`, `adminNonce = 0`.
 
 ##### Updates
 
-`adminAuthorization` is the byte-encoding of a single secp256k1 ECDSA signature `(r, s, v)` over the `Update` `signalHash`.
+`adminAuthorization` is `rlp([y_parity, r, s])` for a single secp256k1 ECDSA signature over the `Update` `signalHash`.
 
 Update flow:
 
-1. Load `adminPubkey` from `verificationPublicId` and `adminNonce`.
+1. Load `adminAddress` from `verificationPublicId` and `adminNonce`.
 2. Recompute the `Update` `signalHash` over `(accountAddress, adminNonce, msg.sender, keyringUpdate)`.
-3. Verify the signature is valid for `(signalHash, adminPubkey)`; enforce low-`s`.
-4. Increment `adminNonce`.
-5. Apply `keyringUpdate`, queued behind the timelock.
+3. Decode `adminAuthorization` as `rlp([y_parity, r, s])`.
+4. Recover the Ethereum address from the signature; require it equals `adminAddress`; enforce low-`s`.
+5. Increment `adminNonce`.
+6. Apply `keyringUpdate`, queued behind the timelock.
 
 ##### Recovery
 
-**Not supported.** Loss of the admin key is terminal — the account's keyring can no longer be mutated. Users who require recoverability MUST choose a WorldID-admin account.
+**Not supported by WIP-1001.** Loss of the admin key is terminal -- the account's keyring can no longer be mutated. Users who require protocol-level recovery SHOULD choose a WorldID-admin account or an EIP-1271 admin whose contract policy includes recovery.
 
-#### P256 Admin
+#### EIP-1271 Contract Admin
 
-`adminType = ADMIN_TYPE_P256 = 0x02`.
+`adminType = ADMIN_TYPE_EIP1271 = 0x02`.
 
-`verificationPublicId` is the 64-byte uncompressed P256 (`secp256r1`) admin public key, encoding `(x, y)` as 32-byte big-endian coordinates concatenated. Address-defining material is the same key:
+`verificationPublicId` is `abi.encode(address signer, uint32 validationGasLimit)`. Address-defining material is the 20-byte signer contract address:
 
+```text
+addr = bytes20(keccak256(abi.encodePacked(ADMIN_TYPE_EIP1271, signer)))
 ```
-addr = bytes20(keccak256(abi.encodePacked(ADMIN_TYPE_P256, adminPubkey)))
-```
 
-One admin key controls exactly one P256-admin account address.
+One signer contract address controls exactly one EIP-1271-admin account address. The `validationGasLimit` is fixed at creation and used for all future admin validations.
 
 ##### Creation
 
 `adminCreationData` layout (conceptual):
 
-```
-P256AdminCreationData {
-    bytes adminPubkey;    // 64 bytes — uncompressed P256 pubkey (x || y)
-    bytes p256Sig;        // (r, s) over signalHash
+```solidity
+struct EIP1271AdminCreationData {
+    address signer;
+    uint32  validationGasLimit;
+    bytes   signature;             // EIP-1271 signature over signalHash
 }
 ```
 
 Creation flow:
 
-1. Decode `adminPubkey` and `p256Sig`.
-2. Recompute the `Create` `signalHash`.
-3. Verify `p256Sig` is a valid P256 ECDSA signature over `signalHash` for the public key `adminPubkey`, via the [RIP-7212](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md) precompile or equivalent host function. Implementations MUST reject off-curve points and enforce low-`s`.
-4. Set `addressDefiningMaterial = adminPubkey` and derive `addr` per the abstract address formula.
-5. Require account does not exist at `addr`.
-6. Store `adminType = ADMIN_TYPE_P256`, `verificationPublicId = adminPubkey`, `sessionKeys = keyringUpdate.keys`, `adminNonce = 0`.
+1. Decode `signer`, `validationGasLimit`, and `signature`.
+2. Require `signer` has non-empty code.
+3. Require `validationGasLimit > 0 && validationGasLimit <= MAX_EIP1271_VALIDATION_GAS`.
+4. Recompute the `Create` `signalHash` over `(msg.sender, keyringUpdate)`.
+5. Run the restricted EIP-1271 validation frame against `signer` with `(hash = signalHash, signature, validationGasLimit)`.
+6. Set `addressDefiningMaterial = signer` and derive `addr` per the abstract address formula.
+7. Require account does not exist at `addr`.
+8. Store `adminType = ADMIN_TYPE_EIP1271`, `verificationPublicId = abi.encode(signer, validationGasLimit)`, `sessionSigners = keyringUpdate.signers`, `adminNonce = 0`.
 
 ##### Updates
 
-`adminAuthorization` is the byte-encoding of a P256 ECDSA signature `(r, s)` over the `Update` `signalHash`.
+`adminAuthorization` is the opaque EIP-1271 signature bytes passed to the stored signer contract.
 
 Update flow:
 
-1. Load `adminPubkey` from `verificationPublicId` and `adminNonce`.
-2. Recompute the `Update` `signalHash`.
-3. Verify the signature is valid for `(signalHash, adminPubkey)`; enforce low-`s`.
+1. Decode `(signer, validationGasLimit)` from `verificationPublicId`.
+2. Recompute the `Update` `signalHash` over `(accountAddress, adminNonce, msg.sender, keyringUpdate)`.
+3. Run the restricted EIP-1271 validation frame against `signer` with `(hash = signalHash, signature = adminAuthorization, validationGasLimit)`.
 4. Increment `adminNonce`.
 5. Apply `keyringUpdate`, queued behind the timelock.
 
 ##### Recovery
 
-**Not supported.** Same warning as Secp256k1 admin.
+WIP-1001 does not define a separate recovery path for EIP-1271-admin accounts. Recovery, signer rotation, quorum changes, passkey replacement, or social recovery MAY be implemented inside the signer contract's own state and policy. If the signer contract can no longer return the EIP-1271 magic value under the restricted validation frame, the account's keyring can no longer be mutated.
 
 ### Recovery
 
 Recovery semantics are per-instantiation:
 
-- **WorldID admin.** Recovery is the degenerate case of an `Add` or `Remove` submitted via Session Proof — see the WorldID admin instantiation. Lost or compromised session keys are recovered by any fresh Session Proof bound to the account's stored `sessionId`.
-- **Secp256k1 admin.** **NOT supported.** Loss of the admin key is terminal.
-- **P256 admin.** **NOT supported.** Loss of the admin key is terminal.
+- **WorldID admin.** Recovery is the degenerate case of an `Add` or `Remove` submitted via Session Proof -- see the WorldID admin instantiation. Lost or compromised session signers are recovered by any fresh Session Proof bound to the account's stored `sessionId`.
+- **Secp256k1 EOA admin.** **NOT supported by WIP-1001.** Loss of the admin key is terminal.
+- **EIP-1271 contract admin.** Delegated to the signer contract's own policy. WIP-1001 only checks whether the fixed signer contract returns the EIP-1271 magic value under the restricted validation frame.
 
-Users requiring recoverability MUST choose the WorldID admin instantiation.
+Users requiring protocol-level recovery SHOULD choose the WorldID admin instantiation. Users requiring application-defined recovery MAY choose an EIP-1271 admin, subject to the restricted-frame constraints.
 
 ### Transaction Type `0x1D`
 
-A `0x1D` transaction is signed by a session key of a World Chain Account and submitted directly to the mempool (no [ERC-4337](https://eips.ethereum.org/EIPS/eip-4337) bundler required). `0x1D` transactions are admin-type-agnostic: they are signed by session keys regardless of which admin authority controls the account, and the validation path reads only the account's keyring.
+A `0x1D` transaction is signed by a session signer of a World Chain Account and submitted directly to the mempool (no [ERC-4337](https://eips.ethereum.org/EIPS/eip-4337) bundler required). `0x1D` transactions are admin-type-agnostic: they are signed by session signers regardless of which admin authority controls the account, and the validation path reads only the account's keyring.
 
 #### Envelope
 
-```
+```text
 0x1D || rlp([
     chain_id,                    // 0
     nonce,                       // 1
@@ -478,102 +616,131 @@ A `0x1D` transaction is signed by a session key of a World Chain Account and sub
     value,                       // 6
     data,                        // 7
     access_list,                 // 8
-    account,                     // 9   ← signer's World Chain Account address
-    signature_type,              // 10
-    session_key,                 // 11  ← `keyData` of the signing session key (per §Session Keys)
+    account,                     // 9   -- signer's World Chain Account address
+    signer_type,                 // 10  -- SIGNER_TYPE_*
+    signer,                      // 11  -- 20-byte session signer address
     signature_payload,           // 12
 ])
 ```
 
-```
+```text
 signing_hash = keccak256(0x1D || rlp(fields[0..=11]))
 ```
 
-The `signing_hash` covers every field except `signature_payload` itself, binding the declared `signature_type` and `session_key` to the signature and ruling out scheme-confusion or pubkey-substitution attacks at the consensus layer.
+The `signing_hash` covers every field except `signature_payload` itself, binding the declared `signer_type` and `signer` to the signature and ruling out scheme-confusion or signer-substitution attacks at the consensus layer.
 
-`session_key` is the `keyData` bytes of the `SessionKey` (§Session Keys) used to authenticate the transaction. Its `KeyType` is implied by `signature_type` — implementations MUST reject any transaction where the length of `session_key` does not match the byte length specified for the corresponding `KeyType`.
+| `signer_type`                  | `signature_payload`                                      |
+| ------------------------------ | -------------------------------------------------------- |
+| `0x00` `Secp256k1EOA`          | `rlp([y_parity, r, s])`                                  |
+| `0x01` `EIP1271`               | Opaque bytes passed unchanged as EIP-1271 `_signature`   |
 
-| `signature_type`                                         | `signature_payload`                                 |
-| -------------------------------------------------------- | --------------------------------------------------- |
-| `0x00` [Secp256k1](https://en.bitcoin.it/wiki/Secp256k1) | `rlp([y_parity, r, s])`                             |
-| `0x01` [P256](https://neuromancer.sk/std/nist/P-256)     | `rlp([r, s])`                                       |
-| `0x02` [WebAuthn](https://www.w3.org/TR/webauthn-3/)     | `rlp([authenticator_data, client_data_json, r, s])` |
-| `0x03` [EdDSA](https://en.wikipedia.org/wiki/EdDSA)      | `rlp([R, s])`                                       |
+For `Secp256k1EOA`, implementations MUST enforce the Ethereum [low-`s` rule](https://eips.ethereum.org/EIPS/eip-2) and MUST reject signatures whose recovered address does not equal the declared `signer`.
 
-For `Secp256k1`, the `session_key` field is redundant with the recoverable public key; implementations MUST verify the recovered key matches the declared `session_key` (compressed-form encoding) before accepting the transaction.
+For `EIP1271`, `signature_payload` is not interpreted by the protocol except as bytes supplied to `isValidSignature(signing_hash, signature_payload)`.
 
 #### Validation
 
-1. Verify `signature_payload` against `signing_hash` using `session_key` as the verifying key (for `Secp256k1`, equivalently: recover and assert equality with `session_key`).
-2. Assert `IWorldChainAccount.isAuthorized(account, SessionKey { signature_type, session_key })`.
+The protocol MUST validate a `0x1D` transaction as follows:
+
+1. Compute `signing_hash`.
+2. Load the account's keyring entry for `(signer_type, signer)`.
+3. Reject if no matching authorized session signer exists.
+4. If `signer_type == SIGNER_TYPE_SECP256K1_EOA`, verify `signature_payload` by Ethereum secp256k1 recovery over `signing_hash` and require the recovered address equals `signer`.
+5. If `signer_type == SIGNER_TYPE_EIP1271`, run the restricted EIP-1271 validation frame against `signer` with `(hash = signing_hash, signature = signature_payload, validationGasLimit = stored SignerRef.validationGasLimit)`.
+
+Authorization is checked before EIP-1271 execution so an attacker cannot use an unauthorized `0x1D` transaction to force arbitrary contract validation work.
 
 The envelope is extensible to 2D nonces, batched transactions, and native paymaster support in follow-on WIPs.
 
 ### Extensions
 
-- **Per-key permissions.** Session keys MAY be extended with `(expiry, spendLimit, CallScope[])` metadata enforced by the precompile during `0x1D` validation. This extends `SessionKey` and the `KeyringUpdate` signal; the admin authorization continues to bind the full permission set via `signalHash`.
-- **Admin rotation.** Replacing an account's stored `verificationPublicId` (or `adminType`) under admin authorization, with timelock. Deferred — admin type and authority are pinned at creation in this WIP.
-- **Multi-admin.** M-of-N admin authorization for a single account. Deferred.
-- **Additional admin instantiations.** EdDSA-admin, WebAuthn-as-admin, [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271)-admin (contract-controlled accounts).
-- **WorldID-recovery escape hatch for key-admin accounts.** A Secp256k1 / P256 admin account MAY enroll a WorldID at creation as a recovery-only authority that, after a long timelock, can rotate the admin key.
+- **Per-signer permissions.** Session signers MAY be extended with `(expiry, spendLimit, CallScope[])` metadata enforced by the precompile during `0x1D` validation. This extends `SignerRef` and the `KeyringUpdate` signal; the admin authorization continues to bind the full permission set via `signalHash`.
+- **Admin rotation.** Replacing an account's stored `verificationPublicId` (or `adminType`) under admin authorization, with timelock. Deferred -- admin type and authority are pinned at creation in this WIP.
+- **Multi-admin.** M-of-N admin authorization for a single account. Deferred. Most near-term multi-admin policies SHOULD be represented as EIP-1271 contract admins.
+- **Additional crypto precompiles.** BLS12-381, Ed25519, secp256k1 verification without recovery, or other primitives MAY be added as VM precompiles. Once allowlisted for the restricted validation frame, EIP-1271 signer contracts can use them without changing the `0x1D` envelope.
+- **WorldID-recovery escape hatch for EOA-admin accounts.** A Secp256k1 EOA admin account MAY enroll a WorldID at creation as a recovery-only authority that, after a long timelock, can rotate the admin key.
 - **Session rotation.** Replacing a WorldID-admin account's stored `sessionId` with a newly-provisioned session without re-creating the account.
 - **Bundling, 2D nonces, paymasters.** Reserved for follow-on WIPs on the `0x1D` envelope.
 
 ## Rationale
 
-**Account state as precompile.** The keyring lives in a precompile because `0x1D` signature validation happens at the protocol level and must read the authorized set natively. The same precompile owns the admin verification paths, ensuring the address-to-keyset map is only mutated under valid admin authorizations.
+**Account state as precompile.** The keyring lives in a precompile because `0x1D` signature validation happens at the protocol level and must read the authorized set natively. The same precompile owns the admin verification paths, ensuring the address-to-signer map is only mutated under valid admin authorizations.
 
-**Pluggable admin authorities.** Decoupling the keyring + transaction surface from the admin verification primitive lets a single account abstraction serve users with a WorldID, users with hardware-secured root keys, and integrations driven by existing key-management infrastructure. Sharing `0x1D`, session keys, signal binding, and timelock across instantiations means session-key UX and integration surface are uniform regardless of admin type. Each new instantiation reduces to one verification primitive plus one address-derivation rule.
+**Minimal signature surface.** Secp256k1 address recovery and EIP-1271 contract signatures are the two signature abstractions Ethereum already standardizes. WIP-1001 uses those abstractions directly instead of introducing native P256/WebAuthn/EdDSA/BLS session-key variants. That keeps transaction validation simple and moves signer-specific policy into contracts.
 
-**Single admin authority.** Each account has exactly one admin authority. M-of-N admin authorization is a useful generalization but is deferred — it adds quorum-management state and protocol surface that this WIP does not require for its initial use cases. Multi-admin can be added as an Extension without changing the abstract account model.
+**Reusable precompiles instead of host-only cryptography.** P256, pairing checks, and future curves are useful outside account validation. Exposing them as normal precompiles ensures the protocol and contracts agree on inputs, outputs, gas, and edge cases. EIP-1271 signer contracts become the abstraction layer over those primitives.
+
+**Restricted EIP-1271 validation.** Unrestricted contract signature validation would let a transaction execute an arbitrary read-only call graph before transaction execution, creating DoS risk and state/context-dependent invalidation. The restricted frame bounds gas, fixes the caller, forbids arbitrary call depth, and removes block-, transaction-, and external-state-sensitive opcodes while preserving own-storage policy and direct precompile calls.
+
+**Single admin authority.** Each account has exactly one admin authority. M-of-N admin authorization is a useful generalization but is deferred as native protocol state. EIP-1271 contract admins cover most quorum-management use cases without changing the abstract account model.
 
 **Admin type pinned at creation.** Address determinism: `adminType` and the address-defining material are part of the address preimage, so changing either mid-lifetime would change the address. Rotation within the same admin type is also deferred to keep v1 minimal.
 
-**No recovery for key-admin accounts.** Key-admin accounts are owned exclusively by their admin key; there is no underlying identity anchor to bootstrap recovery from. Users requiring recoverability choose the WorldID admin instantiation. This matches existing precedent (Tempo root keys, Ethereum EOAs) and avoids smuggling a second admin tier into the spec.
+**No WIP-level recovery for EOA admins.** EOA-admin accounts are owned exclusively by their admin key; there is no underlying identity anchor to bootstrap recovery from. Users requiring protocol-level recoverability choose the WorldID admin instantiation. Users requiring contract-defined recoverability use EIP-1271 admin contracts.
 
-**Uniform replay protection.** All admin authorizations bind to a `signalHash` containing a per-account monotonic `adminNonce`; the precompile increments `adminNonce` on every successful update and rejects authorizations against stale values. Across instantiations, this gives one replay-protection contract — no instantiation-specific bespoke replay machinery, and no ambiguity around what "fresh" means per instantiation.
+**Uniform replay protection.** All admin authorizations bind to a `signalHash` containing a per-account monotonic `adminNonce`; the precompile increments `adminNonce` on every successful update and rejects authorizations against stale values. Across instantiations, this gives one replay-protection contract -- no instantiation-specific bespoke replay machinery, and no ambiguity around what "fresh" means per instantiation.
 
 **Domain-separated address derivation.** Prefixing the address preimage with `adminTypeTag` prevents accidental cross-type collisions even when the address-defining material from two instantiations might coincidentally produce identical bytes under different encodings. Domain separation costs nothing and is standard practice for keccak-based identifier schemes.
 
-**`msg.sender` binding in `signalHash`.** Including `msg.sender` in both `Create` and `Update` `signalHash` definitions kills cross-submitter replay of in-flight admin authorizations: a witnessed authorization with `msg.sender = X` will not verify if resubmitted by a different account. Self-replay by `X` is a no-op (the resulting state is identical). This subsumes the `MAY bind proofs to msg.sender` mitigation noted in earlier drafts of this WIP.
+**`msg.sender` binding in `signalHash`.** Including `msg.sender` in both `Create` and `Update` `signalHash` definitions kills cross-submitter replay of in-flight admin authorizations: a witnessed authorization with `msg.sender = X` will not verify if resubmitted by a different account. Self-replay by `X` is a no-op (the resulting state is identical).
 
 **WorldID 4.0 Proofs as authorization.** Within the WorldID admin instantiation, account creation uses a Uniqueness Proof and provisions a fresh session; subsequent mutations use Session Proofs bound to the stored `sessionId`, so repeated account updates do not rely on reusing the creation action. No "super key" ever needs to be stored on-device. The `worldIDAccountNonce`-indexed creation action lets a single WorldID own unlinkably many WorldID-admin accounts.
 
-**No sybil constraint on accounts.** Unlinkability across `worldIDAccountNonce` values is a stronger property than one-account-per-identity, and sybil resistance at the account layer is not the right locus — it belongs to whatever system consumes account addresses (e.g., gas subsidy accounting, application-layer rate limits), which can bind its own per-WorldID limits via independent nullifier domains.
+**No sybil constraint on accounts.** Unlinkability across `worldIDAccountNonce` values is a stronger property than one-account-per-identity, and sybil resistance at the account layer is not the right locus -- it belongs to whatever system consumes account addresses (e.g., gas subsidy accounting, application-layer rate limits), which can bind its own per-WorldID limits via independent nullifier domains.
 
-**Recovery timelock.** Without a delay, a compromised admin authority could instantly replace all session keys and drain the account. The timelock gives existing session key holders a window to detect and cancel malicious changes. The same timelock applies regardless of admin type — a Secp256k1 admin compromise is no less serious than a WorldID compromise, and the cancellation surface (existing session keys) is the same.
+**Recovery timelock.** Without a delay, a compromised admin authority could instantly replace all session signers and drain an account. The timelock gives existing session signer holders a window to detect and cancel malicious changes. The same timelock applies regardless of admin type.
 
 ## Backwards Compatibility
 
 This WIP introduces a new account type and transaction type. Existing EOAs and smart contract accounts are unaffected. Standard [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) transactions continue to work for legacy accounts; the `0x1D` envelope is required only for World-Chain-Account-authenticated execution.
 
-This WIP is Draft. The address-derivation prefix (`adminTypeTag`) and the unified `signalHash` (now including `msg.sender` and `adminNonce`) are breaking changes relative to earlier drafts of this WIP — implementations targeting prior drafts MUST update address derivation and `signalHash` recomputation accordingly. No production accounts exist.
+This WIP is Draft. The replacement of native non-ECDSA session-key types with EIP-1271 contract signers, the `SignerRef` keyring shape, the EIP-1271 restricted validation frame, and the Secp256k1-EOA-admin address derivation are breaking changes relative to earlier drafts of this WIP. No production accounts exist.
 
-### Existing Safe Accounts (WorldID admin)
+### Existing Safe Accounts
 
-Existing [Safe](https://safe.global) accounts MAY adopt a WorldID-admin account as an authenticator without migrating assets or changing the Safe address. The integration reduces to installing a module that gates execution on `msg.sender` matching a bound WorldID-admin account address; because a `0x1D` transaction's sender is the account itself, no additional signature verification is required at the Safe layer — protocol-level validation against `IWorldChainAccount.isAuthorized` already gates execution upstream. Key-admin accounts (Secp256k1, P256) integrate with Safe via Safe's existing native-key support; no module is required.
+Existing [Safe](https://safe.global) accounts MAY integrate with World Chain Accounts without migrating assets or changing the Safe address by installing modules or guards that recognize a World Chain Account as an authorized caller. Existing Safe contracts are not automatically valid WIP-1001 protocol EIP-1271 signers: the restricted validation frame forbids arbitrary call depth, `DELEGATECALL`, and external contract state reads. A Safe-style policy can be used as a protocol signer only through bytecode that satisfies the restricted-frame rules, or through ordinary application-level calls outside WIP-1001 protocol validation.
 
 ## Security Considerations
 
 ### Front-Running Admin Authorizations
 
-Both `Create` and `Update` `signalHash` definitions bind `msg.sender`, so a witnessed admin authorization observed in the mempool cannot be replayed by a different submitter — its `signalHash` would not match. This applies to all instantiations. A griefer can still re-submit an authorization unchanged from the original `msg.sender`, but the resulting state is identical; harm is limited to gas and ordering.
+Both `Create` and `Update` `signalHash` definitions bind `msg.sender`, so a witnessed admin authorization observed in the mempool cannot be replayed by a different submitter -- its `signalHash` would not match. This applies to all instantiations. A griefer can still re-submit an authorization unchanged from the original `msg.sender`, but the resulting state is identical; harm is limited to gas and ordering.
 
 ### Timelock Attacks
 
-The revocation-then-add attack vector (an admin authorization removes all session keys, then adds malicious ones with no keys left to cancel) MUST be addressed in the timelock policy design. Possible mitigations include timelocking removals or allowing recently-removed keys to cancel pending adds. This applies regardless of admin type.
+The revocation-then-add attack vector (an admin authorization removes all session signers, then adds malicious ones with no signers left to cancel) MUST be addressed in the timelock policy design. Possible mitigations include timelocking removals or allowing recently-removed signers to cancel pending adds. This applies regardless of admin type.
 
-### Session Key Deanonymization
+### EIP-1271 Validation DoS
 
-A session key that is also used as an EOA, or added to a different World Chain Account, trivially links the account to that external identity. Clients SHOULD generate fresh session keys per account.
+Protocol EIP-1271 validation is bounded by stored `validationGasLimit` and `MAX_EIP1271_VALIDATION_GAS`. Transactions cannot select a higher gas budget for validation, and authorization is checked before contract validation. This prevents unauthorized transactions from using arbitrary signer contracts as pre-execution gas sinks.
 
-### Signature-key Ambiguity
+### EIP-1271 Call-Graph and External-State Invalidation
 
-A World Chain Account may store up to `MAX_SESSION_KEYS` session keys of mixed `KeyType`, but a `0x1D` transaction declares a single `signature_type`. The spec should define whether a key index is included in the envelope or whether the first matching key is authoritative.
+The restricted validation frame forbids EVM-to-EVM calls except direct `STATICCALL`s to allowlisted precompiles. It also forbids external-code and external-balance inspection opcodes. As a result, protocol signature validity cannot depend on another contract's code, storage, or balance changing before inclusion.
+
+### EIP-1271 Context-Sensitive Opcode Invalidation
+
+Block-context and transaction-context opcodes such as `TIMESTAMP`, `NUMBER`, `BASEFEE`, `GASPRICE`, `ORIGIN`, and blob context are forbidden in the restricted validation frame. Signatures therefore cannot become valid or invalid solely because a block producer selected a different block context.
+
+### EIP-1271 Own-Storage Invalidation
+
+EIP-1271 signer validity MAY depend on the signer contract's own storage. This is intentional: it permits multisig thresholds, passkey rotation, revocation lists, recovery state, and policy updates. It also means a signature that was valid during mempool simulation can become invalid if the signer contract's own storage changes before inclusion. Wallets and relayers MUST treat EIP-1271 validity as state-dependent.
+
+### Contract Upgradeability
+
+Upgradeable EIP-1271 signer contracts can change account authorization policy without changing the World Chain Account keyring. This is a feature when used intentionally, but it is also a risk. Wallets SHOULD surface whether an EIP-1271 signer is upgradeable, proxy-based, or otherwise able to change behavior. Proxy patterns that require `DELEGATECALL` during validation are invalid under the restricted frame.
+
+### Session Signer Deanonymization
+
+A Secp256k1 EOA signer address reused as an EOA, or authorized on a different World Chain Account, links those accounts. An EIP-1271 signer contract reused across contexts likewise links them. Clients SHOULD generate fresh session signers per account when unlinkability matters.
+
+### Signature-Signer Ambiguity
+
+A World Chain Account may store up to `MAX_SESSION_SIGNERS`, but a `0x1D` transaction declares exactly one `(signer_type, signer)`. The keyring lookup is by that pair and MUST be unique. There is no "first matching key" ambiguity.
 
 ### WebAuthn Challenge Binding
 
-For session-key `signature_type = 0x02`, the `0x1D` `signing_hash` MUST appear as the `challenge` field inside `client_data_json`; otherwise the signature could be replayed from a different WebAuthn context.
+For WebAuthn-based EIP-1271 signer contracts, the `0x1D` `signing_hash` SHOULD appear as the WebAuthn challenge, or be bound by an equivalent domain-separated digest inside the contract's validation logic. WIP-1001 does not prescribe the internal EIP-1271 signature format.
 
 ### WorldID-admin: Account Unlinkability
 
@@ -581,20 +748,20 @@ Two WorldID-admin accounts owned by the same WorldID are unlinkable across disti
 
 ### WorldID-admin: Stale Merkle Root
 
-The `WorldIDRegistry` accepts roots within a validity window. An attacker whose credential has been revoked could race to submit `create` or `update` against a still-valid but stale root before expiry. The `expiresAtMin + minExpirationThreshold ≥ block.timestamp` check bounds this window, but its duration is a trust parameter.
+The `WorldIDRegistry` accepts roots within a validity window. An attacker whose credential has been revoked could race to submit `create` or `update` against a still-valid but stale root before expiry. The `expiresAtMin + minExpirationThreshold >= block.timestamp` check bounds this window, but its duration is a trust parameter.
 
 ### WorldID-admin: OPRF Key Rotation
 
-If the OPRF key in `OprfKeyRegistry[480]` is rotated, both creation nullifier derivations and session re-derivations change. Existing $\nu_k$ values become unreachable for new creation proofs, and existing `sessionId` values can no longer be used to derive valid Session Proofs; affected accounts become frozen at their current keyring. The protocol MUST define migration semantics across OPRF key epochs.
+If the OPRF key in `OprfKeyRegistry[480]` is rotated, both creation nullifier derivations and session re-derivations change. Existing creation nullifiers become unreachable for new creation proofs, and existing `sessionId` values can no longer be used to derive valid Session Proofs; affected accounts become frozen at their current keyring. The protocol MUST define migration semantics across OPRF key epochs.
 
-### Key-admin: Admin Key Loss Is Terminal
+### EOA-admin: Admin Key Loss Is Terminal
 
-For Secp256k1 and P256 admin instantiations, loss of the admin key permanently bricks the account — the keyring cannot be mutated, recovered, or rotated. Wallets implementing key-admin accounts MUST surface this risk to users and SHOULD encourage hardware-backed key custody. Users who require recoverability MUST choose the WorldID admin instantiation.
+For Secp256k1 EOA admin instantiations, loss of the admin key permanently bricks the account -- the keyring cannot be mutated, recovered, or rotated by WIP-1001. Wallets implementing EOA-admin accounts MUST surface this risk to users and SHOULD encourage hardware-backed key custody.
 
-### Key-admin: Linkability
+### EOA-admin and EIP-1271-admin: Linkability
 
-A Secp256k1 or P256 admin pubkey is recoverable from any creation transaction's calldata. Unlike WorldID-admin accounts, key-admin accounts carry no unlinkability guarantees: anyone observing the admin pubkey can identify the (single) account derived from it. Cross-chain reuse of an admin key is a deanonymization vector.
+An EOA admin address or EIP-1271 admin contract address is recoverable from any creation transaction's calldata and is part of address derivation. Unlike WorldID-admin accounts, these accounts carry no unlinkability guarantees. Cross-chain or cross-application reuse of an admin address is a deanonymization vector.
 
-### Key-admin: No Liveness Check
+### No Liveness Check
 
-A key-admin account has no protocol-level liveness check on session-key-signed transactions. Session-key compromise can drain account-controlled value at the rate session keys can sign, bounded only by per-key limits (if any) and the timelock on keyring mutation. Sibling WIPs that require WorldID liveness above a value threshold do NOT apply to key-admin accounts.
+A non-WorldID-admin account has no protocol-level liveness check on session-signer-signed transactions. Session-signer compromise can drain account-controlled value at the rate session signers can authorize, bounded only by per-signer limits (if any) and the timelock on keyring mutation. Sibling WIPs that require WorldID liveness above a value threshold do NOT apply to non-WorldID-admin accounts.

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -22,7 +22,7 @@ We design with the principle of not defining signer-specific authentication as n
 
 World Chain accounts need programmable authentication without adding a protocol branch for every signature scheme, or session key policy. Smart contracts allow us to converge protocol level authentication over a single authorization boundary with determinism enforced via protocol level restrictions on programmable validation frames.
 
-Whole-set key ring replacement gives the protocol one account-level mutation path for session authorization. The resulting `keyRingHash` is a deterministic commitment to the verifier set, so any cached signature-validation result can be bound to the exact key ring that made it valid.
+Programmable policies over Session Keys unlock many capabilities that simply are not possible on traditional accounts. Some examples include account subscription models, delegated agent payments with scoped permissions enforced by the VM, social recovery, policy based authentication (e.g. Multi Factor authentication for high value transactions). World Chain accounts are unique in that the policies constraining a Session Key are fully programmable. This allows for expressive policies, and authentication strategies to be composed and updated dynamically without prescriptive standards enforced by the protocol. 
 
 ## Specification
 

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -1,7 +1,7 @@
 ---
 wip: 1001
 title: World Chain Native Account Abstraction
-description: A smart contract managed account model with a single admin authority pinned at creation. Session signers compose a keyring that delegates transaction authorization for the account.
+description: A smart contract managed account model with a single admin authority pinned at creation. Session keys compose a keyring that delegates transaction authorization for the account.
 author: Kilian Glas (@kilianglas), 0xOsiris (@0xOsiris), Eric Woolsey (@0xforerunner)
 status: Draft
 type: Standards Track
@@ -12,22 +12,22 @@ requires: EIP-2, EIP-1559, EIP-196, EIP-197, EIP-198, EIP-2718, EIP-1271, RIP-72
 
 ## Abstract
 
-A *World Chain Account* is a smart contract managed account whose 20-byte address is deterministic and lifetime-stable. Each account has a single *admin authority* fixed at creation, which gates mutation of the account's keyring -- the set of session signers authorized to sign on its behalf. We extend [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) with a typed transaction envelope (`0x1D`) signed by any authorized session signer in a World Chain Account's keyring.
+A *World Chain Account* is a smart contract managed account whose 20-byte address is deterministic and lifetime-stable. Each account has a single *admin authority* fixed at creation, which gates mutation of the account's keyring -- the set of session keys authorized to sign on its behalf. We extend [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) with a typed transaction envelope (`0x1D`) signed by any authorized session key in a World Chain Account's keyring.
 
-This WIP deliberately minimizes the diff from Ethereum's existing signature model. The protocol recognizes only two session-signer verification modes:
+This WIP deliberately minimizes the diff from Ethereum's existing signature model. The protocol recognizes only two session-key verification modes:
 
-- **Secp256k1 EOA signer.** The `0x1D` transaction carries an Ethereum-style secp256k1 ECDSA signature. Validation recovers an address from the transaction signing hash and requires that address to be authorized in the account keyring.
-- **EIP-1271 contract signer.** The `0x1D` transaction names a contract signer. Validation invokes `isValidSignature(bytes32,bytes)` under a restricted, metered validation frame and requires the EIP-1271 magic value.
+- **Secp256k1 EOA key.** The `0x1D` transaction carries an Ethereum-style secp256k1 ECDSA signature. Validation recovers an address from the transaction signing hash and requires that address to be authorized in the account keyring.
+- **EIP-1271 contract key.** The `0x1D` transaction names a contract key. Validation invokes `isValidSignature(bytes32,bytes)` under a restricted, metered validation frame and requires the EIP-1271 magic value.
 
-Non-ECDSA signature algorithms, including P256, WebAuthn, EdDSA, BLS, and pairing-based proof systems, are not native session-signer types in this WIP. They are implemented by EIP-1271 signer contracts using elliptic-curve and pairing precompiles exposed by the VM. The same precompiles are callable by ordinary smart contracts and by protocol/system validation, avoiding private host-only cryptography.
+Non-ECDSA signature algorithms, including P256, WebAuthn, EdDSA, BLS, and pairing-based proof systems, are not native session-key types in this WIP. They are implemented by EIP-1271 key contracts using elliptic-curve and pairing precompiles exposed by the VM. The same precompiles are callable by ordinary smart contracts and by protocol/system validation, avoiding private host-only cryptography.
 
 This WIP specifies three admin authority instantiations:
 
-- **WorldID admin.** Creation gated by a [World ID 4.0](https://github.com/worldcoin/world-id-protocol) Uniqueness Proof; subsequent keyring mutations gated by Session Proofs against a stored `sessionId`. Recovery from lost or compromised session signers is the degenerate case of the same upgrade path, protected by a configurable timelock. A single WorldID `MAY` manage any number of WorldID-admin accounts indexed by a user-chosen `worldIDAccountNonce`; accounts owned by the same WorldID are unlinkable across distinct values.
+- **WorldID admin.** Creation gated by a [World ID 4.0](https://github.com/worldcoin/world-id-protocol) Uniqueness Proof; subsequent keyring mutations gated by Session Proofs against a stored `sessionId`. Recovery from lost or compromised session keys is the degenerate case of the same upgrade path. A single WorldID `MAY` manage any number of WorldID-admin accounts indexed by a user-chosen `worldIDAccountNonce`; accounts owned by the same WorldID are unlinkable across distinct values.
 - **Secp256k1 EOA admin.** Creation and keyring mutations gated by Ethereum-style ECDSA signatures over a uniform `signalHash` from a single admin address fixed at creation. Admin-key loss is terminal.
 - **EIP-1271 contract admin.** Creation and keyring mutations gated by `isValidSignature(bytes32,bytes)` on a single contract signer fixed at creation and evaluated under the restricted validation frame. Recovery, if any, is delegated to the signer contract's own policy.
 
-Account state lives natively in the `WORLD_CHAIN_ACCOUNT_PRECOMPILE`. The account address is a public identifier for an admin-authority-managed set of session signers, not an identity anchor; per-instantiation rules govern how many accounts a given admin authority may own.
+Account state lives natively in the `WORLD_CHAIN_ACCOUNT_PRECOMPILE`. The account address is a public identifier for an admin-authority-managed set of session keys, not an identity anchor; per-instantiation rules govern how many accounts a given admin authority may own.
 
 ## Motivation
 
@@ -45,7 +45,7 @@ Cryptographic accelerators used for account validation should not be protocol-pr
 
 A pluggable admin model lets a single account abstraction serve multiple user populations from one precompile. **WorldID admin** converges key rotation and recovery onto a single proof-verification path after enrollment: a fresh Session Proof. No "super key" is ever stored on-device; recovery is the degenerate case of the same upgrade path. **Secp256k1 EOA admin** lets accounts be owned by existing Ethereum keys. **EIP-1271 contract admin** lets accounts be controlled by multisigs, passkeys, policy engines, or custom recovery contracts without adding new native admin algorithms to this WIP.
 
-Sharing a single keyring + transaction surface (`0x1D`, session signers, signal binding, timelock) across instantiations means session-signer UX and integration surface are uniform regardless of admin type. A new non-ECDSA admin scheme reduces to an EIP-1271 contract plus, if needed, a reusable VM precompile.
+Sharing a single keyring + transaction surface (`0x1D`, session keys, signal binding) across instantiations means session-key UX and integration surface are uniform regardless of admin type. A new non-ECDSA admin scheme reduces to an EIP-1271 contract plus, if needed, a reusable VM precompile.
 
 ## Specification
 
@@ -57,14 +57,14 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 | --------------------------------- | -------------------------------------------- | ------------------------------------------------------------ |
 | `WORLD_TX_TYPE`                   | `0x1D`                                       | [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) tx type  |
 | `WORLD_CHAIN_ACCOUNT_PRECOMPILE`  | `0x000000000000000000000000000000000000001D` | Stateful precompile managing the World Chain Account registry |
-| `MAX_SESSION_SIGNERS`             | `20`                                         | Maximum authorized session signers per account               |
+| `MAX_SESSION_KEYS`                | `20`                                         | Maximum authorized session keys per account                  |
 | `ADMIN_TYPE_WORLD_ID`             | `0x00`                                       | Admin type discriminator: WorldID admin                      |
 | `ADMIN_TYPE_SECP256K1_EOA`        | `0x01`                                       | Admin type discriminator: secp256k1 EOA admin                |
 | `ADMIN_TYPE_EIP1271`              | `0x02`                                       | Admin type discriminator: EIP-1271 contract admin            |
-| `SIGNER_TYPE_SECP256K1_EOA`       | `0x00`                                       | Session signer type: Ethereum secp256k1 address              |
-| `SIGNER_TYPE_EIP1271`             | `0x01`                                       | Session signer type: EIP-1271 contract address               |
+| `KEY_TYPE_SECP256K1_EOA`          | `0x00`                                       | Session key type: Ethereum secp256k1 address                 |
+| `KEY_TYPE_EIP1271`                | `0x01`                                       | Session key type: EIP-1271 contract address                  |
 | `EIP1271_MAGIC_VALUE`             | `0x1626ba7e`                                 | `bytes4(keccak256("isValidSignature(bytes32,bytes)"))`       |
-| `MAX_EIP1271_VALIDATION_GAS`      | `TBD`                                        | Maximum gas for one protocol EIP-1271 validation frame        |
+| `MAX_EIP1271_VALIDATION_GAS`      | `500_000`                                    | Maximum gas for one protocol EIP-1271 validation frame        |
 
 Per-instantiation constants are defined in their respective sections.
 
@@ -88,7 +88,7 @@ Future curve or pairing systems MAY be added by extending this allowlist in a fo
 
 ### Abstract Account Model
 
-An *account* is created by an admin-authorized `Create` operation that fixes an *admin type* `T` and an *admin authority* `A` of type `T`. After creation, `T` and `A` are immutable for the lifetime of the account. The keyring is mutated by admin-authorized `Add` or `Remove` operations. All admin authorizations bind the operation to a uniform `signalHash` defined below; replay protection across operations is provided by a per-account monotonic `adminNonce`.
+An *account* is created by an admin-authorized `Create` operation that fixes an *admin type* `T` and an *admin authority* `A` of type `T`. After creation, `T` and `A` are immutable for the lifetime of the account. The keyring is mutated by admin-authorized full-keyring replacement operations: `SetKeyring`. All admin authorizations bind the operation to a uniform `signalHash` defined below; replay protection across operations is provided by a per-account monotonic `adminNonce`.
 
 #### Account State
 
@@ -98,39 +98,46 @@ Per-account state stored in the precompile:
 struct Account {
     uint8       adminType;             // ADMIN_TYPE_*
     bytes       verificationPublicId;  // variable length per admin type
-    SignerRef[] sessionSigners;        // see Session Signers
+    SessionKey[] sessionKeys;          // see Session Keys
+    bytes32     keyringHash;           // keccak256(abi.encode(sessionKeys))
     uint64      adminNonce;            // monotonic; replay protection
-    // pendingUpdates: see Timelock
 }
 ```
 
-`verificationPublicId` is the persistent public material the admin authority uses to verify subsequent updates. Its encoding is per-instantiation (e.g., `sessionId` for WorldID admin, an admin address for Secp256k1 EOA admin, or `(contract, gasLimit)` for EIP-1271 admin). It is set at creation and is not directly mutable by this WIP -- see [Extensions](#extensions) for admin rotation.
+`verificationPublicId` is the persistent public material the admin authority uses to verify subsequent updates. Its encoding is per-instantiation (e.g., `sessionId` for WorldID admin, an admin address for Secp256k1 EOA admin, or `(contract, gasLimit, codeHash)` for EIP-1271 admin). It is set at creation and is not directly mutable by this WIP -- see [Extensions](#extensions) for admin rotation.
 
-#### Session Signers
+#### Session Keys
 
 ```solidity
-enum SignerType {
+enum KeyType {
     Secp256k1EOA,  // 0x00
     EIP1271        // 0x01
 }
 
-struct SignerRef {
-    SignerType signerType;
-    address    signer;
-    uint32     validationGasLimit;
+struct SessionKey {
+    KeyType keyType;
+    address key;
+    uint32  validationGasLimit;
+    bytes32 codeHash;
+    uint64  validAfter;
+    uint64  validUntil;
 }
 ```
 
-| `signerType`       | Value  | `signer` meaning                                  | `validationGasLimit`                         |
-| ------------------ | ------ | ------------------------------------------------- | -------------------------------------------- |
-| `Secp256k1EOA`     | `0x00` | Ethereum address recovered from secp256k1 ECDSA   | MUST be `0`                                  |
-| `EIP1271`          | `0x01` | Contract implementing `isValidSignature(bytes32,bytes)` | MUST be `> 0` and `<= MAX_EIP1271_VALIDATION_GAS` |
+| `keyType`          | Value  | `key` meaning                                     | `validationGasLimit`                         | `codeHash`             |
+| ------------------ | ------ | ------------------------------------------------- | -------------------------------------------- | ---------------------- |
+| `Secp256k1EOA`     | `0x00` | Ethereum address recovered from secp256k1 ECDSA   | MUST be `0`                                  | MUST be `0x00..00`     |
+| `EIP1271`          | `0x01` | Contract implementing `isValidSignature(bytes32,bytes)` | MUST be `> 0` and `<= MAX_EIP1271_VALIDATION_GAS` | MAY be `0x00..00`, otherwise pins `EXTCODEHASH(key)` |
 
-`signer` MUST NOT be the zero address. For `EIP1271`, `signer` MUST have non-empty code at the time it is added to a keyring or fixed as an admin authority.
+`key` MUST NOT be the zero address. For an `EIP1271` session key, `key` MUST have non-empty code when the keyring update is applied.
 
-Keyring uniqueness is defined by `(signerType, signer)`. A keyring MUST NOT contain two entries with the same `(signerType, signer)`, even if their `validationGasLimit` values differ. Changing an EIP-1271 session signer's gas limit requires removing and re-adding that signer, or a future signer-update operation. A `Remove` operation MUST supply the exact stored `SignerRef`, including `validationGasLimit`, to avoid multiple valid encodings for the same state transition.
+If `codeHash != 0x00..00` for an `EIP1271` session key, the protocol MUST require `EXTCODEHASH(key) == codeHash` when the keyring update is applied and during every `0x1D` validation using that key. A zero `codeHash` deliberately permits upgradeable EIP-1271 key contracts.
 
-Session signers carry no intrinsic privileges beyond signing `0x1D` transactions. Per-signer permissions (expiry, spend limits, call scopes) are out of scope for this WIP (see [Extensions](#extensions)).
+Keyring uniqueness is defined by `(keyType, key)`. A keyring MUST NOT contain two entries with the same `(keyType, key)`, even if their metadata differs. Changing an EIP-1271 session key's gas limit, code hash, or validity window requires replacing the full keyring.
+
+`validAfter` and `validUntil` define the key's validity window in Unix seconds. `validUntil == 0` means no upper bound. If `validUntil != 0`, implementations MUST require `validAfter <= validUntil`. A session key is active at block timestamp `t` iff `t >= validAfter && (validUntil == 0 || t <= validUntil)`.
+
+Session keys carry no intrinsic privileges beyond signing `0x1D` transactions while active. Per-key spend limits and call scopes are out of scope for this WIP (see [Extensions](#extensions)).
 
 #### Admin Authority Interface
 
@@ -144,9 +151,13 @@ verifyAdmin(signalHash, authorization, verificationPublicId) -> bool
 
 Admin authorization at creation is also instantiation-specific. Each instantiation defines an `adminCreationContext`: the canonical ABI tuple of creation fields that fix the admin authority, the address-defining material, and any persistent verification state. The first element of this tuple MUST be the `uint8 adminType` discriminator. Authorization payloads, signatures, and proofs are excluded from this context to avoid recursive hashing. `CreateSignal` binds `adminType` and `adminCreationContextHash = keccak256(adminCreationContext)` so the creation authorization cannot be replayed with different permanent admin state.
 
-Some instantiations take address-defining material directly as a creation input that coincides with `verificationPublicId`; others retain a different persistent verifier identifier. For WorldID admin, the creation nullifier defines the address while `sessionId` is stored as `verificationPublicId`. For EIP-1271 admin, the signer contract defines the address while `(signer, validationGasLimit)` is stored as `verificationPublicId`.
+Some instantiations take address-defining material directly as a creation input that coincides with `verificationPublicId`; others retain a different persistent verifier identifier. For WorldID admin, the creation nullifier defines the address while `sessionId` is stored as `verificationPublicId`. For EIP-1271 admin, the signer contract defines the address while `(signer, validationGasLimit, codeHash)` is stored as `verificationPublicId`.
 
-#### Address Derivation
+#### Account Registry and Address Derivation
+
+A World Chain Account exists iff `WORLD_CHAIN_ACCOUNT_PRECOMPILE` has an account registry entry for its address. Counterfactual prefunding is allowed: `create` MUST NOT reject solely because the target EVM account has a nonzero balance.
+
+`create` MUST reject if the derived address is a reserved precompile or system address, has non-empty EVM code, or has nonzero EVM nonce before creation. On success, `create` initializes only the WIP-1001 account registry entry; it MUST NOT modify the target address's EVM balance, EVM nonce, or EVM code.
 
 ```text
 addr = bytes20(keccak256(abi.encodePacked(adminTypeTag, addressDefiningMaterial)))
@@ -155,33 +166,48 @@ addr = bytes20(keccak256(abi.encodePacked(adminTypeTag, addressDefiningMaterial)
 `adminTypeTag` is the one-byte `ADMIN_TYPE_*` discriminator. `addressDefiningMaterial` is per-instantiation:
 
 - WorldID admin: the creation Uniqueness Proof's nullifier (32 bytes).
-- Secp256k1 EOA admin: the 20-byte admin address (= `verificationPublicId`).
-- EIP-1271 contract admin: the 20-byte signer contract address.
+- Secp256k1 EOA admin: `abi.encode(adminAddress, accountSalt)`.
+- EIP-1271 contract admin: `abi.encode(signer, accountSalt)`.
 
-The address is fixed for the lifetime of the account; session-signer rotation does **NOT** change the address.
+The address is fixed for the lifetime of the account; session-key rotation does **NOT** change the address.
+
+`accountSalt` is a user-chosen `bytes32` value. It lets one EOA admin address or EIP-1271 admin contract control multiple independent World Chain Accounts while keeping each account address deterministic.
 
 #### Signal Semantics
 
 ```solidity
-enum UpdateMode { Create, Add, Remove }
+enum UpdateMode {
+    Create,        // 0x00
+    SetKeyring     // 0x01
+}
 
 struct KeyringUpdate {
-    UpdateMode  mode;
-    SignerRef[] signers;
+    UpdateMode   mode;
+    bytes32      expectedCurrentKeyringHash;
+    SessionKey[] keys;
 }
 ```
 
-- **`Create`** -- installs `signers` as the full keyring at the account's address and initializes the account with the supplied admin authority. MUST revert if the account already exists, if `signers.length == 0`, or if `signers.length > MAX_SESSION_SIGNERS`.
-- **`Add`** -- appends `signers` to the existing keyring. MUST revert if the account does not exist, if any signer is already present by `(signerType, signer)`, or if the resulting keyring would exceed `MAX_SESSION_SIGNERS`.
-- **`Remove`** -- removes each entry in `signers` from the existing keyring. MUST revert if the account does not exist, if any signer is absent by `(signerType, signer)`, or if any supplied `SignerRef` does not exactly match the stored entry. The keyring MAY become empty; an account with zero session signers exists but cannot sign transactions until the next `Add`.
+- **`Create`** -- installs `keys` as the full keyring at the account's address and initializes the account with the supplied admin authority. MUST revert if the account already exists, if `expectedCurrentKeyringHash != 0x00..00`, if `keys.length == 0`, or if `keys.length > MAX_SESSION_KEYS`.
+- **`SetKeyring`** -- proposes replacing the existing keyring with exactly `keys`. MUST revert if the account does not exist, if `expectedCurrentKeyringHash != account.keyringHash`, if `keys.length == 0`, or if `keys.length > MAX_SESSION_KEYS`.
 
-For all modes, every `SignerRef` MUST satisfy the validation rules in [Session Signers](#session-signers). An implementation SHOULD validate signer shape, gas limits, zero addresses, duplicate entries, and EIP-1271 code existence before performing expensive admin authorization.
+For all modes, every `SessionKey` MUST satisfy the validation rules in [Session Keys](#session-keys). An implementation SHOULD validate key shape, gas limits, zero addresses, duplicate entries, and EIP-1271 code existence before performing expensive admin authorization.
+
+The canonical keyring hash is:
+
+```text
+keyringHash = keccak256(abi.encode(keys))
+```
+
+where `keys` is the full ABI-encoded `SessionKey[]` in its stored order. The order is admin-selected and consensus-significant; clients SHOULD sort keys lexicographically by `(keyType, key)` before submitting updates to avoid accidental duplicate representations.
 
 The `signalHash` an admin authority binds to is uniform across instantiations.
 
 ```solidity
 struct CreateSignal {
     bytes32       tag;             // == keccak256("WORLD_CHAIN_ACCOUNT_CREATE")
+    uint256       chainId;
+    address       verifyingContract; // == WORLD_CHAIN_ACCOUNT_PRECOMPILE
     uint8         adminType;
     bytes32       adminCreationContextHash;
     address       msgSender;
@@ -190,6 +216,8 @@ struct CreateSignal {
 
 struct UpdateSignal {
     bytes32       tag;             // == keccak256("WORLD_CHAIN_ACCOUNT_UPDATE")
+    uint256       chainId;
+    address       verifyingContract; // == WORLD_CHAIN_ACCOUNT_PRECOMPILE
     address       accountAddress;
     uint64        adminNonce;
     address       msgSender;
@@ -201,30 +229,30 @@ struct UpdateSignal {
 signalHash = bytes32(uint256(keccak256(abi.encode(signal))) >> 8)
 ```
 
-where `signal` is a populated `CreateSignal` for `Create` and an `UpdateSignal` for `Add` / `Remove`. The resulting value is encoded as a `bytes32` with its high 8 bits set to zero.
+where `signal` is a populated `CreateSignal` for `Create` and an `UpdateSignal` for `SetKeyring`. The resulting value is encoded as a `bytes32` with its high 8 bits set to zero.
 
-`msgSender` is the EVM `msg.sender` of the precompile call -- binding it prevents an in-flight admin authorization observed in the mempool from being replayed by a different submitter. For `Create`, `accountAddress` is omitted because it is not knowable to the admin authority at the time the authorization is produced (it is derived from `Create`'s outputs); the domain tag, `adminType`, `adminCreationContextHash`, `msgSender`, and the keyring payload bind the authorization to its intended creation. For updates, `accountAddress` distinguishes admin authorizations across accounts the same admin might control on different domains.
+`chainId` and `verifyingContract` domain-separate admin authorizations across chains and account-precompile deployments. `msgSender` is the EVM `msg.sender` of the precompile call -- binding it prevents an in-flight admin authorization observed in the mempool from being replayed by a different submitter. For `Create`, `accountAddress` is omitted because it is not knowable to the admin authority at the time the authorization is produced (it is derived from `Create`'s outputs); the domain tag, `chainId`, `verifyingContract`, `adminType`, `adminCreationContextHash`, `msgSender`, and the keyring payload bind the authorization to its intended creation. For updates, `accountAddress` distinguishes admin authorizations across accounts the same admin might control on the same chain.
 
 The `>> 8` truncation reduces the digest to 248 bits so it fits within the BN254 scalar field (matching the WorldID 4.0 proof system's signal field width). Truncation is uniform across instantiations even when the verification primitive does not require the BN254 fit, so the same `signalHash` value is canonical across all admin types.
 
+#### Canonical Encoding
+
+All Solidity-like structs in this WIP are consensus types, not illustrative pseudocode. Unless explicitly stated otherwise:
+
+- Structs are encoded with `abi.encode` using the field order shown in this document.
+- Enums are encoded as `uint8`.
+- `SessionKey[]` order is significant and included in every `keyringHash` and `signalHash`.
+- Dynamic `bytes` fields are ABI-encoded as ordinary Solidity `bytes`.
+- RLP-encoded signatures and transactions MUST use canonical, minimal RLP. Non-canonical RLP is invalid.
+- Integer fields in RLP transaction envelopes MUST use canonical Ethereum transaction integer encoding: zero is encoded as the empty byte string, and nonzero integers MUST NOT contain leading zero bytes.
+
 #### Replay Protection
 
-The precompile stores a per-account monotonic `adminNonce`, initialized to `0` at creation and incremented by `1` on every successful `Add` or `Remove`. Admin authorizations for updates are verified against `signalHash` containing the current value of `adminNonce`; an admin authorization that was valid for `adminNonce = n` is no longer valid once the precompile has incremented past `n`.
+The precompile stores a per-account monotonic `adminNonce`, initialized to `0` at creation and incremented by `1` on every successful `SetKeyring` update. Admin authorizations for updates are verified against `signalHash` containing the current value of `adminNonce`; an admin authorization that was valid for `adminNonce = n` is no longer valid once the precompile has incremented past `n`.
 
 For `Create`, replay is precluded by account-existence: the precompile MUST revert if the account address is already occupied. A creation authorization can only be applied once because the post-condition (account exists at `addr`) blocks any subsequent attempt at the same address.
 
 This is the abstract replay-protection contract; each instantiation realizes it via its own verification primitive. Instantiations MUST NOT introduce additional bespoke replay machinery -- `adminNonce` + account-existence is sufficient and uniform.
-
-#### Timelock
-
-A compromised admin authority could otherwise rotate session signers in a single block and drain an account. Account updates are subject to a configurable delay:
-
-- `Create` executes immediately (no prior session signers exist to cancel).
-- `Add` and `Remove` are pending until the delay elapses.
-- Existing session signers MAY cancel a pending update during the delay window.
-- The revocation-then-add attack (an admin-authorized update removes all signers, then adds malicious ones with no incumbents left to cancel) MUST be mitigated -- e.g., by delaying removals, or by allowing recently-removed signers to cancel pending adds.
-
-Queue / cancel / execute interface additions are TBD. Timelock semantics apply uniformly across admin instantiations.
 
 #### Precompile Interface
 
@@ -237,10 +265,11 @@ interface IWorldChainAccount {
         KeyringUpdate calldata keyringUpdate          // mode == Create
     ) external returns (address account);
 
-    /// @notice Authorize an Add/Remove update. `adminAuthorization` layout is admin-type-specific.
+    /// @notice Authorize and apply a SetKeyring update.
+    /// `adminAuthorization` layout is admin-type-specific.
     function update(
         address account,
-        KeyringUpdate calldata keyringUpdate,         // mode != Create
+        KeyringUpdate calldata keyringUpdate,         // mode == SetKeyring
         bytes calldata adminAuthorization
     ) external;
 
@@ -248,12 +277,12 @@ interface IWorldChainAccount {
     function getAdminType(address account) external view returns (uint8);
     function getVerificationPublicId(address account) external view returns (bytes memory);
     function getAdminNonce(address account) external view returns (uint64);
-    function getSessionSigners(address account) external view returns (SignerRef[] memory);
-    function isAuthorized(address account, uint8 signerType, address signer) external view returns (bool);
-    function getAuthorizedSigner(address account, uint8 signerType, address signer)
+    function getSessionKeys(address account) external view returns (SessionKey[] memory);
+    function isAuthorized(address account, uint8 keyType, address key) external view returns (bool);
+    function getAuthorizedKey(address account, uint8 keyType, address key)
         external
         view
-        returns (SignerRef memory);
+        returns (SessionKey memory);
 }
 ```
 
@@ -262,31 +291,39 @@ interface IWorldChainAccount {
 For `create`, the precompile MUST:
 
 1. Require `keyringUpdate.mode == Create`.
-2. Validate all `keyringUpdate.signers` and keyring-size constraints.
+2. Validate all `keyringUpdate.keys` and keyring-size constraints.
 3. Decode `adminCreationData` per the instantiation specified by `adminType`.
 4. Compute the instantiation's `adminCreationContextHash`.
-5. Recompute the `Create` `signalHash` over `(adminType, adminCreationContextHash, msg.sender, keyringUpdate)`.
+5. Recompute the `Create` `signalHash` over `(chainId, WORLD_CHAIN_ACCOUNT_PRECOMPILE, adminType, adminCreationContextHash, msg.sender, keyringUpdate)`.
 6. Verify the admin authorization per the instantiation, against `signalHash` and the instantiation's `verificationPublicId` (or, for WorldID admin, the equivalent verifier public-input set).
 7. Determine `addressDefiningMaterial` per the instantiation.
 8. Derive `accountAddress = bytes20(keccak256(abi.encodePacked(adminTypeTag, addressDefiningMaterial)))`.
-9. Require the account does not already exist at `accountAddress`.
-10. Initialize the account: store `adminType`, `verificationPublicId`, `sessionSigners = keyringUpdate.signers`, `adminNonce = 0`.
+9. Require the account does not already exist at `accountAddress` and the derived EVM address satisfies the creation checks in [Account Registry and Address Derivation](#account-registry-and-address-derivation).
+10. Initialize the account: store `adminType`, `verificationPublicId`, `sessionKeys = keyringUpdate.keys`, `keyringHash = keccak256(abi.encode(keyringUpdate.keys))`, and `adminNonce = 0`.
 
 For `update`, the precompile MUST:
 
-1. Require `keyringUpdate.mode != Create`.
-2. Validate all `keyringUpdate.signers` and mode-specific keyring constraints.
-3. Load the account's stored `adminType`, `verificationPublicId`, and `adminNonce`.
-4. Recompute the `Update` `signalHash` over `(accountAddress, adminNonce, msg.sender, keyringUpdate)`.
-5. Verify `adminAuthorization` per `adminType` against `signalHash` and `verificationPublicId`.
-6. Increment `adminNonce`.
-7. Queue `keyringUpdate` behind the timelock.
+1. Require `keyringUpdate.mode == SetKeyring`.
+2. Validate all `keyringUpdate.keys` and keyring constraints.
+3. Load the account's stored `adminType`, `verificationPublicId`, `keyringHash`, and `adminNonce`.
+4. Require `keyringUpdate.expectedCurrentKeyringHash == keyringHash`.
+5. Recompute the `Update` `signalHash` over `(chainId, WORLD_CHAIN_ACCOUNT_PRECOMPILE, accountAddress, adminNonce, msg.sender, keyringUpdate)`.
+6. Verify `adminAuthorization` per `adminType` against `signalHash` and `verificationPublicId`.
+7. Replace `sessionKeys` with `keyringUpdate.keys` and store `keyringHash = keccak256(abi.encode(keyringUpdate.keys))`.
+8. Increment `adminNonce`.
 
-> **Note -- Precompile gas accounting out of scope.** The full gas pricing schedule for interacting with `WORLD_CHAIN_ACCOUNT_PRECOMPILE` -- covering admin verification cost, per-session-signer storage mutation, timelock queue/cancel/execute operations, and the amortized cost of reads during `0x1D` validation -- is **NOT** fully defined here. A follow-on revision MUST specify gas costs per operation. EIP-1271 validation gas is separately constrained by [Restricted EIP-1271 Validation Frame](#restricted-eip-1271-validation-frame).
+Precompile gas accounting MUST charge:
+
+- the actual gas consumed by WorldID, ECDSA, EIP-1271, and crypto-precompile verification;
+- EVM-equivalent cold/warm storage read costs for account and keyring reads;
+- EVM-equivalent storage write costs for account creation and keyring replacement;
+- linear calldata/decoding work proportional to `SessionKey[]` length.
+
+The exact numeric schedule for storage-equivalent charges is a chain-configuration parameter, but it MUST be consensus-defined before activation. EIP-1271 validation gas is separately constrained by [Restricted EIP-1271 Validation Frame](#restricted-eip-1271-validation-frame).
 
 ### Restricted EIP-1271 Validation Frame
 
-Protocol EIP-1271 validation is intentionally narrower than an ordinary EVM `STATICCALL`. Normal smart contracts MAY call any EIP-1271 implementation according to Ethereum rules, but WIP-1001 protocol validation of an EIP-1271 session signer or EIP-1271 admin MUST execute in a restricted validation frame.
+Protocol EIP-1271 validation is intentionally narrower than an ordinary EVM `STATICCALL`. Normal smart contracts MAY call any EIP-1271 implementation according to Ethereum rules, but WIP-1001 protocol validation of an EIP-1271 session key or EIP-1271 admin MUST execute in a restricted validation frame.
 
 The goal is:
 
@@ -318,10 +355,10 @@ If the call reverts, runs out of gas, executes a forbidden opcode, calls a forbi
 
 `validationGasLimit` is always loaded from account state:
 
-- for EIP-1271 session signers, from the stored `SignerRef`;
+- for EIP-1271 session keys, from the stored `SessionKey`;
 - for EIP-1271 admins, from the stored `verificationPublicId`.
 
-A `0x1D` transaction MUST NOT choose or override EIP-1271 validation gas. The gas consumed by session-signer validation MUST be metered against the transaction's gas limit before execution of the transaction payload. Admin validation gas is metered against the EVM call to `create` or `update`.
+A `0x1D` transaction MUST NOT choose or override EIP-1271 validation gas. The gas consumed by session-key validation MUST be metered against the transaction's gas limit before execution of the transaction payload. Admin validation gas is metered against the EVM call to `create` or `update`.
 
 #### Call-Depth and Call-Target Rules
 
@@ -336,9 +373,9 @@ Therefore a protocol-valid EIP-1271 signer contract MUST be self-contained excep
 
 #### Opcode Policy
 
-The restricted validation frame permits deterministic computation, calldata/memory access, own-code access, own-storage reads, `KECCAK256`, `CHAINID`, `GAS`, and `STATICCALL` to allowed precompiles. `GAS` is permitted because the frame starts with a fixed stored `validationGasLimit` rather than transaction-selected gas.
+The restricted validation frame is deny-by-default for variable context, call, creation, logging, mutation, and external-state inspection behavior. It permits deterministic computation, stack/memory/calldata/returndata operations, `ADDRESS`, `CALLER`, `CALLVALUE`, own-code access, own-storage reads, `KECCAK256`, `CHAINID`, `GAS`, and `STATICCALL` to allowed precompiles. `ADDRESS`, `CALLER`, and `CALLVALUE` are permitted because the entry call fixes them to `signer`, `WORLD_CHAIN_ACCOUNT_PRECOMPILE`, and `0`. `GAS` is permitted because the frame starts with a fixed stored `validationGasLimit` rather than transaction-selected gas.
 
-The following opcodes are forbidden if executed in the restricted validation frame:
+The following opcodes are forbidden if executed validation frame:
 
 ```text
 BLOCKHASH
@@ -373,7 +410,9 @@ CREATE2
 SELFDESTRUCT
 ```
 
-This list removes block-context, transaction-context, external-state, transient-state, logging, mutation, and arbitrary call-depth dependencies from protocol signature validation. EIP-1271 validity MAY depend on the signer contract's own persistent storage via `SLOAD`; this is the intentional stateful policy surface of contract signatures.
+This list removes block-context, transaction-context, external-state, transient-state, logging, mutation, and call-depth dependencies from protocol level signature validation. EIP-1271 validity MAY depend on the signer contract's own persistent storage via `SLOAD`; this is the intentional stateful policy surface of contract signatures.
+
+Any opcode introduced by a future fork is forbidden in the restricted validation frame until a WIP-1001 follow-on explicitly classifies it as permitted. If an implementation encounters an unknown opcode during restricted validation, validation MUST fail.
 
 ### Admin Instantiations
 
@@ -400,7 +439,7 @@ Per-instantiation constants:
 | `WORLD_CHAIN_RP_ID`           | `480`                                        | World Chain's registered RP ID                        |
 | `WORLD_ID_ACCOUNT_TAG`        | `"WORLD_ID_ACCOUNT"` (UTF-8, 16 bytes)       | Domain tag for WorldID-admin account creation actions |
 
-`verificationPublicId` is `sessionId` (uint256), provisioned by the caller at creation and supplied by the WorldID authenticator via OPRF.
+`verificationPublicId` is `abi.encode(uint256 sessionId)`. `sessionId` is provisioned by the caller at creation and supplied by the WorldID authenticator via OPRF.
 
 Address-defining material is the creation Uniqueness Proof's nullifier:
 
@@ -439,11 +478,11 @@ Creation flow:
 1. Decode `adminCreationData`.
 2. Compute `action`.
 3. Compute `adminCreationContextHash = keccak256(abi.encode(ADMIN_TYPE_WORLD_ID, worldIDAccountNullifier, worldIDAccountNonce, sessionId))`.
-4. Recompute the `Create` `signalHash` over `(ADMIN_TYPE_WORLD_ID, adminCreationContextHash, msg.sender, keyringUpdate)`.
+4. Recompute the `Create` `signalHash` per the abstract `Create` formula.
 5. Invoke `WorldID.verify(worldIDAccountNullifier, action, WORLD_CHAIN_RP_ID, proofNonce, signalHash, issuerSchemaId, expiresAtMin, credentialGenesisIssuedAtMin, proof)`. The verifier asserts the proof commits to the supplied `(worldIDAccountNullifier, action, signalHash)` tuple under the relying party's public inputs. Because `signalHash` includes `adminCreationContextHash`, the proof is also bound to the stored `sessionId`.
 6. Set `addressDefiningMaterial = worldIDAccountNullifier` and derive `addr` per the abstract address formula.
-7. Require account does not exist at `addr`.
-8. Store `adminType = ADMIN_TYPE_WORLD_ID`, `verificationPublicId = abi.encode(sessionId)`, `sessionSigners = keyringUpdate.signers`, `adminNonce = 0`.
+7. Require account does not exist at `addr` and the derived EVM address satisfies the creation checks in [Account Registry and Address Derivation](#account-registry-and-address-derivation).
+8. Store `adminType = ADMIN_TYPE_WORLD_ID`, `verificationPublicId = abi.encode(sessionId)`, `sessionKeys = keyringUpdate.keys`, `keyringHash = keccak256(abi.encode(keyringUpdate.keys))`, `adminNonce = 0`.
 
 The creation nullifier is consumed once to instantiate the account. Because WorldID authenticators do not issue the same `(rpId, action)` nullifier twice, a later mutation MUST NOT attempt to reuse the creation action. The nullifier is not retained as account state after creation -- its only role is address derivation, which is reproducible from any subsequent update's calldata via the precompile's stored `addr`.
 
@@ -465,11 +504,11 @@ struct WorldIDAdminAuth {
 Update flow:
 
 1. Decode `verificationPublicId` to recover `sessionId`.
-2. Recompute the `Update` `signalHash` over `(accountAddress, adminNonce, msg.sender, keyringUpdate)`.
+2. Recompute the `Update` `signalHash` per the abstract `Update` formula.
 3. Invoke `WorldID.verifySession(WORLD_CHAIN_RP_ID, proofNonce, signalHash, issuerSchemaId, expiresAtMin, credentialGenesisIssuedAtMin, sessionId, sessionNullifier, proof)`.
 4. Discard `sessionNullifier` after verification; it MUST NOT be persisted in account state.
-5. Increment `adminNonce`.
-6. Queue `keyringUpdate` behind the timelock.
+5. Require `keyringUpdate.mode == SetKeyring`.
+6. Return success to the precompile `update` flow, which applies the full keyring replacement and increments `adminNonce`.
 
 ##### Session Proof Primer
 
@@ -491,7 +530,7 @@ For account creation, deterministic nullifier derivation binds the creation null
 
 ##### Recovery
 
-Recovery is the degenerate case of an `Add` or `Remove` submitted after session signers are lost or compromised. Because post-creation authorization is a Session Proof bound to the account's stored `sessionId`, recovery requires only a fresh Session Proof -- the full session-signer surface is reachable via the same mutation path. No separate recovery flow or state is introduced.
+Recovery is the degenerate case of a `SetKeyring` submitted after session keys are lost or compromised. Because post-creation authorization is a Session Proof bound to the account's stored `sessionId`, recovery requires only a fresh Session Proof -- the full session-key surface is reachable via the same mutation path. No separate recovery flow or state is introduced.
 
 A single WorldID MAY enable recovery for any number of WorldID-admin accounts; accounts at distinct `worldIDAccountNonce` values remain unlinkable across the recovery event.
 
@@ -499,13 +538,13 @@ A single WorldID MAY enable recovery for any number of WorldID-admin accounts; a
 
 `adminType = ADMIN_TYPE_SECP256K1_EOA = 0x01`.
 
-`verificationPublicId` is the 20-byte Ethereum admin address. Address-defining material is the same address:
+`verificationPublicId` is the 20-byte Ethereum admin address. Address-defining material is `abi.encode(adminAddress, accountSalt)`:
 
 ```text
-addr = bytes20(keccak256(abi.encodePacked(ADMIN_TYPE_SECP256K1_EOA, adminAddress)))
+addr = bytes20(keccak256(abi.encodePacked(ADMIN_TYPE_SECP256K1_EOA, abi.encode(adminAddress, accountSalt))))
 ```
 
-One admin address controls exactly one Secp256k1-EOA-admin account address.
+One admin address MAY control any number of Secp256k1-EOA-admin account addresses by varying `accountSalt`.
 
 ##### Creation
 
@@ -514,20 +553,21 @@ One admin address controls exactly one Secp256k1-EOA-admin account address.
 ```solidity
 struct Secp256k1EOAAdminCreationData {
     address adminAddress;
+    bytes32 accountSalt;
     bytes   ecdsaSig;       // rlp([y_parity, r, s]) over signalHash
 }
 ```
 
 Creation flow:
 
-1. Decode `adminAddress` and `ecdsaSig`.
-2. Compute `adminCreationContextHash = keccak256(abi.encode(ADMIN_TYPE_SECP256K1_EOA, adminAddress))`.
-3. Recompute the `Create` `signalHash` over `(ADMIN_TYPE_SECP256K1_EOA, adminCreationContextHash, msg.sender, keyringUpdate)`.
+1. Decode `adminAddress`, `accountSalt`, and `ecdsaSig`.
+2. Compute `adminCreationContextHash = keccak256(abi.encode(ADMIN_TYPE_SECP256K1_EOA, adminAddress, accountSalt))`.
+3. Recompute the `Create` `signalHash` per the abstract `Create` formula.
 4. Decode `ecdsaSig` as `rlp([y_parity, r, s])`.
 5. Recover the Ethereum address from `ecdsaSig` over `signalHash`; require it equals `adminAddress`. Implementations MUST enforce Ethereum's [low-`s` rule](https://eips.ethereum.org/EIPS/eip-2) for consensus signatures.
-6. Set `addressDefiningMaterial = adminAddress` and derive `addr` per the abstract address formula.
-7. Require account does not exist at `addr`.
-8. Store `adminType = ADMIN_TYPE_SECP256K1_EOA`, `verificationPublicId = abi.encode(adminAddress)`, `sessionSigners = keyringUpdate.signers`, `adminNonce = 0`.
+6. Set `addressDefiningMaterial = abi.encode(adminAddress, accountSalt)` and derive `addr` per the abstract address formula.
+7. Require account does not exist at `addr` and the derived EVM address satisfies the creation checks in [Account Registry and Address Derivation](#account-registry-and-address-derivation).
+8. Store `adminType = ADMIN_TYPE_SECP256K1_EOA`, `verificationPublicId = abi.encode(adminAddress)`, `sessionKeys = keyringUpdate.keys`, `keyringHash = keccak256(abi.encode(keyringUpdate.keys))`, `adminNonce = 0`.
 
 ##### Updates
 
@@ -536,11 +576,11 @@ Creation flow:
 Update flow:
 
 1. Load `adminAddress` from `verificationPublicId` and `adminNonce`.
-2. Recompute the `Update` `signalHash` over `(accountAddress, adminNonce, msg.sender, keyringUpdate)`.
-3. Decode `adminAuthorization` as `rlp([y_parity, r, s])`.
-4. Recover the Ethereum address from the signature; require it equals `adminAddress`; enforce low-`s`.
-5. Increment `adminNonce`.
-6. Queue `keyringUpdate` behind the timelock.
+2. Recompute the `Update` `signalHash` per the abstract `Update` formula.
+3. Require `keyringUpdate.mode == SetKeyring`.
+4. Decode `adminAuthorization` as `rlp([y_parity, r, s])`.
+5. Recover the Ethereum address from the signature; require it equals `adminAddress`; enforce low-`s`.
+6. Return success to the precompile `update` flow, which applies the full keyring replacement and increments `adminNonce`.
 
 ##### Recovery
 
@@ -550,13 +590,13 @@ Update flow:
 
 `adminType = ADMIN_TYPE_EIP1271 = 0x02`.
 
-`verificationPublicId` is `abi.encode(address signer, uint32 validationGasLimit)`. Address-defining material is the 20-byte signer contract address:
+`verificationPublicId` is `abi.encode(address signer, uint32 validationGasLimit, bytes32 codeHash)`. Address-defining material is `abi.encode(signer, accountSalt)`:
 
 ```text
-addr = bytes20(keccak256(abi.encodePacked(ADMIN_TYPE_EIP1271, signer)))
+addr = bytes20(keccak256(abi.encodePacked(ADMIN_TYPE_EIP1271, abi.encode(signer, accountSalt))))
 ```
 
-One signer contract address controls exactly one EIP-1271-admin account address. The `validationGasLimit` is fixed at creation and used for all future admin validations.
+One signer contract address MAY control any number of EIP-1271-admin account addresses by varying `accountSalt`. The `validationGasLimit` is fixed at creation and used for all future admin validations. If `codeHash != 0x00..00`, the precompile MUST require `EXTCODEHASH(signer) == codeHash` at creation and during every future admin validation. A zero `codeHash` deliberately permits upgradeable EIP-1271 admin contracts.
 
 ##### Creation
 
@@ -565,22 +605,25 @@ One signer contract address controls exactly one EIP-1271-admin account address.
 ```solidity
 struct EIP1271AdminCreationData {
     address signer;
+    bytes32 accountSalt;
     uint32  validationGasLimit;
+    bytes32 codeHash;
     bytes   signature;             // EIP-1271 signature over signalHash
 }
 ```
 
 Creation flow:
 
-1. Decode `signer`, `validationGasLimit`, and `signature`.
+1. Decode `signer`, `accountSalt`, `validationGasLimit`, `codeHash`, and `signature`.
 2. Require `signer` has non-empty code.
 3. Require `validationGasLimit > 0 && validationGasLimit <= MAX_EIP1271_VALIDATION_GAS`.
-4. Compute `adminCreationContextHash = keccak256(abi.encode(ADMIN_TYPE_EIP1271, signer, validationGasLimit))`.
-5. Recompute the `Create` `signalHash` over `(ADMIN_TYPE_EIP1271, adminCreationContextHash, msg.sender, keyringUpdate)`.
-6. Run the restricted EIP-1271 validation frame against `signer` with `(hash = signalHash, signature, validationGasLimit)`.
-7. Set `addressDefiningMaterial = signer` and derive `addr` per the abstract address formula.
-8. Require account does not exist at `addr`.
-9. Store `adminType = ADMIN_TYPE_EIP1271`, `verificationPublicId = abi.encode(signer, validationGasLimit)`, `sessionSigners = keyringUpdate.signers`, `adminNonce = 0`.
+4. If `codeHash != 0x00..00`, require `EXTCODEHASH(signer) == codeHash`.
+5. Compute `adminCreationContextHash = keccak256(abi.encode(ADMIN_TYPE_EIP1271, signer, accountSalt, validationGasLimit, codeHash))`.
+6. Recompute the `Create` `signalHash` per the abstract `Create` formula.
+7. Run the restricted EIP-1271 validation frame against `signer` with `(hash = signalHash, signature, validationGasLimit)`.
+8. Set `addressDefiningMaterial = abi.encode(signer, accountSalt)` and derive `addr` per the abstract address formula.
+9. Require account does not exist at `addr` and the derived EVM address satisfies the creation checks in [Account Registry and Address Derivation](#account-registry-and-address-derivation).
+10. Store `adminType = ADMIN_TYPE_EIP1271`, `verificationPublicId = abi.encode(signer, validationGasLimit, codeHash)`, `sessionKeys = keyringUpdate.keys`, `keyringHash = keccak256(abi.encode(keyringUpdate.keys))`, `adminNonce = 0`.
 
 ##### Updates
 
@@ -588,11 +631,12 @@ Creation flow:
 
 Update flow:
 
-1. Decode `(signer, validationGasLimit)` from `verificationPublicId`.
-2. Recompute the `Update` `signalHash` over `(accountAddress, adminNonce, msg.sender, keyringUpdate)`.
-3. Run the restricted EIP-1271 validation frame against `signer` with `(hash = signalHash, signature = adminAuthorization, validationGasLimit)`.
-4. Increment `adminNonce`.
-5. Queue `keyringUpdate` behind the timelock.
+1. Decode `(signer, validationGasLimit, codeHash)` from `verificationPublicId`.
+2. Recompute the `Update` `signalHash` per the abstract `Update` formula.
+3. Require `keyringUpdate.mode == SetKeyring`.
+4. If `codeHash != 0x00..00`, require `EXTCODEHASH(signer) == codeHash`.
+5. Run the restricted EIP-1271 validation frame against `signer` with `(hash = signalHash, signature = adminAuthorization, validationGasLimit)`.
+6. Return success to the precompile `update` flow, which applies the full keyring replacement and increments `adminNonce`.
 
 ##### Recovery
 
@@ -602,7 +646,7 @@ WIP-1001 does not define a separate recovery path for EIP-1271-admin accounts. R
 
 Recovery semantics are per-instantiation:
 
-- **WorldID admin.** Recovery is the degenerate case of an `Add` or `Remove` submitted via Session Proof -- see the WorldID admin instantiation. Lost or compromised session signers are recovered by any fresh Session Proof bound to the account's stored `sessionId`.
+- **WorldID admin.** Recovery is the degenerate case of `SetKeyring` submitted via Session Proof -- see the WorldID admin instantiation. Lost or compromised session keys are recovered by any fresh Session Proof bound to the account's stored `sessionId`.
 - **Secp256k1 EOA admin.** **NOT supported by WIP-1001.** Loss of the admin key is terminal.
 - **EIP-1271 contract admin.** Delegated to the signer contract's own policy. WIP-1001 only checks whether the fixed signer contract returns the EIP-1271 magic value under the restricted validation frame.
 
@@ -610,7 +654,7 @@ Users requiring protocol-level recovery SHOULD choose the WorldID admin instanti
 
 ### Transaction Type `0x1D`
 
-A `0x1D` transaction is signed by a session signer of a World Chain Account and submitted directly to the mempool (no [ERC-4337](https://eips.ethereum.org/EIPS/eip-4337) bundler required). `0x1D` transactions are admin-type-agnostic: they are signed by session signers regardless of which admin authority controls the account, and the validation path reads only the account's keyring.
+A `0x1D` transaction is signed by a session key of a World Chain Account and submitted directly to the mempool (no [ERC-4337](https://eips.ethereum.org/EIPS/eip-4337) bundler required). `0x1D` transactions are admin-type-agnostic: they are signed by session keys regardless of which admin authority controls the account, and the validation path reads only the account's keyring.
 
 #### Envelope
 
@@ -626,8 +670,8 @@ A `0x1D` transaction is signed by a session signer of a World Chain Account and 
     data,                        // 7
     access_list,                 // 8
     account,                     // 9   -- sender's World Chain Account address
-    signer_type,                 // 10  -- SIGNER_TYPE_*
-    signer,                      // 11  -- 20-byte session signer address
+    key_type,                    // 10  -- KEY_TYPE_*
+    key,                         // 11  -- 20-byte session key address
     signature_payload,           // 12
 ])
 ```
@@ -636,14 +680,14 @@ A `0x1D` transaction is signed by a session signer of a World Chain Account and 
 signing_hash = keccak256(0x1D || rlp(fields[0..=11]))
 ```
 
-The `signing_hash` covers every field except `signature_payload` itself, binding the declared `signer_type` and `signer` to the signature and ruling out scheme-confusion or signer-substitution attacks at the consensus layer.
+The `signing_hash` covers every field except `signature_payload` itself, binding the declared `key_type` and `key` to the signature and ruling out scheme-confusion or key-substitution attacks at the consensus layer.
 
-| `signer_type`                  | `signature_payload`                                      |
+| `key_type`                     | `signature_payload`                                      |
 | ------------------------------ | -------------------------------------------------------- |
 | `0x00` `Secp256k1EOA`          | `rlp([y_parity, r, s])`                                  |
 | `0x01` `EIP1271`               | Opaque bytes passed unchanged as EIP-1271 `_signature`   |
 
-For `Secp256k1EOA`, implementations MUST enforce the Ethereum [low-`s` rule](https://eips.ethereum.org/EIPS/eip-2) and MUST reject signatures whose recovered address does not equal the declared `signer`.
+For `Secp256k1EOA`, implementations MUST enforce the Ethereum [low-`s` rule](https://eips.ethereum.org/EIPS/eip-2) and MUST reject signatures whose recovered address does not equal the declared `key`.
 
 For `EIP1271`, `signature_payload` is not interpreted by the protocol except as bytes supplied to `isValidSignature(signing_hash, signature_payload)`.
 
@@ -652,34 +696,56 @@ For `EIP1271`, `signature_payload` is not interpreted by the protocol except as 
 The protocol MUST validate a `0x1D` transaction as follows:
 
 1. Compute `signing_hash`.
-2. Load the account's keyring entry for `(signer_type, signer)`.
-3. Reject if no matching authorized session signer exists.
-4. If `signer_type == SIGNER_TYPE_SECP256K1_EOA`, verify `signature_payload` by Ethereum secp256k1 recovery over `signing_hash` and require the recovered address equals `signer`.
-5. If `signer_type == SIGNER_TYPE_EIP1271`, run the restricted EIP-1271 validation frame against `signer` with `(hash = signing_hash, signature = signature_payload, validationGasLimit = stored SignerRef.validationGasLimit)`.
+2. Load the account's keyring entry for `(key_type, key)`.
+3. Reject if no matching authorized session key exists.
+4. Reject if the session key is not active for the current block timestamp.
+5. If the session key has `codeHash != 0x00..00`, reject unless `EXTCODEHASH(key) == codeHash`.
+6. If `key_type == KEY_TYPE_SECP256K1_EOA`, verify `signature_payload` by Ethereum secp256k1 recovery over `signing_hash` and require the recovered address equals `key`.
+7. If `key_type == KEY_TYPE_EIP1271`, run the restricted EIP-1271 validation frame against `key` with `(hash = signing_hash, signature = signature_payload, validationGasLimit = stored SessionKey.validationGasLimit)`.
 
 Authorization is checked before EIP-1271 execution so an attacker cannot use an unauthorized `0x1D` transaction to force arbitrary contract validation work.
+
+#### Execution Semantics
+
+After signature validation, a `0x1D` transaction executes like an EIP-1559 transaction with the following sender override:
+
+- The transaction sender is `account`, not the session key.
+- The fee payer is `account`.
+- The transaction nonce is the EVM account nonce of `account`. It MUST equal the envelope `nonce`, and it is incremented according to normal Ethereum transaction rules.
+- The account balance at `account` pays intrinsic gas, execution gas, priority fee, and `value`.
+- `tx.origin` is `account`.
+- For the top-level message call, `msg.sender` is `account`.
+- `access_list`, `max_fee_per_gas`, `max_priority_fee_per_gas`, `gas_limit`, `to`, `value`, and `data` have the same execution semantics as EIP-1559 unless this WIP says otherwise.
+- If `to` is empty, the transaction creates a contract using the normal Ethereum contract-creation semantics for a transaction from `account`; the created address is derived from `(account, account.nonce)` under the chain's active contract-creation rules.
+- Receipts, logs, gas refunds, access-list warming, balance transfers, and state reversion follow the chain's normal transaction execution rules.
+
+The WIP-1001 account registry entry is separate from EVM account code. A World Chain Account address can have balance and nonce. It MUST NOT have EVM code when created as a WIP-1001 account, and WIP-1001 does not install code at the account address.
 
 The envelope is extensible to 2D nonces, batched transactions, and native paymaster support in follow-on WIPs.
 
 ### Extensions
 
-- **Per-signer permissions.** Session signers MAY be extended with `(expiry, spendLimit, CallScope[])` metadata enforced by the precompile during `0x1D` validation. This extends `SignerRef` and the `KeyringUpdate` signal; the admin authorization continues to bind the full permission set via `signalHash`.
-- **Admin rotation.** Replacing an account's stored `verificationPublicId` (or `adminType`) under admin authorization, with timelock. Deferred -- admin type and authority are pinned at creation in this WIP.
+- **Per-key permissions.** Session keys MAY be extended with `(spendLimit, CallScope[])` metadata enforced by the precompile during `0x1D` validation. This extends `SessionKey` and the `KeyringUpdate` signal; the admin authorization continues to bind the full permission set via `signalHash`.
+- **Admin rotation.** Replacing an account's stored `verificationPublicId` (or `adminType`) under admin authorization. Deferred -- admin type and authority are pinned at creation in this WIP.
 - **Multi-admin.** M-of-N admin authorization for a single account. Deferred. Most near-term multi-admin policies SHOULD be represented as EIP-1271 contract admins.
 - **Additional crypto precompiles.** BLS12-381, Ed25519, secp256k1 verification without recovery, or other primitives MAY be added as VM precompiles. Once allowlisted for the restricted validation frame, EIP-1271 signer contracts can use them without changing the `0x1D` envelope.
-- **WorldID-recovery escape hatch for EOA-admin accounts.** A Secp256k1 EOA admin account MAY enroll a WorldID at creation as a recovery-only authority that, after a long timelock, can rotate the admin key.
+- **WorldID-recovery escape hatch for EOA-admin accounts.** A Secp256k1 EOA admin account MAY enroll a WorldID at creation as a recovery-only authority that can rotate the admin key under a follow-on recovery policy.
 - **Session rotation.** Replacing a WorldID-admin account's stored `sessionId` with a newly-provisioned session without re-creating the account.
 - **Bundling, 2D nonces, paymasters.** Reserved for follow-on WIPs on the `0x1D` envelope.
 
 ## Rationale
 
-**Account state as precompile.** The keyring lives in a precompile because `0x1D` signature validation happens at the protocol level and must read the authorized set natively. The same precompile owns the admin verification paths, ensuring the address-to-signer map is only mutated under valid admin authorizations.
+**Account state as precompile.** The keyring lives in a precompile because `0x1D` signature validation happens at the protocol level and must read the authorized set natively. The same precompile owns the admin verification paths, ensuring the address-to-key map is only mutated under valid admin authorizations.
 
 **Minimal signature surface.** Secp256k1 address recovery and EIP-1271 contract signatures are the two signature abstractions Ethereum already standardizes. WIP-1001 uses those abstractions directly instead of introducing native P256/WebAuthn/EdDSA/BLS session-key variants. That keeps transaction validation simple and moves signer-specific policy into contracts.
 
 **Reusable precompiles instead of host-only cryptography.** P256, pairing checks, and future curves are useful outside account validation. Exposing them as normal precompiles ensures the protocol and contracts agree on inputs, outputs, gas, and edge cases. EIP-1271 signer contracts become the abstraction layer over those primitives.
 
 **Restricted EIP-1271 validation.** Unrestricted contract signature validation would let a transaction execute an arbitrary read-only call graph before transaction execution, creating DoS risk and state/context-dependent invalidation. The restricted frame bounds gas, fixes the caller, forbids arbitrary call depth, and removes block-, transaction-, and external-state-sensitive opcodes while preserving own-storage policy and direct precompile calls.
+
+**Full-keyring replacement.** Updates carry the complete target keyring rather than add/remove deltas. This makes every admin authorization commit to the exact post-update authorization set, avoids ordering-dependent delta semantics, and removes edge cases where separately authorized removals and additions compose into an unintended intermediate keyring.
+
+**Session-key validity and codehash pinning.** Native `validAfter` / `validUntil` fields cover the most common lifecycle control without introducing a general permission engine. Optional `codeHash` pinning lets users choose between upgradeable EIP-1271 key contracts and immutable bytecode identity. The same pinning option is available for EIP-1271 admin contracts, where upgradeability is either an intentional policy surface or a risk to avoid.
 
 **Single admin authority.** Each account has exactly one admin authority. M-of-N admin authorization is a useful generalization but is deferred as native protocol state. EIP-1271 contract admins cover most quorum-management use cases without changing the abstract account model.
 
@@ -691,7 +757,11 @@ The envelope is extensible to 2D nonces, batched transactions, and native paymas
 
 **Creation context binding.** `CreateSignal` includes `adminType` and `adminCreationContextHash` because creation permanently fixes admin state before an account address exists. Binding this context prevents an otherwise valid creation authorization from being reused with a different WorldID `sessionId`, EIP-1271 validation gas limit, or other persistent admin parameter excluded from the signature/proof bytes themselves.
 
+**Domain-separated admin authorizations.** `chainId`, `verifyingContract`, operation tags, and `msg.sender` are part of admin authorization hashes. This binds signatures and proofs to one chain, one precompile deployment, one operation kind, and one direct submitter.
+
 **Domain-separated address derivation.** Prefixing the address preimage with `adminTypeTag` prevents accidental cross-type collisions even when the address-defining material from two instantiations might coincidentally produce identical bytes under different encodings. Domain separation costs nothing and is standard practice for keccak-based identifier schemes.
+
+**Salted non-WorldID accounts.** `accountSalt` for EOA-admin and EIP-1271-admin accounts avoids making the admin address or signer contract a one-account bottleneck. It also makes deterministic account creation explicit: the same admin can derive multiple independent accounts without inventing additional admin types or rotating authority.
 
 **`msg.sender` binding in `signalHash`.** Including `msg.sender` in both `Create` and `Update` `signalHash` definitions kills cross-submitter replay of in-flight admin authorizations: a witnessed authorization with `msg.sender = X` will not verify if resubmitted by a different account. Self-replay by `X` is a no-op (the resulting state is identical).
 
@@ -699,17 +769,17 @@ The envelope is extensible to 2D nonces, batched transactions, and native paymas
 
 **No sybil constraint on accounts.** Unlinkability across `worldIDAccountNonce` values is a stronger property than one-account-per-identity, and sybil resistance at the account layer is not the right locus -- it belongs to whatever system consumes account addresses (e.g., gas subsidy accounting, application-layer rate limits), which can bind its own per-WorldID limits via independent nullifier domains.
 
-**Recovery timelock.** Without a delay, a compromised admin authority could instantly replace all session signers and drain an account. The timelock gives existing session signer holders a window to detect and cancel malicious changes. The same timelock applies regardless of admin type.
+**Immediate admin updates.** Delayed update and cancellation policies are deferred to follow-on WIPs. WIP-1001 keeps admin-authorized keyring replacement immediate so the core account model only specifies authorization, replay protection, and transaction validation.
 
 ## Backwards Compatibility
 
 This WIP introduces a new account type and transaction type. Existing EOAs and smart contract accounts are unaffected. Standard [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) transactions continue to work for legacy accounts; the `0x1D` envelope is required only for World-Chain-Account-authenticated execution.
 
-This WIP is Draft. The replacement of native non-ECDSA session-key types with EIP-1271 contract signers, the `SignerRef` keyring shape, the EIP-1271 restricted validation frame, creation-context binding in `CreateSignal`, and the Secp256k1-EOA-admin address derivation are breaking changes relative to earlier drafts of this WIP. No production accounts exist.
+This WIP is Draft. The replacement of native non-ECDSA session-key types with EIP-1271 contract keys, the `SessionKey` keyring shape, full-keyring replacement updates, salted non-WorldID address derivation, EIP-1271 admin codehash pinning, the EIP-1271 restricted validation frame, and creation-context binding in `CreateSignal` are breaking changes relative to earlier drafts of this WIP. No production accounts exist.
 
 ### Existing Safe Accounts
 
-Existing [Safe](https://safe.global) accounts MAY integrate with World Chain Accounts without migrating assets or changing the Safe address by installing modules or guards that recognize a World Chain Account as an authorized caller. Existing Safe contracts are not automatically valid WIP-1001 protocol EIP-1271 signers: the restricted validation frame forbids arbitrary call depth, `DELEGATECALL`, and external contract state reads. A Safe-style policy can be used as a protocol signer only through bytecode that satisfies the restricted-frame rules, or through ordinary application-level calls outside WIP-1001 protocol validation.
+Existing [Safe](https://safe.global) accounts MAY integrate with World Chain Accounts without migrating assets or changing the Safe address by installing modules or guards that recognize a World Chain Account as an authorized caller. Existing Safe contracts are not automatically valid WIP-1001 protocol EIP-1271 session keys: the restricted validation frame forbids arbitrary call depth, `DELEGATECALL`, and external contract state reads. A Safe-style policy can be used as a protocol session key only through bytecode that satisfies the restricted-frame rules, or through ordinary application-level calls outside WIP-1001 protocol validation.
 
 ## Security Considerations
 
@@ -719,9 +789,9 @@ Both `Create` and `Update` `signalHash` definitions bind `msg.sender`, so a witn
 
 The binding is to the direct EVM caller of `WORLD_CHAIN_ACCOUNT_PRECOMPILE`. A public factory, relayer, or forwarding contract that calls the precompile on behalf of multiple users MUST enforce its own caller/request binding before forwarding; otherwise two users of the same forwarding contract share the same `msg.sender` for WIP-1001 authorization purposes.
 
-### Timelock Attacks
+### Admin Authority Compromise
 
-The revocation-then-add attack vector (an admin authorization removes all session signers, then adds malicious ones with no signers left to cancel) MUST be addressed in the timelock policy design. Possible mitigations include timelocking removals or allowing recently-removed signers to cancel pending adds. This applies regardless of admin type.
+An admin authority can immediately replace the full session-key set. If the admin authority is compromised, the attacker can rotate the keyring and then authorize `0x1D` transactions with the new keys. This WIP intentionally does not define delayed or cancellable admin updates; wallets and applications that require that behavior should use an EIP-1271 admin contract or a follow-on protocol extension.
 
 ### EIP-1271 Validation DoS
 
@@ -741,15 +811,15 @@ EIP-1271 signer validity MAY depend on the signer contract's own storage. This i
 
 ### Contract Upgradeability
 
-Upgradeable EIP-1271 signer contracts can change account authorization policy without changing the World Chain Account keyring. This is a feature when used intentionally, but it is also a risk. Wallets SHOULD surface whether an EIP-1271 signer is upgradeable, proxy-based, or otherwise able to change behavior. Proxy patterns that require `DELEGATECALL` during validation are invalid under the restricted frame.
+Upgradeable EIP-1271 signer contracts can change account authorization policy without changing the World Chain Account keyring or admin authority. This is a feature when used intentionally, but it is also a risk. Wallets SHOULD surface whether an EIP-1271 signer is upgradeable, proxy-based, codehash-pinned, or otherwise able to change behavior. Proxy patterns that require `DELEGATECALL` during validation are invalid under the restricted frame.
 
-### Session Signer Deanonymization
+### Session Key Deanonymization
 
-A Secp256k1 EOA signer address reused as an EOA, or authorized on a different World Chain Account, links those accounts. An EIP-1271 signer contract reused across contexts likewise links them. Clients SHOULD generate fresh session signers per account when unlinkability matters.
+A Secp256k1 EOA key address reused as an EOA, or authorized on a different World Chain Account, links those accounts. An EIP-1271 key contract reused across contexts likewise links them. Clients SHOULD generate fresh session keys per account when unlinkability matters.
 
-### Signature-Signer Ambiguity
+### Signature-Key Ambiguity
 
-A World Chain Account may store up to `MAX_SESSION_SIGNERS`, but a `0x1D` transaction declares exactly one `(signer_type, signer)`. The keyring lookup is by that pair and MUST be unique. There is no "first matching key" ambiguity.
+A World Chain Account may store up to `MAX_SESSION_KEYS`, but a `0x1D` transaction declares exactly one `(key_type, key)`. The keyring lookup is by that pair and MUST be unique. There is no "first matching key" ambiguity.
 
 ### WebAuthn Challenge Binding
 
@@ -763,10 +833,6 @@ Two WorldID-admin accounts owned by the same WorldID are unlinkable across disti
 
 The `WorldIDRegistry` accepts roots within a validity window. An attacker whose credential has been revoked could race to submit `create` or `update` against a still-valid but stale root before expiry. The `expiresAtMin + minExpirationThreshold >= block.timestamp` check bounds this window, but its duration is a trust parameter.
 
-### WorldID-admin: OPRF Key Rotation
-
-If the OPRF key in `OprfKeyRegistry[480]` is rotated, both creation nullifier derivations and session re-derivations change. Existing creation nullifiers become unreachable for new creation proofs, and existing `sessionId` values can no longer be used to derive valid Session Proofs; affected accounts become frozen at their current keyring. The protocol MUST define migration semantics across OPRF key epochs.
-
 ### EOA-admin: Admin Key Loss Is Terminal
 
 For Secp256k1 EOA admin instantiations, loss of the admin key permanently bricks the account -- the keyring cannot be mutated, recovered, or rotated by WIP-1001. Wallets implementing EOA-admin accounts MUST surface this risk to users and SHOULD encourage hardware-backed key custody.
@@ -777,4 +843,4 @@ An EOA admin address or EIP-1271 admin contract address is recoverable from any 
 
 ### No Liveness Check
 
-A non-WorldID-admin account has no protocol-level liveness check on session-signer-signed transactions. Session-signer compromise can drain account-controlled value at the rate session signers can authorize, bounded only by per-signer limits (if any) and the timelock on keyring mutation. Sibling WIPs that require WorldID liveness above a value threshold do NOT apply to non-WorldID-admin accounts.
+A non-WorldID-admin account has no protocol-level liveness check on session-key-signed transactions. Session-key compromise can drain account-controlled value at the rate session keys can authorize, bounded only by per-key limits (if any), session-key validity windows, and off-protocol controls. Sibling WIPs that require WorldID liveness above a value threshold do NOT apply to non-WorldID-admin accounts.

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -1,7 +1,7 @@
 ---
 wip: 1001
 title: World Chain Native Account Abstraction
-description: A smart contract managed account model with a single admin authority pinned at creation. Session signers compose a Key Ring that allows for tightly scoped delegated authorizations over the account.
+description: A smart contract managed account model with a single admin authority pinned at creation. Session signers compose a keyring that delegates transaction authorization for the account.
 author: Kilian Glas (@kilianglas), 0xOsiris (@0xOsiris), Eric Woolsey (@0xforerunner)
 status: Draft
 type: Standards Track
@@ -12,7 +12,7 @@ requires: EIP-2, EIP-1559, EIP-196, EIP-197, EIP-198, EIP-2718, EIP-1271, RIP-72
 
 ## Abstract
 
-A *World Chain Account* is a smart contract managed account whose 20-byte address is deterministic and lifetime-stable. Each account has a single *admin authority* fixed at creation, which gates mutation of the account's *Keyring* -- the set of session signers authorized to sign on its behalf. We extend [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) with a typed transaction envelope (`0x1D`) signed by any authorized session signer in a World Chain Account's keyring.
+A *World Chain Account* is a smart contract managed account whose 20-byte address is deterministic and lifetime-stable. Each account has a single *admin authority* fixed at creation, which gates mutation of the account's keyring -- the set of session signers authorized to sign on its behalf. We extend [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) with a typed transaction envelope (`0x1D`) signed by any authorized session signer in a World Chain Account's keyring.
 
 This WIP deliberately minimizes the diff from Ethereum's existing signature model. The protocol recognizes only two session-signer verification modes:
 
@@ -142,7 +142,9 @@ verifyAdmin(signalHash, authorization, verificationPublicId) -> bool
 
 `authorization` and `verificationPublicId` are byte strings whose encoding is per-instantiation. The precompile invokes this operation during `update`. Each instantiation specifies how the operation is realized -- see [Admin Instantiations](#admin-instantiations).
 
-Admin authorization at creation is also instantiation-specific. Some instantiations take the address-defining material directly as a creation input that coincides with `verificationPublicId`; others (WorldID admin) take additional address-defining material (a creation nullifier) that is bound by the verifier to `verificationPublicId` (`sessionId`) but stored only as the address. The creation nullifier is not retained as account state.
+Admin authorization at creation is also instantiation-specific. Each instantiation defines an `adminCreationContext`: the canonical ABI tuple of creation fields that fix the admin authority, the address-defining material, and any persistent verification state. The first element of this tuple MUST be the `uint8 adminType` discriminator. Authorization payloads, signatures, and proofs are excluded from this context to avoid recursive hashing. `CreateSignal` binds `adminType` and `adminCreationContextHash = keccak256(adminCreationContext)` so the creation authorization cannot be replayed with different permanent admin state.
+
+Some instantiations take address-defining material directly as a creation input that coincides with `verificationPublicId`; others retain a different persistent verifier identifier. For WorldID admin, the creation nullifier defines the address while `sessionId` is stored as `verificationPublicId`. For EIP-1271 admin, the signer contract defines the address while `(signer, validationGasLimit)` is stored as `verificationPublicId`.
 
 #### Address Derivation
 
@@ -180,6 +182,8 @@ The `signalHash` an admin authority binds to is uniform across instantiations.
 ```solidity
 struct CreateSignal {
     bytes32       tag;             // == keccak256("WORLD_CHAIN_ACCOUNT_CREATE")
+    uint8         adminType;
+    bytes32       adminCreationContextHash;
     address       msgSender;
     KeyringUpdate keyringUpdate;
 }
@@ -199,7 +203,7 @@ signalHash = bytes32(uint256(keccak256(abi.encode(signal))) >> 8)
 
 where `signal` is a populated `CreateSignal` for `Create` and an `UpdateSignal` for `Add` / `Remove`. The resulting value is encoded as a `bytes32` with its high 8 bits set to zero.
 
-`msgSender` is the EVM `msg.sender` of the precompile call -- binding it prevents an in-flight admin authorization observed in the mempool from being replayed by a different submitter. For `Create`, `accountAddress` is omitted because it is not knowable to the admin authority at the time the authorization is produced (it is derived from `Create`'s outputs); the domain tag, `msgSender`, and the keyring payload together suffice to bind the authorization to its intended creation. For updates, `accountAddress` distinguishes admin authorizations across accounts the same admin might control on different domains.
+`msgSender` is the EVM `msg.sender` of the precompile call -- binding it prevents an in-flight admin authorization observed in the mempool from being replayed by a different submitter. For `Create`, `accountAddress` is omitted because it is not knowable to the admin authority at the time the authorization is produced (it is derived from `Create`'s outputs); the domain tag, `adminType`, `adminCreationContextHash`, `msgSender`, and the keyring payload bind the authorization to its intended creation. For updates, `accountAddress` distinguishes admin authorizations across accounts the same admin might control on different domains.
 
 The `>> 8` truncation reduces the digest to 248 bits so it fits within the BN254 scalar field (matching the WorldID 4.0 proof system's signal field width). Truncation is uniform across instantiations even when the verification primitive does not require the BN254 fit, so the same `signalHash` value is canonical across all admin types.
 
@@ -233,7 +237,7 @@ interface IWorldChainAccount {
         KeyringUpdate calldata keyringUpdate          // mode == Create
     ) external returns (address account);
 
-    /// @notice Apply an Add/Remove update. `adminAuthorization` layout is admin-type-specific.
+    /// @notice Authorize an Add/Remove update. `adminAuthorization` layout is admin-type-specific.
     function update(
         address account,
         KeyringUpdate calldata keyringUpdate,         // mode != Create
@@ -260,12 +264,13 @@ For `create`, the precompile MUST:
 1. Require `keyringUpdate.mode == Create`.
 2. Validate all `keyringUpdate.signers` and keyring-size constraints.
 3. Decode `adminCreationData` per the instantiation specified by `adminType`.
-4. Recompute the `Create` `signalHash` over `(msg.sender, keyringUpdate)`.
-5. Verify the admin authorization per the instantiation, against `signalHash` and the instantiation's `verificationPublicId` (or, for WorldID admin, the equivalent verifier public-input set).
-6. Determine `addressDefiningMaterial` per the instantiation.
-7. Derive `accountAddress = bytes20(keccak256(abi.encodePacked(adminTypeTag, addressDefiningMaterial)))`.
-8. Require the account does not already exist at `accountAddress`.
-9. Initialize the account: store `adminType`, `verificationPublicId`, `sessionSigners = keyringUpdate.signers`, `adminNonce = 0`.
+4. Compute the instantiation's `adminCreationContextHash`.
+5. Recompute the `Create` `signalHash` over `(adminType, adminCreationContextHash, msg.sender, keyringUpdate)`.
+6. Verify the admin authorization per the instantiation, against `signalHash` and the instantiation's `verificationPublicId` (or, for WorldID admin, the equivalent verifier public-input set).
+7. Determine `addressDefiningMaterial` per the instantiation.
+8. Derive `accountAddress = bytes20(keccak256(abi.encodePacked(adminTypeTag, addressDefiningMaterial)))`.
+9. Require the account does not already exist at `accountAddress`.
+10. Initialize the account: store `adminType`, `verificationPublicId`, `sessionSigners = keyringUpdate.signers`, `adminNonce = 0`.
 
 For `update`, the precompile MUST:
 
@@ -275,7 +280,7 @@ For `update`, the precompile MUST:
 4. Recompute the `Update` `signalHash` over `(accountAddress, adminNonce, msg.sender, keyringUpdate)`.
 5. Verify `adminAuthorization` per `adminType` against `signalHash` and `verificationPublicId`.
 6. Increment `adminNonce`.
-7. Apply `keyringUpdate`, queued behind the timelock.
+7. Queue `keyringUpdate` behind the timelock.
 
 > **Note -- Precompile gas accounting out of scope.** The full gas pricing schedule for interacting with `WORLD_CHAIN_ACCOUNT_PRECOMPILE` -- covering admin verification cost, per-session-signer storage mutation, timelock queue/cancel/execute operations, and the amortized cost of reads during `0x1D` validation -- is **NOT** fully defined here. A follow-on revision MUST specify gas costs per operation. EIP-1271 validation gas is separately constrained by [Restricted EIP-1271 Validation Frame](#restricted-eip-1271-validation-frame).
 
@@ -426,17 +431,19 @@ The Uniqueness Proof is parameterized by:
 
 - `rpId = WORLD_CHAIN_RP_ID`
 - `action = keccak256(abi.encodePacked(WORLD_ID_ACCOUNT_TAG, uint256(worldIDAccountNonce)))`
-- `signalHash` per the abstract `Create` formula
+- `adminCreationContext = abi.encode(ADMIN_TYPE_WORLD_ID, worldIDAccountNullifier, worldIDAccountNonce, sessionId)`
+- `signalHash` per the abstract `Create` formula, using `keccak256(adminCreationContext)`
 
 Creation flow:
 
 1. Decode `adminCreationData`.
 2. Compute `action`.
-3. Recompute the `Create` `signalHash` over `(msg.sender, keyringUpdate)`.
-4. Invoke `WorldID.verify(worldIDAccountNullifier, action, WORLD_CHAIN_RP_ID, proofNonce, signalHash, issuerSchemaId, expiresAtMin, credentialGenesisIssuedAtMin, proof)`. The verifier asserts the proof commits to the supplied `(worldIDAccountNullifier, action, signalHash)` tuple under the relying party's public inputs.
-5. Set `addressDefiningMaterial = worldIDAccountNullifier` and derive `addr` per the abstract address formula.
-6. Require account does not exist at `addr`.
-7. Store `adminType = ADMIN_TYPE_WORLD_ID`, `verificationPublicId = abi.encode(sessionId)`, `sessionSigners = keyringUpdate.signers`, `adminNonce = 0`.
+3. Compute `adminCreationContextHash = keccak256(abi.encode(ADMIN_TYPE_WORLD_ID, worldIDAccountNullifier, worldIDAccountNonce, sessionId))`.
+4. Recompute the `Create` `signalHash` over `(ADMIN_TYPE_WORLD_ID, adminCreationContextHash, msg.sender, keyringUpdate)`.
+5. Invoke `WorldID.verify(worldIDAccountNullifier, action, WORLD_CHAIN_RP_ID, proofNonce, signalHash, issuerSchemaId, expiresAtMin, credentialGenesisIssuedAtMin, proof)`. The verifier asserts the proof commits to the supplied `(worldIDAccountNullifier, action, signalHash)` tuple under the relying party's public inputs. Because `signalHash` includes `adminCreationContextHash`, the proof is also bound to the stored `sessionId`.
+6. Set `addressDefiningMaterial = worldIDAccountNullifier` and derive `addr` per the abstract address formula.
+7. Require account does not exist at `addr`.
+8. Store `adminType = ADMIN_TYPE_WORLD_ID`, `verificationPublicId = abi.encode(sessionId)`, `sessionSigners = keyringUpdate.signers`, `adminNonce = 0`.
 
 The creation nullifier is consumed once to instantiate the account. Because WorldID authenticators do not issue the same `(rpId, action)` nullifier twice, a later mutation MUST NOT attempt to reuse the creation action. The nullifier is not retained as account state after creation -- its only role is address derivation, which is reproducible from any subsequent update's calldata via the precompile's stored `addr`.
 
@@ -462,7 +469,7 @@ Update flow:
 3. Invoke `WorldID.verifySession(WORLD_CHAIN_RP_ID, proofNonce, signalHash, issuerSchemaId, expiresAtMin, credentialGenesisIssuedAtMin, sessionId, sessionNullifier, proof)`.
 4. Discard `sessionNullifier` after verification; it MUST NOT be persisted in account state.
 5. Increment `adminNonce`.
-6. Apply `keyringUpdate`, queued behind the timelock.
+6. Queue `keyringUpdate` behind the timelock.
 
 ##### Session Proof Primer
 
@@ -480,7 +487,7 @@ The circuit proves knowledge of a private witness satisfying:
 - **Deterministic nullifier derivation.** The nullifier is deterministic per `(identity, rpId, action)`, regardless of blinding factor or proof randomness.
 - **Signal binding.** The `signalHash` is constrained in the circuit, preventing a proof from being reused with a different signal.
 
-For account creation, deterministic nullifier derivation binds the creation nullifier to the tuple (owner leaf, `WORLD_CHAIN_RP_ID`, `action(worldIDAccountNonce)`) -- making `worldIDAccountNonce` the sole account selector per identity -- and signal binding binds the Uniqueness Proof to the exact `Create` payload it authorizes. For later updates, `verifySession` binds the proof to the account's stored `sessionId`; the accompanying `sessionNullifier` is a per-proof verifier input rather than persistent account state.
+For account creation, deterministic nullifier derivation binds the creation nullifier to the tuple (owner leaf, `WORLD_CHAIN_RP_ID`, `action(worldIDAccountNonce)`) -- making `worldIDAccountNonce` the sole account selector per identity -- and signal binding binds the Uniqueness Proof to the exact `Create` payload and stored `sessionId` it authorizes. For later updates, `verifySession` binds the proof to the account's stored `sessionId`; the accompanying `sessionNullifier` is a per-proof verifier input rather than persistent account state.
 
 ##### Recovery
 
@@ -514,12 +521,13 @@ struct Secp256k1EOAAdminCreationData {
 Creation flow:
 
 1. Decode `adminAddress` and `ecdsaSig`.
-2. Recompute the `Create` `signalHash` over `(msg.sender, keyringUpdate)`.
-3. Decode `ecdsaSig` as `rlp([y_parity, r, s])`.
-4. Recover the Ethereum address from `ecdsaSig` over `signalHash`; require it equals `adminAddress`. Implementations MUST enforce Ethereum's [low-`s` rule](https://eips.ethereum.org/EIPS/eip-2) for consensus signatures.
-5. Set `addressDefiningMaterial = adminAddress` and derive `addr` per the abstract address formula.
-6. Require account does not exist at `addr`.
-7. Store `adminType = ADMIN_TYPE_SECP256K1_EOA`, `verificationPublicId = abi.encode(adminAddress)`, `sessionSigners = keyringUpdate.signers`, `adminNonce = 0`.
+2. Compute `adminCreationContextHash = keccak256(abi.encode(ADMIN_TYPE_SECP256K1_EOA, adminAddress))`.
+3. Recompute the `Create` `signalHash` over `(ADMIN_TYPE_SECP256K1_EOA, adminCreationContextHash, msg.sender, keyringUpdate)`.
+4. Decode `ecdsaSig` as `rlp([y_parity, r, s])`.
+5. Recover the Ethereum address from `ecdsaSig` over `signalHash`; require it equals `adminAddress`. Implementations MUST enforce Ethereum's [low-`s` rule](https://eips.ethereum.org/EIPS/eip-2) for consensus signatures.
+6. Set `addressDefiningMaterial = adminAddress` and derive `addr` per the abstract address formula.
+7. Require account does not exist at `addr`.
+8. Store `adminType = ADMIN_TYPE_SECP256K1_EOA`, `verificationPublicId = abi.encode(adminAddress)`, `sessionSigners = keyringUpdate.signers`, `adminNonce = 0`.
 
 ##### Updates
 
@@ -532,7 +540,7 @@ Update flow:
 3. Decode `adminAuthorization` as `rlp([y_parity, r, s])`.
 4. Recover the Ethereum address from the signature; require it equals `adminAddress`; enforce low-`s`.
 5. Increment `adminNonce`.
-6. Apply `keyringUpdate`, queued behind the timelock.
+6. Queue `keyringUpdate` behind the timelock.
 
 ##### Recovery
 
@@ -567,11 +575,12 @@ Creation flow:
 1. Decode `signer`, `validationGasLimit`, and `signature`.
 2. Require `signer` has non-empty code.
 3. Require `validationGasLimit > 0 && validationGasLimit <= MAX_EIP1271_VALIDATION_GAS`.
-4. Recompute the `Create` `signalHash` over `(msg.sender, keyringUpdate)`.
-5. Run the restricted EIP-1271 validation frame against `signer` with `(hash = signalHash, signature, validationGasLimit)`.
-6. Set `addressDefiningMaterial = signer` and derive `addr` per the abstract address formula.
-7. Require account does not exist at `addr`.
-8. Store `adminType = ADMIN_TYPE_EIP1271`, `verificationPublicId = abi.encode(signer, validationGasLimit)`, `sessionSigners = keyringUpdate.signers`, `adminNonce = 0`.
+4. Compute `adminCreationContextHash = keccak256(abi.encode(ADMIN_TYPE_EIP1271, signer, validationGasLimit))`.
+5. Recompute the `Create` `signalHash` over `(ADMIN_TYPE_EIP1271, adminCreationContextHash, msg.sender, keyringUpdate)`.
+6. Run the restricted EIP-1271 validation frame against `signer` with `(hash = signalHash, signature, validationGasLimit)`.
+7. Set `addressDefiningMaterial = signer` and derive `addr` per the abstract address formula.
+8. Require account does not exist at `addr`.
+9. Store `adminType = ADMIN_TYPE_EIP1271`, `verificationPublicId = abi.encode(signer, validationGasLimit)`, `sessionSigners = keyringUpdate.signers`, `adminNonce = 0`.
 
 ##### Updates
 
@@ -583,7 +592,7 @@ Update flow:
 2. Recompute the `Update` `signalHash` over `(accountAddress, adminNonce, msg.sender, keyringUpdate)`.
 3. Run the restricted EIP-1271 validation frame against `signer` with `(hash = signalHash, signature = adminAuthorization, validationGasLimit)`.
 4. Increment `adminNonce`.
-5. Apply `keyringUpdate`, queued behind the timelock.
+5. Queue `keyringUpdate` behind the timelock.
 
 ##### Recovery
 
@@ -616,7 +625,7 @@ A `0x1D` transaction is signed by a session signer of a World Chain Account and 
     value,                       // 6
     data,                        // 7
     access_list,                 // 8
-    account,                     // 9   -- signer's World Chain Account address
+    account,                     // 9   -- sender's World Chain Account address
     signer_type,                 // 10  -- SIGNER_TYPE_*
     signer,                      // 11  -- 20-byte session signer address
     signature_payload,           // 12
@@ -680,6 +689,8 @@ The envelope is extensible to 2D nonces, batched transactions, and native paymas
 
 **Uniform replay protection.** All admin authorizations bind to a `signalHash` containing a per-account monotonic `adminNonce`; the precompile increments `adminNonce` on every successful update and rejects authorizations against stale values. Across instantiations, this gives one replay-protection contract -- no instantiation-specific bespoke replay machinery, and no ambiguity around what "fresh" means per instantiation.
 
+**Creation context binding.** `CreateSignal` includes `adminType` and `adminCreationContextHash` because creation permanently fixes admin state before an account address exists. Binding this context prevents an otherwise valid creation authorization from being reused with a different WorldID `sessionId`, EIP-1271 validation gas limit, or other persistent admin parameter excluded from the signature/proof bytes themselves.
+
 **Domain-separated address derivation.** Prefixing the address preimage with `adminTypeTag` prevents accidental cross-type collisions even when the address-defining material from two instantiations might coincidentally produce identical bytes under different encodings. Domain separation costs nothing and is standard practice for keccak-based identifier schemes.
 
 **`msg.sender` binding in `signalHash`.** Including `msg.sender` in both `Create` and `Update` `signalHash` definitions kills cross-submitter replay of in-flight admin authorizations: a witnessed authorization with `msg.sender = X` will not verify if resubmitted by a different account. Self-replay by `X` is a no-op (the resulting state is identical).
@@ -694,7 +705,7 @@ The envelope is extensible to 2D nonces, batched transactions, and native paymas
 
 This WIP introduces a new account type and transaction type. Existing EOAs and smart contract accounts are unaffected. Standard [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) transactions continue to work for legacy accounts; the `0x1D` envelope is required only for World-Chain-Account-authenticated execution.
 
-This WIP is Draft. The replacement of native non-ECDSA session-key types with EIP-1271 contract signers, the `SignerRef` keyring shape, the EIP-1271 restricted validation frame, and the Secp256k1-EOA-admin address derivation are breaking changes relative to earlier drafts of this WIP. No production accounts exist.
+This WIP is Draft. The replacement of native non-ECDSA session-key types with EIP-1271 contract signers, the `SignerRef` keyring shape, the EIP-1271 restricted validation frame, creation-context binding in `CreateSignal`, and the Secp256k1-EOA-admin address derivation are breaking changes relative to earlier drafts of this WIP. No production accounts exist.
 
 ### Existing Safe Accounts
 
@@ -705,6 +716,8 @@ Existing [Safe](https://safe.global) accounts MAY integrate with World Chain Acc
 ### Front-Running Admin Authorizations
 
 Both `Create` and `Update` `signalHash` definitions bind `msg.sender`, so a witnessed admin authorization observed in the mempool cannot be replayed by a different submitter -- its `signalHash` would not match. This applies to all instantiations. A griefer can still re-submit an authorization unchanged from the original `msg.sender`, but the resulting state is identical; harm is limited to gas and ordering.
+
+The binding is to the direct EVM caller of `WORLD_CHAIN_ACCOUNT_PRECOMPILE`. A public factory, relayer, or forwarding contract that calls the precompile on behalf of multiple users MUST enforce its own caller/request binding before forwarding; otherwise two users of the same forwarding contract share the same `msg.sender` for WIP-1001 authorization purposes.
 
 ### Timelock Attacks
 

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -34,9 +34,6 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 | --- | --- | --- | --- |
 | `WORLD_TX_TYPE` | `uint8` | `0x1D` | EIP-2718 transaction type for World Chain account transactions. |
 | `MAX_SESSION_VERIFIERS` | `uint256` | `20` | Maximum active session verifiers per account. |
-| `EIP1271_MAGIC_VALUE` | `bytes4` | `0x1626ba7e` | Required return value from `isValidSignature`. |
-| `WORLD_CHAIN_RP_ID` | `uint64` | `480` | World Chain relying-party identifier for WebAuthn and World ID challenge binding. |
-| `WORLD_ID_ACCOUNT_TAG` | `bytes` | `"WORLD_ID_ACCOUNT"` | Domain tag for World ID account action derivation. |
 | `WORLD_CHAIN_ACCOUNT_DOMAIN` | `bytes32` | `keccak256("WIP1001_ACCOUNT")` | Domain for account address derivation. |
 | `WORLD_CHAIN_ADMIN_CREATE_DOMAIN` | `bytes32` | `keccak256("WIP1001_ADMIN_CREATE")` | Domain for account creation authorization. |
 | `WORLD_CHAIN_SET_KEY_RING_DOMAIN` | `bytes32` | `keccak256("WIP1001_SET_KEY_RING")` | Domain for key ring replacement authorization. |
@@ -59,7 +56,6 @@ WIP-1001 MUST NOT activate until every parameter below is assigned in fork confi
 | `MAX_SESSION_SIGNATURE_BYTES` | `uint32` | TBD | Maximum length of the session `signature` field. |
 | `MAX_ADMIN_AUTHORIZATION_BYTES` | `uint32` | TBD | Maximum length of `adminAuthorization` calldata. |
 | `WORLD_ID_1271_SIGNER_FACTORY` | `address` | TBD | Default World ID EIP-1271 signer factory. |
-| `SECP256K1_1271_SIGNER_FACTORY` | `address` | TBD | Default secp256k1 EIP-1271 signer factory. |
 | `EDDSA_PRECOMPILE` | `address` | TBD | EdDSA verification precompile address and ABI. |
 | `BLS12_381_PRECOMPILE` | `address` | TBD | BLS12-381 verification precompile address and ABI. |
 
@@ -555,7 +551,6 @@ Complete golden vectors and a conformance test suite MUST be published before th
 - Restricted frames forbid mutable external-state reads and block-context opcodes. Signers that need time, block, or external-state constraints MUST bind them into the signature or proof input.
 - `DELEGATECALL` inside restricted validation frames is safe only when the delegatee bytecode satisfies the same tracer rules recursively.
 - The `0x1D` envelope exposes `account` and `sessionVerifier`. Applications that need stronger privacy should use verifier contracts that aggregate or rotate credentials.
-- WebAuthn-based signers MUST bind challenges to the `0x1D` signing hash and `WORLD_CHAIN_RP_ID`.
 - World ID signers MUST bind `block.chainid` into `worldIdAction` or session nonce inputs to prevent cross-chain proof replay.
 - The default World ID admin signer self-reports `account()`. The manager checks this only for default-factory-deployed World ID admin signers; custom signers are responsible for their own consistency.
 - `create` does not bind `msg.sender`, so a copied call can be front-run. The resulting account state is identical because the authorization commits to all state-determining parameters.

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -7,44 +7,24 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2026-03-27
-requires: EIP-2, EIP-1559, EIP-196, EIP-197, EIP-198, EIP-2718, EIP-1271, RIP-7212
+requires: EIP-1271, EIP-2718, EIP-1559, EIP-2930, ERC-7562, RIP-7212
 ---
 
 ## Abstract
 
-WIP-1001 defines a native World Chain account type managed by the `WORLD_CHAIN_ACCOUNT_MANAGER` predeploy.
+WIP-1001 defines a native World Chain account type managed by the `WORLD_CHAIN_ACCOUNT_MANAGER` predeploy. Each account has one immutable [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) admin signer and one active keyring of EIP-1271 session verifiers.
 
-Each account has one EIP-1271 admin signer and an active keyring of EIP-1271 session verifiers. The admin signer is the root authority for account management. Session verifiers are delegated authorities for `0x1D` transaction execution.
+We extend [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) with a new typed transaction envelope with type flag `0x1D`. `0x1D` transactions executed with the World Chain account **Framed** as the sender. Session verifiers act as the transaction level signatories via programmable [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271). Session verifiers dually function as signature verifiers, and session key policy evaluators.
 
-The protocol does not implement signature schemes directly. Instead, the protocol calls EIP-1271 signers in restricted validation frames. Signature schemes, proof systems, recovery policies, and execution policies are implemented by signer contracts. The protocol provides reusable cryptographic precompiles for common primitives.
-
-Session verifiers also own their execution policy. After tentative transaction execution, the protocol asks the verifier whether the observed execution trace is valid. If the verifier rejects the trace, the tentative execution is reverted.
+We design with the principal of not having signer-specific authentication as a native execution path in the protocol. Signature schemes, proof systems, recovery policies, and spending policies are fully programmable. The protocol only prescribes deterministic context, validation frames, and reusable precompiles for cryptographic operations.
 
 ## Motivation
 
-### One Authorization Path
+World Chain accounts need programmable authentication without adding a protocol branch for every signature scheme, or session key policy. [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) gives the protocol one authorization boundary: a fully programmable smart contract.
 
-World Chain accounts need programmable authentication without adding a protocol branch for every signature scheme or proof system. EIP-1271 gives the protocol one authorization path: call a signer contract and require the standard magic value.
+Admin signers and session verifiers use the same [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) boundary but have different roles. The admin signer authorizes account-management operations. Session verifiers authorize `0x1D` transactions and evaluate the resulting execution trace.
 
-Admin signers and session verifiers both use EIP-1271, but they have different protocol roles. An admin signer authorizes account-management operations. A session verifier authorizes transaction signatures and evaluates the resulting execution trace.
-
-### Reusable Cryptography
-
-Signer contracts need efficient cryptographic primitives, but those primitives should not define account semantics. WIP-1001 exposes reusable precompiles for supported curves and proof systems, while keeping account policy in contracts.
-
-World ID is a reference signer implementation. It verifies an EIP-1271 signature that encodes a World ID proof. It is not a privileged protocol path.
-
-### Programmability
-
-Accounts need authorization logic that can evolve without protocol changes. EIP-1271 lets admin signers define arbitrary account-management authorization, including World ID, secp256k1, secp256r1, EdDSA, BLS12-381, multisig, programmable recovery, multi factor authentication and application-specific schemes.
-
-Session verifiers extend that programmability to transaction execution. A verifier can authenticate a session key, inspect the canonical execution trace, and decide whether the transaction satisfies its policy. The protocol only provides deterministic inputs and enforces the verifier's boolean result.
-
-### Stable Transaction Inclusion
-
-Mempool validation and block inclusion must agree on which keyring is active. Keyring updates are therefore timelocked for longer than the transaction pool expiration window. A transaction that validates against an active keyring cannot become invalid before it expires from the pool because of a keyring update.
-
-Default factories that support mutable signer or verifier state must apply the same rule to state that can invalidate already accepted transactions.
+Stable transaction inclusion requires mempool validation and block execution to agree on which verifier may authorize a transaction. Keyring replacement is therefore timelocked for longer than pool transaction expiration, while emergency revocation can evict only transactions from the revoked verifier.
 
 ## Specification
 
@@ -52,36 +32,46 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Protocol Constants
 
-| Name | Value | Meaning |
-| --- | --- | --- |
-| `WORLD_TX_TYPE` | `0x1D` | EIP-2718 transaction type for World Chain account transactions. |
-| `MAX_SESSION_SIGNERS` | `20` | Maximum active session verifiers per account. |
-| `EIP1271_MAGIC_VALUE` | `0x1626ba7e` | Required return value from `isValidSignature`. |
-| `WORLD_CHAIN_RP_ID` | `480` | World Chain relying-party identifier for WebAuthn challenge binding. |
-| `WORLD_ID_ACCOUNT_TAG` | `"WORLD_ID_ACCOUNT"` | Domain tag for World ID account signals. |
+| Name | Type | Value | Meaning |
+| --- | --- | --- | --- |
+| `WORLD_TX_TYPE` | `uint8` | `0x1D` | EIP-2718 transaction type for World Chain account transactions. |
+| `MAX_SESSION_VERIFIERS` | `uint256` | `20` | Maximum active session verifiers per account. |
+| `EIP1271_MAGIC_VALUE` | `bytes4` | `0x1626ba7e` | Required return value from `isValidSignature`. |
+| `WORLD_CHAIN_RP_ID` | `uint64` | `480` | World Chain relying-party identifier for WebAuthn and World ID challenge binding. |
+| `WORLD_ID_ACCOUNT_TAG` | `bytes` | `"WORLD_ID_ACCOUNT"` | Domain tag for World ID account action derivation. |
+| `WIP1001_ACCOUNT_DOMAIN` | `bytes32` | `keccak256("WIP1001_ACCOUNT")` | Domain for account address derivation. |
+| `WIP1001_ADMIN_CREATE_DOMAIN` | `bytes32` | `keccak256("WIP1001_ADMIN_CREATE")` | Domain for account creation authorization. |
+| `WIP1001_QUEUE_KEYRING_UPDATE_DOMAIN` | `bytes32` | `keccak256("WIP1001_QUEUE_KEYRING_UPDATE")` | Domain for queueing a keyring update authorization. |
+| `WIP1001_CANCEL_KEYRING_UPDATE_DOMAIN` | `bytes32` | `keccak256("WIP1001_CANCEL_KEYRING_UPDATE")` | Domain for cancelling a pending keyring update. |
+| `WIP1001_REVOKE_SESSION_VERIFIER_DOMAIN` | `bytes32` | `keccak256("WIP1001_REVOKE_SESSION_VERIFIER")` | Domain for instant session-verifier revocation. |
+| `WIP1001_SIGNER_DOMAIN` | `bytes32` | `keccak256("WIP1001_SIGNER")` | Domain for default factory `CREATE2` salts. |
 
 ### Activation Parameters
 
-WIP-1001 MUST NOT activate until every parameter below is assigned in the fork configuration.
+WIP-1001 MUST NOT activate until every parameter below is assigned in fork configuration.
 
-| Name | Value | Requirement |
-| --- | --- | --- |
-| `WORLD_CHAIN_ACCOUNT_MANAGER` | TBD | Predeploy address for the account manager. |
-| `EIP1271_VALIDATION_GAS_LIMIT` | TBD | Fixed gas forwarded to `isValidSignature`. |
-| `EXECUTION_TRACE_VALIDATION_GAS_LIMIT` | TBD | Fixed gas forwarded to `evaluateSessionPolicy`. |
-| `MAX_EXECUTION_TRACE_BYTES` | TBD | Maximum ABI-encoded trace size passed to a session verifier. |
-| `TXPOOL_TRANSACTION_EXPIRATION_WINDOW` | TBD | Maximum time a valid transaction remains in the pool. |
-| `MIN_KEYRING_UPDATE_DELAY` | TBD | MUST be greater than `TXPOOL_TRANSACTION_EXPIRATION_WINDOW`. |
-| `WORLD_ID_1271_SIGNER_FACTORY` | TBD | Default World ID EIP-1271 signer factory. |
-| `SECP256K1_1271_SIGNER_FACTORY` | TBD | Default secp256k1 EIP-1271 signer factory. |
-| `EDDSA_PRECOMPILE` | TBD | EdDSA verification precompile address and ABI. |
-| `BLS12_381_PRECOMPILE` | TBD | BLS12-381 verification precompile address and ABI. |
+| Name | Type | Value | Requirement |
+| --- | --- | --- | --- |
+| `WORLD_CHAIN_ACCOUNT_MANAGER` | `address` | TBD | Predeploy address for the account manager. |
+| `EIP1271_VALIDATION_GAS_LIMIT` | `uint64` | TBD | Fixed gas forwarded to `isValidSignature`. |
+| `EXECUTION_TRACE_VALIDATION_GAS_LIMIT` | `uint64` | TBD | Fixed gas forwarded to `evaluateSessionPolicy`. |
+| `BLOCK_VALIDATION_GAS_BUDGET` | `uint64` | TBD | Per-block gas budget reserved for `0x1D` validation calls. |
+| `MIN_VALIDATION_FAILURE_FEE` | `uint256` | TBD | Minimum wei charged to the account on validation failure. |
+| `MAX_EXECUTION_TRACE_BYTES` | `uint32` | TBD | Maximum ABI-encoded trace size passed to a session verifier. |
+| `MAX_PAYLOAD_DATA_BYTES` | `uint32` | TBD | Maximum length of `data` in a `0x1D` envelope. |
+| `MAX_ACCESS_LIST_ENTRIES` | `uint32` | TBD | Maximum number of [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) access-list entries in a `0x1D` envelope. |
+| `MAX_SESSION_SIGNATURE_BYTES` | `uint32` | TBD | Maximum length of the session `signature` field. |
+| `MAX_ADMIN_AUTHORIZATION_BYTES` | `uint32` | TBD | Maximum length of `adminAuthorization` calldata. |
+| `TXPOOL_TRANSACTION_EXPIRATION_WINDOW` | `uint64` | TBD | Maximum time in seconds that a valid transaction remains in the pool. |
+| `MIN_KEYRING_UPDATE_DELAY` | `uint64` | TBD | MUST satisfy `MIN_KEYRING_UPDATE_DELAY > TXPOOL_TRANSACTION_EXPIRATION_WINDOW`. |
+| `WORLD_ID_1271_SIGNER_FACTORY` | `address` | TBD | Default World ID EIP-1271 signer factory. |
+| `SECP256K1_1271_SIGNER_FACTORY` | `address` | TBD | Default secp256k1 EIP-1271 signer factory. |
+| `EDDSA_PRECOMPILE` | `address` | TBD | EdDSA verification precompile address and ABI. |
+| `BLS12_381_PRECOMPILE` | `address` | TBD | BLS12-381 verification precompile address and ABI. |
 
 ### Reusable Crypto Precompiles
 
 Signer contracts MAY call protocol-supported cryptographic precompiles from restricted validation frames.
-
-The validation-frame precompile allowlist is:
 
 | Primitive | Source |
 | --- | --- |
@@ -93,208 +83,130 @@ The validation-frame precompile allowlist is:
 | `bn254 add` | Ethereum precompile |
 | `bn254 scalar multiplication` | Ethereum precompile |
 | `bn254 pairing` | Ethereum precompile |
-| `secp256r1 verify` | RIP-7212 |
+| `secp256r1 verify` | [RIP-7212](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md) |
 | `EdDSA verify` | Activation parameter |
 | `BLS12-381 verify` | Activation parameter |
 
 World Chain clients MUST NOT expose private host validation APIs that are unavailable to contracts. Any primitive used by a default signer MUST be available through an allowlisted precompile.
 
-### Account Model
+### Account State
 
 World Chain accounts are created and managed by `WORLD_CHAIN_ACCOUNT_MANAGER`.
-
-An account has:
-
-- one immutable account address;
-- one EIP-1271 admin signer;
-- one active keyring of EIP-1271 session verifiers;
-- at most one pending keyring update;
-- one admin nonce.
-
-Account authority is hierarchical:
-
-1. The account manager owns account state and enforces account-management rules.
-2. The admin signer is the root account authority. It authorizes account creation and keyring updates through EIP-1271.
-3. Session verifiers are delegated transaction authorities. They authorize `0x1D` transactions through EIP-1271 and approve or reject the observed execution trace through `evaluateSessionPolicy`.
-
-The manager MUST NOT use the admin signer to authorize `0x1D` transaction execution unless the same address is also present in the active session keyring. The manager MUST NOT use a session verifier to authorize account-management operations unless the same address is also configured as the admin signer.
-
-The manager stores account state:
 
 ```solidity
 struct Account {
     address adminSigner;
     bytes32 accountSalt;
-    SessionSigner[] activeSessionSigners;
+    SessionVerifier[] activeSessionVerifiers;
     bytes32 activeKeyringHash;
     PendingKeyringUpdate pendingKeyringUpdate;
     uint64 adminNonce;
+    uint64 transactionNonce;
 }
 
 struct PendingKeyringUpdate {
-    bool exists;
     bytes32 expectedCurrentKeyringHash;
-    SessionSigner[] targetSessionSigners;
+    SessionVerifier[] targetSessionVerifiers;
     bytes32 targetKeyringHash;
     uint64 activateAfter;
     uint64 queuedAtNonce;
+    bool exists;
 }
 
-struct SessionSigner {
-    address signer;
+struct SessionVerifier {
+    address verifier;
 }
 ```
 
-`Account.adminSigner` is an EIP-1271 contract. `SessionSigner.signer` is an EIP-1271 contract that also implements `IWorldChainSessionVerifier`.
+For every existing account:
 
-The protocol does not inspect signer internals. It assigns semantics by account role: admin signer for account management, session verifier for transaction authorization and policy evaluation.
+- `adminSigner` MUST be a deployed EIP-1271 contract and is immutable for the life of the account address.
+- `activeSessionVerifiers.length` MUST be in `[1, MAX_SESSION_VERIFIERS]`.
+- each `SessionVerifier.verifier` MUST be a deployed contract implementing EIP-1271 and `IWorldChainSessionVerifier`;
+- `activeSessionVerifiers` MUST NOT contain duplicate verifier addresses;
+- `activeKeyringHash == keccak256(abi.encode(activeSessionVerifiers))`;
+- `adminNonce` is consumed only by admin operations;
+- `transactionNonce` is consumed only by included `0x1D` transactions.
 
-The active keyring MUST contain at least one session verifier and at most `MAX_SESSION_SIGNERS` session verifiers. A keyring MUST NOT contain duplicate signer addresses.
+The manager MUST NOT use the admin signer to authorize `0x1D` execution unless the admin signer is also in the active session keyring. The manager MUST NOT use a session verifier to authorize account-management operations unless that verifier is also the account's admin signer.
 
-### Address Derivation
+#### Address Derivation
 
-The manager derives an account address from:
-
-- `adminSigner`;
-- `accountSalt`;
-- the manager address;
-- the World Chain chain ID.
-
-This binds the account address to the admin signer, salt, chain, and manager instance.
-
-### Keyring Hash
-
-The manager computes:
+The manager derives an account address as:
 
 ```solidity
-activeKeyringHash = keccak256(abi.encode(activeSessionSigners));
+account = address(uint160(uint256(keccak256(abi.encode(
+    WIP1001_ACCOUNT_DOMAIN,
+    chainId,
+    WORLD_CHAIN_ACCOUNT_MANAGER,
+    adminSigner,
+    accountSalt
+)))));
 ```
 
-The hash commits to signer addresses and ordering. Clients SHOULD preserve ordering when displaying, exporting, or signing over a keyring.
+The address binds the account to the manager instance, chain, admin signer, and salt. WIP-1001 defines no operation that rotates `adminSigner` for an existing account.
 
-### Signal Semantics
+#### Admin Operation Hashes
 
-Account creation and admin authorization signatures MUST use domain-separated signals.
-
-The signal for account creation is:
+For every admin authorization, the manager computes a domain-separated `adminOperationHash` and calls:
 
 ```solidity
-signal = keccak256(
-    abi.encode(
-        WORLD_ID_ACCOUNT_TAG,
-        chainId,
-        WORLD_CHAIN_ACCOUNT_MANAGER,
-        accountAddress,
-        adminSigner,
-        accountSalt,
-        activeKeyringHash
-    )
-);
+adminSigner.isValidSignature(adminOperationHash, adminAuthorization)
 ```
 
-Admin operations MUST include:
+The hash for each operation is:
 
-- `chainId`;
-- `WORLD_CHAIN_ACCOUNT_MANAGER`;
-- `account`;
-- operation selector;
-- operation parameters;
-- `adminNonce`.
+```solidity
+createHash = keccak256(abi.encode(
+    WIP1001_ADMIN_CREATE_DOMAIN,
+    chainId,
+    WORLD_CHAIN_ACCOUNT_MANAGER,
+    account,
+    adminSigner,
+    accountSalt,
+    activeKeyringHash
+));
 
-The manager increments `adminNonce` when it queues a keyring update. Activating a queued update MUST NOT increment `adminNonce`.
+queueHash = keccak256(abi.encode(
+    WIP1001_QUEUE_KEYRING_UPDATE_DOMAIN,
+    chainId,
+    WORLD_CHAIN_ACCOUNT_MANAGER,
+    account,
+    adminNonce,
+    expectedCurrentKeyringHash,
+    targetKeyringHash,
+    activateAfter
+));
 
-### Replay Protection
+cancelHash = keccak256(abi.encode(
+    WIP1001_CANCEL_KEYRING_UPDATE_DOMAIN,
+    chainId,
+    WORLD_CHAIN_ACCOUNT_MANAGER,
+    account,
+    adminNonce,
+    expectedQueuedAtNonce
+));
 
-The account address derivation, signal domain, chain ID, manager address, and admin nonce together provide replay protection for account creation and admin operations.
+revokeHash = keccak256(abi.encode(
+    WIP1001_REVOKE_SESSION_VERIFIER_DOMAIN,
+    chainId,
+    WORLD_CHAIN_ACCOUNT_MANAGER,
+    account,
+    adminNonce,
+    sessionVerifier,
+    expectedCurrentKeyringHash
+));
+```
 
-Session transactions use the transaction nonce in the `0x1D` envelope. This nonce is separate from `adminNonce`.
+### Signer Interfaces
 
-### EIP-1271 Admin Signer Hierarchy
-
-The admin signer is an EIP-1271 contract that authorizes account-management operations. It has no protocol ABI beyond EIP-1271:
+The admin signer has no protocol ABI beyond EIP-1271:
 
 ```solidity
 interface IWorldChainAdminSigner is IERC1271 {}
 ```
 
-The protocol calls the admin signer with a manager-defined operation hash. The signer returns `EIP1271_MAGIC_VALUE` if the operation is authorized.
-
-Admin signer implementations include:
-
-- World ID admin signers;
-- secp256k1 admin signers;
-- multisig admin signers;
-- recovery admin signers;
-- custom application admin signers.
-
-Only the EIP-1271 boundary is protocol-significant. The implementation class is signer contract state, not account manager state.
-
-#### World ID Admin Signer
-
-A World ID admin signer is an EIP-1271 contract whose authorization is a World ID proof bound to the manager-defined operation hash.
-
-The default World ID admin signer MUST expose immutable account-binding state:
-
-```solidity
-interface IWorldIDAdminSigner is IWorldChainAdminSigner {
-    function account() external view returns (address);
-    function externalNullifierHash() external view returns (uint256);
-}
-```
-
-The EIP-1271 signature payload is:
-
-```solidity
-struct WorldIDAdminSignature {
-    uint256 root;
-    uint256 nullifierHash;
-    uint256[8] proof;
-}
-```
-
-The default factory MUST derive `externalNullifierHash()` from `WORLD_ID_ACCOUNT_TAG`, `WORLD_CHAIN_RP_ID`, and `account()`.
-
-`isValidSignature(hash, signature)` MUST:
-
-- decode `signature` as `WorldIDAdminSignature`;
-- require `root` to be accepted by the signer;
-- verify the World ID proof using `hash` as the operation signal and `externalNullifierHash()` as the external nullifier;
-- return `EIP1271_MAGIC_VALUE` only if verification succeeds.
-
-The signer MUST NOT consume nullifiers as part of `isValidSignature`, because EIP-1271 validation is a `view` operation. Replay protection comes from the manager-defined operation hash, including `adminNonce`.
-
-#### Secp256k1 Admin Signer
-
-A secp256k1 admin signer is an EIP-1271 contract whose authorization is a secp256k1 signature by a configured owner.
-
-The default secp256k1 admin signer MUST expose immutable owner state:
-
-```solidity
-interface ISecp256k1AdminSigner is IWorldChainAdminSigner {
-    function owner() external view returns (address);
-}
-```
-
-The EIP-1271 signature payload is the standard 65-byte payload:
-
-```text
-r || s || v
-```
-
-`isValidSignature(hash, signature)` MUST:
-
-- require `signature.length == 65`;
-- decode `r`, `s`, and `v`;
-- require `s` to be in the lower half order as specified by EIP-2;
-- require `v` to be `27` or `28`;
-- recover the signer with `ecrecover(hash, v, r, s)`;
-- return `EIP1271_MAGIC_VALUE` only if the recovered address equals `owner()`.
-
-The secp256k1 admin signer verifies the hash passed by the manager directly. Wallets that need EIP-191, EIP-712, or WebAuthn wrapping MUST implement that wrapping inside a different EIP-1271 signer contract.
-
-### Session Verifier Interface
-
-Session verifier contracts MUST implement this interface in addition to EIP-1271. Admin-only signers only need to implement EIP-1271.
+Session verifier contracts MUST implement EIP-1271 and:
 
 ```solidity
 interface IWorldChainSessionVerifier is IERC1271 {
@@ -307,7 +219,7 @@ interface IWorldChainSessionVerifier is IERC1271 {
         bytes32 signingHash;
         uint256 chainId;
         address account;
-        address signer;
+        address sessionVerifier;
         uint64 nonce;
         uint256 maxPriorityFeePerGas;
         uint256 maxFeePerGas;
@@ -346,6 +258,7 @@ interface IWorldChainSessionVerifier is IERC1271 {
         address emitter;
         bytes32[] topics;
         bytes32 dataHash;
+        uint32 callIndex;
     }
 
     struct WorldChainExecutionTrace {
@@ -367,23 +280,37 @@ interface IWorldChainSessionVerifier is IERC1271 {
 }
 ```
 
-The protocol MUST call `evaluateSessionPolicy` after tentative payload execution and before committing payload state.
+`WorldChainTransactionContext` MUST be derived from the envelope, loaded account state, and computed signing hash. It MUST NOT include block-context values other than `chainId`.
 
-`ExecutionTraceContext.transaction` is derived from the `0x1D` envelope, the active account state, and the computed signing hash. It does not include block-context values other than `chainId`.
+For `WorldChainTransactionContext`:
 
-`ExecutionTraceContext.trace` is canonical and MUST include:
+- `target == to` when `isCreate == false`;
+- `target == address(0)` when `isCreate == true`;
+- `selector == bytes4(data[:4])` when `isCreate == false && data.length >= 4`;
+- `selector == 0x00000000` otherwise;
+- `activeKeyringHash` is the account's active keyring hash observed during transaction validation.
 
-- the final payload success flag;
-- total gas used by payload execution;
-- `keccak256` of payload return data;
-- all internal calls, ordered by execution order and annotated with call depth;
-- all logs emitted by payload execution, ordered by emission order.
+For `WorldChainExecutionTrace`:
 
-The root transaction call is represented by `ExecutionTraceContext.transaction`, not by a `CallTrace` entry.
+- the root transaction call is represented by `transaction`, not by a `CallTrace`;
+- `calls` MUST include every internal call in execution order;
+- `logs` MUST include emitted logs in emission order, excluding logs reverted by EVM revert semantics;
+- `outputHash`, `CallTrace.inputHash`, `CallTrace.outputHash`, and `LogTrace.dataHash` MUST use `keccak256(bytes)`, including `keccak256("")` for empty bytes; `bytes32(0)` MUST NOT be used as an empty-data sentinel;
+- a reverted call's `outputHash` MUST hash revert data;
+- `LogTrace.callIndex == type(uint32).max` identifies a root-call log.
 
-Full internal calldata, return data, and log data are not copied into the trace. The trace includes hashes. A verifier that needs exact bytes MUST bind those bytes through the session signature, transaction calldata, or an application-level commitment.
+For each `CallTrace`:
 
-The ABI-encoded trace MUST be no larger than `MAX_EXECUTION_TRACE_BYTES`. If the trace exceeds this limit, the transaction MUST fail.
+- `depth` is the EVM call depth; the first internal call has depth `1`;
+- `caller` is the address that executed the call opcode;
+- for `Create` and `Create2`, `target` is the deployed address or the address that would have been deployed if the create reverted;
+- `Create2` target addresses are computed per EIP-1014;
+- `Create` target addresses are computed as `keccak256(rlp([sender, nonce]))[12:]`;
+- `DelegateCall.value == 0`, and `DelegateCall.caller` is the address that executed `DELEGATECALL`.
+
+Full internal calldata, return data, and log data are not copied into the trace. A verifier that needs exact bytes MUST bind those bytes through the session signature, transaction calldata, or an application-level commitment.
+
+The ABI encoding of `ExecutionTraceContext.trace` MUST NOT exceed `MAX_EXECUTION_TRACE_BYTES`.
 
 ### Manager Interface
 
@@ -394,163 +321,226 @@ interface IWorldChainAccountManager {
     function create(
         address adminSigner,
         bytes32 accountSalt,
-        SessionSigner[] calldata initialSessionSigners,
+        SessionVerifier[] calldata initialSessionVerifiers,
         bytes calldata adminAuthorization
     ) external returns (address account);
 
     function queueKeyringUpdate(
         address account,
         bytes32 expectedCurrentKeyringHash,
-        SessionSigner[] calldata targetSessionSigners,
+        SessionVerifier[] calldata targetSessionVerifiers,
         uint64 activateAfter,
         bytes calldata adminAuthorization
     ) external;
 
     function activateKeyringUpdate(address account) external;
 
+    function cancelPendingKeyringUpdate(
+        address account,
+        uint64 expectedQueuedAtNonce,
+        bytes calldata adminAuthorization
+    ) external;
+
+    function revokeSessionVerifier(
+        address account,
+        address sessionVerifier,
+        bytes32 expectedCurrentKeyringHash,
+        bytes calldata adminAuthorization
+    ) external;
+
     function getAdminSigner(address account) external view returns (address);
     function getAdminNonce(address account) external view returns (uint64);
+    function getTransactionNonce(address account) external view returns (uint64);
     function getActiveKeyringHash(address account) external view returns (bytes32);
-    function getActiveSessionSigners(address account) external view returns (SessionSigner[] memory);
+    function getActiveSessionVerifiers(address account) external view returns (SessionVerifier[] memory);
     function getPendingKeyringUpdate(address account) external view returns (PendingKeyringUpdate memory);
-    function isAuthorized(address account, address signer) external view returns (bool);
-    function getAuthorizedSigner(address account, address signer) external view returns (SessionSigner memory);
+    function isAuthorizedSessionVerifier(address account, address sessionVerifier) external view returns (bool);
+    function getAuthorizedSessionVerifier(address account, address sessionVerifier) external view returns (SessionVerifier memory);
 }
 ```
 
+The manager MUST expose enough state for txpool revalidation: current active verifier membership, account balance, account transaction nonce, and recent session-verifier revocations that have not aged past `TXPOOL_TRANSACTION_EXPIRATION_WINDOW`.
+
+### Manager Events
+
+Each successful state transition MUST emit exactly one matching event in the same transaction that mutates state.
+
+```solidity
+interface IWorldChainAccountManagerEvents {
+    event AccountCreated(
+        address indexed account,
+        address indexed adminSigner,
+        bytes32 accountSalt,
+        bytes32 activeKeyringHash
+    );
+
+    event KeyringUpdateQueued(
+        address indexed account,
+        bytes32 indexed targetKeyringHash,
+        bytes32 expectedCurrentKeyringHash,
+        uint64 activateAfter,
+        uint64 queuedAtNonce
+    );
+
+    event PendingKeyringUpdateReplaced(
+        address indexed account,
+        bytes32 previousTargetKeyringHash,
+        bytes32 indexed newTargetKeyringHash,
+        uint64 newActivateAfter,
+        uint64 newQueuedAtNonce
+    );
+
+    event KeyringUpdateActivated(
+        address indexed account,
+        bytes32 previousKeyringHash,
+        bytes32 indexed newKeyringHash
+    );
+
+    event KeyringUpdateCancelled(
+        address indexed account,
+        uint64 cancelledQueuedAtNonce,
+        uint64 adminNonce
+    );
+
+    event SessionVerifierRevoked(
+        address indexed account,
+        address indexed sessionVerifier,
+        bytes32 newKeyringHash,
+        uint64 adminNonce
+    );
+}
+```
+
+### Manager State Transitions
+
+Every admin-mutating method MUST reject `adminAuthorization.length > MAX_ADMIN_AUTHORIZATION_BYTES`. If any requirement in a manager state transition fails, the method MUST revert without changing account state, incrementing `adminNonce`, or emitting its state-transition event.
+
+Admin authorization is valid only when `adminSigner.isValidSignature(adminOperationHash, adminAuthorization)` succeeds in a restricted validation frame and returns `EIP1271_MAGIC_VALUE`.
+
+#### `create`
+
 `create` MUST:
 
-- derive the account address;
-- require `initialSessionSigners.length` to be in `[1, MAX_SESSION_SIGNERS]`;
-- reject duplicate session verifiers;
-- verify `adminAuthorization` by calling `adminSigner.isValidSignature(signal, adminAuthorization)`;
-- reject the call if the account already exists;
-- initialize account state.
+1. reject `adminSigner == address(0)`;
+2. require `adminSigner` and each initial session verifier to have deployed code;
+3. require `initialSessionVerifiers.length` to be in `[1, MAX_SESSION_VERIFIERS]`;
+4. reject duplicate or zero session verifier addresses;
+5. derive `account`;
+6. reject if `account` already exists;
+7. compute `activeKeyringHash`;
+8. verify `createHash` through `adminSigner`;
+9. if `WORLD_ID_1271_SIGNER_FACTORY.isFactorySigner(adminSigner) == true`, require `IWorldIDAdminSigner(adminSigner).account() == account`;
+10. initialize account state with `adminNonce = 0`, `transactionNonce = 0`, no pending keyring update, and `activeSessionVerifiers = initialSessionVerifiers`;
+11. emit `AccountCreated(account, adminSigner, accountSalt, activeKeyringHash)`.
+
+#### `queueKeyringUpdate`
 
 `queueKeyringUpdate` MUST:
 
-- require the account to exist;
-- require `expectedCurrentKeyringHash == activeKeyringHash`;
-- require `targetSessionSigners.length` to be in `[1, MAX_SESSION_SIGNERS]`;
-- reject duplicate target signers;
-- require `activateAfter >= block.timestamp + MIN_KEYRING_UPDATE_DELAY`;
-- verify the admin operation through `adminSigner.isValidSignature`;
-- replace any existing pending update with the new pending update;
-- increment `adminNonce`.
+1. require `account` to exist;
+2. require `expectedCurrentKeyringHash == activeKeyringHash`;
+3. require `targetSessionVerifiers.length` to be in `[1, MAX_SESSION_VERIFIERS]`;
+4. reject duplicate, zero, or undeployed target session verifier addresses;
+5. compute `targetKeyringHash = keccak256(abi.encode(targetSessionVerifiers))`;
+6. reject `targetKeyringHash == activeKeyringHash`;
+7. require `activateAfter >= block.timestamp + MIN_KEYRING_UPDATE_DELAY`;
+8. compute `queueHash` using the current `adminNonce`;
+9. verify `queueHash` through `adminSigner`;
+10. replace any existing pending update with the new pending update;
+11. store `queuedAtNonce = adminNonce`;
+12. increment `adminNonce` by one;
+13. emit `PendingKeyringUpdateReplaced` if an update was replaced, otherwise emit `KeyringUpdateQueued`.
 
-`activateKeyringUpdate` MUST:
+#### `activateKeyringUpdate`
 
-- require a pending update;
-- require `block.timestamp >= activateAfter`;
-- require `expectedCurrentKeyringHash == activeKeyringHash`;
-- replace `activeSessionSigners`;
-- update `activeKeyringHash`;
-- clear the pending update.
+`activateKeyringUpdate` MAY be called by any address and MUST:
 
-`activateKeyringUpdate` MAY be called by any address.
+1. require `account` to exist;
+2. require `pendingKeyringUpdate.exists == true`;
+3. require `block.timestamp >= pendingKeyringUpdate.activateAfter`;
+4. require `pendingKeyringUpdate.expectedCurrentKeyringHash == activeKeyringHash`;
+5. require every target session verifier to still have deployed code;
+6. replace `activeSessionVerifiers` with `targetSessionVerifiers`;
+7. set `activeKeyringHash = targetKeyringHash`;
+8. clear the pending update by setting `pendingKeyringUpdate.exists = false`;
+9. emit `KeyringUpdateActivated`.
+
+Activation MUST NOT change `adminNonce`.
+
+#### `cancelPendingKeyringUpdate`
+
+`cancelPendingKeyringUpdate` MUST:
+
+1. require `account` to exist;
+2. require `pendingKeyringUpdate.exists == true`;
+3. require `pendingKeyringUpdate.queuedAtNonce == expectedQueuedAtNonce`;
+4. compute `cancelHash` using the current `adminNonce`;
+5. verify `cancelHash` through `adminSigner`;
+6. clear the pending update by setting `pendingKeyringUpdate.exists = false`;
+7. increment `adminNonce` by one;
+8. emit `KeyringUpdateCancelled(account, expectedQueuedAtNonce, adminNonce)`.
+
+#### `revokeSessionVerifier`
+
+`revokeSessionVerifier` MUST:
+
+1. require `account` to exist;
+2. require `sessionVerifier` to be a current member of `activeSessionVerifiers`;
+3. require `expectedCurrentKeyringHash == activeKeyringHash`;
+4. reject if removal would make the active keyring empty;
+5. compute `revokeHash` using the current `adminNonce`;
+6. verify `revokeHash` through `adminSigner`;
+7. remove `sessionVerifier` while preserving the relative order of all remaining verifiers;
+8. set `activeKeyringHash = keccak256(abi.encode(activeSessionVerifiers))`;
+9. record the revocation for txpool revalidation until `TXPOOL_TRANSACTION_EXPIRATION_WINDOW` has elapsed;
+10. increment `adminNonce` by one;
+11. emit `SessionVerifierRevoked(account, sessionVerifier, activeKeyringHash, adminNonce)`.
+
+Revocation MUST NOT change any pending keyring update.
 
 ### Restricted Validation Frames
 
-The protocol uses restricted validation frames for:
+The protocol uses restricted validation frames for admin authorization, session signature verification, and session policy evaluation.
 
-- admin authorization;
-- session signature verification;
-- session policy evaluation.
+For each EIP-1271 signature check, the protocol MUST perform a `STATICCALL` from `WORLD_CHAIN_ACCOUNT_MANAGER` to the signer with value `0`, gas exactly `EIP1271_VALIDATION_GAS_LIMIT`, and calldata `IERC1271.isValidSignature.selector || abi.encode(hash, signature)`. The call succeeds only if it returns `EIP1271_MAGIC_VALUE` and triggers no tracer rule violation.
 
-Restricted frames make validation deterministic and independent of mutable external contract state.
+For each session policy check, the protocol MUST perform a `STATICCALL` from `WORLD_CHAIN_ACCOUNT_MANAGER` to the session verifier with value `0`, gas exactly `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`, and calldata `IWorldChainSessionVerifier.evaluateSessionPolicy.selector || abi.encode(context)`. The call succeeds only if it returns `true` and triggers no tracer rule violation.
 
-#### EIP-1271 Signature Call
+Failure, revert, out-of-gas, malformed return data, or a tracer violation MUST be treated as signature or policy failure.
 
-For each EIP-1271 signature check, the protocol MUST perform:
+Restricted frames are enforced by a runtime opcode-and-target tracer derived from [ERC-7562](https://eips.ethereum.org/EIPS/eip-7562). Runtime enforcement is authoritative.
 
-- opcode: `STATICCALL`;
-- caller: `WORLD_CHAIN_ACCOUNT_MANAGER`;
-- callee: the signer contract;
-- call value: `0`;
-- gas: exactly `EIP1271_VALIDATION_GAS_LIMIT`;
-- calldata: `IERC1271.isValidSignature.selector || abi.encode(hash, signature)`;
-- success condition: call succeeds and returns `EIP1271_MAGIC_VALUE`.
+| Rule ID | ERC-7562 ref | Description |
+| --- | --- | --- |
+| `WIP1001-VR-1` | OP-011 | Forbid block-context opcodes: `BLOCKHASH`, `COINBASE`, `TIMESTAMP`, `NUMBER`, `PREVRANDAO`/`DIFFICULTY`, `GASLIMIT`, `BASEFEE`, `BLOBHASH`, `BLOBBASEFEE`. |
+| `WIP1001-VR-2` | OP-011 | Forbid transaction-context opcodes: `GASPRICE`, `ORIGIN`. |
+| `WIP1001-VR-3` | OP-020 | Forbid external account inspection: `BALANCE`, `SELFBALANCE`, `EXTCODESIZE`, `EXTCODECOPY`, `EXTCODEHASH`. |
+| `WIP1001-VR-4` | OP-031, OP-032 | Forbid persistent and transient state mutation: `SSTORE`, `TLOAD`, `TSTORE`. |
+| `WIP1001-VR-5` | OP-031 | Forbid log emission: `LOG0`, `LOG1`, `LOG2`, `LOG3`, `LOG4`. |
+| `WIP1001-VR-6` | OP-031, OP-040 | Forbid `CALL`, `CALLCODE`, `CREATE`, `CREATE2`. |
+| `WIP1001-VR-7` | OP-051 | Forbid `SELFDESTRUCT`. |
+| `WIP1001-VR-8` | OP-061 | Permit `STATICCALL` only to allowlisted precompiles. |
+| `WIP1001-VR-9` | OP-052 | Permit `DELEGATECALL` only when the delegatee bytecode satisfies the same rule set. The tracer MUST validate delegatees recursively. |
+| `WIP1001-VR-10` | - | Precompile execution does not create an additional EVM code frame. |
+| `WIP1001-VR-11` | - | Permit reads of the signer contract's own bytecode via `CODECOPY` and `CODESIZE`. |
+| `WIP1001-VR-12` | - | Permit reads of the signer contract's own storage via `SLOAD`. |
+| `WIP1001-VR-13` | - | Permit `KECCAK256`, `CHAINID`, `GAS`, stack, memory, calldata, and deterministic arithmetic opcodes. |
 
-Failure, revert, out-of-gas, malformed return data, or forbidden validation behavior MUST be treated as signature failure.
-
-#### Session Policy Evaluation Call
-
-After tentative payload execution, the protocol MUST perform:
-
-- opcode: `STATICCALL`;
-- caller: `WORLD_CHAIN_ACCOUNT_MANAGER`;
-- callee: the session verifier used for the transaction;
-- call value: `0`;
-- gas: exactly `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`;
-- calldata: `IWorldChainSessionVerifier.evaluateSessionPolicy.selector || abi.encode(context)`;
-- success condition: call succeeds and returns `true`.
-
-Failure, revert, out-of-gas, malformed return data, forbidden validation behavior, or `false` MUST reject the trace and revert tentative payload execution.
-
-#### Call Rules
-
-Inside a restricted validation frame:
-
-- `STATICCALL` to an allowlisted precompile is permitted;
-- `STATICCALL` to any other address is forbidden;
-- `CALL`, `CALLCODE`, `DELEGATECALL`, `CREATE`, and `CREATE2` are forbidden;
-- precompile execution does not create an additional EVM code frame.
-
-#### Opcode Policy
-
-The following opcodes are forbidden inside restricted validation frames:
-
-- block context: `BLOCKHASH`, `COINBASE`, `TIMESTAMP`, `NUMBER`, `PREVRANDAO`/`DIFFICULTY`, `GASLIMIT`, `BASEFEE`, `BLOBHASH`, `BLOBBASEFEE`;
-- transaction context: `GASPRICE`, `ORIGIN`;
-- external account inspection: `BALANCE`, `SELFBALANCE`, `EXTCODESIZE`, `EXTCODECOPY`, `EXTCODEHASH`;
-- mutable state and transient state: `SSTORE`, `TLOAD`, `TSTORE`;
-- logs: `LOG0`, `LOG1`, `LOG2`, `LOG3`, `LOG4`;
-- external execution and creation: `CALL`, `CALLCODE`, `DELEGATECALL`, `CREATE`, `CREATE2`;
-- destruction: `SELFDESTRUCT`.
-
-The following operations are permitted:
-
-- deterministic computation;
-- calldata and memory access;
-- reads of the signer contract's own bytecode;
-- reads of the signer contract's own storage;
-- `KECCAK256`;
-- `CHAINID`;
-- `GAS`;
-- `STATICCALL` to allowlisted precompiles.
-
-An implementation MUST reject the validation call if a forbidden opcode or forbidden call target is reached.
-
-### Timelocked Signer-State Updates
-
-Default factories that expose mutable signer or verifier state capable of invalidating a previously valid signature MUST timelock those updates by at least `MIN_KEYRING_UPDATE_DELAY`.
-
-Examples include:
-
-- root rotations;
-- verification-key rotations;
-- signer recovery changes;
-- signer revocation lists;
-- account binding changes.
-
-Signer state that cannot affect validation of already accepted transactions MAY update without this delay.
+Adding a new precompile to the validation allowlist is a hard-fork change.
 
 ### Transaction Type `0x1D`
 
-#### Envelope
-
-`WORLD_TX_TYPE` transactions use the following payload:
+The wire encoding is:
 
 ```solidity
-rlp([
+0x1D || rlp([
     chainId,
     nonce,
     maxPriorityFeePerGas,
     maxFeePerGas,
     gasLimit,
     account,
-    signer,
-    isCreate,
+    sessionVerifier,
     to,
     value,
     data,
@@ -562,7 +552,7 @@ rlp([
 The signing hash is:
 
 ```solidity
-keccak256(
+signingHash = keccak256(
     0x1D ||
     rlp([
         chainId,
@@ -571,122 +561,305 @@ keccak256(
         maxFeePerGas,
         gasLimit,
         account,
-        signer,
-        isCreate,
+        sessionVerifier,
         to,
         value,
         data,
         accessList
     ])
-)
+);
 ```
 
-#### Validation and Execution
+The transaction hash is:
 
-To validate and execute a `0x1D` transaction, the protocol MUST:
+```solidity
+txHash = keccak256(
+    0x1D ||
+    rlp([
+        chainId,
+        nonce,
+        maxPriorityFeePerGas,
+        maxFeePerGas,
+        gasLimit,
+        account,
+        sessionVerifier,
+        to,
+        value,
+        data,
+        accessList,
+        signature
+    ])
+);
+```
 
-1. Compute the signing hash.
-2. Load the account from `WORLD_CHAIN_ACCOUNT_MANAGER`.
-3. Reject the transaction if `signer` is not in the active keyring.
-4. Verify `signature` by calling `signer.isValidSignature(signingHash, signature)` in a restricted validation frame.
-5. Reject the transaction unless the signer returns `EIP1271_MAGIC_VALUE`.
-6. Execute the payload tentatively with `account` as the EVM transaction sender and collect the canonical execution trace.
-7. Build `ExecutionTraceContext` from the envelope, signing hash, active keyring hash, and canonical execution trace.
-8. Reject the transaction if `abi.encode(context.trace).length > MAX_EXECUTION_TRACE_BYTES`.
-9. Call `signer.evaluateSessionPolicy(context)` in a restricted validation frame.
-10. If session policy evaluation fails, discard tentative payload state and logs, consume nonce and gas according to normal failed-transaction semantics, and mark the transaction failed.
-11. If session policy evaluation succeeds, commit the payload result. If payload execution itself failed, commit the normal failed-call result.
+Envelope validity requirements:
+
+- `chainId` MUST equal the executing chain ID;
+- `nonce` MUST equal `Account.transactionNonce`;
+- `to` MUST be the empty byte string for contract creation or exactly 20 bytes for a call;
+- `data.length <= MAX_PAYLOAD_DATA_BYTES`;
+- `accessList.length <= MAX_ACCESS_LIST_ENTRIES`;
+- `signature.length <= MAX_SESSION_SIGNATURE_BYTES`;
+- `accessList` MUST use EIP-2930 encoding;
+- `maxFeePerGas` and `maxPriorityFeePerGas` follow [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) validity rules.
+
+### Validation, Execution, and Failure Semantics
+
+Block builders MUST reserve `EIP1271_VALIDATION_GAS_LIMIT + EXECUTION_TRACE_VALIDATION_GAS_LIMIT` from `BLOCK_VALIDATION_GAS_BUDGET` before including a `0x1D` transaction. If the remaining budget is insufficient, the transaction MUST be deferred; deferral is not a validation failure and MUST NOT mutate account state.
+
+To include a `0x1D` transaction, the protocol MUST:
+
+1. decode and validate the envelope;
+2. load `account` from `WORLD_CHAIN_ACCOUNT_MANAGER`;
+3. require `sessionVerifier` to be authorized for `account` under the txpool membership rules;
+4. require the account balance to cover the worst-case payload gas charge and `MIN_VALIDATION_FAILURE_FEE`;
+5. compute `signingHash`;
+6. call `sessionVerifier.isValidSignature(signingHash, signature)` in a restricted validation frame;
+7. if signature validation fails, apply validation-failure semantics and stop;
+8. increment `Account.transactionNonce` by one;
+9. execute the payload tentatively with `account` as the EVM sender and gas charged against envelope `gasLimit`;
+10. construct `ExecutionTraceContext`;
+11. if `abi.encode(context.trace).length > MAX_EXECUTION_TRACE_BYTES`, discard tentative payload state, apply trace-overflow semantics, and stop;
+12. call `sessionVerifier.evaluateSessionPolicy(context)` in a restricted validation frame;
+13. if policy validation fails, discard tentative payload state, apply validation-failure semantics, and stop;
+14. otherwise commit the normal payload result, including a reverted payload result if the target call reverted.
+
+Failure classes are:
+
+| Failure | Nonce | Payload state/logs | Fee behavior |
+| --- | --- | --- | --- |
+| Envelope, account, balance, nonce, or authorization precheck failure | unchanged | none | transaction is invalid and not included |
+| Validation budget exhausted | unchanged | none | transaction is deferred |
+| Signature validation failure | incremented | none | charge `max(MIN_VALIDATION_FAILURE_FEE, baseFee * EIP1271_VALIDATION_GAS_LIMIT)` |
+| Trace exceeds `MAX_EXECUTION_TRACE_BYTES` | incremented | discarded | charge as a failed payload execution under the envelope gas rules |
+| Session policy failure | incremented | discarded | charge `max(MIN_VALIDATION_FAILURE_FEE, baseFee * EIP1271_VALIDATION_GAS_LIMIT)`; payload gas is not additionally charged |
+| Payload execution revert with accepted policy | incremented | EVM revert result committed | charge normal payload gas |
+
+All validation gas consumed by signature and policy checks MUST count against `BLOCK_VALIDATION_GAS_BUDGET`. Validation gas is not deducted from the envelope `gasLimit`.
+
+### Txpool Revalidation
+
+World Chain clients MUST revalidate every pooled `0x1D` transaction at least once per block until inclusion, expiration, or eviction.
+
+On pool admission, the client MUST record `entryTimestamp`, `account`, `sessionVerifier`, `nonce`, and the account's active keyring membership at admission. A transaction is eligible to remain pooled only while all conditions hold:
+
+- `block.timestamp < entryTimestamp + TXPOOL_TRANSACTION_EXPIRATION_WINDOW`;
+- `account` exists;
+- the account balance can cover `MIN_VALIDATION_FAILURE_FEE` at the current `baseFee`;
+- the transaction nonce can still become executable under the account nonce ordering rules;
+- `sessionVerifier` has not been revoked after admission.
+
+Activation of a queued keyring update MUST NOT evict already pooled transactions whose verifier was active at admission. `revokeSessionVerifier` MUST immediately evict pooled transactions from the revoked verifier.
+
+### Timelocked Signer-State Updates
+
+Default factory signers with mutable state that can change `isValidSignature` or `evaluateSessionPolicy` for already accepted transactions MUST timelock those updates by at least `MIN_KEYRING_UPDATE_DELAY`.
+
+This applies to root rotations, verification-key rotations, signer recovery changes, signer revocation lists, account binding changes, and policy configuration changes. State that cannot affect validation MAY update without this delay.
 
 ### Default Signer Factories
 
-World Chain provides default EIP-1271 signer factories through predeploy addresses assigned at activation.
+Accounts MAY use any EIP-1271 admin signer or session verifier that satisfies this specification. Default factories are deployment helpers, not authorization registries. A factory-created signer has no account authority until it is used as an admin signer during `create` or added to an account keyring.
 
-Default factories are reference implementations. Accounts MAY use any EIP-1271 admin signer or session verifier that satisfies this specification.
+```solidity
+enum WorldChainSignerRole {
+    AdminSigner,
+    SessionVerifier
+}
 
-#### Secp256k1 Signer
+interface IWorldChainFactoryDeployedSigner {
+    function signerFactory() external view returns (address);
+    function signerRole() external view returns (WorldChainSignerRole);
+    function signerVariantId() external view returns (bytes32);
+    function signerConfigHash() external view returns (bytes32);
+}
 
-`SECP256K1_1271_SIGNER_FACTORY` deploys the secp256k1 admin signer defined in this specification and MAY deploy session verifier variants that use the same secp256k1 authentication core.
+interface IWorldChain1271SignerFactory {
+    event SignerCreated(
+        address indexed signer,
+        WorldChainSignerRole indexed role,
+        bytes32 indexed variantId,
+        bytes32 configHash,
+        bytes32 salt
+    );
 
-The admin signer variant implements EIP-1271 only. A session verifier variant MUST also implement `IWorldChainSessionVerifier`.
-
-#### World ID Signer
-
-`WORLD_ID_1271_SIGNER_FACTORY` deploys the World ID admin signer defined in this specification and MAY deploy session verifier variants that use the same World ID authentication core.
-
-The admin signer variant implements EIP-1271 only. A session verifier variant MUST also implement `IWorldChainSessionVerifier` and MUST bind its World ID proof to the `0x1D` signing hash.
-
-### Visual Flow
-
-```mermaid
-sequenceDiagram
-    autonumber
-    participant User
-    participant Pool as Tx Pool
-    participant Protocol
-    participant Manager as WORLD_CHAIN_ACCOUNT_MANAGER
-    participant Signer as EIP-1271 Session Verifier
-    participant App as Target Contracts
-
-    User->>Pool: Submit 0x1D transaction
-    Pool->>Protocol: Validate transaction
-    Protocol->>Manager: Load active keyring
-    Manager-->>Protocol: signer authorized, activeKeyringHash
-    Protocol->>Signer: isValidSignature(signingHash, signature)
-    Signer-->>Protocol: EIP1271_MAGIC_VALUE
-    Protocol-->>Pool: Valid while keyring is active
-
-    Protocol->>App: Tentative execution as account
-    App-->>Protocol: Result, calls, logs
-    Protocol->>Signer: evaluateSessionPolicy(context)
-    alt trace accepted
-        Signer-->>Protocol: true
-        Protocol-->>User: Commit payload result
-    else trace rejected
-        Signer-->>Protocol: false or failure
-        Protocol-->>User: Revert tentative payload
-    end
-
-    User->>Manager: queueKeyringUpdate(...)
-    Manager-->>User: Pending until activateAfter
-    User->>Manager: activateKeyringUpdate()
-    Manager-->>User: Active keyring replaced
+    function worldChainAccountManager() external view returns (address);
+    function computeAddress(
+        WorldChainSignerRole role,
+        bytes32 variantId,
+        bytes calldata config,
+        bytes32 salt
+    ) external view returns (address signer);
+    function createSigner(
+        WorldChainSignerRole role,
+        bytes32 variantId,
+        bytes calldata config,
+        bytes32 salt
+    ) external returns (address signer);
+    function isFactorySigner(address signer) external view returns (bool);
+}
 ```
 
-### Extensions
+`createSigner` MUST:
 
-WIP-1001 is designed to support future signer contracts without protocol changes, including:
+1. reject unknown `role` or `variantId`;
+2. decode and validate `config`;
+3. compute `configHash = keccak256(config)`;
+4. deploy with `CREATE2` using `keccak256(abi.encode(WIP1001_SIGNER_DOMAIN, chainId, WORLD_CHAIN_ACCOUNT_MANAGER, role, variantId, configHash, salt))` as the salt;
+5. initialize signer metadata;
+6. return the deployed signer address;
+7. emit `SignerCreated`.
 
-- multisig signers;
-- social recovery signers;
-- passkey signers;
-- threshold signers;
-- proof-system signers;
-- enterprise policy signers;
-- application-specific session verifiers.
+`computeAddress` MUST return the address that `createSigner` would deploy. `createSigner` MUST be idempotent when the expected signer already exists with matching metadata and MUST revert when the expected address is occupied by incompatible code. Factory deployment MUST NOT mutate manager state.
 
-New cryptographic primitives SHOULD be added as reusable precompiles, not as account-specific protocol branches.
+### Default Secp256k1 Signers
+
+`SECP256K1_1271_SIGNER_FACTORY` MUST support:
+
+```solidity
+bytes32 constant SECP256K1_ADMIN_SIGNER_V1 =
+    keccak256("world-chain.secp256k1.admin.v1");
+
+bytes32 constant SECP256K1_SESSION_VERIFIER_V1 =
+    keccak256("world-chain.secp256k1.session-verifier.v1");
+
+struct Secp256k1AdminSignerConfig {
+    address owner;
+}
+
+struct Secp256k1SessionVerifierConfig {
+    address account;
+    address owner;
+    bytes32 policyVariantId;
+    bytes policyConfig;
+}
+
+interface ISecp256k1AdminSigner is IWorldChainAdminSigner {
+    function owner() external view returns (address);
+}
+```
+
+The EIP-1271 signature payload is `r || s || v`. `isValidSignature(hash, signature)` MUST require `signature.length == 65`, lower-half-order `s`, `v` equal to `27` or `28`, and `ecrecover(hash, v, r, s) == owner()`.
+
+The secp256k1 session verifier variant MUST verify the same payload against its configured `owner`, reject `evaluateSessionPolicy` unless `context.transaction.account == account` and `context.transaction.sessionVerifier == address(this)`, and evaluate policy internally from its own code and storage.
+
+### Default World ID Signers
+
+`WORLD_ID_1271_SIGNER_FACTORY` MUST support:
+
+```solidity
+bytes32 constant WORLD_ID_ADMIN_SIGNER_V1 =
+    keccak256("world-chain.world-id.admin.v1");
+
+bytes32 constant WORLD_ID_SESSION_VERIFIER_V1 =
+    keccak256("world-chain.world-id.session-verifier.v1");
+
+struct WorldIDAdminSignerConfig {
+    bytes32 accountSalt;
+    address stateUpdater;
+    uint256 treeDepth;
+    uint64 issuerSchemaId;
+    uint256 credentialIssuerPubkeyX;
+    uint256 credentialIssuerPubkeyY;
+    uint256 oprfPubkeyX;
+    uint256 oprfPubkeyY;
+    uint64 minExpiresAt;
+    uint256 minCredentialGenesisIssuedAt;
+    uint256[] initialValidRoots;
+}
+
+struct WorldIDSessionVerifierConfig {
+    address account;
+    address stateUpdater;
+    uint256 treeDepth;
+    uint64 issuerSchemaId;
+    uint256 credentialIssuerPubkeyX;
+    uint256 credentialIssuerPubkeyY;
+    uint256 oprfPubkeyX;
+    uint256 oprfPubkeyY;
+    uint64 minExpiresAt;
+    uint256 minCredentialGenesisIssuedAt;
+    uint256[] initialValidRoots;
+    bytes32 policyVariantId;
+    bytes policyConfig;
+}
+
+interface IWorldIDAdminSigner is IWorldChainAdminSigner {
+    function accountSalt() external view returns (bytes32);
+    function account() external view returns (address);
+    function worldIdRpId() external view returns (uint64);
+    function worldIdAction() external view returns (uint256);
+}
+
+interface IWorldIDSessionVerifier is IWorldChainSessionVerifier {
+    function account() external view returns (address);
+    function worldIdRpId() external view returns (uint64);
+}
+```
+
+`IWorldIDAdminSigner.account()` MUST equal the manager-derived account using `address(this)` as `adminSigner` and `accountSalt()` as `accountSalt`. `worldIdRpId()` MUST equal `WORLD_CHAIN_RP_ID`.
+
+`worldIdAction()` MUST return:
+
+```solidity
+worldIdField(abi.encode(
+    WORLD_ID_ACCOUNT_TAG,
+    block.chainid,
+    WORLD_CHAIN_RP_ID,
+    WORLD_CHAIN_ACCOUNT_MANAGER,
+    account(),
+    address(this)
+))
+```
+
+where `worldIdField(input) = uint256(keccak256(input)) >> 8`.
+
+The World ID admin signer signature payload is:
+
+```solidity
+struct WorldIDUniquenessProofSignature {
+    uint256 nullifier;
+    uint64 expiresAtMin;
+    uint64 issuerSchemaId;
+    uint256 credentialGenesisIssuedAtMin;
+    uint256[5] zeroKnowledgeProof;
+}
+```
+
+Admin `isValidSignature(hash, signature)` MUST decode `WorldIDUniquenessProofSignature`, compute `signalHash = worldIdField(abi.encode(hash))`, compute `nonce = worldIdField(abi.encode("WIP1001_WORLD_ID_ADMIN_NONCE", hash))`, require configured issuer and freshness parameters, require `zeroKnowledgeProof[4]` to be an accepted root, verify a World ID v4 uniqueness proof with `sessionId = 0`, and return `EIP1271_MAGIC_VALUE` only on success.
+
+The World ID session verifier signature payload is:
+
+```solidity
+struct WorldIDSessionProofSignature {
+    uint64 expiresAtMin;
+    uint64 issuerSchemaId;
+    uint256 credentialGenesisIssuedAtMin;
+    uint256 sessionId;
+    uint256[2] sessionNullifier;
+    uint256[5] zeroKnowledgeProof;
+}
+```
+
+Session `isValidSignature(hash, signature)` MUST decode `WorldIDSessionProofSignature`, compute `signalHash = worldIdField(abi.encode(hash))`, compute `nonce = worldIdField(abi.encode("WIP1001_WORLD_ID_SESSION_NONCE", block.chainid, WORLD_CHAIN_ACCOUNT_MANAGER, account(), address(this), hash))`, require `sessionId != 0`, require configured issuer and freshness parameters, require `zeroKnowledgeProof[4]` to be an accepted root, verify a World ID v4 session proof, and return `EIP1271_MAGIC_VALUE` only on success.
+
+World ID signers MUST verify the configured public inputs for issuer schema, credential issuer public key, credential expiration minimum, credential genesis minimum, Merkle root, tree depth, RP ID, OPRF public key, signal hash, nonce, and proof type. They MUST NOT consume nullifiers in `isValidSignature` and MUST NOT call an external World ID verifier from a restricted validation frame.
+
+World ID verifier state MUST be stored in the signer contract itself. If `stateUpdater == address(0)`, the verifier state is immutable. Otherwise, updates that can invalidate accepted transactions MUST follow "Timelocked Signer-State Updates".
 
 ## Rationale
 
-### EIP-1271 as the Signer Boundary
-
 EIP-1271 gives World Chain one protocol boundary for all authorization schemes. The protocol verifies a signer contract; the signer contract decides how to authenticate.
 
-### Verifier-Owned Execution Policy
+Execution policy belongs inside the session verifier. The protocol supplies the canonical transaction context and execution trace, then asks the verifier for a boolean decision.
 
-Execution policy belongs inside the session verifier. The protocol does not need to understand spending limits, method allowlists, intents, or application-specific policy. It only supplies the canonical transaction context and execution trace, then asks the verifier for a boolean decision.
+Validation gas limits are protocol constants, not signer-selected values. This gives clients a fixed resource bound for mempool validation and block execution.
 
-### Fixed Validation Gas
+Validation gas is supplied from a per-block budget rather than the envelope `gasLimit`. This keeps the payload gas model close to EIP-1559 transactions while bounding validation work per block.
 
-Validation gas limits are protocol constants, not signer-selected values. This prevents signers from increasing validation cost per transaction and gives clients a fixed resource bound for mempool validation and block execution.
+Timelocked keyring updates preserve stable inclusion for transactions already accepted by the pool. Instant revocation remains available for compromised session verifiers and only evicts transactions from the revoked verifier.
 
-### Timelocked Keyring Updates
-
-A keyring update can invalidate transactions that already passed mempool validation. Requiring `MIN_KEYRING_UPDATE_DELAY > TXPOOL_TRANSACTION_EXPIRATION_WINDOW` guarantees that a transaction cannot be invalidated by a keyring update while it is still eligible for inclusion.
-
-### Restricted Validation Frames
-
-Restricted validation frames prevent validation results from depending on mutable external state, block metadata, or external contract calls. Signers remain programmable, but validation stays reproducible across pool validation and block execution.
+Restricted validation frames prevent validation from depending on mutable external state, block metadata, or arbitrary external contract calls.
 
 ## Backwards Compatibility
 
@@ -694,52 +867,42 @@ WIP-1001 introduces a new EIP-2718 transaction type and a new account manager pr
 
 Existing Safe accounts MAY deploy or delegate to EIP-1271 signer contracts that satisfy this specification, but WIP-1001 does not require Safe migration.
 
+## Test Cases
+
+Conforming implementations MUST pass vectors for:
+
+- address derivation across multiple `(chainId, manager, adminSigner, accountSalt)` tuples;
+- `activeKeyringHash` ordering and duplicate rejection;
+- each admin operation hash domain, including negative replay cases;
+- `0x1D` RLP encoding, signing hash, and transaction hash;
+- malformed envelope rejection for `to`, `data`, `accessList`, and `signature` bounds;
+- manager state transitions, emitted events, nonce changes, and failure atomicity;
+- transaction validation failures, policy failures, trace overflow, and payload reverts;
+- txpool retention across keyring activation and eviction on revocation;
+- restricted-frame positive cases and each forbidden opcode or call target;
+- World ID `worldIdField`, `worldIdAction`, admin proof, and session proof inputs;
+- default secp256k1 low-s, `v`, owner, and signature-length checks;
+- block validation budget exhaustion and validation-failure fee charging.
+
+Complete golden vectors and a conformance test suite MUST be published before this WIP advances to Review.
+
 ## Security Considerations
 
-### Admin Authorization Front-Running
-
-Admin authorization signatures MUST bind account address, manager address, chain ID, operation selector, operation parameters, and nonce. A signature valid for one admin operation MUST NOT be valid for another.
-
-### Admin Signer Compromise
-
-The admin signer can queue keyring changes. Applications SHOULD support recovery or multisig admin signers where appropriate.
-
-### Signer Validation DoS
-
-Fixed validation gas limits bound signer execution. Signers that exceed the limit fail validation.
-
-### Trace Size DoS
-
-`MAX_EXECUTION_TRACE_BYTES` bounds memory and encoding cost for session policy evaluation. Transactions that exceed the bound fail before the context is passed to the signer.
-
-### External-State Invalidation
-
-Restricted frames forbid external contract reads and calls except allowlisted precompiles. This prevents unrelated contract state from changing signature or session policy outcomes.
-
-### Block-Context Invalidation
-
-Restricted frames forbid block-context opcodes. Signers that need time or block constraints MUST bind them into the signature or proof input.
-
-### Own-Storage Invalidation
-
-Signers and verifiers may read their own storage. Default factories that expose mutable state affecting validation MUST timelock those updates by at least `MIN_KEYRING_UPDATE_DELAY`.
-
-### Upgradeable Signers
-
-Upgradeable signer contracts can change validation behavior. Signer factories SHOULD make upgradeability explicit, and upgrades that affect validation SHOULD be timelocked.
-
-### Session Verifier Deanonymization
-
-The `0x1D` envelope exposes the selected session verifier. Applications that need stronger privacy should use verifier contracts that aggregate or rotate credentials.
-
-### Signature-Signer Ambiguity
-
-The transaction envelope includes both `account` and `signer`. The protocol MUST verify that `signer` is active for `account` before calling EIP-1271.
-
-### WebAuthn Challenge Binding
-
-WebAuthn-based signers MUST bind challenges to the `0x1D` signing hash and `WORLD_CHAIN_RP_ID`.
-
-### World ID Stale Roots
-
-World ID signers MUST define root freshness rules. Root updates that can invalidate previously accepted transactions MUST follow the signer-state timelock requirement.
+- Admin authorization hashes bind domain, chain ID, manager, account, parameters, and nonce where applicable. A signature valid for one operation MUST NOT be valid for another.
+- The admin signer is immutable in the account address. A broken or lost admin signer requires migrating assets to a new account.
+- Applications that need recovery SHOULD use admin signers with recovery or multisig logic from account creation.
+- `revokeSessionVerifier` is effective only after compromise is detected and the admin transaction is included. Monitoring and automated revocation reduce this window.
+- Fixed validation gas limits bound signer execution. Signers that exceed the limit fail validation.
+- `BLOCK_VALIDATION_GAS_BUDGET` is scarce. `MIN_VALIDATION_FAILURE_FEE` MUST be tuned so validation spam is costly, and clients MUST reject pooled transactions that cannot pay it.
+- Builders may prefer transactions with cheaper validation profiles. Fixed validation gas bounds the worst-case bias.
+- `MAX_EXECUTION_TRACE_BYTES`, `MAX_PAYLOAD_DATA_BYTES`, `MAX_ACCESS_LIST_ENTRIES`, `MAX_SESSION_SIGNATURE_BYTES`, and `MAX_ADMIN_AUTHORIZATION_BYTES` bound calldata, decoding, memory, and ABI-encoding costs.
+- Restricted frames forbid mutable external-state reads and block-context opcodes. Signers that need time, block, or external-state constraints MUST bind them into the signature or proof input.
+- Signers may read their own storage. Mutable signer state that can affect accepted transactions MUST be timelocked.
+- Upgradeable signers can change validation behavior. Upgrades that affect validation MUST follow the signer-state timelock requirement.
+- The `0x1D` envelope exposes `account` and `sessionVerifier`. Applications that need stronger privacy should use verifier contracts that aggregate or rotate credentials.
+- The protocol MUST verify that `sessionVerifier` is authorized for `account` before calling EIP-1271.
+- WebAuthn-based signers MUST bind challenges to the `0x1D` signing hash and `WORLD_CHAIN_RP_ID`.
+- World ID signers MUST bind `block.chainid` into `worldIdAction` or session nonce inputs to prevent cross-chain proof replay.
+- The default World ID admin signer self-reports `account()`. The manager checks this only for default-factory-deployed World ID admin signers; custom signers are responsible for their own consistency.
+- `create` does not bind `msg.sender`, so a copied call can be front-run. The resulting account state is identical because the authorization commits to all state-determining parameters.
+- `DELEGATECALL` inside restricted validation frames is safe only when the delegatee bytecode satisfies the same tracer rules recursively.

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -33,15 +33,17 @@ Account state lives natively in the `WORLD_CHAIN_ACCOUNT_PRECOMPILE`. The accoun
 
 ### Minimal Ethereum Diff
 
-Ethereum already has one native transaction-signature algorithm and one standard contract-signature interface. WIP-1001 follows that split: native secp256k1 address recovery for EOA-like signers, and [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) for contract signers. The World Chain Account precompile stores authorization state, but it does not grow a bespoke signature-algorithm registry.
+Ethereum already has one native transaction-signature algorithm and one standard contract-signature interface. WIP-1001 follows that split: native secp256k1 address recovery for EOA-like signers, and [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) for contract signers.
 
 This keeps the `0x1D` transaction model close to existing Ethereum validation while still admitting modern authenticators and application-defined signing policies. A passkey, threshold signer, BLS aggregate signer, or Groth16-backed signer is a contract that returns the EIP-1271 magic value after calling public precompiles.
 
 ### Reusable Cryptography
 
-Cryptographic accelerators used for account validation should not be protocol-private. If the protocol accepts an elliptic-curve or pairing primitive during EIP-1271 validation, the same primitive MUST be exposed as a normal EVM precompile callable by smart contracts. This lets signer contracts, application contracts, and protocol validation share one compatibility surface.
+Cryptographic accelerators used for account validation should not be protocol-private. If the protocol accepts an elliptic-curve or bilinear pairing during EIP-1271 validation, the same primitive MUST be exposed as a normal EVM precompile callable by smart contracts. This lets signer contracts, application contracts, and protocol validation share one compatibility surface.
 
 ### Pluggable Admin Authorities
+
+TODO: FIXME: Rewrite with new Admin Key Model
 
 A pluggable admin model lets a single account abstraction serve multiple user populations from one precompile. **WorldID admin** converges key rotation and recovery onto a single proof-verification path after enrollment: a fresh Session Proof. No "super key" is ever stored on-device; recovery is the degenerate case of the same upgrade path. **Secp256k1 EOA admin** lets accounts be owned by existing Ethereum keys. **EIP-1271 contract admin** lets accounts be controlled by multisigs, passkeys, policy engines, or custom recovery contracts without adding new native admin algorithms to this WIP.
 
@@ -64,7 +66,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 | `KEY_TYPE_SECP256K1_EOA`          | `0x00`                                       | Session key type: Ethereum secp256k1 address                 |
 | `KEY_TYPE_EIP1271`                | `0x01`                                       | Session key type: EIP-1271 contract address                  |
 | `EIP1271_MAGIC_VALUE`             | `0x1626ba7e`                                 | `bytes4(keccak256("isValidSignature(bytes32,bytes)"))`       |
-| `MAX_EIP1271_VALIDATION_GAS`      | `500_000`                                    | Maximum gas for one protocol EIP-1271 validation frame        |
+| `MAX_EIP1271_VALIDATION_GAS`      | `TBD`                                        | Maximum gas for one protocol EIP-1271 validation frame        |
 
 Per-instantiation constants are defined in their respective sections.
 
@@ -83,6 +85,9 @@ The validation precompile allowlist initially contains:
 | `BN254_MUL`       | `0x0000000000000000000000000000000000000007` | BN254 G1 scalar multiplication ([EIP-196](https://eips.ethereum.org/EIPS/eip-196)) |
 | `BN254_PAIRING`   | `0x0000000000000000000000000000000000000008` | BN254 pairing check ([EIP-197](https://eips.ethereum.org/EIPS/eip-197)) |
 | `P256VERIFY`      | `0x0000000000000000000000000000000000000100` | P256/secp256r1 verification ([RIP-7212](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md)) |
+| `EDDSA_VERIFY`    | `TBD`                                        | EdDSA signature verification; specified by a separate WIP |
+
+The concrete address, supported curve(s), input/output encoding, malleability rules, failure behavior, and gas schedule for `EDDSA_VERIFY` are out of scope for WIP-1001 and MUST be specified by a separate WIP before activation.
 
 Future curve or pairing systems MAY be added by extending this allowlist in a follow-on fork. EIP-1271 signer contracts that need a non-allowlisted primitive are invalid for WIP-1001 protocol validation until that primitive is exposed as an allowed precompile.
 
@@ -104,7 +109,7 @@ struct Account {
 }
 ```
 
-`verificationPublicId` is the persistent public material the admin authority uses to verify subsequent updates. Its encoding is per-instantiation (e.g., `sessionId` for WorldID admin, an admin address for Secp256k1 EOA admin, or `(contract, gasLimit, codeHash)` for EIP-1271 admin). It is set at creation and is not directly mutable by this WIP -- see [Extensions](#extensions) for admin rotation.
+`verificationPublicId` is the persistent public material the admin authority uses to verify subsequent updates. Its encoding is per-instantiation (e.g., `sessionId` for WorldID admin, an admin address for Secp256k1 EOA admin, or `(contract, gasLimit)` for EIP-1271 admin). It is set at creation and is not directly mutable by this WIP -- see [Extensions](#extensions) for admin rotation.
 
 #### Session Keys
 
@@ -118,26 +123,40 @@ struct SessionKey {
     KeyType keyType;
     address key;
     uint32  validationGasLimit;
-    bytes32 codeHash;
-    uint64  validAfter;
-    uint64  validUntil;
+    SessionPolicy policy;
+}
+
+struct SessionPolicy {
+    uint64      validAfter;
+    uint64      validUntil;
+    uint256     maxValuePerTx;
+    CallScope[] callScopes;
+}
+
+struct CallScope {
+    address target;
+    bytes4  selector;
 }
 ```
 
-| `keyType`          | Value  | `key` meaning                                     | `validationGasLimit`                         | `codeHash`             |
-| ------------------ | ------ | ------------------------------------------------- | -------------------------------------------- | ---------------------- |
-| `Secp256k1EOA`     | `0x00` | Ethereum address recovered from secp256k1 ECDSA   | MUST be `0`                                  | MUST be `0x00..00`     |
-| `EIP1271`          | `0x01` | Contract implementing `isValidSignature(bytes32,bytes)` | MUST be `> 0` and `<= MAX_EIP1271_VALIDATION_GAS` | MAY be `0x00..00`, otherwise pins `EXTCODEHASH(key)` |
+| `keyType`          | Value  | `key` meaning                                     | `validationGasLimit`                         |
+| ------------------ | ------ | ------------------------------------------------- | -------------------------------------------- |
+| `Secp256k1EOA`     | `0x00` | Ethereum address recovered from secp256k1 ECDSA   | MUST be `0`                                  |
+| `EIP1271`          | `0x01` | Contract implementing `isValidSignature(bytes32,bytes)` | MUST be `> 0` and `<= MAX_EIP1271_VALIDATION_GAS` |
 
-`key` MUST NOT be the zero address. For an `EIP1271` session key, `key` MUST have non-empty code when the keyring update is applied.
+`key` MUST NOT be the zero address. For `EIP1271`, `key` MUST have non-empty code at the time it is added to a keyring or fixed as an admin authority.
 
-If `codeHash != 0x00..00` for an `EIP1271` session key, the protocol MUST require `EXTCODEHASH(key) == codeHash` when the keyring update is applied and during every `0x1D` validation using that key. A zero `codeHash` deliberately permits upgradeable EIP-1271 key contracts.
+Keyring uniqueness is defined by `(keyType, key)`. A keyring MUST NOT contain two entries with the same `(keyType, key)`, even if their `validationGasLimit` or policy values differ. Changing an EIP-1271 session key's gas limit or a session key's policy requires replacing the full keyring with `SetKeyring`.
 
-Keyring uniqueness is defined by `(keyType, key)`. A keyring MUST NOT contain two entries with the same `(keyType, key)`, even if their metadata differs. Changing an EIP-1271 session key's gas limit, code hash, or validity window requires replacing the full keyring.
+Session policies provide the basic scoped-key surface in this WIP:
 
-`validAfter` and `validUntil` define the key's validity window in Unix seconds. `validUntil == 0` means no upper bound. If `validUntil != 0`, implementations MUST require `validAfter <= validUntil`. A session key is active at block timestamp `t` iff `t >= validAfter && (validUntil == 0 || t <= validUntil)`.
+- `validAfter` and `validUntil` define the key's validity window in Unix seconds. `validUntil == 0` means no upper bound. If `validUntil != 0`, implementations MUST require `validAfter <= validUntil`.
+- `maxValuePerTx` is the maximum native-token `value` the key may authorize in one `0x1D` transaction. `type(uint256).max` means no value limit.
+- `callScopes` is an allowlist over `(to, selector)`. If empty, no target/selector restriction is applied. `target == address(0)` matches any target. `selector == 0x00000000` matches any selector; otherwise it is matched against the first four bytes of transaction calldata, with empty calldata treated as selector `0x00000000`.
 
-Session keys carry no intrinsic privileges beyond signing `0x1D` transactions while active. Per-key spend limits and call scopes are out of scope for this WIP (see [Extensions](#extensions)).
+A `0x1D` transaction satisfies a `SessionPolicy` iff the current block timestamp is within the validity window, `value <= maxValuePerTx`, and either `callScopes` is empty or at least one `CallScope` matches the transaction.
+
+Session keys carry no intrinsic privileges beyond signing `0x1D` transactions that satisfy their stored policy.
 
 #### Admin Authority Interface
 
@@ -151,13 +170,9 @@ verifyAdmin(signalHash, authorization, verificationPublicId) -> bool
 
 Admin authorization at creation is also instantiation-specific. Each instantiation defines an `adminCreationContext`: the canonical ABI tuple of creation fields that fix the admin authority, the address-defining material, and any persistent verification state. The first element of this tuple MUST be the `uint8 adminType` discriminator. Authorization payloads, signatures, and proofs are excluded from this context to avoid recursive hashing. `CreateSignal` binds `adminType` and `adminCreationContextHash = keccak256(adminCreationContext)` so the creation authorization cannot be replayed with different permanent admin state.
 
-Some instantiations take address-defining material directly as a creation input that coincides with `verificationPublicId`; others retain a different persistent verifier identifier. For WorldID admin, the creation nullifier defines the address while `sessionId` is stored as `verificationPublicId`. For EIP-1271 admin, the signer contract defines the address while `(signer, validationGasLimit, codeHash)` is stored as `verificationPublicId`.
+Some instantiations take address-defining material directly as a creation input that coincides with `verificationPublicId`; others retain a different persistent verifier identifier. For WorldID admin, the creation nullifier defines the address while `sessionId` is stored as `verificationPublicId`. For EIP-1271 admin, the signer contract defines the address while `(signer, validationGasLimit)` is stored as `verificationPublicId`.
 
-#### Account Registry and Address Derivation
-
-A World Chain Account exists iff `WORLD_CHAIN_ACCOUNT_PRECOMPILE` has an account registry entry for its address. Counterfactual prefunding is allowed: `create` MUST NOT reject solely because the target EVM account has a nonzero balance.
-
-`create` MUST reject if the derived address is a reserved precompile or system address, has non-empty EVM code, or has nonzero EVM nonce before creation. On success, `create` initializes only the WIP-1001 account registry entry; it MUST NOT modify the target address's EVM balance, EVM nonce, or EVM code.
+#### Address Derivation
 
 ```text
 addr = bytes20(keccak256(abi.encodePacked(adminTypeTag, addressDefiningMaterial)))
@@ -166,12 +181,10 @@ addr = bytes20(keccak256(abi.encodePacked(adminTypeTag, addressDefiningMaterial)
 `adminTypeTag` is the one-byte `ADMIN_TYPE_*` discriminator. `addressDefiningMaterial` is per-instantiation:
 
 - WorldID admin: the creation Uniqueness Proof's nullifier (32 bytes).
-- Secp256k1 EOA admin: `abi.encode(adminAddress, accountSalt)`.
-- EIP-1271 contract admin: `abi.encode(signer, accountSalt)`.
+- Secp256k1 EOA admin: the 20-byte admin address (= `verificationPublicId`).
+- EIP-1271 contract admin: the 20-byte signer contract address.
 
 The address is fixed for the lifetime of the account; session-key rotation does **NOT** change the address.
-
-`accountSalt` is a user-chosen `bytes32` value. It lets one EOA admin address or EIP-1271 admin contract control multiple independent World Chain Accounts while keeping each account address deterministic.
 
 #### Signal Semantics
 
@@ -206,8 +219,6 @@ The `signalHash` an admin authority binds to is uniform across instantiations.
 ```solidity
 struct CreateSignal {
     bytes32       tag;             // == keccak256("WORLD_CHAIN_ACCOUNT_CREATE")
-    uint256       chainId;
-    address       verifyingContract; // == WORLD_CHAIN_ACCOUNT_PRECOMPILE
     uint8         adminType;
     bytes32       adminCreationContextHash;
     address       msgSender;
@@ -216,8 +227,6 @@ struct CreateSignal {
 
 struct UpdateSignal {
     bytes32       tag;             // == keccak256("WORLD_CHAIN_ACCOUNT_UPDATE")
-    uint256       chainId;
-    address       verifyingContract; // == WORLD_CHAIN_ACCOUNT_PRECOMPILE
     address       accountAddress;
     uint64        adminNonce;
     address       msgSender;
@@ -231,20 +240,9 @@ signalHash = bytes32(uint256(keccak256(abi.encode(signal))) >> 8)
 
 where `signal` is a populated `CreateSignal` for `Create` and an `UpdateSignal` for `SetKeyring`. The resulting value is encoded as a `bytes32` with its high 8 bits set to zero.
 
-`chainId` and `verifyingContract` domain-separate admin authorizations across chains and account-precompile deployments. `msgSender` is the EVM `msg.sender` of the precompile call -- binding it prevents an in-flight admin authorization observed in the mempool from being replayed by a different submitter. For `Create`, `accountAddress` is omitted because it is not knowable to the admin authority at the time the authorization is produced (it is derived from `Create`'s outputs); the domain tag, `chainId`, `verifyingContract`, `adminType`, `adminCreationContextHash`, `msgSender`, and the keyring payload bind the authorization to its intended creation. For updates, `accountAddress` distinguishes admin authorizations across accounts the same admin might control on the same chain.
+`msgSender` is the EVM `msg.sender` of the precompile call -- binding it prevents an in-flight admin authorization observed in the mempool from being replayed by a different submitter. For `Create`, `accountAddress` is omitted because it is not knowable to the admin authority at the time the authorization is produced (it is derived from `Create`'s outputs); the domain tag, `adminType`, `adminCreationContextHash`, `msgSender`, and the keyring payload bind the authorization to its intended creation. For updates, `accountAddress` distinguishes admin authorizations across accounts the same admin might control on different domains.
 
 The `>> 8` truncation reduces the digest to 248 bits so it fits within the BN254 scalar field (matching the WorldID 4.0 proof system's signal field width). Truncation is uniform across instantiations even when the verification primitive does not require the BN254 fit, so the same `signalHash` value is canonical across all admin types.
-
-#### Canonical Encoding
-
-All Solidity-like structs in this WIP are consensus types, not illustrative pseudocode. Unless explicitly stated otherwise:
-
-- Structs are encoded with `abi.encode` using the field order shown in this document.
-- Enums are encoded as `uint8`.
-- `SessionKey[]` order is significant and included in every `keyringHash` and `signalHash`.
-- Dynamic `bytes` fields are ABI-encoded as ordinary Solidity `bytes`.
-- RLP-encoded signatures and transactions MUST use canonical, minimal RLP. Non-canonical RLP is invalid.
-- Integer fields in RLP transaction envelopes MUST use canonical Ethereum transaction integer encoding: zero is encoded as the empty byte string, and nonzero integers MUST NOT contain leading zero bytes.
 
 #### Replay Protection
 
@@ -294,11 +292,11 @@ For `create`, the precompile MUST:
 2. Validate all `keyringUpdate.keys` and keyring-size constraints.
 3. Decode `adminCreationData` per the instantiation specified by `adminType`.
 4. Compute the instantiation's `adminCreationContextHash`.
-5. Recompute the `Create` `signalHash` over `(chainId, WORLD_CHAIN_ACCOUNT_PRECOMPILE, adminType, adminCreationContextHash, msg.sender, keyringUpdate)`.
+5. Recompute the `Create` `signalHash` over `(adminType, adminCreationContextHash, msg.sender, keyringUpdate)`.
 6. Verify the admin authorization per the instantiation, against `signalHash` and the instantiation's `verificationPublicId` (or, for WorldID admin, the equivalent verifier public-input set).
 7. Determine `addressDefiningMaterial` per the instantiation.
 8. Derive `accountAddress = bytes20(keccak256(abi.encodePacked(adminTypeTag, addressDefiningMaterial)))`.
-9. Require the account does not already exist at `accountAddress` and the derived EVM address satisfies the creation checks in [Account Registry and Address Derivation](#account-registry-and-address-derivation).
+9. Require the account does not already exist at `accountAddress`.
 10. Initialize the account: store `adminType`, `verificationPublicId`, `sessionKeys = keyringUpdate.keys`, `keyringHash = keccak256(abi.encode(keyringUpdate.keys))`, and `adminNonce = 0`.
 
 For `update`, the precompile MUST:
@@ -307,19 +305,12 @@ For `update`, the precompile MUST:
 2. Validate all `keyringUpdate.keys` and keyring constraints.
 3. Load the account's stored `adminType`, `verificationPublicId`, `keyringHash`, and `adminNonce`.
 4. Require `keyringUpdate.expectedCurrentKeyringHash == keyringHash`.
-5. Recompute the `Update` `signalHash` over `(chainId, WORLD_CHAIN_ACCOUNT_PRECOMPILE, accountAddress, adminNonce, msg.sender, keyringUpdate)`.
+5. Recompute the `Update` `signalHash` over `(accountAddress, adminNonce, msg.sender, keyringUpdate)`.
 6. Verify `adminAuthorization` per `adminType` against `signalHash` and `verificationPublicId`.
 7. Replace `sessionKeys` with `keyringUpdate.keys` and store `keyringHash = keccak256(abi.encode(keyringUpdate.keys))`.
 8. Increment `adminNonce`.
 
-Precompile gas accounting MUST charge:
-
-- the actual gas consumed by WorldID, ECDSA, EIP-1271, and crypto-precompile verification;
-- EVM-equivalent cold/warm storage read costs for account and keyring reads;
-- EVM-equivalent storage write costs for account creation and keyring replacement;
-- linear calldata/decoding work proportional to `SessionKey[]` length.
-
-The exact numeric schedule for storage-equivalent charges is a chain-configuration parameter, but it MUST be consensus-defined before activation. EIP-1271 validation gas is separately constrained by [Restricted EIP-1271 Validation Frame](#restricted-eip-1271-validation-frame).
+> **Note -- Precompile gas accounting out of scope.** The full gas pricing schedule for interacting with `WORLD_CHAIN_ACCOUNT_PRECOMPILE` -- covering admin verification cost, per-session-key storage mutation, and the amortized cost of reads during `0x1D` validation -- is **NOT** fully defined here. A follow-on revision MUST specify gas costs per operation. EIP-1271 validation gas is separately constrained by [Restricted EIP-1271 Validation Frame](#restricted-eip-1271-validation-frame).
 
 ### Restricted EIP-1271 Validation Frame
 
@@ -373,9 +364,9 @@ Therefore a protocol-valid EIP-1271 signer contract MUST be self-contained excep
 
 #### Opcode Policy
 
-The restricted validation frame is deny-by-default for variable context, call, creation, logging, mutation, and external-state inspection behavior. It permits deterministic computation, stack/memory/calldata/returndata operations, `ADDRESS`, `CALLER`, `CALLVALUE`, own-code access, own-storage reads, `KECCAK256`, `CHAINID`, `GAS`, and `STATICCALL` to allowed precompiles. `ADDRESS`, `CALLER`, and `CALLVALUE` are permitted because the entry call fixes them to `signer`, `WORLD_CHAIN_ACCOUNT_PRECOMPILE`, and `0`. `GAS` is permitted because the frame starts with a fixed stored `validationGasLimit` rather than transaction-selected gas.
+The restricted validation frame permits deterministic computation, calldata/memory access, own-code access, own-storage reads, `KECCAK256`, `CHAINID`, `GAS`, and `STATICCALL` to allowed precompiles. `GAS` is permitted because the frame starts with a fixed stored `validationGasLimit` rather than transaction-selected gas.
 
-The following opcodes are forbidden if executed validation frame:
+The following opcodes are forbidden if executed in the restricted validation frame:
 
 ```text
 BLOCKHASH
@@ -410,9 +401,7 @@ CREATE2
 SELFDESTRUCT
 ```
 
-This list removes block-context, transaction-context, external-state, transient-state, logging, mutation, and call-depth dependencies from protocol level signature validation. EIP-1271 validity MAY depend on the signer contract's own persistent storage via `SLOAD`; this is the intentional stateful policy surface of contract signatures.
-
-Any opcode introduced by a future fork is forbidden in the restricted validation frame until a WIP-1001 follow-on explicitly classifies it as permitted. If an implementation encounters an unknown opcode during restricted validation, validation MUST fail.
+This list removes block-context, transaction-context, external-state, transient-state, logging, mutation, and arbitrary call-depth dependencies from protocol signature validation. EIP-1271 validity MAY depend on the signer contract's own persistent storage via `SLOAD`; this is the intentional stateful policy surface of contract signatures.
 
 ### Admin Instantiations
 
@@ -481,7 +470,7 @@ Creation flow:
 4. Recompute the `Create` `signalHash` per the abstract `Create` formula.
 5. Invoke `WorldID.verify(worldIDAccountNullifier, action, WORLD_CHAIN_RP_ID, proofNonce, signalHash, issuerSchemaId, expiresAtMin, credentialGenesisIssuedAtMin, proof)`. The verifier asserts the proof commits to the supplied `(worldIDAccountNullifier, action, signalHash)` tuple under the relying party's public inputs. Because `signalHash` includes `adminCreationContextHash`, the proof is also bound to the stored `sessionId`.
 6. Set `addressDefiningMaterial = worldIDAccountNullifier` and derive `addr` per the abstract address formula.
-7. Require account does not exist at `addr` and the derived EVM address satisfies the creation checks in [Account Registry and Address Derivation](#account-registry-and-address-derivation).
+7. Require account does not exist at `addr`.
 8. Store `adminType = ADMIN_TYPE_WORLD_ID`, `verificationPublicId = abi.encode(sessionId)`, `sessionKeys = keyringUpdate.keys`, `keyringHash = keccak256(abi.encode(keyringUpdate.keys))`, `adminNonce = 0`.
 
 The creation nullifier is consumed once to instantiate the account. Because WorldID authenticators do not issue the same `(rpId, action)` nullifier twice, a later mutation MUST NOT attempt to reuse the creation action. The nullifier is not retained as account state after creation -- its only role is address derivation, which is reproducible from any subsequent update's calldata via the precompile's stored `addr`.
@@ -538,13 +527,13 @@ A single WorldID MAY enable recovery for any number of WorldID-admin accounts; a
 
 `adminType = ADMIN_TYPE_SECP256K1_EOA = 0x01`.
 
-`verificationPublicId` is the 20-byte Ethereum admin address. Address-defining material is `abi.encode(adminAddress, accountSalt)`:
+`verificationPublicId` is the 20-byte Ethereum admin address. Address-defining material is the same address:
 
 ```text
-addr = bytes20(keccak256(abi.encodePacked(ADMIN_TYPE_SECP256K1_EOA, abi.encode(adminAddress, accountSalt))))
+addr = bytes20(keccak256(abi.encodePacked(ADMIN_TYPE_SECP256K1_EOA, adminAddress)))
 ```
 
-One admin address MAY control any number of Secp256k1-EOA-admin account addresses by varying `accountSalt`.
+One admin address controls exactly one Secp256k1-EOA-admin account address.
 
 ##### Creation
 
@@ -553,20 +542,19 @@ One admin address MAY control any number of Secp256k1-EOA-admin account addresse
 ```solidity
 struct Secp256k1EOAAdminCreationData {
     address adminAddress;
-    bytes32 accountSalt;
     bytes   ecdsaSig;       // rlp([y_parity, r, s]) over signalHash
 }
 ```
 
 Creation flow:
 
-1. Decode `adminAddress`, `accountSalt`, and `ecdsaSig`.
-2. Compute `adminCreationContextHash = keccak256(abi.encode(ADMIN_TYPE_SECP256K1_EOA, adminAddress, accountSalt))`.
+1. Decode `adminAddress` and `ecdsaSig`.
+2. Compute `adminCreationContextHash = keccak256(abi.encode(ADMIN_TYPE_SECP256K1_EOA, adminAddress))`.
 3. Recompute the `Create` `signalHash` per the abstract `Create` formula.
 4. Decode `ecdsaSig` as `rlp([y_parity, r, s])`.
 5. Recover the Ethereum address from `ecdsaSig` over `signalHash`; require it equals `adminAddress`. Implementations MUST enforce Ethereum's [low-`s` rule](https://eips.ethereum.org/EIPS/eip-2) for consensus signatures.
-6. Set `addressDefiningMaterial = abi.encode(adminAddress, accountSalt)` and derive `addr` per the abstract address formula.
-7. Require account does not exist at `addr` and the derived EVM address satisfies the creation checks in [Account Registry and Address Derivation](#account-registry-and-address-derivation).
+6. Set `addressDefiningMaterial = adminAddress` and derive `addr` per the abstract address formula.
+7. Require account does not exist at `addr`.
 8. Store `adminType = ADMIN_TYPE_SECP256K1_EOA`, `verificationPublicId = abi.encode(adminAddress)`, `sessionKeys = keyringUpdate.keys`, `keyringHash = keccak256(abi.encode(keyringUpdate.keys))`, `adminNonce = 0`.
 
 ##### Updates
@@ -590,13 +578,13 @@ Update flow:
 
 `adminType = ADMIN_TYPE_EIP1271 = 0x02`.
 
-`verificationPublicId` is `abi.encode(address signer, uint32 validationGasLimit, bytes32 codeHash)`. Address-defining material is `abi.encode(signer, accountSalt)`:
+`verificationPublicId` is `abi.encode(address signer, uint32 validationGasLimit)`. Address-defining material is the 20-byte signer contract address:
 
 ```text
-addr = bytes20(keccak256(abi.encodePacked(ADMIN_TYPE_EIP1271, abi.encode(signer, accountSalt))))
+addr = bytes20(keccak256(abi.encodePacked(ADMIN_TYPE_EIP1271, signer)))
 ```
 
-One signer contract address MAY control any number of EIP-1271-admin account addresses by varying `accountSalt`. The `validationGasLimit` is fixed at creation and used for all future admin validations. If `codeHash != 0x00..00`, the precompile MUST require `EXTCODEHASH(signer) == codeHash` at creation and during every future admin validation. A zero `codeHash` deliberately permits upgradeable EIP-1271 admin contracts.
+One signer contract address controls exactly one EIP-1271-admin account address. The `validationGasLimit` is fixed at creation and used for all future admin validations.
 
 ##### Creation
 
@@ -605,25 +593,22 @@ One signer contract address MAY control any number of EIP-1271-admin account add
 ```solidity
 struct EIP1271AdminCreationData {
     address signer;
-    bytes32 accountSalt;
     uint32  validationGasLimit;
-    bytes32 codeHash;
     bytes   signature;             // EIP-1271 signature over signalHash
 }
 ```
 
 Creation flow:
 
-1. Decode `signer`, `accountSalt`, `validationGasLimit`, `codeHash`, and `signature`.
+1. Decode `signer`, `validationGasLimit`, and `signature`.
 2. Require `signer` has non-empty code.
 3. Require `validationGasLimit > 0 && validationGasLimit <= MAX_EIP1271_VALIDATION_GAS`.
-4. If `codeHash != 0x00..00`, require `EXTCODEHASH(signer) == codeHash`.
-5. Compute `adminCreationContextHash = keccak256(abi.encode(ADMIN_TYPE_EIP1271, signer, accountSalt, validationGasLimit, codeHash))`.
-6. Recompute the `Create` `signalHash` per the abstract `Create` formula.
-7. Run the restricted EIP-1271 validation frame against `signer` with `(hash = signalHash, signature, validationGasLimit)`.
-8. Set `addressDefiningMaterial = abi.encode(signer, accountSalt)` and derive `addr` per the abstract address formula.
-9. Require account does not exist at `addr` and the derived EVM address satisfies the creation checks in [Account Registry and Address Derivation](#account-registry-and-address-derivation).
-10. Store `adminType = ADMIN_TYPE_EIP1271`, `verificationPublicId = abi.encode(signer, validationGasLimit, codeHash)`, `sessionKeys = keyringUpdate.keys`, `keyringHash = keccak256(abi.encode(keyringUpdate.keys))`, `adminNonce = 0`.
+4. Compute `adminCreationContextHash = keccak256(abi.encode(ADMIN_TYPE_EIP1271, signer, validationGasLimit))`.
+5. Recompute the `Create` `signalHash` per the abstract `Create` formula.
+6. Run the restricted EIP-1271 validation frame against `signer` with `(hash = signalHash, signature, validationGasLimit)`.
+7. Set `addressDefiningMaterial = signer` and derive `addr` per the abstract address formula.
+8. Require account does not exist at `addr`.
+9. Store `adminType = ADMIN_TYPE_EIP1271`, `verificationPublicId = abi.encode(signer, validationGasLimit)`, `sessionKeys = keyringUpdate.keys`, `keyringHash = keccak256(abi.encode(keyringUpdate.keys))`, `adminNonce = 0`.
 
 ##### Updates
 
@@ -631,12 +616,11 @@ Creation flow:
 
 Update flow:
 
-1. Decode `(signer, validationGasLimit, codeHash)` from `verificationPublicId`.
+1. Decode `(signer, validationGasLimit)` from `verificationPublicId`.
 2. Recompute the `Update` `signalHash` per the abstract `Update` formula.
 3. Require `keyringUpdate.mode == SetKeyring`.
-4. If `codeHash != 0x00..00`, require `EXTCODEHASH(signer) == codeHash`.
-5. Run the restricted EIP-1271 validation frame against `signer` with `(hash = signalHash, signature = adminAuthorization, validationGasLimit)`.
-6. Return success to the precompile `update` flow, which applies the full keyring replacement and increments `adminNonce`.
+4. Run the restricted EIP-1271 validation frame against `signer` with `(hash = signalHash, signature = adminAuthorization, validationGasLimit)`.
+5. Return success to the precompile `update` flow, which applies the full keyring replacement and increments `adminNonce`.
 
 ##### Recovery
 
@@ -698,37 +682,20 @@ The protocol MUST validate a `0x1D` transaction as follows:
 1. Compute `signing_hash`.
 2. Load the account's keyring entry for `(key_type, key)`.
 3. Reject if no matching authorized session key exists.
-4. Reject if the session key is not active for the current block timestamp.
-5. If the session key has `codeHash != 0x00..00`, reject unless `EXTCODEHASH(key) == codeHash`.
-6. If `key_type == KEY_TYPE_SECP256K1_EOA`, verify `signature_payload` by Ethereum secp256k1 recovery over `signing_hash` and require the recovered address equals `key`.
-7. If `key_type == KEY_TYPE_EIP1271`, run the restricted EIP-1271 validation frame against `key` with `(hash = signing_hash, signature = signature_payload, validationGasLimit = stored SessionKey.validationGasLimit)`.
+4. Reject if the transaction does not satisfy the stored `SessionPolicy`.
+5. If `key_type == KEY_TYPE_SECP256K1_EOA`, verify `signature_payload` by Ethereum secp256k1 recovery over `signing_hash` and require the recovered address equals `key`.
+6. If `key_type == KEY_TYPE_EIP1271`, run the restricted EIP-1271 validation frame against `key` with `(hash = signing_hash, signature = signature_payload, validationGasLimit = stored SessionKey.validationGasLimit)`.
 
 Authorization is checked before EIP-1271 execution so an attacker cannot use an unauthorized `0x1D` transaction to force arbitrary contract validation work.
-
-#### Execution Semantics
-
-After signature validation, a `0x1D` transaction executes like an EIP-1559 transaction with the following sender override:
-
-- The transaction sender is `account`, not the session key.
-- The fee payer is `account`.
-- The transaction nonce is the EVM account nonce of `account`. It MUST equal the envelope `nonce`, and it is incremented according to normal Ethereum transaction rules.
-- The account balance at `account` pays intrinsic gas, execution gas, priority fee, and `value`.
-- `tx.origin` is `account`.
-- For the top-level message call, `msg.sender` is `account`.
-- `access_list`, `max_fee_per_gas`, `max_priority_fee_per_gas`, `gas_limit`, `to`, `value`, and `data` have the same execution semantics as EIP-1559 unless this WIP says otherwise.
-- If `to` is empty, the transaction creates a contract using the normal Ethereum contract-creation semantics for a transaction from `account`; the created address is derived from `(account, account.nonce)` under the chain's active contract-creation rules.
-- Receipts, logs, gas refunds, access-list warming, balance transfers, and state reversion follow the chain's normal transaction execution rules.
-
-The WIP-1001 account registry entry is separate from EVM account code. A World Chain Account address can have balance and nonce. It MUST NOT have EVM code when created as a WIP-1001 account, and WIP-1001 does not install code at the account address.
 
 The envelope is extensible to 2D nonces, batched transactions, and native paymaster support in follow-on WIPs.
 
 ### Extensions
 
-- **Per-key permissions.** Session keys MAY be extended with `(spendLimit, CallScope[])` metadata enforced by the precompile during `0x1D` validation. This extends `SessionKey` and the `KeyringUpdate` signal; the admin authorization continues to bind the full permission set via `signalHash`.
+- **Richer key policies.** Session policies MAY be extended with rate limits, aggregate spend limits, paymaster scopes, or more expressive call constraints. Any extension to `SessionPolicy` remains bound by the `KeyringUpdate` `signalHash`.
 - **Admin rotation.** Replacing an account's stored `verificationPublicId` (or `adminType`) under admin authorization. Deferred -- admin type and authority are pinned at creation in this WIP.
 - **Multi-admin.** M-of-N admin authorization for a single account. Deferred. Most near-term multi-admin policies SHOULD be represented as EIP-1271 contract admins.
-- **Additional crypto precompiles.** BLS12-381, Ed25519, secp256k1 verification without recovery, or other primitives MAY be added as VM precompiles. Once allowlisted for the restricted validation frame, EIP-1271 signer contracts can use them without changing the `0x1D` envelope.
+- **Additional crypto precompiles.** BLS12-381, secp256k1 verification without recovery, or other primitives MAY be added as VM precompiles. Once allowlisted for the restricted validation frame, EIP-1271 signer contracts can use them without changing the `0x1D` envelope.
 - **WorldID-recovery escape hatch for EOA-admin accounts.** A Secp256k1 EOA admin account MAY enroll a WorldID at creation as a recovery-only authority that can rotate the admin key under a follow-on recovery policy.
 - **Session rotation.** Replacing a WorldID-admin account's stored `sessionId` with a newly-provisioned session without re-creating the account.
 - **Bundling, 2D nonces, paymasters.** Reserved for follow-on WIPs on the `0x1D` envelope.
@@ -745,7 +712,7 @@ The envelope is extensible to 2D nonces, batched transactions, and native paymas
 
 **Full-keyring replacement.** Updates carry the complete target keyring rather than add/remove deltas. This makes every admin authorization commit to the exact post-update authorization set, avoids ordering-dependent delta semantics, and removes edge cases where separately authorized removals and additions compose into an unintended intermediate keyring.
 
-**Session-key validity and codehash pinning.** Native `validAfter` / `validUntil` fields cover the most common lifecycle control without introducing a general permission engine. Optional `codeHash` pinning lets users choose between upgradeable EIP-1271 key contracts and immutable bytecode identity. The same pinning option is available for EIP-1271 admin contracts, where upgradeability is either an intentional policy surface or a risk to avoid.
+**Scoped session keys.** The basic `SessionPolicy` fields cover the most common session-key limits -- time bounds, per-transaction value caps, and target/selector allowlists -- without introducing a general-purpose permission language. More expressive policy logic can still live inside EIP-1271 key contracts.
 
 **Single admin authority.** Each account has exactly one admin authority. M-of-N admin authorization is a useful generalization but is deferred as native protocol state. EIP-1271 contract admins cover most quorum-management use cases without changing the abstract account model.
 
@@ -757,11 +724,7 @@ The envelope is extensible to 2D nonces, batched transactions, and native paymas
 
 **Creation context binding.** `CreateSignal` includes `adminType` and `adminCreationContextHash` because creation permanently fixes admin state before an account address exists. Binding this context prevents an otherwise valid creation authorization from being reused with a different WorldID `sessionId`, EIP-1271 validation gas limit, or other persistent admin parameter excluded from the signature/proof bytes themselves.
 
-**Domain-separated admin authorizations.** `chainId`, `verifyingContract`, operation tags, and `msg.sender` are part of admin authorization hashes. This binds signatures and proofs to one chain, one precompile deployment, one operation kind, and one direct submitter.
-
 **Domain-separated address derivation.** Prefixing the address preimage with `adminTypeTag` prevents accidental cross-type collisions even when the address-defining material from two instantiations might coincidentally produce identical bytes under different encodings. Domain separation costs nothing and is standard practice for keccak-based identifier schemes.
-
-**Salted non-WorldID accounts.** `accountSalt` for EOA-admin and EIP-1271-admin accounts avoids making the admin address or signer contract a one-account bottleneck. It also makes deterministic account creation explicit: the same admin can derive multiple independent accounts without inventing additional admin types or rotating authority.
 
 **`msg.sender` binding in `signalHash`.** Including `msg.sender` in both `Create` and `Update` `signalHash` definitions kills cross-submitter replay of in-flight admin authorizations: a witnessed authorization with `msg.sender = X` will not verify if resubmitted by a different account. Self-replay by `X` is a no-op (the resulting state is identical).
 
@@ -775,7 +738,7 @@ The envelope is extensible to 2D nonces, batched transactions, and native paymas
 
 This WIP introduces a new account type and transaction type. Existing EOAs and smart contract accounts are unaffected. Standard [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) transactions continue to work for legacy accounts; the `0x1D` envelope is required only for World-Chain-Account-authenticated execution.
 
-This WIP is Draft. The replacement of native non-ECDSA session-key types with EIP-1271 contract keys, the `SessionKey` keyring shape, full-keyring replacement updates, salted non-WorldID address derivation, EIP-1271 admin codehash pinning, the EIP-1271 restricted validation frame, and creation-context binding in `CreateSignal` are breaking changes relative to earlier drafts of this WIP. No production accounts exist.
+This WIP is Draft. The replacement of native non-ECDSA session-key types with EIP-1271 contract keys, the `SessionKey` keyring shape, scoped session policies, full-keyring replacement updates, the EIP-1271 restricted validation frame, and creation-context binding in `CreateSignal` are breaking changes relative to earlier drafts of this WIP. No production accounts exist.
 
 ### Existing Safe Accounts
 
@@ -811,7 +774,7 @@ EIP-1271 signer validity MAY depend on the signer contract's own storage. This i
 
 ### Contract Upgradeability
 
-Upgradeable EIP-1271 signer contracts can change account authorization policy without changing the World Chain Account keyring or admin authority. This is a feature when used intentionally, but it is also a risk. Wallets SHOULD surface whether an EIP-1271 signer is upgradeable, proxy-based, codehash-pinned, or otherwise able to change behavior. Proxy patterns that require `DELEGATECALL` during validation are invalid under the restricted frame.
+Upgradeable EIP-1271 signer contracts can change account authorization policy without changing the World Chain Account keyring or admin authority. This is a feature when used intentionally, but it is also a risk. Wallets SHOULD surface whether an EIP-1271 signer is upgradeable, proxy-based, or otherwise able to change behavior. Proxy patterns that require `DELEGATECALL` during validation are invalid under the restricted frame.
 
 ### Session Key Deanonymization
 
@@ -843,4 +806,4 @@ An EOA admin address or EIP-1271 admin contract address is recoverable from any 
 
 ### No Liveness Check
 
-A non-WorldID-admin account has no protocol-level liveness check on session-key-signed transactions. Session-key compromise can drain account-controlled value at the rate session keys can authorize, bounded only by per-key limits (if any), session-key validity windows, and off-protocol controls. Sibling WIPs that require WorldID liveness above a value threshold do NOT apply to non-WorldID-admin accounts.
+A non-WorldID-admin account has no protocol-level liveness check on session-key-signed transactions. Session-key compromise can drain account-controlled value at the rate session keys can authorize, bounded only by configured `SessionPolicy` limits and off-protocol controls. Sibling WIPs that require WorldID liveness above a value threshold do NOT apply to non-WorldID-admin accounts.

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -12,19 +12,17 @@ requires: EIP-1271, EIP-2718, EIP-1559, EIP-2930, ERC-7562, RIP-7212
 
 ## Abstract
 
-WIP-1001 defines a native World Chain account type managed by the `WORLD_CHAIN_ACCOUNT_MANAGER` predeploy. Each account has one immutable [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) compliant admin signer and one active keyring of EIP-1271 compliant session verifiers.
+We define a native World Chain account type managed by the `WORLD_CHAIN_ACCOUNT_MANAGER` predeploy. Each account has one immutable [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) compliant admin signer and one active key ring of [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) compliant session verifiers.
 
 We extend [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) with a new typed transaction envelope with type flag `0x1D`. `0x1D` transactions are executed with the World Chain account **Framed** as the sender. Session verifiers act as the transaction level signatories via programmable [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) smart contracts. Session verifiers dually function as signature verifiers, and session key policy evaluators.
 
-We design with the principal of not having signer-specific authentication as a native execution path in the protocol. Signature schemes, proof systems, recovery policies, and spending policies are fully programmable. The protocol only prescribes deterministic context, validation frames, and reusable precompiles for cryptographic operations.
+We design with the principle of not defining signer-specific authentication as native execution paths. Signature schemes, proof systems, recovery policies, and spending policies are fully programmable. The protocol only prescribes deterministic transaction context, validation frames, and reusable precompiles for cryptographic operations.
 
 ## Motivation
 
-World Chain accounts need programmable authentication without adding a protocol branch for every signature scheme, or session key policy. [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) gives the protocol one authorization boundary: a fully programmable smart contract.
+World Chain accounts need programmable authentication without adding a protocol branch for every signature scheme, or session key policy. Smart contracts allow us to converge protocol level authentication over a single authorization boundary with determinism enforced via protocol level restrictions on programmable validation frames.
 
-Admin signers and session verifiers use the same [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) boundary but have different roles. The admin signer authorizes account-management operations. Session verifiers authorize `0x1D` transactions and evaluate the resulting execution trace.
-
-Stable transaction inclusion requires transaction validation to be stable from the time a transaction hits the mempool to the time of inclusion in the block. Keyring updates are therefore timelocked for longer than the eviction time of transactions in the transaction pool.
+Whole-set key ring replacement gives the protocol one account-level mutation path for session authorization. The resulting `keyRingHash` is a deterministic commitment to the verifier set, so any cached signature-validation result can be bound to the exact key ring that made it valid.
 
 ## Specification
 
@@ -39,11 +37,9 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 | `EIP1271_MAGIC_VALUE` | `bytes4` | `0x1626ba7e` | Required return value from `isValidSignature`. |
 | `WORLD_CHAIN_RP_ID` | `uint64` | `480` | World Chain relying-party identifier for WebAuthn and World ID challenge binding. |
 | `WORLD_ID_ACCOUNT_TAG` | `bytes` | `"WORLD_ID_ACCOUNT"` | Domain tag for World ID account action derivation. |
-| `WIP1001_ACCOUNT_DOMAIN` | `bytes32` | `keccak256("WIP1001_ACCOUNT")` | Domain for account address derivation. |
-| `WIP1001_ADMIN_CREATE_DOMAIN` | `bytes32` | `keccak256("WIP1001_ADMIN_CREATE")` | Domain for account creation authorization. |
-| `WIP1001_QUEUE_KEYRING_UPDATE_DOMAIN` | `bytes32` | `keccak256("WIP1001_QUEUE_KEYRING_UPDATE")` | Domain for queueing a keyring update authorization. |
-| `WIP1001_CANCEL_KEYRING_UPDATE_DOMAIN` | `bytes32` | `keccak256("WIP1001_CANCEL_KEYRING_UPDATE")` | Domain for cancelling a pending keyring update. |
-| `WIP1001_REVOKE_SESSION_VERIFIER_DOMAIN` | `bytes32` | `keccak256("WIP1001_REVOKE_SESSION_VERIFIER")` | Domain for instant session-verifier revocation. |
+| `WORLD_CHAIN_ACCOUNT_DOMAIN` | `bytes32` | `keccak256("WIP1001_ACCOUNT")` | Domain for account address derivation. |
+| `WORLD_CHAIN_ADMIN_CREATE_DOMAIN` | `bytes32` | `keccak256("WIP1001_ADMIN_CREATE")` | Domain for account creation authorization. |
+| `WORLD_CHAIN_SET_KEY_RING_DOMAIN` | `bytes32` | `keccak256("WIP1001_SET_KEY_RING")` | Domain for key ring replacement authorization. |
 | `WIP1001_SIGNER_DOMAIN` | `bytes32` | `keccak256("WIP1001_SIGNER")` | Domain for default factory `CREATE2` salts. |
 
 ### Activation Parameters
@@ -62,8 +58,6 @@ WIP-1001 MUST NOT activate until every parameter below is assigned in fork confi
 | `MAX_ACCESS_LIST_ENTRIES` | `uint32` | TBD | Maximum number of [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) access-list entries in a `0x1D` envelope. |
 | `MAX_SESSION_SIGNATURE_BYTES` | `uint32` | TBD | Maximum length of the session `signature` field. |
 | `MAX_ADMIN_AUTHORIZATION_BYTES` | `uint32` | TBD | Maximum length of `adminAuthorization` calldata. |
-| `TXPOOL_TRANSACTION_EXPIRATION_WINDOW` | `uint64` | TBD | Maximum time in seconds that a valid transaction remains in the pool. |
-| `MIN_KEYRING_UPDATE_DELAY` | `uint64` | TBD | MUST satisfy `MIN_KEYRING_UPDATE_DELAY > TXPOOL_TRANSACTION_EXPIRATION_WINDOW`. |
 | `WORLD_ID_1271_SIGNER_FACTORY` | `address` | TBD | Default World ID EIP-1271 signer factory. |
 | `SECP256K1_1271_SIGNER_FACTORY` | `address` | TBD | Default secp256k1 EIP-1271 signer factory. |
 | `EDDSA_PRECOMPILE` | `address` | TBD | EdDSA verification precompile address and ABI. |
@@ -95,19 +89,10 @@ World Chain accounts are created and managed by `WORLD_CHAIN_ACCOUNT_MANAGER`.
 struct Account {
     address adminSigner;
     bytes32 accountSalt;
-    SessionVerifier[] activeSessionVerifiers;
-    bytes32 activeKeyringHash;
-    PendingKeyringUpdate pendingKeyringUpdate;
+    SessionVerifier[] sessionVerifiers;
+    bytes32 keyRingHash;
     uint64 adminNonce;
-}
-
-struct PendingKeyringUpdate {
-    bytes32 expectedCurrentKeyringHash;
-    SessionVerifier[] targetSessionVerifiers;
-    bytes32 targetKeyringHash;
-    uint64 activateAfter;
-    uint64 queuedAtNonce;
-    bool exists;
+    uint64 transactionNonce;
 }
 
 struct SessionVerifier {
@@ -117,12 +102,15 @@ struct SessionVerifier {
 
 For every existing account:
 
-- `adminSigner` MUST be a deployed as a EIP-1271 contract and is immutable for the life of the account address.
-- `activeSessionVerifiers.length` MUST be in `[1, MAX_SESSION_VERIFIERS]`.
+- `adminSigner` MUST be deployed as an EIP-1271 contract and is immutable for the life of the account address.
+- `sessionVerifiers.length` MUST be in `[1, MAX_SESSION_VERIFIERS]`.
 - each `SessionVerifier.verifier` MUST be a deployed contract adhering to EIP-1271 and `IWorldChainSessionVerifier`;
-- `activeSessionVerifiers` MUST NOT contain duplicate verifier addresses;
-- `activeKeyringHash == keccak256(abi.encode(activeSessionVerifiers))`;
+- `sessionVerifiers` MUST NOT contain duplicate verifier addresses;
+- `keyRingHash == keccak256(abi.encode(sessionVerifiers))`;
 - `adminNonce` is consumed only by admin operations;
+- `transactionNonce` is consumed only by successful `0x1D` transaction execution attempts;
+
+After account creation, `setKeyRing` is the only execution path that mutates `sessionVerifiers` or `keyRingHash`.
 
 #### Address Derivation
 
@@ -130,7 +118,7 @@ The manager derives an account address as:
 
 ```solidity
 account = address(uint160(uint256(keccak256(abi.encode(
-    WIP1001_ACCOUNT_DOMAIN,
+    WORLD_CHAIN_ACCOUNT_DOMAIN,
     chainId,
     WORLD_CHAIN_ACCOUNT_MANAGER,
     adminSigner,
@@ -152,43 +140,23 @@ The hash for each operation is:
 
 ```solidity
 createHash = keccak256(abi.encode(
-    WIP1001_ADMIN_CREATE_DOMAIN,
+    WORLD_CHAIN_ADMIN_CREATE_DOMAIN,
     chainId,
     WORLD_CHAIN_ACCOUNT_MANAGER,
     account,
     adminSigner,
     accountSalt,
-    activeKeyringHash
+    keyRingHash
 ));
 
-queueHash = keccak256(abi.encode(
-    WIP1001_QUEUE_KEYRING_UPDATE_DOMAIN,
+setKeyRingHash = keccak256(abi.encode(
+    WORLD_CHAIN_SET_KEY_RING_DOMAIN,
     chainId,
     WORLD_CHAIN_ACCOUNT_MANAGER,
     account,
     adminNonce,
-    expectedCurrentKeyringHash,
-    targetKeyringHash,
-    activateAfter
-));
-
-cancelHash = keccak256(abi.encode(
-    WIP1001_CANCEL_KEYRING_UPDATE_DOMAIN,
-    chainId,
-    WORLD_CHAIN_ACCOUNT_MANAGER,
-    account,
-    adminNonce,
-    expectedQueuedAtNonce
-));
-
-revokeHash = keccak256(abi.encode(
-    WIP1001_REVOKE_SESSION_VERIFIER_DOMAIN,
-    chainId,
-    WORLD_CHAIN_ACCOUNT_MANAGER,
-    account,
-    adminNonce,
-    sessionVerifier,
-    expectedCurrentKeyringHash
+    expectedCurrentKeyRingHash,
+    newKeyRingHash
 ));
 ```
 
@@ -224,7 +192,7 @@ interface IWorldChainSessionVerifier is IERC1271 {
         bytes data;
         bytes4 selector;
         AccessListEntry[] accessList;
-        bytes32 activeKeyringHash;
+        bytes32 keyRingHash;
     }
 
     enum TraceCallKind {
@@ -287,35 +255,18 @@ interface IWorldChainAccountManager {
         bytes calldata adminAuthorization
     ) external returns (address account);
 
-    function queueKeyringUpdate(
+    function setKeyRing(
         address account,
-        bytes32 expectedCurrentKeyringHash,
-        SessionVerifier[] calldata targetSessionVerifiers,
-        uint64 activateAfter,
-        bytes calldata adminAuthorization
-    ) external;
-
-    function activateKeyringUpdate(address account) external;
-
-    function cancelPendingKeyringUpdate(
-        address account,
-        uint64 expectedQueuedAtNonce,
-        bytes calldata adminAuthorization
-    ) external;
-
-    function revokeSessionVerifier(
-        address account,
-        address sessionVerifier,
-        bytes32 expectedCurrentKeyringHash,
+        bytes32 expectedCurrentKeyRingHash,
+        SessionVerifier[] calldata sessionVerifiers,
         bytes calldata adminAuthorization
     ) external;
 
     function getAdminSigner(address account) external view returns (address);
     function getAdminNonce(address account) external view returns (uint64);
     function getTransactionNonce(address account) external view returns (uint64);
-    function getActiveKeyringHash(address account) external view returns (bytes32);
-    function getActiveSessionVerifiers(address account) external view returns (SessionVerifier[] memory);
-    function getPendingKeyringUpdate(address account) external view returns (PendingKeyringUpdate memory);
+    function getKeyRingHash(address account) external view returns (bytes32);
+    function getSessionVerifiers(address account) external view returns (SessionVerifier[] memory);
     function isAuthorizedSessionVerifier(address account, address sessionVerifier) external view returns (bool);
     function getAuthorizedSessionVerifier(address account, address sessionVerifier) external view returns (SessionVerifier memory);
 }
@@ -331,41 +282,13 @@ interface IWorldChainAccountManagerEvents {
         address indexed account,
         address indexed adminSigner,
         bytes32 accountSalt,
-        bytes32 activeKeyringHash
+        bytes32 keyRingHash
     );
 
-    event KeyringUpdateQueued(
+    event KeyRingSet(
         address indexed account,
-        bytes32 indexed targetKeyringHash,
-        bytes32 expectedCurrentKeyringHash,
-        uint64 activateAfter,
-        uint64 queuedAtNonce
-    );
-
-    event PendingKeyringUpdateReplaced(
-        address indexed account,
-        bytes32 previousTargetKeyringHash,
-        bytes32 indexed newTargetKeyringHash,
-        uint64 newActivateAfter,
-        uint64 newQueuedAtNonce
-    );
-
-    event KeyringUpdateActivated(
-        address indexed account,
-        bytes32 previousKeyringHash,
-        bytes32 indexed newKeyringHash
-    );
-
-    event KeyringUpdateCancelled(
-        address indexed account,
-        uint64 cancelledQueuedAtNonce,
-        uint64 adminNonce
-    );
-
-    event SessionVerifierRevoked(
-        address indexed account,
-        address indexed sessionVerifier,
-        bytes32 newKeyringHash,
+        bytes32 indexed previousKeyRingHash,
+        bytes32 indexed newKeyRingHash,
         uint64 adminNonce
     );
 }
@@ -387,76 +310,29 @@ Admin authorization is valid only when `adminSigner.isValidSignature(adminOperat
 4. reject duplicate or zero session verifier addresses;
 5. derive `account`;
 6. reject if `account` already exists;
-7. compute `activeKeyringHash`;
+7. compute `keyRingHash = keccak256(abi.encode(initialSessionVerifiers))`;
 8. verify `createHash` through `adminSigner`;
 9. if `WORLD_ID_1271_SIGNER_FACTORY.isFactorySigner(adminSigner) == true`, require `IWorldIDAdminSigner(adminSigner).account() == account`;
-10. initialize account state with `adminNonce = 0`, `transactionNonce = 0`, no pending keyring update, and `activeSessionVerifiers = initialSessionVerifiers`;
-11. emit `AccountCreated(account, adminSigner, accountSalt, activeKeyringHash)`.
+10. initialize account state with `adminNonce = 0`, `transactionNonce = 0`, `sessionVerifiers = initialSessionVerifiers`, and `keyRingHash`;
+11. emit `AccountCreated(account, adminSigner, accountSalt, keyRingHash)`.
 
-#### `queueKeyringUpdate`
+#### `setKeyRing`
 
-`queueKeyringUpdate` MUST:
+`setKeyRing` is the only post-creation method that mutates the key ring and MUST:
 
 1. require `account` to exist;
-2. require `expectedCurrentKeyringHash == activeKeyringHash`;
-3. require `targetSessionVerifiers.length` to be in `[1, MAX_SESSION_VERIFIERS]`;
-4. reject duplicate, zero, or undeployed target session verifier addresses;
-5. compute `targetKeyringHash = keccak256(abi.encode(targetSessionVerifiers))`;
-6. reject `targetKeyringHash == activeKeyringHash`;
-7. require `activateAfter >= block.timestamp + MIN_KEYRING_UPDATE_DELAY`;
-8. compute `queueHash` using the current `adminNonce`;
-9. verify `queueHash` through `adminSigner`;
-10. replace any existing pending update with the new pending update;
-11. store `queuedAtNonce = adminNonce`;
+2. require `expectedCurrentKeyRingHash == keyRingHash`;
+3. require `sessionVerifiers.length` to be in `[1, MAX_SESSION_VERIFIERS]`;
+4. reject duplicate, zero, or undeployed session verifier addresses;
+5. compute `newKeyRingHash = keccak256(abi.encode(sessionVerifiers))`;
+6. reject `newKeyRingHash == keyRingHash`;
+7. compute `setKeyRingHash` using the current `adminNonce`;
+8. verify `setKeyRingHash` through `adminSigner`;
+9. set `previousKeyRingHash = keyRingHash`;
+10. replace the account's full `sessionVerifiers` set with the supplied `sessionVerifiers`;
+11. set `keyRingHash = newKeyRingHash`;
 12. increment `adminNonce` by one;
-13. emit `PendingKeyringUpdateReplaced` if an update was replaced, otherwise emit `KeyringUpdateQueued`.
-
-#### `activateKeyringUpdate`
-
-`activateKeyringUpdate` MAY be called by any address and MUST:
-
-1. require `account` to exist;
-2. require `pendingKeyringUpdate.exists == true`;
-3. require `block.timestamp >= pendingKeyringUpdate.activateAfter`;
-4. require `pendingKeyringUpdate.expectedCurrentKeyringHash == activeKeyringHash`;
-5. require every target session verifier to still have deployed code;
-6. replace `activeSessionVerifiers` with `targetSessionVerifiers`;
-7. set `activeKeyringHash = targetKeyringHash`;
-8. clear the pending update by setting `pendingKeyringUpdate.exists = false`;
-9. emit `KeyringUpdateActivated`.
-
-Activation MUST NOT change `adminNonce`.
-
-#### `cancelPendingKeyringUpdate`
-
-`cancelPendingKeyringUpdate` MUST:
-
-1. require `account` to exist;
-2. require `pendingKeyringUpdate.exists == true`;
-3. require `pendingKeyringUpdate.queuedAtNonce == expectedQueuedAtNonce`;
-4. compute `cancelHash` using the current `adminNonce`;
-5. verify `cancelHash` through `adminSigner`;
-6. clear the pending update by setting `pendingKeyringUpdate.exists = false`;
-7. increment `adminNonce` by one;
-8. emit `KeyringUpdateCancelled(account, expectedQueuedAtNonce, adminNonce)`.
-
-#### `revokeSessionVerifier`
-
-`revokeSessionVerifier` MUST:
-
-1. require `account` to exist;
-2. require `sessionVerifier` to be a current member of `activeSessionVerifiers`;
-3. require `expectedCurrentKeyringHash == activeKeyringHash`;
-4. reject if removal would make the active keyring empty;
-5. compute `revokeHash` using the current `adminNonce`;
-6. verify `revokeHash` through `adminSigner`;
-7. remove `sessionVerifier` while preserving the relative order of all remaining verifiers;
-8. set `activeKeyringHash = keccak256(abi.encode(activeSessionVerifiers))`;
-9. record the revocation for txpool revalidation until `TXPOOL_TRANSACTION_EXPIRATION_WINDOW` has elapsed;
-10. increment `adminNonce` by one;
-11. emit `SessionVerifierRevoked(account, sessionVerifier, activeKeyringHash, adminNonce)`.
-
-Revocation MUST NOT change any pending keyring update.
+13. emit `KeyRingSet(account, previousKeyRingHash, newKeyRingHash, adminNonce)`.
 
 ### Restricted Validation Frames
 
@@ -571,14 +447,14 @@ To include a `0x1D` transaction, the protocol MUST:
 
 1. decode and validate the envelope;
 2. load `account` from `WORLD_CHAIN_ACCOUNT_MANAGER`;
-3. require `sessionVerifier` to be authorized for `account` under the txpool membership rules;
+3. require `sessionVerifier` to be authorized for `account` in the current `sessionVerifiers` set and load the current `keyRingHash`;
 4. require the account balance to cover the worst-case payload gas charge and `MIN_VALIDATION_FAILURE_FEE`;
 5. compute `signingHash`;
 6. call `sessionVerifier.isValidSignature(signingHash, signature)` in a restricted validation frame;
 7. if signature validation fails, apply validation-failure semantics and stop;
 8. increment `Account.transactionNonce` by one;
 9. execute the payload tentatively with `account` as the EVM sender and gas charged against envelope `gasLimit`;
-10. construct `ExecutionTraceContext`;
+10. construct `ExecutionTraceContext` with `context.transaction.keyRingHash` set to the current account `keyRingHash`;
 11. if `abi.encode(context.trace).length > MAX_EXECUTION_TRACE_BYTES`, discard tentative payload state, apply trace-overflow semantics, and stop;
 12. call `sessionVerifier.evaluateSessionPolicy(context)` in a restricted validation frame;
 13. if policy validation fails, discard tentative payload state, apply validation-failure semantics, and stop;
@@ -599,213 +475,25 @@ All validation gas consumed by signature and policy checks MUST count against `B
 
 ### Txpool Revalidation
 
-World Chain clients MUST revalidate every pooled `0x1D` transaction at least once per block until inclusion, expiration, or eviction.
+World Chain clients MUST revalidate every pooled `0x1D` transaction at least once per block until inclusion or eviction.
 
-On pool admission, the client MUST record `entryTimestamp`, `account`, `sessionVerifier`, `nonce`, and the account's active keyring membership at admission. A transaction is eligible to remain pooled only while all conditions hold:
+On pool admission or successful revalidation, the client MUST record `account`, `sessionVerifier`, `nonce`, `signingHash`, `signature`, and the account's active `keyRingHash`. A transaction is eligible to remain pooled only while all conditions hold:
 
-- `block.timestamp < entryTimestamp + TXPOOL_TRANSACTION_EXPIRATION_WINDOW`;
 - `account` exists;
 - the account balance can cover `MIN_VALIDATION_FAILURE_FEE` at the current `baseFee`;
 - the transaction nonce can still become executable under the account nonce ordering rules;
-- `sessionVerifier` has not been revoked after admission.
+- `sessionVerifier` is a member of the account's current `sessionVerifiers` set;
+- the current account `keyRingHash` equals the hash recorded when the transaction was admitted or last revalidated.
 
-Activation of a queued keyring update MUST NOT evict already pooled transactions whose verifier was active at admission. `revokeSessionVerifier` MUST immediately evict pooled transactions from the revoked verifier.
+A client MAY reuse a prior successful signature-validation result only when the cached `(account, sessionVerifier, signingHash, signature, keyRingHash)` tuple exactly matches the current transaction and account state. Block builders MAY rely on such a cache to avoid repeating signature verification before block construction; if the active `keyRingHash` changes, the cached result MUST be discarded and the signature MUST be revalidated.
 
-### Timelocked Signer-State Updates
+The `keyRingHash` comparison is the deterministic anchor for block validation: a verifier MAY accept a cached signature result only if the active account hash equals the recorded hash; otherwise it MUST execute signature validation again.
 
-Default factory signers with mutable state that can change `isValidSignature` or `evaluateSessionPolicy` for already accepted transactions MUST timelock those updates by at least `MIN_KEYRING_UPDATE_DELAY`.
+### Signer-State Determinism
 
-This applies to root rotations, verification-key rotations, signer recovery changes, signer revocation lists, account binding changes, and policy configuration changes. State that cannot affect validation MAY update without this delay.
+Session verifier behavior that can change `isValidSignature` or `evaluateSessionPolicy` for already accepted transactions MUST be immutable for a verifier address. Validation-affecting updates MUST be represented by deploying or selecting a different session verifier address and installing a replacement set through `setKeyRing`, which updates `keyRingHash`.
 
-### Default Signer Factories
-
-Accounts MAY use any EIP-1271 admin signer or session verifier that satisfies this specification. Default factories are deployment helpers, not authorization registries. A factory-created signer has no account authority until it is used as an admin signer during `create` or added to an account keyring.
-
-```solidity
-enum WorldChainSignerRole {
-    AdminSigner,
-    SessionVerifier
-}
-
-interface IWorldChainFactoryDeployedSigner {
-    function signerFactory() external view returns (address);
-    function signerRole() external view returns (WorldChainSignerRole);
-    function signerVariantId() external view returns (bytes32);
-    function signerConfigHash() external view returns (bytes32);
-}
-
-interface IWorldChain1271SignerFactory {
-    event SignerCreated(
-        address indexed signer,
-        WorldChainSignerRole indexed role,
-        bytes32 indexed variantId,
-        bytes32 configHash,
-        bytes32 salt
-    );
-
-    function worldChainAccountManager() external view returns (address);
-    function computeAddress(
-        WorldChainSignerRole role,
-        bytes32 variantId,
-        bytes calldata config,
-        bytes32 salt
-    ) external view returns (address signer);
-    function createSigner(
-        WorldChainSignerRole role,
-        bytes32 variantId,
-        bytes calldata config,
-        bytes32 salt
-    ) external returns (address signer);
-    function isFactorySigner(address signer) external view returns (bool);
-}
-```
-
-`createSigner` MUST:
-
-1. reject unknown `role` or `variantId`;
-2. decode and validate `config`;
-3. compute `configHash = keccak256(config)`;
-4. deploy with `CREATE2` using `keccak256(abi.encode(WIP1001_SIGNER_DOMAIN, chainId, WORLD_CHAIN_ACCOUNT_MANAGER, role, variantId, configHash, salt))` as the salt;
-5. initialize signer metadata;
-6. return the deployed signer address;
-7. emit `SignerCreated`.
-
-`computeAddress` MUST return the address that `createSigner` would deploy. `createSigner` MUST be idempotent when the expected signer already exists with matching metadata and MUST revert when the expected address is occupied by incompatible code. Factory deployment MUST NOT mutate manager state.
-
-### Default Secp256k1 Signers
-
-`SECP256K1_1271_SIGNER_FACTORY` MUST support:
-
-```solidity
-bytes32 constant SECP256K1_ADMIN_SIGNER_V1 =
-    keccak256("world-chain.secp256k1.admin.v1");
-
-bytes32 constant SECP256K1_SESSION_VERIFIER_V1 =
-    keccak256("world-chain.secp256k1.session-verifier.v1");
-
-struct Secp256k1AdminSignerConfig {
-    address owner;
-}
-
-struct Secp256k1SessionVerifierConfig {
-    address account;
-    address owner;
-    bytes32 policyVariantId;
-    bytes policyConfig;
-}
-
-interface ISecp256k1AdminSigner is IWorldChainAdminSigner {
-    function owner() external view returns (address);
-}
-```
-
-The EIP-1271 signature payload is `r || s || v`. `isValidSignature(hash, signature)` MUST require `signature.length == 65`, lower-half-order `s`, `v` equal to `27` or `28`, and `ecrecover(hash, v, r, s) == owner()`.
-
-The secp256k1 session verifier variant MUST verify the same payload against its configured `owner`, reject `evaluateSessionPolicy` unless `context.transaction.account == account` and `context.transaction.sessionVerifier == address(this)`, and evaluate policy internally from its own code and storage.
-
-### Default World ID Signers
-
-`WORLD_ID_1271_SIGNER_FACTORY` MUST support:
-
-```solidity
-bytes32 constant WORLD_ID_ADMIN_SIGNER_V1 =
-    keccak256("world-chain.world-id.admin.v1");
-
-bytes32 constant WORLD_ID_SESSION_VERIFIER_V1 =
-    keccak256("world-chain.world-id.session-verifier.v1");
-
-struct WorldIDAdminSignerConfig {
-    bytes32 accountSalt;
-    address stateUpdater;
-    uint256 treeDepth;
-    uint64 issuerSchemaId;
-    uint256 credentialIssuerPubkeyX;
-    uint256 credentialIssuerPubkeyY;
-    uint256 oprfPubkeyX;
-    uint256 oprfPubkeyY;
-    uint64 minExpiresAt;
-    uint256 minCredentialGenesisIssuedAt;
-    uint256[] initialValidRoots;
-}
-
-struct WorldIDSessionVerifierConfig {
-    address account;
-    address stateUpdater;
-    uint256 treeDepth;
-    uint64 issuerSchemaId;
-    uint256 credentialIssuerPubkeyX;
-    uint256 credentialIssuerPubkeyY;
-    uint256 oprfPubkeyX;
-    uint256 oprfPubkeyY;
-    uint64 minExpiresAt;
-    uint256 minCredentialGenesisIssuedAt;
-    uint256[] initialValidRoots;
-    bytes32 policyVariantId;
-    bytes policyConfig;
-}
-
-interface IWorldIDAdminSigner is IWorldChainAdminSigner {
-    function accountSalt() external view returns (bytes32);
-    function account() external view returns (address);
-    function worldIdRpId() external view returns (uint64);
-    function worldIdAction() external view returns (uint256);
-}
-
-interface IWorldIDSessionVerifier is IWorldChainSessionVerifier {
-    function account() external view returns (address);
-    function worldIdRpId() external view returns (uint64);
-}
-```
-
-`IWorldIDAdminSigner.account()` MUST equal the manager-derived account using `address(this)` as `adminSigner` and `accountSalt()` as `accountSalt`. `worldIdRpId()` MUST equal `WORLD_CHAIN_RP_ID`.
-
-`worldIdAction()` MUST return:
-
-```solidity
-worldIdField(abi.encode(
-    WORLD_ID_ACCOUNT_TAG,
-    block.chainid,
-    WORLD_CHAIN_RP_ID,
-    WORLD_CHAIN_ACCOUNT_MANAGER,
-    account(),
-    address(this)
-))
-```
-
-where `worldIdField(input) = uint256(keccak256(input)) >> 8`.
-
-The World ID admin signer signature payload is:
-
-```solidity
-struct WorldIDUniquenessProofSignature {
-    uint256 nullifier;
-    uint64 expiresAtMin;
-    uint64 issuerSchemaId;
-    uint256 credentialGenesisIssuedAtMin;
-    uint256[5] zeroKnowledgeProof;
-}
-```
-
-Admin `isValidSignature(hash, signature)` MUST decode `WorldIDUniquenessProofSignature`, compute `signalHash = worldIdField(abi.encode(hash))`, compute `nonce = worldIdField(abi.encode("WIP1001_WORLD_ID_ADMIN_NONCE", hash))`, require configured issuer and freshness parameters, require `zeroKnowledgeProof[4]` to be an accepted root, verify a World ID v4 uniqueness proof with `sessionId = 0`, and return `EIP1271_MAGIC_VALUE` only on success.
-
-The World ID session verifier signature payload is:
-
-```solidity
-struct WorldIDSessionProofSignature {
-    uint64 expiresAtMin;
-    uint64 issuerSchemaId;
-    uint256 credentialGenesisIssuedAtMin;
-    uint256 sessionId;
-    uint256[2] sessionNullifier;
-    uint256[5] zeroKnowledgeProof;
-}
-```
-
-Session `isValidSignature(hash, signature)` MUST decode `WorldIDSessionProofSignature`, compute `signalHash = worldIdField(abi.encode(hash))`, compute `nonce = worldIdField(abi.encode("WIP1001_WORLD_ID_SESSION_NONCE", block.chainid, WORLD_CHAIN_ACCOUNT_MANAGER, account(), address(this), hash))`, require `sessionId != 0`, require configured issuer and freshness parameters, require `zeroKnowledgeProof[4]` to be an accepted root, verify a World ID v4 session proof, and return `EIP1271_MAGIC_VALUE` only on success.
-
-World ID signers MUST verify the configured public inputs for issuer schema, credential issuer public key, credential expiration minimum, credential genesis minimum, Merkle root, tree depth, RP ID, OPRF public key, signal hash, nonce, and proof type. They MUST NOT consume nullifiers in `isValidSignature` and MUST NOT call an external World ID verifier from a restricted validation frame.
-
-World ID verifier state MUST be stored in the signer contract itself. If `stateUpdater == address(0)`, the verifier state is immutable. Otherwise, updates that can invalidate accepted transactions MUST follow "Timelocked Signer-State Updates".
+This applies to root rotations, verification-key rotations, signer recovery changes, signer revocation lists, account binding changes, and policy configuration changes. State that cannot affect validation MAY update in place.
 
 ## Rationale
 
@@ -817,7 +505,7 @@ Validation gas limits are protocol constants, not signer-selected values. This g
 
 Validation gas is supplied from a per-block budget rather than the envelope `gasLimit`. This keeps the payload gas model close to EIP-1559 transactions while bounding validation work per block.
 
-Timelocked keyring updates preserve stable inclusion for transactions already accepted by the pool. Instant revocation remains available for compromised session verifiers and only evicts transactions from the revoked verifier.
+Whole-set `setKeyRing` updates make the account's session authorization state a single ordered set with one deterministic `keyRingHash`. Clients can bind cached signature validation to that hash and must revalidate when it changes.
 
 Restricted validation frames prevent validation from depending on mutable external state, block metadata, or arbitrary external contract calls.
 
@@ -832,14 +520,19 @@ Existing Safe accounts MAY deploy or delegate to EIP-1271 signer contracts that 
 Conforming implementations MUST pass vectors for:
 
 - address derivation across multiple `(chainId, manager, adminSigner, accountSalt)` tuples;
-- `activeKeyringHash` ordering and duplicate rejection;
-- each admin operation hash domain, including negative replay cases;
+- `keyRingHash = keccak256(abi.encode(sessionVerifiers))` for empty-forbidden, single-verifier, multi-verifier, and reordered verifier sets;
+- `create` validation, including deployed-code checks, duplicate and zero verifier rejection, account-exists rejection, initial nonce values, initial `keyRingHash`, `AccountCreated`, and default World ID admin signer account binding;
+- `setKeyRing` validation, including stale `expectedCurrentKeyRingHash`, duplicate, zero, undeployed, empty, oversized, and no-op verifier set rejection;
+- `setKeyRing` success behavior, including full-set replacement, `newKeyRingHash`, `adminNonce` increment, `KeyRingSet`, authorization lookup updates, and failure atomicity;
+- `createHash` and `setKeyRingHash` domain separation, parameter binding, nonce binding, and negative replay cases across accounts, chains, managers, hashes, and operation types;
 - `0x1D` RLP encoding, signing hash, and transaction hash;
-- malformed envelope rejection for `to`, `data`, `accessList`, and `signature` bounds;
-- manager state transitions, emitted events, nonce changes, and failure atomicity;
-- transaction validation failures, policy failures, trace overflow, and payload reverts;
-- txpool retention across keyring activation and eviction on revocation;
+- malformed envelope rejection for `chainId`, `nonce`, `to`, `data`, `accessList`, `signature`, and EIP-1559 fee bounds;
+- transaction validation against the current verifier set, including unauthorized verifier rejection and `ExecutionTraceContext.transaction.keyRingHash`;
+- failure semantics for envelope/precheck failures, validation-budget exhaustion, signature failures, trace overflow, policy failures, and payload reverts;
+- txpool revalidation, signature-validation cache reuse, and cache invalidation when `keyRingHash`, verifier membership, account balance, or nonce eligibility changes;
+- signer-state determinism, including rejection of validation-affecting session verifier updates behind an unchanged verifier address;
 - restricted-frame positive cases and each forbidden opcode or call target;
+- default signer factory `CREATE2` address computation, idempotency, metadata, and incompatible-code rejection;
 - World ID `worldIdField`, `worldIdAction`, admin proof, and session proof inputs;
 - default secp256k1 low-s, `v`, owner, and signature-length checks;
 - block validation budget exhaustion and validation-failure fee charging.
@@ -848,21 +541,21 @@ Complete golden vectors and a conformance test suite MUST be published before th
 
 ## Security Considerations
 
-- Admin authorization hashes bind domain, chain ID, manager, account, parameters, and nonce where applicable. A signature valid for one operation MUST NOT be valid for another.
-- The admin signer is immutable in the account address. A broken or lost admin signer requires migrating assets to a new account.
-- Applications that need recovery SHOULD use admin signers with recovery or multisig logic from account creation.
-- `revokeSessionVerifier` is effective only after compromise is detected and the admin transaction is included. Monitoring and automated revocation reduce this window.
-- Fixed validation gas limits bound signer execution. Signers that exceed the limit fail validation.
+- Admin authorization hashes bind domain, chain ID, manager, account, operation parameters, and nonce where applicable. A signature valid for `create` MUST NOT be valid for `setKeyRing`, another account, another chain, another manager, or another key ring hash.
+- The admin signer is immutable in the account address. A broken or lost admin signer requires migrating assets to a new account; applications that need recovery SHOULD use admin signers with recovery or multisig logic from account creation.
+- `setKeyRing` is the only post-creation key ring mutation path. A compromised session verifier remains authorized until an admin-authorized replacement set is included.
+- `expectedCurrentKeyRingHash` protects `setKeyRing` authorizations from applying to an unexpected current set. Admin tooling SHOULD surface the complete replacement set before signing because omitted verifiers are removed atomically.
+- `keyRingHash` binds cached validation to the ordered `SessionVerifier[]` set. Clients MUST discard cached signature results when the active hash changes, even if the transaction's `sessionVerifier` remains present in the new set.
+- `keyRingHash` does not commit to mutable verifier behavior by itself. Session verifier state that can affect `isValidSignature` or `evaluateSessionPolicy` MUST be immutable for that verifier address; upgrades that affect validation require a new verifier address installed through `setKeyRing`.
+- The protocol MUST verify that `sessionVerifier` is authorized for `account` before calling EIP-1271. Unauthorized verifiers MUST fail as a precheck rather than receiving a validation call.
+- Fixed validation gas limits bound signer execution. Signers that exceed the limit fail validation, and all signature and policy validation gas counts against `BLOCK_VALIDATION_GAS_BUDGET`.
 - `BLOCK_VALIDATION_GAS_BUDGET` is scarce. `MIN_VALIDATION_FAILURE_FEE` MUST be tuned so validation spam is costly, and clients MUST reject pooled transactions that cannot pay it.
-- Builders may prefer transactions with cheaper validation profiles. Fixed validation gas bounds the worst-case bias.
+- Builders may prefer transactions with cheaper validation profiles. Fixed validation gas bounds the worst-case bias but does not eliminate ordering incentives.
 - `MAX_EXECUTION_TRACE_BYTES`, `MAX_PAYLOAD_DATA_BYTES`, `MAX_ACCESS_LIST_ENTRIES`, `MAX_SESSION_SIGNATURE_BYTES`, and `MAX_ADMIN_AUTHORIZATION_BYTES` bound calldata, decoding, memory, and ABI-encoding costs.
 - Restricted frames forbid mutable external-state reads and block-context opcodes. Signers that need time, block, or external-state constraints MUST bind them into the signature or proof input.
-- Signers may read their own storage. Mutable signer state that can affect accepted transactions MUST be timelocked.
-- Upgradeable signers can change validation behavior. Upgrades that affect validation MUST follow the signer-state timelock requirement.
+- `DELEGATECALL` inside restricted validation frames is safe only when the delegatee bytecode satisfies the same tracer rules recursively.
 - The `0x1D` envelope exposes `account` and `sessionVerifier`. Applications that need stronger privacy should use verifier contracts that aggregate or rotate credentials.
-- The protocol MUST verify that `sessionVerifier` is authorized for `account` before calling EIP-1271.
 - WebAuthn-based signers MUST bind challenges to the `0x1D` signing hash and `WORLD_CHAIN_RP_ID`.
 - World ID signers MUST bind `block.chainid` into `worldIdAction` or session nonce inputs to prevent cross-chain proof replay.
 - The default World ID admin signer self-reports `account()`. The manager checks this only for default-factory-deployed World ID admin signers; custom signers are responsible for their own consistency.
 - `create` does not bind `msg.sender`, so a copied call can be front-run. The resulting account state is identical because the authorization commits to all state-determining parameters.
-- `DELEGATECALL` inside restricted validation frames is safe only when the delegatee bytecode satisfies the same tracer rules recursively.

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -1,7 +1,7 @@
 ---
 wip: 1001
 title: World Chain Native Account Abstraction
-description: A smart contract managed account model with a single admin authority pinned at creation. Session keys compose a keyring that delegates transaction authorization for the account.
+description: A predeploy-managed account model whose admin and session authorization are verified through EIP-1271 smart contract signers.
 author: Kilian Glas (@kilianglas), 0xOsiris (@0xOsiris), Eric Woolsey (@0xforerunner)
 status: Draft
 type: Standards Track
@@ -12,42 +12,35 @@ requires: EIP-2, EIP-1559, EIP-196, EIP-197, EIP-198, EIP-2718, EIP-1271, RIP-72
 
 ## Abstract
 
-A *World Chain Account* is a smart contract managed account whose 20-byte address is deterministic and lifetime-stable. Each account has a single *admin authority* fixed at creation, which gates mutation of the account's keyring -- the set of session keys authorized to sign on its behalf. We extend [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) with a typed transaction envelope (`0x1D`) signed by any authorized session key in a World Chain Account's keyring.
+A *World Chain Account* is a predeploy-managed account whose 20-byte address is deterministic and lifetime-stable. Each account has one admin signer fixed at creation and an active **keyring** of session signers authorized to sign transactions on the account's behalf. Both admin authorization and session-key transaction authorization are verified exclusively through [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) smart contract signers.
 
-This WIP deliberately minimizes the diff from Ethereum's existing signature model. The protocol recognizes only two session-key verification modes:
+This WIP extends [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) with a typed transaction envelope (`0x1D`) whose signature payload is passed to an authorized session signer's `isValidSignature(bytes32,bytes)` implementation under a restricted, metered validation frame. The protocol does not natively dispatch over secp256k1, P256, WebAuthn, EdDSA, BLS, World ID, or any other signature scheme. Those schemes are implemented by EIP-1271 signer contracts using reusable EVM precompiles.
 
-- **Secp256k1 EOA key.** The `0x1D` transaction carries an Ethereum-style secp256k1 ECDSA signature. Validation recovers an address from the transaction signing hash and requires that address to be authorized in the account keyring.
-- **EIP-1271 contract key.** The `0x1D` transaction names a contract key. Validation invokes `isValidSignature(bytes32,bytes)` under a restricted, metered validation frame and requires the EIP-1271 magic value.
+Session signers also define programmable execution policy. The protocol does not store or interpret that policy. After signature verification and tentative transaction execution, the protocol supplies the resulting execution trace to the same session verifier contract. The verifier evaluates its internal policy as `f(transactionContext, executionTrace) -> bool`; if it returns false or fails, the transaction reverts.
 
-Non-ECDSA signature algorithms, including P256, WebAuthn, EdDSA, BLS, and pairing-based proof systems, are not native session-key types in this WIP. They are implemented by EIP-1271 key contracts using elliptic-curve and pairing precompiles exposed by the VM. The same precompiles are callable by ordinary smart contracts and by protocol/system validation, avoiding private host-only cryptography.
+Account state and keyring management live in the `WORLD_CHAIN_ACCOUNT_MANAGER` predeploy. The manager exposes default signer factories for common strategies, including a World ID signer that verifies World ID proofs encoded in EIP-1271 signature bytes, and a secp256k1 signer that wraps EOA-style signatures. These default signers are reference implementations, not privileged protocol paths.
 
-This WIP specifies three admin authority instantiations:
-
-- **WorldID admin.** Creation gated by a [World ID 4.0](https://github.com/worldcoin/world-id-protocol) Uniqueness Proof; subsequent keyring mutations gated by Session Proofs against a stored `sessionId`. Recovery from lost or compromised session keys is the degenerate case of the same upgrade path. A single WorldID `MAY` manage any number of WorldID-admin accounts indexed by a user-chosen `worldIDAccountNonce`; accounts owned by the same WorldID are unlinkable across distinct values.
-- **Secp256k1 EOA admin.** Creation and keyring mutations gated by Ethereum-style ECDSA signatures over a uniform `signalHash` from a single admin address fixed at creation. Admin-key loss is terminal.
-- **EIP-1271 contract admin.** Creation and keyring mutations gated by `isValidSignature(bytes32,bytes)` on a single contract signer fixed at creation and evaluated under the restricted validation frame. Recovery, if any, is delegated to the signer contract's own policy.
-
-Account state lives natively in the `WORLD_CHAIN_ACCOUNT_PRECOMPILE`. The account address is a public identifier for an admin-authority-managed set of session keys, not an identity anchor; per-instantiation rules govern how many accounts a given admin authority may own.
+Keyring updates are timelocked. An admin-authorized update first queues a full replacement keyring, and that keyring can only become active after a protocol-defined delay longer than the public transaction-pool expiration window. Default signer factories MUST apply the same delay discipline to signer authorization state so that EIP-1271 verification cannot fail between public transaction-pool validation and inclusion due to keyring or signer-state mutation.
 
 ## Motivation
 
-### Minimal Ethereum Diff
+### One Signature Abstraction
 
-Ethereum already has one native transaction-signature algorithm and one standard contract-signature interface. WIP-1001 follows that split: native secp256k1 address recovery for EOA-like signers, and [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) for contract signers.
+Ethereum already standardizes contract-based signature validation through EIP-1271. WIP-1001 makes EIP-1271 the only native authorization abstraction for World Chain Accounts. This keeps the transaction envelope small and scheme-agnostic while allowing wallets, applications, and future protocol features to introduce new signing policies without changing the transaction type.
 
-This keeps the `0x1D` transaction model close to existing Ethereum validation while still admitting modern authenticators and application-defined signing policies. A passkey, threshold signer, BLS aggregate signer, or Groth16-backed signer is a contract that returns the EIP-1271 magic value after calling public precompiles.
+An EOA wrapper, a passkey signer, a World ID proof verifier, a threshold signer, an EdDSA signer, or a BLS aggregate signer is simply a contract that returns the EIP-1271 magic value for a given hash and opaque signature bytes. The same signer can also own the session policy for what that session key may do.
 
 ### Reusable Cryptography
 
-Cryptographic accelerators used for account validation should not be protocol-private. If the protocol accepts an elliptic-curve or bilinear pairing during EIP-1271 validation, the same primitive MUST be exposed as a normal EVM precompile callable by smart contracts. This lets signer contracts, application contracts, and protocol validation share one compatibility surface.
+Cryptographic accelerators used for account validation should not be host-private. If WIP-1001 signers depend on an elliptic-curve, hash, pairing, EdDSA, or BLS primitive, the primitive MUST be exposed as a normal EVM precompile with the same behavior for contracts and protocol validation. This makes signer contracts the compatibility layer over public VM functionality.
 
-### Pluggable Admin Authorities
+### Programmable Keyrings
 
-TODO: FIXME: Rewrite with new Admin Key Model
+The keyring should be an elegant authorization registry, not a catalogue of native signature algorithms or call-scope rules. A World Chain Account stores signer contracts. The signer contract owns the verification strategy, recovery strategy, quorum rules, proof format, authenticator-specific state, and programmable execution policy. This gives the protocol one validation path while preserving a programmable account surface.
 
-A pluggable admin model lets a single account abstraction serve multiple user populations from one precompile. **WorldID admin** converges key rotation and recovery onto a single proof-verification path after enrollment: a fresh Session Proof. No "super key" is ever stored on-device; recovery is the degenerate case of the same upgrade path. **Secp256k1 EOA admin** lets accounts be owned by existing Ethereum keys. **EIP-1271 contract admin** lets accounts be controlled by multisigs, passkeys, policy engines, or custom recovery contracts without adding new native admin algorithms to this WIP.
+### Pool-Stable Validation
 
-Sharing a single keyring + transaction surface (`0x1D`, session keys, signal binding) across instantiations means session-key UX and integration surface are uniform regardless of admin type. A new non-ECDSA admin scheme reduces to an EIP-1271 contract plus, if needed, a reusable VM precompile.
+Public transaction pools validate transactions before inclusion. If a keyring or signer can invalidate a signature immediately after validation, a transaction can be accepted by the pool and then fail during block construction. WIP-1001 therefore requires keyring replacements and default signer authorization-state changes to be delayed by more than the public pool expiration window. A transaction that is pool-valid against the active keyring and a compliant default signer remains valid until it either expires from the pool or is included, assuming no other transaction fields become invalid.
 
 ## Specification
 
@@ -55,278 +48,344 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Constants
 
-| Name                              | Value                                        | Description                                                  |
-| --------------------------------- | -------------------------------------------- | ------------------------------------------------------------ |
-| `WORLD_TX_TYPE`                   | `0x1D`                                       | [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) tx type  |
-| `WORLD_CHAIN_ACCOUNT_PRECOMPILE`  | `0x000000000000000000000000000000000000001D` | Stateful precompile managing the World Chain Account registry |
-| `MAX_SESSION_KEYS`                | `20`                                         | Maximum authorized session keys per account                  |
-| `ADMIN_TYPE_WORLD_ID`             | `0x00`                                       | Admin type discriminator: WorldID admin                      |
-| `ADMIN_TYPE_SECP256K1_EOA`        | `0x01`                                       | Admin type discriminator: secp256k1 EOA admin                |
-| `ADMIN_TYPE_EIP1271`              | `0x02`                                       | Admin type discriminator: EIP-1271 contract admin            |
-| `KEY_TYPE_SECP256K1_EOA`          | `0x00`                                       | Session key type: Ethereum secp256k1 address                 |
-| `KEY_TYPE_EIP1271`                | `0x01`                                       | Session key type: EIP-1271 contract address                  |
-| `EIP1271_MAGIC_VALUE`             | `0x1626ba7e`                                 | `bytes4(keccak256("isValidSignature(bytes32,bytes)"))`       |
-| `MAX_EIP1271_VALIDATION_GAS`      | `TBD`                                        | Maximum gas for one protocol EIP-1271 validation frame        |
+| Name | Value | Description |
+| ---- | ----- | ----------- |
+| `WORLD_TX_TYPE` | `0x1D` | EIP-2718 transaction type |
+| `WORLD_CHAIN_ACCOUNT_MANAGER` | `TBD` | World Chain Account Manager predeploy address |
+| `MAX_SESSION_SIGNERS` | `20` | Maximum active session signers per account |
+| `EIP1271_MAGIC_VALUE` | `0x1626ba7e` | `bytes4(keccak256("isValidSignature(bytes32,bytes)"))` |
+| `EIP1271_VALIDATION_GAS_LIMIT` | `TBD` | Fixed gas supplied to every protocol EIP-1271 validation frame |
+| `EXECUTION_TRACE_VALIDATION_GAS_LIMIT` | `TBD` | Fixed gas supplied to every protocol execution-trace policy validation frame |
+| `MAX_EXECUTION_TRACE_BYTES` | `TBD` | Maximum ABI-encoded execution trace size supplied to a verifier |
+| `TXPOOL_TRANSACTION_EXPIRATION_WINDOW` | `TBD` | Maximum public transaction-pool lifetime for a `0x1D` transaction |
+| `MIN_KEYRING_UPDATE_DELAY` | `> TXPOOL_TRANSACTION_EXPIRATION_WINDOW` | Minimum delay before a queued keyring can activate |
+| `WORLD_ID_1271_SIGNER_FACTORY` | `TBD` | Default World ID EIP-1271 signer factory |
+| `SECP256K1_1271_SIGNER_FACTORY` | `TBD` | Default secp256k1 EIP-1271 signer factory |
+| `WORLD_CHAIN_RP_ID` | `480` | World Chain's registered World ID relying-party ID |
+| `WORLD_ID_ACCOUNT_TAG` | `"WORLD_ID_ACCOUNT"` | Domain tag for World ID account/signer creation actions |
 
-Per-instantiation constants are defined in their respective sections.
+`EIP1271_VALIDATION_GAS_LIMIT`, `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`, and `MAX_EXECUTION_TRACE_BYTES` are protocol constants. They are not selected by the transaction, account, signer, keyring entry, admin authorization, or factory.
+
+`MIN_KEYRING_UPDATE_DELAY` MUST be strictly greater than the maximum configured public transaction-pool expiration window for `0x1D` transactions. If a client or network changes the public pool expiration window, this constant MUST remain larger than the new window before WIP-1001 public-pool admission is enabled under that configuration.
 
 ### Reusable Crypto Precompiles
 
-Any cryptographic primitive used by WIP-1001 protocol validation MUST be available through an EVM precompile with the same behavior for smart contracts and protocol/system callers. Implementations MUST NOT validate WIP-1001 EIP-1271 signers with private host functions that are unavailable to contracts.
+Any accelerated cryptographic primitive used by protocol-valid EIP-1271 signers MUST be available through an EVM precompile with the same behavior for smart contracts and protocol/system callers. Implementations MUST NOT validate WIP-1001 signers with private host functions unavailable to contracts.
 
-The validation precompile allowlist initially contains:
+The restricted validation-frame precompile allowlist initially contains:
 
-| Name              | Address                                      | Purpose                                      |
-| ----------------- | -------------------------------------------- | -------------------------------------------- |
-| `ECRECOVER`       | `0x0000000000000000000000000000000000000001` | Ethereum secp256k1 recovery                  |
-| `SHA256`          | `0x0000000000000000000000000000000000000002` | WebAuthn and other hash-based verification   |
-| `MODEXP`          | `0x0000000000000000000000000000000000000005` | Modular exponentiation ([EIP-198](https://eips.ethereum.org/EIPS/eip-198)) |
-| `BN254_ADD`       | `0x0000000000000000000000000000000000000006` | BN254 G1 addition ([EIP-196](https://eips.ethereum.org/EIPS/eip-196)) |
-| `BN254_MUL`       | `0x0000000000000000000000000000000000000007` | BN254 G1 scalar multiplication ([EIP-196](https://eips.ethereum.org/EIPS/eip-196)) |
-| `BN254_PAIRING`   | `0x0000000000000000000000000000000000000008` | BN254 pairing check ([EIP-197](https://eips.ethereum.org/EIPS/eip-197)) |
-| `P256VERIFY`      | `0x0000000000000000000000000000000000000100` | P256/secp256r1 verification ([RIP-7212](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md)) |
-| `EDDSA_VERIFY`    | `TBD`                                        | EdDSA signature verification; specified by a separate WIP |
+| Name | Address | Purpose |
+| ---- | ------- | ------- |
+| `ECRECOVER` | `0x0000000000000000000000000000000000000001` | Ethereum secp256k1 recovery |
+| `SHA256` | `0x0000000000000000000000000000000000000002` | WebAuthn and other hash-based verification |
+| `MODEXP` | `0x0000000000000000000000000000000000000005` | Modular exponentiation ([EIP-198](https://eips.ethereum.org/EIPS/eip-198)) |
+| `BN254_ADD` | `0x0000000000000000000000000000000000000006` | BN254 G1 addition ([EIP-196](https://eips.ethereum.org/EIPS/eip-196)) |
+| `BN254_MUL` | `0x0000000000000000000000000000000000000007` | BN254 G1 scalar multiplication ([EIP-196](https://eips.ethereum.org/EIPS/eip-196)) |
+| `BN254_PAIRING` | `0x0000000000000000000000000000000000000008` | BN254 pairing check ([EIP-197](https://eips.ethereum.org/EIPS/eip-197)) |
+| `P256VERIFY` | `0x0000000000000000000000000000000000000100` | P256/secp256r1 verification ([RIP-7212](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md)) |
+| `EDDSA_VERIFY` | `TBD` | EdDSA signature verification; specified by a separate WIP |
+| `BLS12_381_VERIFY` | `TBD` | BLS12-381 verification or pairing suite; specified by a separate WIP |
 
-The concrete address, supported curve(s), input/output encoding, malleability rules, failure behavior, and gas schedule for `EDDSA_VERIFY` are out of scope for WIP-1001 and MUST be specified by a separate WIP before activation.
-
-Future curve or pairing systems MAY be added by extending this allowlist in a follow-on fork. EIP-1271 signer contracts that need a non-allowlisted primitive are invalid for WIP-1001 protocol validation until that primitive is exposed as an allowed precompile.
+The concrete address, supported curve(s), input/output encoding, malleability rules, failure behavior, and gas schedule for `EDDSA_VERIFY` and `BLS12_381_VERIFY` are out of scope for this WIP and MUST be specified before activation. Future curve, pairing, or proof-system precompiles MAY be added by a follow-on fork.
 
 ### Abstract Account Model
 
-An *account* is created by an admin-authorized `Create` operation that fixes an *admin type* `T` and an *admin authority* `A` of type `T`. After creation, `T` and `A` are immutable for the lifetime of the account. The keyring is mutated by admin-authorized full-keyring replacement operations: `SetKeyring`. All admin authorizations bind the operation to a uniform `signalHash` defined below; replay protection across operations is provided by a per-account monotonic `adminNonce`.
+An account is created by an EIP-1271-admin-authorized `create` operation. Creation fixes:
+
+- `adminSigner`, the EIP-1271 contract that authorizes future keyring updates;
+- `accountSalt`, the admin-selected salt used for deterministic address derivation;
+- the initial active keyring of session signers.
+
+After creation, `adminSigner` and `accountSalt` are immutable for the lifetime of the account. Keyring mutation is performed by queueing a full replacement keyring, then activating it after the timelock delay has elapsed.
 
 #### Account State
 
-Per-account state stored in the precompile:
+Per-account state stored by the `WORLD_CHAIN_ACCOUNT_MANAGER` predeploy:
 
 ```solidity
 struct Account {
-    uint8       adminType;             // ADMIN_TYPE_*
-    bytes       verificationPublicId;  // variable length per admin type
-    SessionKey[] sessionKeys;          // see Session Keys
-    bytes32     keyringHash;           // keccak256(abi.encode(sessionKeys))
-    uint64      adminNonce;            // monotonic; replay protection
+    address         adminSigner;
+    bytes32         accountSalt;
+    SessionSigner[] activeSessionSigners;
+    bytes32         activeKeyringHash;
+    PendingKeyringUpdate pendingKeyringUpdate;
+    uint64          adminNonce;
+}
+
+struct PendingKeyringUpdate {
+    bool            exists;
+    bytes32         expectedCurrentKeyringHash;
+    SessionSigner[] targetSessionSigners;
+    bytes32         targetKeyringHash;
+    uint64          activateAfter;
+    uint64          queuedAtNonce;
 }
 ```
 
-`verificationPublicId` is the persistent public material the admin authority uses to verify subsequent updates. Its encoding is per-instantiation (e.g., `sessionId` for WorldID admin, an admin address for Secp256k1 EOA admin, or `(contract, gasLimit)` for EIP-1271 admin). It is set at creation and is not directly mutable by this WIP -- see [Extensions](#extensions) for admin rotation.
+`adminNonce` is initialized to `0` at creation and incremented by `1` whenever a keyring update is successfully queued. `activateKeyringUpdate` does not require a new admin authorization and does not increment `adminNonce`.
 
-#### Session Keys
+#### Session Signers
 
 ```solidity
-enum KeyType {
-    Secp256k1EOA,  // 0x00
-    EIP1271        // 0x01
-}
-
-struct SessionKey {
-    KeyType keyType;
-    address key;
-    uint32  validationGasLimit;
-    SessionPolicy policy;
-}
-
-struct SessionPolicy {
-    uint64      validAfter;
-    uint64      validUntil;
-    uint256     maxValuePerTx;
-    CallScope[] callScopes;
-}
-
-struct CallScope {
-    address target;
-    bytes4  selector;
+struct SessionSigner {
+    address signer;
 }
 ```
 
-| `keyType`          | Value  | `key` meaning                                     | `validationGasLimit`                         |
-| ------------------ | ------ | ------------------------------------------------- | -------------------------------------------- |
-| `Secp256k1EOA`     | `0x00` | Ethereum address recovered from secp256k1 ECDSA   | MUST be `0`                                  |
-| `EIP1271`          | `0x01` | Contract implementing `isValidSignature(bytes32,bytes)` | MUST be `> 0` and `<= MAX_EIP1271_VALIDATION_GAS` |
+`signer` MUST NOT be the zero address and MUST have non-empty code when it is added to a keyring. The signer MUST implement `IERC1271.isValidSignature(bytes32,bytes)` and `IWorldChainSessionVerifier.isValidExecutionTrace(WorldChainTransactionContext,WorldChainExecutionTrace)`.
 
-`key` MUST NOT be the zero address. For `EIP1271`, `key` MUST have non-empty code at the time it is added to a keyring or fixed as an admin authority.
+Protocol native EIP-1271 signature verification is constrained to `EIP1271_VALIDATION_GAS_LIMIT`.
 
-Keyring uniqueness is defined by `(keyType, key)`. A keyring MUST NOT contain two entries with the same `(keyType, key)`, even if their `validationGasLimit` or policy values differ. Changing an EIP-1271 session key's gas limit or a session key's policy requires replacing the full keyring with `SetKeyring`.
+A keyring MUST contain at least one session signer and MUST NOT contain more than `MAX_SESSION_SIGNERS`.
 
-Session policies provide the basic scoped-key surface in this WIP:
+Session signers carry no intrinsic privileges beyond signing `0x1D` transactions whose execution traces are accepted by their verifier policy.
 
-- `validAfter` and `validUntil` define the key's validity window in Unix seconds. `validUntil == 0` means no upper bound. If `validUntil != 0`, implementations MUST require `validAfter <= validUntil`.
-- `maxValuePerTx` is the maximum native-token `value` the key may authorize in one `0x1D` transaction. `type(uint256).max` means no value limit.
-- `callScopes` is an allowlist over `(to, selector)`. If empty, no target/selector restriction is applied. `target == address(0)` matches any target. `selector == 0x00000000` matches any selector; otherwise it is matched against the first four bytes of transaction calldata, with empty calldata treated as selector `0x00000000`.
+#### Session Verifier Execution Policy Interface
 
-A `0x1D` transaction satisfies a `SessionPolicy` iff the current block timestamp is within the validity window, `value <= maxValuePerTx`, and either `callScopes` is empty or at least one `CallScope` matches the transaction.
+Session signers MUST implement:
 
-Session keys carry no intrinsic privileges beyond signing `0x1D` transactions that satisfy their stored policy.
+```solidity
+interface IWorldChainSessionVerifier is IERC1271 {
+    struct AccessListEntry {
+        address account;
+        bytes32[] storageKeys;
+    }
 
-#### Admin Authority Interface
+    struct WorldChainTransactionContext {
+        bytes32 signingHash;
+        uint256 chainId;
+        address account;
+        address signer;
+        uint64  nonce;
+        uint256 maxPriorityFeePerGas;
+        uint256 maxFeePerGas;
+        uint64  gasLimit;
+        bool    isCreate;
+        address target;
+        uint256 value;
+        bytes   data;
+        bytes4  selector;
+        AccessListEntry[] accessList;
+        bytes32 activeKeyringHash;
+    }
 
-The abstract operation each admin authority provides is:
+    enum TraceCallKind {
+        Call,
+        StaticCall,
+        DelegateCall,
+        Create,
+        Create2
+    }
 
-```text
-verifyAdmin(signalHash, authorization, verificationPublicId) -> bool
+    struct CallTrace {
+        uint32        depth;
+        TraceCallKind kind;
+        address       caller;
+        address       target;
+        uint256       value;
+        bytes4        selector;
+        bytes32       inputHash;
+        bytes32       outputHash;
+        bool          success;
+        uint64        gasUsed;
+    }
+
+    struct LogTrace {
+        address   emitter;
+        bytes32[] topics;
+        bytes32   dataHash;
+    }
+
+    struct WorldChainExecutionTrace {
+        bool        success;
+        uint64      gasUsed;
+        bytes32     outputHash;
+        CallTrace[] calls;
+        LogTrace[]  logs;
+    }
+
+    function isValidExecutionTrace(
+        WorldChainTransactionContext calldata context,
+        WorldChainExecutionTrace calldata trace
+    ) external view returns (bool allowed);
+}
 ```
 
-`authorization` and `verificationPublicId` are byte strings whose encoding is per-instantiation. The precompile invokes this operation during `update`. Each instantiation specifies how the operation is realized -- see [Admin Instantiations](#admin-instantiations).
+The protocol constructs `WorldChainTransactionContext` from the `0x1D` transaction after computing `signingHash` and loading the active keyring entry:
 
-Admin authorization at creation is also instantiation-specific. Each instantiation defines an `adminCreationContext`: the canonical ABI tuple of creation fields that fix the admin authority, the address-defining material, and any persistent verification state. The first element of this tuple MUST be the `uint8 adminType` discriminator. Authorization payloads, signatures, and proofs are excluded from this context to avoid recursive hashing. `CreateSignal` binds `adminType` and `adminCreationContextHash = keccak256(adminCreationContext)` so the creation authorization cannot be replayed with different permanent admin state.
+- `signingHash` is the canonical `0x1D` signing hash.
+- `chainId`, `nonce`, fee fields, `gasLimit`, `value`, `data`, and `accessList` are copied from the transaction.
+- `account` is the World Chain Account sender.
+- `signer` is the declared session signer.
+- For a call transaction, `isCreate == false` and `target == to`.
+- For a contract-creation transaction, `isCreate == true`, `target == address(0)`, and `data` is init code.
+- `selector` is the first four bytes of `data`; if `data.length < 4`, `selector == 0x00000000`.
+- `activeKeyringHash` is the account's active keyring hash at validation time.
 
-Some instantiations take address-defining material directly as a creation input that coincides with `verificationPublicId`; others retain a different persistent verifier identifier. For WorldID admin, the creation nullifier defines the address while `sessionId` is stored as `verificationPublicId`. For EIP-1271 admin, the signer contract defines the address while `(signer, validationGasLimit)` is stored as `verificationPublicId`.
+The protocol constructs `WorldChainExecutionTrace` from the tentative execution of the `0x1D` payload:
+
+- `success` is the success status of the root transaction payload execution.
+- `gasUsed` is the gas consumed by the root transaction payload execution before trace validation.
+- `outputHash` is `keccak256(returnData)` for the root transaction payload execution.
+- `calls` is the ordered, depth-annotated call/create trace emitted by the root execution. The root call itself is excluded because it is already represented by `WorldChainTransactionContext`.
+- `logs` is the ordered log summary emitted by the root execution.
+
+Full internal calldata, return data, and log data are not copied into the trace by default; their hashes are supplied to keep trace validation bounded. A verifier that needs to authorize exact internal calldata SHOULD require the caller to include the relevant commitments in the session signature or in root transaction calldata. The ABI-encoded trace supplied to the verifier MUST NOT exceed `MAX_EXECUTION_TRACE_BYTES`.
+
+No block-context fields other than `chainId` are supplied. If a verifier policy depends on time, block number, or other context, it MUST bind that data through its own signature/proof payload rather than reading block opcodes during trace validation.
+
+The execution-trace policy check is evaluated after tentative execution and before state commit, under the same call-target and opcode restrictions as EIP-1271 signature validation, with gas exactly `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`. If the call reverts, runs out of gas, executes a forbidden opcode, calls a forbidden address, returns malformed data, or returns `false`, the transaction-level authorization fails and the tentative payload execution is reverted.
+
+The policy function is intentionally `f(transactionContext, executionTrace) -> bool`: the protocol supplies what happened, while the verifier defines whether that execution is allowed. Examples include target/selector allowlists, method-argument commitments, value-flow limits, internal-call restrictions, log emission requirements, proof-bound permissions, per-session spending state, or app-specific invariants over the call trace.
 
 #### Address Derivation
 
 ```text
-addr = bytes20(keccak256(abi.encodePacked(adminTypeTag, addressDefiningMaterial)))
+account = bytes20(keccak256(abi.encodePacked(
+    bytes32("WORLD_CHAIN_ACCOUNT"),
+    block.chainid,
+    WORLD_CHAIN_ACCOUNT_MANAGER,
+    adminSigner,
+    accountSalt
+)))
 ```
 
-`adminTypeTag` is the one-byte `ADMIN_TYPE_*` discriminator. `addressDefiningMaterial` is per-instantiation:
+The address is fixed for the lifetime of the account. Keyring updates, signer state changes, and admin-signer internal recovery do not change the account address.
 
-- WorldID admin: the creation Uniqueness Proof's nullifier (32 bytes).
-- Secp256k1 EOA admin: the 20-byte admin address (= `verificationPublicId`).
-- EIP-1271 contract admin: the 20-byte signer contract address.
+The default World ID signer factory SHOULD derive different signer addresses for different World ID account nonces. A World ID holder who wants unlinkability across accounts SHOULD use distinct World ID signer instances and distinct `accountSalt` values.
 
-The address is fixed for the lifetime of the account; session-key rotation does **NOT** change the address.
-
-#### Signal Semantics
-
-```solidity
-enum UpdateMode {
-    Create,        // 0x00
-    SetKeyring     // 0x01
-}
-
-struct KeyringUpdate {
-    UpdateMode   mode;
-    bytes32      expectedCurrentKeyringHash;
-    SessionKey[] keys;
-}
-```
-
-- **`Create`** -- installs `keys` as the full keyring at the account's address and initializes the account with the supplied admin authority. MUST revert if the account already exists, if `expectedCurrentKeyringHash != 0x00..00`, if `keys.length == 0`, or if `keys.length > MAX_SESSION_KEYS`.
-- **`SetKeyring`** -- proposes replacing the existing keyring with exactly `keys`. MUST revert if the account does not exist, if `expectedCurrentKeyringHash != account.keyringHash`, if `keys.length == 0`, or if `keys.length > MAX_SESSION_KEYS`.
-
-For all modes, every `SessionKey` MUST satisfy the validation rules in [Session Keys](#session-keys). An implementation SHOULD validate key shape, gas limits, zero addresses, duplicate entries, and EIP-1271 code existence before performing expensive admin authorization.
+#### Keyring Hash
 
 The canonical keyring hash is:
 
 ```text
-keyringHash = keccak256(abi.encode(keys))
+keyringHash = keccak256(abi.encode(sessionSigners))
 ```
 
-where `keys` is the full ABI-encoded `SessionKey[]` in its stored order. The order is admin-selected and consensus-significant; clients SHOULD sort keys lexicographically by `(keyType, key)` before submitting updates to avoid accidental duplicate representations.
+where `sessionSigners` is the full ABI-encoded `SessionSigner[]` in its stored order. The order is admin-selected and consensus-significant. Clients SHOULD sort signers lexicographically by `signer` before submitting updates to avoid accidental duplicate representations.
 
-The `signalHash` an admin authority binds to is uniform across instantiations.
+#### Signal Semantics
 
-```solidity
-struct CreateSignal {
-    bytes32       tag;             // == keccak256("WORLD_CHAIN_ACCOUNT_CREATE")
-    uint8         adminType;
-    bytes32       adminCreationContextHash;
-    address       msgSender;
-    KeyringUpdate keyringUpdate;
-}
-
-struct UpdateSignal {
-    bytes32       tag;             // == keccak256("WORLD_CHAIN_ACCOUNT_UPDATE")
-    address       accountAddress;
-    uint64        adminNonce;
-    address       msgSender;
-    KeyringUpdate keyringUpdate;
-}
-```
+Admin authorizations bind to a uniform `signalHash`. The hash supplied to an admin signer is always the 248-bit truncated keccak value:
 
 ```text
 signalHash = bytes32(uint256(keccak256(abi.encode(signal))) >> 8)
 ```
 
-where `signal` is a populated `CreateSignal` for `Create` and an `UpdateSignal` for `SetKeyring`. The resulting value is encoded as a `bytes32` with its high 8 bits set to zero.
-
-`msgSender` is the EVM `msg.sender` of the precompile call -- binding it prevents an in-flight admin authorization observed in the mempool from being replayed by a different submitter. For `Create`, `accountAddress` is omitted because it is not knowable to the admin authority at the time the authorization is produced (it is derived from `Create`'s outputs); the domain tag, `adminType`, `adminCreationContextHash`, `msgSender`, and the keyring payload bind the authorization to its intended creation. For updates, `accountAddress` distinguishes admin authorizations across accounts the same admin might control on different domains.
-
-The `>> 8` truncation reduces the digest to 248 bits so it fits within the BN254 scalar field (matching the WorldID 4.0 proof system's signal field width). Truncation is uniform across instantiations even when the verification primitive does not require the BN254 fit, so the same `signalHash` value is canonical across all admin types.
-
-#### Replay Protection
-
-The precompile stores a per-account monotonic `adminNonce`, initialized to `0` at creation and incremented by `1` on every successful `SetKeyring` update. Admin authorizations for updates are verified against `signalHash` containing the current value of `adminNonce`; an admin authorization that was valid for `adminNonce = n` is no longer valid once the precompile has incremented past `n`.
-
-For `Create`, replay is precluded by account-existence: the precompile MUST revert if the account address is already occupied. A creation authorization can only be applied once because the post-condition (account exists at `addr`) blocks any subsequent attempt at the same address.
-
-This is the abstract replay-protection contract; each instantiation realizes it via its own verification primitive. Instantiations MUST NOT introduce additional bespoke replay machinery -- `adminNonce` + account-existence is sufficient and uniform.
-
-#### Precompile Interface
+The truncation keeps the value within the BN254 scalar field for World ID proof-backed EIP-1271 signers. It is uniform for all admin signers so that the signed value is independent of the signer implementation.
 
 ```solidity
-interface IWorldChainAccount {
-    /// @notice Create an account. `adminCreationData` layout is admin-type-specific.
-    function create(
-        uint8 adminType,
-        bytes calldata adminCreationData,
-        KeyringUpdate calldata keyringUpdate          // mode == Create
-    ) external returns (address account);
+struct CreateSignal {
+    bytes32         tag;               // keccak256("WORLD_CHAIN_ACCOUNT_CREATE")
+    address         adminSigner;
+    bytes32         accountSalt;
+    address         msgSender;
+    SessionSigner[] initialSessionSigners;
+}
 
-    /// @notice Authorize and apply a SetKeyring update.
-    /// `adminAuthorization` layout is admin-type-specific.
-    function update(
-        address account,
-        KeyringUpdate calldata keyringUpdate,         // mode == SetKeyring
-        bytes calldata adminAuthorization
-    ) external;
-
-    // Reads
-    function getAdminType(address account) external view returns (uint8);
-    function getVerificationPublicId(address account) external view returns (bytes memory);
-    function getAdminNonce(address account) external view returns (uint64);
-    function getSessionKeys(address account) external view returns (SessionKey[] memory);
-    function isAuthorized(address account, uint8 keyType, address key) external view returns (bool);
-    function getAuthorizedKey(address account, uint8 keyType, address key)
-        external
-        view
-        returns (SessionKey memory);
+struct QueueKeyringUpdateSignal {
+    bytes32         tag;               // keccak256("WORLD_CHAIN_ACCOUNT_QUEUE_KEYRING_UPDATE")
+    address         account;
+    address         adminSigner;
+    uint64          adminNonce;
+    address         msgSender;
+    bytes32         expectedCurrentKeyringHash;
+    SessionSigner[] targetSessionSigners;
+    bytes32         targetKeyringHash;
+    uint64          activateAfter;
 }
 ```
 
-`adminCreationData` and `adminAuthorization` are opaque bytes blobs; each admin instantiation specifies the ABI-encoded tuple they decode to.
+`msgSender` is the EVM `msg.sender` of the manager call. Binding it prevents an in-flight admin authorization observed in the mempool from being replayed by a different submitter. A public factory, relayer, or forwarding contract that calls the manager for multiple users MUST enforce its own caller/request binding before forwarding; otherwise those users share the same `msg.sender` for WIP-1001 authorization purposes.
 
-For `create`, the precompile MUST:
+#### Replay Protection
 
-1. Require `keyringUpdate.mode == Create`.
-2. Validate all `keyringUpdate.keys` and keyring-size constraints.
-3. Decode `adminCreationData` per the instantiation specified by `adminType`.
-4. Compute the instantiation's `adminCreationContextHash`.
-5. Recompute the `Create` `signalHash` over `(adminType, adminCreationContextHash, msg.sender, keyringUpdate)`.
-6. Verify the admin authorization per the instantiation, against `signalHash` and the instantiation's `verificationPublicId` (or, for WorldID admin, the equivalent verifier public-input set).
-7. Determine `addressDefiningMaterial` per the instantiation.
-8. Derive `accountAddress = bytes20(keccak256(abi.encodePacked(adminTypeTag, addressDefiningMaterial)))`.
-9. Require the account does not already exist at `accountAddress`.
-10. Initialize the account: store `adminType`, `verificationPublicId`, `sessionKeys = keyringUpdate.keys`, `keyringHash = keccak256(abi.encode(keyringUpdate.keys))`, and `adminNonce = 0`.
+For `create`, replay is precluded by account existence: the manager MUST revert if the derived account already exists.
 
-For `update`, the precompile MUST:
+For `queueKeyringUpdate`, replay is prevented by `adminNonce`. The signal contains the current `adminNonce`; after a successful queue operation the manager increments `adminNonce`. An authorization for nonce `n` is invalid after the account advances to nonce `n + 1`.
 
-1. Require `keyringUpdate.mode == SetKeyring`.
-2. Validate all `keyringUpdate.keys` and keyring constraints.
-3. Load the account's stored `adminType`, `verificationPublicId`, `keyringHash`, and `adminNonce`.
-4. Require `keyringUpdate.expectedCurrentKeyringHash == keyringHash`.
-5. Recompute the `Update` `signalHash` over `(accountAddress, adminNonce, msg.sender, keyringUpdate)`.
-6. Verify `adminAuthorization` per `adminType` against `signalHash` and `verificationPublicId`.
-7. Replace `sessionKeys` with `keyringUpdate.keys` and store `keyringHash = keccak256(abi.encode(keyringUpdate.keys))`.
-8. Increment `adminNonce`.
+Queueing a new keyring update while another update is pending is permitted. The new queue operation MUST be independently admin-authorized, MUST satisfy the same delay rules, and replaces the previous pending update.
 
-> **Note -- Precompile gas accounting out of scope.** The full gas pricing schedule for interacting with `WORLD_CHAIN_ACCOUNT_PRECOMPILE` -- covering admin verification cost, per-session-key storage mutation, and the amortized cost of reads during `0x1D` validation -- is **NOT** fully defined here. A follow-on revision MUST specify gas costs per operation. EIP-1271 validation gas is separately constrained by [Restricted EIP-1271 Validation Frame](#restricted-eip-1271-validation-frame).
+### Manager Interface
 
-### Restricted EIP-1271 Validation Frame
+```solidity
+interface IWorldChainAccountManager {
+    function create(
+        address adminSigner,
+        bytes32 accountSalt,
+        SessionSigner[] calldata initialSessionSigners,
+        bytes calldata adminAuthorization
+    ) external returns (address account);
 
-Protocol EIP-1271 validation is intentionally narrower than an ordinary EVM `STATICCALL`. Normal smart contracts MAY call any EIP-1271 implementation according to Ethereum rules, but WIP-1001 protocol validation of an EIP-1271 session key or EIP-1271 admin MUST execute in a restricted validation frame.
+    function queueKeyringUpdate(
+        address account,
+        bytes32 expectedCurrentKeyringHash,
+        SessionSigner[] calldata targetSessionSigners,
+        uint64 activateAfter,
+        bytes calldata adminAuthorization
+    ) external;
+
+    function activateKeyringUpdate(address account) external;
+
+    function getAdminSigner(address account) external view returns (address);
+    function getAdminNonce(address account) external view returns (uint64);
+    function getActiveKeyringHash(address account) external view returns (bytes32);
+    function getActiveSessionSigners(address account) external view returns (SessionSigner[] memory);
+    function getPendingKeyringUpdate(address account) external view returns (PendingKeyringUpdate memory);
+    function isAuthorized(address account, address signer) external view returns (bool);
+    function getAuthorizedSigner(address account, address signer) external view returns (SessionSigner memory);
+}
+```
+
+For `create`, the manager MUST:
+
+1. Require `adminSigner` has non-empty code.
+2. Validate all `initialSessionSigners` and keyring-size constraints.
+3. Compute the deterministic account address from `(adminSigner, accountSalt)`.
+4. Require the account does not already exist.
+5. Recompute the `CreateSignal` `signalHash`.
+6. Run the restricted EIP-1271 validation frame against `adminSigner` with `(hash = signalHash, signature = adminAuthorization)`.
+7. Store `adminSigner`, `accountSalt`, `activeSessionSigners = initialSessionSigners`, `activeKeyringHash`, no pending update, and `adminNonce = 0`.
+
+For `queueKeyringUpdate`, the manager MUST:
+
+1. Require the account exists.
+2. Validate all `targetSessionSigners` and keyring-size constraints.
+3. Require `expectedCurrentKeyringHash == activeKeyringHash`.
+4. Require `activateAfter >= block.timestamp + MIN_KEYRING_UPDATE_DELAY`.
+5. Compute `targetKeyringHash = keccak256(abi.encode(targetSessionSigners))`.
+6. Recompute the `QueueKeyringUpdateSignal` `signalHash` using the current `adminNonce`.
+7. Run the restricted EIP-1271 validation frame against the account's `adminSigner` with `(hash = signalHash, signature = adminAuthorization)`.
+8. Store the pending update, replacing any previous pending update.
+9. Increment `adminNonce`.
+
+For `activateKeyringUpdate`, the manager MUST:
+
+1. Require the account exists.
+2. Require a pending update exists.
+3. Require `block.timestamp >= pending.activateAfter`.
+4. Require `pending.expectedCurrentKeyringHash == activeKeyringHash`.
+5. Replace `activeSessionSigners` with `pending.targetSessionSigners`.
+6. Store `activeKeyringHash = pending.targetKeyringHash`.
+7. Clear the pending update.
+
+`activateKeyringUpdate` is permissionless. It applies only a previously admin-authorized update after the required delay.
+
+### Restricted Validation Frames
+
+Protocol signer validation is intentionally narrower than an ordinary EVM `STATICCALL`. Normal smart contracts MAY call any EIP-1271 or policy implementation according to Ethereum rules, but WIP-1001 protocol validation of an admin signer, session signer, or session policy MUST execute in a restricted validation frame.
 
 The goal is:
 
 ```text
-protocol -> EIP-1271 signer contract -> allowlisted crypto precompiles only
+protocol -> WORLD_CHAIN_ACCOUNT_MANAGER -> signer validation hook -> allowlisted crypto precompiles only
 ```
 
-There MUST NOT be an arbitrary EVM-to-EVM call graph during signature validation.
+There MUST NOT be an arbitrary EVM-to-EVM call graph during protocol signature or policy validation.
 
-#### Entry Call
+#### Signature Entry Call
 
-For a signer contract `signer`, hash `hash`, signature bytes `signature`, and stored gas limit `validationGasLimit`, the protocol invokes:
+For a signer contract `signer`, hash `hash`, and signature bytes `signature`, the protocol invokes:
 
 ```solidity
 IERC1271(signer).isValidSignature(hash, signature)
@@ -335,21 +394,38 @@ IERC1271(signer).isValidSignature(hash, signature)
 with:
 
 - call type: `STATICCALL` semantics;
-- `CALLER`: `WORLD_CHAIN_ACCOUNT_PRECOMPILE`;
+- `CALLER`: `WORLD_CHAIN_ACCOUNT_MANAGER`;
 - `ADDRESS`: `signer`;
 - `CALLVALUE`: `0`;
-- gas: exactly `validationGasLimit`;
+- gas: exactly `EIP1271_VALIDATION_GAS_LIMIT`;
 - calldata: `IERC1271.isValidSignature.selector || abi.encode(hash, signature)`;
 - success condition: the call succeeds and returns ABI-encoded `bytes4(EIP1271_MAGIC_VALUE)`.
 
 If the call reverts, runs out of gas, executes a forbidden opcode, calls a forbidden address, returns malformed data, or returns any value other than `EIP1271_MAGIC_VALUE`, the signature is invalid.
 
-`validationGasLimit` is always loaded from account state:
+A `0x1D` transaction, account, keyring entry, admin signer, and session signer MUST NOT choose or override the signature-validation gas. The gas consumed by session-signer validation MUST be metered against the transaction's gas limit before execution of the transaction payload. Admin validation gas is metered against the EVM call to the manager.
 
-- for EIP-1271 session keys, from the stored `SessionKey`;
-- for EIP-1271 admins, from the stored `verificationPublicId`.
+#### Execution Trace Policy Entry Call
 
-A `0x1D` transaction MUST NOT choose or override EIP-1271 validation gas. The gas consumed by session-key validation MUST be metered against the transaction's gas limit before execution of the transaction payload. Admin validation gas is metered against the EVM call to `create` or `update`.
+After tentative transaction payload execution, for a session signer `signer`, transaction context `context`, and execution trace `trace`, the protocol invokes:
+
+```solidity
+IWorldChainSessionVerifier(signer).isValidExecutionTrace(context, trace)
+```
+
+with:
+
+- call type: `STATICCALL` semantics;
+- `CALLER`: `WORLD_CHAIN_ACCOUNT_MANAGER`;
+- `ADDRESS`: `signer`;
+- `CALLVALUE`: `0`;
+- gas: exactly `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`;
+- calldata: `IWorldChainSessionVerifier.isValidExecutionTrace.selector || abi.encode(context, trace)`;
+- success condition: the call succeeds and returns ABI-encoded `bool(true)`.
+
+If the call reverts, runs out of gas, executes a forbidden opcode, calls a forbidden address, returns malformed data, or returns `false`, trace validation fails and the tentative transaction payload execution MUST be reverted.
+
+A `0x1D` transaction, account, keyring entry, admin signer, and session signer MUST NOT choose or override the trace-validation gas. The gas consumed by execution-trace policy validation MUST be metered against the transaction's gas limit after payload execution and before transaction finalization.
 
 #### Call-Depth and Call-Target Rules
 
@@ -364,7 +440,7 @@ Therefore a protocol-valid EIP-1271 signer contract MUST be self-contained excep
 
 #### Opcode Policy
 
-The restricted validation frame permits deterministic computation, calldata/memory access, own-code access, own-storage reads, `KECCAK256`, `CHAINID`, `GAS`, and `STATICCALL` to allowed precompiles. `GAS` is permitted because the frame starts with a fixed stored `validationGasLimit` rather than transaction-selected gas.
+The restricted validation frame permits deterministic computation, calldata/memory access, own-code access, own-storage reads, `KECCAK256`, `CHAINID`, `GAS`, and `STATICCALL` to allowed precompiles. `GAS` is permitted because each frame starts with a fixed protocol gas limit rather than transaction-selected gas.
 
 The following opcodes are forbidden if executed in the restricted validation frame:
 
@@ -401,244 +477,74 @@ CREATE2
 SELFDESTRUCT
 ```
 
-This list removes block-context, transaction-context, external-state, transient-state, logging, mutation, and arbitrary call-depth dependencies from protocol signature validation. EIP-1271 validity MAY depend on the signer contract's own persistent storage via `SLOAD`; this is the intentional stateful policy surface of contract signatures.
+This list removes block-context, transaction-context, external-state, transient-state, logging, mutation, and arbitrary call-depth dependencies from protocol signature and execution-trace policy validation. EIP-1271 validity and trace-policy validity MAY depend on the signer's own persistent storage via `SLOAD`, subject to the signer-state timelock requirements below.
 
-### Admin Instantiations
+### Signer-State Timelock Requirements
 
-Each instantiation specifies:
+To make public-pool validation stable, any signer state that can cause a previously valid signature or previously accepted execution trace to become invalid MUST transition through a delay of at least `MIN_KEYRING_UPDATE_DELAY` before it becomes effective.
 
-1. The `verificationPublicId` encoding.
-2. The address-defining material.
-3. The `adminCreationData` layout for `create()`.
-4. The creation flow.
-5. The `adminAuthorization` layout for `update()`.
-6. The verification primitive.
-7. Recovery semantics.
+For default manager-supported signer factories, this is mandatory:
 
-Additional non-ECDSA admin schemes SHOULD be implemented as EIP-1271 contract admins backed by reusable precompiles, rather than as new native admin types.
+- owner rotation in a secp256k1 signer MUST be queued before activation;
+- World ID session verifier state that changes accepted session material MUST be queued before activation;
+- threshold, key, revocation, recovery, or trace-policy state in any default signer MUST be queued before activation.
 
-#### WorldID Admin
+Custom EIP-1271 signers are protocol-compatible only if all storage values read during signature or trace-policy restricted frames obey the same delay discipline. Public transaction-pool implementations MUST NOT advertise full validation-stability guarantees for custom signers unless the signer bytecode or deployment is known to satisfy this property. Consensus validation still executes the signature and trace-policy calls at inclusion time; the timelock requirement defines WIP-1001-compliant signer behavior and public-pool admission policy.
 
-`adminType = ADMIN_TYPE_WORLD_ID = 0x00`.
+### Default Signer Factories
 
-Per-instantiation constants:
+Default signer factories are ordinary contracts, exposed by or discoverable from `WORLD_CHAIN_ACCOUNT_MANAGER`, that deploy deterministic EIP-1271 signer contracts with WIP-1001-compliant restricted-frame behavior and signer-state timelocks.
 
-| Name                          | Value                                        | Description                                           |
-| ----------------------------- | -------------------------------------------- | ----------------------------------------------------- |
-| `WORLD_CHAIN_RP_ID`           | `480`                                        | World Chain's registered RP ID                        |
-| `WORLD_ID_ACCOUNT_TAG`        | `"WORLD_ID_ACCOUNT"` (UTF-8, 16 bytes)       | Domain tag for WorldID-admin account creation actions |
+The default factories are not special validation paths. A signer produced by a default factory is authorized only if it appears in the active keyring or is fixed as an account's admin signer.
 
-`verificationPublicId` is `abi.encode(uint256 sessionId)`. `sessionId` is provisioned by the caller at creation and supplied by the WorldID authenticator via OPRF.
+Default signer implementations MUST implement `isValidExecutionTrace`. A signer with no additional execution policy MAY return `true` for every well-formed trace after signature validation succeeds, but any configurable execution policy it exposes MUST be stored and updated inside the signer under the signer-state timelock rules.
 
-Address-defining material is the creation Uniqueness Proof's nullifier:
+#### Secp256k1 EIP-1271 Signer
 
-```text
-addr = bytes20(keccak256(abi.encodePacked(ADMIN_TYPE_WORLD_ID, worldIDAccountNullifier)))
-```
+The secp256k1 signer factory deploys signer contracts that store an Ethereum address `owner`.
 
-A single WorldID `MAY` manage any number of WorldID-admin accounts by variation over a user-chosen `worldIDAccountNonce`; accounts owned by the same WorldID are unlinkable across distinct values by the ZK property of the OPRF proof.
+`isValidSignature(hash, signature)` MUST:
 
-##### Creation
+1. Decode `signature` as an Ethereum secp256k1 ECDSA signature.
+2. Enforce the Ethereum low-`s` rule from [EIP-2](https://eips.ethereum.org/EIPS/eip-2).
+3. Recover the signer address over `hash` using `ECRECOVER`.
+4. Return `EIP1271_MAGIC_VALUE` iff the recovered address equals the active `owner`.
 
-`adminCreationData` layout (conceptual; ABI-encoded as a tuple):
+Owner rotation, owner revocation, or any trace-policy update that can invalidate a previously valid signature or accepted execution trace MUST be timelocked by at least `MIN_KEYRING_UPDATE_DELAY`.
 
-```solidity
-struct WorldIDAdminCreationData {
-    uint256       worldIDAccountNullifier;      // creation nullifier, public verifier input
-    uint256       worldIDAccountNonce;          // recomputed into action
-    uint256       sessionId;                    // freshly provisioned by authenticator
-    uint256       proofNonce;                   // verifier request nonce
-    uint64        issuerSchemaId;
-    uint64        expiresAtMin;
-    uint256       credentialGenesisIssuedAtMin;
-    uint256[5]    proof;                        // compressed Groth16 proof
-}
-```
+#### World ID EIP-1271 Signer
 
-The Uniqueness Proof is parameterized by:
+The World ID signer factory deploys signer contracts that verify World ID proofs encoded inside EIP-1271 signature bytes. World ID is a reference EIP-1271 verification strategy, not a native WIP-1001 admin or session-key type.
 
-- `rpId = WORLD_CHAIN_RP_ID`
-- `action = keccak256(abi.encodePacked(WORLD_ID_ACCOUNT_TAG, uint256(worldIDAccountNonce)))`
-- `adminCreationContext = abi.encode(ADMIN_TYPE_WORLD_ID, worldIDAccountNullifier, worldIDAccountNonce, sessionId)`
-- `signalHash` per the abstract `Create` formula, using `keccak256(adminCreationContext)`
+A World ID signer stores the public verifier state required to validate future proofs, including at minimum the relevant `sessionId` or equivalent World ID session-verification material.
 
-Creation flow:
+For transaction or admin validation, `isValidSignature(hash, signature)` MUST:
 
-1. Decode `adminCreationData`.
-2. Compute `action`.
-3. Compute `adminCreationContextHash = keccak256(abi.encode(ADMIN_TYPE_WORLD_ID, worldIDAccountNullifier, worldIDAccountNonce, sessionId))`.
-4. Recompute the `Create` `signalHash` per the abstract `Create` formula.
-5. Invoke `WorldID.verify(worldIDAccountNullifier, action, WORLD_CHAIN_RP_ID, proofNonce, signalHash, issuerSchemaId, expiresAtMin, credentialGenesisIssuedAtMin, proof)`. The verifier asserts the proof commits to the supplied `(worldIDAccountNullifier, action, signalHash)` tuple under the relying party's public inputs. Because `signalHash` includes `adminCreationContextHash`, the proof is also bound to the stored `sessionId`.
-6. Set `addressDefiningMaterial = worldIDAccountNullifier` and derive `addr` per the abstract address formula.
-7. Require account does not exist at `addr`.
-8. Store `adminType = ADMIN_TYPE_WORLD_ID`, `verificationPublicId = abi.encode(sessionId)`, `sessionKeys = keyringUpdate.keys`, `keyringHash = keccak256(abi.encode(keyringUpdate.keys))`, `adminNonce = 0`.
+1. Decode `signature` as a World ID proof payload.
+2. Derive the World ID proof `signalHash` from `hash`, using `uint256(hash) >> 8` when the proof system requires a BN254-field signal.
+3. Verify the World ID proof against the stored session-verification material and the decoded public inputs.
+4. Return `EIP1271_MAGIC_VALUE` iff verification succeeds.
 
-The creation nullifier is consumed once to instantiate the account. Because WorldID authenticators do not issue the same `(rpId, action)` nullifier twice, a later mutation MUST NOT attempt to reuse the creation action. The nullifier is not retained as account state after creation -- its only role is address derivation, which is reproducible from any subsequent update's calldata via the precompile's stored `addr`.
-
-##### Updates
-
-`adminAuthorization` layout (conceptual; ABI-encoded as a tuple):
+A conceptual session-proof signature payload is:
 
 ```solidity
-struct WorldIDAdminAuth {
+struct WorldID1271Signature {
     uint256    proofNonce;
     uint64     issuerSchemaId;
     uint64     expiresAtMin;
     uint256    credentialGenesisIssuedAtMin;
-    uint256[2] sessionNullifier;                // ephemeral per-update verifier input
-    uint256[5] proof;                           // compressed Groth16 proof
+    uint256[2] sessionNullifier;
+    uint256[5] proof;
 }
 ```
 
-Update flow:
+The signer MUST NOT persist `sessionNullifier` as account-manager state. Replay prevention for manager operations comes from account existence and `adminNonce`; replay prevention or nullifier tracking internal to a World ID signer is signer-policy-specific and MUST preserve the signer-state timelock guarantee if it can invalidate pooled transactions.
 
-1. Decode `verificationPublicId` to recover `sessionId`.
-2. Recompute the `Update` `signalHash` per the abstract `Update` formula.
-3. Invoke `WorldID.verifySession(WORLD_CHAIN_RP_ID, proofNonce, signalHash, issuerSchemaId, expiresAtMin, credentialGenesisIssuedAtMin, sessionId, sessionNullifier, proof)`.
-4. Discard `sessionNullifier` after verification; it MUST NOT be persisted in account state.
-5. Require `keyringUpdate.mode == SetKeyring`.
-6. Return success to the precompile `update` flow, which applies the full keyring replacement and increments `adminNonce`.
-
-##### Session Proof Primer
-
-A Session Proof proves that the caller controls the same WorldID that previously established the stored `sessionId`, without reusing the account creation action. The `sessionId` is the long-lived verification public identifier retained for the account across updates. The `sessionNullifier` is fresh per proof, passed only to `verifySession`, and discarded after verification.
-
-##### OPRF Nullifier Proof Primer
-
-An `OPRFNullifierProof` is a [Groth16](https://eprint.iacr.org/2016/260) proof over [BN254](https://hackmd.io/@jpw/bn254) submitted on-chain as `uint256[5] = [a, b0, b1, c, merkle_root]`. The `WorldIDVerifier` reconstructs the public inputs from calldata and on-chain registry lookups (notably `merkle_root` via `WorldIDRegistry.isValidRoot()` and `oprfPublicKey` via `OprfKeyRegistry[rpId]`) and invokes the Groth16 verifier. The Groth16 verifier MUST ultimately use the same BN254 precompiles exposed to smart contracts.
-
-The circuit proves knowledge of a private witness satisfying:
-
-- **Merkle membership.** The authenticator key is a leaf in the `WorldIDRegistry` tree at the declared root.
-- **Credential validity.** The credential bears a valid EdDSA-Poseidon2 signature over BabyJubJub from the issuer identified by `issuerSchemaId`, and has not expired.
-- **OPRF correctness.** The OPRF response was evaluated under the registered key for `rpId`, with a DLog equality proof binding blinded and unblinded responses.
-- **Deterministic nullifier derivation.** The nullifier is deterministic per `(identity, rpId, action)`, regardless of blinding factor or proof randomness.
-- **Signal binding.** The `signalHash` is constrained in the circuit, preventing a proof from being reused with a different signal.
-
-For account creation, deterministic nullifier derivation binds the creation nullifier to the tuple (owner leaf, `WORLD_CHAIN_RP_ID`, `action(worldIDAccountNonce)`) -- making `worldIDAccountNonce` the sole account selector per identity -- and signal binding binds the Uniqueness Proof to the exact `Create` payload and stored `sessionId` it authorizes. For later updates, `verifySession` binds the proof to the account's stored `sessionId`; the accompanying `sessionNullifier` is a per-proof verifier input rather than persistent account state.
-
-##### Recovery
-
-Recovery is the degenerate case of a `SetKeyring` submitted after session keys are lost or compromised. Because post-creation authorization is a Session Proof bound to the account's stored `sessionId`, recovery requires only a fresh Session Proof -- the full session-key surface is reachable via the same mutation path. No separate recovery flow or state is introduced.
-
-A single WorldID MAY enable recovery for any number of WorldID-admin accounts; accounts at distinct `worldIDAccountNonce` values remain unlinkable across the recovery event.
-
-#### Secp256k1 EOA Admin
-
-`adminType = ADMIN_TYPE_SECP256K1_EOA = 0x01`.
-
-`verificationPublicId` is the 20-byte Ethereum admin address. Address-defining material is the same address:
-
-```text
-addr = bytes20(keccak256(abi.encodePacked(ADMIN_TYPE_SECP256K1_EOA, adminAddress)))
-```
-
-One admin address controls exactly one Secp256k1-EOA-admin account address.
-
-##### Creation
-
-`adminCreationData` layout (conceptual):
-
-```solidity
-struct Secp256k1EOAAdminCreationData {
-    address adminAddress;
-    bytes   ecdsaSig;       // rlp([y_parity, r, s]) over signalHash
-}
-```
-
-Creation flow:
-
-1. Decode `adminAddress` and `ecdsaSig`.
-2. Compute `adminCreationContextHash = keccak256(abi.encode(ADMIN_TYPE_SECP256K1_EOA, adminAddress))`.
-3. Recompute the `Create` `signalHash` per the abstract `Create` formula.
-4. Decode `ecdsaSig` as `rlp([y_parity, r, s])`.
-5. Recover the Ethereum address from `ecdsaSig` over `signalHash`; require it equals `adminAddress`. Implementations MUST enforce Ethereum's [low-`s` rule](https://eips.ethereum.org/EIPS/eip-2) for consensus signatures.
-6. Set `addressDefiningMaterial = adminAddress` and derive `addr` per the abstract address formula.
-7. Require account does not exist at `addr`.
-8. Store `adminType = ADMIN_TYPE_SECP256K1_EOA`, `verificationPublicId = abi.encode(adminAddress)`, `sessionKeys = keyringUpdate.keys`, `keyringHash = keccak256(abi.encode(keyringUpdate.keys))`, `adminNonce = 0`.
-
-##### Updates
-
-`adminAuthorization` is `rlp([y_parity, r, s])` for a single secp256k1 ECDSA signature over the `Update` `signalHash`.
-
-Update flow:
-
-1. Load `adminAddress` from `verificationPublicId` and `adminNonce`.
-2. Recompute the `Update` `signalHash` per the abstract `Update` formula.
-3. Require `keyringUpdate.mode == SetKeyring`.
-4. Decode `adminAuthorization` as `rlp([y_parity, r, s])`.
-5. Recover the Ethereum address from the signature; require it equals `adminAddress`; enforce low-`s`.
-6. Return success to the precompile `update` flow, which applies the full keyring replacement and increments `adminNonce`.
-
-##### Recovery
-
-**Not supported by WIP-1001.** Loss of the admin key is terminal -- the account's keyring can no longer be mutated. Users who require protocol-level recovery SHOULD choose a WorldID-admin account or an EIP-1271 admin whose contract policy includes recovery.
-
-#### EIP-1271 Contract Admin
-
-`adminType = ADMIN_TYPE_EIP1271 = 0x02`.
-
-`verificationPublicId` is `abi.encode(address signer, uint32 validationGasLimit)`. Address-defining material is the 20-byte signer contract address:
-
-```text
-addr = bytes20(keccak256(abi.encodePacked(ADMIN_TYPE_EIP1271, signer)))
-```
-
-One signer contract address controls exactly one EIP-1271-admin account address. The `validationGasLimit` is fixed at creation and used for all future admin validations.
-
-##### Creation
-
-`adminCreationData` layout (conceptual):
-
-```solidity
-struct EIP1271AdminCreationData {
-    address signer;
-    uint32  validationGasLimit;
-    bytes   signature;             // EIP-1271 signature over signalHash
-}
-```
-
-Creation flow:
-
-1. Decode `signer`, `validationGasLimit`, and `signature`.
-2. Require `signer` has non-empty code.
-3. Require `validationGasLimit > 0 && validationGasLimit <= MAX_EIP1271_VALIDATION_GAS`.
-4. Compute `adminCreationContextHash = keccak256(abi.encode(ADMIN_TYPE_EIP1271, signer, validationGasLimit))`.
-5. Recompute the `Create` `signalHash` per the abstract `Create` formula.
-6. Run the restricted EIP-1271 validation frame against `signer` with `(hash = signalHash, signature, validationGasLimit)`.
-7. Set `addressDefiningMaterial = signer` and derive `addr` per the abstract address formula.
-8. Require account does not exist at `addr`.
-9. Store `adminType = ADMIN_TYPE_EIP1271`, `verificationPublicId = abi.encode(signer, validationGasLimit)`, `sessionKeys = keyringUpdate.keys`, `keyringHash = keccak256(abi.encode(keyringUpdate.keys))`, `adminNonce = 0`.
-
-##### Updates
-
-`adminAuthorization` is the opaque EIP-1271 signature bytes passed to the stored signer contract.
-
-Update flow:
-
-1. Decode `(signer, validationGasLimit)` from `verificationPublicId`.
-2. Recompute the `Update` `signalHash` per the abstract `Update` formula.
-3. Require `keyringUpdate.mode == SetKeyring`.
-4. Run the restricted EIP-1271 validation frame against `signer` with `(hash = signalHash, signature = adminAuthorization, validationGasLimit)`.
-5. Return success to the precompile `update` flow, which applies the full keyring replacement and increments `adminNonce`.
-
-##### Recovery
-
-WIP-1001 does not define a separate recovery path for EIP-1271-admin accounts. Recovery, signer rotation, quorum changes, passkey replacement, or social recovery MAY be implemented inside the signer contract's own state and policy. If the signer contract can no longer return the EIP-1271 magic value under the restricted validation frame, the account's keyring can no longer be mutated.
-
-### Recovery
-
-Recovery semantics are per-instantiation:
-
-- **WorldID admin.** Recovery is the degenerate case of `SetKeyring` submitted via Session Proof -- see the WorldID admin instantiation. Lost or compromised session keys are recovered by any fresh Session Proof bound to the account's stored `sessionId`.
-- **Secp256k1 EOA admin.** **NOT supported by WIP-1001.** Loss of the admin key is terminal.
-- **EIP-1271 contract admin.** Delegated to the signer contract's own policy. WIP-1001 only checks whether the fixed signer contract returns the EIP-1271 magic value under the restricted validation frame.
-
-Users requiring protocol-level recovery SHOULD choose the WorldID admin instantiation. Users requiring application-defined recovery MAY choose an EIP-1271 admin, subject to the restricted-frame constraints.
+World ID signer creation MAY be gated by a World ID Uniqueness Proof. The creation proof, account nonce, signer salt, and initial session-verification material are factory-level concerns. Once deployed, the signer is just an EIP-1271 contract from the manager's perspective.
 
 ### Transaction Type `0x1D`
 
-A `0x1D` transaction is signed by a session key of a World Chain Account and submitted directly to the mempool (no [ERC-4337](https://eips.ethereum.org/EIPS/eip-4337) bundler required). `0x1D` transactions are admin-type-agnostic: they are signed by session keys regardless of which admin authority controls the account, and the validation path reads only the account's keyring.
+A `0x1D` transaction is signed by a session signer of a World Chain Account and submitted directly to the public transaction pool. `0x1D` transactions are signer-strategy-agnostic: transaction validation reads the active keyring, invokes EIP-1271 on the declared signer, tentatively executes the payload, then asks the same signer whether the resulting execution trace satisfies its internal policy.
 
 #### Envelope
 
@@ -654,156 +560,163 @@ A `0x1D` transaction is signed by a session key of a World Chain Account and sub
     data,                        // 7
     access_list,                 // 8
     account,                     // 9   -- sender's World Chain Account address
-    key_type,                    // 10  -- KEY_TYPE_*
-    key,                         // 11  -- 20-byte session key address
-    signature_payload,           // 12
+    signer,                      // 10  -- authorized EIP-1271 session signer
+    signature,                   // 11  -- opaque bytes passed to isValidSignature
 ])
 ```
 
 ```text
-signing_hash = keccak256(0x1D || rlp(fields[0..=11]))
+signing_hash = keccak256(0x1D || rlp(fields[0..=10]))
 ```
 
-The `signing_hash` covers every field except `signature_payload` itself, binding the declared `key_type` and `key` to the signature and ruling out scheme-confusion or key-substitution attacks at the consensus layer.
+The `signing_hash` covers every field except `signature` itself, binding the declared session signer to the transaction and ruling out signer-substitution attacks at the consensus layer.
 
-| `key_type`                     | `signature_payload`                                      |
-| ------------------------------ | -------------------------------------------------------- |
-| `0x00` `Secp256k1EOA`          | `rlp([y_parity, r, s])`                                  |
-| `0x01` `EIP1271`               | Opaque bytes passed unchanged as EIP-1271 `_signature`   |
+The protocol does not interpret `signature`. It is passed unchanged to:
 
-For `Secp256k1EOA`, implementations MUST enforce the Ethereum [low-`s` rule](https://eips.ethereum.org/EIPS/eip-2) and MUST reject signatures whose recovered address does not equal the declared `key`.
+```solidity
+IERC1271(signer).isValidSignature(signing_hash, signature)
+```
 
-For `EIP1271`, `signature_payload` is not interpreted by the protocol except as bytes supplied to `isValidSignature(signing_hash, signature_payload)`.
+#### Validation and Execution
 
-#### Validation
-
-The protocol MUST validate a `0x1D` transaction as follows:
+The protocol MUST validate and execute a `0x1D` transaction as follows:
 
 1. Compute `signing_hash`.
-2. Load the account's keyring entry for `(key_type, key)`.
-3. Reject if no matching authorized session key exists.
-4. Reject if the transaction does not satisfy the stored `SessionPolicy`.
-5. If `key_type == KEY_TYPE_SECP256K1_EOA`, verify `signature_payload` by Ethereum secp256k1 recovery over `signing_hash` and require the recovered address equals `key`.
-6. If `key_type == KEY_TYPE_EIP1271`, run the restricted EIP-1271 validation frame against `key` with `(hash = signing_hash, signature = signature_payload, validationGasLimit = stored SessionKey.validationGasLimit)`.
+2. Load the active keyring entry for `(account, signer)`.
+3. Reject if no matching active session signer exists.
+4. Run the restricted EIP-1271 validation frame against `signer` with `(hash = signing_hash, signature = signature)`.
+5. Reject if the frame does not return `EIP1271_MAGIC_VALUE`.
+6. Tentatively execute the transaction payload under normal EVM rules, collecting the canonical `WorldChainExecutionTrace`.
+7. Construct `WorldChainTransactionContext` from the transaction and active keyring state.
+8. Require `abi.encode(trace).length <= MAX_EXECUTION_TRACE_BYTES`.
+9. Run the restricted execution-trace policy validation frame against `signer` with `(context, trace)`.
+10. If the frame does not return `true`, revert the tentative payload execution and mark the transaction as failed by policy.
+11. If the frame returns `true`, finalize the transaction according to the tentative payload execution result.
 
-Authorization is checked before EIP-1271 execution so an attacker cannot use an unauthorized `0x1D` transaction to force arbitrary contract validation work.
+Authorization is checked before any signer call so an attacker cannot use an unauthorized `0x1D` transaction to force arbitrary signature or trace-policy validation work.
 
 The envelope is extensible to 2D nonces, batched transactions, and native paymaster support in follow-on WIPs.
 
+### Visual Flow
+
+```mermaid
+flowchart TD
+    Wallet[Wallet or App] --> Tx[0x1D Transaction]
+    Tx --> Pool[Public Tx Pool Validation]
+    Pool --> Manager[WORLD_CHAIN_ACCOUNT_MANAGER Predeploy]
+    Manager --> Active[Active Session Signer Set]
+    Active --> Signer[Authorized EIP-1271 Session Signer]
+    Signer --> Frame[Restricted Signature Frame]
+    Frame --> SigResult{Returns magic value?}
+    SigResult -->|no| Reject[Reject Transaction]
+    SigResult -->|yes| Exec[Tentative EVM Execution]
+    Exec --> Trace[Canonical Execution Trace]
+    Trace --> Policy[Verifier Trace Policy]
+    Policy --> PolicyResult{Trace allowed?}
+    PolicyResult -->|yes| Include[Finalize Transaction]
+    PolicyResult -->|no| Revert[Revert Tentative Execution]
+    Frame --> Crypto[Allowlisted Crypto Precompiles]
+    Policy --> Crypto
+
+    Admin[Admin EIP-1271 Signer] --> Queue[queueKeyringUpdate]
+    Queue --> Pending[Pending Keyring + activateAfter]
+    Pending -->|delay > txpool expiration| Activate[activateKeyringUpdate]
+    Activate --> Active
+
+    WorldID[World ID Proof in Signature Bytes] --> WIDSigner[WorldID1271Signer]
+    WIDSigner --> Frame
+    EOA[EOA Signature Bytes] --> EOASigner[Secp256k1 1271 Signer]
+    EOASigner --> Frame
+```
+
 ### Extensions
 
-- **Richer key policies.** Session policies MAY be extended with rate limits, aggregate spend limits, paymaster scopes, or more expressive call constraints. Any extension to `SessionPolicy` remains bound by the `KeyringUpdate` `signalHash`.
-- **Admin rotation.** Replacing an account's stored `verificationPublicId` (or `adminType`) under admin authorization. Deferred -- admin type and authority are pinned at creation in this WIP.
-- **Multi-admin.** M-of-N admin authorization for a single account. Deferred. Most near-term multi-admin policies SHOULD be represented as EIP-1271 contract admins.
-- **Additional crypto precompiles.** BLS12-381, secp256k1 verification without recovery, or other primitives MAY be added as VM precompiles. Once allowlisted for the restricted validation frame, EIP-1271 signer contracts can use them without changing the `0x1D` envelope.
-- **WorldID-recovery escape hatch for EOA-admin accounts.** A Secp256k1 EOA admin account MAY enroll a WorldID at creation as a recovery-only authority that can rotate the admin key under a follow-on recovery policy.
-- **Session rotation.** Replacing a WorldID-admin account's stored `sessionId` with a newly-provisioned session without re-creating the account.
+- **Trace schema extensions.** The execution trace schema MAY be extended with additional bounded summaries such as storage-write commitments, balance-delta commitments, or transient-storage summaries. The verifier remains the policy owner; the protocol only defines the trace data it supplies.
+- **Admin rotation.** Replacing an account's fixed `adminSigner` under a separate timelocked admin-rotation flow. Deferred in this WIP.
+- **Multi-admin.** M-of-N admin authorization for a single account. Deferred as native manager state; near-term policies SHOULD be represented inside an EIP-1271 admin signer.
+- **Additional crypto precompiles.** BLS12-381, EdDSA variants, secp256k1 verification without recovery, or other primitives MAY be added as VM precompiles. Once allowlisted for the restricted validation frame, EIP-1271 signer contracts can use them without changing the `0x1D` envelope.
 - **Bundling, 2D nonces, paymasters.** Reserved for follow-on WIPs on the `0x1D` envelope.
 
 ## Rationale
 
-**Account state as precompile.** The keyring lives in a precompile because `0x1D` signature validation happens at the protocol level and must read the authorized set natively. The same precompile owns the admin verification paths, ensuring the address-to-key map is only mutated under valid admin authorizations.
+**Account state as predeploy.** The keyring lives in the `WORLD_CHAIN_ACCOUNT_MANAGER` predeploy because `0x1D` validation must read the active signer set natively while preserving an ordinary Solidity/EVM-bytecode implementation surface for account management and default factories.
 
-**Minimal signature surface.** Secp256k1 address recovery and EIP-1271 contract signatures are the two signature abstractions Ethereum already standardizes. WIP-1001 uses those abstractions directly instead of introducing native P256/WebAuthn/EdDSA/BLS session-key variants. That keeps transaction validation simple and moves signer-specific policy into contracts.
+**EIP-1271-only verification.** A single contract-signature abstraction avoids protocol branches for every authenticator or cryptographic scheme. New signer strategies can be deployed as contracts and audited independently without changing the transaction type.
 
-**Reusable precompiles instead of host-only cryptography.** P256, pairing checks, and future curves are useful outside account validation. Exposing them as normal precompiles ensures the protocol and contracts agree on inputs, outputs, gas, and edge cases. EIP-1271 signer contracts become the abstraction layer over those primitives.
+**Fixed validation gas.** Per-signer gas limits make keyring entries harder to reason about, expand the admin-authorized state surface, and let signer deployment choices affect transaction validation economics. A single `EIP1271_VALIDATION_GAS_LIMIT` gives every protocol 1271 validation frame the same execution budget.
 
-**Restricted EIP-1271 validation.** Unrestricted contract signature validation would let a transaction execute an arbitrary read-only call graph before transaction execution, creating DoS risk and state/context-dependent invalidation. The restricted frame bounds gas, fixes the caller, forbids arbitrary call depth, and removes block-, transaction-, and external-state-sensitive opcodes while preserving own-storage policy and direct precompile calls.
+**Verifier-owned programmable policy.** Static `(target, selector)` allowlists are too narrow for account-native sessions, and the manager should not store a policy language. Passing the post-execution trace to the same verifier that authenticated the session lets policy be expressed as `f(transactionContext, executionTrace) -> bool`, so the verifier can decide whether what actually happened is allowed.
+
+**Reusable precompiles instead of host-only cryptography.** P256, EdDSA, BLS, pairing checks, and future curves are useful outside account validation. Exposing them as normal precompiles ensures the protocol and contracts agree on inputs, outputs, gas, and edge cases.
+
+**Restricted validation frames.** Unrestricted contract signature or policy validation would allow an arbitrary read-only call graph before transaction execution. The restricted frame bounds gas, fixes the caller, forbids arbitrary call depth, and removes block-, transaction-, and external-state-sensitive opcodes while preserving own-storage policy and direct precompile calls.
 
 **Full-keyring replacement.** Updates carry the complete target keyring rather than add/remove deltas. This makes every admin authorization commit to the exact post-update authorization set, avoids ordering-dependent delta semantics, and removes edge cases where separately authorized removals and additions compose into an unintended intermediate keyring.
 
-**Scoped session keys.** The basic `SessionPolicy` fields cover the most common session-key limits -- time bounds, per-transaction value caps, and target/selector allowlists -- without introducing a general-purpose permission language. More expressive policy logic can still live inside EIP-1271 key contracts.
+**Timelocked activation.** Delaying keyring activation by more than the transaction-pool expiration window prevents manager-owned keyring changes from invalidating transactions that were already admitted to the public pool. Applying the same discipline to default signer authorization and policy state extends that guarantee through signer validation.
 
-**Single admin authority.** Each account has exactly one admin authority. M-of-N admin authorization is a useful generalization but is deferred as native protocol state. EIP-1271 contract admins cover most quorum-management use cases without changing the abstract account model.
-
-**Admin type pinned at creation.** Address determinism: `adminType` and the address-defining material are part of the address preimage, so changing either mid-lifetime would change the address. Rotation within the same admin type is also deferred to keep v1 minimal.
-
-**No WIP-level recovery for EOA admins.** EOA-admin accounts are owned exclusively by their admin key; there is no underlying identity anchor to bootstrap recovery from. Users requiring protocol-level recoverability choose the WorldID admin instantiation. Users requiring contract-defined recoverability use EIP-1271 admin contracts.
-
-**Uniform replay protection.** All admin authorizations bind to a `signalHash` containing a per-account monotonic `adminNonce`; the precompile increments `adminNonce` on every successful update and rejects authorizations against stale values. Across instantiations, this gives one replay-protection contract -- no instantiation-specific bespoke replay machinery, and no ambiguity around what "fresh" means per instantiation.
-
-**Creation context binding.** `CreateSignal` includes `adminType` and `adminCreationContextHash` because creation permanently fixes admin state before an account address exists. Binding this context prevents an otherwise valid creation authorization from being reused with a different WorldID `sessionId`, EIP-1271 validation gas limit, or other persistent admin parameter excluded from the signature/proof bytes themselves.
-
-**Domain-separated address derivation.** Prefixing the address preimage with `adminTypeTag` prevents accidental cross-type collisions even when the address-defining material from two instantiations might coincidentally produce identical bytes under different encodings. Domain separation costs nothing and is standard practice for keccak-based identifier schemes.
-
-**`msg.sender` binding in `signalHash`.** Including `msg.sender` in both `Create` and `Update` `signalHash` definitions kills cross-submitter replay of in-flight admin authorizations: a witnessed authorization with `msg.sender = X` will not verify if resubmitted by a different account. Self-replay by `X` is a no-op (the resulting state is identical).
-
-**WorldID 4.0 Proofs as authorization.** Within the WorldID admin instantiation, account creation uses a Uniqueness Proof and provisions a fresh session; subsequent mutations use Session Proofs bound to the stored `sessionId`, so repeated account updates do not rely on reusing the creation action. No "super key" ever needs to be stored on-device. The `worldIDAccountNonce`-indexed creation action lets a single WorldID own unlinkably many WorldID-admin accounts.
-
-**No sybil constraint on accounts.** Unlinkability across `worldIDAccountNonce` values is a stronger property than one-account-per-identity, and sybil resistance at the account layer is not the right locus -- it belongs to whatever system consumes account addresses (e.g., gas subsidy accounting, application-layer rate limits), which can bind its own per-WorldID limits via independent nullifier domains.
-
-**Immediate admin updates.** Delayed update and cancellation policies are deferred to follow-on WIPs. WIP-1001 keeps admin-authorized keyring replacement immediate so the core account model only specifies authorization, replay protection, and transaction validation.
+**World ID as reference signer.** World ID proofs are powerful authorization material, but they do not need a native WIP-1001 admin type. Encoding World ID proof payloads in EIP-1271 signatures makes World ID one programmable signer implementation among many and keeps the manager's account model uniform.
 
 ## Backwards Compatibility
 
 This WIP introduces a new account type and transaction type. Existing EOAs and smart contract accounts are unaffected. Standard [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) transactions continue to work for legacy accounts; the `0x1D` envelope is required only for World-Chain-Account-authenticated execution.
 
-This WIP is Draft. The replacement of native non-ECDSA session-key types with EIP-1271 contract keys, the `SessionKey` keyring shape, scoped session policies, full-keyring replacement updates, the EIP-1271 restricted validation frame, and creation-context binding in `CreateSignal` are breaking changes relative to earlier drafts of this WIP. No production accounts exist.
+This WIP is Draft. The move to EIP-1271-only session and admin verification, the replacement of native account-manager language with a manager predeploy, the removal of native signature-type dispatch, and timelocked keyring activation are breaking changes relative to earlier drafts. No production accounts exist.
+
+Existing draft implementations or libraries that expose native P256, WebAuthn, EdDSA, or secp256k1 WIP-1001 transaction signature variants are obsolete relative to this specification. Those strategies SHOULD migrate to EIP-1271 signer contracts or default signer factories.
 
 ### Existing Safe Accounts
 
-Existing [Safe](https://safe.global) accounts MAY integrate with World Chain Accounts without migrating assets or changing the Safe address by installing modules or guards that recognize a World Chain Account as an authorized caller. Existing Safe contracts are not automatically valid WIP-1001 protocol EIP-1271 session keys: the restricted validation frame forbids arbitrary call depth, `DELEGATECALL`, and external contract state reads. A Safe-style policy can be used as a protocol session key only through bytecode that satisfies the restricted-frame rules, or through ordinary application-level calls outside WIP-1001 protocol validation.
+Existing [Safe](https://safe.global) accounts MAY integrate with World Chain Accounts without migrating assets or changing the Safe address by installing modules or guards that recognize a World Chain Account as an authorized caller. Existing Safe contracts are not automatically valid WIP-1001 protocol signers: the restricted validation frames forbid arbitrary call depth, `DELEGATECALL`, and external contract state reads. A Safe-style policy can be used as a protocol signer only through bytecode that satisfies the signature interface, execution-trace policy interface, restricted-frame rules, and signer-state timelock rules, or through ordinary application-level calls outside WIP-1001 protocol validation.
 
 ## Security Considerations
 
 ### Front-Running Admin Authorizations
 
-Both `Create` and `Update` `signalHash` definitions bind `msg.sender`, so a witnessed admin authorization observed in the mempool cannot be replayed by a different submitter -- its `signalHash` would not match. This applies to all instantiations. A griefer can still re-submit an authorization unchanged from the original `msg.sender`, but the resulting state is identical; harm is limited to gas and ordering.
+Both `CreateSignal` and `QueueKeyringUpdateSignal` bind `msg.sender`, so a witnessed admin authorization observed in the mempool cannot be replayed by a different submitter. A griefer can still re-submit an authorization unchanged from the original `msg.sender`, but the resulting state is either identical or supersedes the same pending update under the same admin intent.
 
-The binding is to the direct EVM caller of `WORLD_CHAIN_ACCOUNT_PRECOMPILE`. A public factory, relayer, or forwarding contract that calls the precompile on behalf of multiple users MUST enforce its own caller/request binding before forwarding; otherwise two users of the same forwarding contract share the same `msg.sender` for WIP-1001 authorization purposes.
+The binding is to the direct EVM caller of `WORLD_CHAIN_ACCOUNT_MANAGER`. A public factory, relayer, or forwarding contract that calls the manager on behalf of multiple users MUST enforce its own caller/request binding before forwarding.
 
-### Admin Authority Compromise
+### Admin Signer Compromise
 
-An admin authority can immediately replace the full session-key set. If the admin authority is compromised, the attacker can rotate the keyring and then authorize `0x1D` transactions with the new keys. This WIP intentionally does not define delayed or cancellable admin updates; wallets and applications that require that behavior should use an EIP-1271 admin contract or a follow-on protocol extension.
+An admin signer can queue a full keyring replacement, but the replacement cannot activate until `MIN_KEYRING_UPDATE_DELAY` has elapsed. The delay gives wallets and monitoring systems time to warn users or move funds using still-active session signers. If the admin signer remains compromised until activation, the attacker can eventually replace the keyring.
 
-### EIP-1271 Validation DoS
+### Signer Validation DoS
 
-Protocol EIP-1271 validation is bounded by stored `validationGasLimit` and `MAX_EIP1271_VALIDATION_GAS`. Transactions cannot select a higher gas budget for validation, and authorization is checked before contract validation. This prevents unauthorized transactions from using arbitrary signer contracts as pre-execution gas sinks.
+Protocol signature validation is bounded by the fixed `EIP1271_VALIDATION_GAS_LIMIT`, execution-trace policy validation is bounded by the fixed `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`, and trace size is bounded by `MAX_EXECUTION_TRACE_BYTES`. Transactions cannot select a higher gas budget for either validation frame, and keyring authorization is checked before signer calls. This prevents unauthorized transactions from using arbitrary signer contracts as validation gas sinks.
 
-### EIP-1271 Call-Graph and External-State Invalidation
+### Call-Graph and External-State Invalidation
 
-The restricted validation frame forbids EVM-to-EVM calls except direct `STATICCALL`s to allowlisted precompiles. It also forbids external-code and external-balance inspection opcodes. As a result, protocol signature validity cannot depend on another contract's code, storage, or balance changing before inclusion.
+Restricted validation frames forbid EVM-to-EVM calls except direct `STATICCALL`s to allowlisted precompiles. They also forbid external-code and external-balance inspection opcodes. As a result, protocol signature and trace-policy validity cannot depend on another contract's code, storage, or balance changing before inclusion.
 
-### EIP-1271 Context-Sensitive Opcode Invalidation
+### Context-Sensitive Opcode Invalidation
 
-Block-context and transaction-context opcodes such as `TIMESTAMP`, `NUMBER`, `BASEFEE`, `GASPRICE`, `ORIGIN`, and blob context are forbidden in the restricted validation frame. Signatures therefore cannot become valid or invalid solely because a block producer selected a different block context.
+Block-context and transaction-context opcodes such as `TIMESTAMP`, `NUMBER`, `BASEFEE`, `GASPRICE`, `ORIGIN`, and blob context are forbidden in restricted validation frames. Signatures and trace-policy decisions therefore cannot become valid or invalid solely because a block producer selected a different block context.
 
-### EIP-1271 Own-Storage Invalidation
+### Own-Storage Invalidation
 
-EIP-1271 signer validity MAY depend on the signer contract's own storage. This is intentional: it permits multisig thresholds, passkey rotation, revocation lists, recovery state, and policy updates. It also means a signature that was valid during mempool simulation can become invalid if the signer contract's own storage changes before inclusion. Wallets and relayers MUST treat EIP-1271 validity as state-dependent.
+Signer validity and execution-trace policy validity MAY depend on the signer's own storage. This is the intentional programmable policy surface. To preserve public-pool stability, any own-storage change that can invalidate a previously valid signature or previously accepted execution trace MUST be timelocked by at least `MIN_KEYRING_UPDATE_DELAY` for WIP-1001-compliant signers.
+
+### Custom Signer Safety
+
+The manager can verify any signer that satisfies the signature and execution-trace policy restricted frames at inclusion time, but public transaction pools should distinguish default or otherwise known-safe signers from arbitrary custom signers. If a custom signer can immediately change own-storage validation or trace-policy state, it can invalidate pooled transactions before inclusion and should not receive the full WIP-1001 pool-stability guarantee.
 
 ### Contract Upgradeability
 
-Upgradeable EIP-1271 signer contracts can change account authorization policy without changing the World Chain Account keyring or admin authority. This is a feature when used intentionally, but it is also a risk. Wallets SHOULD surface whether an EIP-1271 signer is upgradeable, proxy-based, or otherwise able to change behavior. Proxy patterns that require `DELEGATECALL` during validation are invalid under the restricted frame.
+Upgradeable signer contracts can change account authorization policy without changing the World Chain Account keyring. Proxy patterns that require `DELEGATECALL` during validation are invalid under the restricted frame. Upgrade paths that can invalidate signatures MUST themselves obey the signer-state timelock discipline.
 
-### Session Key Deanonymization
+### Session Signer Deanonymization
 
-A Secp256k1 EOA key address reused as an EOA, or authorized on a different World Chain Account, links those accounts. An EIP-1271 key contract reused across contexts likewise links them. Clients SHOULD generate fresh session keys per account when unlinkability matters.
+A signer contract reused across accounts links those accounts. Clients SHOULD deploy fresh signer instances per account when unlinkability matters. World ID users who require unlinkability SHOULD use distinct World ID account nonces and signer instances.
 
-### Signature-Key Ambiguity
+### Signature-Signer Ambiguity
 
-A World Chain Account may store up to `MAX_SESSION_KEYS`, but a `0x1D` transaction declares exactly one `(key_type, key)`. The keyring lookup is by that pair and MUST be unique. There is no "first matching key" ambiguity.
+A World Chain Account may store up to `MAX_SESSION_SIGNERS`, but a `0x1D` transaction declares exactly one `signer`. The keyring lookup is by signer address and MUST be unique. There is no "first matching signer" ambiguity.
 
 ### WebAuthn Challenge Binding
 
 For WebAuthn-based EIP-1271 signer contracts, the `0x1D` `signing_hash` SHOULD appear as the WebAuthn challenge, or be bound by an equivalent domain-separated digest inside the contract's validation logic. WIP-1001 does not prescribe the internal EIP-1271 signature format.
 
-### WorldID-admin: Account Unlinkability
+### World ID Stale Roots
 
-Two WorldID-admin accounts owned by the same WorldID are unlinkable across distinct creation `worldIDAccountNonce` values by the ZK property of the OPRF proof. Subsequent updates no longer reuse the creation action; they are authorized via Session Proofs bound to the account's stored `sessionId`. Updates to the same account remain linkable through the account address and its on-chain state transitions.
-
-### WorldID-admin: Stale Merkle Root
-
-The `WorldIDRegistry` accepts roots within a validity window. An attacker whose credential has been revoked could race to submit `create` or `update` against a still-valid but stale root before expiry. The `expiresAtMin + minExpirationThreshold >= block.timestamp` check bounds this window, but its duration is a trust parameter.
-
-### EOA-admin: Admin Key Loss Is Terminal
-
-For Secp256k1 EOA admin instantiations, loss of the admin key permanently bricks the account -- the keyring cannot be mutated, recovered, or rotated by WIP-1001. Wallets implementing EOA-admin accounts MUST surface this risk to users and SHOULD encourage hardware-backed key custody.
-
-### EOA-admin and EIP-1271-admin: Linkability
-
-An EOA admin address or EIP-1271 admin contract address is recoverable from any creation transaction's calldata and is part of address derivation. Unlike WorldID-admin accounts, these accounts carry no unlinkability guarantees. Cross-chain or cross-application reuse of an admin address is a deanonymization vector.
-
-### No Liveness Check
-
-A non-WorldID-admin account has no protocol-level liveness check on session-key-signed transactions. Session-key compromise can drain account-controlled value at the rate session keys can authorize, bounded only by configured `SessionPolicy` limits and off-protocol controls. Sibling WIPs that require WorldID liveness above a value threshold do NOT apply to non-WorldID-admin accounts.
+World ID signer implementations that accept roots within a validity window inherit the stale-root risks of the underlying World ID verifier. A credential revoked shortly before root expiry may still authorize a signature until the verifier's root-validity and credential-expiration checks reject it. The signer implementation MUST surface and document those verifier trust parameters.

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -12,7 +12,7 @@ requires: EIP-1271, EIP-2718, EIP-1559, EIP-2930, ERC-7562, RIP-7212
 
 ## Abstract
 
-WIP-1001 defines a native World Chain account type managed by the `WORLD_CHAIN_ACCOUNT_MANAGER` predeploy. Each account has one immutable [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) admin signer and one active keyring of EIP-1271 session verifiers.
+WIP-1001 defines a native World Chain account type managed by the `WORLD_CHAIN_ACCOUNT_MANAGER` predeploy. Each account has one immutable [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) compliant admin signer and one active keyring of EIP-1271 compliant session verifiers.
 
 We extend [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) with a new typed transaction envelope with type flag `0x1D`. `0x1D` transactions executed with the World Chain account **Framed** as the sender. Session verifiers act as the transaction level signatories via programmable [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271). Session verifiers dually function as signature verifiers, and session key policy evaluators.
 

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -360,6 +360,116 @@ Restricted frames are enforced by a runtime opcode-and-target tracer derived fro
 
 Adding a new precompile to the validation allowlist is a hard-fork change.
 
+### Execution Trace Construction
+
+Step 10 of §Validation, Execution, and Failure Semantics requires constructing `ExecutionTraceContext` from the result of the tentative payload execution. This section specifies the inspector configuration and trace encoding implementations MUST use.
+
+#### Inspector Configuration
+
+The protocol MUST collect the trace using a call-and-log tracing inspector configured to:
+
+- record the call tree (depth, kind, caller, target, value, input, output, success, gasUsed for every frame);
+- record emitted logs with their emitter, topics, data, and the call frame index that emitted them.
+
+The inspector MUST NOT record opcode-level steps, memory or stack snapshots, returndata snapshots, state diff, or immediate bytes — none of these feed the trace and recording them inflates execution cost. The inspector MUST NOT exclude precompile frames; verifiers may legitimately constrain precompile use.
+
+The reference implementation uses `TracingInspector` from `revm-inspectors` with `TracingInspectorConfig::none().set_record_logs(true)`. Equivalent configurations in other implementations MUST capture the same data.
+
+#### Trace Encoding
+
+Implementations MUST construct `WorldChainExecutionTrace` using the following struct layout:
+
+```solidity
+enum TraceCallKind {
+    Call,
+    StaticCall,
+    CallCode,
+    DelegateCall,
+    Create,
+    Create2
+}
+
+struct CallTrace {
+    uint32 depth;
+    TraceCallKind kind;
+    address caller;
+    address target;
+    uint256 value;
+    bytes4 selector;
+    bool success;
+    uint64 gasUsed;
+    uint32 inputOffset;
+    uint32 inputLength;
+    uint32 outputOffset;
+    uint32 outputLength;
+}
+
+struct LogTrace {
+    address emitter;
+    bytes32[] topics;
+    uint32 dataOffset;
+    uint32 dataLength;
+    uint32 callIndex;
+}
+
+struct WorldChainExecutionTrace {
+    bool success;
+    uint64 gasUsed;
+    CallTrace[] calls;
+    LogTrace[] logs;
+    bytes inputsBlob;
+    bytes outputsBlob;
+    bytes logDataBlob;
+}
+```
+
+This layout supersedes the `TraceCallKind`, `CallTrace`, `LogTrace`, and `WorldChainExecutionTrace` definitions in §Signer Interfaces; the interfaces section MUST be updated to match.
+
+Calldata and return data are packed into three flat byte blobs (`inputsBlob`, `outputsBlob`, `logDataBlob`). Each `CallTrace` and `LogTrace` references its slice by `(offset, length)`. This amortises the ABI dynamic-field overhead across one blob per role rather than paying offset + length headers per element.
+
+#### Field Construction
+
+For each call frame, in pre-order traversal of the call tree, with the implementation maintaining per-blob byte cursors:
+
+- `depth`: EVM frame depth; `0` for the root frame (the payload's top-level call);
+- `kind`: the call kind, mapped from the EVM operation that opened the frame;
+- `caller`: address of the frame that opened this frame;
+- `target`: callee address for call-like kinds; address of the created contract for `Create`/`Create2`;
+- `value`: value transferred in wei;
+- `selector`: `bytes4` of the first four input bytes when at least four are present, else `bytes4(0)`. Carries no semantic meaning for `Create`/`Create2`; verifiers SHOULD gate selector checks on `kind ∉ {Create, Create2}`;
+- `success`: `true` iff the frame returned normally;
+- `gasUsed`: total gas consumed by this frame including descendants;
+- `inputOffset`, `inputLength`: position and length of this frame's input bytes within `inputsBlob`. The bytes MUST be appended to `inputsBlob` in pre-order traversal order with no padding between frames;
+- `outputOffset`, `outputLength`: same scheme against `outputsBlob`.
+
+`calls[]` entries MUST appear in pre-order traversal order. As a consequence, `calls[i].depth - calls[i-1].depth ∈ {+1, ≤0}`, and a verifier may walk children by scanning forward until `depth` drops to or below the parent's depth.
+
+For each emitted log, in pre-order intra-frame emission order (equivalent to receipt order):
+
+- `emitter`: address that emitted the log;
+- `topics`: log topics, in order;
+- `dataOffset`, `dataLength`: position and length of the log data within `logDataBlob`, with bytes appended in emission order and no padding between logs;
+- `callIndex`: index of the emitting frame in `calls[]`. MUST satisfy `callIndex < calls.length`.
+
+Trace-level fields mirror the root frame:
+
+- `trace.success` MUST equal `calls[0].success`;
+- `trace.gasUsed` MUST equal `calls[0].gasUsed`.
+
+The root frame's return data is reachable via `calls[0].outputOffset` and `calls[0].outputLength`; no separate trace-level output field is provided.
+
+After construction, the trace is wrapped with the `WorldChainTransactionContext` (built before tentative execution) into `ExecutionTraceContext`. Per §Validation, Execution, and Failure Semantics step 11, `abi.encode(context.trace).length` MUST be checked against `MAX_EXECUTION_TRACE_BYTES` before the policy staticcall. The bound applies to `context.trace` only; top-level `data` and `accessList` travel in `context.transaction` and are not counted, preserving the verifier's access to full top-level arguments independent of trace size.
+
+#### Rationale
+
+Raw byte access to every subcall's input and output is necessary to express the policy classes WIP-1001 enables — allowance caps, recipient allowlists, swap slippage bounds, and in general any policy whose constraint depends on a *dynamic* subcall argument. A hash-only encoding would force the verifier to commit-and-compare against precomputed constants, which can only express fully fixed-template policies; any policy whose arguments vary at submission time would be inexpressible.
+
+Packing bytes into per-role blobs amortises the ABI dynamic-field overhead across one blob per role rather than per element. For a trace with `N` call frames carrying input and output bytes, this saves approximately `N × 64` bytes of header overhead plus per-frame 32-byte data padding compared to embedding `bytes` fields inside each `CallTrace`.
+
+`CALLCODE` MAY appear in the call tree even though §Restricted Validation Frames forbids it inside validation frames. The restriction applies only to the three restricted staticcalls (admin authorization, session signature verification, session policy evaluation); payload execution is unrestricted, and legacy contracts that use `CALLCODE` are valid call targets. `TraceCallKind` includes `CallCode` to represent these frames. `AuthCall` is intentionally not represented — EIP-3074 was withdrawn, and EIP-7702 does not introduce a separate auth-call opcode.
+
+Trace size grows linearly with total subcall data. Applications with wide subcall fan-out may exceed `MAX_EXECUTION_TRACE_BYTES` and SHOULD split into multiple `0x1D` transactions, each validated independently. This is intentional and bounds verifier decode work within `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`.
+
 ### Transaction Type `0x1D`
 
 The wire encoding is:

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -12,137 +12,289 @@ requires: EIP-2, EIP-1559, EIP-196, EIP-197, EIP-198, EIP-2718, EIP-1271, RIP-72
 
 ## Abstract
 
-A *World Chain Account* is a predeploy-managed account whose 20-byte address is deterministic and lifetime-stable. Each account has one admin signer fixed at creation and an active **keyring** of session signers authorized to sign transactions on the account's behalf. Both admin authorization and session-key transaction authorization are verified exclusively through [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) smart contract signers.
+WIP-1001 defines a native World Chain account type managed by the `WORLD_CHAIN_ACCOUNT_MANAGER` predeploy.
 
-This WIP extends [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) with a typed transaction envelope (`0x1D`) whose signature payload is passed to an authorized session signer's `isValidSignature(bytes32,bytes)` implementation under a restricted, metered validation frame. The protocol does not natively dispatch over secp256k1, P256, WebAuthn, EdDSA, BLS, World ID, or any other signature scheme. Those schemes are implemented by EIP-1271 signer contracts using reusable EVM precompiles.
+Each account has one EIP-1271 admin signer and an active keyring of EIP-1271 session verifiers. The admin signer is the root authority for account management. Session verifiers are delegated authorities for `0x1D` transaction execution.
 
-Session signers also define programmable execution policy. The protocol does not store or interpret that policy. After signature verification and tentative transaction execution, the protocol supplies the resulting execution trace to the same session verifier contract. The verifier evaluates its internal policy as `f(transactionContext, executionTrace) -> bool`; if it returns false or fails, the transaction reverts.
+The protocol does not implement signature schemes directly. Instead, the protocol calls EIP-1271 signers in restricted validation frames. Signature schemes, proof systems, recovery policies, and execution policies are implemented by signer contracts. The protocol provides reusable cryptographic precompiles for common primitives.
 
-Account state and keyring management live in the `WORLD_CHAIN_ACCOUNT_MANAGER` predeploy. The manager exposes default signer factories for common strategies, including a World ID signer that verifies World ID proofs encoded in EIP-1271 signature bytes, and a secp256k1 signer that wraps EOA-style signatures. These default signers are reference implementations, not privileged protocol paths.
-
-Keyring updates are timelocked. An admin-authorized update first queues a full replacement keyring, and that keyring can only become active after a protocol-defined delay longer than the public transaction-pool expiration window. Default signer factories MUST apply the same delay discipline to signer authorization state so that EIP-1271 verification cannot fail between public transaction-pool validation and inclusion due to keyring or signer-state mutation.
+Session verifiers also own their execution policy. After tentative transaction execution, the protocol asks the verifier whether the observed execution trace is valid. If the verifier rejects the trace, the tentative execution is reverted.
 
 ## Motivation
 
-### One Signature Abstraction
+### One Authorization Path
 
-Ethereum already standardizes contract-based signature validation through EIP-1271. WIP-1001 makes EIP-1271 the only native authorization abstraction for World Chain Accounts. This keeps the transaction envelope small and scheme-agnostic while allowing wallets, applications, and future protocol features to introduce new signing policies without changing the transaction type.
+World Chain accounts need programmable authentication without adding a protocol branch for every signature scheme or proof system. EIP-1271 gives the protocol one authorization path: call a signer contract and require the standard magic value.
 
-An EOA wrapper, a passkey signer, a World ID proof verifier, a threshold signer, an EdDSA signer, or a BLS aggregate signer is simply a contract that returns the EIP-1271 magic value for a given hash and opaque signature bytes. The same signer can also own the session policy for what that session key may do.
+Admin signers and session verifiers both use EIP-1271, but they have different protocol roles. An admin signer authorizes account-management operations. A session verifier authorizes transaction signatures and evaluates the resulting execution trace.
 
 ### Reusable Cryptography
 
-Cryptographic accelerators used for account validation should not be host-private. If WIP-1001 signers depend on an elliptic-curve, hash, pairing, EdDSA, or BLS primitive, the primitive MUST be exposed as a normal EVM precompile with the same behavior for contracts and protocol validation. This makes signer contracts the compatibility layer over public VM functionality.
+Signer contracts need efficient cryptographic primitives, but those primitives should not define account semantics. WIP-1001 exposes reusable precompiles for supported curves and proof systems, while keeping account policy in contracts.
 
-### Programmable Keyrings
+World ID is a reference signer implementation. It verifies an EIP-1271 signature that encodes a World ID proof. It is not a privileged protocol path.
 
-The keyring should be an elegant authorization registry, not a catalogue of native signature algorithms or call-scope rules. A World Chain Account stores signer contracts. The signer contract owns the verification strategy, recovery strategy, quorum rules, proof format, authenticator-specific state, and programmable execution policy. This gives the protocol one validation path while preserving a programmable account surface.
+### Programmability
 
-### Pool-Stable Validation
+Accounts need authorization logic that can evolve without protocol changes. EIP-1271 lets admin signers define arbitrary account-management authorization, including World ID, secp256k1, secp256r1, EdDSA, BLS12-381, multisig, programmable recovery, multi factor authentication and application-specific schemes.
 
-Public transaction pools validate transactions before inclusion. If a keyring or signer can invalidate a signature immediately after validation, a transaction can be accepted by the pool and then fail during block construction. WIP-1001 therefore requires keyring replacements and default signer authorization-state changes to be delayed by more than the public pool expiration window. A transaction that is pool-valid against the active keyring and a compliant default signer remains valid until it either expires from the pool or is included, assuming no other transaction fields become invalid.
+Session verifiers extend that programmability to transaction execution. A verifier can authenticate a session key, inspect the canonical execution trace, and decide whether the transaction satisfies its policy. The protocol only provides deterministic inputs and enforces the verifier's boolean result.
+
+### Stable Transaction Inclusion
+
+Mempool validation and block inclusion must agree on which keyring is active. Keyring updates are therefore timelocked for longer than the transaction pool expiration window. A transaction that validates against an active keyring cannot become invalid before it expires from the pool because of a keyring update.
+
+Default factories that support mutable signer or verifier state must apply the same rule to state that can invalidate already accepted transactions.
 
 ## Specification
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) and [RFC 8174](https://www.rfc-editor.org/rfc/rfc8174).
+The keywords "MUST", "MUST NOT", "SHOULD", and "MAY" are to be interpreted as described in RFC 2119.
 
-### Constants
+### Protocol Constants
 
-| Name | Value | Description |
-| ---- | ----- | ----------- |
-| `WORLD_TX_TYPE` | `0x1D` | EIP-2718 transaction type |
-| `WORLD_CHAIN_ACCOUNT_MANAGER` | `TBD` | World Chain Account Manager predeploy address |
-| `MAX_SESSION_SIGNERS` | `20` | Maximum active session signers per account |
-| `EIP1271_MAGIC_VALUE` | `0x1626ba7e` | `bytes4(keccak256("isValidSignature(bytes32,bytes)"))` |
-| `EIP1271_VALIDATION_GAS_LIMIT` | `TBD` | Fixed gas supplied to every protocol EIP-1271 validation frame |
-| `EXECUTION_TRACE_VALIDATION_GAS_LIMIT` | `TBD` | Fixed gas supplied to every protocol execution-trace policy validation frame |
-| `MAX_EXECUTION_TRACE_BYTES` | `TBD` | Maximum ABI-encoded execution trace size supplied to a verifier |
-| `TXPOOL_TRANSACTION_EXPIRATION_WINDOW` | `TBD` | Maximum public transaction-pool lifetime for a `0x1D` transaction |
-| `MIN_KEYRING_UPDATE_DELAY` | `> TXPOOL_TRANSACTION_EXPIRATION_WINDOW` | Minimum delay before a queued keyring can activate |
-| `WORLD_ID_1271_SIGNER_FACTORY` | `TBD` | Default World ID EIP-1271 signer factory |
-| `SECP256K1_1271_SIGNER_FACTORY` | `TBD` | Default secp256k1 EIP-1271 signer factory |
-| `WORLD_CHAIN_RP_ID` | `480` | World Chain's registered World ID relying-party ID |
-| `WORLD_ID_ACCOUNT_TAG` | `"WORLD_ID_ACCOUNT"` | Domain tag for World ID account/signer creation actions |
+| Name | Value | Meaning |
+| --- | --- | --- |
+| `WORLD_TX_TYPE` | `0x1D` | EIP-2718 transaction type for World Chain account transactions. |
+| `MAX_SESSION_SIGNERS` | `20` | Maximum active session verifiers per account. |
+| `EIP1271_MAGIC_VALUE` | `0x1626ba7e` | Required return value from `isValidSignature`. |
+| `WORLD_CHAIN_RP_ID` | `480` | World Chain relying-party identifier for WebAuthn challenge binding. |
+| `WORLD_ID_ACCOUNT_TAG` | `"WORLD_ID_ACCOUNT"` | Domain tag for World ID account signals. |
 
-`EIP1271_VALIDATION_GAS_LIMIT`, `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`, and `MAX_EXECUTION_TRACE_BYTES` are protocol constants. They are not selected by the transaction, account, signer, keyring entry, admin authorization, or factory.
+### Activation Parameters
 
-`MIN_KEYRING_UPDATE_DELAY` MUST be strictly greater than the maximum configured public transaction-pool expiration window for `0x1D` transactions. If a client or network changes the public pool expiration window, this constant MUST remain larger than the new window before WIP-1001 public-pool admission is enabled under that configuration.
+WIP-1001 MUST NOT activate until every parameter below is assigned in the fork configuration.
+
+| Name | Value | Requirement |
+| --- | --- | --- |
+| `WORLD_CHAIN_ACCOUNT_MANAGER` | TBD | Predeploy address for the account manager. |
+| `EIP1271_VALIDATION_GAS_LIMIT` | TBD | Fixed gas forwarded to `isValidSignature`. |
+| `EXECUTION_TRACE_VALIDATION_GAS_LIMIT` | TBD | Fixed gas forwarded to `evaluateSessionPolicy`. |
+| `MAX_EXECUTION_TRACE_BYTES` | TBD | Maximum ABI-encoded trace size passed to a session verifier. |
+| `TXPOOL_TRANSACTION_EXPIRATION_WINDOW` | TBD | Maximum time a valid transaction remains in the pool. |
+| `MIN_KEYRING_UPDATE_DELAY` | TBD | MUST be greater than `TXPOOL_TRANSACTION_EXPIRATION_WINDOW`. |
+| `WORLD_ID_1271_SIGNER_FACTORY` | TBD | Default World ID EIP-1271 signer factory. |
+| `SECP256K1_1271_SIGNER_FACTORY` | TBD | Default secp256k1 EIP-1271 signer factory. |
+| `EDDSA_PRECOMPILE` | TBD | EdDSA verification precompile address and ABI. |
+| `BLS12_381_PRECOMPILE` | TBD | BLS12-381 verification precompile address and ABI. |
 
 ### Reusable Crypto Precompiles
 
-Any accelerated cryptographic primitive used by protocol-valid EIP-1271 signers MUST be available through an EVM precompile with the same behavior for smart contracts and protocol/system callers. Implementations MUST NOT validate WIP-1001 signers with private host functions unavailable to contracts.
+Signer contracts MAY call protocol-supported cryptographic precompiles from restricted validation frames.
 
-The restricted validation-frame precompile allowlist initially contains:
+The validation-frame precompile allowlist is:
 
-| Name | Address | Purpose |
-| ---- | ------- | ------- |
-| `ECRECOVER` | `0x0000000000000000000000000000000000000001` | Ethereum secp256k1 recovery |
-| `SHA256` | `0x0000000000000000000000000000000000000002` | WebAuthn and other hash-based verification |
-| `MODEXP` | `0x0000000000000000000000000000000000000005` | Modular exponentiation ([EIP-198](https://eips.ethereum.org/EIPS/eip-198)) |
-| `BN254_ADD` | `0x0000000000000000000000000000000000000006` | BN254 G1 addition ([EIP-196](https://eips.ethereum.org/EIPS/eip-196)) |
-| `BN254_MUL` | `0x0000000000000000000000000000000000000007` | BN254 G1 scalar multiplication ([EIP-196](https://eips.ethereum.org/EIPS/eip-196)) |
-| `BN254_PAIRING` | `0x0000000000000000000000000000000000000008` | BN254 pairing check ([EIP-197](https://eips.ethereum.org/EIPS/eip-197)) |
-| `P256VERIFY` | `0x0000000000000000000000000000000000000100` | P256/secp256r1 verification ([RIP-7212](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md)) |
-| `EDDSA_VERIFY` | `TBD` | EdDSA signature verification; specified by a separate WIP |
-| `BLS12_381_VERIFY` | `TBD` | BLS12-381 verification or pairing suite; specified by a separate WIP |
+| Primitive | Source |
+| --- | --- |
+| `ecrecover` | Ethereum precompile |
+| `sha256` | Ethereum precompile |
+| `ripemd160` | Ethereum precompile |
+| `identity` | Ethereum precompile |
+| `modexp` | Ethereum precompile |
+| `bn254 add` | Ethereum precompile |
+| `bn254 scalar multiplication` | Ethereum precompile |
+| `bn254 pairing` | Ethereum precompile |
+| `secp256r1 verify` | RIP-7212 |
+| `EdDSA verify` | Activation parameter |
+| `BLS12-381 verify` | Activation parameter |
 
-The concrete address, supported curve(s), input/output encoding, malleability rules, failure behavior, and gas schedule for `EDDSA_VERIFY` and `BLS12_381_VERIFY` are out of scope for this WIP and MUST be specified before activation. Future curve, pairing, or proof-system precompiles MAY be added by a follow-on fork.
+World Chain clients MUST NOT expose private host validation APIs that are unavailable to contracts. Any primitive used by a default signer MUST be available through an allowlisted precompile.
 
-### Abstract Account Model
+### Account Model
 
-An account is created by an EIP-1271-admin-authorized `create` operation. Creation fixes:
+World Chain accounts are created and managed by `WORLD_CHAIN_ACCOUNT_MANAGER`.
 
-- `adminSigner`, the EIP-1271 contract that authorizes future keyring updates;
-- `accountSalt`, the admin-selected salt used for deterministic address derivation;
-- the initial active keyring of session signers.
+An account has:
 
-After creation, `adminSigner` and `accountSalt` are immutable for the lifetime of the account. Keyring mutation is performed by queueing a full replacement keyring, then activating it after the timelock delay has elapsed.
+- one immutable account address;
+- one EIP-1271 admin signer;
+- one active keyring of EIP-1271 session verifiers;
+- at most one pending keyring update;
+- one admin nonce.
 
-#### Account State
+Account authority is hierarchical:
 
-Per-account state stored by the `WORLD_CHAIN_ACCOUNT_MANAGER` predeploy:
+1. The account manager owns account state and enforces account-management rules.
+2. The admin signer is the root account authority. It authorizes account creation and keyring updates through EIP-1271.
+3. Session verifiers are delegated transaction authorities. They authorize `0x1D` transactions through EIP-1271 and approve or reject the observed execution trace through `evaluateSessionPolicy`.
+
+The manager MUST NOT use the admin signer to authorize `0x1D` transaction execution unless the same address is also present in the active session keyring. The manager MUST NOT use a session verifier to authorize account-management operations unless the same address is also configured as the admin signer.
+
+The manager stores account state:
 
 ```solidity
 struct Account {
-    address         adminSigner;
-    bytes32         accountSalt;
+    address adminSigner;
+    bytes32 accountSalt;
     SessionSigner[] activeSessionSigners;
-    bytes32         activeKeyringHash;
+    bytes32 activeKeyringHash;
     PendingKeyringUpdate pendingKeyringUpdate;
-    uint64          adminNonce;
+    uint64 adminNonce;
 }
 
 struct PendingKeyringUpdate {
-    bool            exists;
-    bytes32         expectedCurrentKeyringHash;
+    bool exists;
+    bytes32 expectedCurrentKeyringHash;
     SessionSigner[] targetSessionSigners;
-    bytes32         targetKeyringHash;
-    uint64          activateAfter;
-    uint64          queuedAtNonce;
+    bytes32 targetKeyringHash;
+    uint64 activateAfter;
+    uint64 queuedAtNonce;
 }
-```
 
-`adminNonce` is initialized to `0` at creation and incremented by `1` whenever a keyring update is successfully queued. `activateKeyringUpdate` does not require a new admin authorization and does not increment `adminNonce`.
-
-#### Session Signers
-
-```solidity
 struct SessionSigner {
     address signer;
 }
 ```
 
-`signer` MUST NOT be the zero address and MUST have non-empty code when it is added to a keyring. The signer MUST implement `IERC1271.isValidSignature(bytes32,bytes)` and `IWorldChainSessionVerifier.isValidExecutionTrace(WorldChainTransactionContext,WorldChainExecutionTrace)`.
+`Account.adminSigner` is an EIP-1271 contract. `SessionSigner.signer` is an EIP-1271 contract that also implements `IWorldChainSessionVerifier`.
 
-Protocol native EIP-1271 signature verification is constrained to `EIP1271_VALIDATION_GAS_LIMIT`.
+The protocol does not inspect signer internals. It assigns semantics by account role: admin signer for account management, session verifier for transaction authorization and policy evaluation.
 
-A keyring MUST contain at least one session signer and MUST NOT contain more than `MAX_SESSION_SIGNERS`.
+The active keyring MUST contain at least one session verifier and at most `MAX_SESSION_SIGNERS` session verifiers. A keyring MUST NOT contain duplicate signer addresses.
 
-Session signers carry no intrinsic privileges beyond signing `0x1D` transactions whose execution traces are accepted by their verifier policy.
+### Address Derivation
 
-#### Session Verifier Execution Policy Interface
+The manager derives an account address from:
 
-Session signers MUST implement:
+- `adminSigner`;
+- `accountSalt`;
+- the manager address;
+- the World Chain chain ID.
+
+This binds the account address to the admin signer, salt, chain, and manager instance.
+
+### Keyring Hash
+
+The manager computes:
+
+```solidity
+activeKeyringHash = keccak256(abi.encode(activeSessionSigners));
+```
+
+The hash commits to signer addresses and ordering. Clients SHOULD preserve ordering when displaying, exporting, or signing over a keyring.
+
+### Signal Semantics
+
+Account creation and admin authorization signatures MUST use domain-separated signals.
+
+The signal for account creation is:
+
+```solidity
+signal = keccak256(
+    abi.encode(
+        WORLD_ID_ACCOUNT_TAG,
+        chainId,
+        WORLD_CHAIN_ACCOUNT_MANAGER,
+        accountAddress,
+        adminSigner,
+        accountSalt,
+        activeKeyringHash
+    )
+);
+```
+
+Admin operations MUST include:
+
+- `chainId`;
+- `WORLD_CHAIN_ACCOUNT_MANAGER`;
+- `account`;
+- operation selector;
+- operation parameters;
+- `adminNonce`.
+
+The manager increments `adminNonce` when it queues a keyring update. Activating a queued update MUST NOT increment `adminNonce`.
+
+### Replay Protection
+
+The account address derivation, signal domain, chain ID, manager address, and admin nonce together provide replay protection for account creation and admin operations.
+
+Session transactions use the transaction nonce in the `0x1D` envelope. This nonce is separate from `adminNonce`.
+
+### EIP-1271 Admin Signer Hierarchy
+
+The admin signer is an EIP-1271 contract that authorizes account-management operations. It has no protocol ABI beyond EIP-1271:
+
+```solidity
+interface IWorldChainAdminSigner is IERC1271 {}
+```
+
+The protocol calls the admin signer with a manager-defined operation hash. The signer returns `EIP1271_MAGIC_VALUE` if the operation is authorized.
+
+Admin signer implementations include:
+
+- World ID admin signers;
+- secp256k1 admin signers;
+- multisig admin signers;
+- recovery admin signers;
+- custom application admin signers.
+
+Only the EIP-1271 boundary is protocol-significant. The implementation class is signer contract state, not account manager state.
+
+#### World ID Admin Signer
+
+A World ID admin signer is an EIP-1271 contract whose authorization is a World ID proof bound to the manager-defined operation hash.
+
+The default World ID admin signer MUST expose immutable account-binding state:
+
+```solidity
+interface IWorldIDAdminSigner is IWorldChainAdminSigner {
+    function account() external view returns (address);
+    function externalNullifierHash() external view returns (uint256);
+}
+```
+
+The EIP-1271 signature payload is:
+
+```solidity
+struct WorldIDAdminSignature {
+    uint256 root;
+    uint256 nullifierHash;
+    uint256[8] proof;
+}
+```
+
+The default factory MUST derive `externalNullifierHash()` from `WORLD_ID_ACCOUNT_TAG`, `WORLD_CHAIN_RP_ID`, and `account()`.
+
+`isValidSignature(hash, signature)` MUST:
+
+- decode `signature` as `WorldIDAdminSignature`;
+- require `root` to be accepted by the signer;
+- verify the World ID proof using `hash` as the operation signal and `externalNullifierHash()` as the external nullifier;
+- return `EIP1271_MAGIC_VALUE` only if verification succeeds.
+
+The signer MUST NOT consume nullifiers as part of `isValidSignature`, because EIP-1271 validation is a `view` operation. Replay protection comes from the manager-defined operation hash, including `adminNonce`.
+
+#### Secp256k1 Admin Signer
+
+A secp256k1 admin signer is an EIP-1271 contract whose authorization is a secp256k1 signature by a configured owner.
+
+The default secp256k1 admin signer MUST expose immutable owner state:
+
+```solidity
+interface ISecp256k1AdminSigner is IWorldChainAdminSigner {
+    function owner() external view returns (address);
+}
+```
+
+The EIP-1271 signature payload is the standard 65-byte payload:
+
+```text
+r || s || v
+```
+
+`isValidSignature(hash, signature)` MUST:
+
+- require `signature.length == 65`;
+- decode `r`, `s`, and `v`;
+- require `s` to be in the lower half order as specified by EIP-2;
+- require `v` to be `27` or `28`;
+- recover the signer with `ecrecover(hash, v, r, s)`;
+- return `EIP1271_MAGIC_VALUE` only if the recovered address equals `owner()`.
+
+The secp256k1 admin signer verifies the hash passed by the manager directly. Wallets that need EIP-191, EIP-712, or WebAuthn wrapping MUST implement that wrapping inside a different EIP-1271 signer contract.
+
+### Session Verifier Interface
+
+Session verifier contracts MUST implement this interface in addition to EIP-1271. Admin-only signers only need to implement EIP-1271.
 
 ```solidity
 interface IWorldChainSessionVerifier is IERC1271 {
@@ -156,15 +308,15 @@ interface IWorldChainSessionVerifier is IERC1271 {
         uint256 chainId;
         address account;
         address signer;
-        uint64  nonce;
+        uint64 nonce;
         uint256 maxPriorityFeePerGas;
         uint256 maxFeePerGas;
-        uint64  gasLimit;
-        bool    isCreate;
+        uint64 gasLimit;
+        bool isCreate;
         address target;
         uint256 value;
-        bytes   data;
-        bytes4  selector;
+        bytes data;
+        bytes4 selector;
         AccessListEntry[] accessList;
         bytes32 activeKeyringHash;
     }
@@ -178,135 +330,64 @@ interface IWorldChainSessionVerifier is IERC1271 {
     }
 
     struct CallTrace {
-        uint32        depth;
+        uint32 depth;
         TraceCallKind kind;
-        address       caller;
-        address       target;
-        uint256       value;
-        bytes4        selector;
-        bytes32       inputHash;
-        bytes32       outputHash;
-        bool          success;
-        uint64        gasUsed;
+        address caller;
+        address target;
+        uint256 value;
+        bytes4 selector;
+        bytes32 inputHash;
+        bytes32 outputHash;
+        bool success;
+        uint64 gasUsed;
     }
 
     struct LogTrace {
-        address   emitter;
+        address emitter;
         bytes32[] topics;
-        bytes32   dataHash;
+        bytes32 dataHash;
     }
 
     struct WorldChainExecutionTrace {
-        bool        success;
-        uint64      gasUsed;
-        bytes32     outputHash;
+        bool success;
+        uint64 gasUsed;
+        bytes32 outputHash;
         CallTrace[] calls;
-        LogTrace[]  logs;
+        LogTrace[] logs;
     }
 
-    function isValidExecutionTrace(
-        WorldChainTransactionContext calldata context,
-        WorldChainExecutionTrace calldata trace
+    struct ExecutionTraceContext {
+        WorldChainTransactionContext transaction;
+        WorldChainExecutionTrace trace;
+    }
+
+    function evaluateSessionPolicy(
+        ExecutionTraceContext calldata context
     ) external view returns (bool allowed);
 }
 ```
 
-The protocol constructs `WorldChainTransactionContext` from the `0x1D` transaction after computing `signingHash` and loading the active keyring entry:
+The protocol MUST call `evaluateSessionPolicy` after tentative payload execution and before committing payload state.
 
-- `signingHash` is the canonical `0x1D` signing hash.
-- `chainId`, `nonce`, fee fields, `gasLimit`, `value`, `data`, and `accessList` are copied from the transaction.
-- `account` is the World Chain Account sender.
-- `signer` is the declared session signer.
-- For a call transaction, `isCreate == false` and `target == to`.
-- For a contract-creation transaction, `isCreate == true`, `target == address(0)`, and `data` is init code.
-- `selector` is the first four bytes of `data`; if `data.length < 4`, `selector == 0x00000000`.
-- `activeKeyringHash` is the account's active keyring hash at validation time.
+`ExecutionTraceContext.transaction` is derived from the `0x1D` envelope, the active account state, and the computed signing hash. It does not include block-context values other than `chainId`.
 
-The protocol constructs `WorldChainExecutionTrace` from the tentative execution of the `0x1D` payload:
+`ExecutionTraceContext.trace` is canonical and MUST include:
 
-- `success` is the success status of the root transaction payload execution.
-- `gasUsed` is the gas consumed by the root transaction payload execution before trace validation.
-- `outputHash` is `keccak256(returnData)` for the root transaction payload execution.
-- `calls` is the ordered, depth-annotated call/create trace emitted by the root execution. The root call itself is excluded because it is already represented by `WorldChainTransactionContext`.
-- `logs` is the ordered log summary emitted by the root execution.
+- the final payload success flag;
+- total gas used by payload execution;
+- `keccak256` of payload return data;
+- all internal calls, ordered by execution order and annotated with call depth;
+- all logs emitted by payload execution, ordered by emission order.
 
-Full internal calldata, return data, and log data are not copied into the trace by default; their hashes are supplied to keep trace validation bounded. A verifier that needs to authorize exact internal calldata SHOULD require the caller to include the relevant commitments in the session signature or in root transaction calldata. The ABI-encoded trace supplied to the verifier MUST NOT exceed `MAX_EXECUTION_TRACE_BYTES`.
+The root transaction call is represented by `ExecutionTraceContext.transaction`, not by a `CallTrace` entry.
 
-No block-context fields other than `chainId` are supplied. If a verifier policy depends on time, block number, or other context, it MUST bind that data through its own signature/proof payload rather than reading block opcodes during trace validation.
+Full internal calldata, return data, and log data are not copied into the trace. The trace includes hashes. A verifier that needs exact bytes MUST bind those bytes through the session signature, transaction calldata, or an application-level commitment.
 
-The execution-trace policy check is evaluated after tentative execution and before state commit, under the same call-target and opcode restrictions as EIP-1271 signature validation, with gas exactly `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`. If the call reverts, runs out of gas, executes a forbidden opcode, calls a forbidden address, returns malformed data, or returns `false`, the transaction-level authorization fails and the tentative payload execution is reverted.
-
-The policy function is intentionally `f(transactionContext, executionTrace) -> bool`: the protocol supplies what happened, while the verifier defines whether that execution is allowed. Examples include target/selector allowlists, method-argument commitments, value-flow limits, internal-call restrictions, log emission requirements, proof-bound permissions, per-session spending state, or app-specific invariants over the call trace.
-
-#### Address Derivation
-
-```text
-account = bytes20(keccak256(abi.encodePacked(
-    bytes32("WORLD_CHAIN_ACCOUNT"),
-    block.chainid,
-    WORLD_CHAIN_ACCOUNT_MANAGER,
-    adminSigner,
-    accountSalt
-)))
-```
-
-The address is fixed for the lifetime of the account. Keyring updates, signer state changes, and admin-signer internal recovery do not change the account address.
-
-The default World ID signer factory SHOULD derive different signer addresses for different World ID account nonces. A World ID holder who wants unlinkability across accounts SHOULD use distinct World ID signer instances and distinct `accountSalt` values.
-
-#### Keyring Hash
-
-The canonical keyring hash is:
-
-```text
-keyringHash = keccak256(abi.encode(sessionSigners))
-```
-
-where `sessionSigners` is the full ABI-encoded `SessionSigner[]` in its stored order. The order is admin-selected and consensus-significant. Clients SHOULD sort signers lexicographically by `signer` before submitting updates to avoid accidental duplicate representations.
-
-#### Signal Semantics
-
-Admin authorizations bind to a uniform `signalHash`. The hash supplied to an admin signer is always the 248-bit truncated keccak value:
-
-```text
-signalHash = bytes32(uint256(keccak256(abi.encode(signal))) >> 8)
-```
-
-The truncation keeps the value within the BN254 scalar field for World ID proof-backed EIP-1271 signers. It is uniform for all admin signers so that the signed value is independent of the signer implementation.
-
-```solidity
-struct CreateSignal {
-    bytes32         tag;               // keccak256("WORLD_CHAIN_ACCOUNT_CREATE")
-    address         adminSigner;
-    bytes32         accountSalt;
-    address         msgSender;
-    SessionSigner[] initialSessionSigners;
-}
-
-struct QueueKeyringUpdateSignal {
-    bytes32         tag;               // keccak256("WORLD_CHAIN_ACCOUNT_QUEUE_KEYRING_UPDATE")
-    address         account;
-    address         adminSigner;
-    uint64          adminNonce;
-    address         msgSender;
-    bytes32         expectedCurrentKeyringHash;
-    SessionSigner[] targetSessionSigners;
-    bytes32         targetKeyringHash;
-    uint64          activateAfter;
-}
-```
-
-`msgSender` is the EVM `msg.sender` of the manager call. Binding it prevents an in-flight admin authorization observed in the mempool from being replayed by a different submitter. A public factory, relayer, or forwarding contract that calls the manager for multiple users MUST enforce its own caller/request binding before forwarding; otherwise those users share the same `msg.sender` for WIP-1001 authorization purposes.
-
-#### Replay Protection
-
-For `create`, replay is precluded by account existence: the manager MUST revert if the derived account already exists.
-
-For `queueKeyringUpdate`, replay is prevented by `adminNonce`. The signal contains the current `adminNonce`; after a successful queue operation the manager increments `adminNonce`. An authorization for nonce `n` is invalid after the account advances to nonce `n + 1`.
-
-Queueing a new keyring update while another update is pending is permitted. The new queue operation MUST be independently admin-authorized, MUST satisfy the same delay rules, and replaces the previous pending update.
+The ABI-encoded trace MUST be no larger than `MAX_EXECUTION_TRACE_BYTES`. If the trace exceeds this limit, the transaction MUST fail.
 
 ### Manager Interface
+
+`WORLD_CHAIN_ACCOUNT_MANAGER` exposes:
 
 ```solidity
 interface IWorldChainAccountManager {
@@ -337,386 +418,328 @@ interface IWorldChainAccountManager {
 }
 ```
 
-For `create`, the manager MUST:
+`create` MUST:
 
-1. Require `adminSigner` has non-empty code.
-2. Validate all `initialSessionSigners` and keyring-size constraints.
-3. Compute the deterministic account address from `(adminSigner, accountSalt)`.
-4. Require the account does not already exist.
-5. Recompute the `CreateSignal` `signalHash`.
-6. Run the restricted EIP-1271 validation frame against `adminSigner` with `(hash = signalHash, signature = adminAuthorization)`.
-7. Store `adminSigner`, `accountSalt`, `activeSessionSigners = initialSessionSigners`, `activeKeyringHash`, no pending update, and `adminNonce = 0`.
+- derive the account address;
+- require `initialSessionSigners.length` to be in `[1, MAX_SESSION_SIGNERS]`;
+- reject duplicate session verifiers;
+- verify `adminAuthorization` by calling `adminSigner.isValidSignature(signal, adminAuthorization)`;
+- reject the call if the account already exists;
+- initialize account state.
 
-For `queueKeyringUpdate`, the manager MUST:
+`queueKeyringUpdate` MUST:
 
-1. Require the account exists.
-2. Validate all `targetSessionSigners` and keyring-size constraints.
-3. Require `expectedCurrentKeyringHash == activeKeyringHash`.
-4. Require `activateAfter >= block.timestamp + MIN_KEYRING_UPDATE_DELAY`.
-5. Compute `targetKeyringHash = keccak256(abi.encode(targetSessionSigners))`.
-6. Recompute the `QueueKeyringUpdateSignal` `signalHash` using the current `adminNonce`.
-7. Run the restricted EIP-1271 validation frame against the account's `adminSigner` with `(hash = signalHash, signature = adminAuthorization)`.
-8. Store the pending update, replacing any previous pending update.
-9. Increment `adminNonce`.
+- require the account to exist;
+- require `expectedCurrentKeyringHash == activeKeyringHash`;
+- require `targetSessionSigners.length` to be in `[1, MAX_SESSION_SIGNERS]`;
+- reject duplicate target signers;
+- require `activateAfter >= block.timestamp + MIN_KEYRING_UPDATE_DELAY`;
+- verify the admin operation through `adminSigner.isValidSignature`;
+- replace any existing pending update with the new pending update;
+- increment `adminNonce`.
 
-For `activateKeyringUpdate`, the manager MUST:
+`activateKeyringUpdate` MUST:
 
-1. Require the account exists.
-2. Require a pending update exists.
-3. Require `block.timestamp >= pending.activateAfter`.
-4. Require `pending.expectedCurrentKeyringHash == activeKeyringHash`.
-5. Replace `activeSessionSigners` with `pending.targetSessionSigners`.
-6. Store `activeKeyringHash = pending.targetKeyringHash`.
-7. Clear the pending update.
+- require a pending update;
+- require `block.timestamp >= activateAfter`;
+- require `expectedCurrentKeyringHash == activeKeyringHash`;
+- replace `activeSessionSigners`;
+- update `activeKeyringHash`;
+- clear the pending update.
 
-`activateKeyringUpdate` is permissionless. It applies only a previously admin-authorized update after the required delay.
+`activateKeyringUpdate` MAY be called by any address.
 
 ### Restricted Validation Frames
 
-Protocol signer validation is intentionally narrower than an ordinary EVM `STATICCALL`. Normal smart contracts MAY call any EIP-1271 or policy implementation according to Ethereum rules, but WIP-1001 protocol validation of an admin signer, session signer, or session policy MUST execute in a restricted validation frame.
+The protocol uses restricted validation frames for:
 
-The goal is:
+- admin authorization;
+- session signature verification;
+- session policy evaluation.
 
-```text
-protocol -> WORLD_CHAIN_ACCOUNT_MANAGER -> signer validation hook -> allowlisted crypto precompiles only
-```
+Restricted frames make validation deterministic and independent of mutable external contract state.
 
-There MUST NOT be an arbitrary EVM-to-EVM call graph during protocol signature or policy validation.
+#### EIP-1271 Signature Call
 
-#### Signature Entry Call
+For each EIP-1271 signature check, the protocol MUST perform:
 
-For a signer contract `signer`, hash `hash`, and signature bytes `signature`, the protocol invokes:
-
-```solidity
-IERC1271(signer).isValidSignature(hash, signature)
-```
-
-with:
-
-- call type: `STATICCALL` semantics;
-- `CALLER`: `WORLD_CHAIN_ACCOUNT_MANAGER`;
-- `ADDRESS`: `signer`;
-- `CALLVALUE`: `0`;
+- opcode: `STATICCALL`;
+- caller: `WORLD_CHAIN_ACCOUNT_MANAGER`;
+- callee: the signer contract;
+- call value: `0`;
 - gas: exactly `EIP1271_VALIDATION_GAS_LIMIT`;
 - calldata: `IERC1271.isValidSignature.selector || abi.encode(hash, signature)`;
-- success condition: the call succeeds and returns ABI-encoded `bytes4(EIP1271_MAGIC_VALUE)`.
+- success condition: call succeeds and returns `EIP1271_MAGIC_VALUE`.
 
-If the call reverts, runs out of gas, executes a forbidden opcode, calls a forbidden address, returns malformed data, or returns any value other than `EIP1271_MAGIC_VALUE`, the signature is invalid.
+Failure, revert, out-of-gas, malformed return data, or forbidden validation behavior MUST be treated as signature failure.
 
-A `0x1D` transaction, account, keyring entry, admin signer, and session signer MUST NOT choose or override the signature-validation gas. The gas consumed by session-signer validation MUST be metered against the transaction's gas limit before execution of the transaction payload. Admin validation gas is metered against the EVM call to the manager.
+#### Session Policy Evaluation Call
 
-#### Execution Trace Policy Entry Call
+After tentative payload execution, the protocol MUST perform:
 
-After tentative transaction payload execution, for a session signer `signer`, transaction context `context`, and execution trace `trace`, the protocol invokes:
-
-```solidity
-IWorldChainSessionVerifier(signer).isValidExecutionTrace(context, trace)
-```
-
-with:
-
-- call type: `STATICCALL` semantics;
-- `CALLER`: `WORLD_CHAIN_ACCOUNT_MANAGER`;
-- `ADDRESS`: `signer`;
-- `CALLVALUE`: `0`;
+- opcode: `STATICCALL`;
+- caller: `WORLD_CHAIN_ACCOUNT_MANAGER`;
+- callee: the session verifier used for the transaction;
+- call value: `0`;
 - gas: exactly `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`;
-- calldata: `IWorldChainSessionVerifier.isValidExecutionTrace.selector || abi.encode(context, trace)`;
-- success condition: the call succeeds and returns ABI-encoded `bool(true)`.
+- calldata: `IWorldChainSessionVerifier.evaluateSessionPolicy.selector || abi.encode(context)`;
+- success condition: call succeeds and returns `true`.
 
-If the call reverts, runs out of gas, executes a forbidden opcode, calls a forbidden address, returns malformed data, or returns `false`, trace validation fails and the tentative transaction payload execution MUST be reverted.
+Failure, revert, out-of-gas, malformed return data, forbidden validation behavior, or `false` MUST reject the trace and revert tentative payload execution.
 
-A `0x1D` transaction, account, keyring entry, admin signer, and session signer MUST NOT choose or override the trace-validation gas. The gas consumed by execution-trace policy validation MUST be metered against the transaction's gas limit after payload execution and before transaction finalization.
+#### Call Rules
 
-#### Call-Depth and Call-Target Rules
+Inside a restricted validation frame:
 
-During the restricted validation frame:
-
-- `STATICCALL` to an address in the validation precompile allowlist is permitted.
-- `STATICCALL` to any non-allowlisted address is forbidden.
-- `CALL`, `CALLCODE`, `DELEGATECALL`, `CREATE`, and `CREATE2` are forbidden.
-- Precompile execution does not introduce an additional EVM-code frame for purposes of this rule.
-
-Therefore a protocol-valid EIP-1271 signer contract MUST be self-contained except for direct calls to allowed precompiles. Proxy patterns, module systems, and library dispatch through `DELEGATECALL` are invalid in the restricted frame unless a future WIP relaxes this rule.
+- `STATICCALL` to an allowlisted precompile is permitted;
+- `STATICCALL` to any other address is forbidden;
+- `CALL`, `CALLCODE`, `DELEGATECALL`, `CREATE`, and `CREATE2` are forbidden;
+- precompile execution does not create an additional EVM code frame.
 
 #### Opcode Policy
 
-The restricted validation frame permits deterministic computation, calldata/memory access, own-code access, own-storage reads, `KECCAK256`, `CHAINID`, `GAS`, and `STATICCALL` to allowed precompiles. `GAS` is permitted because each frame starts with a fixed protocol gas limit rather than transaction-selected gas.
+The following opcodes are forbidden inside restricted validation frames:
 
-The following opcodes are forbidden if executed in the restricted validation frame:
+- block context: `BLOCKHASH`, `COINBASE`, `TIMESTAMP`, `NUMBER`, `PREVRANDAO`/`DIFFICULTY`, `GASLIMIT`, `BASEFEE`, `BLOBHASH`, `BLOBBASEFEE`;
+- transaction context: `GASPRICE`, `ORIGIN`;
+- external account inspection: `BALANCE`, `SELFBALANCE`, `EXTCODESIZE`, `EXTCODECOPY`, `EXTCODEHASH`;
+- mutable state and transient state: `SSTORE`, `TLOAD`, `TSTORE`;
+- logs: `LOG0`, `LOG1`, `LOG2`, `LOG3`, `LOG4`;
+- external execution and creation: `CALL`, `CALLCODE`, `DELEGATECALL`, `CREATE`, `CREATE2`;
+- destruction: `SELFDESTRUCT`.
 
-```text
-BLOCKHASH
-COINBASE
-TIMESTAMP
-NUMBER
-PREVRANDAO / DIFFICULTY
-GASLIMIT
-BASEFEE
-BLOBHASH
-BLOBBASEFEE
-GASPRICE
-ORIGIN
-BALANCE
-SELFBALANCE
-EXTCODESIZE
-EXTCODECOPY
-EXTCODEHASH
-SSTORE
-TLOAD
-TSTORE
-LOG0
-LOG1
-LOG2
-LOG3
-LOG4
-CALL
-CALLCODE
-DELEGATECALL
-CREATE
-CREATE2
-SELFDESTRUCT
-```
+The following operations are permitted:
 
-This list removes block-context, transaction-context, external-state, transient-state, logging, mutation, and arbitrary call-depth dependencies from protocol signature and execution-trace policy validation. EIP-1271 validity and trace-policy validity MAY depend on the signer's own persistent storage via `SLOAD`, subject to the signer-state timelock requirements below.
+- deterministic computation;
+- calldata and memory access;
+- reads of the signer contract's own bytecode;
+- reads of the signer contract's own storage;
+- `KECCAK256`;
+- `CHAINID`;
+- `GAS`;
+- `STATICCALL` to allowlisted precompiles.
 
-### Signer-State Timelock Requirements
+An implementation MUST reject the validation call if a forbidden opcode or forbidden call target is reached.
 
-To make public-pool validation stable, any signer state that can cause a previously valid signature or previously accepted execution trace to become invalid MUST transition through a delay of at least `MIN_KEYRING_UPDATE_DELAY` before it becomes effective.
+### Timelocked Signer-State Updates
 
-For default manager-supported signer factories, this is mandatory:
+Default factories that expose mutable signer or verifier state capable of invalidating a previously valid signature MUST timelock those updates by at least `MIN_KEYRING_UPDATE_DELAY`.
 
-- owner rotation in a secp256k1 signer MUST be queued before activation;
-- World ID session verifier state that changes accepted session material MUST be queued before activation;
-- threshold, key, revocation, recovery, or trace-policy state in any default signer MUST be queued before activation.
+Examples include:
 
-Custom EIP-1271 signers are protocol-compatible only if all storage values read during signature or trace-policy restricted frames obey the same delay discipline. Public transaction-pool implementations MUST NOT advertise full validation-stability guarantees for custom signers unless the signer bytecode or deployment is known to satisfy this property. Consensus validation still executes the signature and trace-policy calls at inclusion time; the timelock requirement defines WIP-1001-compliant signer behavior and public-pool admission policy.
+- root rotations;
+- verification-key rotations;
+- signer recovery changes;
+- signer revocation lists;
+- account binding changes.
 
-### Default Signer Factories
-
-Default signer factories are ordinary contracts, exposed by or discoverable from `WORLD_CHAIN_ACCOUNT_MANAGER`, that deploy deterministic EIP-1271 signer contracts with WIP-1001-compliant restricted-frame behavior and signer-state timelocks.
-
-The default factories are not special validation paths. A signer produced by a default factory is authorized only if it appears in the active keyring or is fixed as an account's admin signer.
-
-Default signer implementations MUST implement `isValidExecutionTrace`. A signer with no additional execution policy MAY return `true` for every well-formed trace after signature validation succeeds, but any configurable execution policy it exposes MUST be stored and updated inside the signer under the signer-state timelock rules.
-
-#### Secp256k1 EIP-1271 Signer
-
-The secp256k1 signer factory deploys signer contracts that store an Ethereum address `owner`.
-
-`isValidSignature(hash, signature)` MUST:
-
-1. Decode `signature` as an Ethereum secp256k1 ECDSA signature.
-2. Enforce the Ethereum low-`s` rule from [EIP-2](https://eips.ethereum.org/EIPS/eip-2).
-3. Recover the signer address over `hash` using `ECRECOVER`.
-4. Return `EIP1271_MAGIC_VALUE` iff the recovered address equals the active `owner`.
-
-Owner rotation, owner revocation, or any trace-policy update that can invalidate a previously valid signature or accepted execution trace MUST be timelocked by at least `MIN_KEYRING_UPDATE_DELAY`.
-
-#### World ID EIP-1271 Signer
-
-The World ID signer factory deploys signer contracts that verify World ID proofs encoded inside EIP-1271 signature bytes. World ID is a reference EIP-1271 verification strategy, not a native WIP-1001 admin or session-key type.
-
-A World ID signer stores the public verifier state required to validate future proofs, including at minimum the relevant `sessionId` or equivalent World ID session-verification material.
-
-For transaction or admin validation, `isValidSignature(hash, signature)` MUST:
-
-1. Decode `signature` as a World ID proof payload.
-2. Derive the World ID proof `signalHash` from `hash`, using `uint256(hash) >> 8` when the proof system requires a BN254-field signal.
-3. Verify the World ID proof against the stored session-verification material and the decoded public inputs.
-4. Return `EIP1271_MAGIC_VALUE` iff verification succeeds.
-
-A conceptual session-proof signature payload is:
-
-```solidity
-struct WorldID1271Signature {
-    uint256    proofNonce;
-    uint64     issuerSchemaId;
-    uint64     expiresAtMin;
-    uint256    credentialGenesisIssuedAtMin;
-    uint256[2] sessionNullifier;
-    uint256[5] proof;
-}
-```
-
-The signer MUST NOT persist `sessionNullifier` as account-manager state. Replay prevention for manager operations comes from account existence and `adminNonce`; replay prevention or nullifier tracking internal to a World ID signer is signer-policy-specific and MUST preserve the signer-state timelock guarantee if it can invalidate pooled transactions.
-
-World ID signer creation MAY be gated by a World ID Uniqueness Proof. The creation proof, account nonce, signer salt, and initial session-verification material are factory-level concerns. Once deployed, the signer is just an EIP-1271 contract from the manager's perspective.
+Signer state that cannot affect validation of already accepted transactions MAY update without this delay.
 
 ### Transaction Type `0x1D`
 
-A `0x1D` transaction is signed by a session signer of a World Chain Account and submitted directly to the public transaction pool. `0x1D` transactions are signer-strategy-agnostic: transaction validation reads the active keyring, invokes EIP-1271 on the declared signer, tentatively executes the payload, then asks the same signer whether the resulting execution trace satisfies its internal policy.
-
 #### Envelope
 
-```text
-0x1D || rlp([
-    chain_id,                    // 0
-    nonce,                       // 1
-    max_priority_fee_per_gas,    // 2
-    max_fee_per_gas,             // 3
-    gas_limit,                   // 4
-    to,                          // 5
-    value,                       // 6
-    data,                        // 7
-    access_list,                 // 8
-    account,                     // 9   -- sender's World Chain Account address
-    signer,                      // 10  -- authorized EIP-1271 session signer
-    signature,                   // 11  -- opaque bytes passed to isValidSignature
+`WORLD_TX_TYPE` transactions use the following payload:
+
+```solidity
+rlp([
+    chainId,
+    nonce,
+    maxPriorityFeePerGas,
+    maxFeePerGas,
+    gasLimit,
+    account,
+    signer,
+    isCreate,
+    to,
+    value,
+    data,
+    accessList,
+    signature
 ])
 ```
 
-```text
-signing_hash = keccak256(0x1D || rlp(fields[0..=10]))
-```
-
-The `signing_hash` covers every field except `signature` itself, binding the declared session signer to the transaction and ruling out signer-substitution attacks at the consensus layer.
-
-The protocol does not interpret `signature`. It is passed unchanged to:
+The signing hash is:
 
 ```solidity
-IERC1271(signer).isValidSignature(signing_hash, signature)
+keccak256(
+    0x1D ||
+    rlp([
+        chainId,
+        nonce,
+        maxPriorityFeePerGas,
+        maxFeePerGas,
+        gasLimit,
+        account,
+        signer,
+        isCreate,
+        to,
+        value,
+        data,
+        accessList
+    ])
+)
 ```
 
 #### Validation and Execution
 
-The protocol MUST validate and execute a `0x1D` transaction as follows:
+To validate and execute a `0x1D` transaction, the protocol MUST:
 
-1. Compute `signing_hash`.
-2. Load the active keyring entry for `(account, signer)`.
-3. Reject if no matching active session signer exists.
-4. Run the restricted EIP-1271 validation frame against `signer` with `(hash = signing_hash, signature = signature)`.
-5. Reject if the frame does not return `EIP1271_MAGIC_VALUE`.
-6. Tentatively execute the transaction payload under normal EVM rules, collecting the canonical `WorldChainExecutionTrace`.
-7. Construct `WorldChainTransactionContext` from the transaction and active keyring state.
-8. Require `abi.encode(trace).length <= MAX_EXECUTION_TRACE_BYTES`.
-9. Run the restricted execution-trace policy validation frame against `signer` with `(context, trace)`.
-10. If the frame does not return `true`, revert the tentative payload execution and mark the transaction as failed by policy.
-11. If the frame returns `true`, finalize the transaction according to the tentative payload execution result.
+1. Compute the signing hash.
+2. Load the account from `WORLD_CHAIN_ACCOUNT_MANAGER`.
+3. Reject the transaction if `signer` is not in the active keyring.
+4. Verify `signature` by calling `signer.isValidSignature(signingHash, signature)` in a restricted validation frame.
+5. Reject the transaction unless the signer returns `EIP1271_MAGIC_VALUE`.
+6. Execute the payload tentatively with `account` as the EVM transaction sender and collect the canonical execution trace.
+7. Build `ExecutionTraceContext` from the envelope, signing hash, active keyring hash, and canonical execution trace.
+8. Reject the transaction if `abi.encode(context.trace).length > MAX_EXECUTION_TRACE_BYTES`.
+9. Call `signer.evaluateSessionPolicy(context)` in a restricted validation frame.
+10. If session policy evaluation fails, discard tentative payload state and logs, consume nonce and gas according to normal failed-transaction semantics, and mark the transaction failed.
+11. If session policy evaluation succeeds, commit the payload result. If payload execution itself failed, commit the normal failed-call result.
 
-Authorization is checked before any signer call so an attacker cannot use an unauthorized `0x1D` transaction to force arbitrary signature or trace-policy validation work.
+### Default Signer Factories
 
-The envelope is extensible to 2D nonces, batched transactions, and native paymaster support in follow-on WIPs.
+World Chain provides default EIP-1271 signer factories through predeploy addresses assigned at activation.
+
+Default factories are reference implementations. Accounts MAY use any EIP-1271 admin signer or session verifier that satisfies this specification.
+
+#### Secp256k1 Signer
+
+`SECP256K1_1271_SIGNER_FACTORY` deploys the secp256k1 admin signer defined in this specification and MAY deploy session verifier variants that use the same secp256k1 authentication core.
+
+The admin signer variant implements EIP-1271 only. A session verifier variant MUST also implement `IWorldChainSessionVerifier`.
+
+#### World ID Signer
+
+`WORLD_ID_1271_SIGNER_FACTORY` deploys the World ID admin signer defined in this specification and MAY deploy session verifier variants that use the same World ID authentication core.
+
+The admin signer variant implements EIP-1271 only. A session verifier variant MUST also implement `IWorldChainSessionVerifier` and MUST bind its World ID proof to the `0x1D` signing hash.
 
 ### Visual Flow
 
 ```mermaid
-flowchart TD
-    Wallet[Wallet or App] --> Tx[0x1D Transaction]
-    Tx --> Pool[Public Tx Pool Validation]
-    Pool --> Manager[WORLD_CHAIN_ACCOUNT_MANAGER Predeploy]
-    Manager --> Active[Active Session Signer Set]
-    Active --> Signer[Authorized EIP-1271 Session Signer]
-    Signer --> Frame[Restricted Signature Frame]
-    Frame --> SigResult{Returns magic value?}
-    SigResult -->|no| Reject[Reject Transaction]
-    SigResult -->|yes| Exec[Tentative EVM Execution]
-    Exec --> Trace[Canonical Execution Trace]
-    Trace --> Policy[Verifier Trace Policy]
-    Policy --> PolicyResult{Trace allowed?}
-    PolicyResult -->|yes| Include[Finalize Transaction]
-    PolicyResult -->|no| Revert[Revert Tentative Execution]
-    Frame --> Crypto[Allowlisted Crypto Precompiles]
-    Policy --> Crypto
+sequenceDiagram
+    autonumber
+    participant User
+    participant Pool as Tx Pool
+    participant Protocol
+    participant Manager as WORLD_CHAIN_ACCOUNT_MANAGER
+    participant Signer as EIP-1271 Session Verifier
+    participant App as Target Contracts
 
-    Admin[Admin EIP-1271 Signer] --> Queue[queueKeyringUpdate]
-    Queue --> Pending[Pending Keyring + activateAfter]
-    Pending -->|delay > txpool expiration| Activate[activateKeyringUpdate]
-    Activate --> Active
+    User->>Pool: Submit 0x1D transaction
+    Pool->>Protocol: Validate transaction
+    Protocol->>Manager: Load active keyring
+    Manager-->>Protocol: signer authorized, activeKeyringHash
+    Protocol->>Signer: isValidSignature(signingHash, signature)
+    Signer-->>Protocol: EIP1271_MAGIC_VALUE
+    Protocol-->>Pool: Valid while keyring is active
 
-    WorldID[World ID Proof in Signature Bytes] --> WIDSigner[WorldID1271Signer]
-    WIDSigner --> Frame
-    EOA[EOA Signature Bytes] --> EOASigner[Secp256k1 1271 Signer]
-    EOASigner --> Frame
+    Protocol->>App: Tentative execution as account
+    App-->>Protocol: Result, calls, logs
+    Protocol->>Signer: evaluateSessionPolicy(context)
+    alt trace accepted
+        Signer-->>Protocol: true
+        Protocol-->>User: Commit payload result
+    else trace rejected
+        Signer-->>Protocol: false or failure
+        Protocol-->>User: Revert tentative payload
+    end
+
+    User->>Manager: queueKeyringUpdate(...)
+    Manager-->>User: Pending until activateAfter
+    User->>Manager: activateKeyringUpdate()
+    Manager-->>User: Active keyring replaced
 ```
 
 ### Extensions
 
-- **Trace schema extensions.** The execution trace schema MAY be extended with additional bounded summaries such as storage-write commitments, balance-delta commitments, or transient-storage summaries. The verifier remains the policy owner; the protocol only defines the trace data it supplies.
-- **Admin rotation.** Replacing an account's fixed `adminSigner` under a separate timelocked admin-rotation flow. Deferred in this WIP.
-- **Multi-admin.** M-of-N admin authorization for a single account. Deferred as native manager state; near-term policies SHOULD be represented inside an EIP-1271 admin signer.
-- **Additional crypto precompiles.** BLS12-381, EdDSA variants, secp256k1 verification without recovery, or other primitives MAY be added as VM precompiles. Once allowlisted for the restricted validation frame, EIP-1271 signer contracts can use them without changing the `0x1D` envelope.
-- **Bundling, 2D nonces, paymasters.** Reserved for follow-on WIPs on the `0x1D` envelope.
+WIP-1001 is designed to support future signer contracts without protocol changes, including:
+
+- multisig signers;
+- social recovery signers;
+- passkey signers;
+- threshold signers;
+- proof-system signers;
+- enterprise policy signers;
+- application-specific session verifiers.
+
+New cryptographic primitives SHOULD be added as reusable precompiles, not as account-specific protocol branches.
 
 ## Rationale
 
-**Account state as predeploy.** The keyring lives in the `WORLD_CHAIN_ACCOUNT_MANAGER` predeploy because `0x1D` validation must read the active signer set natively while preserving an ordinary Solidity/EVM-bytecode implementation surface for account management and default factories.
+### EIP-1271 as the Signer Boundary
 
-**EIP-1271-only verification.** A single contract-signature abstraction avoids protocol branches for every authenticator or cryptographic scheme. New signer strategies can be deployed as contracts and audited independently without changing the transaction type.
+EIP-1271 gives World Chain one protocol boundary for all authorization schemes. The protocol verifies a signer contract; the signer contract decides how to authenticate.
 
-**Fixed validation gas.** Per-signer gas limits make keyring entries harder to reason about, expand the admin-authorized state surface, and let signer deployment choices affect transaction validation economics. A single `EIP1271_VALIDATION_GAS_LIMIT` gives every protocol 1271 validation frame the same execution budget.
+### Verifier-Owned Execution Policy
 
-**Verifier-owned programmable policy.** Static `(target, selector)` allowlists are too narrow for account-native sessions, and the manager should not store a policy language. Passing the post-execution trace to the same verifier that authenticated the session lets policy be expressed as `f(transactionContext, executionTrace) -> bool`, so the verifier can decide whether what actually happened is allowed.
+Execution policy belongs inside the session verifier. The protocol does not need to understand spending limits, method allowlists, intents, or application-specific policy. It only supplies the canonical transaction context and execution trace, then asks the verifier for a boolean decision.
 
-**Reusable precompiles instead of host-only cryptography.** P256, EdDSA, BLS, pairing checks, and future curves are useful outside account validation. Exposing them as normal precompiles ensures the protocol and contracts agree on inputs, outputs, gas, and edge cases.
+### Fixed Validation Gas
 
-**Restricted validation frames.** Unrestricted contract signature or policy validation would allow an arbitrary read-only call graph before transaction execution. The restricted frame bounds gas, fixes the caller, forbids arbitrary call depth, and removes block-, transaction-, and external-state-sensitive opcodes while preserving own-storage policy and direct precompile calls.
+Validation gas limits are protocol constants, not signer-selected values. This prevents signers from increasing validation cost per transaction and gives clients a fixed resource bound for mempool validation and block execution.
 
-**Full-keyring replacement.** Updates carry the complete target keyring rather than add/remove deltas. This makes every admin authorization commit to the exact post-update authorization set, avoids ordering-dependent delta semantics, and removes edge cases where separately authorized removals and additions compose into an unintended intermediate keyring.
+### Timelocked Keyring Updates
 
-**Timelocked activation.** Delaying keyring activation by more than the transaction-pool expiration window prevents manager-owned keyring changes from invalidating transactions that were already admitted to the public pool. Applying the same discipline to default signer authorization and policy state extends that guarantee through signer validation.
+A keyring update can invalidate transactions that already passed mempool validation. Requiring `MIN_KEYRING_UPDATE_DELAY > TXPOOL_TRANSACTION_EXPIRATION_WINDOW` guarantees that a transaction cannot be invalidated by a keyring update while it is still eligible for inclusion.
 
-**World ID as reference signer.** World ID proofs are powerful authorization material, but they do not need a native WIP-1001 admin type. Encoding World ID proof payloads in EIP-1271 signatures makes World ID one programmable signer implementation among many and keeps the manager's account model uniform.
+### Restricted Validation Frames
+
+Restricted validation frames prevent validation results from depending on mutable external state, block metadata, or external contract calls. Signers remain programmable, but validation stays reproducible across pool validation and block execution.
 
 ## Backwards Compatibility
 
-This WIP introduces a new account type and transaction type. Existing EOAs and smart contract accounts are unaffected. Standard [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) transactions continue to work for legacy accounts; the `0x1D` envelope is required only for World-Chain-Account-authenticated execution.
+WIP-1001 introduces a new EIP-2718 transaction type and a new account manager predeploy. Existing Ethereum transaction types, EOAs, contracts, and Safe accounts are unchanged.
 
-This WIP is Draft. The move to EIP-1271-only session and admin verification, the replacement of native account-manager language with a manager predeploy, the removal of native signature-type dispatch, and timelocked keyring activation are breaking changes relative to earlier drafts. No production accounts exist.
-
-Existing draft implementations or libraries that expose native P256, WebAuthn, EdDSA, or secp256k1 WIP-1001 transaction signature variants are obsolete relative to this specification. Those strategies SHOULD migrate to EIP-1271 signer contracts or default signer factories.
-
-### Existing Safe Accounts
-
-Existing [Safe](https://safe.global) accounts MAY integrate with World Chain Accounts without migrating assets or changing the Safe address by installing modules or guards that recognize a World Chain Account as an authorized caller. Existing Safe contracts are not automatically valid WIP-1001 protocol signers: the restricted validation frames forbid arbitrary call depth, `DELEGATECALL`, and external contract state reads. A Safe-style policy can be used as a protocol signer only through bytecode that satisfies the signature interface, execution-trace policy interface, restricted-frame rules, and signer-state timelock rules, or through ordinary application-level calls outside WIP-1001 protocol validation.
+Existing Safe accounts MAY deploy or delegate to EIP-1271 signer contracts that satisfy this specification, but WIP-1001 does not require Safe migration.
 
 ## Security Considerations
 
-### Front-Running Admin Authorizations
+### Admin Authorization Front-Running
 
-Both `CreateSignal` and `QueueKeyringUpdateSignal` bind `msg.sender`, so a witnessed admin authorization observed in the mempool cannot be replayed by a different submitter. A griefer can still re-submit an authorization unchanged from the original `msg.sender`, but the resulting state is either identical or supersedes the same pending update under the same admin intent.
-
-The binding is to the direct EVM caller of `WORLD_CHAIN_ACCOUNT_MANAGER`. A public factory, relayer, or forwarding contract that calls the manager on behalf of multiple users MUST enforce its own caller/request binding before forwarding.
+Admin authorization signatures MUST bind account address, manager address, chain ID, operation selector, operation parameters, and nonce. A signature valid for one admin operation MUST NOT be valid for another.
 
 ### Admin Signer Compromise
 
-An admin signer can queue a full keyring replacement, but the replacement cannot activate until `MIN_KEYRING_UPDATE_DELAY` has elapsed. The delay gives wallets and monitoring systems time to warn users or move funds using still-active session signers. If the admin signer remains compromised until activation, the attacker can eventually replace the keyring.
+The admin signer can queue keyring changes. Applications SHOULD support recovery or multisig admin signers where appropriate.
 
 ### Signer Validation DoS
 
-Protocol signature validation is bounded by the fixed `EIP1271_VALIDATION_GAS_LIMIT`, execution-trace policy validation is bounded by the fixed `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`, and trace size is bounded by `MAX_EXECUTION_TRACE_BYTES`. Transactions cannot select a higher gas budget for either validation frame, and keyring authorization is checked before signer calls. This prevents unauthorized transactions from using arbitrary signer contracts as validation gas sinks.
+Fixed validation gas limits bound signer execution. Signers that exceed the limit fail validation.
 
-### Call-Graph and External-State Invalidation
+### Trace Size DoS
 
-Restricted validation frames forbid EVM-to-EVM calls except direct `STATICCALL`s to allowlisted precompiles. They also forbid external-code and external-balance inspection opcodes. As a result, protocol signature and trace-policy validity cannot depend on another contract's code, storage, or balance changing before inclusion.
+`MAX_EXECUTION_TRACE_BYTES` bounds memory and encoding cost for session policy evaluation. Transactions that exceed the bound fail before the context is passed to the signer.
 
-### Context-Sensitive Opcode Invalidation
+### External-State Invalidation
 
-Block-context and transaction-context opcodes such as `TIMESTAMP`, `NUMBER`, `BASEFEE`, `GASPRICE`, `ORIGIN`, and blob context are forbidden in restricted validation frames. Signatures and trace-policy decisions therefore cannot become valid or invalid solely because a block producer selected a different block context.
+Restricted frames forbid external contract reads and calls except allowlisted precompiles. This prevents unrelated contract state from changing signature or session policy outcomes.
+
+### Block-Context Invalidation
+
+Restricted frames forbid block-context opcodes. Signers that need time or block constraints MUST bind them into the signature or proof input.
 
 ### Own-Storage Invalidation
 
-Signer validity and execution-trace policy validity MAY depend on the signer's own storage. This is the intentional programmable policy surface. To preserve public-pool stability, any own-storage change that can invalidate a previously valid signature or previously accepted execution trace MUST be timelocked by at least `MIN_KEYRING_UPDATE_DELAY` for WIP-1001-compliant signers.
+Signers and verifiers may read their own storage. Default factories that expose mutable state affecting validation MUST timelock those updates by at least `MIN_KEYRING_UPDATE_DELAY`.
 
-### Custom Signer Safety
+### Upgradeable Signers
 
-The manager can verify any signer that satisfies the signature and execution-trace policy restricted frames at inclusion time, but public transaction pools should distinguish default or otherwise known-safe signers from arbitrary custom signers. If a custom signer can immediately change own-storage validation or trace-policy state, it can invalidate pooled transactions before inclusion and should not receive the full WIP-1001 pool-stability guarantee.
+Upgradeable signer contracts can change validation behavior. Signer factories SHOULD make upgradeability explicit, and upgrades that affect validation SHOULD be timelocked.
 
-### Contract Upgradeability
+### Session Verifier Deanonymization
 
-Upgradeable signer contracts can change account authorization policy without changing the World Chain Account keyring. Proxy patterns that require `DELEGATECALL` during validation are invalid under the restricted frame. Upgrade paths that can invalidate signatures MUST themselves obey the signer-state timelock discipline.
-
-### Session Signer Deanonymization
-
-A signer contract reused across accounts links those accounts. Clients SHOULD deploy fresh signer instances per account when unlinkability matters. World ID users who require unlinkability SHOULD use distinct World ID account nonces and signer instances.
+The `0x1D` envelope exposes the selected session verifier. Applications that need stronger privacy should use verifier contracts that aggregate or rotate credentials.
 
 ### Signature-Signer Ambiguity
 
-A World Chain Account may store up to `MAX_SESSION_SIGNERS`, but a `0x1D` transaction declares exactly one `signer`. The keyring lookup is by signer address and MUST be unique. There is no "first matching signer" ambiguity.
+The transaction envelope includes both `account` and `signer`. The protocol MUST verify that `signer` is active for `account` before calling EIP-1271.
 
 ### WebAuthn Challenge Binding
 
-For WebAuthn-based EIP-1271 signer contracts, the `0x1D` `signing_hash` SHOULD appear as the WebAuthn challenge, or be bound by an equivalent domain-separated digest inside the contract's validation logic. WIP-1001 does not prescribe the internal EIP-1271 signature format.
+WebAuthn-based signers MUST bind challenges to the `0x1D` signing hash and `WORLD_CHAIN_RP_ID`.
 
 ### World ID Stale Roots
 
-World ID signer implementations that accept roots within a validity window inherit the stale-root risks of the underlying World ID verifier. A credential revoked shortly before root expiry may still authorize a signature until the verifier's root-validity and credential-expiration checks reject it. The signer implementation MUST surface and document those verifier trust parameters.
+World ID signers MUST define root freshness rules. Root updates that can invalidate previously accepted transactions MUST follow the signer-state timelock requirement.


### PR DESCRIPTION
## Summary

Adds a new `### Execution Trace Construction` subsection to `wips/wip-1001.md` under `## Specification`, between `### Restricted Validation Frames` and `### Transaction Type 0x1D`. The section specifies how implementations build the `WorldChainExecutionTrace` passed to `evaluateSessionPolicy`:

- inspector configuration (which fields to record, which to omit, why);
- struct layout for `CallTrace`, `LogTrace`, `WorldChainExecutionTrace` using a packed-blob encoding (fixed-size structs + `(offset, length)` pairs into per-role flat byte blobs);
- field-by-field construction rules (pre-order traversal, blob append order, invariants);
- rationale (why bytes are exposed rather than hashed, ABI overhead amortisation, CALLCODE inclusion, fan-out trade-off).

The proposed struct layout supersedes the corresponding definitions in `### Signer Interfaces`. This PR notes the conflict but intentionally does not modify `### Signer Interfaces`, to keep the diff additive and minimise merge friction with in-flight edits on this branch. The interface section should be updated in a follow-up.

## Key design choice — bytes vs hashes

The current `### Signer Interfaces` struct definitions commit calldata and return data via `keccak256` (`inputHash`, `outputHash`, `dataHash`). This limits the verifier to commit-and-compare against precomputed constants, which only expresses fully fixed-template policies. Policies whose arguments vary at submission time (allowance caps, recipient allowlists, swap slippage) are inexpressible.

The proposed encoding exposes raw bytes via three flat blobs (`inputsBlob`, `outputsBlob`, `logDataBlob`) with `(offset, length)` pairs in each `CallTrace` / `LogTrace`. This costs roughly 10–40% more bytes than the hash-only layout on typical workloads and grows linearly with total subcall data. A verifier that wants the commit-and-compare primitive can compute `keccak256(blob[off:off+len])` itself.

Sizing note: `MAX_EXECUTION_TRACE_BYTES` should be set with the per-byte cost in mind (suggested range 32–64 KB). Wide-fan-out applications can still hit the ceiling and should split into multiple `0x1D` transactions; this is intentional and bounds verifier decode work within `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`.
