### PR TITLE
chore: Input Selector on Acceptance Test Workflow

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -54,7 +54,10 @@ jobs:
     steps:
       - name: Skip unselected network
         if: ${{ inputs.network != 'all' && inputs.network != matrix.network }}
-        run: echo 'Skipping ${{ matrix.network }} because ${{ inputs.network }} was selected.'
+        env:
+          MATRIX_NETWORK: ${{ matrix.network }}
+          SELECTED_NETWORK: ${{ inputs.network }}
+        run: printf 'Skipping %s because %s was selected.\n' "$MATRIX_NETWORK" "$SELECTED_NETWORK"
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.02
         if: ${{ inputs.network == 'all' || inputs.network == matrix.network }}

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -2,6 +2,17 @@ name: Acceptance Tests
 
 on:
   workflow_dispatch:
+    inputs:
+      network:
+        description: Network to test
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - stage
+          - dev-us-east-1
+          - dev-eu-central-2
 
 permissions:
   contents: read
@@ -41,11 +52,18 @@ jobs:
             expected_chain_id: "69420"
             allow_failure: true
     steps:
+      - name: Skip unselected network
+        if: ${{ inputs.network != 'all' && inputs.network != matrix.network }}
+        run: echo 'Skipping ${{ matrix.network }} because ${{ inputs.network }} was selected.'
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.02
+        if: ${{ inputs.network == 'all' || inputs.network == matrix.network }}
 
       - uses: dtolnay/rust-toolchain@stable
+        if: ${{ inputs.network == 'all' || inputs.network == matrix.network }}
 
       - name: Cache
+        if: ${{ inputs.network == 'all' || inputs.network == matrix.network }}
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.05
         with:
           path: |
@@ -56,17 +74,19 @@ jobs:
           restore-keys: cargo-acceptance-tests-
 
       - uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2.78.1
+        if: ${{ inputs.network == 'all' || inputs.network == matrix.network }}
         with:
           tool: nextest@0.9.135
 
       - name: Build acceptance tests
         id: build
+        if: ${{ inputs.network == 'all' || inputs.network == matrix.network }}
         continue-on-error: ${{ matrix.allow_failure }}
         run: cargo nextest run --profile ci -p world-chain-tests -E 'package(world-chain-tests) & binary(world-chain-tests) & test(/acceptance_tests::test_network/)' --no-run
 
       - name: Run acceptance tests
         id: run
-        if: ${{ steps.build.outcome == 'success' }}
+        if: ${{ (inputs.network == 'all' || inputs.network == matrix.network) && steps.build.outcome == 'success' }}
         continue-on-error: ${{ matrix.allow_failure }}
         env:
           ACCEPTANCE_NETWORK: ${{ matrix.network }}
@@ -79,9 +99,9 @@ jobs:
         run: cargo nextest run --profile ci -p world-chain-tests -E 'package(world-chain-tests) & binary(world-chain-tests) & test(/acceptance_tests::test_network/)'
 
       - name: Report allowed build failure
-        if: ${{ matrix.allow_failure && steps.build.outcome == 'failure' }}
+        if: ${{ (inputs.network == 'all' || inputs.network == matrix.network) && matrix.allow_failure && steps.build.outcome == 'failure' }}
         run: echo '::warning::Acceptance test build failed for ${{ matrix.network }}, but this network is allowed to fail.'
 
       - name: Report allowed test failure
-        if: ${{ matrix.allow_failure && steps.run.outcome == 'failure' }}
+        if: ${{ (inputs.network == 'all' || inputs.network == matrix.network) && matrix.allow_failure && steps.run.outcome == 'failure' }}
         run: echo '::warning::Acceptance tests failed for ${{ matrix.network }}, but this network is allowed to fail.'

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -103,8 +103,12 @@ jobs:
 
       - name: Report allowed build failure
         if: ${{ (inputs.network == 'all' || inputs.network == matrix.network) && matrix.allow_failure && steps.build.outcome == 'failure' }}
-        run: echo '::warning::Acceptance test build failed for ${{ matrix.network }}, but this network is allowed to fail.'
+        env:
+          NETWORK: ${{ matrix.network }}
+        run: printf '::warning::Acceptance test build failed for %s, but this network is allowed to fail.\n' "$NETWORK"
 
       - name: Report allowed test failure
         if: ${{ (inputs.network == 'all' || inputs.network == matrix.network) && matrix.allow_failure && steps.run.outcome == 'failure' }}
-        run: echo '::warning::Acceptance tests failed for ${{ matrix.network }}, but this network is allowed to fail.'
+        env:
+          NETWORK: ${{ matrix.network }}
+        run: printf '::warning::Acceptance tests failed for %s, but this network is allowed to fail.\n' "$NETWORK"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that gates steps based on a user-selected `workflow_dispatch` input; main risk is misconfigured `if` conditions causing networks to be unintentionally skipped or not executed.
> 
> **Overview**
> Adds a `workflow_dispatch` input (`network`) to the Acceptance Tests workflow so runs can target a single network (or `all`).
> 
> Updates the matrix job to **skip non-selected networks** and gates checkout/toolchain/cache/build/run and allowed-failure reporting steps behind consistent `if` conditions tied to the selected network.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21c3b242004e6df7047d8ed2712de697ee35039e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->