### PR TITLE
feat: add WIP-1004 subsidy enforcement via handler hooks

### DIFF
--- a/wips/README.md
+++ b/wips/README.md
@@ -27,6 +27,7 @@ WIPs are modeled after [Ethereum Improvement Proposals (EIPs)](https://github.co
 | ------ | ---------------------------------- | ------ | -------- | ---------- |
 | [1001](./wip-1001.md) | WorldID Native Account Abstraction | Draft  | Core     | 2026-03-27 |
 | [1002](./wip-1002.md) | WorldID Subsidy Accounting         | Draft  | Core     | 2026-04-21 |
+| [1004](./wip-1004.md) | Subsidy Enforcement via Handler Hooks | Draft  | Core     | 2026-05-13 |
 
 ---
 

--- a/wips/wip-1004.md
+++ b/wips/wip-1004.md
@@ -1,0 +1,176 @@
+---
+wip: 1004
+title: Subsidy Enforcement via Handler Hooks
+description: A minimal-envelope realization of World ID subsidy enforcement for WIP-1001 transactions, implemented through three revm `Handler` hook overrides that split the fee charge between a WIP-1002 subsidy budget and the sender.
+author: Kilian Glas (@kilianglas), Alessandro Mazza (@alessandromazza98)
+status: Draft
+type: Standards Track
+category: Core
+created: 2026-05-13
+requires: WIP-1001, WIP-1002, EIP-1559
+---
+
+## Abstract
+
+This WIP specifies an alternative realization of **Subsidy Enforcement** for World Chain — the mechanism that turns a verified World ID's remaining gas budget (tracked in [WIP-1002](./wip-1002.md)) into a discounted transaction at inclusion time. The mechanism is scoped to [WIP-1001](./wip-1001.md) `0x1D` transactions and is realized as three overrides of the revm `Handler` trait: `validate_against_state_and_deduct_caller`, `reimburse_caller`, and `reward_beneficiary`.
+
+The protocol base fee market is left untouched; no envelope fields are added; no per-block subsidy-accounting transaction is required. The subsidy covers the base fee for a `0x1D` transaction whose sender resolves to an authorized WIP-1002 nullifier with non-zero remaining budget; the priority fee is always paid by the sender. When the budget is insufficient or absent, the transaction falls back to standard EIP-1559 charging.
+
+This proposal stands as an alternative to [WIP-1003](./wip-1003.md), which realizes subsidy enforcement through builder policy and a virtual fee market with the protocol base fee pinned to `0`.
+
+## Motivation
+
+[WIP-1002](./wip-1002.md) defines per-credential, ETH-denominated subsidy budgets for verified World IDs and exposes a `consumeBudget(nullifier, gasUsed, baseFee)` consumption hook, but it deliberately leaves the *enforcement* mechanism — how that budget is actually applied at transaction inclusion time — out of scope.
+
+[WIP-1003](./wip-1003.md) is the existing proposal for that mechanism. It introduces:
+
+- chain-wide protocol `baseFeePerGas` pinning to `0`,
+- an out-of-protocol virtual fee market with deterministic per-block parameters,
+- wallet-facing RPC overrides so non-subsidized traffic still sees a quoted fee,
+- a builder-owned end-of-block transaction that pushes per-period subsidy deltas into WIP-1002.
+
+These changes touch all traffic on World Chain, not only subsidy-eligible traffic, and the §6 settlement formula in WIP-1003 is ambiguous between `gasLimit` and `gasUsed`.
+
+This WIP is motivated by the observation that, once World Chain has WIP-1001 (a new transaction type with a dedicated execution path) *and* WIP-1002 (an on-chain consumption hook), subsidy enforcement can be expressed as a small handler override on the new transaction type alone. The protocol fee market, the wallet RPC surface, and non-`0x1D` traffic remain unaffected.
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) and [RFC 8174](https://www.rfc-editor.org/rfc/rfc8174).
+
+### Scope
+
+Subsidy enforcement under this WIP applies to [WIP-1001](./wip-1001.md) transactions only (type flag `0x1D`). All other transaction types follow standard EIP-1559 charging, unchanged by this WIP. The protocol `baseFeePerGas` retains its EIP-1559 semantics for all transaction types, including `0x1D`.
+
+### Subsidy Resolution
+
+For a `0x1D` transaction whose framed sender is `account`, subsidy eligibility is resolved deterministically against [WIP-1002](./wip-1002.md) Subsidy Accounting:
+
+1. Resolve `account` to a `nullifier` via the WIP-1002 authorization map. If `account` is authorized under multiple nullifiers, the WIP-1002 deterministic nullifier-selection rule MUST be used to choose exactly one record.
+2. If no authorized `nullifier` exists for `account` in the current WIP-1002 period, the transaction is **not subsidy-eligible** and standard EIP-1559 charging applies for all phases below.
+3. If an authorized `nullifier` exists, let `budget = ISubsidyAccounting.getBudget(nullifier)`. The transaction is **subsidy-eligible** if and only if `budget > 0`.
+
+Subsidy eligibility MUST be evaluated against post-validation state, after the framed-sender and session verifier checks defined by WIP-1001.
+
+### Handler Overrides
+
+This WIP overrides three methods of the revm `Handler` trait on the `0x1D` execution path. All other handler methods follow their default implementation. The override semantics below are normative; the field names match the revm trait signatures.
+
+Let:
+
+- `gas_limit` — the `0x1D` envelope's gas limit;
+- `max_fee_per_gas`, `max_priority_fee_per_gas` — the EIP-1559 fee fields from the envelope;
+- `base_fee_per_gas` — the block's protocol base fee;
+- `effective_gas_price = min(max_fee_per_gas, base_fee_per_gas + max_priority_fee_per_gas)`;
+- `priority_fee_per_gas = effective_gas_price - base_fee_per_gas`.
+
+#### `validate_against_state_and_deduct_caller` (pre-execution)
+
+The pre-charge MUST split the maximum possible fee `gas_limit * effective_gas_price` between the WIP-1002 subsidy budget and the sender balance:
+
+1. Standard EIP-1559 validation checks (nonce, sufficient balance for non-subsidized portion, `max_fee_per_gas >= base_fee_per_gas`, `max_priority_fee_per_gas <= max_fee_per_gas`) MUST be performed before any subsidy logic.
+2. If the transaction is **not subsidy-eligible** (per [Subsidy Resolution](#subsidy-resolution)): the entire `gas_limit * effective_gas_price` MUST be debited from the sender, following default revm behavior.
+3. If the transaction is **subsidy-eligible**:
+   - Let `pre_subsidy = min(budget, gas_limit * base_fee_per_gas)` — the maximum base-fee portion that the budget can cover.
+   - Let `pre_sender = gas_limit * effective_gas_price - pre_subsidy` — the residual the sender pre-pays.
+   - The sender balance MUST be debited by `pre_sender`. The transaction MUST be rejected if the sender balance is insufficient to cover `pre_sender`.
+   - The WIP-1002 budget for `nullifier` MUST be marked as conditionally consumed by `pre_subsidy` for the duration of this transaction. Implementations MAY realize this either as an in-handler shadow value or by calling `ISubsidyAccounting.consumeBudget` here and reconciling in [`reimburse_caller`](#reimburse_caller-post-execution); the externally observable result MUST match the post-tx semantics in [`reimburse_caller`](#reimburse_caller-post-execution).
+
+The chosen `nullifier` and the `pre_subsidy` value MUST be carried through to the post-execution phase so the exact final settlement can be computed against `gas_used`.
+
+#### `reimburse_caller` (post-execution)
+
+Once `gas_used` is known, the post-charge MUST settle the subsidy and sender contributions to their exact final values:
+
+1. Let `used_basefee_cost = gas_used * base_fee_per_gas`.
+2. Let `used_total_cost   = gas_used * effective_gas_price`.
+3. If the transaction is **not subsidy-eligible**: `gas_limit * effective_gas_price - used_total_cost` MUST be credited back to the sender. No WIP-1002 interaction occurs. This matches default revm behavior.
+4. If the transaction is **subsidy-eligible**:
+   - Let `final_subsidy = min(pre_subsidy, used_basefee_cost)`.
+   - Let `final_sender  = used_total_cost - final_subsidy`.
+   - The WIP-1002 budget for `nullifier` MUST end this transaction having been debited by exactly `final_subsidy`. Any pre-charged excess (`pre_subsidy - final_subsidy`) MUST be credited back to the budget.
+   - The sender balance MUST end this transaction having been debited by exactly `final_sender`. Any pre-charged excess (`pre_sender - final_sender`) MUST be credited back to the sender.
+
+The WIP-1002 budget call MUST be the canonical `ISubsidyAccounting.consumeBudget(nullifier, gas_used, base_fee_per_gas)` invocation (or an internal equivalent if WIP-1002 is realized as a precompile rather than a predeploy). Implementations MUST ensure that the externally observable WIP-1002 state after this hook is identical to a single `consumeBudget(nullifier, gas_used, base_fee_per_gas)` call having been made for this transaction.
+
+#### `reward_beneficiary` (post-execution)
+
+The validator MUST be credited the priority-fee portion only:
+
+1. If the transaction is **not subsidy-eligible**: `gas_used * priority_fee_per_gas` is credited to the block beneficiary, matching default revm behavior.
+2. If the transaction is **subsidy-eligible**:
+   - `gas_used * priority_fee_per_gas` MUST be credited to the block beneficiary from the sender's contribution.
+   - The base-fee portion covered by `final_subsidy` MUST NOT be credited to the beneficiary, MUST NOT be burned, and MUST NOT be minted. It is absorbed by the chain as a no-op transfer (the budget is virtual per-credential state on WIP-1002, not an ETH balance).
+   - The base-fee portion *not* covered by the subsidy — i.e. `used_basefee_cost - final_subsidy` — MUST follow EIP-1559's base-fee burn rule, since the sender paid it in ETH.
+
+Validator economics on a subsidized `0x1D` transaction are therefore identical to a non-subsidized `0x1D` transaction with the same `gas_used` and `priority_fee_per_gas`: the validator receives the same priority-fee payment, and the chain absorbs the subsidized base-fee portion in place of an EIP-1559 burn.
+
+### Failed Validation
+
+If a `0x1D` transaction fails validation (per WIP-1001 §"Validation, Execution, and Failure Semantics") before [`validate_against_state_and_deduct_caller`](#validate_against_state_and_deduct_caller-pre-execution) completes successfully, the validation-failure fee defined by WIP-1001 MUST be charged in full to the sender and MUST NOT be debited from the WIP-1002 budget, regardless of subsidy eligibility. This prevents budget drain through repeated failing validations.
+
+### Interaction with WIP-1002
+
+This WIP does not modify the WIP-1002 interface. The only new requirement is that the consumption path described in [`reimburse_caller`](#reimburse_caller-post-execution) is invoked exactly once per included `0x1D` transaction that was subsidy-eligible at pre-execution, with `gas_used` and `base_fee_per_gas` matching the executed transaction.
+
+### Wallet RPC
+
+Standard EIP-1559 fee RPCs (`eth_maxPriorityFeePerGas`, `eth_gasPrice`, `eth_feeHistory`, block-header `baseFeePerGas`) continue to return their normal protocol-derived values, since the protocol fee market is unchanged. Subsidy-aware wallets MAY additionally query WIP-1002 directly for the framed `account`'s remaining budget and reduce the requested `gas_limit * (effective_gas_price - base_fee_per_gas)` accordingly. No wallet-facing RPC overrides are mandated by this WIP.
+
+## Rationale
+
+### Comparison to WIP-1003
+
+[WIP-1003](./wip-1003.md) reaches the same end state — subsidized verified traffic, market-priced other traffic — by moving the fee market out of protocol. This WIP reaches it by moving subsidy enforcement into the existing `0x1D` execution path. The trade is:
+
+- **Protocol `baseFeePerGas`** stays at its EIP-1559 value here; WIP-1003 pins it to `0` chain-wide.
+- **Virtual fee market and `VirtualFeeOracle`** are not introduced here; WIP-1003 requires them.
+- **Per-block builder-owned accounting transaction** is not introduced here; WIP-1003 requires one.
+- **`gasLimit` vs `gasUsed` ambiguity** in WIP-1003 §6 is resolved by construction here: the final debit is computed in `reimburse_caller`, after `gas_used` is known.
+- **Wallet RPC overrides** are not required here; WIP-1003 requires them so wallets see the virtual base fee instead of the pinned-`0` header value.
+- **Generic third-party gas sponsorship** is not supported by either proposal as written. If sponsorship is later required, it is an envelope-additive extension over this proposal (a Tempo-style `fee_payer_signature` field on `0x1D` with an additional charge tier between subsidy and sender).
+
+The cost of the trade is scope: this WIP applies only to `0x1D` transactions, while WIP-1003 applies to all transaction types. Non-`0x1D` traffic on World Chain is not subsidy-eligible under either proposal in practice, since WIP-1002 authorization is keyed to WIP-1001 accounts in the expected deployment.
+
+### Why three handler hooks
+
+The three overrides correspond exactly to the three points in the revm execution pipeline where fee state is moved between accounts: pre-execution deduction of the maximum possible charge, post-execution refund of unused gas, and post-execution payment of the validator. Overriding any fewer of them leaves an asymmetry that is hard to keep consistent under refunds and gas-used variability. Overriding any more is unnecessary because no other phase touches fee state.
+
+### Pre-charge over-estimation
+
+The pre-charge uses `gas_limit * base_fee_per_gas` as the subsidy upper bound rather than waiting for `gas_used`. This matches default revm behavior (which pre-charges `gas_limit * effective_gas_price` from the sender) and is corrected exactly in `reimburse_caller`. The alternative — deferring all subsidy interaction to post-execution — would require the sender to hold enough balance to cover `gas_limit * effective_gas_price` in addition to having a non-zero subsidy budget, which negates the user-visible benefit of the subsidy for budget-covered traffic.
+
+### Subsidy is base-fee only
+
+The subsidy unit follows WIP-1002's existing `consumeBudget(nullifier, gas_used, base_fee_per_gas)` signature: only the base-fee portion of the fee is subsidizable, the priority fee is always paid by the sender. This keeps validator economics on a subsidized transaction identical to a non-subsidized transaction with the same `gas_used` and tip; the chain absorbs the subsidized base-fee portion in place of the EIP-1559 burn.
+
+## Backwards Compatibility
+
+- The protocol fee market and EIP-1559 semantics are unchanged for all non-`0x1D` traffic and for non-subsidy-eligible `0x1D` traffic.
+- `0x1D` envelope encoding, signing-hash construction, and validation rules from WIP-1001 are unchanged.
+- The WIP-1002 interface is unchanged.
+- This WIP requires activation alongside (or after) WIP-1001 and WIP-1002. Activating it independently is meaningless.
+- Block-header `baseFeePerGas` continues to follow EIP-1559, so wallets and indexers reading the block header are not affected.
+
+## Test Cases
+
+Test cases SHOULD exercise the following points, at minimum:
+
+- `0x1D` transaction with no WIP-1002 authorization — full sender pre-charge, full sender post-refund, no WIP-1002 interaction. Indistinguishable from a default-handler trace.
+- `0x1D` transaction with subsidy fully covering the executed base-fee cost (`budget >= gas_used * base_fee_per_gas`) — sender pays exactly `gas_used * priority_fee_per_gas`, budget debited by exactly `gas_used * base_fee_per_gas`, beneficiary receives exactly `gas_used * priority_fee_per_gas`, no EIP-1559 burn for the subsidized portion.
+- `0x1D` transaction with subsidy partially covering the executed base-fee cost (`0 < budget < gas_used * base_fee_per_gas`) — sender pays `used_total_cost - budget`, budget debited to `0`, beneficiary receives `gas_used * priority_fee_per_gas`, EIP-1559 burn applies to `used_basefee_cost - budget`.
+- `0x1D` transaction with `gas_used` strictly less than `gas_limit` — pre-charged excess is refunded to both budget and sender in the proportions defined by [`reimburse_caller`](#reimburse_caller-post-execution).
+- `0x1D` transaction failing pre-execution validation — full WIP-1001 validation-failure fee charged to sender, budget untouched.
+- `0x1D` transaction whose framed sender is authorized under multiple nullifiers — the chosen nullifier matches the WIP-1002 deterministic selection rule, and only that nullifier's budget is debited.
+
+## Reference Implementation
+
+No reference implementation is included in this draft. The expected shape is a revm `Handler` variant for `0x1D` transactions overriding the three methods named in [Handler Overrides](#handler-overrides); the variant dispatches on the WIP-1002 resolution result at pre-execution and stores the `(nullifier, pre_subsidy)` pair on the execution context for use in `reimburse_caller`.
+
+## Security Considerations
+
+- **Budget drain via failing transactions.** All validation-failure costs MUST be paid by the sender, never the budget. See [Failed Validation](#failed-validation). Implementations MUST NOT route any failure path through WIP-1002 consumption.
+- **Pre-charge / post-refund consistency.** A buggy `reimburse_caller` that fails to credit unused budget back would silently drain budgets even for normally successful transactions. Implementations MUST treat the equality `final_subsidy + final_sender = used_total_cost` (and the equalities for refunds) as invariants and enforce them in tests.
+- **Deterministic nullifier selection.** When an account is authorized under multiple nullifiers, the WIP-1002 deterministic selection rule MUST be used at every site that resolves an account to a nullifier (pre-execution, post-execution, RPC) so all sites agree on which budget is debited.
+- **Validator opt-in.** Because validator economics are unchanged from a non-subsidized transaction, no validator opt-in mechanism is required. Validators that wish to exclude subsidized traffic for policy reasons MAY do so through the standard transaction-selection layer; this WIP imposes no requirement either way.
+- **Re-entrancy with WIP-1002 as predeploy.** If WIP-1002 is realized as a predeploy (rather than a precompile), the `consumeBudget` reconciliation in `reimburse_caller` runs after `gas_used` is finalized and therefore cannot re-enter the executing transaction. If WIP-1002 calls are batched or deferred for performance, the deferred calls MUST be ordered and applied atomically with block production so that observable WIP-1002 state remains consistent with executed transactions.
+- **Interaction with EIP-1559 burn.** The base-fee portion paid in ETH by the sender (when subsidy is partial) MUST still be burned per EIP-1559. Only the subsidy-covered portion is absorbed.


### PR DESCRIPTION
## Summary

Adds [WIP-1004](./wips/wip-1004.md), an alternative realization of subsidy enforcement to [WIP-1003](./wips/wip-1003.md), scoped to WIP-1001 `0x1D` transactions and realized through three revm `Handler` hook overrides.

- Subsidy applies to `0x1D` transactions only; protocol `baseFeePerGas` and EIP-1559 semantics are unchanged for all other traffic.
- Eligibility is resolved against WIP-1002 (`getBudget`, deterministic nullifier selection). The subsidy covers `gas_used * base_fee_per_gas`; the sender always pays the priority fee.
- Three overrides — `validate_against_state_and_deduct_caller`, `reimburse_caller`, `reward_beneficiary` — split the pre-charge between the WIP-1002 budget and the sender, settle the exact final amounts once `gas_used` is known, and credit only the priority fee to the validator.

### Differences vs WIP-1003

- No chain-wide `baseFeePerGas = 0` pinning.
- No virtual fee market or `VirtualFeeOracle`.
- No per-block builder-owned subsidy-accounting transaction.
- No mandated wallet RPC overrides.
- The `gasLimit` vs `gasUsed` ambiguity in WIP-1003 §6 is resolved by construction (final settlement happens in `reimburse_caller`).

Generic third-party gas sponsorship is not supported by either proposal as written; if needed, it is an envelope-additive extension (Tempo-style `fee_payer_signature`) over WIP-1004.

## Test plan

- [ ] Spec review by core team
- [ ] Cross-check pre-charge/post-refund invariants with WIP-1002 `consumeBudget` semantics
- [ ] Decide between WIP-1003 and WIP-1004 (or alternative envelope-additive sponsorship path)