### PR TITLE
chore: define diamond proxy router pattern for delegated verifiers

### DIFF
--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -22,7 +22,7 @@ We design with the principle of not defining signer-specific authentication as n
 
 World Chain accounts need programmable authentication without adding a protocol branch for every signature scheme, or session key policy. Smart contracts allow us to converge protocol level authentication over a single authorization boundary with determinism enforced via protocol level restrictions on programmable validation frames.
 
-Programmable policies over Session Keys unlock many capabilities that simply are not possible on traditional accounts. Some examples include account subscription models, delegated agent payments with scoped permissions enforced by the VM, social recovery, policy based authentication (e.g. Multi Factor authentication for high value transactions). World Chain accounts are unique in that the policies constraining a Session Key are fully programmable. This allows for expressive policies, and authentication strategies to be composed and updated dynamically without prescriptive standards enforced by the protocol. 
+Programmable policies over session keys unlock many capabilities that simply are not possible on traditional accounts. Some examples include account subscription models, delegated agent payments with scoped permissions enforced by the VM, social recovery, policy-based authentication (e.g. multi-factor authentication for high value transactions). World Chain accounts are unique in that the policies constraining a session key are fully programmable. This allows for expressive policies, and authentication strategies to be composed and updated dynamically without prescriptive standards enforced by the protocol.
 
 ## Specification
 
@@ -32,7 +32,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 | Name | Type | Value | Meaning |
 | --- | --- | --- | --- |
-| `WORLD_TX_TYPE` | `uint8` | `0x1D` | EIP-2718 transaction type for World Chain account transactions. |
+| `WIP_1001_TX_TYPE` | `uint8` | `0x1D` | EIP-2718 transaction type for World Chain account transactions. |
 | `MAX_SESSION_VERIFIERS` | `uint256` | `20` | Maximum active session verifiers per account. |
 | `WORLD_CHAIN_ACCOUNT_DOMAIN` | `bytes32` | `keccak256("WIP1001_ACCOUNT")` | Domain for account address derivation. |
 | `WORLD_CHAIN_ACCOUNT_CREATE_DOMAIN` | `bytes32` | `keccak256("WORLD_CHAIN_ACCOUNT_CREATE")` | Domain for account creation authorization. |
@@ -55,7 +55,7 @@ WIP-1001 MUST NOT activate until every parameter below is assigned in fork confi
 | `MAX_ACCESS_LIST_ENTRIES` | `uint32` | TBD | Maximum number of [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) access-list entries in a `0x1D` envelope. |
 | `MAX_SESSION_SIGNATURE_BYTES` | `uint32` | TBD | Maximum length of the session `signature` field. |
 | `MAX_ADMIN_AUTHORIZATION_BYTES` | `uint32` | TBD | Maximum length of `adminAuthorization` calldata. |
-| `MAX_VERIFIER_INSTALL_DATA_BYTES` | `uint32` | TBD | Maximum length of `installData` in an admin or session verifier configuration. |
+| `MAX_VERIFIER_INSTALL_DATA_BYTES` | `uint32` | TBD | Maximum length of `installation` in an admin or session verifier configuration. |
 | `EDDSA_PRECOMPILE` | `address` | TBD | EdDSA verification precompile address and ABI. |
 | `BLS12_381_PRECOMPILE` | `address` | TBD | BLS12-381 verification precompile address and ABI. |
 
@@ -103,13 +103,13 @@ For every existing account:
 - `admin.verifier` MUST be a deployed EIP-1271 verifier implementation and the full `admin` value is immutable for the life of the account address;
 - `sessionVerifiers.length` MUST be in `[1, MAX_SESSION_VERIFIERS]`;
 - each `installation.length` in `admin` and `sessionVerifiers` MUST be at most `MAX_VERIFIER_INSTALL_DATA_BYTES`;
-- each `SessionVerifier.verifier` MUST be a deployed EIP-1271 verifier implementation adhering to `IWorldChainSessionVerifier`;
+- each `sessionVerifiers[i].verifier` MUST be a deployed EIP-1271 verifier implementation adhering to `IWorldChainSessionVerifier`;
 - `sessionVerifiers` MUST NOT contain duplicate verifier addresses;
 - `keyRingHash == keccak256(abi.encode(sessionVerifiers))`;
 - `adminNonce` is consumed only by admin operations;
 - `transactionNonce` is consumed only by successful `0x1D` transaction execution attempts;
 
-Verifier behavior is selected by verifier implementation address, not by a protocol-level enum. `installData` is opaque to the protocol and is interpreted only by the selected verifier implementation.
+Verifier behavior is selected by verifier implementation address, not by a protocol-level enum. `installation` is opaque to the protocol and is interpreted only by the selected verifier implementation.
 
 After account creation, `setKeyRing` is the only execution path that mutates `sessionVerifiers`, `keyRingHash`, or validation-affecting account storage for active session verifiers. WIP-1001 defines no operation that mutates `admin` or the account router runtime code.
 
@@ -147,7 +147,7 @@ The hash for each operation is:
 
 ```solidity
 createHash = keccak256(abi.encode(
-    WORLD_CHAIN_ADMIN_CREATE_DOMAIN,
+    WORLD_CHAIN_ACCOUNT_CREATE_DOMAIN,
     chainId,
     WORLD_CHAIN_ACCOUNT_MANAGER,
     WORLD_CHAIN_ACCOUNT_ROUTER_CODE_HASH,
@@ -158,7 +158,7 @@ createHash = keccak256(abi.encode(
 ));
 
 setKeyRingHash = keccak256(abi.encode(
-    WORLD_CHAIN_SET_KEY_RING_DOMAIN,
+    WORLD_CHAIN_ACCOUNT_SET_DOMAIN,
     chainId,
     WORLD_CHAIN_ACCOUNT_MANAGER,
     account,
@@ -212,7 +212,7 @@ interface IWorldChainAccountHooks {
 }
 ```
 
-Admin verifier implementations MUST implement EIP-1271 and `IWorldChainAccountVerifierHooks`. Session verifier implementations MUST implement EIP-1271, `IWorldChainVerifierInstaller`, and:
+Admin verifier implementations MUST implement EIP-1271 and `IWorldChainAccountHooks`. Session verifier implementations MUST implement `IWorldChainSessionVerifier`:
 
 ```solidity
 interface IWorldChainSessionVerifier is IERC1271, IWorldChainAccountHooks {
@@ -306,7 +306,7 @@ interface IWorldChainAccountManager {
     function setKeyRing(
         address account,
         bytes32 expectedCurrentKeyRingHash,
-        SessionVerifier[] calldata sessionVerifiers,
+        WorldChainAccountVerifier[] calldata sessionVerifiers,
         bytes calldata adminAuthorization
     ) external;
 
@@ -345,7 +345,7 @@ interface IWorldChainAccountManagerEvents {
 
 ### Manager State Transitions
 
-Every admin-mutating method MUST reject `adminAuthorization.length > MAX_ADMIN_AUTHORIZATION_BYTES`. It MUST also reject any `installData.length > MAX_VERIFIER_INSTALL_DATA_BYTES`. If any requirement in a manager state transition fails, the method MUST revert without changing account state, account code, account storage, incrementing `adminNonce`, or emitting its state-transition event.
+Every admin-mutating method MUST reject `adminAuthorization.length > MAX_ADMIN_AUTHORIZATION_BYTES`. It MUST also reject any `installation.length > MAX_VERIFIER_INSTALL_DATA_BYTES`. If any requirement in a manager state transition fails, the method MUST revert without changing account state, account code, account storage, incrementing `adminNonce`, or emitting its state-transition event.
 
 Admin authorization is valid only when `IWorldChainAccountRouter(account).isValidSignatureForAdmin(adminOperationHash, adminAuthorization)` succeeds in a restricted validation frame and returns `EIP1271_MAGIC_VALUE`.
 
@@ -359,7 +359,7 @@ Installing canonical account-router runtime bytecode is a native manager state t
 2. require `admin.verifier` and each initial session verifier to have deployed code;
 3. require `initialSessionVerifiers.length` to be in `[1, MAX_SESSION_VERIFIERS]`;
 4. reject duplicate or zero session verifier addresses;
-5. reject oversized `admin.installData` or session verifier `installData`;
+5. reject oversized `admin.installation` or session verifier `installation`;
 6. compute `adminHash = keccak256(abi.encode(admin))`;
 7. derive `account`;
 8. reject if `account` already exists or already has deployed code;
@@ -426,7 +426,7 @@ Adding a new precompile to the validation allowlist is a hard-fork change.
 
 ### Verifier Installation Frames
 
-`installAdmin` and `installKeyRing` are state-mutating account setup paths, not EIP-1271 validation frames. During installation, the account router MUST perform at most one direct `DELEGATECALL` per verifier entry with calldata `IWorldChainVerifierInstaller.install.selector || abi.encode(installData)`. Verifier implementation code MUST NOT execute `DELEGATECALL` from within `install`.
+`installAdmin` and `installKeyRing` are state-mutating account setup paths, not EIP-1271 validation frames. During installation, the account router MUST perform at most one direct `DELEGATECALL` per verifier entry with calldata `IWorldChainAccountHooks.install.selector || abi.encode(installation)`. Verifier implementation code MUST NOT execute `DELEGATECALL` from within `install`.
 
 If an install hook reverts, exhausts gas, or violates the nested-`DELEGATECALL` ban, the enclosing `create` or `setKeyRing` MUST revert atomically.
 
@@ -557,7 +557,7 @@ The `keyRingHash` comparison is the deterministic anchor for block validation: a
 
 ### Verifier-State Determinism
 
-Session verifier behavior that can change `isValidSignature` or `evaluateSessionPolicy` for already accepted transactions MUST be immutable while `keyRingHash` is unchanged. Validation-affecting updates MUST be represented by installing a replacement key ring through `setKeyRing`, which updates `keyRingHash`. A replacement key ring MAY reuse the same verifier implementation address with different `installData`, but the changed `installData` MUST be committed through the new `keyRingHash`.
+Session verifier behavior that can change `isValidSignature` or `evaluateSessionPolicy` for already accepted transactions MUST be immutable while `keyRingHash` is unchanged. Validation-affecting updates MUST be represented by installing a replacement key ring through `setKeyRing`, which updates `keyRingHash`. A replacement key ring MAY reuse the same verifier implementation address with different `installation`, but the changed `installation` MUST be committed through the new `keyRingHash`.
 
 Verifier implementation contracts MUST NOT be upgradeable for validation-affecting behavior. Implementations that route validation through upgradeable proxies, beacons, mutable implementation pointers, nested `DELEGATECALL`, or mutable external state are non-conformant. This applies to root rotations, verification-key rotations, signer recovery changes, signer revocation lists, account binding changes, and policy configuration changes. State that cannot affect validation MAY update in place.
 
@@ -588,8 +588,8 @@ Existing Safe accounts MAY use EIP-1271 verifier contracts that satisfy the same
 Conforming implementations MUST pass vectors for:
 
 - address derivation across multiple `(chainId, manager, routerCodeHash, adminHash, accountSalt)` tuples;
-- `adminHash = keccak256(abi.encode(admin))` and `keyRingHash = keccak256(abi.encode(sessionVerifiers))` for install data changes, empty-forbidden, single-verifier, multi-verifier, and reordered verifier sets;
-- `create` validation, including account-router code installation, admin install, key-ring install, deployed-code checks, duplicate and zero verifier rejection, account-exists/code-exists rejection, initial nonce values, initial `keyRingHash`, and `AccountCreated`;
+- `adminHash = keccak256(abi.encode(admin))` and `keyRingHash = keccak256(abi.encode(sessionVerifiers))` for installation changes, empty-forbidden, single-verifier, multi-verifier, and reordered verifier sets;
+- `create` validation, including account-router code installation, admin install, key ring install, deployed-code checks, duplicate and zero verifier rejection, account-exists/code-exists rejection, initial nonce values, initial `keyRingHash`, and `AccountCreated`;
 - `setKeyRing` validation, including stale `expectedCurrentKeyRingHash`, duplicate, zero, undeployed, empty, oversized, and no-op verifier set rejection;
 - `setKeyRing` success behavior, including full-set replacement, verifier reinstall, `newKeyRingHash`, `adminNonce` increment, `KeyRingSet`, authorization lookup updates, and failure atomicity;
 - `createHash` and `setKeyRingHash` domain separation, parameter binding, nonce binding, and negative replay cases across accounts, chains, managers, hashes, and operation types;
@@ -600,7 +600,7 @@ Conforming implementations MUST pass vectors for:
 - txpool revalidation, signature-validation cache reuse, and cache invalidation when `keyRingHash`, verifier membership, account balance, or nonce eligibility changes;
 - verifier-state determinism, including rejection of validation-affecting session verifier updates behind an unchanged `keyRingHash`;
 - restricted-frame positive cases, the single account-router `DELEGATECALL` exception, nested `DELEGATECALL` rejection, and each forbidden opcode or call target;
-- install hook success, install hook failure atomicity, install-data length bounds, and namespaced account-storage behavior;
+- install hook success, install hook failure atomicity, installation length bounds, and namespaced account-storage behavior;
 - block validation budget exhaustion and validation-failure fee charging.
 
 Complete golden vectors and a conformance test suite MUST be published before this WIP advances to Review.
@@ -611,7 +611,7 @@ Complete golden vectors and a conformance test suite MUST be published before th
 - The full admin verifier configuration is immutable in the account address. A broken or lost admin verifier configuration requires migrating assets to a new account; applications that need recovery SHOULD use admin verifier implementations with recovery or multisig logic from account creation.
 - `setKeyRing` is the only post-creation key ring mutation path. A compromised session verifier remains authorized until an admin-authorized replacement set is included.
 - `expectedCurrentKeyRingHash` protects `setKeyRing` authorizations from applying to an unexpected current set. Admin tooling SHOULD surface the complete replacement set before signing because omitted verifiers are removed atomically.
-- `keyRingHash` binds cached validation to the ordered `SessionVerifier[]` set, including verifier addresses and install data. Clients MUST discard cached signature results when the active hash changes, even if the transaction's `sessionVerifier` remains present in the new set.
+- `keyRingHash` binds cached validation to the ordered `WorldChainAccountVerifier[]` set, including verifier addresses and installation. Clients MUST discard cached signature results when the active hash changes, even if the transaction's `sessionVerifier` remains present in the new set.
 - `keyRingHash` does not commit to mutable verifier implementation behavior by itself. Session verifier code and validation-affecting installed state MUST be immutable while the hash is unchanged; upgrades that affect validation require `setKeyRing`.
 - The protocol MUST verify that `sessionVerifier` is authorized for `account` before calling the account router. Unauthorized verifiers MUST fail as a precheck rather than receiving a validation call.
 - Fixed validation gas limits bound verifier execution. Verifiers that exceed the limit fail validation, and all signature and policy validation gas counts against `BLOCK_VALIDATION_GAS_BUDGET`.

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -1,7 +1,7 @@
 ---
 wip: 1001
 title: World Chain Native Account Abstraction
-description: A predeploy-managed account model whose admin and session authorization are verified through EIP-1271 smart contract signers.
+description: A predeploy-managed account model whose admin and session authorization are verified through an account-routed EIP-1271 verifier system.
 author: Kilian Glas (@kilianglas), 0xOsiris (@0xOsiris), Eric Woolsey (@0xforerunner)
 status: Draft
 type: Standards Track
@@ -35,9 +35,8 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 | `WORLD_TX_TYPE` | `uint8` | `0x1D` | EIP-2718 transaction type for World Chain account transactions. |
 | `MAX_SESSION_VERIFIERS` | `uint256` | `20` | Maximum active session verifiers per account. |
 | `WORLD_CHAIN_ACCOUNT_DOMAIN` | `bytes32` | `keccak256("WIP1001_ACCOUNT")` | Domain for account address derivation. |
-| `WORLD_CHAIN_ADMIN_CREATE_DOMAIN` | `bytes32` | `keccak256("WIP1001_ADMIN_CREATE")` | Domain for account creation authorization. |
-| `WORLD_CHAIN_SET_KEY_RING_DOMAIN` | `bytes32` | `keccak256("WIP1001_SET_KEY_RING")` | Domain for key ring replacement authorization. |
-| `WIP1001_SIGNER_DOMAIN` | `bytes32` | `keccak256("WIP1001_SIGNER")` | Domain for default factory `CREATE2` salts. |
+| `WORLD_CHAIN_ACCOUNT_CREATE_DOMAIN` | `bytes32` | `keccak256("WORLD_CHAIN_ACCOUNT_CREATE")` | Domain for account creation authorization. |
+| `WORLD_CHAIN_ACCOUNT_SET_DOMAIN` | `bytes32` | `keccak256("WORLD_CHAIN_ACCOUNT_SET")` | Domain for key ring replacement authorization. |
 
 ### Activation Parameters
 
@@ -46,6 +45,7 @@ WIP-1001 MUST NOT activate until every parameter below is assigned in fork confi
 | Name | Type | Value | Requirement |
 | --- | --- | --- | --- |
 | `WORLD_CHAIN_ACCOUNT_MANAGER` | `address` | TBD | Predeploy address for the account manager. |
+| `WORLD_CHAIN_ACCOUNT_ROUTER_CODE_HASH` | `bytes32` | TBD | Runtime code hash required at every World Chain account address. |
 | `EIP1271_VALIDATION_GAS_LIMIT` | `uint64` | TBD | Fixed gas forwarded to `isValidSignature`. |
 | `EXECUTION_TRACE_VALIDATION_GAS_LIMIT` | `uint64` | TBD | Fixed gas forwarded to `evaluateSessionPolicy`. |
 | `BLOCK_VALIDATION_GAS_BUDGET` | `uint64` | TBD | Per-block gas budget reserved for `0x1D` validation calls. |
@@ -55,7 +55,7 @@ WIP-1001 MUST NOT activate until every parameter below is assigned in fork confi
 | `MAX_ACCESS_LIST_ENTRIES` | `uint32` | TBD | Maximum number of [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) access-list entries in a `0x1D` envelope. |
 | `MAX_SESSION_SIGNATURE_BYTES` | `uint32` | TBD | Maximum length of the session `signature` field. |
 | `MAX_ADMIN_AUTHORIZATION_BYTES` | `uint32` | TBD | Maximum length of `adminAuthorization` calldata. |
-| `WORLD_ID_1271_SIGNER_FACTORY` | `address` | TBD | Default World ID EIP-1271 signer factory. |
+| `MAX_VERIFIER_INSTALL_DATA_BYTES` | `uint32` | TBD | Maximum length of `installData` in an admin or session verifier configuration. |
 | `EDDSA_PRECOMPILE` | `address` | TBD | EdDSA verification precompile address and ABI. |
 | `BLS12_381_PRECOMPILE` | `address` | TBD | BLS12-381 verification precompile address and ABI. |
 
@@ -83,53 +83,64 @@ World Chain accounts are created and managed by `WORLD_CHAIN_ACCOUNT_MANAGER`.
 
 ```solidity
 struct Account {
-    address adminSigner;
+    WorldChainAccountVerifier admin;
     bytes32 accountSalt;
-    SessionVerifier[] sessionVerifiers;
+    WorldChainAccountVerifier[] sessionVerifiers;
     bytes32 keyRingHash;
     uint64 adminNonce;
     uint64 transactionNonce;
 }
 
-struct SessionVerifier {
+struct WorldChainAccountVerifier {
     address verifier;
+    bytes installation;
 }
 ```
 
 For every existing account:
 
-- `adminSigner` MUST be deployed as an EIP-1271 contract and is immutable for the life of the account address.
-- `sessionVerifiers.length` MUST be in `[1, MAX_SESSION_VERIFIERS]`.
-- each `SessionVerifier.verifier` MUST be a deployed contract adhering to EIP-1271 and `IWorldChainSessionVerifier`;
+- the account address MUST have deployed runtime bytecode whose hash equals `WORLD_CHAIN_ACCOUNT_ROUTER_CODE_HASH`;
+- `admin.verifier` MUST be a deployed EIP-1271 verifier implementation and the full `admin` value is immutable for the life of the account address;
+- `sessionVerifiers.length` MUST be in `[1, MAX_SESSION_VERIFIERS]`;
+- each `installation.length` in `admin` and `sessionVerifiers` MUST be at most `MAX_VERIFIER_INSTALL_DATA_BYTES`;
+- each `SessionVerifier.verifier` MUST be a deployed EIP-1271 verifier implementation adhering to `IWorldChainSessionVerifier`;
 - `sessionVerifiers` MUST NOT contain duplicate verifier addresses;
 - `keyRingHash == keccak256(abi.encode(sessionVerifiers))`;
 - `adminNonce` is consumed only by admin operations;
 - `transactionNonce` is consumed only by successful `0x1D` transaction execution attempts;
 
-After account creation, `setKeyRing` is the only execution path that mutates `sessionVerifiers` or `keyRingHash`.
+Verifier behavior is selected by verifier implementation address, not by a protocol-level enum. `installData` is opaque to the protocol and is interpreted only by the selected verifier implementation.
+
+After account creation, `setKeyRing` is the only execution path that mutates `sessionVerifiers`, `keyRingHash`, or validation-affecting account storage for active session verifiers. WIP-1001 defines no operation that mutates `admin` or the account router runtime code.
 
 #### Address Derivation
 
 The manager derives an account address as:
 
 ```solidity
+adminHash = keccak256(abi.encode(admin));
+
 account = address(uint160(uint256(keccak256(abi.encode(
     WORLD_CHAIN_ACCOUNT_DOMAIN,
     chainId,
     WORLD_CHAIN_ACCOUNT_MANAGER,
-    adminSigner,
+    WORLD_CHAIN_ACCOUNT_ROUTER_CODE_HASH,
+    adminHash,
     accountSalt
 )))));
 ```
 
-The address binds the account to the manager instance, chain, admin signer, and salt. WIP-1001 defines no operation that rotates `adminSigner` for an existing account.
+The address binds the account to the manager instance, chain, account router runtime code, full admin verifier configuration, and salt. WIP-1001 defines no operation that rotates or reinstalls `admin` for an existing account.
 
 #### Admin Operation Hashes
 
 For every admin authorization, the manager computes a domain-separated `adminOperationHash` and calls:
 
 ```solidity
-adminSigner.isValidSignature(adminOperationHash, adminAuthorization)
+IWorldChainAccountRouter(account).isValidSignatureForAdmin(
+    adminOperationHash,
+    adminAuthorization
+)
 ```
 
 The hash for each operation is:
@@ -139,8 +150,9 @@ createHash = keccak256(abi.encode(
     WORLD_CHAIN_ADMIN_CREATE_DOMAIN,
     chainId,
     WORLD_CHAIN_ACCOUNT_MANAGER,
+    WORLD_CHAIN_ACCOUNT_ROUTER_CODE_HASH,
     account,
-    adminSigner,
+    adminHash,
     accountSalt,
     keyRingHash
 ));
@@ -156,18 +168,54 @@ setKeyRingHash = keccak256(abi.encode(
 ));
 ```
 
-### Signer Interfaces
+### Account Router and Verifier Interfaces
 
-The admin signer has no protocol ABI beyond EIP-1271:
+The account router is the only validation target called by the manager. It dispatches to configured verifier implementations using a single controlled `DELEGATECALL`, so verifier implementations execute against the account's storage.
 
 ```solidity
-interface IWorldChainAdminSigner is IERC1271 {}
+interface IWorldChainAccountRouter {
+    function installAdmin(WorldChainAccountVerifier calldata admin) external;
+
+    function installKeyRing(
+        WorldChainAccountVerifier[] calldata sessionVerifiers
+    ) external;
+
+    function isValidSignatureForAdmin(
+        bytes32 hash,
+        bytes calldata signature
+    ) external view returns (bytes4 magicValue);
+
+    function isValidSignatureForVerifier(
+        address verifier,
+        bytes32 hash,
+        bytes calldata signature
+    ) external view returns (bytes4 magicValue);
+
+    function evaluateSessionPolicyForVerifier(
+        address verifier,
+        IWorldChainSessionVerifier.ExecutionTraceContext calldata context
+    ) external view returns (bool allowed);
+}
 ```
 
-Session verifier contracts MUST implement EIP-1271 and:
+`installAdmin` and `installKeyRing` MUST reject any caller other than `WORLD_CHAIN_ACCOUNT_MANAGER`. The account router MUST expose no non-manager path that can mutate validation-affecting verifier storage. `isValidSignatureForAdmin`, `isValidSignatureForVerifier`, and `evaluateSessionPolicyForVerifier` MUST be callable by `WORLD_CHAIN_ACCOUNT_MANAGER` in restricted validation frames.
+
+The account router MUST dispatch admin validation only to its installed `admin.verifier`. It MUST dispatch session validation only to an installed session verifier address; unknown session verifier addresses MUST fail without executing verifier implementation code.
+
+`isValidSignatureForAdmin` and `isValidSignatureForVerifier` MUST dispatch using calldata `IERC1271.isValidSignature.selector || abi.encode(hash, signature)`. `evaluateSessionPolicyForVerifier` MUST dispatch using calldata `IWorldChainSessionVerifier.evaluateSessionPolicy.selector || abi.encode(context)`.
+
+Verifier implementations install scoped storage through the following installation hook:
 
 ```solidity
-interface IWorldChainSessionVerifier is IERC1271 {
+interface IWorldChainAccountHooks {
+    function install(bytes calldata installation) external;
+}
+```
+
+Admin verifier implementations MUST implement EIP-1271 and `IWorldChainAccountVerifierHooks`. Session verifier implementations MUST implement EIP-1271, `IWorldChainVerifierInstaller`, and:
+
+```solidity
+interface IWorldChainSessionVerifier is IERC1271, IWorldChainAccountHooks {
     struct AccessListEntry {
         address account;
         bytes32[] storageKeys;
@@ -238,6 +286,10 @@ interface IWorldChainSessionVerifier is IERC1271 {
 }
 ```
 
+`installation` is verifier-defined. The protocol does not parse it, but it commits to it through `adminHash`, `createHash`, and `keyRingHash`. A verifier implementation's `install` function MUST fully write all validation-affecting state implied by `installation` into the verifier's own deterministic account-storage namespace. Removed verifier state MAY remain in account storage, but it MUST be unreachable unless that verifier address is installed again through a later `setKeyRing`.
+
+Verifier implementations MUST NOT rely on validation-affecting state stored at the verifier implementation address. Validation-affecting state MUST live in account storage installed through the account router.
+
 ### Manager Interface
 
 `WORLD_CHAIN_ACCOUNT_MANAGER` exposes:
@@ -245,9 +297,9 @@ interface IWorldChainSessionVerifier is IERC1271 {
 ```solidity
 interface IWorldChainAccountManager {
     function create(
-        address adminSigner,
+        WorldChainAccountVerifier calldata admin,
         bytes32 accountSalt,
-        SessionVerifier[] calldata initialSessionVerifiers,
+        WorldChainAccountVerifier[] calldata initialSessionVerifiers,
         bytes calldata adminAuthorization
     ) external returns (address account);
 
@@ -258,13 +310,13 @@ interface IWorldChainAccountManager {
         bytes calldata adminAuthorization
     ) external;
 
-    function getAdminSigner(address account) external view returns (address);
+    function getAdmin(address account) external view returns (WorldChainAccountVerifier memory);
     function getAdminNonce(address account) external view returns (uint64);
     function getTransactionNonce(address account) external view returns (uint64);
     function getKeyRingHash(address account) external view returns (bytes32);
-    function getSessionVerifiers(address account) external view returns (SessionVerifier[] memory);
+    function getSessionVerifiers(address account) external view returns (WorldChainAccountVerifier[] memory);
     function isAuthorizedSessionVerifier(address account, address sessionVerifier) external view returns (bool);
-    function getAuthorizedSessionVerifier(address account, address sessionVerifier) external view returns (SessionVerifier memory);
+    function getAuthorizedSessionVerifier(address account, address sessionVerifier) external view returns (WorldChainAccountVerifier memory);
 }
 ```
 
@@ -276,7 +328,8 @@ Each successful state transition MUST emit exactly one matching event in the sam
 interface IWorldChainAccountManagerEvents {
     event AccountCreated(
         address indexed account,
-        address indexed adminSigner,
+        address indexed adminVerifier,
+        bytes32 indexed adminHash,
         bytes32 accountSalt,
         bytes32 keyRingHash
     );
@@ -292,25 +345,31 @@ interface IWorldChainAccountManagerEvents {
 
 ### Manager State Transitions
 
-Every admin-mutating method MUST reject `adminAuthorization.length > MAX_ADMIN_AUTHORIZATION_BYTES`. If any requirement in a manager state transition fails, the method MUST revert without changing account state, incrementing `adminNonce`, or emitting its state-transition event.
+Every admin-mutating method MUST reject `adminAuthorization.length > MAX_ADMIN_AUTHORIZATION_BYTES`. It MUST also reject any `installData.length > MAX_VERIFIER_INSTALL_DATA_BYTES`. If any requirement in a manager state transition fails, the method MUST revert without changing account state, account code, account storage, incrementing `adminNonce`, or emitting its state-transition event.
 
-Admin authorization is valid only when `adminSigner.isValidSignature(adminOperationHash, adminAuthorization)` succeeds in a restricted validation frame and returns `EIP1271_MAGIC_VALUE`.
+Admin authorization is valid only when `IWorldChainAccountRouter(account).isValidSignatureForAdmin(adminOperationHash, adminAuthorization)` succeeds in a restricted validation frame and returns `EIP1271_MAGIC_VALUE`.
+
+Installing canonical account-router runtime bytecode is a native manager state transition. It MUST NOT execute account-supplied init code and MUST NOT be represented as an EVM `CREATE` or `CREATE2` from the manager.
 
 #### `create`
 
 `create` MUST:
 
-1. reject `adminSigner == address(0)`;
-2. require `adminSigner` and each initial session verifier to have deployed code;
+1. reject `admin.verifier == address(0)`;
+2. require `admin.verifier` and each initial session verifier to have deployed code;
 3. require `initialSessionVerifiers.length` to be in `[1, MAX_SESSION_VERIFIERS]`;
 4. reject duplicate or zero session verifier addresses;
-5. derive `account`;
-6. reject if `account` already exists;
-7. compute `keyRingHash = keccak256(abi.encode(initialSessionVerifiers))`;
-8. verify `createHash` through `adminSigner`;
-9. if `WORLD_ID_1271_SIGNER_FACTORY.isFactorySigner(adminSigner) == true`, require `IWorldIDAdminSigner(adminSigner).account() == account`;
-10. initialize account state with `adminNonce = 0`, `transactionNonce = 0`, `sessionVerifiers = initialSessionVerifiers`, and `keyRingHash`;
-11. emit `AccountCreated(account, adminSigner, accountSalt, keyRingHash)`.
+5. reject oversized `admin.installData` or session verifier `installData`;
+6. compute `adminHash = keccak256(abi.encode(admin))`;
+7. derive `account`;
+8. reject if `account` already exists or already has deployed code;
+9. compute `keyRingHash = keccak256(abi.encode(initialSessionVerifiers))`;
+10. atomically install canonical account-router runtime bytecode at `account`;
+11. call `IWorldChainAccountRouter(account).installAdmin(admin)`;
+12. call `IWorldChainAccountRouter(account).installKeyRing(initialSessionVerifiers)`;
+13. verify `createHash` through the account router's admin validation path;
+14. initialize manager state with `admin`, `adminNonce = 0`, `transactionNonce = 0`, `sessionVerifiers = initialSessionVerifiers`, and `keyRingHash`;
+15. emit `AccountCreated(account, admin.verifier, adminHash, accountSalt, keyRingHash)`.
 
 #### `setKeyRing`
 
@@ -319,24 +378,29 @@ Admin authorization is valid only when `adminSigner.isValidSignature(adminOperat
 1. require `account` to exist;
 2. require `expectedCurrentKeyRingHash == keyRingHash`;
 3. require `sessionVerifiers.length` to be in `[1, MAX_SESSION_VERIFIERS]`;
-4. reject duplicate, zero, or undeployed session verifier addresses;
+4. reject duplicate, zero, undeployed, or oversized session verifier entries;
 5. compute `newKeyRingHash = keccak256(abi.encode(sessionVerifiers))`;
 6. reject `newKeyRingHash == keyRingHash`;
 7. compute `setKeyRingHash` using the current `adminNonce`;
-8. verify `setKeyRingHash` through `adminSigner`;
-9. set `previousKeyRingHash = keyRingHash`;
-10. replace the account's full `sessionVerifiers` set with the supplied `sessionVerifiers`;
-11. set `keyRingHash = newKeyRingHash`;
-12. increment `adminNonce` by one;
-13. emit `KeyRingSet(account, previousKeyRingHash, newKeyRingHash, adminNonce)`.
+8. verify `setKeyRingHash` through the account router's admin validation path;
+9. call `IWorldChainAccountRouter(account).installKeyRing(sessionVerifiers)`;
+10. set `previousKeyRingHash = keyRingHash`;
+11. replace the account's full `sessionVerifiers` set with the supplied `sessionVerifiers`;
+12. set `keyRingHash = newKeyRingHash`;
+13. increment `adminNonce` by one;
+14. emit `KeyRingSet(account, previousKeyRingHash, newKeyRingHash, adminNonce)`.
 
 ### Restricted Validation Frames
 
 The protocol uses restricted validation frames for admin authorization, session signature verification, and session policy evaluation.
 
-For each EIP-1271 signature check, the protocol MUST perform a `STATICCALL` from `WORLD_CHAIN_ACCOUNT_MANAGER` to the signer with value `0`, gas exactly `EIP1271_VALIDATION_GAS_LIMIT`, and calldata `IERC1271.isValidSignature.selector || abi.encode(hash, signature)`. The call succeeds only if it returns `EIP1271_MAGIC_VALUE` and triggers no tracer rule violation.
+For each admin EIP-1271 signature check, the protocol MUST perform a `STATICCALL` from `WORLD_CHAIN_ACCOUNT_MANAGER` to the account router with value `0`, gas exactly `EIP1271_VALIDATION_GAS_LIMIT`, and calldata `IWorldChainAccountRouter.isValidSignatureForAdmin.selector || abi.encode(hash, signature)`. The call succeeds only if it returns `EIP1271_MAGIC_VALUE` and triggers no tracer rule violation.
 
-For each session policy check, the protocol MUST perform a `STATICCALL` from `WORLD_CHAIN_ACCOUNT_MANAGER` to the session verifier with value `0`, gas exactly `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`, and calldata `IWorldChainSessionVerifier.evaluateSessionPolicy.selector || abi.encode(context)`. The call succeeds only if it returns `true` and triggers no tracer rule violation.
+For each session EIP-1271 signature check, the protocol MUST perform a `STATICCALL` from `WORLD_CHAIN_ACCOUNT_MANAGER` to the account router with value `0`, gas exactly `EIP1271_VALIDATION_GAS_LIMIT`, and calldata `IWorldChainAccountRouter.isValidSignatureForVerifier.selector || abi.encode(sessionVerifier, hash, signature)`. The call succeeds only if it returns `EIP1271_MAGIC_VALUE` and triggers no tracer rule violation.
+
+For each session policy check, the protocol MUST perform a `STATICCALL` from `WORLD_CHAIN_ACCOUNT_MANAGER` to the account router with value `0`, gas exactly `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`, and calldata `IWorldChainAccountRouter.evaluateSessionPolicyForVerifier.selector || abi.encode(sessionVerifier, context)`. The call succeeds only if it returns `true` and triggers no tracer rule violation.
+
+The manager MUST NOT call admin or session verifier implementation addresses directly for validation. Verifier implementation code is reached only through the canonical account router dispatch.
 
 Failure, revert, out-of-gas, malformed return data, or a tracer violation MUST be treated as signature or policy failure.
 
@@ -352,13 +416,19 @@ Restricted frames are enforced by a runtime opcode-and-target tracer derived fro
 | `WIP1001-VR-6` | OP-031, OP-040 | Forbid `CALL`, `CALLCODE`, `CREATE`, `CREATE2`. |
 | `WIP1001-VR-7` | OP-051 | Forbid `SELFDESTRUCT`. |
 | `WIP1001-VR-8` | OP-061 | Permit `STATICCALL` only to allowlisted precompiles. |
-| `WIP1001-VR-9` | OP-052 | Permit `DELEGATECALL` only when the delegatee bytecode satisfies the same rule set. The tracer MUST validate delegatees recursively. |
+| `WIP1001-VR-9` | OP-052 | Permit exactly one `DELEGATECALL` from canonical account-router bytecode to the selected configured verifier implementation: `admin.verifier` for admin validation or the authorized `sessionVerifier` for session validation. Forbid every other `DELEGATECALL`, including nested `DELEGATECALL` from verifier implementation code. |
 | `WIP1001-VR-10` | - | Precompile execution does not create an additional EVM code frame. |
-| `WIP1001-VR-11` | - | Permit reads of the signer contract's own bytecode via `CODECOPY` and `CODESIZE`. |
-| `WIP1001-VR-12` | - | Permit reads of the signer contract's own storage via `SLOAD`. |
+| `WIP1001-VR-11` | - | Permit reads of the current execution frame's own bytecode via `CODECOPY` and `CODESIZE`. |
+| `WIP1001-VR-12` | - | Permit reads of account storage via `SLOAD`. |
 | `WIP1001-VR-13` | - | Permit `KECCAK256`, `CHAINID`, `GAS`, stack, memory, calldata, and deterministic arithmetic opcodes. |
 
 Adding a new precompile to the validation allowlist is a hard-fork change.
+
+### Verifier Installation Frames
+
+`installAdmin` and `installKeyRing` are state-mutating account setup paths, not EIP-1271 validation frames. During installation, the account router MUST perform at most one direct `DELEGATECALL` per verifier entry with calldata `IWorldChainVerifierInstaller.install.selector || abi.encode(installData)`. Verifier implementation code MUST NOT execute `DELEGATECALL` from within `install`.
+
+If an install hook reverts, exhausts gas, or violates the nested-`DELEGATECALL` ban, the enclosing `create` or `setKeyRing` MUST revert atomically.
 
 ### Transaction Type `0x1D`
 
@@ -446,13 +516,13 @@ To include a `0x1D` transaction, the protocol MUST:
 3. require `sessionVerifier` to be authorized for `account` in the current `sessionVerifiers` set and load the current `keyRingHash`;
 4. require the account balance to cover the worst-case payload gas charge and `MIN_VALIDATION_FAILURE_FEE`;
 5. compute `signingHash`;
-6. call `sessionVerifier.isValidSignature(signingHash, signature)` in a restricted validation frame;
+6. call `IWorldChainAccountRouter(account).isValidSignatureForVerifier(sessionVerifier, signingHash, signature)` in a restricted validation frame;
 7. if signature validation fails, apply validation-failure semantics and stop;
 8. increment `Account.transactionNonce` by one;
 9. execute the payload tentatively with `account` as the EVM sender and gas charged against envelope `gasLimit`;
 10. construct `ExecutionTraceContext` with `context.transaction.keyRingHash` set to the current account `keyRingHash`;
 11. if `abi.encode(context.trace).length > MAX_EXECUTION_TRACE_BYTES`, discard tentative payload state, apply trace-overflow semantics, and stop;
-12. call `sessionVerifier.evaluateSessionPolicy(context)` in a restricted validation frame;
+12. call `IWorldChainAccountRouter(account).evaluateSessionPolicyForVerifier(sessionVerifier, context)` in a restricted validation frame;
 13. if policy validation fails, discard tentative payload state, apply validation-failure semantics, and stop;
 14. otherwise commit the normal payload result, including a reverted payload result if the target call reverted.
 
@@ -485,19 +555,21 @@ A client MAY reuse a prior successful signature-validation result only when the 
 
 The `keyRingHash` comparison is the deterministic anchor for block validation: a verifier MAY accept a cached signature result only if the active account hash equals the recorded hash; otherwise it MUST execute signature validation again.
 
-### Signer-State Determinism
+### Verifier-State Determinism
 
-Session verifier behavior that can change `isValidSignature` or `evaluateSessionPolicy` for already accepted transactions MUST be immutable for a verifier address. Validation-affecting updates MUST be represented by deploying or selecting a different session verifier address and installing a replacement set through `setKeyRing`, which updates `keyRingHash`.
+Session verifier behavior that can change `isValidSignature` or `evaluateSessionPolicy` for already accepted transactions MUST be immutable while `keyRingHash` is unchanged. Validation-affecting updates MUST be represented by installing a replacement key ring through `setKeyRing`, which updates `keyRingHash`. A replacement key ring MAY reuse the same verifier implementation address with different `installData`, but the changed `installData` MUST be committed through the new `keyRingHash`.
 
-This applies to root rotations, verification-key rotations, signer recovery changes, signer revocation lists, account binding changes, and policy configuration changes. State that cannot affect validation MAY update in place.
+Verifier implementation contracts MUST NOT be upgradeable for validation-affecting behavior. Implementations that route validation through upgradeable proxies, beacons, mutable implementation pointers, nested `DELEGATECALL`, or mutable external state are non-conformant. This applies to root rotations, verification-key rotations, signer recovery changes, signer revocation lists, account binding changes, and policy configuration changes. State that cannot affect validation MAY update in place.
 
 ## Rationale
 
-EIP-1271 gives World Chain one protocol boundary for all authorization schemes. The protocol verifies a signer contract; the signer contract decides how to authenticate.
+EIP-1271 gives World Chain one protocol boundary for all authorization schemes. The protocol verifies through the account router; verifier implementation code decides how to authenticate.
+
+Account-resident routing gives each World Chain account one deployed code body while allowing different admin and session verifier implementations to write and read account-local validation state. The verifier address is the dispatch selector; the protocol does not define a verifier-type enum.
 
 Execution policy belongs inside the session verifier. The protocol supplies the canonical transaction context and execution trace, then asks the verifier for a boolean decision.
 
-Validation gas limits are protocol constants, not signer-selected values. This gives clients a fixed resource bound for mempool validation and block execution.
+Validation gas limits are protocol constants, not verifier-selected values. This gives clients a fixed resource bound for mempool validation and block execution.
 
 Validation gas is supplied from a per-block budget rather than the envelope `gasLimit`. This keeps the payload gas model close to EIP-1559 transactions while bounding validation work per block.
 
@@ -509,48 +581,44 @@ Restricted validation frames prevent validation from depending on mutable extern
 
 WIP-1001 introduces a new EIP-2718 transaction type and a new account manager predeploy. Existing Ethereum transaction types, EOAs, contracts, and Safe accounts are unchanged.
 
-Existing Safe accounts MAY deploy or delegate to EIP-1271 signer contracts that satisfy this specification, but WIP-1001 does not require Safe migration.
+Existing Safe accounts MAY use EIP-1271 verifier contracts that satisfy the same deterministic-validation constraints, but WIP-1001 does not require Safe migration.
 
 ## Test Cases
 
 Conforming implementations MUST pass vectors for:
 
-- address derivation across multiple `(chainId, manager, adminSigner, accountSalt)` tuples;
-- `keyRingHash = keccak256(abi.encode(sessionVerifiers))` for empty-forbidden, single-verifier, multi-verifier, and reordered verifier sets;
-- `create` validation, including deployed-code checks, duplicate and zero verifier rejection, account-exists rejection, initial nonce values, initial `keyRingHash`, `AccountCreated`, and default World ID admin signer account binding;
+- address derivation across multiple `(chainId, manager, routerCodeHash, adminHash, accountSalt)` tuples;
+- `adminHash = keccak256(abi.encode(admin))` and `keyRingHash = keccak256(abi.encode(sessionVerifiers))` for install data changes, empty-forbidden, single-verifier, multi-verifier, and reordered verifier sets;
+- `create` validation, including account-router code installation, admin install, key-ring install, deployed-code checks, duplicate and zero verifier rejection, account-exists/code-exists rejection, initial nonce values, initial `keyRingHash`, and `AccountCreated`;
 - `setKeyRing` validation, including stale `expectedCurrentKeyRingHash`, duplicate, zero, undeployed, empty, oversized, and no-op verifier set rejection;
-- `setKeyRing` success behavior, including full-set replacement, `newKeyRingHash`, `adminNonce` increment, `KeyRingSet`, authorization lookup updates, and failure atomicity;
+- `setKeyRing` success behavior, including full-set replacement, verifier reinstall, `newKeyRingHash`, `adminNonce` increment, `KeyRingSet`, authorization lookup updates, and failure atomicity;
 - `createHash` and `setKeyRingHash` domain separation, parameter binding, nonce binding, and negative replay cases across accounts, chains, managers, hashes, and operation types;
 - `0x1D` RLP encoding, signing hash, and transaction hash;
 - malformed envelope rejection for `chainId`, `nonce`, `to`, `data`, `accessList`, `signature`, and EIP-1559 fee bounds;
-- transaction validation against the current verifier set, including unauthorized verifier rejection and `ExecutionTraceContext.transaction.keyRingHash`;
+- transaction validation against the current verifier set, including account-router dispatch, unauthorized verifier rejection, and `ExecutionTraceContext.transaction.keyRingHash`;
 - failure semantics for envelope/precheck failures, validation-budget exhaustion, signature failures, trace overflow, policy failures, and payload reverts;
 - txpool revalidation, signature-validation cache reuse, and cache invalidation when `keyRingHash`, verifier membership, account balance, or nonce eligibility changes;
-- signer-state determinism, including rejection of validation-affecting session verifier updates behind an unchanged verifier address;
-- restricted-frame positive cases and each forbidden opcode or call target;
-- default signer factory `CREATE2` address computation, idempotency, metadata, and incompatible-code rejection;
-- World ID `worldIdField`, `worldIdAction`, admin proof, and session proof inputs;
-- default secp256k1 low-s, `v`, owner, and signature-length checks;
+- verifier-state determinism, including rejection of validation-affecting session verifier updates behind an unchanged `keyRingHash`;
+- restricted-frame positive cases, the single account-router `DELEGATECALL` exception, nested `DELEGATECALL` rejection, and each forbidden opcode or call target;
+- install hook success, install hook failure atomicity, install-data length bounds, and namespaced account-storage behavior;
 - block validation budget exhaustion and validation-failure fee charging.
 
 Complete golden vectors and a conformance test suite MUST be published before this WIP advances to Review.
 
 ## Security Considerations
 
-- Admin authorization hashes bind domain, chain ID, manager, account, operation parameters, and nonce where applicable. A signature valid for `create` MUST NOT be valid for `setKeyRing`, another account, another chain, another manager, or another key ring hash.
-- The admin signer is immutable in the account address. A broken or lost admin signer requires migrating assets to a new account; applications that need recovery SHOULD use admin signers with recovery or multisig logic from account creation.
+- Admin authorization hashes bind domain, chain ID, manager, account router code hash, account, operation parameters, and nonce where applicable. A signature valid for `create` MUST NOT be valid for `setKeyRing`, another account, another chain, another manager, another router code hash, or another key ring hash.
+- The full admin verifier configuration is immutable in the account address. A broken or lost admin verifier configuration requires migrating assets to a new account; applications that need recovery SHOULD use admin verifier implementations with recovery or multisig logic from account creation.
 - `setKeyRing` is the only post-creation key ring mutation path. A compromised session verifier remains authorized until an admin-authorized replacement set is included.
 - `expectedCurrentKeyRingHash` protects `setKeyRing` authorizations from applying to an unexpected current set. Admin tooling SHOULD surface the complete replacement set before signing because omitted verifiers are removed atomically.
-- `keyRingHash` binds cached validation to the ordered `SessionVerifier[]` set. Clients MUST discard cached signature results when the active hash changes, even if the transaction's `sessionVerifier` remains present in the new set.
-- `keyRingHash` does not commit to mutable verifier behavior by itself. Session verifier state that can affect `isValidSignature` or `evaluateSessionPolicy` MUST be immutable for that verifier address; upgrades that affect validation require a new verifier address installed through `setKeyRing`.
-- The protocol MUST verify that `sessionVerifier` is authorized for `account` before calling EIP-1271. Unauthorized verifiers MUST fail as a precheck rather than receiving a validation call.
-- Fixed validation gas limits bound signer execution. Signers that exceed the limit fail validation, and all signature and policy validation gas counts against `BLOCK_VALIDATION_GAS_BUDGET`.
+- `keyRingHash` binds cached validation to the ordered `SessionVerifier[]` set, including verifier addresses and install data. Clients MUST discard cached signature results when the active hash changes, even if the transaction's `sessionVerifier` remains present in the new set.
+- `keyRingHash` does not commit to mutable verifier implementation behavior by itself. Session verifier code and validation-affecting installed state MUST be immutable while the hash is unchanged; upgrades that affect validation require `setKeyRing`.
+- The protocol MUST verify that `sessionVerifier` is authorized for `account` before calling the account router. Unauthorized verifiers MUST fail as a precheck rather than receiving a validation call.
+- Fixed validation gas limits bound verifier execution. Verifiers that exceed the limit fail validation, and all signature and policy validation gas counts against `BLOCK_VALIDATION_GAS_BUDGET`.
 - `BLOCK_VALIDATION_GAS_BUDGET` is scarce. `MIN_VALIDATION_FAILURE_FEE` MUST be tuned so validation spam is costly, and clients MUST reject pooled transactions that cannot pay it.
 - Builders may prefer transactions with cheaper validation profiles. Fixed validation gas bounds the worst-case bias but does not eliminate ordering incentives.
-- `MAX_EXECUTION_TRACE_BYTES`, `MAX_PAYLOAD_DATA_BYTES`, `MAX_ACCESS_LIST_ENTRIES`, `MAX_SESSION_SIGNATURE_BYTES`, and `MAX_ADMIN_AUTHORIZATION_BYTES` bound calldata, decoding, memory, and ABI-encoding costs.
-- Restricted frames forbid mutable external-state reads and block-context opcodes. Signers that need time, block, or external-state constraints MUST bind them into the signature or proof input.
-- `DELEGATECALL` inside restricted validation frames is safe only when the delegatee bytecode satisfies the same tracer rules recursively.
+- `MAX_EXECUTION_TRACE_BYTES`, `MAX_PAYLOAD_DATA_BYTES`, `MAX_ACCESS_LIST_ENTRIES`, `MAX_SESSION_SIGNATURE_BYTES`, `MAX_ADMIN_AUTHORIZATION_BYTES`, and `MAX_VERIFIER_INSTALL_DATA_BYTES` bound calldata, decoding, memory, storage, and ABI-encoding costs.
+- Restricted frames forbid mutable external-state reads and block-context opcodes. Verifiers that need time, block, or external-state constraints MUST bind them into the signature or proof input.
+- `DELEGATECALL` is permitted only for the account router's direct dispatch to the selected configured verifier implementation. Nested verifier `DELEGATECALL` is forbidden.
 - The `0x1D` envelope exposes `account` and `sessionVerifier`. Applications that need stronger privacy should use verifier contracts that aggregate or rotate credentials.
-- World ID signers MUST bind `block.chainid` into `worldIdAction` or session nonce inputs to prevent cross-chain proof replay.
-- The default World ID admin signer self-reports `account()`. The manager checks this only for default-factory-deployed World ID admin signers; custom signers are responsible for their own consistency.
 - `create` does not bind `msg.sender`, so a copied call can be front-run. The resulting account state is identical because the authorization commits to all state-determining parameters.

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -109,8 +109,9 @@ For every existing account:
 - `adminNonce` is consumed only by admin operations;
 - `transactionNonce` is consumed only by successful `0x1D` transaction execution attempts;
 
-After account creation, `setKeyRing` is the only execution path that mutates `sessionVerifiers` or `keyRingHash`.
+Verifier behavior is selected by verifier implementation address, not by a protocol-level enum. `installation` is opaque to the protocol and is interpreted only by the selected verifier implementation.
 
+After account creation, `setKeyRing` is the only execution path that mutates `sessionVerifiers`, `keyRingHash`, or validation-affecting account storage for active session verifiers. WIP-1001 defines no operation that mutates `admin` or the account router runtime code.
 
 #### Address Derivation
 
@@ -169,7 +170,7 @@ setKeyRingHash = keccak256(abi.encode(
 
 ### Account Router and Verifier Interfaces
 
-The account router is the runtime byte code that lives at all World Chain Accounts. It acts as a proxy router over the admin, and all `sessionVerifiers`.
+The account router is the only validation target called by the manager. It dispatches to configured verifier implementations using a single controlled `DELEGATECALL`, so verifier implementations execute against the account's storage.
 
 ```solidity
 interface IWorldChainAccountRouter {
@@ -197,7 +198,7 @@ interface IWorldChainAccountRouter {
 }
 ```
 
-`installAdmin` and `installKeyRing` MUST reject any caller other than `WORLD_CHAIN_ACCOUNT_MANAGER`. The account router MUST expose no non-manager path that can mutate validation-affecting verifier storage. `isValidSignatureForAdmin`, `isValidSignatureForVerifier`, and `evaluateSessionPolicyForVerifier` MUST be callable in restricted validation frames.
+`installAdmin` and `installKeyRing` MUST reject any caller other than `WORLD_CHAIN_ACCOUNT_MANAGER`. The account router MUST expose no non-manager path that can mutate validation-affecting verifier storage. `isValidSignatureForAdmin`, `isValidSignatureForVerifier`, and `evaluateSessionPolicyForVerifier` MUST be callable by `WORLD_CHAIN_ACCOUNT_MANAGER` in restricted validation frames.
 
 The account router MUST dispatch admin validation only to its installed `admin.verifier`. It MUST dispatch session validation only to an installed session verifier address; unknown session verifier addresses MUST fail without executing verifier implementation code.
 
@@ -388,7 +389,123 @@ Installing canonical account-router runtime bytecode is a native manager state t
 12. set `keyRingHash = newKeyRingHash`;
 13. increment `adminNonce` by one;
 14. emit `KeyRingSet(account, previousKeyRingHash, newKeyRingHash, adminNonce)`.
+
 ### Restricted Validation Frames
+
+The protocol uses restricted validation frames for admin authorization, session signature verification, and session policy evaluation.
+
+For each admin EIP-1271 signature check, the protocol MUST perform a `STATICCALL` from `WORLD_CHAIN_ACCOUNT_MANAGER` to the account router with value `0`, gas exactly `EIP1271_VALIDATION_GAS_LIMIT`, and calldata `IWorldChainAccountRouter.isValidSignatureForAdmin.selector || abi.encode(hash, signature)`. The call succeeds only if it returns `EIP1271_MAGIC_VALUE` and triggers no tracer rule violation.
+
+For each session EIP-1271 signature check, the protocol MUST perform a `STATICCALL` from `WORLD_CHAIN_ACCOUNT_MANAGER` to the account router with value `0`, gas exactly `EIP1271_VALIDATION_GAS_LIMIT`, and calldata `IWorldChainAccountRouter.isValidSignatureForVerifier.selector || abi.encode(sessionVerifier, hash, signature)`. The call succeeds only if it returns `EIP1271_MAGIC_VALUE` and triggers no tracer rule violation.
+
+For each session policy check, the protocol MUST perform a `STATICCALL` from `WORLD_CHAIN_ACCOUNT_MANAGER` to the account router with value `0`, gas exactly `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`, and calldata `IWorldChainAccountRouter.evaluateSessionPolicyForVerifier.selector || abi.encode(sessionVerifier, context)`. The call succeeds only if it returns `true` and triggers no tracer rule violation.
+
+The manager MUST NOT call admin or session verifier implementation addresses directly for validation. Verifier implementation code is reached only through the canonical account router dispatch.
+
+Failure, revert, out-of-gas, malformed return data, or a tracer violation MUST be treated as signature or policy failure.
+
+Restricted frames are enforced by a runtime opcode-and-target tracer derived from [ERC-7562](https://eips.ethereum.org/EIPS/eip-7562). Runtime enforcement is authoritative.
+
+| Rule ID | ERC-7562 ref | Description |
+| --- | --- | --- |
+| `WIP1001-VR-1` | OP-011 | Forbid block-context opcodes: `BLOCKHASH`, `COINBASE`, `TIMESTAMP`, `NUMBER`, `PREVRANDAO`/`DIFFICULTY`, `GASLIMIT`, `BASEFEE`, `BLOBHASH`, `BLOBBASEFEE`. |
+| `WIP1001-VR-2` | OP-011 | Forbid transaction-context opcodes: `GASPRICE`, `ORIGIN`. |
+| `WIP1001-VR-3` | OP-020 | Forbid external account inspection: `BALANCE`, `SELFBALANCE`, `EXTCODESIZE`, `EXTCODECOPY`, `EXTCODEHASH`. |
+| `WIP1001-VR-4` | OP-031, OP-032 | Forbid persistent and transient state mutation: `SSTORE`, `TLOAD`, `TSTORE`. |
+| `WIP1001-VR-5` | OP-031 | Forbid log emission: `LOG0`, `LOG1`, `LOG2`, `LOG3`, `LOG4`. |
+| `WIP1001-VR-6` | OP-031, OP-040 | Forbid `CALL`, `CALLCODE`, `CREATE`, `CREATE2`. |
+| `WIP1001-VR-7` | OP-051 | Forbid `SELFDESTRUCT`. |
+| `WIP1001-VR-8` | OP-061 | Permit `STATICCALL` only to allowlisted precompiles. |
+| `WIP1001-VR-9` | OP-052 | Permit exactly one `DELEGATECALL` from canonical account-router bytecode to the selected configured verifier implementation: `admin.verifier` for admin validation or the authorized `sessionVerifier` for session validation. Forbid every other `DELEGATECALL`, including nested `DELEGATECALL` from verifier implementation code. |
+| `WIP1001-VR-10` | - | Precompile execution does not create an additional EVM code frame. |
+| `WIP1001-VR-11` | - | Permit reads of the current execution frame's own bytecode via `CODECOPY` and `CODESIZE`. |
+| `WIP1001-VR-12` | - | Permit reads of account storage via `SLOAD`. |
+| `WIP1001-VR-13` | - | Permit `KECCAK256`, `CHAINID`, `GAS`, stack, memory, calldata, and deterministic arithmetic opcodes. |
+
+Adding a new precompile to the validation allowlist is a hard-fork change.
+
+### Verifier Installation Frames
+
+`installAdmin` and `installKeyRing` are state-mutating account setup paths, not EIP-1271 validation frames. During installation, the account router MUST perform at most one direct `DELEGATECALL` per verifier entry with calldata `IWorldChainAccountHooks.install.selector || abi.encode(installation)`. Verifier implementation code MUST NOT execute `DELEGATECALL` from within `install`.
+
+If an install hook reverts, exhausts gas, or violates the nested-`DELEGATECALL` ban, the enclosing `create` or `setKeyRing` MUST revert atomically.
+
+### Transaction Type `0x1D`
+
+The wire encoding is:
+
+```solidity
+0x1D || rlp([
+    chainId,
+    nonce,
+    maxPriorityFeePerGas,
+    maxFeePerGas,
+    gasLimit,
+    account,
+    sessionVerifier,
+    to,
+    value,
+    data,
+    accessList,
+    signature
+])
+```
+
+The signing hash is:
+
+```solidity
+signingHash = keccak256(
+    0x1D ||
+    rlp([
+        chainId,
+        nonce,
+        maxPriorityFeePerGas,
+        maxFeePerGas,
+        gasLimit,
+        account,
+        sessionVerifier,
+        to,
+        value,
+        data,
+        accessList
+    ])
+);
+```
+
+The transaction hash is:
+
+```solidity
+txHash = keccak256(
+    0x1D ||
+    rlp([
+        chainId,
+        nonce,
+        maxPriorityFeePerGas,
+        maxFeePerGas,
+        gasLimit,
+        account,
+        sessionVerifier,
+        to,
+        value,
+        data,
+        accessList,
+        signature
+    ])
+);
+```
+
+Envelope validity requirements:
+
+- `chainId` MUST equal the executing chain ID;
+- `nonce` MUST equal `Account.transactionNonce`;
+- `to` MUST be the empty byte string for contract creation or exactly 20 bytes for a call;
+- `data.length <= MAX_PAYLOAD_DATA_BYTES`;
+- `accessList.length <= MAX_ACCESS_LIST_ENTRIES`;
+- `signature.length <= MAX_SESSION_SIGNATURE_BYTES`;
+- `accessList` MUST use EIP-2930 encoding;
+- `maxFeePerGas` and `maxPriorityFeePerGas` follow [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) validity rules.
+
+### Validation, Execution, and Failure Semantics
 
 Block builders MUST reserve `EIP1271_VALIDATION_GAS_LIMIT + EXECUTION_TRACE_VALIDATION_GAS_LIMIT` from `BLOCK_VALIDATION_GAS_BUDGET` before including a `0x1D` transaction. If the remaining budget is insufficient, the transaction MUST be deferred; deferral is not a validation failure and MUST NOT mutate account state.
 
@@ -399,13 +516,13 @@ To include a `0x1D` transaction, the protocol MUST:
 3. require `sessionVerifier` to be authorized for `account` in the current `sessionVerifiers` set and load the current `keyRingHash`;
 4. require the account balance to cover the worst-case payload gas charge and `MIN_VALIDATION_FAILURE_FEE`;
 5. compute `signingHash`;
-6. call `sessionVerifier.isValidSignature(signingHash, signature)` in a restricted validation frame;
+6. call `IWorldChainAccountRouter(account).isValidSignatureForVerifier(sessionVerifier, signingHash, signature)` in a restricted validation frame;
 7. if signature validation fails, apply validation-failure semantics and stop;
 8. increment `Account.transactionNonce` by one;
 9. execute the payload tentatively with `account` as the EVM sender and gas charged against envelope `gasLimit`;
 10. construct `ExecutionTraceContext` with `context.transaction.keyRingHash` set to the current account `keyRingHash`;
 11. if `abi.encode(context.trace).length > MAX_EXECUTION_TRACE_BYTES`, discard tentative payload state, apply trace-overflow semantics, and stop;
-12. call `sessionVerifier.evaluateSessionPolicy(context)` in a restricted validation frame;
+12. call `IWorldChainAccountRouter(account).evaluateSessionPolicyForVerifier(sessionVerifier, context)` in a restricted validation frame;
 13. if policy validation fails, discard tentative payload state, apply validation-failure semantics, and stop;
 14. otherwise commit the normal payload result, including a reverted payload result if the target call reverted.
 
@@ -438,19 +555,21 @@ A client MAY reuse a prior successful signature-validation result only when the 
 
 The `keyRingHash` comparison is the deterministic anchor for block validation: a verifier MAY accept a cached signature result only if the active account hash equals the recorded hash; otherwise it MUST execute signature validation again.
 
-### Signer-State Determinism
+### Verifier-State Determinism
 
-Session verifier behavior that can change `isValidSignature` or `evaluateSessionPolicy` for already accepted transactions MUST be immutable for a verifier address. Validation-affecting updates MUST be represented by deploying or selecting a different session verifier address and installing a replacement set through `setKeyRing`, which updates `keyRingHash`.
+Session verifier behavior that can change `isValidSignature` or `evaluateSessionPolicy` for already accepted transactions MUST be immutable while `keyRingHash` is unchanged. Validation-affecting updates MUST be represented by installing a replacement key ring through `setKeyRing`, which updates `keyRingHash`. A replacement key ring MAY reuse the same verifier implementation address with different `installation`, but the changed `installation` MUST be committed through the new `keyRingHash`.
 
-This applies to root rotations, verification-key rotations, signer recovery changes, signer revocation lists, account binding changes, and policy configuration changes. State that cannot affect validation MAY update in place.
+Verifier implementation contracts MUST NOT be upgradeable for validation-affecting behavior. Implementations that route validation through upgradeable proxies, beacons, mutable implementation pointers, nested `DELEGATECALL`, or mutable external state are non-conformant. This applies to root rotations, verification-key rotations, signer recovery changes, signer revocation lists, account binding changes, and policy configuration changes. State that cannot affect validation MAY update in place.
 
 ## Rationale
 
-EIP-1271 gives World Chain one protocol boundary for all authorization schemes. The protocol verifies a signer contract; the signer contract decides how to authenticate.
+EIP-1271 gives World Chain one protocol boundary for all authorization schemes. The protocol verifies through the account router; verifier implementation code decides how to authenticate.
+
+Account-resident routing gives each World Chain account one deployed code body while allowing different admin and session verifier implementations to write and read account-local validation state. The verifier address is the dispatch selector; the protocol does not define a verifier-type enum.
 
 Execution policy belongs inside the session verifier. The protocol supplies the canonical transaction context and execution trace, then asks the verifier for a boolean decision.
 
-Validation gas limits are protocol constants, not signer-selected values. This gives clients a fixed resource bound for mempool validation and block execution.
+Validation gas limits are protocol constants, not verifier-selected values. This gives clients a fixed resource bound for mempool validation and block execution.
 
 Validation gas is supplied from a per-block budget rather than the envelope `gasLimit`. This keeps the payload gas model close to EIP-1559 transactions while bounding validation work per block.
 
@@ -462,48 +581,44 @@ Restricted validation frames prevent validation from depending on mutable extern
 
 WIP-1001 introduces a new EIP-2718 transaction type and a new account manager predeploy. Existing Ethereum transaction types, EOAs, contracts, and Safe accounts are unchanged.
 
-Existing Safe accounts MAY deploy or delegate to EIP-1271 signer contracts that satisfy this specification, but WIP-1001 does not require Safe migration.
+Existing Safe accounts MAY use EIP-1271 verifier contracts that satisfy the same deterministic-validation constraints, but WIP-1001 does not require Safe migration.
 
 ## Test Cases
 
 Conforming implementations MUST pass vectors for:
 
-- address derivation across multiple `(chainId, manager, adminSigner, accountSalt)` tuples;
-- `keyRingHash = keccak256(abi.encode(sessionVerifiers))` for empty-forbidden, single-verifier, multi-verifier, and reordered verifier sets;
-- `create` validation, including deployed-code checks, duplicate and zero verifier rejection, account-exists rejection, initial nonce values, initial `keyRingHash`, `AccountCreated`, and default World ID admin signer account binding;
+- address derivation across multiple `(chainId, manager, routerCodeHash, adminHash, accountSalt)` tuples;
+- `adminHash = keccak256(abi.encode(admin))` and `keyRingHash = keccak256(abi.encode(sessionVerifiers))` for installation changes, empty-forbidden, single-verifier, multi-verifier, and reordered verifier sets;
+- `create` validation, including account-router code installation, admin install, key ring install, deployed-code checks, duplicate and zero verifier rejection, account-exists/code-exists rejection, initial nonce values, initial `keyRingHash`, and `AccountCreated`;
 - `setKeyRing` validation, including stale `expectedCurrentKeyRingHash`, duplicate, zero, undeployed, empty, oversized, and no-op verifier set rejection;
-- `setKeyRing` success behavior, including full-set replacement, `newKeyRingHash`, `adminNonce` increment, `KeyRingSet`, authorization lookup updates, and failure atomicity;
+- `setKeyRing` success behavior, including full-set replacement, verifier reinstall, `newKeyRingHash`, `adminNonce` increment, `KeyRingSet`, authorization lookup updates, and failure atomicity;
 - `createHash` and `setKeyRingHash` domain separation, parameter binding, nonce binding, and negative replay cases across accounts, chains, managers, hashes, and operation types;
 - `0x1D` RLP encoding, signing hash, and transaction hash;
 - malformed envelope rejection for `chainId`, `nonce`, `to`, `data`, `accessList`, `signature`, and EIP-1559 fee bounds;
-- transaction validation against the current verifier set, including unauthorized verifier rejection and `ExecutionTraceContext.transaction.keyRingHash`;
+- transaction validation against the current verifier set, including account-router dispatch, unauthorized verifier rejection, and `ExecutionTraceContext.transaction.keyRingHash`;
 - failure semantics for envelope/precheck failures, validation-budget exhaustion, signature failures, trace overflow, policy failures, and payload reverts;
 - txpool revalidation, signature-validation cache reuse, and cache invalidation when `keyRingHash`, verifier membership, account balance, or nonce eligibility changes;
-- signer-state determinism, including rejection of validation-affecting session verifier updates behind an unchanged verifier address;
-- restricted-frame positive cases and each forbidden opcode or call target;
-- default signer factory `CREATE2` address computation, idempotency, metadata, and incompatible-code rejection;
-- World ID `worldIdField`, `worldIdAction`, admin proof, and session proof inputs;
-- default secp256k1 low-s, `v`, owner, and signature-length checks;
+- verifier-state determinism, including rejection of validation-affecting session verifier updates behind an unchanged `keyRingHash`;
+- restricted-frame positive cases, the single account-router `DELEGATECALL` exception, nested `DELEGATECALL` rejection, and each forbidden opcode or call target;
+- install hook success, install hook failure atomicity, installation length bounds, and namespaced account-storage behavior;
 - block validation budget exhaustion and validation-failure fee charging.
 
 Complete golden vectors and a conformance test suite MUST be published before this WIP advances to Review.
 
 ## Security Considerations
 
-- Admin authorization hashes bind domain, chain ID, manager, account, operation parameters, and nonce where applicable. A signature valid for `create` MUST NOT be valid for `setKeyRing`, another account, another chain, another manager, or another key ring hash.
-- The admin signer is immutable in the account address. A broken or lost admin signer requires migrating assets to a new account; applications that need recovery SHOULD use admin signers with recovery or multisig logic from account creation.
+- Admin authorization hashes bind domain, chain ID, manager, account router code hash, account, operation parameters, and nonce where applicable. A signature valid for `create` MUST NOT be valid for `setKeyRing`, another account, another chain, another manager, another router code hash, or another key ring hash.
+- The full admin verifier configuration is immutable in the account address. A broken or lost admin verifier configuration requires migrating assets to a new account; applications that need recovery SHOULD use admin verifier implementations with recovery or multisig logic from account creation.
 - `setKeyRing` is the only post-creation key ring mutation path. A compromised session verifier remains authorized until an admin-authorized replacement set is included.
 - `expectedCurrentKeyRingHash` protects `setKeyRing` authorizations from applying to an unexpected current set. Admin tooling SHOULD surface the complete replacement set before signing because omitted verifiers are removed atomically.
-- `keyRingHash` binds cached validation to the ordered `SessionVerifier[]` set. Clients MUST discard cached signature results when the active hash changes, even if the transaction's `sessionVerifier` remains present in the new set.
-- `keyRingHash` does not commit to mutable verifier behavior by itself. Session verifier state that can affect `isValidSignature` or `evaluateSessionPolicy` MUST be immutable for that verifier address; upgrades that affect validation require a new verifier address installed through `setKeyRing`.
-- The protocol MUST verify that `sessionVerifier` is authorized for `account` before calling EIP-1271. Unauthorized verifiers MUST fail as a precheck rather than receiving a validation call.
-- Fixed validation gas limits bound signer execution. Signers that exceed the limit fail validation, and all signature and policy validation gas counts against `BLOCK_VALIDATION_GAS_BUDGET`.
+- `keyRingHash` binds cached validation to the ordered `WorldChainAccountVerifier[]` set, including verifier addresses and installation. Clients MUST discard cached signature results when the active hash changes, even if the transaction's `sessionVerifier` remains present in the new set.
+- `keyRingHash` does not commit to mutable verifier implementation behavior by itself. Session verifier code and validation-affecting installed state MUST be immutable while the hash is unchanged; upgrades that affect validation require `setKeyRing`.
+- The protocol MUST verify that `sessionVerifier` is authorized for `account` before calling the account router. Unauthorized verifiers MUST fail as a precheck rather than receiving a validation call.
+- Fixed validation gas limits bound verifier execution. Verifiers that exceed the limit fail validation, and all signature and policy validation gas counts against `BLOCK_VALIDATION_GAS_BUDGET`.
 - `BLOCK_VALIDATION_GAS_BUDGET` is scarce. `MIN_VALIDATION_FAILURE_FEE` MUST be tuned so validation spam is costly, and clients MUST reject pooled transactions that cannot pay it.
 - Builders may prefer transactions with cheaper validation profiles. Fixed validation gas bounds the worst-case bias but does not eliminate ordering incentives.
-- `MAX_EXECUTION_TRACE_BYTES`, `MAX_PAYLOAD_DATA_BYTES`, `MAX_ACCESS_LIST_ENTRIES`, `MAX_SESSION_SIGNATURE_BYTES`, and `MAX_ADMIN_AUTHORIZATION_BYTES` bound calldata, decoding, memory, and ABI-encoding costs.
-- Restricted frames forbid mutable external-state reads and block-context opcodes. Signers that need time, block, or external-state constraints MUST bind them into the signature or proof input.
-- `DELEGATECALL` inside restricted validation frames is safe only when the delegatee bytecode satisfies the same tracer rules recursively.
+- `MAX_EXECUTION_TRACE_BYTES`, `MAX_PAYLOAD_DATA_BYTES`, `MAX_ACCESS_LIST_ENTRIES`, `MAX_SESSION_SIGNATURE_BYTES`, `MAX_ADMIN_AUTHORIZATION_BYTES`, and `MAX_VERIFIER_INSTALL_DATA_BYTES` bound calldata, decoding, memory, storage, and ABI-encoding costs.
+- Restricted frames forbid mutable external-state reads and block-context opcodes. Verifiers that need time, block, or external-state constraints MUST bind them into the signature or proof input.
+- `DELEGATECALL` is permitted only for the account router's direct dispatch to the selected configured verifier implementation. Nested verifier `DELEGATECALL` is forbidden.
 - The `0x1D` envelope exposes `account` and `sessionVerifier`. Applications that need stronger privacy should use verifier contracts that aggregate or rotate credentials.
-- World ID signers MUST bind `block.chainid` into `worldIdAction` or session nonce inputs to prevent cross-chain proof replay.
-- The default World ID admin signer self-reports `account()`. The manager checks this only for default-factory-deployed World ID admin signers; custom signers are responsible for their own consistency.
 - `create` does not bind `msg.sender`, so a copied call can be front-run. The resulting account state is identical because the authorization commits to all state-determining parameters.

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -390,6 +390,108 @@ Installing canonical account-router runtime bytecode is a native manager state t
 13. increment `adminNonce` by one;
 14. emit `KeyRingSet(account, previousKeyRingHash, newKeyRingHash, adminNonce)`.
 
+### Restricted Validation Frames
+
+The protocol uses restricted validation frames for admin authorization, session signature verification, and session policy evaluation.
+
+For each EIP-1271 signature check, the protocol MUST perform a `STATICCALL` from `WORLD_CHAIN_ACCOUNT_MANAGER` to the signer with value `0`, gas exactly `EIP1271_VALIDATION_GAS_LIMIT`, and calldata `IERC1271.isValidSignature.selector || abi.encode(hash, signature)`. The call succeeds only if it returns `EIP1271_MAGIC_VALUE` and triggers no tracer rule violation.
+
+For each session policy check, the protocol MUST perform a `STATICCALL` from `WORLD_CHAIN_ACCOUNT_MANAGER` to the session verifier with value `0`, gas exactly `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`, and calldata `IWorldChainSessionVerifier.evaluateSessionPolicy.selector || abi.encode(context)`. The call succeeds only if it returns `true` and triggers no tracer rule violation.
+
+Failure, revert, out-of-gas, malformed return data, or a tracer violation MUST be treated as signature or policy failure.
+
+Restricted frames are enforced by a runtime opcode-and-target tracer derived from [ERC-7562](https://eips.ethereum.org/EIPS/eip-7562). Runtime enforcement is authoritative.
+
+| Rule ID | ERC-7562 ref | Description |
+| --- | --- | --- |
+| `WIP1001-VR-1` | OP-011 | Forbid block-context opcodes: `BLOCKHASH`, `COINBASE`, `TIMESTAMP`, `NUMBER`, `PREVRANDAO`/`DIFFICULTY`, `GASLIMIT`, `BASEFEE`, `BLOBHASH`, `BLOBBASEFEE`. |
+| `WIP1001-VR-2` | OP-011 | Forbid transaction-context opcodes: `GASPRICE`, `ORIGIN`. |
+| `WIP1001-VR-3` | OP-020 | Forbid external account inspection: `BALANCE`, `SELFBALANCE`, `EXTCODESIZE`, `EXTCODECOPY`, `EXTCODEHASH`. |
+| `WIP1001-VR-4` | OP-031, OP-032 | Forbid persistent and transient state mutation: `SSTORE`, `TLOAD`, `TSTORE`. |
+| `WIP1001-VR-5` | OP-031 | Forbid log emission: `LOG0`, `LOG1`, `LOG2`, `LOG3`, `LOG4`. |
+| `WIP1001-VR-6` | OP-031, OP-040 | Forbid `CALL`, `CALLCODE`, `CREATE`, `CREATE2`. |
+| `WIP1001-VR-7` | OP-051 | Forbid `SELFDESTRUCT`. |
+| `WIP1001-VR-8` | OP-061 | Permit `STATICCALL` only to allowlisted precompiles. |
+| `WIP1001-VR-9` | OP-052 | Permit `DELEGATECALL` only when the delegatee bytecode satisfies the same rule set. The tracer MUST validate delegatees recursively. |
+| `WIP1001-VR-10` | - | Precompile execution does not create an additional EVM code frame. |
+| `WIP1001-VR-11` | - | Permit reads of the signer contract's own bytecode via `CODECOPY` and `CODESIZE`. |
+| `WIP1001-VR-12` | - | Permit reads of the signer contract's own storage via `SLOAD`. |
+| `WIP1001-VR-13` | - | Permit `KECCAK256`, `CHAINID`, `GAS`, stack, memory, calldata, and deterministic arithmetic opcodes. |
+
+Adding a new precompile to the validation allowlist is a hard-fork change.
+
+### Transaction Type `0x1D`
+
+The wire encoding is:
+
+```solidity
+0x1D || rlp([
+    chainId,
+    nonce,
+    maxPriorityFeePerGas,
+    maxFeePerGas,
+    gasLimit,
+    account,
+    sessionVerifier,
+    to,
+    value,
+    data,
+    accessList,
+    signature
+])
+```
+
+The signing hash is:
+
+```solidity
+signingHash = keccak256(
+    0x1D ||
+    rlp([
+        chainId,
+        nonce,
+        maxPriorityFeePerGas,
+        maxFeePerGas,
+        gasLimit,
+        account,
+        sessionVerifier,
+        to,
+        value,
+        data,
+        accessList
+    ])
+);
+```
+
+The transaction hash is:
+
+```solidity
+txHash = keccak256(
+    0x1D ||
+    rlp([
+        chainId,
+        nonce,
+        maxPriorityFeePerGas,
+        maxFeePerGas,
+        gasLimit,
+        account,
+        sessionVerifier,
+        to,
+        value,
+        data,
+        accessList,
+        signature
+    ])
+);
+```
+
+Envelope validity requirements:
+
+- `chainId` MUST equal the executing chain ID;
+- `nonce` MUST equal `Account.transactionNonce`;
+- `to` MUST be the empty byte string for contract creation or exactly 20 bytes for a call;
+- `data.length <= MAX_PAYLOAD_DATA_BYTES`;
+- `accessList.length <= MAX_ACCESS_LIST_ENTRIES`;
+- `signature.length <= MAX_SESSION_SIGNATURE_BYTES`;
 - `accessList` MUST use EIP-2930 encoding;
 - `maxFeePerGas` and `maxPriorityFeePerGas` follow [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) validity rules.
 

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -111,7 +111,6 @@ For every existing account:
 
 After account creation, `setKeyRing` is the only execution path that mutates `sessionVerifiers` or `keyRingHash`.
 
-After account creation, `setKeyRing` is the only execution path that mutates `sessionVerifiers`, `keyRingHash`, or validation-affecting account storage for active session verifiers. WIP-1001 defines no operation that mutates `admin` or the account router runtime code.
 
 #### Address Derivation
 

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -22,7 +22,7 @@ We design with the principle of not defining signer-specific authentication as n
 
 World Chain accounts need programmable authentication without adding a protocol branch for every signature scheme, or session key policy. Smart contracts allow us to converge protocol level authentication over a single authorization boundary with determinism enforced via protocol level restrictions on programmable validation frames.
 
-Programmable policies over session keys unlock many capabilities that simply are not possible on traditional accounts. Some examples include account subscription models, delegated agent payments with scoped permissions enforced by the VM, social recovery, policy-based authentication (e.g. multi-factor authentication for high value transactions). World Chain accounts are unique in that the policies constraining a session key are fully programmable. This allows for expressive policies, and authentication strategies to be composed and updated dynamically without prescriptive standards enforced by the protocol.
+Programmable policies over Session Keys unlock many capabilities that simply are not possible on traditional accounts. Some examples include account subscription models, delegated agent payments with scoped permissions enforced by the VM, social recovery, policy based authentication (e.g. Multi Factor authentication for high value transactions). World Chain accounts are unique in that the policies constraining a Session Key are fully programmable. This allows for expressive policies, and authentication strategies to be composed and updated dynamically without prescriptive standards enforced by the protocol.
 
 ## Specification
 

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -32,7 +32,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 | Name | Type | Value | Meaning |
 | --- | --- | --- | --- |
-| `WIP_1001_TX_TYPE` | `uint8` | `0x1D` | EIP-2718 transaction type for World Chain account transactions. |
+| `WORLD_TX_TYPE` | `uint8` | `0x1D` | EIP-2718 transaction type for World Chain account transactions. |
 | `MAX_SESSION_VERIFIERS` | `uint256` | `20` | Maximum active session verifiers per account. |
 | `WORLD_CHAIN_ACCOUNT_DOMAIN` | `bytes32` | `keccak256("WIP1001_ACCOUNT")` | Domain for account address derivation. |
 | `WORLD_CHAIN_ACCOUNT_CREATE_DOMAIN` | `bytes32` | `keccak256("WORLD_CHAIN_ACCOUNT_CREATE")` | Domain for account creation authorization. |

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -2,7 +2,7 @@
 wip: 1001
 title: World Chain Native Account Abstraction
 description: A predeploy-managed account model whose admin and session authorization are verified through an account-routed EIP-1271 verifier system.
-author: Kilian Glas (@kilianglas), 0xOsiris (@0xOsiris), Eric Woolsey (@0xforerunner)
+author: 0xOsiris, Kilian Glas (@kilianglas) Eric Woolsey (@0xforerunner)
 status: Draft
 type: Standards Track
 category: Core

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -390,118 +390,6 @@ Installing canonical account-router runtime bytecode is a native manager state t
 13. increment `adminNonce` by one;
 14. emit `KeyRingSet(account, previousKeyRingHash, newKeyRingHash, adminNonce)`.
 
-### Restricted Validation Frames
-
-The protocol uses restricted validation frames for admin authorization, session signature verification, and session policy evaluation.
-
-For each admin EIP-1271 signature check, the protocol MUST perform a `STATICCALL` from `WORLD_CHAIN_ACCOUNT_MANAGER` to the account router with value `0`, gas exactly `EIP1271_VALIDATION_GAS_LIMIT`, and calldata `IWorldChainAccountRouter.isValidSignatureForAdmin.selector || abi.encode(hash, signature)`. The call succeeds only if it returns `EIP1271_MAGIC_VALUE` and triggers no tracer rule violation.
-
-For each session EIP-1271 signature check, the protocol MUST perform a `STATICCALL` from `WORLD_CHAIN_ACCOUNT_MANAGER` to the account router with value `0`, gas exactly `EIP1271_VALIDATION_GAS_LIMIT`, and calldata `IWorldChainAccountRouter.isValidSignatureForVerifier.selector || abi.encode(sessionVerifier, hash, signature)`. The call succeeds only if it returns `EIP1271_MAGIC_VALUE` and triggers no tracer rule violation.
-
-For each session policy check, the protocol MUST perform a `STATICCALL` from `WORLD_CHAIN_ACCOUNT_MANAGER` to the account router with value `0`, gas exactly `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`, and calldata `IWorldChainAccountRouter.evaluateSessionPolicyForVerifier.selector || abi.encode(sessionVerifier, context)`. The call succeeds only if it returns `true` and triggers no tracer rule violation.
-
-The manager MUST NOT call admin or session verifier implementation addresses directly for validation. Verifier implementation code is reached only through the canonical account router dispatch.
-
-Failure, revert, out-of-gas, malformed return data, or a tracer violation MUST be treated as signature or policy failure.
-
-Restricted frames are enforced by a runtime opcode-and-target tracer derived from [ERC-7562](https://eips.ethereum.org/EIPS/eip-7562). Runtime enforcement is authoritative.
-
-| Rule ID | ERC-7562 ref | Description |
-| --- | --- | --- |
-| `WIP1001-VR-1` | OP-011 | Forbid block-context opcodes: `BLOCKHASH`, `COINBASE`, `TIMESTAMP`, `NUMBER`, `PREVRANDAO`/`DIFFICULTY`, `GASLIMIT`, `BASEFEE`, `BLOBHASH`, `BLOBBASEFEE`. |
-| `WIP1001-VR-2` | OP-011 | Forbid transaction-context opcodes: `GASPRICE`, `ORIGIN`. |
-| `WIP1001-VR-3` | OP-020 | Forbid external account inspection: `BALANCE`, `SELFBALANCE`, `EXTCODESIZE`, `EXTCODECOPY`, `EXTCODEHASH`. |
-| `WIP1001-VR-4` | OP-031, OP-032 | Forbid persistent and transient state mutation: `SSTORE`, `TLOAD`, `TSTORE`. |
-| `WIP1001-VR-5` | OP-031 | Forbid log emission: `LOG0`, `LOG1`, `LOG2`, `LOG3`, `LOG4`. |
-| `WIP1001-VR-6` | OP-031, OP-040 | Forbid `CALL`, `CALLCODE`, `CREATE`, `CREATE2`. |
-| `WIP1001-VR-7` | OP-051 | Forbid `SELFDESTRUCT`. |
-| `WIP1001-VR-8` | OP-061 | Permit `STATICCALL` only to allowlisted precompiles. |
-| `WIP1001-VR-9` | OP-052 | Permit exactly one `DELEGATECALL` from canonical account-router bytecode to the selected configured verifier implementation: `admin.verifier` for admin validation or the authorized `sessionVerifier` for session validation. Forbid every other `DELEGATECALL`, including nested `DELEGATECALL` from verifier implementation code. |
-| `WIP1001-VR-10` | - | Precompile execution does not create an additional EVM code frame. |
-| `WIP1001-VR-11` | - | Permit reads of the current execution frame's own bytecode via `CODECOPY` and `CODESIZE`. |
-| `WIP1001-VR-12` | - | Permit reads of account storage via `SLOAD`. |
-| `WIP1001-VR-13` | - | Permit `KECCAK256`, `CHAINID`, `GAS`, stack, memory, calldata, and deterministic arithmetic opcodes. |
-
-Adding a new precompile to the validation allowlist is a hard-fork change.
-
-### Verifier Installation Frames
-
-`installAdmin` and `installKeyRing` are state-mutating account setup paths, not EIP-1271 validation frames. During installation, the account router MUST perform at most one direct `DELEGATECALL` per verifier entry with calldata `IWorldChainAccountHooks.install.selector || abi.encode(installation)`. Verifier implementation code MUST NOT execute `DELEGATECALL` from within `install`.
-
-If an install hook reverts, exhausts gas, or violates the nested-`DELEGATECALL` ban, the enclosing `create` or `setKeyRing` MUST revert atomically.
-
-### Transaction Type `0x1D`
-
-The wire encoding is:
-
-```solidity
-0x1D || rlp([
-    chainId,
-    nonce,
-    maxPriorityFeePerGas,
-    maxFeePerGas,
-    gasLimit,
-    account,
-    sessionVerifier,
-    to,
-    value,
-    data,
-    accessList,
-    signature
-])
-```
-
-The signing hash is:
-
-```solidity
-signingHash = keccak256(
-    0x1D ||
-    rlp([
-        chainId,
-        nonce,
-        maxPriorityFeePerGas,
-        maxFeePerGas,
-        gasLimit,
-        account,
-        sessionVerifier,
-        to,
-        value,
-        data,
-        accessList
-    ])
-);
-```
-
-The transaction hash is:
-
-```solidity
-txHash = keccak256(
-    0x1D ||
-    rlp([
-        chainId,
-        nonce,
-        maxPriorityFeePerGas,
-        maxFeePerGas,
-        gasLimit,
-        account,
-        sessionVerifier,
-        to,
-        value,
-        data,
-        accessList,
-        signature
-    ])
-);
-```
-
-Envelope validity requirements:
-
-- `chainId` MUST equal the executing chain ID;
-- `nonce` MUST equal `Account.transactionNonce`;
-- `to` MUST be the empty byte string for contract creation or exactly 20 bytes for a call;
-- `data.length <= MAX_PAYLOAD_DATA_BYTES`;
-- `accessList.length <= MAX_ACCESS_LIST_ENTRIES`;
-- `signature.length <= MAX_SESSION_SIGNATURE_BYTES`;
 - `accessList` MUST use EIP-2930 encoding;
 - `maxFeePerGas` and `maxPriorityFeePerGas` follow [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) validity rules.
 
@@ -516,13 +404,13 @@ To include a `0x1D` transaction, the protocol MUST:
 3. require `sessionVerifier` to be authorized for `account` in the current `sessionVerifiers` set and load the current `keyRingHash`;
 4. require the account balance to cover the worst-case payload gas charge and `MIN_VALIDATION_FAILURE_FEE`;
 5. compute `signingHash`;
-6. call `IWorldChainAccountRouter(account).isValidSignatureForVerifier(sessionVerifier, signingHash, signature)` in a restricted validation frame;
+6. call `sessionVerifier.isValidSignature(signingHash, signature)` in a restricted validation frame;
 7. if signature validation fails, apply validation-failure semantics and stop;
 8. increment `Account.transactionNonce` by one;
 9. execute the payload tentatively with `account` as the EVM sender and gas charged against envelope `gasLimit`;
 10. construct `ExecutionTraceContext` with `context.transaction.keyRingHash` set to the current account `keyRingHash`;
 11. if `abi.encode(context.trace).length > MAX_EXECUTION_TRACE_BYTES`, discard tentative payload state, apply trace-overflow semantics, and stop;
-12. call `IWorldChainAccountRouter(account).evaluateSessionPolicyForVerifier(sessionVerifier, context)` in a restricted validation frame;
+12. call `sessionVerifier.evaluateSessionPolicy(context)` in a restricted validation frame;
 13. if policy validation fails, discard tentative payload state, apply validation-failure semantics, and stop;
 14. otherwise commit the normal payload result, including a reverted payload result if the target call reverted.
 
@@ -555,21 +443,19 @@ A client MAY reuse a prior successful signature-validation result only when the 
 
 The `keyRingHash` comparison is the deterministic anchor for block validation: a verifier MAY accept a cached signature result only if the active account hash equals the recorded hash; otherwise it MUST execute signature validation again.
 
-### Verifier-State Determinism
+### Signer-State Determinism
 
-Session verifier behavior that can change `isValidSignature` or `evaluateSessionPolicy` for already accepted transactions MUST be immutable while `keyRingHash` is unchanged. Validation-affecting updates MUST be represented by installing a replacement key ring through `setKeyRing`, which updates `keyRingHash`. A replacement key ring MAY reuse the same verifier implementation address with different `installation`, but the changed `installation` MUST be committed through the new `keyRingHash`.
+Session verifier behavior that can change `isValidSignature` or `evaluateSessionPolicy` for already accepted transactions MUST be immutable for a verifier address. Validation-affecting updates MUST be represented by deploying or selecting a different session verifier address and installing a replacement set through `setKeyRing`, which updates `keyRingHash`.
 
-Verifier implementation contracts MUST NOT be upgradeable for validation-affecting behavior. Implementations that route validation through upgradeable proxies, beacons, mutable implementation pointers, nested `DELEGATECALL`, or mutable external state are non-conformant. This applies to root rotations, verification-key rotations, signer recovery changes, signer revocation lists, account binding changes, and policy configuration changes. State that cannot affect validation MAY update in place.
+This applies to root rotations, verification-key rotations, signer recovery changes, signer revocation lists, account binding changes, and policy configuration changes. State that cannot affect validation MAY update in place.
 
 ## Rationale
 
-EIP-1271 gives World Chain one protocol boundary for all authorization schemes. The protocol verifies through the account router; verifier implementation code decides how to authenticate.
-
-Account-resident routing gives each World Chain account one deployed code body while allowing different admin and session verifier implementations to write and read account-local validation state. The verifier address is the dispatch selector; the protocol does not define a verifier-type enum.
+EIP-1271 gives World Chain one protocol boundary for all authorization schemes. The protocol verifies a signer contract; the signer contract decides how to authenticate.
 
 Execution policy belongs inside the session verifier. The protocol supplies the canonical transaction context and execution trace, then asks the verifier for a boolean decision.
 
-Validation gas limits are protocol constants, not verifier-selected values. This gives clients a fixed resource bound for mempool validation and block execution.
+Validation gas limits are protocol constants, not signer-selected values. This gives clients a fixed resource bound for mempool validation and block execution.
 
 Validation gas is supplied from a per-block budget rather than the envelope `gasLimit`. This keeps the payload gas model close to EIP-1559 transactions while bounding validation work per block.
 
@@ -581,44 +467,48 @@ Restricted validation frames prevent validation from depending on mutable extern
 
 WIP-1001 introduces a new EIP-2718 transaction type and a new account manager predeploy. Existing Ethereum transaction types, EOAs, contracts, and Safe accounts are unchanged.
 
-Existing Safe accounts MAY use EIP-1271 verifier contracts that satisfy the same deterministic-validation constraints, but WIP-1001 does not require Safe migration.
+Existing Safe accounts MAY deploy or delegate to EIP-1271 signer contracts that satisfy this specification, but WIP-1001 does not require Safe migration.
 
 ## Test Cases
 
 Conforming implementations MUST pass vectors for:
 
-- address derivation across multiple `(chainId, manager, routerCodeHash, adminHash, accountSalt)` tuples;
-- `adminHash = keccak256(abi.encode(admin))` and `keyRingHash = keccak256(abi.encode(sessionVerifiers))` for installation changes, empty-forbidden, single-verifier, multi-verifier, and reordered verifier sets;
-- `create` validation, including account-router code installation, admin install, key ring install, deployed-code checks, duplicate and zero verifier rejection, account-exists/code-exists rejection, initial nonce values, initial `keyRingHash`, and `AccountCreated`;
+- address derivation across multiple `(chainId, manager, adminSigner, accountSalt)` tuples;
+- `keyRingHash = keccak256(abi.encode(sessionVerifiers))` for empty-forbidden, single-verifier, multi-verifier, and reordered verifier sets;
+- `create` validation, including deployed-code checks, duplicate and zero verifier rejection, account-exists rejection, initial nonce values, initial `keyRingHash`, `AccountCreated`, and default World ID admin signer account binding;
 - `setKeyRing` validation, including stale `expectedCurrentKeyRingHash`, duplicate, zero, undeployed, empty, oversized, and no-op verifier set rejection;
-- `setKeyRing` success behavior, including full-set replacement, verifier reinstall, `newKeyRingHash`, `adminNonce` increment, `KeyRingSet`, authorization lookup updates, and failure atomicity;
+- `setKeyRing` success behavior, including full-set replacement, `newKeyRingHash`, `adminNonce` increment, `KeyRingSet`, authorization lookup updates, and failure atomicity;
 - `createHash` and `setKeyRingHash` domain separation, parameter binding, nonce binding, and negative replay cases across accounts, chains, managers, hashes, and operation types;
 - `0x1D` RLP encoding, signing hash, and transaction hash;
 - malformed envelope rejection for `chainId`, `nonce`, `to`, `data`, `accessList`, `signature`, and EIP-1559 fee bounds;
-- transaction validation against the current verifier set, including account-router dispatch, unauthorized verifier rejection, and `ExecutionTraceContext.transaction.keyRingHash`;
+- transaction validation against the current verifier set, including unauthorized verifier rejection and `ExecutionTraceContext.transaction.keyRingHash`;
 - failure semantics for envelope/precheck failures, validation-budget exhaustion, signature failures, trace overflow, policy failures, and payload reverts;
 - txpool revalidation, signature-validation cache reuse, and cache invalidation when `keyRingHash`, verifier membership, account balance, or nonce eligibility changes;
-- verifier-state determinism, including rejection of validation-affecting session verifier updates behind an unchanged `keyRingHash`;
-- restricted-frame positive cases, the single account-router `DELEGATECALL` exception, nested `DELEGATECALL` rejection, and each forbidden opcode or call target;
-- install hook success, install hook failure atomicity, installation length bounds, and namespaced account-storage behavior;
+- signer-state determinism, including rejection of validation-affecting session verifier updates behind an unchanged verifier address;
+- restricted-frame positive cases and each forbidden opcode or call target;
+- default signer factory `CREATE2` address computation, idempotency, metadata, and incompatible-code rejection;
+- World ID `worldIdField`, `worldIdAction`, admin proof, and session proof inputs;
+- default secp256k1 low-s, `v`, owner, and signature-length checks;
 - block validation budget exhaustion and validation-failure fee charging.
 
 Complete golden vectors and a conformance test suite MUST be published before this WIP advances to Review.
 
 ## Security Considerations
 
-- Admin authorization hashes bind domain, chain ID, manager, account router code hash, account, operation parameters, and nonce where applicable. A signature valid for `create` MUST NOT be valid for `setKeyRing`, another account, another chain, another manager, another router code hash, or another key ring hash.
-- The full admin verifier configuration is immutable in the account address. A broken or lost admin verifier configuration requires migrating assets to a new account; applications that need recovery SHOULD use admin verifier implementations with recovery or multisig logic from account creation.
+- Admin authorization hashes bind domain, chain ID, manager, account, operation parameters, and nonce where applicable. A signature valid for `create` MUST NOT be valid for `setKeyRing`, another account, another chain, another manager, or another key ring hash.
+- The admin signer is immutable in the account address. A broken or lost admin signer requires migrating assets to a new account; applications that need recovery SHOULD use admin signers with recovery or multisig logic from account creation.
 - `setKeyRing` is the only post-creation key ring mutation path. A compromised session verifier remains authorized until an admin-authorized replacement set is included.
 - `expectedCurrentKeyRingHash` protects `setKeyRing` authorizations from applying to an unexpected current set. Admin tooling SHOULD surface the complete replacement set before signing because omitted verifiers are removed atomically.
-- `keyRingHash` binds cached validation to the ordered `WorldChainAccountVerifier[]` set, including verifier addresses and installation. Clients MUST discard cached signature results when the active hash changes, even if the transaction's `sessionVerifier` remains present in the new set.
-- `keyRingHash` does not commit to mutable verifier implementation behavior by itself. Session verifier code and validation-affecting installed state MUST be immutable while the hash is unchanged; upgrades that affect validation require `setKeyRing`.
-- The protocol MUST verify that `sessionVerifier` is authorized for `account` before calling the account router. Unauthorized verifiers MUST fail as a precheck rather than receiving a validation call.
-- Fixed validation gas limits bound verifier execution. Verifiers that exceed the limit fail validation, and all signature and policy validation gas counts against `BLOCK_VALIDATION_GAS_BUDGET`.
+- `keyRingHash` binds cached validation to the ordered `SessionVerifier[]` set. Clients MUST discard cached signature results when the active hash changes, even if the transaction's `sessionVerifier` remains present in the new set.
+- `keyRingHash` does not commit to mutable verifier behavior by itself. Session verifier state that can affect `isValidSignature` or `evaluateSessionPolicy` MUST be immutable for that verifier address; upgrades that affect validation require a new verifier address installed through `setKeyRing`.
+- The protocol MUST verify that `sessionVerifier` is authorized for `account` before calling EIP-1271. Unauthorized verifiers MUST fail as a precheck rather than receiving a validation call.
+- Fixed validation gas limits bound signer execution. Signers that exceed the limit fail validation, and all signature and policy validation gas counts against `BLOCK_VALIDATION_GAS_BUDGET`.
 - `BLOCK_VALIDATION_GAS_BUDGET` is scarce. `MIN_VALIDATION_FAILURE_FEE` MUST be tuned so validation spam is costly, and clients MUST reject pooled transactions that cannot pay it.
 - Builders may prefer transactions with cheaper validation profiles. Fixed validation gas bounds the worst-case bias but does not eliminate ordering incentives.
-- `MAX_EXECUTION_TRACE_BYTES`, `MAX_PAYLOAD_DATA_BYTES`, `MAX_ACCESS_LIST_ENTRIES`, `MAX_SESSION_SIGNATURE_BYTES`, `MAX_ADMIN_AUTHORIZATION_BYTES`, and `MAX_VERIFIER_INSTALL_DATA_BYTES` bound calldata, decoding, memory, storage, and ABI-encoding costs.
-- Restricted frames forbid mutable external-state reads and block-context opcodes. Verifiers that need time, block, or external-state constraints MUST bind them into the signature or proof input.
-- `DELEGATECALL` is permitted only for the account router's direct dispatch to the selected configured verifier implementation. Nested verifier `DELEGATECALL` is forbidden.
+- `MAX_EXECUTION_TRACE_BYTES`, `MAX_PAYLOAD_DATA_BYTES`, `MAX_ACCESS_LIST_ENTRIES`, `MAX_SESSION_SIGNATURE_BYTES`, and `MAX_ADMIN_AUTHORIZATION_BYTES` bound calldata, decoding, memory, and ABI-encoding costs.
+- Restricted frames forbid mutable external-state reads and block-context opcodes. Signers that need time, block, or external-state constraints MUST bind them into the signature or proof input.
+- `DELEGATECALL` inside restricted validation frames is safe only when the delegatee bytecode satisfies the same tracer rules recursively.
 - The `0x1D` envelope exposes `account` and `sessionVerifier`. Applications that need stronger privacy should use verifier contracts that aggregate or rotate credentials.
+- World ID signers MUST bind `block.chainid` into `worldIdAction` or session nonce inputs to prevent cross-chain proof replay.
+- The default World ID admin signer self-reports `account()`. The manager checks this only for default-factory-deployed World ID admin signers; custom signers are responsible for their own consistency.
 - `create` does not bind `msg.sender`, so a copied call can be front-run. The resulting account state is identical because the authorization commits to all state-determining parameters.

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -169,7 +169,7 @@ setKeyRingHash = keccak256(abi.encode(
 
 ### Account Router and Verifier Interfaces
 
-The account router is the only validation target called by the manager. It dispatches to configured verifier implementations using a single controlled `DELEGATECALL`, so verifier implementations execute against the account's storage.
+The account router is the runtime byte code that lives at all World Chain Accounts. It acts as a proxy router over the admin, and all `sessionVerifiers`.
 
 ```solidity
 interface IWorldChainAccountRouter {

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -7,7 +7,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2026-03-27
-requires: EIP-1271, EIP-2718, EIP-1559, EIP-2930, ERC-7562, RIP-7212
+requires: [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271), [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718), [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559), [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930), [ERC-7562](https://eips.ethereum.org/EIPS/eip-7562), [RIP-7212](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md)
 ---
 
 ## Abstract

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -388,123 +388,7 @@ Installing canonical account-router runtime bytecode is a native manager state t
 12. set `keyRingHash = newKeyRingHash`;
 13. increment `adminNonce` by one;
 14. emit `KeyRingSet(account, previousKeyRingHash, newKeyRingHash, adminNonce)`.
-
 ### Restricted Validation Frames
-
-The protocol uses restricted validation frames for admin authorization, session signature verification, and session policy evaluation.
-
-For each admin EIP-1271 signature check, the protocol MUST perform a `STATICCALL` from `WORLD_CHAIN_ACCOUNT_MANAGER` to the account router with value `0`, gas exactly `EIP1271_VALIDATION_GAS_LIMIT`, and calldata `IWorldChainAccountRouter.isValidSignatureForAdmin.selector || abi.encode(hash, signature)`. The call succeeds only if it returns `EIP1271_MAGIC_VALUE` and triggers no tracer rule violation.
-
-For each session EIP-1271 signature check, the protocol MUST perform a `STATICCALL` from `WORLD_CHAIN_ACCOUNT_MANAGER` to the account router with value `0`, gas exactly `EIP1271_VALIDATION_GAS_LIMIT`, and calldata `IWorldChainAccountRouter.isValidSignatureForVerifier.selector || abi.encode(sessionVerifier, hash, signature)`. The call succeeds only if it returns `EIP1271_MAGIC_VALUE` and triggers no tracer rule violation.
-
-For each session policy check, the protocol MUST perform a `STATICCALL` from `WORLD_CHAIN_ACCOUNT_MANAGER` to the account router with value `0`, gas exactly `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`, and calldata `IWorldChainAccountRouter.evaluateSessionPolicyForVerifier.selector || abi.encode(sessionVerifier, context)`. The call succeeds only if it returns `true` and triggers no tracer rule violation.
-
-The manager MUST NOT call admin or session verifier implementation addresses directly for validation. Verifier implementation code is reached only through the canonical account router dispatch.
-
-Failure, revert, out-of-gas, malformed return data, or a tracer violation MUST be treated as signature or policy failure.
-
-Restricted frames are enforced by a runtime opcode-and-target tracer derived from [ERC-7562](https://eips.ethereum.org/EIPS/eip-7562). Runtime enforcement is authoritative.
-
-| Rule ID | ERC-7562 ref | Description |
-| --- | --- | --- |
-| `WIP1001-VR-1` | OP-011 | Forbid block-context opcodes: `BLOCKHASH`, `COINBASE`, `TIMESTAMP`, `NUMBER`, `PREVRANDAO`/`DIFFICULTY`, `GASLIMIT`, `BASEFEE`, `BLOBHASH`, `BLOBBASEFEE`. |
-| `WIP1001-VR-2` | OP-011 | Forbid transaction-context opcodes: `GASPRICE`, `ORIGIN`. |
-| `WIP1001-VR-3` | OP-020 | Forbid external account inspection: `BALANCE`, `SELFBALANCE`, `EXTCODESIZE`, `EXTCODECOPY`, `EXTCODEHASH`. |
-| `WIP1001-VR-4` | OP-031, OP-032 | Forbid persistent and transient state mutation: `SSTORE`, `TLOAD`, `TSTORE`. |
-| `WIP1001-VR-5` | OP-031 | Forbid log emission: `LOG0`, `LOG1`, `LOG2`, `LOG3`, `LOG4`. |
-| `WIP1001-VR-6` | OP-031, OP-040 | Forbid `CALL`, `CALLCODE`, `CREATE`, `CREATE2`. |
-| `WIP1001-VR-7` | OP-051 | Forbid `SELFDESTRUCT`. |
-| `WIP1001-VR-8` | OP-061 | Permit `STATICCALL` only to allowlisted precompiles. |
-| `WIP1001-VR-9` | OP-052 | Permit exactly one `DELEGATECALL` from canonical account-router bytecode to the selected configured verifier implementation: `admin.verifier` for admin validation or the authorized `sessionVerifier` for session validation. Forbid every other `DELEGATECALL`, including nested `DELEGATECALL` from verifier implementation code. |
-| `WIP1001-VR-10` | - | Precompile execution does not create an additional EVM code frame. |
-| `WIP1001-VR-11` | - | Permit reads of the current execution frame's own bytecode via `CODECOPY` and `CODESIZE`. |
-| `WIP1001-VR-12` | - | Permit reads of account storage via `SLOAD`. |
-| `WIP1001-VR-13` | - | Permit `KECCAK256`, `CHAINID`, `GAS`, stack, memory, calldata, and deterministic arithmetic opcodes. |
-
-Adding a new precompile to the validation allowlist is a hard-fork change.
-
-### Verifier Installation Frames
-
-`installAdmin` and `installKeyRing` are state-mutating account setup paths, not EIP-1271 validation frames. During installation, the account router MUST perform at most one direct `DELEGATECALL` per verifier entry with calldata `IWorldChainAccountHooks.install.selector || abi.encode(installation)`. Verifier implementation code MUST NOT execute `DELEGATECALL` from within `install`.
-
-If an install hook reverts, exhausts gas, or violates the nested-`DELEGATECALL` ban, the enclosing `create` or `setKeyRing` MUST revert atomically.
-
-### Transaction Type `0x1D`
-
-The wire encoding is:
-
-```solidity
-0x1D || rlp([
-    chainId,
-    nonce,
-    maxPriorityFeePerGas,
-    maxFeePerGas,
-    gasLimit,
-    account,
-    sessionVerifier,
-    to,
-    value,
-    data,
-    accessList,
-    signature
-])
-```
-
-The signing hash is:
-
-```solidity
-signingHash = keccak256(
-    0x1D ||
-    rlp([
-        chainId,
-        nonce,
-        maxPriorityFeePerGas,
-        maxFeePerGas,
-        gasLimit,
-        account,
-        sessionVerifier,
-        to,
-        value,
-        data,
-        accessList
-    ])
-);
-```
-
-The transaction hash is:
-
-```solidity
-txHash = keccak256(
-    0x1D ||
-    rlp([
-        chainId,
-        nonce,
-        maxPriorityFeePerGas,
-        maxFeePerGas,
-        gasLimit,
-        account,
-        sessionVerifier,
-        to,
-        value,
-        data,
-        accessList,
-        signature
-    ])
-);
-```
-
-Envelope validity requirements:
-
-- `chainId` MUST equal the executing chain ID;
-- `nonce` MUST equal `Account.transactionNonce`;
-- `to` MUST be the empty byte string for contract creation or exactly 20 bytes for a call;
-- `data.length <= MAX_PAYLOAD_DATA_BYTES`;
-- `accessList.length <= MAX_ACCESS_LIST_ENTRIES`;
-- `signature.length <= MAX_SESSION_SIGNATURE_BYTES`;
-- `accessList` MUST use EIP-2930 encoding;
-- `maxFeePerGas` and `maxPriorityFeePerGas` follow [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) validity rules.
-
-### Validation, Execution, and Failure Semantics
 
 Block builders MUST reserve `EIP1271_VALIDATION_GAS_LIMIT + EXECUTION_TRACE_VALIDATION_GAS_LIMIT` from `BLOCK_VALIDATION_GAS_BUDGET` before including a `0x1D` transaction. If the remaining budget is insufficient, the transaction MUST be deferred; deferral is not a validation failure and MUST NOT mutate account state.
 
@@ -515,13 +399,13 @@ To include a `0x1D` transaction, the protocol MUST:
 3. require `sessionVerifier` to be authorized for `account` in the current `sessionVerifiers` set and load the current `keyRingHash`;
 4. require the account balance to cover the worst-case payload gas charge and `MIN_VALIDATION_FAILURE_FEE`;
 5. compute `signingHash`;
-6. call `IWorldChainAccountRouter(account).isValidSignatureForVerifier(sessionVerifier, signingHash, signature)` in a restricted validation frame;
+6. call `sessionVerifier.isValidSignature(signingHash, signature)` in a restricted validation frame;
 7. if signature validation fails, apply validation-failure semantics and stop;
 8. increment `Account.transactionNonce` by one;
 9. execute the payload tentatively with `account` as the EVM sender and gas charged against envelope `gasLimit`;
 10. construct `ExecutionTraceContext` with `context.transaction.keyRingHash` set to the current account `keyRingHash`;
 11. if `abi.encode(context.trace).length > MAX_EXECUTION_TRACE_BYTES`, discard tentative payload state, apply trace-overflow semantics, and stop;
-12. call `IWorldChainAccountRouter(account).evaluateSessionPolicyForVerifier(sessionVerifier, context)` in a restricted validation frame;
+12. call `sessionVerifier.evaluateSessionPolicy(context)` in a restricted validation frame;
 13. if policy validation fails, discard tentative payload state, apply validation-failure semantics, and stop;
 14. otherwise commit the normal payload result, including a reverted payload result if the target call reverted.
 
@@ -554,21 +438,19 @@ A client MAY reuse a prior successful signature-validation result only when the 
 
 The `keyRingHash` comparison is the deterministic anchor for block validation: a verifier MAY accept a cached signature result only if the active account hash equals the recorded hash; otherwise it MUST execute signature validation again.
 
-### Verifier-State Determinism
+### Signer-State Determinism
 
-Session verifier behavior that can change `isValidSignature` or `evaluateSessionPolicy` for already accepted transactions MUST be immutable while `keyRingHash` is unchanged. Validation-affecting updates MUST be represented by installing a replacement key ring through `setKeyRing`, which updates `keyRingHash`. A replacement key ring MAY reuse the same verifier implementation address with different `installation`, but the changed `installation` MUST be committed through the new `keyRingHash`.
+Session verifier behavior that can change `isValidSignature` or `evaluateSessionPolicy` for already accepted transactions MUST be immutable for a verifier address. Validation-affecting updates MUST be represented by deploying or selecting a different session verifier address and installing a replacement set through `setKeyRing`, which updates `keyRingHash`.
 
-Verifier implementation contracts MUST NOT be upgradeable for validation-affecting behavior. Implementations that route validation through upgradeable proxies, beacons, mutable implementation pointers, nested `DELEGATECALL`, or mutable external state are non-conformant. This applies to root rotations, verification-key rotations, signer recovery changes, signer revocation lists, account binding changes, and policy configuration changes. State that cannot affect validation MAY update in place.
+This applies to root rotations, verification-key rotations, signer recovery changes, signer revocation lists, account binding changes, and policy configuration changes. State that cannot affect validation MAY update in place.
 
 ## Rationale
 
-EIP-1271 gives World Chain one protocol boundary for all authorization schemes. The protocol verifies through the account router; verifier implementation code decides how to authenticate.
-
-Account-resident routing gives each World Chain account one deployed code body while allowing different admin and session verifier implementations to write and read account-local validation state. The verifier address is the dispatch selector; the protocol does not define a verifier-type enum.
+EIP-1271 gives World Chain one protocol boundary for all authorization schemes. The protocol verifies a signer contract; the signer contract decides how to authenticate.
 
 Execution policy belongs inside the session verifier. The protocol supplies the canonical transaction context and execution trace, then asks the verifier for a boolean decision.
 
-Validation gas limits are protocol constants, not verifier-selected values. This gives clients a fixed resource bound for mempool validation and block execution.
+Validation gas limits are protocol constants, not signer-selected values. This gives clients a fixed resource bound for mempool validation and block execution.
 
 Validation gas is supplied from a per-block budget rather than the envelope `gasLimit`. This keeps the payload gas model close to EIP-1559 transactions while bounding validation work per block.
 
@@ -580,44 +462,48 @@ Restricted validation frames prevent validation from depending on mutable extern
 
 WIP-1001 introduces a new EIP-2718 transaction type and a new account manager predeploy. Existing Ethereum transaction types, EOAs, contracts, and Safe accounts are unchanged.
 
-Existing Safe accounts MAY use EIP-1271 verifier contracts that satisfy the same deterministic-validation constraints, but WIP-1001 does not require Safe migration.
+Existing Safe accounts MAY deploy or delegate to EIP-1271 signer contracts that satisfy this specification, but WIP-1001 does not require Safe migration.
 
 ## Test Cases
 
 Conforming implementations MUST pass vectors for:
 
-- address derivation across multiple `(chainId, manager, routerCodeHash, adminHash, accountSalt)` tuples;
-- `adminHash = keccak256(abi.encode(admin))` and `keyRingHash = keccak256(abi.encode(sessionVerifiers))` for installation changes, empty-forbidden, single-verifier, multi-verifier, and reordered verifier sets;
-- `create` validation, including account-router code installation, admin install, key ring install, deployed-code checks, duplicate and zero verifier rejection, account-exists/code-exists rejection, initial nonce values, initial `keyRingHash`, and `AccountCreated`;
+- address derivation across multiple `(chainId, manager, adminSigner, accountSalt)` tuples;
+- `keyRingHash = keccak256(abi.encode(sessionVerifiers))` for empty-forbidden, single-verifier, multi-verifier, and reordered verifier sets;
+- `create` validation, including deployed-code checks, duplicate and zero verifier rejection, account-exists rejection, initial nonce values, initial `keyRingHash`, `AccountCreated`, and default World ID admin signer account binding;
 - `setKeyRing` validation, including stale `expectedCurrentKeyRingHash`, duplicate, zero, undeployed, empty, oversized, and no-op verifier set rejection;
-- `setKeyRing` success behavior, including full-set replacement, verifier reinstall, `newKeyRingHash`, `adminNonce` increment, `KeyRingSet`, authorization lookup updates, and failure atomicity;
+- `setKeyRing` success behavior, including full-set replacement, `newKeyRingHash`, `adminNonce` increment, `KeyRingSet`, authorization lookup updates, and failure atomicity;
 - `createHash` and `setKeyRingHash` domain separation, parameter binding, nonce binding, and negative replay cases across accounts, chains, managers, hashes, and operation types;
 - `0x1D` RLP encoding, signing hash, and transaction hash;
 - malformed envelope rejection for `chainId`, `nonce`, `to`, `data`, `accessList`, `signature`, and EIP-1559 fee bounds;
-- transaction validation against the current verifier set, including account-router dispatch, unauthorized verifier rejection, and `ExecutionTraceContext.transaction.keyRingHash`;
+- transaction validation against the current verifier set, including unauthorized verifier rejection and `ExecutionTraceContext.transaction.keyRingHash`;
 - failure semantics for envelope/precheck failures, validation-budget exhaustion, signature failures, trace overflow, policy failures, and payload reverts;
 - txpool revalidation, signature-validation cache reuse, and cache invalidation when `keyRingHash`, verifier membership, account balance, or nonce eligibility changes;
-- verifier-state determinism, including rejection of validation-affecting session verifier updates behind an unchanged `keyRingHash`;
-- restricted-frame positive cases, the single account-router `DELEGATECALL` exception, nested `DELEGATECALL` rejection, and each forbidden opcode or call target;
-- install hook success, install hook failure atomicity, installation length bounds, and namespaced account-storage behavior;
+- signer-state determinism, including rejection of validation-affecting session verifier updates behind an unchanged verifier address;
+- restricted-frame positive cases and each forbidden opcode or call target;
+- default signer factory `CREATE2` address computation, idempotency, metadata, and incompatible-code rejection;
+- World ID `worldIdField`, `worldIdAction`, admin proof, and session proof inputs;
+- default secp256k1 low-s, `v`, owner, and signature-length checks;
 - block validation budget exhaustion and validation-failure fee charging.
 
 Complete golden vectors and a conformance test suite MUST be published before this WIP advances to Review.
 
 ## Security Considerations
 
-- Admin authorization hashes bind domain, chain ID, manager, account router code hash, account, operation parameters, and nonce where applicable. A signature valid for `create` MUST NOT be valid for `setKeyRing`, another account, another chain, another manager, another router code hash, or another key ring hash.
-- The full admin verifier configuration is immutable in the account address. A broken or lost admin verifier configuration requires migrating assets to a new account; applications that need recovery SHOULD use admin verifier implementations with recovery or multisig logic from account creation.
+- Admin authorization hashes bind domain, chain ID, manager, account, operation parameters, and nonce where applicable. A signature valid for `create` MUST NOT be valid for `setKeyRing`, another account, another chain, another manager, or another key ring hash.
+- The admin signer is immutable in the account address. A broken or lost admin signer requires migrating assets to a new account; applications that need recovery SHOULD use admin signers with recovery or multisig logic from account creation.
 - `setKeyRing` is the only post-creation key ring mutation path. A compromised session verifier remains authorized until an admin-authorized replacement set is included.
 - `expectedCurrentKeyRingHash` protects `setKeyRing` authorizations from applying to an unexpected current set. Admin tooling SHOULD surface the complete replacement set before signing because omitted verifiers are removed atomically.
-- `keyRingHash` binds cached validation to the ordered `WorldChainAccountVerifier[]` set, including verifier addresses and installation. Clients MUST discard cached signature results when the active hash changes, even if the transaction's `sessionVerifier` remains present in the new set.
-- `keyRingHash` does not commit to mutable verifier implementation behavior by itself. Session verifier code and validation-affecting installed state MUST be immutable while the hash is unchanged; upgrades that affect validation require `setKeyRing`.
-- The protocol MUST verify that `sessionVerifier` is authorized for `account` before calling the account router. Unauthorized verifiers MUST fail as a precheck rather than receiving a validation call.
-- Fixed validation gas limits bound verifier execution. Verifiers that exceed the limit fail validation, and all signature and policy validation gas counts against `BLOCK_VALIDATION_GAS_BUDGET`.
+- `keyRingHash` binds cached validation to the ordered `SessionVerifier[]` set. Clients MUST discard cached signature results when the active hash changes, even if the transaction's `sessionVerifier` remains present in the new set.
+- `keyRingHash` does not commit to mutable verifier behavior by itself. Session verifier state that can affect `isValidSignature` or `evaluateSessionPolicy` MUST be immutable for that verifier address; upgrades that affect validation require a new verifier address installed through `setKeyRing`.
+- The protocol MUST verify that `sessionVerifier` is authorized for `account` before calling EIP-1271. Unauthorized verifiers MUST fail as a precheck rather than receiving a validation call.
+- Fixed validation gas limits bound signer execution. Signers that exceed the limit fail validation, and all signature and policy validation gas counts against `BLOCK_VALIDATION_GAS_BUDGET`.
 - `BLOCK_VALIDATION_GAS_BUDGET` is scarce. `MIN_VALIDATION_FAILURE_FEE` MUST be tuned so validation spam is costly, and clients MUST reject pooled transactions that cannot pay it.
 - Builders may prefer transactions with cheaper validation profiles. Fixed validation gas bounds the worst-case bias but does not eliminate ordering incentives.
-- `MAX_EXECUTION_TRACE_BYTES`, `MAX_PAYLOAD_DATA_BYTES`, `MAX_ACCESS_LIST_ENTRIES`, `MAX_SESSION_SIGNATURE_BYTES`, `MAX_ADMIN_AUTHORIZATION_BYTES`, and `MAX_VERIFIER_INSTALL_DATA_BYTES` bound calldata, decoding, memory, storage, and ABI-encoding costs.
-- Restricted frames forbid mutable external-state reads and block-context opcodes. Verifiers that need time, block, or external-state constraints MUST bind them into the signature or proof input.
-- `DELEGATECALL` is permitted only for the account router's direct dispatch to the selected configured verifier implementation. Nested verifier `DELEGATECALL` is forbidden.
+- `MAX_EXECUTION_TRACE_BYTES`, `MAX_PAYLOAD_DATA_BYTES`, `MAX_ACCESS_LIST_ENTRIES`, `MAX_SESSION_SIGNATURE_BYTES`, and `MAX_ADMIN_AUTHORIZATION_BYTES` bound calldata, decoding, memory, and ABI-encoding costs.
+- Restricted frames forbid mutable external-state reads and block-context opcodes. Signers that need time, block, or external-state constraints MUST bind them into the signature or proof input.
+- `DELEGATECALL` inside restricted validation frames is safe only when the delegatee bytecode satisfies the same tracer rules recursively.
 - The `0x1D` envelope exposes `account` and `sessionVerifier`. Applications that need stronger privacy should use verifier contracts that aggregate or rotate credentials.
+- World ID signers MUST bind `block.chainid` into `worldIdAction` or session nonce inputs to prevent cross-chain proof replay.
+- The default World ID admin signer self-reports `account()`. The manager checks this only for default-factory-deployed World ID admin signers; custom signers are responsible for their own consistency.
 - `create` does not bind `msg.sender`, so a copied call can be front-run. The resulting account state is identical because the authorization commits to all state-determining parameters.

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -109,7 +109,7 @@ For every existing account:
 - `adminNonce` is consumed only by admin operations;
 - `transactionNonce` is consumed only by successful `0x1D` transaction execution attempts;
 
-Verifier behavior is selected by verifier implementation address, not by a protocol-level enum. `installation` is opaque to the protocol and is interpreted only by the selected verifier implementation.
+After account creation, `setKeyRing` is the only execution path that mutates `sessionVerifiers` or `keyRingHash`.
 
 After account creation, `setKeyRing` is the only execution path that mutates `sessionVerifiers`, `keyRingHash`, or validation-affecting account storage for active session verifiers. WIP-1001 defines no operation that mutates `admin` or the account router runtime code.
 

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -197,7 +197,7 @@ interface IWorldChainAccountRouter {
 }
 ```
 
-`installAdmin` and `installKeyRing` MUST reject any caller other than `WORLD_CHAIN_ACCOUNT_MANAGER`. The account router MUST expose no non-manager path that can mutate validation-affecting verifier storage. `isValidSignatureForAdmin`, `isValidSignatureForVerifier`, and `evaluateSessionPolicyForVerifier` MUST be callable by `WORLD_CHAIN_ACCOUNT_MANAGER` in restricted validation frames.
+`installAdmin` and `installKeyRing` MUST reject any caller other than `WORLD_CHAIN_ACCOUNT_MANAGER`. The account router MUST expose no non-manager path that can mutate validation-affecting verifier storage. `isValidSignatureForAdmin`, `isValidSignatureForVerifier`, and `evaluateSessionPolicyForVerifier` MUST be callable in restricted validation frames.
 
 The account router MUST dispatch admin validation only to its installed `admin.verifier`. It MUST dispatch session validation only to an installed session verifier address; unknown session verifier addresses MUST fail without executing verifier implementation code.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates the core WIP-1001 protocol spec to route all admin/session validation through an account-resident router with `DELEGATECALL`-installed verifier state, which materially changes address derivation, authorization hashing, and validation/installation semantics.
> 
> **Overview**
> Refactors WIP-1001 from *direct* admin/session EIP-1271 calls to an **account-router pattern**: the manager now calls `IWorldChainAccountRouter(account)` for admin signatures, session signatures, and session policy evaluation, and the router performs a single controlled `DELEGATECALL` into the selected verifier implementation.
> 
> Updates the account model to store an `admin` verifier config plus per-session verifier configs (each with opaque `installData`), adds bounds for `installData`, and changes address derivation + `createHash` binding to include `WORLD_CHAIN_ACCOUNT_ROUTER_CODE_HASH` and `adminHash`.
> 
> Specifies router installation/immutability requirements (canonical router code installed at account creation), adds verifier installation frames and stricter tracer rules banning nested `DELEGATECALL`, and updates manager interfaces/events/test and security considerations accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8760608353c8fc8bb3754799e4805e13aeaba112. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->