### PR TITLE
docs: rewrite wip-1003 as handler-hook subsidy enforcement

### DIFF
--- a/wips/wip-1003.md
+++ b/wips/wip-1003.md
@@ -1,200 +1,166 @@
-|             |                                                                                                                                              |
-| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| WIP         | 1003                                                                                                                                         |
-| Title       | World ID Transaction Subsidies                                                                                                               |
-| Author      | Eric Woolsey (0xForerunner)                                                                                                                  |
-| Description | A draft core proposal replacing PBH with builder-enforced virtual fees and per-epoch gas subsidies for World ID verified addresses           |
-| Status      | Draft                                                                                                                                        |
-| Category    | Core                                                                                                                                         |
-| Created     | 2026/04/03                                                                                                                                   |
-| Requires    | [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559), WIP-1002                                                                                |
+---
+wip: 1003
+title: World ID Transaction Subsidies
+description: A subsidy-enforcement mechanism for WIP-1001 transactions that splits the fee charge between a WIP-1002 subsidy budget and the sender via three revm `Handler` hook overrides, without modifying the protocol fee market or the transaction envelope.
+author: Kilian Glas (@kilianglas), Alessandro Mazza (@alessandromazza98), Eric Woolsey (@0xforerunner)
+status: Draft
+type: Standards Track
+category: Core
+created: 2026-04-03
+requires: WIP-1001, WIP-1002, EIP-1559
+---
 
 ## Abstract
 
-This WIP replaces PBH with a builder-enforced transaction subsidy system for World ID verified addresses.
+This WIP specifies **Subsidy Enforcement** for World Chain — the mechanism that turns a verified World ID's remaining gas budget (tracked in [WIP-1002](./wip-1002.md)) into a discounted transaction at inclusion time. The mechanism is scoped to [WIP-1001](./wip-1001.md) `0x1D` transactions and is realized as three overrides of the revm `Handler` trait: `validate_against_state_and_deduct_caller`, `reimburse_caller`, and `reward_beneficiary`.
 
-The protocol fee market is effectively disabled: the in-protocol gas target and gas limit are set high enough that the protocol base fee never rises above the configured minimum base fee, and once the chain is running the `minBaseFee`-aware payload path that minimum base fee is set to `0`. As a result, `baseFeePerGas` is always `0`.
-
-Fee pricing moves out of protocol. Builders maintain a virtual fee market with a `virtualBaseFee`, `virtualMinBaseFee`, `virtualGasTarget`, and `virtualGasLimit`. For ordinary transactions, the virtual base fee is enforced through `maxPriorityFeePerGas`, so the chain behaves like a simulated EIP-1559 market even though the protocol base fee is `0`. For eligible World ID transactions, the builder may discount or fully waive that virtual fee floor and charge the waived amount against the account's subsidy budget for the current WIP-1002 epoch.
+The protocol base fee market is left untouched, no envelope fields are added, and no per-block subsidy-accounting transaction is required. The subsidy covers the base fee for a `0x1D` transaction whose sender resolves to an authorized WIP-1002 nullifier with non-zero remaining budget; the priority fee is always paid by the sender. When the budget is insufficient or absent, the transaction falls back to standard EIP-1559 charging.
 
 ## Motivation
 
+[WIP-1002](./wip-1002.md) defines per-credential, ETH-denominated subsidy budgets for verified World IDs and exposes a `consumeBudget(nullifier, gasUsed, baseFee)` consumption hook, but it deliberately leaves the *enforcement* mechanism — how that budget is actually applied at transaction inclusion time — out of scope.
+
 World Chain wants two properties at the same time:
 
-- a real fee market for non-verified traffic
-- fully subsidized transactions for verified humans up to a bounded limit
+- a real fee market for non-verified traffic,
+- subsidized transactions for verified humans up to a bounded per-period budget.
 
-PBH solves priority and fairness, but it does not provide a unified fee model for free verified transactions and market-priced non-verified transactions. This WIP makes the subsidy model native to normal transaction inclusion. Verified transactions can be literally free up to a per-epoch wei limit, while the rest of the chain still sees a fee floor and blockspace competition.
+[WIP-1001](./wip-1001.md) introduces a new transaction type (`0x1D`) with a dedicated execution path. Once that path exists and WIP-1002 exposes an on-chain consumption hook, subsidy enforcement can be expressed as a small handler override on the new transaction type alone. The protocol fee market, the wallet RPC surface, and non-`0x1D` traffic remain unaffected. PBH is superseded by this mechanism for the subsidy use case; lane/inclusion policy is a separate concern from pricing and is out of scope for this WIP.
 
-## Proposal
+## Specification
 
-### 1. Protocol Fee Market
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) and [RFC 8174](https://www.rfc-editor.org/rfc/rfc8174).
 
-- The protocol gas target and protocol gas limit are set arbitrarily high, so the protocol base fee does not rise above the protocol minimum base fee.
-- The chain must run the fork and client path that supports configurable `minBaseFee` in payload attributes and block extra data.
-- Once that path is active, `SystemConfig.setMinBaseFee(0)` disables the protocol minimum base fee floor.
-- After that, the protocol `baseFeePerGas` is always `0`.
-- This WIP does not introduce a new transaction type.
+### Scope
 
-### 2. Virtual Fee Market
+Subsidy enforcement under this WIP applies to [WIP-1001](./wip-1001.md) transactions only (type flag `0x1D`). All other transaction types follow standard EIP-1559 charging, unchanged by this WIP. The protocol `baseFeePerGas` retains its EIP-1559 semantics for all transaction types, including `0x1D`.
 
-Builders maintain a virtual fee market with the following values:
+### Subsidy Resolution
 
-- `virtualBaseFee`
-- `virtualMinBaseFee`
-- `virtualGasTarget`
-- `virtualGasLimit`
+For a `0x1D` transaction whose framed sender is `account`, subsidy eligibility is resolved deterministically against [WIP-1002](./wip-1002.md) Subsidy Accounting:
 
-These values are out of protocol. They control transaction admission and ordering in the World Chain client, but they do not affect block validity at the protocol level.
+1. Resolve `account` to a `nullifier` via the WIP-1002 authorization map. If `account` is authorized under multiple nullifiers, the WIP-1002 deterministic nullifier-selection rule MUST be used to choose exactly one record.
+2. If no authorized `nullifier` exists for `account` in the current WIP-1002 period, the transaction is **not subsidy-eligible** and standard EIP-1559 charging applies for all phases below.
+3. If an authorized `nullifier` exists, let `budget = ISubsidyAccounting.getBudget(nullifier)`. The transaction is **subsidy-eligible** if and only if `budget > 0`.
 
-`virtualGasLimit` is the builder-local effective gas limit used for transaction selection and verified blockspace segmentation.
-`virtualGasTarget` is the target used by the virtual fee controller when deriving the next `virtualBaseFee`.
+Subsidy eligibility MUST be evaluated against post-validation state, after the framed-sender and session verifier checks defined by WIP-1001.
 
-This WIP assumes the virtual fee parameters are made deterministic by a system contract, referred to here as `VirtualFeeOracle`.
+### Handler Overrides
 
-- A builder-owned transaction at the end of block `N` writes the virtual fee parameters that apply to block `N + 1`.
-- All builders validating or constructing block `N + 1` use the parameters committed in block `N`.
-- The virtual fee controller is intended to be EIP-1559-like, but the exact control law is out of scope for this WIP so long as the per-block values are deterministic.
+This WIP overrides three methods of the revm `Handler` trait on the `0x1D` execution path. All other handler methods follow their default implementation. The override semantics below are normative; the field names match the revm trait signatures.
 
-### 3. Transaction Pricing
+Let:
 
-Because the protocol base fee is `0`, the virtual base fee is represented through the priority fee.
+- `gas_limit` — the `0x1D` envelope's gas limit;
+- `max_fee_per_gas`, `max_priority_fee_per_gas` — the EIP-1559 fee fields from the envelope;
+- `base_fee_per_gas` — the block's protocol base fee;
+- `effective_gas_price = min(max_fee_per_gas, base_fee_per_gas + max_priority_fee_per_gas)`;
+- `priority_fee_per_gas = effective_gas_price - base_fee_per_gas`.
 
-For an ordinary non-subsidized transaction:
+#### `validate_against_state_and_deduct_caller` (pre-execution)
 
-- `maxPriorityFeePerGas` must be at least `virtualBaseFee`
-- any amount above `virtualBaseFee` is an optional tip
+The pre-charge MUST split the maximum possible fee `gas_limit * effective_gas_price` between the WIP-1002 subsidy budget and the sender balance:
 
-For a subsidy-eligible transaction, the required priority fee may be reduced by the account's remaining subsidy.
+1. Standard EIP-1559 validation checks (nonce, sufficient balance for non-subsidized portion, `max_fee_per_gas >= base_fee_per_gas`, `max_priority_fee_per_gas <= max_fee_per_gas`) MUST be performed before any subsidy logic.
+2. If the transaction is **not subsidy-eligible** (per [Subsidy Resolution](#subsidy-resolution)): the entire `gas_limit * effective_gas_price` MUST be debited from the sender, following default revm behavior.
+3. If the transaction is **subsidy-eligible**:
+   - Let `pre_subsidy = min(budget, gas_limit * base_fee_per_gas)` — the maximum base-fee portion that the budget can cover.
+   - Let `pre_sender = gas_limit * effective_gas_price - pre_subsidy` — the residual the sender pre-pays.
+   - The sender balance MUST be debited by `pre_sender`. The transaction MUST be rejected if the sender balance is insufficient to cover `pre_sender`.
+   - The WIP-1002 budget for `nullifier` MUST be marked as conditionally consumed by `pre_subsidy` for the duration of this transaction. Implementations MAY realize this either as an in-handler shadow value or by calling `ISubsidyAccounting.consumeBudget` here and reconciling in [`reimburse_caller`](#reimburse_caller-post-execution); the externally observable result MUST match the post-tx semantics in [`reimburse_caller`](#reimburse_caller-post-execution).
 
-### 4. Transaction Validation
+The chosen `nullifier` and the `pre_subsidy` value MUST be carried through to the post-execution phase so the exact final settlement can be computed against `gas_used`.
 
-The World Chain transaction validator is extended to enforce the virtual fee floor for in-scope transactions. `WIP-1002` contains the specification for how to determine the subsidies available to an address.
+#### `reimburse_caller` (post-execution)
 
-- If a transaction is not subsidy-eligible, it is invalid unless it pays at least the virtual fee floor through `maxPriorityFeePerGas`.
-- If a transaction is subsidy-eligible, the validator discounts the required priority fee using the charged account's remaining subsidy.
-- For admission, a conservative rule may use the transaction gas limit `G` and remaining subsidy `S` to derive:
-  `discountPerGas = min(virtualBaseFee, floor(S / G))`
-  `requiredPriorityFeePerGas = virtualBaseFee - discountPerGas`
-- This allows full subsidy when `S >= G * virtualBaseFee` and partial subsidy otherwise.
-- Final settlement uses `gasUsed`, not `gasLimit`.
-- PBH is removed by this WIP. Bundler transactions remain out of scope.
+Once `gas_used` is known, the post-charge MUST settle the subsidy and sender contributions to their exact final values:
 
-### 5. Subsidy Eligibility
+1. Let `used_basefee_cost = gas_used * base_fee_per_gas`.
+2. Let `used_total_cost   = gas_used * effective_gas_price`.
+3. If the transaction is **not subsidy-eligible**: `gas_limit * effective_gas_price - used_total_cost` MUST be credited back to the sender. No WIP-1002 interaction occurs. This matches default revm behavior.
+4. If the transaction is **subsidy-eligible**:
+   - Let `final_subsidy = min(pre_subsidy, used_basefee_cost)`.
+   - Let `final_sender  = used_total_cost - final_subsidy`.
+   - The WIP-1002 budget for `nullifier` MUST end this transaction having been debited by exactly `final_subsidy`. Any pre-charged excess (`pre_subsidy - final_subsidy`) MUST be credited back to the budget.
+   - The sender balance MUST end this transaction having been debited by exactly `final_sender`. Any pre-charged excess (`pre_sender - final_sender`) MUST be credited back to the sender.
 
-A transaction is subsidy-eligible if either of the following is true:
+The WIP-1002 budget call MUST be the canonical `ISubsidyAccounting.consumeBudget(nullifier, gas_used, base_fee_per_gas)` invocation (or an internal equivalent if WIP-1002 is realized as a precompile rather than a predeploy). Implementations MUST ensure that the externally observable WIP-1002 state after this hook is identical to a single `consumeBudget(nullifier, gas_used, base_fee_per_gas)` call having been made for this transaction.
 
-- the sender is verified in the WIP-1002 defined contract for the current epoch
-- the transaction is a valid WIP-1002 registration transaction that verifies a specific address for the current epoch or next epoch
+#### `reward_beneficiary` (post-execution)
 
-For WIP-1002 registration transactions:
+The validator MUST be credited the priority-fee portion only:
 
-- the subsidy is attributed to the address being verified, not necessarily `msg.sender`
-- the registration transaction counts toward that address's subsidy budget for the current WIP-1002 epoch
-- only canonical WIP-1002 registration calls are eligible
+1. If the transaction is **not subsidy-eligible**: `gas_used * priority_fee_per_gas` is credited to the block beneficiary, matching default revm behavior.
+2. If the transaction is **subsidy-eligible**:
+   - `gas_used * priority_fee_per_gas` MUST be credited to the block beneficiary from the sender's contribution.
+   - The base-fee portion covered by `final_subsidy` MUST NOT be credited to the beneficiary, MUST NOT be burned, and MUST NOT be minted. It is absorbed by the chain as a no-op transfer (the budget is virtual per-credential state on WIP-1002, not an ETH balance).
+   - The base-fee portion *not* covered by the subsidy — i.e. `used_basefee_cost - final_subsidy` — MUST follow EIP-1559's base-fee burn rule, since the sender paid it in ETH.
 
-Exact WIP-1002 ABI and storage changes are out of scope here. A separate spec can define them in detail.
+Validator economics on a subsidized `0x1D` transaction are therefore identical to a non-subsidized `0x1D` transaction with the same `gas_used` and `priority_fee_per_gas`: the validator receives the same priority-fee payment, and the chain absorbs the subsidized base-fee portion in place of an EIP-1559 burn.
 
-### 6. Subsidy Accounting
+### Failed Validation
 
-Each verified address has a subsidy budget denominated in wei for each WIP-1002 epoch.
+If a `0x1D` transaction fails validation (per WIP-1001 §"Validation, Execution, and Failure Semantics") before [`validate_against_state_and_deduct_caller`](#validate_against_state_and_deduct_caller-pre-execution) completes successfully, the validation-failure fee defined by WIP-1001 MUST be charged in full to the sender and MUST NOT be debited from the WIP-1002 budget, regardless of subsidy eligibility. This prevents budget drain through repeated failing validations.
 
-- the subsidy budget uses the same epoch boundaries as the WIP-1002
-- the full virtual base fee liability for an included transaction is `gasUsed * virtualBaseFee`
-- the actual subsidy applied is `min(remainingSubsidy, gasUsed * virtualBaseFee)`
-- the unsubsidized remainder is paid by the sender through priority fee
-- any fee paid above the unsubsidized remainder is an optional tip and is not subsidized
-- partial subsidy is allowed
+### Interaction with WIP-1002
 
-### 7. Block Construction
+This WIP does not modify the WIP-1002 interface. The only new requirement is that the consumption path described in [`reimburse_caller`](#reimburse_caller-post-execution) is invoked exactly once per included `0x1D` transaction that was subsidy-eligible at pre-execution, with `gas_used` and `base_fee_per_gas` matching the executed transaction.
 
-The builder preferentially uses a fraction of each block, and optionally each flashblock, for verified transactions. This replaces PBH block segmentation.
+### Wallet RPC
 
-- verified transactions get preferential access to the verified portion even if they have no subsidy remaining
-- non-verified transactions may use the remainder of that portion near the end of block construction if verified demand does not fill it
-- the rest of the block remains open to ordinary transactions
-- transaction selection is bounded by `virtualGasLimit`, not the protocol gas limit
-
-When constructing a block, the builder:
-
-1. determines the charged account for each subsidy-eligible transaction
-2. executes the transaction
-3. computes `virtualBaseFeeLiability = gasUsed * virtualBaseFee`
-4. computes `actualSubsidy = min(remainingSubsidy, virtualBaseFeeLiability)`
-5. checks that the sender-paid priority fee covers `virtualBaseFeeLiability - actualSubsidy`
-6. updates the charged account by `actualSubsidy`
-
-Within the verified segment, transactions may still compete via optional tip.
-
-### 8. Address-Book Updates
-
-The WIP-1002 is extended to track subsidy usage per address per epoch.
-
-At minimum it must support:
-
-- checking whether an address is verified for the current epoch
-- tracking total subsidized wei used by an address for a given epoch
-- exposing enough state for builders to determine remaining subsidy
-
-At the end of each block, the builder sends a builder-owned transaction that updates the WIP-1002 with the subsidy deltas for that block.
-
-### 9. RPC Behavior
-
-Current wallets typically estimate fees using some combination of:
-
-- `eth_estimateGas`
-- `eth_maxPriorityFeePerGas`
-- `eth_gasPrice`
-- `eth_feeHistory`
-- the latest block's `baseFeePerGas`
-
-The World Chain client overrides fee suggestion RPC behavior so wallets quote the virtual fee market instead of the protocol base fee.
-
-This includes:
-
-- `eth_maxPriorityFeePerGas`
-- `eth_gasPrice`
-- `eth_feeHistory`, where needed for wallet compatibility
-
-`eth_estimateGas` continues to estimate gas usage, not fees.
-
-For ordinary transactions, overriding these fee RPCs is sufficient for compatibility with wallets that already rely on them.
-
-Wallets that derive fees directly from the block header `baseFeePerGas` may underquote, because the protocol header value remains `0`. Wallets integrating World Chain should therefore prefer the overridden fee RPCs rather than raw block-header base fee.
-
-World Chain clients should also expose account-aware subsidy information. A client can read the WIP-1002 state for an account and return at least:
-
-- whether the account is currently verified
-- its remaining subsidy for the current epoch
-- an account-specific suggested `maxPriorityFeePerGas` given an estimated gas limit
-
-Subsidy-aware wallets may then send a lower priority fee, including `0`, when the sender's remaining subsidy covers the virtual base fee liability.
+Standard EIP-1559 fee RPCs (`eth_maxPriorityFeePerGas`, `eth_gasPrice`, `eth_feeHistory`, block-header `baseFeePerGas`) continue to return their normal protocol-derived values, since the protocol fee market is unchanged. Subsidy-aware wallets MAY additionally query WIP-1002 directly for the framed `account`'s remaining budget and reduce the requested `gas_limit * (effective_gas_price - base_fee_per_gas)` accordingly. No wallet-facing RPC overrides are mandated by this WIP.
 
 ## Rationale
 
-The protocol base fee is pinned to `0` so verified transactions can be literally free. The fee market is moved into builder policy so World Chain can still price ordinary traffic while waiving fees for verified humans up to a bounded limit.
+### Why three handler hooks
 
-The virtual fee parameters are committed one block ahead so all builders can validate the same fee floor for the next block. Using the WIP-1002 epoch for subsidy accounting keeps verification state and subsidy state aligned.
+The three overrides correspond exactly to the three points in the revm execution pipeline where fee state is moved between accounts: pre-execution deduction of the maximum possible charge, post-execution refund of unused gas, and post-execution payment of the validator. Overriding any fewer of them leaves an asymmetry that is hard to keep consistent under refunds and gas-used variability. Overriding any more is unnecessary because no other phase touches fee state.
 
-Charging registration subsidies to the address being verified avoids tying subsidy attribution to the relayer or caller, which matches the intended beneficiary of the verification.
+### Pre-charge over-estimation
+
+The pre-charge uses `gas_limit * base_fee_per_gas` as the subsidy upper bound rather than waiting for `gas_used`. This matches default revm behavior (which pre-charges `gas_limit * effective_gas_price` from the sender) and is corrected exactly in `reimburse_caller`. The alternative — deferring all subsidy interaction to post-execution — would require the sender to hold enough balance to cover `gas_limit * effective_gas_price` in addition to having a non-zero subsidy budget, which negates the user-visible benefit of the subsidy for budget-covered traffic.
+
+### Subsidy is base-fee only
+
+The subsidy unit follows WIP-1002's existing `consumeBudget(nullifier, gas_used, base_fee_per_gas)` signature: only the base-fee portion of the fee is subsidizable, the priority fee is always paid by the sender. This keeps validator economics on a subsidized transaction identical to a non-subsidized transaction with the same `gas_used` and tip; the chain absorbs the subsidized base-fee portion in place of the EIP-1559 burn.
+
+### Scope to `0x1D`
+
+Constraining subsidy enforcement to the WIP-1001 execution path keeps the protocol fee market, wallet RPC surface, and non-`0x1D` traffic unchanged. WIP-1002 authorization is keyed to WIP-1001 accounts in the expected deployment, so subsidy-eligible traffic is in practice a subset of `0x1D` traffic; widening the scope would expand surface area without expanding the set of subsidized transactions.
+
+### Third-party gas sponsorship
+
+Generic third-party gas sponsorship (an external EOA paying for an unrelated user's transaction) is not supported by this WIP. If sponsorship becomes a requirement, it is an envelope-additive extension over this proposal: a Tempo-style `fee_payer_signature` field on `0x1D` with an additional charge tier between subsidy and sender. The handler structure above generalizes naturally to a three-tier (subsidy → sponsor → sender) charge without changing the per-tier semantics.
 
 ## Backwards Compatibility
 
-This WIP intentionally changes World Chain transaction admission, fee quoting, and block segmentation behavior.
+- The protocol fee market and EIP-1559 semantics are unchanged for all non-`0x1D` traffic and for non-subsidy-eligible `0x1D` traffic.
+- `0x1D` envelope encoding, signing-hash construction, and validation rules from WIP-1001 are unchanged.
+- The WIP-1002 interface is unchanged.
+- This WIP requires activation alongside (or after) WIP-1001 and WIP-1002. Activating it independently is meaningless.
+- Block-header `baseFeePerGas` continues to follow EIP-1559, so wallets and indexers reading the block header are not affected.
+- PBH is superseded by this mechanism for the subsidy use case.
 
-- PBH is replaced by subsidy-aware verified blockspace
-- the protocol block header still exposes `baseFeePerGas = 0`
-- ordinary wallets interacting through standard fee RPCs continue to see a fee quote, but that quote is virtual rather than protocol-derived
+## Test Cases
+
+Test cases SHOULD exercise the following points, at minimum:
+
+- `0x1D` transaction with no WIP-1002 authorization — full sender pre-charge, full sender post-refund, no WIP-1002 interaction. Indistinguishable from a default-handler trace.
+- `0x1D` transaction with subsidy fully covering the executed base-fee cost (`budget >= gas_used * base_fee_per_gas`) — sender pays exactly `gas_used * priority_fee_per_gas`, budget debited by exactly `gas_used * base_fee_per_gas`, beneficiary receives exactly `gas_used * priority_fee_per_gas`, no EIP-1559 burn for the subsidized portion.
+- `0x1D` transaction with subsidy partially covering the executed base-fee cost (`0 < budget < gas_used * base_fee_per_gas`) — sender pays `used_total_cost - budget`, budget debited to `0`, beneficiary receives `gas_used * priority_fee_per_gas`, EIP-1559 burn applies to `used_basefee_cost - budget`.
+- `0x1D` transaction with `gas_used` strictly less than `gas_limit` — pre-charged excess is refunded to both budget and sender in the proportions defined by [`reimburse_caller`](#reimburse_caller-post-execution).
+- `0x1D` transaction failing pre-execution validation — full WIP-1001 validation-failure fee charged to sender, budget untouched.
+- `0x1D` transaction whose framed sender is authorized under multiple nullifiers — the chosen nullifier matches the WIP-1002 deterministic selection rule, and only that nullifier's budget is debited.
+
+## Reference Implementation
+
+No reference implementation is included in this draft. The expected shape is a revm `Handler` variant for `0x1D` transactions overriding the three methods named in [Handler Overrides](#handler-overrides); the variant dispatches on the WIP-1002 resolution result at pre-execution and stores the `(nullifier, pre_subsidy)` pair on the execution context for use in `reimburse_caller`.
 
 ## Security Considerations
 
-Because the fee market is out of protocol, all builders must derive the same virtual fee parameters for the same block. If they do not, transaction admission diverges. The fallback builder must therefore run the same World Chain client behavior.
-
-Verified free transactions create a DoS surface unless both of the following are enforced:
-
-- the preferential verified portion remains capped
-- each verified address remains bounded by a per-epoch wei subsidy limit
-
-Address-book registration transactions need careful attribution and selector filtering so callers cannot redirect subsidy eligibility to arbitrary calls. Only canonical registration calls that successfully verify an address should receive subsidy treatment.
-
-The builder-owned end-of-block accounting transaction is trusted operational infrastructure. If it is omitted or delayed, subsidy accounting becomes stale. 
+- **Budget drain via failing transactions.** All validation-failure costs MUST be paid by the sender, never the budget. See [Failed Validation](#failed-validation). Implementations MUST NOT route any failure path through WIP-1002 consumption.
+- **Pre-charge / post-refund consistency.** A buggy `reimburse_caller` that fails to credit unused budget back would silently drain budgets even for normally successful transactions. Implementations MUST treat the equality `final_subsidy + final_sender = used_total_cost` (and the equalities for refunds) as invariants and enforce them in tests.
+- **Deterministic nullifier selection.** When an account is authorized under multiple nullifiers, the WIP-1002 deterministic selection rule MUST be used at every site that resolves an account to a nullifier (pre-execution, post-execution, RPC) so all sites agree on which budget is debited.
+- **Validator opt-in.** Because validator economics are unchanged from a non-subsidized transaction, no validator opt-in mechanism is required. Validators that wish to exclude subsidized traffic for policy reasons MAY do so through the standard transaction-selection layer; this WIP imposes no requirement either way.
+- **Re-entrancy with WIP-1002 as predeploy.** If WIP-1002 is realized as a predeploy (rather than a precompile), the `consumeBudget` reconciliation in `reimburse_caller` runs after `gas_used` is finalized and therefore cannot re-enter the executing transaction. If WIP-1002 calls are batched or deferred for performance, the deferred calls MUST be ordered and applied atomically with block production so that observable WIP-1002 state remains consistent with executed transactions.
+- **Interaction with EIP-1559 burn.** The base-fee portion paid in ETH by the sender (when subsidy is partial) MUST still be burned per EIP-1559. Only the subsidy-covered portion is absorbed.

--- a/wips/wip-1003.md
+++ b/wips/wip-1003.md
@@ -1,7 +1,7 @@
 ---
 wip: 1003
 title: World ID Transaction Subsidies
-description: A subsidy-enforcement mechanism for WIP-1001 transactions that splits the fee charge between a WIP-1002 subsidy budget and the sender via three revm `Handler` hook overrides, without modifying the protocol fee market or the transaction envelope.
+description: A subsidy-enforcement mechanism for WIP-1001 transactions that, on OP-Stack, models the subsidy as skipped credits to the L2 fee vaults and a skipped caller pre-charge — no ETH ever moves for the subsidized portion, and the per-nullifier WIP-1002 budget caps the operator's forgone fee revenue.
 author: Eric Woolsey (@0xforerunner), Kilian Glas (@kilianglas), Alessandro Mazza (@alessandromazza98)
 status: Draft
 type: Standards Track
@@ -14,18 +14,20 @@ requires: WIP-1001, WIP-1002, EIP-1559
 
 This WIP specifies **Subsidy Enforcement** for World Chain — the mechanism that turns a verified World ID's remaining gas budget (tracked in [WIP-1002](./wip-1002.md)) into a discounted transaction at inclusion time. The mechanism is scoped to [WIP-1001](./wip-1001.md) `0x1D` transactions and is realized as three overrides of the revm `Handler` trait: `validate_against_state_and_deduct_caller`, `reimburse_caller`, and `reward_beneficiary`.
 
-The protocol base fee market is left untouched, no envelope fields are added, and no per-block subsidy-accounting transaction is required. The subsidy covers the base fee for a `0x1D` transaction whose sender resolves to an authorized WIP-1002 nullifier with non-zero remaining budget; the priority fee is always paid by the sender. When the budget is insufficient or absent, the transaction falls back to standard EIP-1559 charging.
+Because World Chain runs on the OP-Stack, where every L2 fee component (base fee, priority fee, L1 data fee, operator fee) is credited to an operator-controlled predeploy vault rather than burned, the subsidy is realized as a **no-op for the chain's ETH ledger**: the caller is not pre-charged for the subsidized fraction of the fee, and the corresponding vault credits in the standard `reward_beneficiary` are skipped. The per-nullifier WIP-1002 budget caps the wei the chain operator forgoes per credential per period. No treasury is required, no ETH is minted, and no validator compensation gap is introduced under the centralized-sequencer model.
+
+A 0x1D transaction whose framed sender is authorized under a WIP-1002 nullifier with sufficient remaining budget can be sent with zero ETH held by the sender. When budget is insufficient or absent, the transaction falls back to standard EIP-1559 / OP-Stack charging.
 
 ## Motivation
 
-[WIP-1002](./wip-1002.md) defines per-credential, ETH-denominated subsidy budgets for verified World IDs and exposes a `consumeBudget(nullifier, gasUsed, baseFee)` consumption hook, but it deliberately leaves the *enforcement* mechanism — how that budget is actually applied at transaction inclusion time — out of scope.
+[WIP-1002](./wip-1002.md) defines per-credential, wei-denominated subsidy budgets for verified World IDs and exposes an on-chain consumption hook, but deliberately leaves the *enforcement* mechanism — how that budget is actually applied at transaction inclusion time — out of scope.
 
 World Chain wants two properties at the same time:
 
 - a real fee market for non-verified traffic,
-- subsidized transactions for verified humans up to a bounded per-period budget.
+- transactions for verified humans that can be fully fee-free up to a bounded per-period budget, including from accounts holding zero ETH.
 
-[WIP-1001](./wip-1001.md) introduces a new transaction type (`0x1D`) with a dedicated execution path. Once that path exists and WIP-1002 exposes an on-chain consumption hook, subsidy enforcement can be expressed as a small handler override on the new transaction type alone. The protocol fee market, the wallet RPC surface, and non-`0x1D` traffic remain unaffected. PBH is superseded by this mechanism for the subsidy use case; lane/inclusion policy is a separate concern from pricing and is out of scope for this WIP.
+[WIP-1001](./wip-1001.md) introduces a new transaction type (`0x1D`) with a dedicated execution path. Once that path exists, WIP-1002 exposes an on-chain consumption hook, and the OP-Stack fee model is taken into account, subsidy enforcement reduces to a small handler override on the new transaction type alone. The protocol fee market, the wallet RPC surface, and non-`0x1D` traffic remain unaffected. PBH is superseded by this mechanism for the subsidy use case; lane/inclusion policy is a separate concern from pricing and is out of scope for this WIP.
 
 ## Specification
 
@@ -33,96 +35,150 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Scope
 
-Subsidy enforcement under this WIP applies to [WIP-1001](./wip-1001.md) transactions only (type flag `0x1D`). All other transaction types follow standard EIP-1559 charging, unchanged by this WIP. The protocol `baseFeePerGas` retains its EIP-1559 semantics for all transaction types, including `0x1D`.
+Subsidy enforcement under this WIP applies to [WIP-1001](./wip-1001.md) transactions only (type flag `0x1D`). All other transaction types follow standard OP-Stack charging, unchanged by this WIP. The protocol `baseFeePerGas` retains its EIP-1559 semantics for all transaction types.
+
+This WIP relies on the OP-Stack fee model. The funding analysis in [Fee Accounting on OP-Stack](#fee-accounting-on-op-stack) and the no-op realization in [Handler Overrides](#handler-overrides) presume that the chain operator owns the L2 fee vaults named below; they do not apply unchanged on non-OP-Stack deployments.
+
+### Fee Accounting on OP-Stack
+
+On the OP-Stack, none of the L2 transaction fee components are burned. Each component is credited to an operator-controlled predeploy:
+
+- **Priority fee** → `block.coinbase`, set by the L2 derivation pipeline to `SequencerFeeVault` (`0x4200…0011`); credited by the mainnet `reward_beneficiary` path the op-revm handler calls through to.
+- **Base fee** → `BaseFeeVault` (`0x4200…0019`); credited by op-revm via an explicit `balance_incr(BASE_FEE_RECIPIENT, base_fee * gas_used)` in `reward_beneficiary`.
+- **L1 data fee** → `L1FeeVault` (`0x4200…001A`); deducted from the caller in `validate_against_state_and_deduct_caller` via the L1-block info accounting, and credited in `reward_beneficiary`.
+- **Operator fee** (Isthmus+) → `OPERATOR_FEE_RECIPIENT` (`0x4200…001B`); same pattern as L1 fee.
+
+The chain operator owns all four vaults and withdraws their accumulated balances to L1 via `OptimismPortal`. EIP-1559's burn-to-`address(0)` does not occur on the OP-Stack — base fee is *collected*, not destroyed.
+
+Consequently, "subsidizing the fee" can be modeled as **skipping the caller deduction and skipping the corresponding vault credits**, with no ETH transferred anywhere. The cost of the subsidy is the chain operator's opportunity cost — forgone fee revenue on the subsidized fraction. The per-nullifier WIP-1002 budget is the hard cap on that opportunity cost per credential per period.
 
 ### Subsidy Resolution
 
 For a `0x1D` transaction whose framed sender is `account`, subsidy eligibility is resolved deterministically against [WIP-1002](./wip-1002.md) Subsidy Accounting:
 
 1. Resolve `account` to a `nullifier` via the WIP-1002 authorization map. If `account` is authorized under multiple nullifiers, the WIP-1002 deterministic nullifier-selection rule MUST be used to choose exactly one record.
-2. If no authorized `nullifier` exists for `account` in the current WIP-1002 period, the transaction is **not subsidy-eligible** and standard EIP-1559 charging applies for all phases below.
+2. If no authorized `nullifier` exists for `account` in the current WIP-1002 period, the transaction is **not subsidy-eligible** and standard OP-Stack charging applies for all phases below.
 3. If an authorized `nullifier` exists, let `budget = ISubsidyAccounting.getBudget(nullifier)`. The transaction is **subsidy-eligible** if and only if `budget > 0`.
 
-Subsidy eligibility MUST be evaluated against post-validation state, after the framed-sender and session verifier checks defined by WIP-1001.
+The resolution result (eligibility flag and chosen `nullifier`) MUST be computed once per transaction and reused at every site that consults it (the [WIP-1001 pre-validation balance check](#wip-1001-pre-validation-balance-check), all three handler hooks, RPC).
+
+### Subsidy Coverage
+
+For a subsidy-eligible transaction, let `pre_total` be the wei amount the standard OP-Stack pre-charge would deduct from the caller in `validate_against_state_and_deduct_caller`:
+
+```
+pre_total = gas_limit * effective_gas_price + tx_l1_cost + operator_fee_charge
+```
+
+where `effective_gas_price = min(max_fee_per_gas, base_fee_per_gas + max_priority_fee_per_gas)`. Let `priority_fee_per_gas = effective_gas_price - base_fee_per_gas`.
+
+The subsidy MAY cover any prefix of this total. The pre-execution upper bound is:
+
+```
+pre_subsidy = min(budget, pre_total)
+pre_sender  = pre_total - pre_subsidy
+```
+
+The final post-execution settlement (in `reimburse_caller`) computes the equivalent quantities against the actual `used_total = gas_used * effective_gas_price + tx_l1_cost + operator_fee_charge`:
+
+```
+final_subsidy = min(pre_subsidy, used_total)
+final_sender  = used_total - final_subsidy
+```
+
+Both base fee and priority fee are subsidisable; L1 data fee and operator fee are likewise subsidisable through the same vault-credit-skip mechanism. Governance MAY tune per-credential budgets to account for the operator's real L1 cost (see [Security Considerations](#security-considerations)).
 
 ### Handler Overrides
 
-This WIP overrides three methods of the revm `Handler` trait on the `0x1D` execution path. All other handler methods follow their default implementation. The override semantics below are normative; the field names match the revm trait signatures.
-
-Let:
-
-- `gas_limit` — the `0x1D` envelope's gas limit;
-- `max_fee_per_gas`, `max_priority_fee_per_gas` — the EIP-1559 fee fields from the envelope;
-- `base_fee_per_gas` — the block's protocol base fee;
-- `effective_gas_price = min(max_fee_per_gas, base_fee_per_gas + max_priority_fee_per_gas)`;
-- `priority_fee_per_gas = effective_gas_price - base_fee_per_gas`.
+This WIP overrides three methods of the revm `Handler` trait on the `0x1D` execution path. All other handler methods follow their op-revm default implementation. The override semantics below are normative; field names match the revm trait signatures.
 
 #### `validate_against_state_and_deduct_caller` (pre-execution)
 
-The pre-charge MUST split the maximum possible fee `gas_limit * effective_gas_price` between the WIP-1002 subsidy budget and the sender balance:
+The pre-charge MUST split `pre_total` between the WIP-1002 budget and the caller balance:
 
-1. Standard EIP-1559 validation checks (nonce, sufficient balance for non-subsidized portion, `max_fee_per_gas >= base_fee_per_gas`, `max_priority_fee_per_gas <= max_fee_per_gas`) MUST be performed before any subsidy logic.
-2. If the transaction is **not subsidy-eligible** (per [Subsidy Resolution](#subsidy-resolution)): the entire `gas_limit * effective_gas_price` MUST be debited from the sender, following default revm behavior.
-3. If the transaction is **subsidy-eligible**:
-   - Let `pre_subsidy = min(budget, gas_limit * base_fee_per_gas)` — the maximum base-fee portion that the budget can cover.
-   - Let `pre_sender = gas_limit * effective_gas_price - pre_subsidy` — the residual the sender pre-pays.
-   - The sender balance MUST be debited by `pre_sender`. The transaction MUST be rejected if the sender balance is insufficient to cover `pre_sender`.
-   - The WIP-1002 budget for `nullifier` MUST be marked as conditionally consumed by `pre_subsidy` for the duration of this transaction. Implementations MAY realize this either as an in-handler shadow value or by calling `ISubsidyAccounting.consumeBudget` here and reconciling in [`reimburse_caller`](#reimburse_caller-post-execution); the externally observable result MUST match the post-tx semantics in [`reimburse_caller`](#reimburse_caller-post-execution).
+1. Standard EIP-1559 envelope-validity checks (`max_fee_per_gas >= base_fee_per_gas`, `max_priority_fee_per_gas <= max_fee_per_gas`) MUST be performed first. Nonce and code checks proceed as in the op-revm default.
+2. The caller balance check MUST require only `pre_sender` (not the full `pre_total`). If the balance is insufficient to cover `pre_sender`, the transaction MUST be rejected with the standard "lack of funds" error.
+3. The caller balance MUST be debited by `pre_sender` only. The subsidized fraction is NOT taken from the caller and is NOT moved anywhere — it is held as a virtual conditional debit `pre_subsidy` against the chosen `nullifier`, carried through to [`reimburse_caller`](#reimburse_caller-post-execution) on the execution context.
+4. The L1 block info accounting that records the tx's L1 cost MUST still be performed; subsidizing the L1 fee changes only whether the caller is debited and whether `L1FeeVault` is credited, not the L1 cost computation itself.
 
-The chosen `nullifier` and the `pre_subsidy` value MUST be carried through to the post-execution phase so the exact final settlement can be computed against `gas_used`.
+Non-subsidy-eligible `0x1D` transactions take the op-revm default path with no modifications.
 
 #### `reimburse_caller` (post-execution)
 
-Once `gas_used` is known, the post-charge MUST settle the subsidy and sender contributions to their exact final values:
+Once `gas_used` is known, the post-charge MUST settle the subsidy and caller contributions to their exact final values:
 
-1. Let `used_basefee_cost = gas_used * base_fee_per_gas`.
-2. Let `used_total_cost   = gas_used * effective_gas_price`.
-3. If the transaction is **not subsidy-eligible**: `gas_limit * effective_gas_price - used_total_cost` MUST be credited back to the sender. No WIP-1002 interaction occurs. This matches default revm behavior.
-4. If the transaction is **subsidy-eligible**:
-   - Let `final_subsidy = min(pre_subsidy, used_basefee_cost)`.
-   - Let `final_sender  = used_total_cost - final_subsidy`.
-   - The WIP-1002 budget for `nullifier` MUST end this transaction having been debited by exactly `final_subsidy`. Any pre-charged excess (`pre_subsidy - final_subsidy`) MUST be credited back to the budget.
-   - The sender balance MUST end this transaction having been debited by exactly `final_sender`. Any pre-charged excess (`pre_sender - final_sender`) MUST be credited back to the sender.
+1. Compute `used_total` per [Subsidy Coverage](#subsidy-coverage). Let `final_subsidy = min(pre_subsidy, used_total)` and `final_sender = used_total - final_subsidy`.
+2. The WIP-1002 budget for the chosen `nullifier` MUST end this transaction having been decremented by exactly `final_subsidy`. Implementations realize this by calling the WIP-1002 consumption interface with `final_subsidy` as the wei amount (the existing `consumeBudget(nullifier, gasUsed, baseFee)` signature is insufficient to express a general wei amount; see [Interaction with WIP-1002](#interaction-with-wip-1002)).
+3. The caller balance MUST end this transaction having been debited by exactly `final_sender`. Any excess of `pre_sender` over `final_sender` MUST be credited back to the caller.
 
-The WIP-1002 budget call MUST be the canonical `ISubsidyAccounting.consumeBudget(nullifier, gas_used, base_fee_per_gas)` invocation (or an internal equivalent if WIP-1002 is realized as a precompile rather than a predeploy). Implementations MUST ensure that the externally observable WIP-1002 state after this hook is identical to a single `consumeBudget(nullifier, gas_used, base_fee_per_gas)` call having been made for this transaction.
+For non-subsidy-eligible transactions, the op-revm default refund path applies.
 
 #### `reward_beneficiary` (post-execution)
 
-The validator MUST be credited the priority-fee portion only:
+The vault credits MUST be reduced by exactly the subsidized fraction of each component:
 
-1. If the transaction is **not subsidy-eligible**: `gas_used * priority_fee_per_gas` is credited to the block beneficiary, matching default revm behavior.
-2. If the transaction is **subsidy-eligible**:
-   - `gas_used * priority_fee_per_gas` MUST be credited to the block beneficiary from the sender's contribution.
-   - The base-fee portion covered by `final_subsidy` MUST NOT be credited to the beneficiary, MUST NOT be burned, and MUST NOT be minted. It is absorbed by the chain as a no-op transfer (the budget is virtual per-credential state on WIP-1002, not an ETH balance).
-   - The base-fee portion *not* covered by the subsidy — i.e. `used_basefee_cost - final_subsidy` — MUST follow EIP-1559's base-fee burn rule, since the sender paid it in ETH.
+1. Let `subsidy_fraction = final_subsidy / used_total` (taken as a rational fraction; implementations MUST compute the per-component subsidized amounts without intermediate rounding, e.g. by debiting components in a fixed priority order; see [Rationale](#rationale)).
+2. For each fee component otherwise credited in op-revm's `reward_beneficiary` (base fee → `BaseFeeVault`, priority fee → `block.coinbase`, L1 cost → `L1FeeVault`, operator fee → `OPERATOR_FEE_RECIPIENT`), the credited amount MUST equal the sender-paid portion of that component, i.e. `default_credit * (1 - subsidy_fraction_for_component)`.
+3. The omitted credits (the `subsidy_fraction_for_component * default_credit` portion) MUST NOT be credited to any other address, MUST NOT be burned, and MUST NOT be minted. They are skipped — the chain operator forgoes the corresponding vault inflow.
 
-Validator economics on a subsidized `0x1D` transaction are therefore identical to a non-subsidized `0x1D` transaction with the same `gas_used` and `priority_fee_per_gas`: the validator receives the same priority-fee payment, and the chain absorbs the subsidized base-fee portion in place of an EIP-1559 burn.
+Conservation:
+
+- Non-subsidy-eligible 0x1D tx: indistinguishable from op-revm default.
+- Fully subsidized 0x1D tx with `budget ≥ used_total`: caller balance unchanged, no vault credits issued, WIP-1002 budget debited by `used_total`.
+- Partial subsidy: caller debited by `final_sender`; vault credits sum to `final_sender`; WIP-1002 budget debited by `final_subsidy`.
+
+### WIP-1001 Pre-validation Balance Check
+
+[WIP-1001](./wip-1001.md) §"Validation, Execution, and Failure Semantics" requires the chain to "require the account balance to cover the worst-case payload gas charge and `MIN_VALIDATION_FAILURE_FEE`". For this WIP to admit subsidy-eligible transactions from accounts holding zero ETH, that check MUST be subsidy-aware:
+
+1. Before the WIP-1001 balance check runs, perform [Subsidy Resolution](#subsidy-resolution) against WIP-1002 to determine eligibility and the remaining `budget`.
+2. The "worst-case payload gas charge" used in the WIP-1001 check MUST be reduced by `min(budget, gas_limit * effective_gas_price + tx_l1_cost + operator_fee_charge)`.
+3. `MIN_VALIDATION_FAILURE_FEE` MAY be subsidy-covered (see [Failed Validation](#failed-validation)); if so, the WIP-1001 check MUST reduce its `MIN_VALIDATION_FAILURE_FEE` requirement by the corresponding subsidisable portion.
+
+This is the only required modification to WIP-1001 by this WIP. WIP-1001's envelope-validity rules, signing hash, and session-verifier execution model are unchanged.
 
 ### Failed Validation
 
-If a `0x1D` transaction fails validation (per WIP-1001 §"Validation, Execution, and Failure Semantics") before [`validate_against_state_and_deduct_caller`](#validate_against_state_and_deduct_caller-pre-execution) completes successfully, the validation-failure fee defined by WIP-1001 MUST be charged in full to the sender and MUST NOT be debited from the WIP-1002 budget, regardless of subsidy eligibility. This prevents budget drain through repeated failing validations.
+If a `0x1D` transaction fails validation (per WIP-1001 §"Validation, Execution, and Failure Semantics") *after* envelope decoding, signature recovery, and session-verifier dispatch have all succeeded — i.e. a real, well-formed transaction whose execution-phase validation produced a halt or invalid result — the validation-failure fee MAY be subsidy-covered using the same vault-credit-skip mechanism as a successful transaction.
+
+If the transaction fails *before* the session verifier returns (malformed envelope, signature recovery failure, unauthorized session verifier, exhausted block validation budget), the validation-failure fee MUST be charged to the sender in the standard sender-paid manner — the budget is not yet known to be associated with a genuine WIP-1001 signing key holder, so subsidizing this path opens a low-cost mempool spam vector that does not consume the attacker's own resources.
+
+Implementations realize this split by treating the result of the session-verifier dispatch as the gating signal: the chosen `nullifier` and `pre_subsidy` are committed to the execution context only after that dispatch succeeds, and the post-failure fee accounting MUST consult that commitment.
 
 ### Interaction with WIP-1002
 
-This WIP does not modify the WIP-1002 interface. The only new requirement is that the consumption path described in [`reimburse_caller`](#reimburse_caller-post-execution) is invoked exactly once per included `0x1D` transaction that was subsidy-eligible at pre-execution, with `gas_used` and `base_fee_per_gas` matching the executed transaction.
+This WIP requires WIP-1002 to expose a wei-amount consumption call. The existing `consumeBudget(nullifier, gasUsed, baseFee)` signature in WIP-1002 §"Subsidy Accounting Interface" assumes the subsidisable cost equals `gasUsed * baseFee`; under this WIP the consumed amount is general (covers priority fee, L1 fee, operator fee, and validation-failure fee). The required addition is either:
+
+- a new entry point `consumeBudget(uint256 nullifier, uint256 weiAmount)`, or
+- a redefinition of the existing call to interpret its third argument as a generic wei-per-gas-unit price.
+
+WIP-1002 is otherwise unchanged. The consumption call MUST be invoked exactly once per included subsidy-eligible 0x1D transaction (success or post-session-verifier failure), with the wei amount equal to `final_subsidy`. The externally observable WIP-1002 state after a transaction MUST be identical to a single such call having been made.
 
 ### Wallet RPC
 
-Standard EIP-1559 fee RPCs (`eth_maxPriorityFeePerGas`, `eth_gasPrice`, `eth_feeHistory`, block-header `baseFeePerGas`) continue to return their normal protocol-derived values, since the protocol fee market is unchanged. Subsidy-aware wallets MAY additionally query WIP-1002 directly for the framed `account`'s remaining budget and reduce the requested `gas_limit * (effective_gas_price - base_fee_per_gas)` accordingly. No wallet-facing RPC overrides are mandated by this WIP.
+Standard EIP-1559 fee RPCs (`eth_maxPriorityFeePerGas`, `eth_gasPrice`, `eth_feeHistory`, block-header `baseFeePerGas`) continue to return their normal protocol-derived values; the protocol fee market is unchanged. Subsidy-aware wallets MAY additionally query WIP-1002 directly for the framed `account`'s remaining budget and select `max_fee_per_gas` / `max_priority_fee_per_gas` accordingly — including zero priority fee, since the subsidy now covers it. No wallet-facing RPC overrides are mandated by this WIP.
 
 ## Rationale
 
+### Why no-op funding works on OP-Stack
+
+On L1 Ethereum, EIP-1559 burns the base fee, so a "subsidy that covers the base fee" cannot be realized without either (a) a treasury that holds the wei the user does not pay, (b) minting, or (c) violating EIP-1559's burn invariant. On the OP-Stack none of these tensions exist: every fee component is credited to an operator-controlled predeploy, and the operator already has unilateral control over how those vaults are subsequently used. Skipping the credit is therefore a clean reduction of the operator's claim on the chain's value flow, not a manipulation of validator economics or supply. This makes the subsidy a pure no-op at the ETH-ledger level.
+
 ### Why three handler hooks
 
-The three overrides correspond exactly to the three points in the revm execution pipeline where fee state is moved between accounts: pre-execution deduction of the maximum possible charge, post-execution refund of unused gas, and post-execution payment of the validator. Overriding any fewer of them leaves an asymmetry that is hard to keep consistent under refunds and gas-used variability. Overriding any more is unnecessary because no other phase touches fee state.
+The three overrides correspond exactly to the three points in the revm execution pipeline where fee state moves between accounts on the OP-Stack: pre-execution deduction from the caller, post-execution refund to the caller, and post-execution crediting of the L2 fee vaults. Overriding any fewer of them leaves an asymmetry that is hard to keep consistent under refunds and gas-used variability. Overriding any more is unnecessary — no other phase touches fee state.
 
 ### Pre-charge over-estimation
 
-The pre-charge uses `gas_limit * base_fee_per_gas` as the subsidy upper bound rather than waiting for `gas_used`. This matches default revm behavior (which pre-charges `gas_limit * effective_gas_price` from the sender) and is corrected exactly in `reimburse_caller`. The alternative — deferring all subsidy interaction to post-execution — would require the sender to hold enough balance to cover `gas_limit * effective_gas_price` in addition to having a non-zero subsidy budget, which negates the user-visible benefit of the subsidy for budget-covered traffic.
+The pre-charge uses worst-case gas (`gas_limit`) as the subsidy upper bound rather than waiting for `gas_used`. This matches the op-revm default behavior (which pre-charges `gas_limit * effective_gas_price` plus L1 cost from the caller) and is corrected exactly in `reimburse_caller`. Deferring all subsidy interaction to post-execution would require the caller to hold enough balance to cover `gas_limit * effective_gas_price + L1 cost` in addition to having a non-zero subsidy budget, which negates the zero-ETH-sender property this WIP is designed to deliver.
 
-### Subsidy is base-fee only
+### Subsidy covers the full effective gas price (not just base fee)
 
-The subsidy unit follows WIP-1002's existing `consumeBudget(nullifier, gas_used, base_fee_per_gas)` signature: only the base-fee portion of the fee is subsidizable, the priority fee is always paid by the sender. This keeps validator economics on a subsidized transaction identical to a non-subsidized transaction with the same `gas_used` and tip; the chain absorbs the subsidized base-fee portion in place of the EIP-1559 burn.
+A prior version of this design subsidized only the base-fee portion, on the reasoning that priority fee is real validator compensation that the chain cannot freely waive. On OP-Stack that constraint does not bind: the priority fee credits `SequencerFeeVault`, owned by the operator, not an external validator. Subsidizing it is the same no-op as subsidizing base fee. Restricting the subsidy to base fee would force a zero-ETH user to send transactions with `max_priority_fee_per_gas = 0` and still rely on the verified-lane policy for inclusion — workable but strictly weaker UX, and asymmetric for no real reason on this stack.
+
+### Component apportionment
+
+When the subsidy partially covers `used_total`, the per-component apportionment (how much of base fee vs. priority fee vs. L1 fee is subsidized) is observable through the per-vault credits. Implementations SHOULD use a fixed priority order — e.g. base fee → priority fee → L1 fee → operator fee — so that traces are deterministic. The choice of order does not affect the user-visible outcome (sender pays `final_sender`, budget pays `final_subsidy`); it affects only which vault sees the partial credit at the boundary.
 
 ### Scope to `0x1D`
 
@@ -130,37 +186,41 @@ Constraining subsidy enforcement to the WIP-1001 execution path keeps the protoc
 
 ### Third-party gas sponsorship
 
-Generic third-party gas sponsorship (an external EOA paying for an unrelated user's transaction) is not supported by this WIP. If sponsorship becomes a requirement, it is an envelope-additive extension over this proposal: a Tempo-style `fee_payer_signature` field on `0x1D` with an additional charge tier between subsidy and sender. The handler structure above generalizes naturally to a three-tier (subsidy → sponsor → sender) charge without changing the per-tier semantics.
+Generic third-party gas sponsorship (an external EOA paying for an unrelated user's transaction) is not in scope for this WIP. If sponsorship becomes a requirement, it is an envelope-additive extension over this proposal: a Tempo-style `fee_payer_signature` field on `0x1D` with an additional charge tier between subsidy and sender. The handler structure above generalizes naturally to a three-tier (subsidy → sponsor → sender) charge without changing the per-tier semantics.
 
 ## Backwards Compatibility
 
-- The protocol fee market and EIP-1559 semantics are unchanged for all non-`0x1D` traffic and for non-subsidy-eligible `0x1D` traffic.
-- `0x1D` envelope encoding, signing-hash construction, and validation rules from WIP-1001 are unchanged.
-- The WIP-1002 interface is unchanged.
+- The protocol fee market and EIP-1559 / OP-Stack semantics are unchanged for all non-`0x1D` traffic and for non-subsidy-eligible `0x1D` traffic.
+- The `0x1D` envelope encoding, signing-hash construction, and validation rules from WIP-1001 are unchanged; the only WIP-1001 modification is the subsidy-aware reading of the pre-validation balance check (see [WIP-1001 Pre-validation Balance Check](#wip-1001-pre-validation-balance-check)).
+- WIP-1002's `consumeBudget` interface requires the wei-amount addition described in [Interaction with WIP-1002](#interaction-with-wip-1002).
 - This WIP requires activation alongside (or after) WIP-1001 and WIP-1002. Activating it independently is meaningless.
 - Block-header `baseFeePerGas` continues to follow EIP-1559, so wallets and indexers reading the block header are not affected.
 - PBH is superseded by this mechanism for the subsidy use case.
+- This WIP presumes the OP-Stack centralized-sequencer fee-vault model; see [Security Considerations](#security-considerations).
 
 ## Test Cases
 
-Test cases SHOULD exercise the following points, at minimum:
+Test cases SHOULD exercise at minimum:
 
-- `0x1D` transaction with no WIP-1002 authorization — full sender pre-charge, full sender post-refund, no WIP-1002 interaction. Indistinguishable from a default-handler trace.
-- `0x1D` transaction with subsidy fully covering the executed base-fee cost (`budget >= gas_used * base_fee_per_gas`) — sender pays exactly `gas_used * priority_fee_per_gas`, budget debited by exactly `gas_used * base_fee_per_gas`, beneficiary receives exactly `gas_used * priority_fee_per_gas`, no EIP-1559 burn for the subsidized portion.
-- `0x1D` transaction with subsidy partially covering the executed base-fee cost (`0 < budget < gas_used * base_fee_per_gas`) — sender pays `used_total_cost - budget`, budget debited to `0`, beneficiary receives `gas_used * priority_fee_per_gas`, EIP-1559 burn applies to `used_basefee_cost - budget`.
-- `0x1D` transaction with `gas_used` strictly less than `gas_limit` — pre-charged excess is refunded to both budget and sender in the proportions defined by [`reimburse_caller`](#reimburse_caller-post-execution).
-- `0x1D` transaction failing pre-execution validation — full WIP-1001 validation-failure fee charged to sender, budget untouched.
-- `0x1D` transaction whose framed sender is authorized under multiple nullifiers — the chosen nullifier matches the WIP-1002 deterministic selection rule, and only that nullifier's budget is debited.
+- `0x1D` transaction with no WIP-1002 authorization — full caller pre-charge, full caller post-refund, all vault credits as in op-revm default, no WIP-1002 interaction.
+- `0x1D` transaction with subsidy fully covering `used_total` and a caller balance of zero — caller balance untouched, no vault credits issued, WIP-1002 budget debited by `used_total`.
+- `0x1D` transaction with subsidy partially covering `used_total` (`0 < budget < used_total`) — caller debited by `used_total - budget`, vault credits sum to that amount under the chosen priority order, WIP-1002 budget debited to zero.
+- `0x1D` transaction with `gas_used < gas_limit` and subsidy budget — both the caller-pre-charge excess and the budget-pre-charge excess refunded; WIP-1002 budget ends at exactly `budget_initial - final_subsidy`.
+- `0x1D` transaction failing in the session-verifier dispatch (envelope OK, signature recovery OK, verifier returns wrong magic) — validation-failure fee subsidy-covered if budget present; otherwise sender-paid.
+- `0x1D` transaction failing before session-verifier dispatch (bad signature, unauthorized verifier) — validation-failure fee sender-paid regardless of budget.
+- `0x1D` transaction whose framed sender is authorized under multiple nullifiers — the chosen nullifier matches the WIP-1002 deterministic selection rule; only that nullifier's budget is debited.
 
 ## Reference Implementation
 
-No reference implementation is included in this draft. The expected shape is a revm `Handler` variant for `0x1D` transactions overriding the three methods named in [Handler Overrides](#handler-overrides); the variant dispatches on the WIP-1002 resolution result at pre-execution and stores the `(nullifier, pre_subsidy)` pair on the execution context for use in `reimburse_caller`.
+No reference implementation is included in this draft. The expected shape is an op-revm `Handler` variant for `0x1D` transactions overriding the three methods named in [Handler Overrides](#handler-overrides); the variant dispatches on the WIP-1002 resolution result at pre-execution and stores the `(nullifier, pre_subsidy)` pair on the execution context for use in `reimburse_caller` and `reward_beneficiary`. The `reward_beneficiary` override calls through to op-revm's default to perform the standard vault credits, then issues compensating debits for the subsidized component shares.
 
 ## Security Considerations
 
-- **Budget drain via failing transactions.** All validation-failure costs MUST be paid by the sender, never the budget. See [Failed Validation](#failed-validation). Implementations MUST NOT route any failure path through WIP-1002 consumption.
-- **Pre-charge / post-refund consistency.** A buggy `reimburse_caller` that fails to credit unused budget back would silently drain budgets even for normally successful transactions. Implementations MUST treat the equality `final_subsidy + final_sender = used_total_cost` (and the equalities for refunds) as invariants and enforce them in tests.
-- **Deterministic nullifier selection.** When an account is authorized under multiple nullifiers, the WIP-1002 deterministic selection rule MUST be used at every site that resolves an account to a nullifier (pre-execution, post-execution, RPC) so all sites agree on which budget is debited.
-- **Validator opt-in.** Because validator economics are unchanged from a non-subsidized transaction, no validator opt-in mechanism is required. Validators that wish to exclude subsidized traffic for policy reasons MAY do so through the standard transaction-selection layer; this WIP imposes no requirement either way.
-- **Re-entrancy with WIP-1002 as predeploy.** If WIP-1002 is realized as a predeploy (rather than a precompile), the `consumeBudget` reconciliation in `reimburse_caller` runs after `gas_used` is finalized and therefore cannot re-enter the executing transaction. If WIP-1002 calls are batched or deferred for performance, the deferred calls MUST be ordered and applied atomically with block production so that observable WIP-1002 state remains consistent with executed transactions.
-- **Interaction with EIP-1559 burn.** The base-fee portion paid in ETH by the sender (when subsidy is partial) MUST still be burned per EIP-1559. Only the subsidy-covered portion is absorbed.
+- **Operator opportunity cost as the security boundary.** Under the no-op design the subsidy never spends real ETH the operator does not already implicitly hold; the worst-case loss is forgone fee revenue. The per-nullifier WIP-1002 budget per period is the hard cap on that loss per credential.
+- **Grief via co-authorized addresses.** A human's WIP-1002 nullifier may have multiple authorized addresses (per WIP-1002 `updateAddresses`). A co-authorized address can drain the human's per-period budget by issuing failing transactions or transactions whose `used_total` is high. The human still benefits from the operator's forgone revenue but loses their budget for the period. Mitigations belong in WIP-1002 (authorization-revocation flow, per-address sub-caps) rather than here.
+- **Pre-session-verifier failure fees stay sender-paid.** Subsidizing the fee for transactions that fail before the session verifier returns would let any address spam failing 0x1D txs against the authorized account's budget at zero marginal cost. Keeping that path sender-paid retains a small mempool-economic floor without blocking zero-ETH first transactions on real WIP-1001-signed traffic.
+- **L1 fee is a real outflow, not just opportunity cost.** Base fee and priority fee subsidies forgo *future* operator revenue. L1 fee subsidy forgoes vault revenue that itself was meant to repay the operator's *already-paid* L1 DA cost. Governance should size per-credential budgets with this asymmetry in mind; budgets that fund only L2 fee components MAY be specified by setting `tx_l1_cost` outside the subsidisable prefix (see [Subsidy Coverage](#subsidy-coverage), apportionment order).
+- **Centralized-sequencer assumption.** The no-op realization depends on the entity setting subsidy policy being the same as the entity owning the L2 fee vaults. Under World Chain's current centralized-sequencer model this holds by construction. A future decentralized sequencer model would require external compensation for the priority-fee portion of subsidized transactions (the priority fee normally compensates sequencers); that extension is out of scope.
+- **Deterministic nullifier selection.** All sites that resolve an account to a nullifier (WIP-1001 pre-validation balance check, pre-execution, post-execution, RPC) MUST use the WIP-1002 deterministic selection rule so they agree on which budget is debited.
+- **Pre-charge / post-refund consistency.** `final_subsidy + final_sender = used_total` is an invariant. Implementations MUST enforce it in tests; a divergence silently drains either user balances or the operator's vault revenue without surface symptoms.
+- **Re-entrancy with WIP-1002 as predeploy.** If WIP-1002 is realized as a predeploy rather than a precompile, the consumption call in `reimburse_caller` runs after `gas_used` is finalized and cannot re-enter the executing transaction. Deferred / batched consumption calls MUST be applied atomically with block production so observable WIP-1002 state remains consistent with executed transactions.

--- a/wips/wip-1003.md
+++ b/wips/wip-1003.md
@@ -2,7 +2,7 @@
 wip: 1003
 title: World ID Transaction Subsidies
 description: A subsidy-enforcement mechanism for WIP-1001 transactions that splits the fee charge between a WIP-1002 subsidy budget and the sender via three revm `Handler` hook overrides, without modifying the protocol fee market or the transaction envelope.
-author: Kilian Glas (@kilianglas), Alessandro Mazza (@alessandromazza98), Eric Woolsey (@0xforerunner)
+author: Eric Woolsey (@0xforerunner), Kilian Glas (@kilianglas), Alessandro Mazza (@alessandromazza98)
 status: Draft
 type: Standards Track
 category: Core


### PR DESCRIPTION
## Summary

Rewrites [WIP-1003](./wips/wip-1003.md) (World ID Transaction Subsidies) as a handler-hook design rather than a virtual-fee-market design. Scope is unchanged — Subsidy Enforcement for World Chain — and the WIP number, file, and title stay the same.

Mechanism, in summary:

- Subsidy enforcement is scoped to WIP-1001 `0x1D` transactions only; the protocol `baseFeePerGas` and EIP-1559 semantics stay as-is for all other traffic.
- Eligibility is resolved against WIP-1002 (`getBudget`, deterministic nullifier selection). The subsidy covers `gas_used * base_fee_per_gas`; the sender always pays the priority fee.
- Three revm `Handler` overrides — `validate_against_state_and_deduct_caller`, `reimburse_caller`, `reward_beneficiary` — split the pre-charge between the WIP-1002 budget and the sender, settle the exact final amounts once `gas_used` is known, and credit only the priority fee to the validator.

### Changes vs the previous WIP-1003

- No chain-wide `baseFeePerGas = 0` pinning.
- No virtual fee market or `VirtualFeeOracle`.
- No per-block builder-owned subsidy-accounting transaction.
- No mandated wallet RPC overrides.
- The `gasLimit` vs `gasUsed` ambiguity in the previous §6 is resolved by construction — final settlement happens in `reimburse_caller`.

Generic third-party gas sponsorship is not in scope for this WIP; if needed later, it is an envelope-additive extension (Tempo-style `fee_payer_signature`) over this design.