### PR TITLE
feat(rpc): allow simulate_unsignedUserOp to target a specific block

### DIFF
--- a/crates/rpc/src/simulate.rs
+++ b/crates/rpc/src/simulate.rs
@@ -633,7 +633,7 @@ where
             .ok_or_else(|| {
                 jsonrpsee::types::ErrorObjectOwned::owned(
                     jsonrpsee::types::error::INVALID_PARAMS_CODE,
-                    format!("Block not found: {requested_block:?}"),
+                    format!("Block not found: {requested_block}"),
                     None::<String>,
                 )
             })?;

--- a/crates/rpc/src/simulate.rs
+++ b/crates/rpc/src/simulate.rs
@@ -52,6 +52,9 @@ pub struct SimulateUnsignedUserOpRequest {
     /// Must not exceed `MAX_SIMULATION_GAS`.
     #[serde(default)]
     pub call_gas_limit: Option<U256>,
+    /// Block to simulate against. Defaults to `latest` when omitted.
+    #[serde(default)]
+    pub block: Option<BlockId>,
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -619,17 +622,18 @@ where
         &self,
         request: SimulateUnsignedUserOpRequest,
     ) -> RpcResult<SimulateUnsignedUserOpResult> {
-        // 1. Resolve the latest sealed header. Subsequent lookups go by its
-        //    concrete hash so a new block arriving mid-request can't desync
-        //    the header from the state we read.
+        // 1. Resolve the requested sealed header (defaulting to latest).
+        //    Subsequent lookups go by its concrete hash so a new block arriving
+        //    mid-request can't desync the header from the state we read.
+        let requested_block = request.block.unwrap_or(BlockNumberOrTag::Latest.into());
         let header = self
             .client
-            .sealed_header_by_id(BlockNumberOrTag::Latest.into())
+            .sealed_header_by_id(requested_block)
             .map_err(internal_err)?
             .ok_or_else(|| {
                 jsonrpsee::types::ErrorObjectOwned::owned(
                     jsonrpsee::types::error::INVALID_PARAMS_CODE,
-                    "Latest block not found",
+                    format!("Block not found: {requested_block:?}"),
                     None::<String>,
                 )
             })?;


### PR DESCRIPTION
## Summary
- Adds an optional `block` field to `SimulateUnsignedUserOpRequest` so callers can simulate against a specific `BlockId` (number, hash, or tag) instead of being pinned to `latest`.
- Defaults to `latest` when the field is omitted — fully backwards compatible with existing callers.
- "Block not found" error now includes the requested `BlockId` so callers can tell which lookup missed.

## Test plan
- [ ] `cargo check -p world-chain-rpc` (passes locally)
- [ ] Existing simulate request without `block` continues to resolve to latest
- [ ] Request with `block: "0x..."` (number) resolves to that block
- [ ] Request with a non-existent block returns `INVALID_PARAMS` with the requested id in the message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new request parameter that changes which chain state `simulate_unsignedUserOp` reads, so incorrect block resolution could alter simulation results or error behavior. Backwards compatibility is maintained by defaulting to `latest`.
> 
> **Overview**
> `simulate_unsignedUserOp` now accepts an optional `block: BlockId` on `SimulateUnsignedUserOpRequest`, allowing simulations to run against a specific block hash/number/tag while defaulting to `latest` when omitted.
> 
> Block header resolution in `simulate_blocking` now uses the requested block id and the `INVALID_PARAMS` error message includes the requested `BlockId` when no block is found.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8f25a2212ffc9750cd1d68e48e8e75ae9e9ac19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->