### PR TITLE
feat: add wip1001 tx envelope

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13800,7 +13800,6 @@ dependencies = [
  "alloy-rpc-types-eth 2.0.4",
  "alloy-serde 2.0.4",
  "alloy-signer-local",
- "base64 0.22.1",
  "blake3",
  "bytes",
  "chrono",
@@ -13810,7 +13809,6 @@ dependencies = [
  "op-alloy-network",
  "op-alloy-rpc-types",
  "op-revm",
- "p256",
  "reth-basic-payload-builder",
  "reth-chainspec",
  "reth-codecs",
@@ -13823,7 +13821,6 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "sha2",
  "thiserror 2.0.18",
  "world-chain-chainspec",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13997,7 +13997,6 @@ dependencies = [
  "alloy-rpc-types",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth 2.0.4",
- "alloy-signer 2.0.4",
  "alloy-signer-local",
  "alloy-transport 2.0.4",
  "alloy-transport-http 2.0.4",

--- a/crates/node/src/pool.rs
+++ b/crates/node/src/pool.rs
@@ -21,7 +21,6 @@ use world_chain_pool::{
     tx::{WorldChainPoolTransaction, WorldChainPooledTransaction},
     validator::WorldChainTransactionValidator,
 };
-use world_chain_primitives::transaction::WIP_1001_TX_TYPE;
 /// A basic World Chain transaction pool.
 ///
 /// This contains various settings that can be configured and take precedence over the node's
@@ -92,7 +91,6 @@ where
 
         let validator =
             TransactionValidationTaskExecutor::eth_builder(ctx.provider().clone(), evm_config)
-                .with_custom_tx_type(WIP_1001_TX_TYPE)
                 .no_eip4844()
                 .kzg_settings(ctx.kzg_settings()?)
                 .with_additional_tasks(

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -43,9 +43,6 @@ blake3.workspace = true
 ed25519-dalek.workspace = true
 bytes.workspace = true
 chrono.workspace = true
-p256.workspace = true
-sha2.workspace = true
-base64.workspace = true
 
 [features]
 default = []

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -2,11 +2,9 @@
 //!
 //! [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
 
-use crate::transaction::verify::verify_wip1001_signature;
 use alloy_consensus::{
     EthereumTxEnvelope, Sealable, Sealed, SignableTransaction, Signed, TransactionEnvelope,
     TxEip1559, TxEip2930, TxEip7702, TxEnvelope, TxLegacy, Typed2718,
-    crypto::RecoveryError,
     error::ValueError,
     transaction::{RlpEcdsaEncodableTx, TxHashRef},
 };
@@ -590,7 +588,12 @@ impl alloy_consensus::transaction::SignerRecoverable for WorldChainTxEnvelope {
             Self::Eip2930(tx) => (tx.signature(), tx.signature_hash()),
             Self::Eip1559(tx) => (tx.signature(), tx.signature_hash()),
             Self::Eip7702(tx) => (tx.signature(), tx.signature_hash()),
-            Self::Wip1001(tx) => return Ok(tx.tx().session_verifier),
+            // For WIP-1001 the protocol-level "from" is the world chain account
+            // (the payload executes with this address as the EVM sender — see
+            // WIP-1001 "Validation, Execution, and Failure Semantics" step 9).
+            // Signature authenticity is verified out-of-band via EIP-1271
+            // through the account router (`isValidSignatureForVerifier`).
+            Self::Wip1001(tx) => return Ok(tx.tx().world_chain_account),
             // Optimism's Deposit transaction does not have a signature. Directly return the
             // `from` address.
             Self::Deposit(tx) => return Ok(tx.from),
@@ -607,7 +610,7 @@ impl alloy_consensus::transaction::SignerRecoverable for WorldChainTxEnvelope {
             Self::Eip2930(tx) => (tx.signature(), tx.signature_hash()),
             Self::Eip1559(tx) => (tx.signature(), tx.signature_hash()),
             Self::Eip7702(tx) => (tx.signature(), tx.signature_hash()),
-            Self::Wip1001(tx) => return Ok(tx.tx().session_verifier),
+            Self::Wip1001(tx) => return Ok(tx.tx().world_chain_account),
             // Optimism's Deposit transaction does not have a signature. Directly return the
             // `from` address.
             Self::Deposit(tx) => return Ok(tx.from),
@@ -633,7 +636,7 @@ impl alloy_consensus::transaction::SignerRecoverable for WorldChainTxEnvelope {
             Self::Eip7702(tx) => {
                 alloy_consensus::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
             }
-            Self::Wip1001(tx) => Ok(tx.tx().session_verifier),
+            Self::Wip1001(tx) => Ok(tx.tx().world_chain_account),
             Self::Deposit(tx) => Ok(tx.from),
             Self::PostExec(tx) => Ok(tx.inner().signer_address()),
         }
@@ -917,43 +920,39 @@ mod tests {
         }
     }
 
-    fn sample_wip1001(signer: &PrivateKeySigner) -> TxWip1001 {
+    fn sample_wip1001() -> TxWip1001 {
         TxWip1001 {
             chain_id: 480,
             nonce: 3,
             max_priority_fee_per_gas: 2_000_000_000,
             max_fee_per_gas: 4_000_000_000,
             gas_limit: 100_000,
+            world_chain_account: address!("000000000000000000000000000000000000001d"),
+            session_verifier: address!("00000000000000000000000000000000000000aa"),
             to: address!("6069a6c32cf691f5982febae4faf8a6f3ab2f0f6").into(),
             value: U256::from(42u64),
             input: hex!("deadbeef").into(),
             access_list: AccessList::default(),
-            world_id_account: address!("000000000000000000000000000000000000001d"),
-            signature_type: Wip1001Signature::SECP256K1_TYPE,
-            session_key: secp256k1_compressed_pubkey(signer),
         }
     }
 
-    /// Returns the 33-byte SEC1-compressed secp256k1 public key for `signer`.
-    fn secp256k1_compressed_pubkey(signer: &PrivateKeySigner) -> Bytes {
-        let encoded = signer.credential().verifying_key().to_encoded_point(true);
-        Bytes::copy_from_slice(encoded.as_bytes())
-    }
-
+    /// Signs `tx` with `signer` via the `SignableTransaction<Signature>` bridge.
+    ///
+    /// The resulting [`Wip1001Signature`] holds the raw secp256k1 bytes — the WIP-1001
+    /// envelope is opaque to signature scheme (verification happens on-chain via
+    /// EIP-1271 against the session verifier; see `wips/wip-1001.md`).
     fn sign_wip1001(signer: &PrivateKeySigner, tx: TxWip1001) -> SignedWip1001 {
-        // Sign the WIP-1001 signing hash via the `SignableTransaction<Signature>`
-        // bridge and wrap the secp256k1 result as a Wip1001Signature.
         let mut tx = tx;
         let signature = signer
             .sign_transaction_sync(&mut tx)
             .expect("signing works");
-        SignedWip1001::new_signed(tx, Wip1001Signature::Secp256k1(signature))
+        SignedWip1001::new_signed(tx, Wip1001Signature::from(signature))
     }
 
     #[test]
     fn envelope_wip1001_variant_accessors() {
         let signer = PrivateKeySigner::random();
-        let signed = sign_wip1001(&signer, sample_wip1001(&signer));
+        let signed = sign_wip1001(&signer, sample_wip1001());
         let envelope: WorldChainTxEnvelope = signed.clone().into();
 
         assert!(envelope.is_wip1001());
@@ -973,7 +972,7 @@ mod tests {
     #[test]
     fn envelope_wip1001_eip2718_round_trip() {
         let signer = PrivateKeySigner::random();
-        let signed = sign_wip1001(&signer, sample_wip1001(&signer));
+        let signed = sign_wip1001(&signer, sample_wip1001());
         let envelope: WorldChainTxEnvelope = signed.clone().into();
 
         let mut buf = Vec::new();
@@ -993,7 +992,7 @@ mod tests {
         use alloy_rlp::Decodable as _;
 
         let signer = PrivateKeySigner::random();
-        let signed = sign_wip1001(&signer, sample_wip1001(&signer));
+        let signed = sign_wip1001(&signer, sample_wip1001());
         let envelope: WorldChainTxEnvelope = signed.clone().into();
 
         // network_encode wraps the 2718 bytes in an outer byte-string header.
@@ -1005,38 +1004,25 @@ mod tests {
     }
 
     #[test]
-    fn envelope_wip1001_signer_recoverable() {
+    fn envelope_wip1001_recover_signer_returns_world_chain_account() {
+        // For WIP-1001, `recover_signer` returns the world chain account — the
+        // protocol-level "from" that executes as the EVM sender (see WIP-1001
+        // §"Validation, Execution, and Failure Semantics" step 9). Signature
+        // authenticity is checked elsewhere via EIP-1271 through the account
+        // router (`isValidSignatureForVerifier`).
         let signer = PrivateKeySigner::random();
-        let signed = sign_wip1001(&signer, sample_wip1001(&signer));
-        let expected_world_id_account = signed.tx().world_id_account;
+        let signed = sign_wip1001(&signer, sample_wip1001());
+        let expected_world_chain_account = signed.tx().world_chain_account;
         let envelope: WorldChainTxEnvelope = signed.into();
 
-        // recover_signer for WIP-1001 returns the World ID Account
-        // (protocol-level "from"), NOT the session-key signer's EOA. Crypto
-        // verification still happens inside recover_signer — a tampered
-        // signature would error here.
         let recovered = envelope.recover_signer().expect("recover");
-        assert_eq!(recovered, expected_world_id_account);
-    }
-
-    #[test]
-    fn envelope_wip1001_recover_signer_rejects_tampered_signature() {
-        let signer = PrivateKeySigner::random();
-        let signed = sign_wip1001(&signer, sample_wip1001(&signer));
-        let mut tx = signed.tx().clone();
-        // Flip a bit in `input` so the cached signature no longer covers the tx.
-        tx.input = Bytes::from_static(b"tampered");
-        let tampered = SignedWip1001::new(Signed::new_unhashed(tx, signed.signature().clone()));
-        let envelope: WorldChainTxEnvelope = tampered.into();
-        envelope
-            .recover_signer()
-            .expect_err("tampered signature must not recover");
+        assert_eq!(recovered, expected_world_chain_account);
     }
 
     #[test]
     fn envelope_wip1001_try_into_eth_envelope_rejected() {
         let signer = PrivateKeySigner::random();
-        let signed = sign_wip1001(&signer, sample_wip1001(&signer));
+        let signed = sign_wip1001(&signer, sample_wip1001());
         let envelope: WorldChainTxEnvelope = signed.into();
 
         let err = envelope
@@ -1048,7 +1034,7 @@ mod tests {
     #[test]
     fn envelope_wip1001_try_into_op_envelope_rejected() {
         let signer = PrivateKeySigner::random();
-        let signed = sign_wip1001(&signer, sample_wip1001(&signer));
+        let signed = sign_wip1001(&signer, sample_wip1001());
         let envelope: WorldChainTxEnvelope = signed.into();
 
         let err =
@@ -1079,126 +1065,13 @@ mod tests {
     }
 
     #[test]
-    fn envelope_wip1001_p256_round_trip_and_recover() {
-        use alloy_primitives::B256;
-        use p256::{
-            ecdsa::{SigningKey as P256SigningKey, signature::hazmat::PrehashSigner},
-            elliptic_curve::rand_core::OsRng,
-        };
-
-        let signing_key = P256SigningKey::random(&mut OsRng);
-        let verifying_key = signing_key.verifying_key();
-        let encoded = verifying_key.to_encoded_point(false);
-        let mut session_key = Vec::with_capacity(64);
-        session_key.extend_from_slice(encoded.x().expect("x").as_ref());
-        session_key.extend_from_slice(encoded.y().expect("y").as_ref());
-
-        let world_id_account = address!("000000000000000000000000000000000000001d");
-        let tx = TxWip1001 {
-            chain_id: 480,
-            nonce: 7,
-            max_priority_fee_per_gas: 2_000_000_000,
-            max_fee_per_gas: 4_000_000_000,
-            gas_limit: 100_000,
-            to: address!("6069a6c32cf691f5982febae4faf8a6f3ab2f0f6").into(),
-            value: U256::from(99u64),
-            input: hex!("cafef00d").into(),
-            access_list: AccessList::default(),
-            world_id_account,
-            signature_type: Wip1001Signature::P256_TYPE,
-            session_key: Bytes::from(session_key),
-        };
-
-        let signing_hash = tx.signing_hash();
-        let raw: p256::ecdsa::Signature = signing_key
-            .sign_prehash(signing_hash.as_slice())
-            .expect("p256 sign");
-        let raw_bytes = raw.to_bytes();
-        let r = B256::from_slice(&raw_bytes[..32]);
-        let s_u = U256::from_be_slice(&raw_bytes[32..]);
-        let p256_n_half = crate::transaction::verify::P256N_HALF;
-        let p256_order = crate::transaction::verify::P256_ORDER;
-        let s_norm = if s_u > p256_n_half {
-            p256_order - s_u
-        } else {
-            s_u
-        };
-        let p256_sig = crate::transaction::P256Signature {
-            r,
-            s: B256::from(s_norm.to_be_bytes::<32>()),
-        };
-        let signature = Wip1001Signature::P256(p256_sig);
-
-        let signed = SignedWip1001::new_signed(tx.clone(), signature.clone());
-        let envelope: WorldChainTxEnvelope = signed.clone().into();
-
-        // EIP-2718 round-trip preserves the P-256 variant.
-        let mut buf = Vec::new();
-        envelope.encode_2718(&mut buf);
-        let decoded = WorldChainTxEnvelope::decode_2718(&mut buf.as_slice()).expect("decode_2718");
-        assert!(decoded.is_wip1001());
-        assert_eq!(decoded.hash(), envelope.hash());
-        let decoded_wip = decoded.as_wip1001().expect("is wip1001");
-        assert_eq!(decoded_wip.tx(), &tx);
-        assert_eq!(decoded_wip.signature(), &signature);
-
-        // recover_signer verifies the P-256 signature and returns the World ID Account.
-        let recovered = envelope.recover_signer().expect("recover");
-        assert_eq!(recovered, world_id_account);
-    }
-
-    #[test]
-    fn envelope_wip1001_eddsa_round_trip_and_recover() {
-        use ed25519_dalek::Signer;
-
-        let signing_key = ed25519_dalek::SigningKey::from_bytes(&[0xAB; 32]);
-        let verifying_key = signing_key.verifying_key();
-        let session_key_bytes = verifying_key.to_bytes();
-
-        let keyring = address!("000000000000000000000000000000000000001d");
-        let tx = TxWip1001 {
-            chain_id: 480,
-            nonce: 11,
-            max_priority_fee_per_gas: 2_000_000_000,
-            max_fee_per_gas: 4_000_000_000,
-            gas_limit: 100_000,
-            to: address!("6069a6c32cf691f5982febae4faf8a6f3ab2f0f6").into(),
-            value: U256::from(123u64),
-            input: hex!("c0ffee").into(),
-            access_list: AccessList::default(),
-            world_id_account: keyring,
-            signature_type: Wip1001Signature::EDDSA_TYPE,
-            session_key: Bytes::copy_from_slice(&session_key_bytes),
-        };
-
-        let signing_hash = tx.signing_hash();
-        let sig = signing_key.sign(signing_hash.as_slice());
-        let signature = Wip1001Signature::EdDSA(sig);
-
-        let signed = SignedWip1001::new_signed(tx.clone(), signature.clone());
-        let envelope: WorldChainTxEnvelope = signed.into();
-
-        let mut buf = Vec::new();
-        envelope.encode_2718(&mut buf);
-        let decoded = WorldChainTxEnvelope::decode_2718(&mut buf.as_slice()).expect("decode_2718");
-        assert!(decoded.is_wip1001());
-        assert_eq!(decoded.hash(), envelope.hash());
-        let decoded_wip = decoded.as_wip1001().expect("is wip1001");
-        assert_eq!(decoded_wip.tx(), &tx);
-        assert_eq!(decoded_wip.signature(), &signature);
-
-        // recover_signer verifies the EdDSA signature and returns the keyring.
-        let recovered = envelope.recover_signer().expect("recover");
-        assert_eq!(recovered, keyring);
-    }
-
-    #[test]
     fn envelope_wip1001_via_typed_transaction_path() {
         // Exercise the `Signed<WorldChainTypedTransaction>` -> `WorldChainTxEnvelope`
-        // conversion for the WIP-1001 variant: the default secp256k1 Signature
-        // should be wrapped as `Wip1001Signature::Secp256k1`.
+        // conversion for the WIP-1001 variant. The default secp256k1 signature
+        // should be wrapped into the opaque-bytes [`Wip1001Signature`] via the
+        // `From<Signature>` impl.
         let signer = PrivateKeySigner::random();
-        let tx = sample_wip1001(&signer);
+        let tx = sample_wip1001();
         let mut typed = WorldChainTypedTransaction::Wip1001(tx.clone());
         let signature = signer
             .sign_transaction_sync(&mut typed)
@@ -1207,12 +1080,10 @@ mod tests {
 
         let wip = envelope.as_wip1001().expect("is wip1001");
         assert_eq!(wip.tx(), &tx);
-        match wip.signature() {
-            Wip1001Signature::Secp256k1(inner) => assert_eq!(*inner, signature),
-            other => panic!("expected Secp256k1 variant, got {other:?}"),
-        }
-        // recover_signer returns the World ID Account per WIP-1001; verification of the
-        // session-key signature happens internally.
-        assert_eq!(envelope.recover_signer().unwrap(), tx.world_id_account);
+        assert_eq!(wip.signature(), &Wip1001Signature::from(signature));
+        // `recover_signer` returns the world chain account (the protocol-level
+        // "from"); signature authenticity is checked elsewhere via on-chain
+        // EIP-1271.
+        assert_eq!(envelope.recover_signer().unwrap(), tx.world_chain_account);
     }
 }

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -2,9 +2,11 @@
 //!
 //! [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
 
+use crate::transaction::verify::verify_wip1001_signature;
 use alloy_consensus::{
     EthereumTxEnvelope, Sealable, Sealed, SignableTransaction, Signed, TransactionEnvelope,
     TxEip1559, TxEip2930, TxEip7702, TxEnvelope, TxLegacy, Typed2718,
+    crypto::RecoveryError,
     error::ValueError,
     transaction::{RlpEcdsaEncodableTx, TxHashRef},
 };
@@ -249,9 +251,12 @@ impl From<Signed<WorldChainTypedTransaction>> for WorldChainTxEnvelope {
                 Self::Eip7702(Signed::new_unchecked(tx_eip7702, sig, hash))
             }
             // Default `Signature` is secp256k1; wrap it into the WIP-1001 signature enum.
-            WorldChainTypedTransaction::Wip1001(tx_wip) => Self::Wip1001(SignedWip1001::new(
-                Signed::new_unchecked(tx_wip, Wip1001Signature::Secp256k1(sig), hash),
-            )),
+            WorldChainTypedTransaction::Wip1001(tx_wip) => {
+                let wip_sig: Wip1001Signature = sig.into();
+                Self::Wip1001(SignedWip1001::new(Signed::new_unchecked(
+                    tx_wip, wip_sig, hash,
+                )))
+            }
             WorldChainTypedTransaction::Deposit(tx) => {
                 Self::Deposit(Sealed::new_unchecked(tx, hash))
             }
@@ -585,7 +590,7 @@ impl alloy_consensus::transaction::SignerRecoverable for WorldChainTxEnvelope {
             Self::Eip2930(tx) => (tx.signature(), tx.signature_hash()),
             Self::Eip1559(tx) => (tx.signature(), tx.signature_hash()),
             Self::Eip7702(tx) => (tx.signature(), tx.signature_hash()),
-            Self::Wip1001(tx) => return recover_wip1001_signer(tx),
+            Self::Wip1001(tx) => return Ok(tx.tx().session_verifier),
             // Optimism's Deposit transaction does not have a signature. Directly return the
             // `from` address.
             Self::Deposit(tx) => return Ok(tx.from),
@@ -602,7 +607,7 @@ impl alloy_consensus::transaction::SignerRecoverable for WorldChainTxEnvelope {
             Self::Eip2930(tx) => (tx.signature(), tx.signature_hash()),
             Self::Eip1559(tx) => (tx.signature(), tx.signature_hash()),
             Self::Eip7702(tx) => (tx.signature(), tx.signature_hash()),
-            Self::Wip1001(tx) => return recover_wip1001_signer(tx),
+            Self::Wip1001(tx) => return Ok(tx.tx().session_verifier),
             // Optimism's Deposit transaction does not have a signature. Directly return the
             // `from` address.
             Self::Deposit(tx) => return Ok(tx.from),
@@ -628,30 +633,11 @@ impl alloy_consensus::transaction::SignerRecoverable for WorldChainTxEnvelope {
             Self::Eip7702(tx) => {
                 alloy_consensus::transaction::SignerRecoverable::recover_unchecked_with_buf(tx, buf)
             }
-            Self::Wip1001(tx) => recover_wip1001_signer(tx),
+            Self::Wip1001(tx) => Ok(tx.tx().session_verifier),
             Self::Deposit(tx) => Ok(tx.from),
             Self::PostExec(tx) => Ok(tx.inner().signer_address()),
         }
     }
-}
-
-/// Verifies the WIP-1001 signature against the embedded `session_key` and
-/// returns the World ID Account address (the protocol-level "from" per WIP-1001).
-///
-/// The precompile-managed Key Ring lookup —
-/// `IWorldIDAccount.isAuthorized(world_id_account, session_key)` — is performed
-/// downstream and is **not** part of this verification.
-fn recover_wip1001_signer(
-    tx: &SignedWip1001,
-) -> Result<alloy_primitives::Address, alloy_consensus::crypto::RecoveryError> {
-    let body = tx.tx();
-    crate::transaction::verify_wip1001_signature(
-        body.signature_type,
-        body.session_key.as_ref(),
-        tx.signature(),
-        &body.signing_hash(),
-    )?;
-    Ok(body.world_id_account)
 }
 
 impl WorldChainTypedTransaction {
@@ -680,7 +666,10 @@ impl WorldChainTypedTransaction {
             Self::Eip2930(tx) => tx.tx_hash(signature),
             Self::Eip1559(tx) => tx.tx_hash(signature),
             Self::Eip7702(tx) => tx.tx_hash(signature),
-            Self::Wip1001(tx) => tx.tx_hash(&Wip1001Signature::Secp256k1(*signature)),
+            Self::Wip1001(tx) => {
+                let wip_sig: Wip1001Signature = signature.into();
+                tx.tx_hash(&wip_sig)
+            }
             Self::Deposit(tx) => tx.tx_hash(),
             Self::PostExec(tx) => tx.tx_hash(),
         }
@@ -726,7 +715,10 @@ impl RlpEcdsaEncodableTx for WorldChainTypedTransaction {
             Self::Eip2930(tx) => tx.eip2718_encode_with_type(signature, tx.ty(), out),
             Self::Eip1559(tx) => tx.eip2718_encode_with_type(signature, tx.ty(), out),
             Self::Eip7702(tx) => tx.eip2718_encode_with_type(signature, tx.ty(), out),
-            Self::Wip1001(tx) => tx.eip2718_encode(&Wip1001Signature::Secp256k1(*signature), out),
+            Self::Wip1001(tx) => {
+                let wip_sig: Wip1001Signature = signature.into();
+                tx.eip2718_encode(&wip_sig, out)
+            }
             Self::Deposit(tx) => tx.encode_2718(out),
             Self::PostExec(tx) => tx.encode_2718(out),
         }
@@ -738,7 +730,10 @@ impl RlpEcdsaEncodableTx for WorldChainTypedTransaction {
             Self::Eip2930(tx) => tx.eip2718_encode(signature, out),
             Self::Eip1559(tx) => tx.eip2718_encode(signature, out),
             Self::Eip7702(tx) => tx.eip2718_encode(signature, out),
-            Self::Wip1001(tx) => tx.eip2718_encode(&Wip1001Signature::Secp256k1(*signature), out),
+            Self::Wip1001(tx) => {
+                let wip_sig: Wip1001Signature = signature.into();
+                tx.eip2718_encode(&wip_sig, out)
+            }
             Self::Deposit(tx) => tx.encode_2718(out),
             Self::PostExec(tx) => tx.encode_2718(out),
         }
@@ -751,7 +746,8 @@ impl RlpEcdsaEncodableTx for WorldChainTypedTransaction {
             Self::Eip1559(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
             Self::Eip7702(tx) => tx.network_encode_with_type(signature, tx.ty(), out),
             Self::Wip1001(tx) => {
-                wip1001_network_encode(tx, &Wip1001Signature::Secp256k1(*signature), out)
+                let wip_sig: Wip1001Signature = signature.into();
+                wip1001_network_encode(tx, &wip_sig, out)
             }
             Self::Deposit(tx) => tx.network_encode(out),
             Self::PostExec(tx) => tx.network_encode(out),
@@ -765,7 +761,8 @@ impl RlpEcdsaEncodableTx for WorldChainTypedTransaction {
             Self::Eip1559(tx) => tx.network_encode(signature, out),
             Self::Eip7702(tx) => tx.network_encode(signature, out),
             Self::Wip1001(tx) => {
-                wip1001_network_encode(tx, &Wip1001Signature::Secp256k1(*signature), out)
+                let wip_sig: Wip1001Signature = signature.into();
+                wip1001_network_encode(tx, &wip_sig, out)
             }
             Self::Deposit(tx) => tx.network_encode(out),
             Self::PostExec(tx) => tx.network_encode(out),
@@ -778,7 +775,10 @@ impl RlpEcdsaEncodableTx for WorldChainTypedTransaction {
             Self::Eip2930(tx) => tx.tx_hash_with_type(signature, tx.ty()),
             Self::Eip1559(tx) => tx.tx_hash_with_type(signature, tx.ty()),
             Self::Eip7702(tx) => tx.tx_hash_with_type(signature, tx.ty()),
-            Self::Wip1001(tx) => tx.tx_hash(&Wip1001Signature::Secp256k1(*signature)),
+            Self::Wip1001(tx) => {
+                let wip_sig: Wip1001Signature = signature.into();
+                tx.tx_hash(&wip_sig)
+            }
             Self::Deposit(tx) => tx.tx_hash(),
             Self::PostExec(tx) => tx.tx_hash(),
         }
@@ -790,7 +790,10 @@ impl RlpEcdsaEncodableTx for WorldChainTypedTransaction {
             Self::Eip2930(tx) => tx.tx_hash(signature),
             Self::Eip1559(tx) => tx.tx_hash(signature),
             Self::Eip7702(tx) => tx.tx_hash(signature),
-            Self::Wip1001(tx) => tx.tx_hash(&Wip1001Signature::Secp256k1(*signature)),
+            Self::Wip1001(tx) => {
+                let wip_sig: Wip1001Signature = signature.into();
+                tx.tx_hash(&wip_sig)
+            }
             Self::Deposit(tx) => tx.tx_hash(),
             Self::PostExec(tx) => tx.tx_hash(),
         }

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -248,7 +248,7 @@ impl From<Signed<WorldChainTypedTransaction>> for WorldChainTxEnvelope {
             WorldChainTypedTransaction::Eip7702(tx_eip7702) => {
                 Self::Eip7702(Signed::new_unchecked(tx_eip7702, sig, hash))
             }
-            // Default `Signature` is secp256k1; wrap it into the WIP-1001 signature enum.
+            // Default `Signature` is secp256k1; wrap it into WIP-1001 signature.
             WorldChainTypedTransaction::Wip1001(tx_wip) => {
                 let wip_sig: Wip1001Signature = sig.into();
                 Self::Wip1001(SignedWip1001::new(Signed::new_unchecked(
@@ -592,7 +592,7 @@ impl alloy_consensus::transaction::SignerRecoverable for WorldChainTxEnvelope {
             // (the payload executes with this address as the EVM sender — see
             // WIP-1001 "Validation, Execution, and Failure Semantics" step 9).
             // Signature authenticity is verified out-of-band via EIP-1271
-            // through the account router (`isValidSignatureForVerifier`).
+            // through the world chain account (`isValidSignatureForVerifier`).
             Self::Wip1001(tx) => return Ok(tx.tx().world_chain_account),
             // Optimism's Deposit transaction does not have a signature. Directly return the
             // `from` address.

--- a/crates/primitives/src/transaction/keyring.rs
+++ b/crates/primitives/src/transaction/keyring.rs
@@ -1,40 +1,40 @@
 //! Authorization lookup against the WIP-1001 keyring registry.
 //!
-//! [`KeyringRegistry`] is the interface between the [signature
-//! verifier](super::verify) and whatever holds the precompile-managed keyring
+//! [`WorldChainAccountManager`] is the interface between the [signature
+//! verifier](super::verify) and whatever holds the predeploy-managed keyring
 //! state — the pool's state provider, the builder, the RPC layer, or a test
-//! double. It deliberately mirrors `IWorldIDKeyRing.isAuthorized` from the
-//! spec so the eventual precompile-backed implementation is a thin adapter.
+//! double. It deliberately mirrors `IWorldChainAccountManager.isAuthorizedSessionVerifier`
+//! from the spec so the eventual predeploy-backed implementation is a thin adapter.
 //!
 //! [`validate_wip1001`] is the one-stop entry point that callers (pool,
 //! builder, RPC) should use: it computes the signing hash, runs the per-scheme
 //! cryptographic verification, and gates the result on the registry's
-//! `is_authorized` answer.
-
-use alloy_primitives::Address;
+//! `isAuthorizedSessionVerifier` answer.
 
 use crate::transaction::{
-    SessionKey, TxWip1001, Wip1001Signature, Wip1001VerifyError, verify_wip1001_signature,
+    TxWip1001, Wip1001Signature,
+    verify::{SessionVerifier, Wip1001VerifyError},
 };
+use alloy_primitives::Address;
 
-/// Read-only view of the precompile-managed keyring state.
+/// Read-only view of the predeploy-managed world chain account manager.
 ///
-/// Implementors translate `is_authorized` into a state lookup at the current
-/// block height. The trait is sync because pool/builder admission paths are
+/// Implementors translate `isAuthorizedSessionVerifier` into a state lookup at the
+/// current block height. The trait is sync because pool/builder admission paths are
 /// sync; async callers can wrap a sync registry behind their own boundary.
-pub trait KeyringRegistry {
+pub trait WorldChainAccountManager {
     /// Backend-specific lookup error (e.g. database failure). Returning
     /// `Ok(false)` denotes "key is not authorized"; an `Err` denotes "the
     /// answer is not available" and callers should treat the transaction as
     /// pending or rejected accordingly.
     type Error;
 
-    /// Returns `Ok(true)` iff `session_key` is currently in the authorized set
-    /// of `keyring`.
-    fn is_authorized(
+    /// Returns `Ok(true)` iff `sessionVerifier` is currently in the authorized set
+    /// of `world_chain_account`.
+    fn is_authorized_session_verifier(
         &self,
-        keyring: Address,
-        session_key: &SessionKey,
+        world_chain_account: Address,
+        session_verifier: Address,
     ) -> Result<bool, Self::Error>;
 }
 
@@ -50,38 +50,47 @@ pub enum Wip1001ValidationError<E> {
     /// rejected or pending.
     #[error("keyring registry lookup failed: {0}")]
     Registry(E),
-    /// Signature is valid but the recovered session key is not in the
-    /// keyring's authorized set at the current state height.
-    #[error("session key is not authorized for keyring {keyring}")]
+    /// Signature is valid but the session verifier is not in the
+    /// world chain account's authorized set at the current state height.
+    #[error("session key is not authorized for world chain account {world_chain_account}")]
     NotAuthorized {
-        /// The keyring address that the unauthorized key was presented for.
-        keyring: Address,
+        /// The world chain account address that the unauthorized key was presented for.
+        world_chain_account: Address,
     },
 }
 
 /// Verify a WIP-1001 transaction's signature against its embedded
-/// `session_key`, then assert that the registry authorizes the key for the
-/// declared keyring.
-///
-/// On success returns the typed [`SessionKey`] that was bound to the
-/// signature, ready to be passed onward to gas/nonce accounting.
-pub fn validate_wip1001<R: KeyringRegistry>(
+/// `session_verifier`, then assert that the registry authorizes the key for the
+/// declared world chain account.
+pub fn validate_wip1001<M, V>(
     tx: &TxWip1001,
     sig: &Wip1001Signature,
-    registry: &R,
-) -> Result<SessionKey, Wip1001ValidationError<R::Error>> {
-    let signing_hash = tx.signing_hash();
-    let session_key = verify_wip1001_signature(
-        tx.signature_type,
-        tx.session_key.as_ref(),
-        sig,
-        &signing_hash,
-    )?;
-
-    match registry.is_authorized(tx.world_id_account, &session_key) {
-        Ok(true) => Ok(session_key),
+    world_chain_account_manager: &M,
+    session_verifier: &V,
+) -> Result<(), Wip1001ValidationError<M::Error>>
+where
+    M: WorldChainAccountManager,
+    V: SessionVerifier,
+{
+    let world_chain_account_addr = tx.world_chain_account;
+    let session_verifier_addr = tx.session_verifier;
+    match world_chain_account_manager
+        .is_authorized_session_verifier(world_chain_account_addr, session_verifier_addr)
+    {
+        Ok(true) => {
+            let signing_hash = tx.signing_hash();
+            session_verifier
+                .is_valid_signature(
+                    world_chain_account_addr,
+                    session_verifier_addr,
+                    signing_hash,
+                    sig,
+                )
+                .map_err(|_| Wip1001VerifyError::Invalid)?;
+            Ok(())
+        }
         Ok(false) => Err(Wip1001ValidationError::NotAuthorized {
-            keyring: tx.world_id_account,
+            world_chain_account: world_chain_account_addr,
         }),
         Err(e) => Err(Wip1001ValidationError::Registry(e)),
     }
@@ -125,10 +134,10 @@ mod mock {
         }
     }
 
-    impl KeyringRegistry for MockKeyringRegistry {
+    impl WorldChainAccountManager for MockKeyringRegistry {
         type Error = Infallible;
 
-        fn is_authorized(
+        fn is_authorized_session_verifier(
             &self,
             keyring: Address,
             session_key: &SessionKey,
@@ -163,9 +172,9 @@ mod tests {
     /// Registry that always errors. Useful for asserting we propagate
     /// `Registry(...)` instead of silently treating it as "not authorized".
     struct FailingRegistry;
-    impl KeyringRegistry for FailingRegistry {
+    impl WorldChainAccountManager for FailingRegistry {
         type Error = LookupFailed;
-        fn is_authorized(
+        fn is_authorized_session_verifier(
             &self,
             _keyring: Address,
             _session_key: &SessionKey,
@@ -241,7 +250,7 @@ mod tests {
         let err = validate_wip1001(&tx, &sig, &registry).expect_err("must reject");
         assert!(matches!(
             err,
-            Wip1001ValidationError::NotAuthorized { keyring } if keyring == tx.world_id_account
+            Wip1001ValidationError::NotAuthorized { world_chain_account } if keyring == tx.world_id_account
         ));
     }
 
@@ -254,7 +263,7 @@ mod tests {
         let err = validate_wip1001(&tx, &sig, &registry).expect_err("must reject");
         assert!(matches!(
             err,
-            Wip1001ValidationError::NotAuthorized { keyring } if keyring == tx.world_id_account
+            Wip1001ValidationError::NotAuthorized { world_chain_account } if keyring == tx.world_id_account
         ));
     }
 
@@ -277,9 +286,13 @@ mod tests {
         // Registry that would PANIC if called — proves we error out before
         // touching it on a verification failure.
         struct PanicRegistry;
-        impl KeyringRegistry for PanicRegistry {
+        impl WorldChainAccountManager for PanicRegistry {
             type Error = Infallible;
-            fn is_authorized(&self, _: Address, _: &SessionKey) -> Result<bool, Infallible> {
+            fn is_authorized_session_verifier(
+                &self,
+                _: Address,
+                _: &SessionKey,
+            ) -> Result<bool, Infallible> {
                 panic!("registry must not be consulted on verify failure");
             }
         }
@@ -296,9 +309,9 @@ mod tests {
         let kr = address!("00000000000000000000000000000000000000aa");
         let mut registry = MockKeyringRegistry::new();
         registry.authorize(kr, key.clone());
-        assert!(registry.is_authorized(kr, &key).unwrap());
+        assert!(registry.is_authorized_session_verifier(kr, &key).unwrap());
         assert!(registry.revoke(kr, &key));
-        assert!(!registry.is_authorized(kr, &key).unwrap());
+        assert!(!registry.is_authorized_session_verifier(kr, &key).unwrap());
         // Idempotent revoke.
         assert!(!registry.revoke(kr, &key));
     }

--- a/crates/primitives/src/transaction/keyring.rs
+++ b/crates/primitives/src/transaction/keyring.rs
@@ -99,37 +99,43 @@ where
 #[cfg(any(test, feature = "test-utils"))]
 mod mock {
     use super::*;
+    use alloy_primitives::B256;
     use std::{
         collections::{HashMap, HashSet},
         convert::Infallible,
     };
 
-    /// In-memory [`KeyringRegistry`] for tests and downstream development.
+    /// In-memory [`WorldChainAccountManager`] for tests and downstream development.
     ///
-    /// Authorizations are stored explicitly; lookups never fail (`Error =
+    /// Authorizations are stored explicitly as `(world_chain_account ->
+    /// {session_verifier_addresses})`; lookups never fail (`Error =
     /// Infallible`). For richer scenarios (e.g. simulating a state-lookup
     /// failure) write a bespoke mock in the calling crate.
     #[derive(Debug, Default, Clone)]
     pub struct MockKeyringRegistry {
-        authorized: HashMap<Address, HashSet<SessionKey>>,
+        authorized: HashMap<Address, HashSet<Address>>,
     }
 
     impl MockKeyringRegistry {
-        /// Creates an empty registry with no authorized session keys.
+        /// Creates an empty registry with no authorized session verifiers.
         pub fn new() -> Self {
             Self::default()
         }
 
-        /// Authorizes `key` on `keyring`. Idempotent.
-        pub fn authorize(&mut self, keyring: Address, key: SessionKey) {
-            self.authorized.entry(keyring).or_default().insert(key);
+        /// Authorizes `session_verifier` on `world_chain_account`. Idempotent.
+        pub fn authorize(&mut self, world_chain_account: Address, session_verifier: Address) {
+            self.authorized
+                .entry(world_chain_account)
+                .or_default()
+                .insert(session_verifier);
         }
 
-        /// Revokes `key` on `keyring`. Returns `true` if a removal occurred.
-        pub fn revoke(&mut self, keyring: Address, key: &SessionKey) -> bool {
+        /// Revokes `session_verifier` on `world_chain_account`. Returns `true`
+        /// if a removal occurred.
+        pub fn revoke(&mut self, world_chain_account: Address, session_verifier: &Address) -> bool {
             self.authorized
-                .get_mut(&keyring)
-                .map(|set| set.remove(key))
+                .get_mut(&world_chain_account)
+                .map(|set| set.remove(session_verifier))
                 .unwrap_or(false)
         }
     }
@@ -139,30 +145,71 @@ mod mock {
 
         fn is_authorized_session_verifier(
             &self,
-            keyring: Address,
-            session_key: &SessionKey,
+            world_chain_account: Address,
+            session_verifier: Address,
         ) -> Result<bool, Self::Error> {
             Ok(self
                 .authorized
-                .get(&keyring)
-                .is_some_and(|set| set.contains(session_key)))
+                .get(&world_chain_account)
+                .is_some_and(|set| set.contains(&session_verifier)))
+        }
+    }
+
+    /// In-memory [`SessionVerifier`] for tests and downstream development.
+    ///
+    /// Returns a fixed verdict (`accept` or reject) for every call; the
+    /// real backend is an EVM-driven STATICCALL through the account router
+    /// (see [`SessionVerifier`] and WIP-1001 §"Restricted Validation Frames").
+    #[derive(Debug, Clone, Copy, Default)]
+    pub struct MockSessionVerifier {
+        accept: bool,
+    }
+
+    impl MockSessionVerifier {
+        /// Returns a verifier that accepts every signature.
+        pub fn accept_all() -> Self {
+            Self { accept: true }
+        }
+
+        /// Returns a verifier that rejects every signature.
+        pub fn reject_all() -> Self {
+            Self { accept: false }
+        }
+    }
+
+    /// Error returned by [`MockSessionVerifier::reject_all`].
+    #[derive(Debug, thiserror::Error, PartialEq, Eq, Clone, Copy)]
+    #[error("mock session verifier rejected the signature")]
+    pub struct MockSessionVerifierRejected;
+
+    impl SessionVerifier for MockSessionVerifier {
+        type Error = MockSessionVerifierRejected;
+
+        fn is_valid_signature(
+            &self,
+            _world_chain_account: Address,
+            _session_verifier: Address,
+            _signing_hash: B256,
+            _signature: &Wip1001Signature,
+        ) -> Result<(), Self::Error> {
+            if self.accept {
+                Ok(())
+            } else {
+                Err(MockSessionVerifierRejected)
+            }
         }
     }
 }
 
 #[cfg(any(test, feature = "test-utils"))]
-pub use mock::MockKeyringRegistry;
+pub use mock::{MockKeyringRegistry, MockSessionVerifier, MockSessionVerifierRejected};
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::transaction::{P256Signature, signature::P256_PUBKEY_LEN, verify::P256N_HALF};
     use alloy_eips::eip2930::AccessList;
-    use alloy_primitives::{B256, Bytes, U256, address, hex};
-    use p256::{
-        ecdsa::{SigningKey as P256SigningKey, signature::hazmat::PrehashSigner},
-        elliptic_curve::rand_core::OsRng,
-    };
+    use alloy_primitives::{Bytes, U256, address, hex};
+    use std::convert::Infallible;
 
     /// Lookup error stand-in for tests that need to simulate registry failures.
     #[derive(Debug, thiserror::Error, PartialEq, Eq, Clone, Copy)]
@@ -176,101 +223,86 @@ mod tests {
         type Error = LookupFailed;
         fn is_authorized_session_verifier(
             &self,
-            _keyring: Address,
-            _session_key: &SessionKey,
+            _world_chain_account: Address,
+            _session_verifier: Address,
         ) -> Result<bool, Self::Error> {
             Err(LookupFailed)
         }
     }
 
-    fn p256_keypair() -> (P256SigningKey, [u8; P256_PUBKEY_LEN]) {
-        let sk = P256SigningKey::random(&mut OsRng);
-        let vk = sk.verifying_key().to_encoded_point(false);
-        let mut bytes = [0u8; P256_PUBKEY_LEN];
-        bytes[..32].copy_from_slice(vk.x().expect("x").as_ref());
-        bytes[32..].copy_from_slice(vk.y().expect("y").as_ref());
-        (sk, bytes)
-    }
-
-    fn p256_sign(sk: &P256SigningKey, hash: &B256) -> P256Signature {
-        let raw: p256::ecdsa::Signature = sk.sign_prehash(hash.as_slice()).expect("sign");
-        let bytes = raw.to_bytes();
-        let r = B256::from_slice(&bytes[..32]);
-        let s_u = U256::from_be_slice(&bytes[32..]);
-        let s_norm = if s_u > P256N_HALF {
-            crate::transaction::verify::P256_ORDER - s_u
-        } else {
-            s_u
-        };
-        P256Signature {
-            r,
-            s: B256::from(s_norm.to_be_bytes::<32>()),
-        }
-    }
-
-    /// Builds a P-256-signed `(tx, signature)` pair plus the typed session key.
-    fn signed_p256() -> (TxWip1001, Wip1001Signature, SessionKey) {
-        let (sk, key_bytes) = p256_keypair();
-        let session_key = SessionKey::from_wire(Wip1001Signature::P256_TYPE, &key_bytes)
-            .expect("typed session key");
-
+    /// Builds a fixed `(tx, signature)` pair. The signature payload is opaque
+    /// to the protocol (verification is delegated to the on-chain session
+    /// verifier via EIP-1271) so we use a constant blob.
+    fn signed_tx() -> (TxWip1001, Wip1001Signature) {
         let tx = TxWip1001 {
             chain_id: 480,
             nonce: 0,
             max_priority_fee_per_gas: 1,
             max_fee_per_gas: 2,
             gas_limit: 21_000,
+            world_chain_account: address!("000000000000000000000000000000000000001d"),
+            session_verifier: address!("00000000000000000000000000000000000000aa"),
             to: address!("6069a6c32cf691f5982febae4faf8a6f3ab2f0f6").into(),
             value: U256::ZERO,
-            input: hex!("").into(),
+            input: Bytes::default(),
             access_list: AccessList::default(),
-            world_id_account: address!("000000000000000000000000000000000000001d"),
-            signature_type: Wip1001Signature::P256_TYPE,
-            session_key: Bytes::copy_from_slice(&key_bytes),
         };
-        let sig = Wip1001Signature::P256(p256_sign(&sk, &tx.signing_hash()));
-        (tx, sig, session_key)
+        let sig = Wip1001Signature {
+            signature: hex!("deadbeefcafef00d").into(),
+        };
+        (tx, sig)
     }
 
     #[test]
-    fn validate_ok_when_authorized() {
-        let (tx, sig, key) = signed_p256();
+    fn validate_ok_when_authorized_and_session_verifier_accepts() {
+        let (tx, sig) = signed_tx();
         let mut registry = MockKeyringRegistry::new();
-        registry.authorize(tx.world_id_account, key.clone());
+        registry.authorize(tx.world_chain_account, tx.session_verifier);
 
-        let recovered = validate_wip1001(&tx, &sig, &registry).expect("ok");
-        assert_eq!(recovered, key);
+        validate_wip1001(&tx, &sig, &registry, &MockSessionVerifier::accept_all()).expect("ok");
     }
 
     #[test]
-    fn validate_rejects_unauthorized_key() {
-        let (tx, sig, _key) = signed_p256();
-        // Empty registry — key is not authorized.
+    fn validate_rejects_unauthorized_verifier() {
+        let (tx, sig) = signed_tx();
+        // Empty registry — session verifier is not authorized.
         let registry = MockKeyringRegistry::new();
-        let err = validate_wip1001(&tx, &sig, &registry).expect_err("must reject");
+
+        let err = validate_wip1001(&tx, &sig, &registry, &MockSessionVerifier::accept_all())
+            .expect_err("must reject");
         assert!(matches!(
             err,
-            Wip1001ValidationError::NotAuthorized { world_chain_account } if keyring == tx.world_id_account
+            Wip1001ValidationError::NotAuthorized { world_chain_account }
+                if world_chain_account == tx.world_chain_account
         ));
     }
 
     #[test]
-    fn validate_rejects_when_authorized_for_different_keyring() {
-        let (tx, sig, key) = signed_p256();
+    fn validate_rejects_when_authorized_for_different_account() {
+        let (tx, sig) = signed_tx();
         let mut registry = MockKeyringRegistry::new();
-        // Authorize the key on a *different* keyring.
-        registry.authorize(Address::with_last_byte(0xAA), key);
-        let err = validate_wip1001(&tx, &sig, &registry).expect_err("must reject");
+        // Authorize the verifier on a *different* world chain account.
+        registry.authorize(Address::with_last_byte(0xAA), tx.session_verifier);
+
+        let err = validate_wip1001(&tx, &sig, &registry, &MockSessionVerifier::accept_all())
+            .expect_err("must reject");
         assert!(matches!(
             err,
-            Wip1001ValidationError::NotAuthorized { world_chain_account } if keyring == tx.world_id_account
+            Wip1001ValidationError::NotAuthorized { world_chain_account }
+                if world_chain_account == tx.world_chain_account
         ));
     }
 
     #[test]
     fn validate_propagates_registry_error() {
-        let (tx, sig, _key) = signed_p256();
-        let err = validate_wip1001(&tx, &sig, &FailingRegistry).expect_err("must propagate");
+        let (tx, sig) = signed_tx();
+        let err = validate_wip1001(
+            &tx,
+            &sig,
+            &FailingRegistry,
+            &MockSessionVerifier::accept_all(),
+        )
+        .expect_err("must propagate");
         assert!(matches!(
             err,
             Wip1001ValidationError::Registry(LookupFailed)
@@ -278,43 +310,67 @@ mod tests {
     }
 
     #[test]
-    fn validate_rejects_tampered_signature_without_registry_call() {
-        let (mut tx, sig, key) = signed_p256();
-        // Mutate `input` so the cached signature no longer covers the message.
-        tx.input = Bytes::from_static(b"tampered");
+    fn validate_returns_verify_when_session_verifier_rejects() {
+        let (tx, sig) = signed_tx();
+        let mut registry = MockKeyringRegistry::new();
+        registry.authorize(tx.world_chain_account, tx.session_verifier);
 
-        // Registry that would PANIC if called — proves we error out before
-        // touching it on a verification failure.
-        struct PanicRegistry;
-        impl WorldChainAccountManager for PanicRegistry {
-            type Error = Infallible;
-            fn is_authorized_session_verifier(
-                &self,
-                _: Address,
-                _: &SessionKey,
-            ) -> Result<bool, Infallible> {
-                panic!("registry must not be consulted on verify failure");
-            }
-        }
-
-        let err = validate_wip1001(&tx, &sig, &PanicRegistry).expect_err("verify must fail");
+        let err = validate_wip1001(&tx, &sig, &registry, &MockSessionVerifier::reject_all())
+            .expect_err("must reject signature");
         assert!(matches!(err, Wip1001ValidationError::Verify(_)));
-        // Silence unused-binding warnings on the original key.
-        let _ = key;
     }
 
     #[test]
-    fn mock_revoke_round_trip() {
-        let (_, _, key) = signed_p256();
-        let kr = address!("00000000000000000000000000000000000000aa");
-        let mut registry = MockKeyringRegistry::new();
-        registry.authorize(kr, key.clone());
-        assert!(registry.is_authorized_session_verifier(kr, &key).unwrap());
-        assert!(registry.revoke(kr, &key));
-        assert!(!registry.is_authorized_session_verifier(kr, &key).unwrap());
-        // Idempotent revoke.
-        assert!(!registry.revoke(kr, &key));
+    fn validate_skips_session_verifier_when_unauthorized() {
+        // Asserts the spec-mandated ordering: the authorization precheck
+        // (WIP-1001 step 3) runs *before* the EIP-1271 signature call (step 6).
+        let (tx, sig) = signed_tx();
+        let registry = MockKeyringRegistry::new();
+
+        struct PanicVerifier;
+        impl SessionVerifier for PanicVerifier {
+            type Error = Infallible;
+            fn is_valid_signature(
+                &self,
+                _: Address,
+                _: Address,
+                _: alloy_primitives::B256,
+                _: &Wip1001Signature,
+            ) -> Result<(), Self::Error> {
+                panic!("session verifier must not be consulted on unauthorized verifier");
+            }
+        }
+
+        let err = validate_wip1001(&tx, &sig, &registry, &PanicVerifier)
+            .expect_err("authorization precheck must fail first");
+        assert!(matches!(
+            err,
+            Wip1001ValidationError::NotAuthorized { world_chain_account }
+                if world_chain_account == tx.world_chain_account
+        ));
     }
 
-    use std::convert::Infallible;
+    #[test]
+    fn mock_authorize_and_revoke_round_trip() {
+        let account = address!("00000000000000000000000000000000000000aa");
+        let session_verifier = address!("00000000000000000000000000000000000000bb");
+        let mut registry = MockKeyringRegistry::new();
+
+        registry.authorize(account, session_verifier);
+        assert!(
+            registry
+                .is_authorized_session_verifier(account, session_verifier)
+                .unwrap()
+        );
+
+        assert!(registry.revoke(account, &session_verifier));
+        assert!(
+            !registry
+                .is_authorized_session_verifier(account, session_verifier)
+                .unwrap()
+        );
+
+        // Idempotent revoke.
+        assert!(!registry.revoke(account, &session_verifier));
+    }
 }

--- a/crates/primitives/src/transaction/keyring.rs
+++ b/crates/primitives/src/transaction/keyring.rs
@@ -13,7 +13,7 @@
 
 use crate::transaction::{
     TxWip1001, Wip1001Signature,
-    verify::{SessionVerifier, Wip1001VerifyError},
+    verify::{SessionVerifier, Wip1001VerifyError, verify_wip1001_signature},
 };
 use alloy_primitives::Address;
 
@@ -79,14 +79,14 @@ where
     {
         Ok(true) => {
             let signing_hash = tx.signing_hash();
-            session_verifier
-                .is_valid_signature(
-                    world_chain_account_addr,
-                    session_verifier_addr,
-                    signing_hash,
-                    sig,
-                )
-                .map_err(|_| Wip1001VerifyError::Invalid)?;
+            verify_wip1001_signature(
+                session_verifier,
+                world_chain_account_addr,
+                session_verifier_addr,
+                signing_hash,
+                sig,
+            )
+            .map_err(|_| Wip1001VerifyError::Invalid)?;
             Ok(())
         }
         Ok(false) => Err(Wip1001ValidationError::NotAuthorized {

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -10,10 +10,6 @@ pub use envelope::{WorldChainTxEnvelope, WorldChainTxType, WorldChainTypedTransa
 #[cfg(any(test, feature = "test-utils"))]
 pub use keyring::MockKeyringRegistry;
 
-pub use keyring::{KeyringRegistry, Wip1001ValidationError, validate_wip1001};
-pub use signature::{
-    P256Signature, SessionKey, SessionKeyError, WIP_1001_TX_TYPE, WebAuthnSignature,
-    Wip1001Signature,
-};
-pub use verify::{Wip1001VerifyError, verify_wip1001_signature};
+pub use keyring::{Wip1001ValidationError, WorldChainAccountManager, validate_wip1001};
+pub use signature::{WIP_1001_TX_TYPE, Wip1001Signature};
 pub use wip_1001::{SignedWip1001, TxWip1001};

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -8,9 +8,9 @@ pub mod wip_1001;
 
 pub use envelope::{WorldChainTxEnvelope, WorldChainTxType, WorldChainTypedTransaction};
 #[cfg(any(test, feature = "test-utils"))]
-pub use keyring::MockKeyringRegistry;
+pub use keyring::{MockKeyringRegistry, MockSessionVerifier};
 
 pub use keyring::{Wip1001ValidationError, WorldChainAccountManager, validate_wip1001};
 pub use signature::{WIP_1001_TX_TYPE, Wip1001Signature};
-pub use verify::verify_wip1001_signature;
+pub use verify::{SessionVerifier, verify_wip1001_signature};
 pub use wip_1001::{SignedWip1001, TxWip1001};

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -12,4 +12,5 @@ pub use keyring::MockKeyringRegistry;
 
 pub use keyring::{Wip1001ValidationError, WorldChainAccountManager, validate_wip1001};
 pub use signature::{WIP_1001_TX_TYPE, Wip1001Signature};
+pub use verify::verify_wip1001_signature;
 pub use wip_1001::{SignedWip1001, TxWip1001};

--- a/crates/primitives/src/transaction/signature.rs
+++ b/crates/primitives/src/transaction/signature.rs
@@ -1,472 +1,73 @@
-use core::hash::{Hash, Hasher};
-
-use alloy_primitives::{B256, Bytes, Signature, U256, bytes::BufMut};
+use alloy_primitives::{Bytes, Signature, bytes::BufMut};
 use alloy_rlp::{Decodable, Encodable, Header};
+use core::hash::Hash;
 
 /// The EIP-2718 transaction type byte for WIP-1001 transactions.
 pub const WIP_1001_TX_TYPE: u8 = 0x1D;
 
-/// Length of a SEC1-compressed secp256k1 public key.
-pub const SECP256K1_PUBKEY_LEN: usize = 33;
-/// Length of an uncompressed `(x, y)` P-256 public key.
-pub const P256_PUBKEY_LEN: usize = 64;
-/// Length of a compressed Ed25519 public key.
-pub const ED25519_PUBKEY_LEN: usize = 32;
-
 /// Signature scheme for a [`TxWip1001`](crate::transaction::TxWip1001).
 ///
-/// The WIP-1001 envelope is polymorphic over the signing algorithm: each
-/// session key may be a secp256k1, P256, WebAuthn (P256 under WebAuthn), or
-/// Ed25519 key. The `signature_type` byte and `session_key` bytes live on
-/// [`TxWip1001`] (covered by `signing_hash`); this enum carries only the
-/// scheme-specific signature payload.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(tag = "signatureType", content = "signaturePayload")]
-#[non_exhaustive]
-pub enum Wip1001Signature {
-    /// secp256k1 ECDSA, `signature_type = 0x00`.
-    ///
-    /// `signature_payload = rlp([y_parity, r, s])`.
-    #[serde(rename = "0x0")]
-    Secp256k1(Signature),
-    /// NIST P-256 ECDSA, `signature_type = 0x01`.
-    ///
-    /// `signature_payload = rlp([r, s])`.
-    #[serde(rename = "0x1")]
-    P256(P256Signature),
-    /// WebAuthn (P-256 under WebAuthn), `signature_type = 0x02`.
-    ///
-    /// `signature_payload = rlp([authenticator_data, client_data_json, r, s])`.
-    #[serde(rename = "0x2")]
-    WebAuthn(WebAuthnSignature),
-    /// Ed25519 EdDSA over edwards25519, `signature_type = 0x03`.
-    ///
-    /// `signature_payload = rlp([R, s])` — where `R || s` is the canonical
-    /// 64-byte [`ed25519_dalek::Signature`].
-    #[serde(rename = "0x3")]
-    EdDSA(ed25519_dalek::Signature),
-}
-
-/// Raw P-256 ECDSA `(r, s)` signature pair.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-pub struct P256Signature {
-    /// ECDSA `r` scalar.
-    pub r: B256,
-    /// ECDSA `s` scalar.
-    pub s: B256,
-}
-
-/// WebAuthn assertion signature.
-///
-/// Verification computes `sha256(authenticator_data || sha256(client_data_json))`
-/// and feeds the result to P-256 verification using the session pubkey from the
-/// transaction.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-pub struct WebAuthnSignature {
-    /// Raw WebAuthn `authenticatorData` (≥ 37 bytes).
-    pub authenticator_data: Bytes,
-    /// Raw WebAuthn `clientDataJSON`.
-    pub client_data_json: Bytes,
-    /// ECDSA `r` scalar.
-    pub r: B256,
-    /// ECDSA `s` scalar.
-    pub s: B256,
+/// The WIP-1001 envelope doesn't put any restriction on the signature, that is opaque
+/// to the protocol and it's interpreted and validated directly by the session verifier
+/// contract through the `sessionVerifier.isValidSignature(signingHash, signature)` fn.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct Wip1001Signature {
+    /// The opaque signature bytes.
+    pub signature: Bytes,
 }
 
 impl Wip1001Signature {
-    /// `signature_type` byte for the secp256k1 variant.
-    pub const SECP256K1_TYPE: u8 = 0x00;
-    /// `signature_type` byte for the raw P-256 variant.
-    pub const P256_TYPE: u8 = 0x01;
-    /// `signature_type` byte for the WebAuthn variant.
-    pub const WEBAUTHN_TYPE: u8 = 0x02;
-    /// `signature_type` byte for the EdDSA variant.
-    pub const EDDSA_TYPE: u8 = 0x03;
-
-    /// Returns the `signature_type` tag byte for this variant.
-    #[inline]
-    pub const fn signature_type(&self) -> u8 {
-        match self {
-            Self::Secp256k1(_) => Self::SECP256K1_TYPE,
-            Self::P256(_) => Self::P256_TYPE,
-            Self::WebAuthn(_) => Self::WEBAUTHN_TYPE,
-            Self::EdDSA(_) => Self::EDDSA_TYPE,
-        }
-    }
-
-    /// Returns the inner secp256k1 [`Signature`] if this is the `Secp256k1` variant.
-    pub const fn as_secp256k1(&self) -> Option<&Signature> {
-        match self {
-            Self::Secp256k1(sig) => Some(sig),
-            _ => None,
-        }
-    }
-
-    /// Returns the inner [`P256Signature`] if this is the `P256` variant.
-    pub const fn as_p256(&self) -> Option<&P256Signature> {
-        match self {
-            Self::P256(sig) => Some(sig),
-            _ => None,
-        }
-    }
-
-    /// Returns the inner [`WebAuthnSignature`] if this is the `WebAuthn` variant.
-    pub const fn as_webauthn(&self) -> Option<&WebAuthnSignature> {
-        match self {
-            Self::WebAuthn(sig) => Some(sig),
-            _ => None,
-        }
-    }
-
-    /// Returns the inner [`ed25519_dalek::Signature`] if this is the `EdDSA` variant.
-    pub const fn as_eddsa(&self) -> Option<&ed25519_dalek::Signature> {
-        match self {
-            Self::EdDSA(sig) => Some(sig),
-            _ => None,
-        }
-    }
-
     /// Length of the RLP-encoded `signature_payload` bytes (no outer string header).
     pub(crate) fn payload_encoded_len(&self) -> usize {
-        match self {
-            Self::Secp256k1(sig) => {
-                let y_parity = sig.v() as u8;
-                let list_payload_len = y_parity.length() + sig.r().length() + sig.s().length();
-                Header {
-                    list: true,
-                    payload_length: list_payload_len,
-                }
-                .length_with_payload()
-            }
-            Self::P256(sig) => {
-                let r = U256::from_be_bytes(sig.r.0);
-                let s = U256::from_be_bytes(sig.s.0);
-                let list_payload_len = r.length() + s.length();
-                Header {
-                    list: true,
-                    payload_length: list_payload_len,
-                }
-                .length_with_payload()
-            }
-            Self::WebAuthn(sig) => {
-                let r = U256::from_be_bytes(sig.r.0);
-                let s = U256::from_be_bytes(sig.s.0);
-                let list_payload_len = sig.authenticator_data.0.length()
-                    + sig.client_data_json.0.length()
-                    + r.length()
-                    + s.length();
-                Header {
-                    list: true,
-                    payload_length: list_payload_len,
-                }
-                .length_with_payload()
-            }
-            Self::EdDSA(sig) => {
-                let bytes = sig.to_bytes();
-                let r = U256::from_be_bytes::<32>(bytes[..32].try_into().expect("32 bytes"));
-                let s = U256::from_be_bytes::<32>(bytes[32..].try_into().expect("32 bytes"));
-                let list_payload_len = r.length() + s.length();
-                Header {
-                    list: true,
-                    payload_length: list_payload_len,
-                }
-                .length_with_payload()
-            }
+        Header {
+            list: true,
+            payload_length: self.signature.length(),
         }
+        .length_with_payload()
     }
 
     /// Encodes the `signature_payload` into `out` without an outer RLP string header.
-    ///
-    /// Per WIP-1001 §Envelope, this writes the per-scheme RLP list directly:
-    /// - secp256k1: `rlp([y_parity, r, s])`
-    /// - P256: `rlp([r, s])`
-    /// - WebAuthn: `rlp([authenticator_data, client_data_json, r, s])`
-    /// - EdDSA: `rlp([R, s])` where `R || s` is the canonical 64-byte signature
     pub(crate) fn encode_payload_raw(&self, out: &mut dyn BufMut) {
-        match self {
-            Self::Secp256k1(sig) => {
-                let y_parity = sig.v() as u8;
-                let list_payload_len = y_parity.length() + sig.r().length() + sig.s().length();
-                Header {
-                    list: true,
-                    payload_length: list_payload_len,
-                }
-                .encode(out);
-                y_parity.encode(out);
-                sig.r().encode(out);
-                sig.s().encode(out);
-            }
-            Self::P256(sig) => {
-                let r = U256::from_be_bytes(sig.r.0);
-                let s = U256::from_be_bytes(sig.s.0);
-                let list_payload_len = r.length() + s.length();
-                Header {
-                    list: true,
-                    payload_length: list_payload_len,
-                }
-                .encode(out);
-                r.encode(out);
-                s.encode(out);
-            }
-            Self::WebAuthn(sig) => {
-                let r = U256::from_be_bytes(sig.r.0);
-                let s = U256::from_be_bytes(sig.s.0);
-                let list_payload_len = sig.authenticator_data.0.length()
-                    + sig.client_data_json.0.length()
-                    + r.length()
-                    + s.length();
-                Header {
-                    list: true,
-                    payload_length: list_payload_len,
-                }
-                .encode(out);
-                sig.authenticator_data.0.encode(out);
-                sig.client_data_json.0.encode(out);
-                r.encode(out);
-                s.encode(out);
-            }
-            Self::EdDSA(sig) => {
-                let bytes = sig.to_bytes();
-                let r = U256::from_be_bytes::<32>(bytes[..32].try_into().expect("32 bytes"));
-                let s = U256::from_be_bytes::<32>(bytes[32..].try_into().expect("32 bytes"));
-                let list_payload_len = r.length() + s.length();
-                Header {
-                    list: true,
-                    payload_length: list_payload_len,
-                }
-                .encode(out);
-                r.encode(out);
-                s.encode(out);
-            }
+        Header {
+            list: true,
+            payload_length: self.signature.length(),
         }
+        .encode(out);
+        self.signature.encode(out);
     }
 
-    /// Decodes a `signature_payload` byte string, given its `signature_type`.
+    /// Decodes a `signature_payload` byte string.
     ///
     /// The caller has already consumed the outer RLP string header around
     /// `signature_payload`; this reads the raw payload bytes.
-    pub(crate) fn decode_payload_raw(ty: u8, buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
-        match ty {
-            Self::SECP256K1_TYPE => {
-                let header = Header::decode(buf)?;
-                if !header.list {
-                    return Err(alloy_rlp::Error::UnexpectedString);
-                }
-                let start = buf.len();
-                let y_parity: u8 = Decodable::decode(buf)?;
-                let r: U256 = Decodable::decode(buf)?;
-                let s: U256 = Decodable::decode(buf)?;
-                let consumed = start - buf.len();
-                if consumed != header.payload_length {
-                    return Err(alloy_rlp::Error::ListLengthMismatch {
-                        expected: header.payload_length,
-                        got: consumed,
-                    });
-                }
-                if y_parity > 1 {
-                    return Err(alloy_rlp::Error::Custom("invalid y_parity"));
-                }
-                Ok(Self::Secp256k1(Signature::new(r, s, y_parity != 0)))
-            }
-            Self::P256_TYPE => {
-                let header = Header::decode(buf)?;
-                if !header.list {
-                    return Err(alloy_rlp::Error::UnexpectedString);
-                }
-                let start = buf.len();
-                let r: U256 = Decodable::decode(buf)?;
-                let s: U256 = Decodable::decode(buf)?;
-                let consumed = start - buf.len();
-                if consumed != header.payload_length {
-                    return Err(alloy_rlp::Error::ListLengthMismatch {
-                        expected: header.payload_length,
-                        got: consumed,
-                    });
-                }
-                Ok(Self::P256(P256Signature {
-                    r: B256::from(r.to_be_bytes::<32>()),
-                    s: B256::from(s.to_be_bytes::<32>()),
-                }))
-            }
-            Self::WEBAUTHN_TYPE => {
-                let header = Header::decode(buf)?;
-                if !header.list {
-                    return Err(alloy_rlp::Error::UnexpectedString);
-                }
-                let start = buf.len();
-                let authenticator_data: alloy_primitives::bytes::Bytes = Decodable::decode(buf)?;
-                let client_data_json: alloy_primitives::bytes::Bytes = Decodable::decode(buf)?;
-                let r: U256 = Decodable::decode(buf)?;
-                let s: U256 = Decodable::decode(buf)?;
-                let consumed = start - buf.len();
-                if consumed != header.payload_length {
-                    return Err(alloy_rlp::Error::ListLengthMismatch {
-                        expected: header.payload_length,
-                        got: consumed,
-                    });
-                }
-                Ok(Self::WebAuthn(WebAuthnSignature {
-                    authenticator_data: Bytes(authenticator_data),
-                    client_data_json: Bytes(client_data_json),
-                    r: B256::from(r.to_be_bytes::<32>()),
-                    s: B256::from(s.to_be_bytes::<32>()),
-                }))
-            }
-            Self::EDDSA_TYPE => {
-                let header = Header::decode(buf)?;
-                if !header.list {
-                    return Err(alloy_rlp::Error::UnexpectedString);
-                }
-                let start = buf.len();
-                let r: U256 = Decodable::decode(buf)?;
-                let s: U256 = Decodable::decode(buf)?;
-                let consumed = start - buf.len();
-                if consumed != header.payload_length {
-                    return Err(alloy_rlp::Error::ListLengthMismatch {
-                        expected: header.payload_length,
-                        got: consumed,
-                    });
-                }
-                let mut sig_bytes = [0u8; 64];
-                sig_bytes[..32].copy_from_slice(&r.to_be_bytes::<32>());
-                sig_bytes[32..].copy_from_slice(&s.to_be_bytes::<32>());
-                Ok(Self::EdDSA(ed25519_dalek::Signature::from_bytes(
-                    &sig_bytes,
-                )))
-            }
-            _ => Err(alloy_rlp::Error::Custom(
-                "unsupported wip-1001 signature type",
-            )),
+    pub(crate) fn decode_payload_raw(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let header = Header::decode(buf)?;
+        if !header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
         }
-    }
-}
-
-// `ed25519_dalek::Signature` does not implement `Hash`. Hash via the canonical
-// 64-byte representation; tag the variant with `signature_type` so different
-// schemes don't collide.
-impl Hash for Wip1001Signature {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.signature_type().hash(state);
-        match self {
-            Self::Secp256k1(sig) => sig.hash(state),
-            Self::P256(sig) => sig.hash(state),
-            Self::WebAuthn(sig) => sig.hash(state),
-            Self::EdDSA(sig) => sig.to_bytes().hash(state),
+        let start = buf.len();
+        let signature: Bytes = Decodable::decode(buf)?;
+        let consumed = start - buf.len();
+        if consumed != header.payload_length {
+            return Err(alloy_rlp::Error::ListLengthMismatch {
+                expected: header.payload_length,
+                got: consumed,
+            });
         }
+        Ok(Self { signature })
     }
 }
 
-/// Typed view of a session key, parsed from a `(signature_type, key_data)` pair
-/// stored on a [`TxWip1001`](crate::transaction::TxWip1001).
-///
-/// Lengths are validated per WIP-1001 §Session Keys:
-/// - `Secp256k1`: 33 bytes (SEC1-compressed pubkey)
-/// - `P256` / `WebAuthn`: 64 bytes (uncompressed `x || y`)
-/// - `EdDSA`: 32 bytes (compressed Ed25519 pubkey)
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[non_exhaustive]
-pub enum SessionKey {
-    /// SEC1-compressed secp256k1 public key (33 bytes).
-    Secp256k1([u8; SECP256K1_PUBKEY_LEN]),
-    /// Uncompressed P-256 public key, `x || y` (64 bytes).
-    P256 {
-        /// Affine x coordinate.
-        x: B256,
-        /// Affine y coordinate.
-        y: B256,
-    },
-    /// Uncompressed P-256 public key for WebAuthn assertions (64 bytes).
-    WebAuthn {
-        /// Affine x coordinate.
-        x: B256,
-        /// Affine y coordinate.
-        y: B256,
-    },
-    /// Compressed Ed25519 public key (32 bytes), validated on-curve at parse time.
-    EdDSA(ed25519_dalek::VerifyingKey),
-}
-
-/// Parse error for [`SessionKey::from_wire`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum SessionKeyError {
-    /// `signature_type` is not one of the supported variants.
-    #[error("unsupported session key type: 0x{0:02x}")]
-    UnsupportedType(u8),
-    /// `key_data` length does not match the spec for the declared `signature_type`.
-    #[error("invalid session key length: expected {expected}, got {got}")]
-    InvalidLength {
-        /// Expected length in bytes.
-        expected: usize,
-        /// Actual length in bytes.
-        got: usize,
-    },
-    /// `key_data` is the right length but does not decode to a valid public key
-    /// (e.g. Ed25519 point not on the curve).
-    #[error("malformed public key")]
-    MalformedKey,
-}
-
-impl SessionKey {
-    /// Parse a `(signature_type, key_data)` wire pair into a typed session key.
-    pub fn from_wire(signature_type: u8, key_data: &[u8]) -> Result<Self, SessionKeyError> {
-        match signature_type {
-            Wip1001Signature::SECP256K1_TYPE => {
-                if key_data.len() != SECP256K1_PUBKEY_LEN {
-                    return Err(SessionKeyError::InvalidLength {
-                        expected: SECP256K1_PUBKEY_LEN,
-                        got: key_data.len(),
-                    });
-                }
-                let mut buf = [0u8; SECP256K1_PUBKEY_LEN];
-                buf.copy_from_slice(key_data);
-                Ok(Self::Secp256k1(buf))
-            }
-            Wip1001Signature::P256_TYPE => {
-                let (x, y) = parse_p256_key_data(key_data)?;
-                Ok(Self::P256 { x, y })
-            }
-            Wip1001Signature::WEBAUTHN_TYPE => {
-                let (x, y) = parse_p256_key_data(key_data)?;
-                Ok(Self::WebAuthn { x, y })
-            }
-            Wip1001Signature::EDDSA_TYPE => {
-                if key_data.len() != ED25519_PUBKEY_LEN {
-                    return Err(SessionKeyError::InvalidLength {
-                        expected: ED25519_PUBKEY_LEN,
-                        got: key_data.len(),
-                    });
-                }
-                let mut buf = [0u8; ED25519_PUBKEY_LEN];
-                buf.copy_from_slice(key_data);
-                let vk = ed25519_dalek::VerifyingKey::from_bytes(&buf)
-                    .map_err(|_| SessionKeyError::MalformedKey)?;
-                Ok(Self::EdDSA(vk))
-            }
-            other => Err(SessionKeyError::UnsupportedType(other)),
-        }
-    }
-
-    /// Returns the `signature_type` tag byte associated with this session key.
-    #[inline]
-    pub const fn signature_type(&self) -> u8 {
-        match self {
-            Self::Secp256k1(_) => Wip1001Signature::SECP256K1_TYPE,
-            Self::P256 { .. } => Wip1001Signature::P256_TYPE,
-            Self::WebAuthn { .. } => Wip1001Signature::WEBAUTHN_TYPE,
-            Self::EdDSA(_) => Wip1001Signature::EDDSA_TYPE,
-        }
+impl From<Signature> for Wip1001Signature {
+    fn from(value: Signature) -> Self {
+        let signature = value.as_bytes().into();
+        Self { signature }
     }
 }
 
-fn parse_p256_key_data(key_data: &[u8]) -> Result<(B256, B256), SessionKeyError> {
-    if key_data.len() != P256_PUBKEY_LEN {
-        return Err(SessionKeyError::InvalidLength {
-            expected: P256_PUBKEY_LEN,
-            got: key_data.len(),
-        });
+impl From<&Signature> for Wip1001Signature {
+    fn from(value: &Signature) -> Self {
+        let signature = value.as_bytes().into();
+        Self { signature }
     }
-    Ok((
-        B256::from_slice(&key_data[..32]),
-        B256::from_slice(&key_data[32..]),
-    ))
 }

--- a/crates/primitives/src/transaction/signature.rs
+++ b/crates/primitives/src/transaction/signature.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::{Bytes, Signature, bytes::BufMut};
-use alloy_rlp::{Decodable, Encodable, Header};
+use alloy_rlp::{Decodable, Encodable};
 use core::hash::Hash;
 
 /// The EIP-2718 transaction type byte for WIP-1001 transactions.
@@ -17,43 +17,20 @@ pub struct Wip1001Signature {
 }
 
 impl Wip1001Signature {
-    /// Length of the RLP-encoded `signature_payload` bytes (no outer string header).
+    /// Length of the RLP encoding of the signature as a single byte-string item
+    /// (byte-string head + body).
     pub(crate) fn payload_encoded_len(&self) -> usize {
-        Header {
-            list: true,
-            payload_length: self.signature.length(),
-        }
-        .length_with_payload()
+        self.signature.length()
     }
 
-    /// Encodes the `signature_payload` into `out` without an outer RLP string header.
+    /// RLP-encodes the signature as a single byte-string item (no extra wrapping).
     pub(crate) fn encode_payload_raw(&self, out: &mut dyn BufMut) {
-        Header {
-            list: true,
-            payload_length: self.signature.length(),
-        }
-        .encode(out);
         self.signature.encode(out);
     }
 
-    /// Decodes a `signature_payload` byte string.
-    ///
-    /// The caller has already consumed the outer RLP string header around
-    /// `signature_payload`; this reads the raw payload bytes.
+    /// RLP-decodes the signature from a single byte-string item.
     pub(crate) fn decode_payload_raw(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
-        let header = Header::decode(buf)?;
-        if !header.list {
-            return Err(alloy_rlp::Error::UnexpectedString);
-        }
-        let start = buf.len();
         let signature: Bytes = Decodable::decode(buf)?;
-        let consumed = start - buf.len();
-        if consumed != header.payload_length {
-            return Err(alloy_rlp::Error::ListLengthMismatch {
-                expected: header.payload_length,
-                got: consumed,
-            });
-        }
         Ok(Self { signature })
     }
 }

--- a/crates/primitives/src/transaction/verify.rs
+++ b/crates/primitives/src/transaction/verify.rs
@@ -1,75 +1,74 @@
 //! WIP-1001 signature verification.
 //!
-//! Generalized verification across all schemes defined in the
-//! [WIP-1001](https://github.com/worldcoin/world-chain/blob/main/wips/wip-1001.md)
-//! envelope: secp256k1, P-256, WebAuthn, and Ed25519.
-//!
-//! For non-recoverable schemes (P-256, WebAuthn, Ed25519), the session pubkey
-//! is read from the transaction's `session_key` field; for secp256k1, the
-//! recovered pubkey is checked against `session_key`.
+//! Generalized verification defined in the
+//! [WIP-1001](https://github.com/worldcoin/world-chain/blob/main/wips/wip-1001.md).
 
+use crate::transaction::Wip1001Signature;
 use alloy_consensus::crypto::RecoveryError;
-use alloy_primitives::{B256, U256, uint};
-use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
-use p256::{
-    EncodedPoint,
-    ecdsa::{Signature as P256EcdsaSignature, VerifyingKey, signature::hazmat::PrehashVerifier},
-};
-use sha2::{Digest, Sha256};
+use alloy_primitives::{Address, B256};
 
-use crate::transaction::{
-    P256Signature, SessionKey, WebAuthnSignature, Wip1001Signature, signature::SessionKeyError,
-};
+/// Read-only backend that performs the EIP-1271 signature validation call
+/// described in WIP-1001's "Account Router and Verifier Interfaces" and
+/// "Restricted Validation Frames" sections.
+///
+/// An implementation MUST, acting as `WORLD_CHAIN_ACCOUNT_MANAGER`, perform a
+/// `STATICCALL` to `world_chain_account` with:
+///
+/// - calldata `IWorldChainAccountRouter.isValidSignatureForVerifier.selector
+///   || abi.encode(session_verifier, signing_hash, signature)`,
+/// - value `0`,
+/// - gas exactly `EIP1271_VALIDATION_GAS_LIMIT`,
+/// - the WIP-1001 restricted-frame tracer attached.
+///
+/// The account router at `world_chain_account` then dispatches the call to
+/// `session_verifier`'s EIP-1271 entry via `DELEGATECALL`, so the verifier
+/// implementation executes against the account's storage. The call succeeds
+/// only if the router returns `EIP1271_MAGIC_VALUE` and no tracer rule is
+/// violated.
+///
+/// Per WIP-1001, revert, out-of-gas, malformed return data, missing magic
+/// value, and tracer rule violations are all treated identically as
+/// "signature failure". Implementations are free to surface richer cause
+/// information through [`SessionVerifier::Error`], but
+/// [`verify_wip1001_signature`] collapses every failure mode into
+/// [`Wip1001VerifyError::Invalid`].
+pub trait SessionVerifier {
+    /// Backend-specific error. A real EVM-backed implementation will surface
+    /// state-lookup failures, EVM execution errors, tracer violations, etc.;
+    /// a mock can use [`std::convert::Infallible`].
+    type Error;
 
-/// The P-256 (secp256r1) curve order n.
-pub const P256_ORDER: U256 =
-    uint!(0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551_U256);
-
-/// `n / 2`. Signatures with `s > n/2` are rejected as non-canonical (low-s rule)
-/// to prevent signature malleability.
-pub const P256N_HALF: U256 =
-    uint!(0x7FFFFFFF800000007FFFFFFFFFFFFFFFDE737D56D38BCF4279DCE5617E3192A8_U256);
-
-/// Minimum WebAuthn `authenticatorData` length: 32-byte rpIdHash + 1-byte flags
-/// + 4-byte signCount.
-const MIN_AUTH_DATA_LEN: usize = 37;
-
-// `authenticatorData` flag bits, byte 32. ref: <https://www.w3.org/TR/webauthn-2/#sctn-authenticator-data>
-const FLAG_UP: u8 = 0x01; // User Presence
-const FLAG_UV: u8 = 0x04; // User Verified
-const FLAG_AT: u8 = 0x40; // Attested credential data — must be unset for assertions
-const FLAG_ED: u8 = 0x80; // Extension data — unsupported
+    /// Returns `Ok(())` iff the router-dispatched EIP-1271 call returns
+    /// `EIP1271_MAGIC_VALUE` and triggers no tracer rule violation.
+    ///
+    /// `world_chain_account` is the `STATICCALL` target: the account
+    /// address, whose deployed bytecode is the world chain account router.
+    /// `session_verifier` is the dispatch identifier forwarded to the
+    /// router's `isValidSignatureForVerifier`; it is **not** the
+    /// `STATICCALL` target.
+    fn is_valid_signature(
+        &self,
+        world_chain_account: Address,
+        session_verifier: Address,
+        signing_hash: B256,
+        signature: &Wip1001Signature,
+    ) -> Result<(), Self::Error>;
+}
 
 /// Errors returned by [`verify_wip1001_signature`].
+///
+/// Intentionally non-generic so it composes with the cross-module
+/// validation error in [`crate::transaction::keyring`]. The protocol folds
+/// every EIP-1271 failure mode (revert, OOG, malformed return, tracer
+/// violation, missing magic value) into the single `Invalid` variant;
+/// callers that need richer diagnostics should invoke
+/// [`SessionVerifier::is_valid_signature`] directly and inspect
+/// [`SessionVerifier::Error`].
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum Wip1001VerifyError {
-    /// The declared `signature_type` byte and the [`Wip1001Signature`] variant
-    /// disagree.
-    #[error("signature_type mismatch: tx={tx:#04x} sig={sig:#04x}")]
-    SignatureTypeMismatch {
-        /// `signature_type` field on the transaction.
-        tx: u8,
-        /// Discriminator on the [`Wip1001Signature`] variant.
-        sig: u8,
-    },
-    /// `session_key` bytes are malformed for the declared `signature_type`.
-    #[error(transparent)]
-    InvalidSessionKey(#[from] SessionKeyError),
-    /// secp256k1 ECDSA recovery failed.
-    #[error("secp256k1 recovery failed")]
-    Secp256k1RecoveryFailed,
-    /// Recovered secp256k1 pubkey did not match the declared `session_key`.
-    #[error("secp256k1 recovered pubkey does not match session_key")]
-    Secp256k1KeyMismatch,
-    /// P-256 signature failed cryptographic verification.
-    #[error("P-256 verification failed: {0}")]
-    P256VerificationFailed(&'static str),
-    /// WebAuthn `authenticatorData` / `clientDataJSON` failed validation.
-    #[error("WebAuthn validation failed: {0}")]
-    WebAuthnInvalid(&'static str),
-    /// Ed25519 EdDSA signature failed `verify_strict`.
-    #[error("EdDSA verification failed")]
-    EddsaVerificationFailed,
+    /// The router-dispatched EIP-1271 call did not authorize the signature.
+    #[error("WIP-1001 signature is not valid for the supplied session verifier")]
+    Invalid,
 }
 
 impl From<Wip1001VerifyError> for RecoveryError {
@@ -78,470 +77,26 @@ impl From<Wip1001VerifyError> for RecoveryError {
     }
 }
 
-/// Verify a WIP-1001 signature against the supplied `signing_hash` and
-/// `session_key`.
+/// Verify a WIP-1001 signature against `signing_hash` for the
+/// `(world_chain_account, session_verifier)` pair, using the supplied
+/// [`SessionVerifier`] backend.
 ///
-/// On success, returns the typed [`SessionKey`] that was bound to the
-/// signature. The caller is responsible for invoking
-/// `IWorldIDAccount.isAuthorized(world_id_account, session_key)` separately.
-pub fn verify_wip1001_signature(
-    signature_type: u8,
-    session_key: &[u8],
+/// The caller is responsible for separately invoking
+/// `IWorldChainAccountManager.isAuthorizedSessionVerifier(world_chain_account, session_verifier)`
+/// — see [`crate::transaction::keyring`].
+pub fn verify_wip1001_signature<V: SessionVerifier>(
+    verifier: &V,
+    world_chain_account: Address,
+    session_verifier: Address,
+    signing_hash: B256,
     signature: &Wip1001Signature,
-    signing_hash: &B256,
-) -> Result<SessionKey, Wip1001VerifyError> {
-    if signature.signature_type() != signature_type {
-        return Err(Wip1001VerifyError::SignatureTypeMismatch {
-            tx: signature_type,
-            sig: signature.signature_type(),
-        });
-    }
-
-    let session_key = SessionKey::from_wire(signature_type, session_key)?;
-
-    match (&session_key, signature) {
-        (SessionKey::Secp256k1(declared_pubkey), Wip1001Signature::Secp256k1(sig)) => {
-            verify_secp256k1(declared_pubkey, sig, signing_hash)?;
-        }
-        (SessionKey::P256 { x, y }, Wip1001Signature::P256(sig)) => {
-            verify_p256(sig, x, y, signing_hash)?;
-        }
-        (SessionKey::WebAuthn { x, y }, Wip1001Signature::WebAuthn(sig)) => {
-            verify_webauthn(sig, x, y, signing_hash)?;
-        }
-        (SessionKey::EdDSA(verifying_key), Wip1001Signature::EdDSA(sig)) => {
-            verify_eddsa(verifying_key, sig, signing_hash)?;
-        }
-        // Already covered by the discriminator equality check above.
-        _ => unreachable!("signature_type was checked equal to session key type"),
-    }
-
-    Ok(session_key)
-}
-
-/// Recover the secp256k1 pubkey from `(sig, signing_hash)` and assert it
-/// matches the declared compressed pubkey.
-fn verify_secp256k1(
-    declared_pubkey: &[u8; 33],
-    sig: &alloy_primitives::Signature,
-    signing_hash: &B256,
 ) -> Result<(), Wip1001VerifyError> {
-    use alloy_consensus::crypto::secp256k1;
-
-    // Recover the uncompressed (x, y) Ethereum-style pubkey, then re-encode in
-    // SEC1-compressed form and compare. We cannot use ecrecover -> Address here
-    // because the spec authorizes on the compressed pubkey, not its keccak256
-    // image.
-    let _addr = secp256k1::recover_signer(sig, *signing_hash)
-        .map_err(|_| Wip1001VerifyError::Secp256k1RecoveryFailed)?;
-
-    let recovered_compressed = recover_secp256k1_compressed(sig, signing_hash)
-        .ok_or(Wip1001VerifyError::Secp256k1RecoveryFailed)?;
-
-    if recovered_compressed != *declared_pubkey {
-        return Err(Wip1001VerifyError::Secp256k1KeyMismatch);
-    }
-    Ok(())
-}
-
-/// Recover the SEC1-compressed (33-byte) secp256k1 pubkey from a signature.
-fn recover_secp256k1_compressed(
-    sig: &alloy_primitives::Signature,
-    signing_hash: &B256,
-) -> Option<[u8; 33]> {
-    let verifying_key = sig.recover_from_prehash(signing_hash).ok()?;
-    let encoded = verifying_key.to_encoded_point(true);
-    let bytes = encoded.as_bytes();
-    if bytes.len() != 33 {
-        return None;
-    }
-    let mut out = [0u8; 33];
-    out.copy_from_slice(bytes);
-    Some(out)
-}
-
-/// Verify a raw P-256 ECDSA signature against `signing_hash` using the supplied
-/// `(x, y)` public key. Enforces the low-s canonicalization rule.
-pub fn verify_p256(
-    sig: &P256Signature,
-    pub_key_x: &B256,
-    pub_key_y: &B256,
-    signing_hash: &B256,
-) -> Result<(), Wip1001VerifyError> {
-    if U256::from_be_bytes(sig.s.0) > P256N_HALF {
-        return Err(Wip1001VerifyError::P256VerificationFailed(
-            "s value above n/2 (low-s rule)",
-        ));
-    }
-
-    let encoded_point = EncodedPoint::from_affine_coordinates(
-        pub_key_x.0.as_slice().into(),
-        pub_key_y.0.as_slice().into(),
-        false,
-    );
-    let verifying_key = VerifyingKey::from_encoded_point(&encoded_point)
-        .map_err(|_| Wip1001VerifyError::P256VerificationFailed("invalid pubkey"))?;
-
-    let mut sig_bytes = [0u8; 64];
-    sig_bytes[..32].copy_from_slice(sig.r.as_slice());
-    sig_bytes[32..].copy_from_slice(sig.s.as_slice());
-    let p256_sig = P256EcdsaSignature::from_slice(&sig_bytes)
-        .map_err(|_| Wip1001VerifyError::P256VerificationFailed("invalid (r, s)"))?;
-
-    verifying_key
-        .verify_prehash(signing_hash.as_slice(), &p256_sig)
-        .map_err(|_| Wip1001VerifyError::P256VerificationFailed("ecdsa verify"))
-}
-
-/// Verify a WebAuthn assertion: parse `authenticatorData` flags, validate
-/// `clientDataJSON` (`type == "webauthn.get"`, `challenge == base64url(signing_hash)`),
-/// then verify the inner P-256 signature over
-/// `sha256(authenticator_data || sha256(client_data_json))`.
-pub fn verify_webauthn(
-    sig: &WebAuthnSignature,
-    pub_key_x: &B256,
-    pub_key_y: &B256,
-    signing_hash: &B256,
-) -> Result<(), Wip1001VerifyError> {
-    let auth = sig.authenticator_data.as_ref();
-    let cdj = sig.client_data_json.as_ref();
-    let message_hash = compute_webauthn_message_hash(auth, cdj, signing_hash)?;
-
-    let p256_sig = P256Signature { r: sig.r, s: sig.s };
-    verify_p256(&p256_sig, pub_key_x, pub_key_y, &message_hash)
-}
-
-/// Verify an Ed25519 EdDSA signature against `signing_hash` using the supplied
-/// `verifying_key`.
-///
-/// Treats `signing_hash` as the *message* (not a prehash) — Ed25519 internally
-/// hashes its input via SHA-512 as part of the signing/verification equation.
-/// `verify_strict` rejects mixed-order public keys and small-subgroup signatures.
-pub fn verify_eddsa(
-    verifying_key: &ed25519_dalek::VerifyingKey,
-    sig: &ed25519_dalek::Signature,
-    signing_hash: &B256,
-) -> Result<(), Wip1001VerifyError> {
-    verifying_key
-        .verify_strict(signing_hash.as_slice(), sig)
-        .map_err(|_| Wip1001VerifyError::EddsaVerificationFailed)
-}
-
-fn compute_webauthn_message_hash(
-    authenticator_data: &[u8],
-    client_data_json: &[u8],
-    signing_hash: &B256,
-) -> Result<B256, Wip1001VerifyError> {
-    if authenticator_data.len() < MIN_AUTH_DATA_LEN {
-        return Err(Wip1001VerifyError::WebAuthnInvalid(
-            "authenticatorData too short",
-        ));
-    }
-    let flags = authenticator_data[32];
-    let (up, uv, at, ed) = (
-        flags & FLAG_UP,
-        flags & FLAG_UV,
-        flags & FLAG_AT,
-        flags & FLAG_ED,
-    );
-    if up == 0 && uv == 0 {
-        return Err(Wip1001VerifyError::WebAuthnInvalid(
-            "neither UP nor UV flag set",
-        ));
-    }
-    if at != 0 {
-        return Err(Wip1001VerifyError::WebAuthnInvalid(
-            "AT flag must not be set on assertion",
-        ));
-    }
-    if ed != 0 {
-        return Err(Wip1001VerifyError::WebAuthnInvalid(
-            "ED (extension) flag unsupported",
-        ));
-    }
-    if authenticator_data.len() != MIN_AUTH_DATA_LEN {
-        return Err(Wip1001VerifyError::WebAuthnInvalid(
-            "authenticatorData has unexpected trailing bytes",
-        ));
-    }
-
-    let client_data: ClientDataJson<'_> = serde_json::from_slice(client_data_json)
-        .map_err(|_| Wip1001VerifyError::WebAuthnInvalid("clientDataJSON malformed"))?;
-    if client_data.type_field != "webauthn.get" {
-        return Err(Wip1001VerifyError::WebAuthnInvalid(
-            "clientDataJSON.type != \"webauthn.get\"",
-        ));
-    }
-    let expected_challenge = URL_SAFE_NO_PAD.encode(signing_hash.as_slice());
-    if client_data.challenge != expected_challenge {
-        return Err(Wip1001VerifyError::WebAuthnInvalid(
-            "clientDataJSON.challenge does not match signing_hash",
-        ));
-    }
-
-    let cdj_hash = Sha256::digest(client_data_json);
-    let mut hasher = Sha256::new();
-    hasher.update(authenticator_data);
-    hasher.update(cdj_hash);
-    Ok(B256::from_slice(&hasher.finalize()))
-}
-
-#[derive(serde::Deserialize)]
-struct ClientDataJson<'a> {
-    #[serde(rename = "type")]
-    type_field: &'a str,
-    challenge: &'a str,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use alloy_primitives::Bytes;
-    use p256::{
-        ecdsa::{SigningKey as P256SigningKey, signature::hazmat::PrehashSigner},
-        elliptic_curve::rand_core::OsRng,
-    };
-
-    /// Returns `(signing_key, x, y)`.
-    fn p256_keypair() -> (P256SigningKey, B256, B256) {
-        let signing_key = P256SigningKey::random(&mut OsRng);
-        let verifying_key = signing_key.verifying_key();
-        let encoded = verifying_key.to_encoded_point(false);
-        let x = B256::from_slice(encoded.x().expect("x").as_ref());
-        let y = B256::from_slice(encoded.y().expect("y").as_ref());
-        (signing_key, x, y)
-    }
-
-    /// Signs `hash` with low-s normalization.
-    fn p256_sign(signing_key: &P256SigningKey, hash: &B256) -> P256Signature {
-        let signature: p256::ecdsa::Signature = signing_key
-            .sign_prehash(hash.as_slice())
-            .expect("p256 sign");
-        let bytes = signature.to_bytes();
-        let r = B256::from_slice(&bytes[..32]);
-        let s = U256::from_be_slice(&bytes[32..]);
-        let s = if s > P256N_HALF { P256_ORDER - s } else { s };
-        P256Signature {
-            r,
-            s: B256::from(s.to_be_bytes::<32>()),
-        }
-    }
-
-    #[test]
-    fn p256_happy_path() {
-        let (key, x, y) = p256_keypair();
-        let hash = B256::from_slice(&[0xAB; 32]);
-        let sig = p256_sign(&key, &hash);
-        verify_p256(&sig, &x, &y, &hash).expect("valid p256 signature");
-    }
-
-    #[test]
-    fn p256_rejects_high_s() {
-        let (key, x, y) = p256_keypair();
-        let hash = B256::from_slice(&[0xCD; 32]);
-        let sig = p256_sign(&key, &hash);
-        // Flip s to its high-s counterpart; should now reject.
-        let high_s = P256_ORDER - U256::from_be_bytes(sig.s.0);
-        let bad = P256Signature {
-            r: sig.r,
-            s: B256::from(high_s.to_be_bytes::<32>()),
-        };
-        let err = verify_p256(&bad, &x, &y, &hash).unwrap_err();
-        assert!(matches!(err, Wip1001VerifyError::P256VerificationFailed(_)));
-    }
-
-    #[test]
-    fn p256_rejects_tampered_hash() {
-        let (key, x, y) = p256_keypair();
-        let hash = B256::from_slice(&[0x11; 32]);
-        let sig = p256_sign(&key, &hash);
-        let other = B256::from_slice(&[0x22; 32]);
-        let err = verify_p256(&sig, &x, &y, &other).unwrap_err();
-        assert!(matches!(err, Wip1001VerifyError::P256VerificationFailed(_)));
-    }
-
-    fn make_authenticator_data() -> Vec<u8> {
-        let mut data = vec![0u8; MIN_AUTH_DATA_LEN];
-        data[32] = FLAG_UP; // UP set, AT/ED clear
-        data
-    }
-
-    fn make_client_data_json(challenge_b64: &str) -> Vec<u8> {
-        format!(
-            "{{\"type\":\"webauthn.get\",\"challenge\":\"{challenge_b64}\",\"origin\":\"https://example\"}}"
+    verifier
+        .is_valid_signature(
+            world_chain_account,
+            session_verifier,
+            signing_hash,
+            signature,
         )
-        .into_bytes()
-    }
-
-    fn webauthn_message_hash(auth: &[u8], cdj: &[u8]) -> B256 {
-        let cdj_hash = Sha256::digest(cdj);
-        let mut hasher = Sha256::new();
-        hasher.update(auth);
-        hasher.update(cdj_hash);
-        B256::from_slice(&hasher.finalize())
-    }
-
-    #[test]
-    fn webauthn_happy_path() {
-        let (key, x, y) = p256_keypair();
-        let signing_hash = B256::from_slice(&[0x42; 32]);
-        let challenge = URL_SAFE_NO_PAD.encode(signing_hash.as_slice());
-        let auth = make_authenticator_data();
-        let cdj = make_client_data_json(&challenge);
-        let msg_hash = webauthn_message_hash(&auth, &cdj);
-        let sig = p256_sign(&key, &msg_hash);
-
-        let webauthn = WebAuthnSignature {
-            authenticator_data: Bytes::from(auth),
-            client_data_json: Bytes::from(cdj),
-            r: sig.r,
-            s: sig.s,
-        };
-        verify_webauthn(&webauthn, &x, &y, &signing_hash).expect("valid webauthn signature");
-    }
-
-    #[test]
-    fn webauthn_rejects_bad_challenge() {
-        let (key, x, y) = p256_keypair();
-        let signing_hash = B256::from_slice(&[0x42; 32]);
-        let bad_hash = B256::from_slice(&[0x43; 32]);
-        let challenge = URL_SAFE_NO_PAD.encode(bad_hash.as_slice()); // wrong!
-        let auth = make_authenticator_data();
-        let cdj = make_client_data_json(&challenge);
-        let msg_hash = webauthn_message_hash(&auth, &cdj);
-        let sig = p256_sign(&key, &msg_hash);
-
-        let webauthn = WebAuthnSignature {
-            authenticator_data: Bytes::from(auth),
-            client_data_json: Bytes::from(cdj),
-            r: sig.r,
-            s: sig.s,
-        };
-        let err = verify_webauthn(&webauthn, &x, &y, &signing_hash).unwrap_err();
-        assert!(matches!(err, Wip1001VerifyError::WebAuthnInvalid(_)));
-    }
-
-    #[test]
-    fn webauthn_rejects_missing_user_flags() {
-        let (key, x, y) = p256_keypair();
-        let signing_hash = B256::from_slice(&[0x42; 32]);
-        let challenge = URL_SAFE_NO_PAD.encode(signing_hash.as_slice());
-        let mut auth = make_authenticator_data();
-        auth[32] = 0; // clear UP, no UV either
-        let cdj = make_client_data_json(&challenge);
-        let msg_hash = webauthn_message_hash(&auth, &cdj);
-        let sig = p256_sign(&key, &msg_hash);
-
-        let webauthn = WebAuthnSignature {
-            authenticator_data: Bytes::from(auth),
-            client_data_json: Bytes::from(cdj),
-            r: sig.r,
-            s: sig.s,
-        };
-        let err = verify_webauthn(&webauthn, &x, &y, &signing_hash).unwrap_err();
-        assert!(matches!(err, Wip1001VerifyError::WebAuthnInvalid(_)));
-    }
-
-    #[test]
-    fn webauthn_rejects_at_flag() {
-        let (key, x, y) = p256_keypair();
-        let signing_hash = B256::from_slice(&[0x42; 32]);
-        let challenge = URL_SAFE_NO_PAD.encode(signing_hash.as_slice());
-        let mut auth = make_authenticator_data();
-        auth[32] |= FLAG_AT;
-        let cdj = make_client_data_json(&challenge);
-        let msg_hash = webauthn_message_hash(&auth, &cdj);
-        let sig = p256_sign(&key, &msg_hash);
-
-        let webauthn = WebAuthnSignature {
-            authenticator_data: Bytes::from(auth),
-            client_data_json: Bytes::from(cdj),
-            r: sig.r,
-            s: sig.s,
-        };
-        let err = verify_webauthn(&webauthn, &x, &y, &signing_hash).unwrap_err();
-        assert!(matches!(err, Wip1001VerifyError::WebAuthnInvalid(_)));
-    }
-
-    /// Deterministic Ed25519 keypair from a fixed seed (no RNG dependency).
-    fn ed25519_keypair() -> (ed25519_dalek::SigningKey, ed25519_dalek::VerifyingKey) {
-        let seed: [u8; 32] = [
-            0x9d, 0x61, 0xb1, 0x9d, 0xef, 0xfd, 0x5a, 0x60, 0xba, 0x84, 0x4a, 0xf4, 0x92, 0xec,
-            0x2c, 0xc4, 0x44, 0x49, 0xc5, 0x69, 0x7b, 0x32, 0x69, 0x19, 0x70, 0x3b, 0xac, 0x03,
-            0x1c, 0xae, 0x7f, 0x60,
-        ];
-        let sk = ed25519_dalek::SigningKey::from_bytes(&seed);
-        let vk = sk.verifying_key();
-        (sk, vk)
-    }
-
-    #[test]
-    fn eddsa_happy_path() {
-        use ed25519_dalek::Signer;
-        let (sk, vk) = ed25519_keypair();
-        let signing_hash = B256::from_slice(&[0x55; 32]);
-        let sig = sk.sign(signing_hash.as_slice());
-        verify_eddsa(&vk, &sig, &signing_hash).expect("valid eddsa signature");
-    }
-
-    #[test]
-    fn eddsa_rejects_tampered_hash() {
-        use ed25519_dalek::Signer;
-        let (sk, vk) = ed25519_keypair();
-        let signing_hash = B256::from_slice(&[0x55; 32]);
-        let other = B256::from_slice(&[0x66; 32]);
-        let sig = sk.sign(signing_hash.as_slice());
-        let err = verify_eddsa(&vk, &sig, &other).unwrap_err();
-        assert!(matches!(err, Wip1001VerifyError::EddsaVerificationFailed));
-    }
-
-    #[test]
-    fn eddsa_rejects_wrong_pubkey() {
-        use ed25519_dalek::Signer;
-        let (sk_a, _vk_a) = ed25519_keypair();
-        // Different seed -> different keypair.
-        let sk_b = ed25519_dalek::SigningKey::from_bytes(&[0xCD; 32]);
-        let vk_b = sk_b.verifying_key();
-        let signing_hash = B256::from_slice(&[0x55; 32]);
-        let sig = sk_a.sign(signing_hash.as_slice());
-        // Verifying with someone else's pubkey must fail.
-        let err = verify_eddsa(&vk_b, &sig, &signing_hash).unwrap_err();
-        assert!(matches!(err, Wip1001VerifyError::EddsaVerificationFailed));
-    }
-
-    #[test]
-    fn session_key_from_wire_rejects_wrong_length_eddsa() {
-        let too_short = [0xAAu8; 31];
-        let err = SessionKey::from_wire(Wip1001Signature::EDDSA_TYPE, &too_short);
-        assert!(matches!(
-            err,
-            Err(SessionKeyError::InvalidLength {
-                expected: 32,
-                got: 31
-            })
-        ));
-    }
-
-    #[test]
-    fn verify_wip1001_signature_eddsa_round_trip() {
-        use ed25519_dalek::Signer;
-        let (sk, vk) = ed25519_keypair();
-        let signing_hash = B256::from_slice(&[0x77; 32]);
-        let sig = sk.sign(signing_hash.as_slice());
-
-        let key_bytes = vk.to_bytes();
-        let signature = Wip1001Signature::EdDSA(sig);
-
-        let session_key = verify_wip1001_signature(
-            Wip1001Signature::EDDSA_TYPE,
-            &key_bytes,
-            &signature,
-            &signing_hash,
-        )
-        .expect("verify");
-        match session_key {
-            SessionKey::EdDSA(recovered_vk) => assert_eq!(recovered_vk, vk),
-            other => panic!("expected EdDSA SessionKey, got {other:?}"),
-        }
-    }
+        .map_err(|_| Wip1001VerifyError::Invalid)
 }

--- a/crates/primitives/src/transaction/wip_1001.rs
+++ b/crates/primitives/src/transaction/wip_1001.rs
@@ -674,7 +674,7 @@ impl Decodable for SignedWip1001 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::{address, b256, hex};
+    use alloy_primitives::{address, hex};
 
     fn sample_tx() -> TxWip1001 {
         TxWip1001 {
@@ -683,28 +683,25 @@ mod tests {
             max_priority_fee_per_gas: 0x3b9aca00,
             max_fee_per_gas: 0x4a817c800,
             gas_limit: 44386,
+            world_chain_account: address!("000000000000000000000000000000000000001d"),
+            session_verifier: address!("00000000000000000000000000000000000000aa"),
             to: address!("6069a6c32cf691f5982febae4faf8a6f3ab2f0f6").into(),
             value: U256::from(1u64),
             input: hex!("a22cb465").into(),
             access_list: AccessList::default(),
-            world_id_account: address!("000000000000000000000000000000000000001d"),
-            signature_type: Wip1001Signature::SECP256K1_TYPE,
-            // 33-byte compressed secp256k1 placeholder.
-            session_key: hex!("0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798")
-                .into(),
         }
     }
 
     fn sample_sig() -> Wip1001Signature {
-        Wip1001Signature::Secp256k1(Signature::new(
-            U256::from_be_slice(
-                &b256!("840cfc572845f5786e702984c2a582528cad4b49b2a10b9db1be7fca90058565")[..],
-            ),
-            U256::from_be_slice(
-                &b256!("25e7109ceb98168d95b09b18bbf6b685130e0562f233877d492b94eee0c5b6d1")[..],
-            ),
-            false,
-        ))
+        // The WIP-1001 envelope does not interpret signature bytes; verification
+        // is delegated to the on-chain session verifier contract via EIP-1271
+        // (see `wips/wip-1001.md`). Use an arbitrary opaque payload here.
+        Wip1001Signature {
+            signature: hex!(
+                "840cfc572845f5786e702984c2a582528cad4b49b2a10b9db1be7fca9005856525e7109ceb98168d95b09b18bbf6b685130e0562f233877d492b94eee0c5b6d1"
+            )
+            .into(),
+        }
     }
 
     #[test]
@@ -715,8 +712,7 @@ mod tests {
         assert_eq!(buf.len(), sig.payload_encoded_len());
 
         let mut slice = buf.as_slice();
-        let decoded = Wip1001Signature::decode_payload_raw(sig.signature_type(), &mut slice)
-            .expect("decode payload");
+        let decoded = Wip1001Signature::decode_payload_raw(&mut slice).expect("decode payload");
         assert!(slice.is_empty());
         assert_eq!(decoded, sig);
     }
@@ -809,8 +805,9 @@ mod tests {
     fn wip1001_signing_hash_excludes_signature() {
         let tx = sample_tx();
         let sig1 = sample_sig();
-        let sig2 =
-            Wip1001Signature::Secp256k1(Signature::new(U256::from(7u64), U256::from(9u64), true));
+        let sig2 = Wip1001Signature {
+            signature: hex!("aabbccddeeff").into(),
+        };
         assert_eq!(tx.signing_hash(), tx.signing_hash());
         let h1 = tx.tx_hash(&sig1);
         let h2 = tx.tx_hash(&sig2);

--- a/crates/primitives/src/transaction/wip_1001.rs
+++ b/crates/primitives/src/transaction/wip_1001.rs
@@ -63,7 +63,8 @@ pub struct TxWip1001 {
 }
 
 impl TxWip1001 {
-    /// Length of the RLP-encoded fields (positions 0..=11), without a list header.
+    /// Length of the RLP-encoded unsigned fields (positions 0..=10, i.e. the
+    /// 11 envelope fields excluding `signature`), without a list header.
     #[inline]
     pub fn rlp_encoded_fields_length(&self) -> usize {
         self.chain_id.length()
@@ -79,7 +80,7 @@ impl TxWip1001 {
             + self.access_list.length()
     }
 
-    /// Encodes the fields (positions 0..=11) into `out`, without a list header.
+    /// Encodes the unsigned fields (positions 0..=10) into `out`, without a list header.
     pub fn rlp_encode_fields(&self, out: &mut dyn BufMut) {
         self.chain_id.encode(out);
         self.nonce.encode(out);
@@ -94,8 +95,8 @@ impl TxWip1001 {
         self.access_list.encode(out);
     }
 
-    /// Decodes the unsigned fields (positions 0..=11) from RLP bytes, without a
-    /// list header.
+    /// Decodes the unsigned fields (positions 0..=10) from RLP bytes, without
+    /// a list header.
     pub fn rlp_decode_fields(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
         Ok(Self {
             chain_id: Decodable::decode(buf)?,
@@ -125,20 +126,18 @@ impl TxWip1001 {
         self.rlp_header().length_with_payload()
     }
 
-    /// RLP-encodes the *unsigned* transaction (list of fields 0..=9).
+    /// RLP-encodes the *unsigned* transaction (list of the 11 fields at
+    /// positions 0..=10, i.e. all envelope fields except `signature`).
     fn rlp_encode(&self, out: &mut dyn BufMut) {
         self.rlp_header().encode(out);
         self.rlp_encode_fields(out);
     }
 
-    /// Length of the signed payload (fields[0..=11] + signature_payload).
+    /// Length of the *signed* transaction's RLP payload, i.e. the contents of
+    /// the outer list: the 11 unsigned fields plus the opaque `signature`
+    /// byte-string at position 12.
     fn signed_payload_length(&self, sig: &Wip1001Signature) -> usize {
-        let payload_bytes_len = sig.payload_encoded_len();
-        let payload_header = Header {
-            list: false,
-            payload_length: payload_bytes_len,
-        };
-        self.rlp_encoded_fields_length() + payload_header.length_with_payload()
+        self.rlp_encoded_fields_length() + sig.payload_encoded_len()
     }
 
     /// RLP list header for the *signed* transaction.
@@ -149,23 +148,18 @@ impl TxWip1001 {
         }
     }
 
-    /// RLP-encoded length of the *signed* transaction (list header + fields + signature_payload).
+    /// RLP-encoded length of the *signed* transaction (list header + fields + signature).
     pub fn rlp_encoded_length_with_signature(&self, sig: &Wip1001Signature) -> usize {
         self.rlp_header_signed(sig).length_with_payload()
     }
 
-    /// RLP-encodes the *signed* transaction (`rlp([fields[0..=11], signature_payload])`).
+    /// RLP-encodes the *signed* transaction per WIP-1001:
+    /// `rlp([chainId, nonce, ..., accessList, signature])`. The `signature`
+    /// is emitted as a plain RLP byte-string at position 12 with no extra
+    /// wrapping.
     pub fn rlp_encode_signed(&self, sig: &Wip1001Signature, out: &mut dyn BufMut) {
         self.rlp_header_signed(sig).encode(out);
         self.rlp_encode_fields(out);
-
-        // Encode signature_payload as an RLP byte-string wrapping `rlp([...])`.
-        let payload_bytes_len = sig.payload_encoded_len();
-        Header {
-            list: false,
-            payload_length: payload_bytes_len,
-        }
-        .encode(out);
         sig.encode_payload_raw(out);
     }
 
@@ -179,24 +173,7 @@ impl TxWip1001 {
         }
         let remaining = buf.len();
         let tx = Self::rlp_decode_fields(buf)?;
-
-        // `signature_payload` is stored as an RLP byte-string whose contents are
-        // themselves an RLP encoding (`rlp([...])`).
-        let payload_header = Header::decode(buf)?;
-        if payload_header.list {
-            return Err(alloy_rlp::Error::UnexpectedList);
-        }
-        if payload_header.payload_length > buf.len() {
-            return Err(alloy_rlp::Error::InputTooShort);
-        }
-        let (mut payload_slice, rest) = buf.split_at(payload_header.payload_length);
-        *buf = rest;
-        let sig = Wip1001Signature::decode_payload_raw(&mut payload_slice)?;
-        if !payload_slice.is_empty() {
-            return Err(alloy_rlp::Error::Custom(
-                "trailing bytes in signature_payload",
-            ));
-        }
+        let sig = Wip1001Signature::decode_payload_raw(buf)?;
 
         if buf.len() + header.payload_length != remaining {
             return Err(alloy_rlp::Error::ListLengthMismatch {
@@ -273,7 +250,10 @@ impl TxWip1001 {
         keccak256(&buf)
     }
 
-    /// Computes the signing hash: `keccak256(0x1D || rlp([fields 0..=9]))`.
+    /// Computes the signing hash per WIP-1001:
+    /// `keccak256(0x1D || rlp([chainId, nonce, maxPriorityFeePerGas,
+    /// maxFeePerGas, gasLimit, account, sessionVerifier, to, value, data,
+    /// accessList]))`.
     pub fn signing_hash(&self) -> B256 {
         let mut buf = Vec::with_capacity(1 + self.rlp_encoded_length());
         buf.put_u8(WIP_1001_TX_TYPE);
@@ -834,5 +814,36 @@ mod tests {
         assert_eq!(signed.tx(), &tx);
         assert_eq!(signed.signature(), &sig);
         assert_eq!(*signed.hash(), tx.tx_hash(&sig));
+    }
+
+    /// Pins the WIP-1001 wire format: the 12th list item is a plain RLP
+    /// byte-string carrying the opaque signature bytes — no inner list
+    /// wrapper, no outer byte-string wrapping.
+    #[test]
+    fn wip1001_signed_wire_format_signature_is_plain_byte_string() {
+        let tx = sample_tx();
+        let sig = Wip1001Signature {
+            signature: hex!("deadbeef").into(),
+        };
+
+        let mut buf = Vec::new();
+        tx.rlp_encode_signed(&sig, &mut buf);
+
+        let mut slice = buf.as_slice();
+        let outer = Header::decode(&mut slice).expect("outer list header");
+        assert!(outer.list, "outer envelope must be an RLP list");
+
+        // Consume the 11 unsigned fields (positions 0..=10).
+        let _ = TxWip1001::rlp_decode_fields(&mut slice).expect("decode unsigned fields");
+
+        // The remaining bytes are exactly the signature item. For a 4-byte
+        // payload, RLP encodes it as `0x84 || payload`.
+        assert_eq!(
+            slice,
+            hex!("84deadbeef").as_slice(),
+            "signature must be a plain RLP byte-string at position 12 \
+             (head 0x84 + 4 payload bytes); any list head (0xc0+) or extra \
+             wrapping indicates a spec violation",
+        );
     }
 }

--- a/crates/primitives/src/transaction/wip_1001.rs
+++ b/crates/primitives/src/transaction/wip_1001.rs
@@ -22,11 +22,11 @@ use crate::transaction::{WIP_1001_TX_TYPE, Wip1001Signature};
 
 /// A WIP-1001 typed transaction (`0x1D`).
 ///
-/// The transaction is signed by a *session key* in the *Key Ring* of a
-/// *World ID Account* — the [`world_id_account`](Self::world_id_account) field
+/// The transaction is signed by a *session verifier* in the *Key Ring* of a
+/// *World Chain Account* — the [`world_chain_account`](Self::world_chain_account) field
 /// carries that account's 20-byte address and is the protocol-level sender.
 /// Protocol validation authorizes the recovered public key against the
-/// precompile-managed Key Ring of `world_id_account`.
+/// predeploy-managed Key Ring of `world_chain_account`.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TxWip1001 {

--- a/crates/primitives/src/transaction/wip_1001.rs
+++ b/crates/primitives/src/transaction/wip_1001.rs
@@ -46,6 +46,10 @@ pub struct TxWip1001 {
     /// Gas limit.
     #[serde(with = "alloy_serde::quantity", rename = "gas", alias = "gasLimit")]
     pub gas_limit: u64,
+    /// The World Chain Account.
+    pub world_chain_account: Address,
+    /// The session verifier.
+    pub session_verifier: Address,
     /// Target of the message call, or `Create` for contract creation.
     #[serde(default)]
     pub to: TxKind,
@@ -56,25 +60,6 @@ pub struct TxWip1001 {
     /// EIP-2930 access list.
     #[serde(default)]
     pub access_list: AccessList,
-    /// 20-byte address of the signing *World ID Account*. Protocol validation
-    /// authorizes the recovered session public key against this account's
-    /// *Key Ring* (the precompile-managed set of authorized session keys).
-    pub world_id_account: Address,
-    /// Wire `signature_type` byte. Must equal the accompanying
-    /// [`Wip1001Signature`] variant's discriminator at signing/verification time.
-    ///
-    /// Stored on the transaction (not solely on the signature) because it is
-    /// covered by `signing_hash`, binding the chosen scheme to the message.
-    #[serde(with = "alloy_serde::quantity")]
-    pub signature_type: u8,
-    /// `keyData` of the [`SessionKey`](crate::transaction::SessionKey) used to
-    /// authenticate this transaction.
-    ///
-    /// The `KeyType` is implied by [`signature_type`](Self::signature_type) —
-    /// implementations MUST reject transactions where the length of
-    /// `session_key` does not match the byte length specified for that key
-    /// type (see WIP-1001 §Session Keys).
-    pub session_key: Bytes,
 }
 
 impl TxWip1001 {
@@ -86,13 +71,12 @@ impl TxWip1001 {
             + self.max_priority_fee_per_gas.length()
             + self.max_fee_per_gas.length()
             + self.gas_limit.length()
+            + self.world_chain_account.length()
+            + self.session_verifier.length()
             + self.to.length()
             + self.value.length()
             + self.input.0.length()
             + self.access_list.length()
-            + self.world_id_account.length()
-            + self.signature_type.length()
-            + self.session_key.0.length()
     }
 
     /// Encodes the fields (positions 0..=11) into `out`, without a list header.
@@ -102,13 +86,12 @@ impl TxWip1001 {
         self.max_priority_fee_per_gas.encode(out);
         self.max_fee_per_gas.encode(out);
         self.gas_limit.encode(out);
+        self.world_chain_account.encode(out);
+        self.session_verifier.encode(out);
         self.to.encode(out);
         self.value.encode(out);
         self.input.0.encode(out);
         self.access_list.encode(out);
-        self.world_id_account.encode(out);
-        self.signature_type.encode(out);
-        self.session_key.0.encode(out);
     }
 
     /// Decodes the unsigned fields (positions 0..=11) from RLP bytes, without a
@@ -120,13 +103,12 @@ impl TxWip1001 {
             max_priority_fee_per_gas: Decodable::decode(buf)?,
             max_fee_per_gas: Decodable::decode(buf)?,
             gas_limit: Decodable::decode(buf)?,
+            world_chain_account: Decodable::decode(buf)?,
+            session_verifier: Decodable::decode(buf)?,
             to: Decodable::decode(buf)?,
             value: Decodable::decode(buf)?,
             input: Decodable::decode(buf)?,
             access_list: Decodable::decode(buf)?,
-            world_id_account: Decodable::decode(buf)?,
-            signature_type: Decodable::decode(buf)?,
-            session_key: Decodable::decode(buf)?,
         })
     }
 
@@ -209,7 +191,7 @@ impl TxWip1001 {
         }
         let (mut payload_slice, rest) = buf.split_at(payload_header.payload_length);
         *buf = rest;
-        let sig = Wip1001Signature::decode_payload_raw(tx.signature_type, &mut payload_slice)?;
+        let sig = Wip1001Signature::decode_payload_raw(&mut payload_slice)?;
         if !payload_slice.is_empty() {
             return Err(alloy_rlp::Error::Custom(
                 "trailing bytes in signature_payload",
@@ -437,7 +419,7 @@ impl SignableTransaction<Signature> for TxWip1001 {
     }
 
     fn into_signed(self, signature: Signature) -> Signed<Self, Signature> {
-        let wip_sig = Wip1001Signature::Secp256k1(signature);
+        let wip_sig: Wip1001Signature = signature.into();
         let hash = self.tx_hash(&wip_sig);
         Signed::new_unchecked(self, signature, hash)
     }

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -51,7 +51,6 @@ alloy-rpc-client.workspace = true
 alloy-rpc-types.workspace = true
 alloy-rpc-types-engine.workspace = true
 alloy-rpc-types-eth.workspace = true
-alloy-signer.workspace = true
 alloy-signer-local.workspace = true
 alloy-transport.workspace = true
 alloy-transport-http.workspace = true

--- a/e2e-tests/src/it/testsuite.rs
+++ b/e2e-tests/src/it/testsuite.rs
@@ -98,10 +98,6 @@ async fn create_priority_transaction(
 
 fn create_wip1001_transaction() -> eyre::Result<(Bytes, B256)> {
     let session_signer = signer(0);
-    let session_key = session_signer
-        .credential()
-        .verifying_key()
-        .to_encoded_point(true);
 
     let tx = TxWip1001 {
         chain_id: CHAIN_SPEC.chain.id(),
@@ -109,19 +105,23 @@ fn create_wip1001_transaction() -> eyre::Result<(Bytes, B256)> {
         max_priority_fee_per_gas: 1_000_000_000,
         max_fee_per_gas: 2_000_000_000,
         gas_limit: 21_000,
+        // The world chain account (protocol-level "from") and the on-chain
+        // session verifier address that authenticates the signature via
+        // EIP-1271 — see `wips/wip-1001.md`. The verifier address is a
+        // placeholder for this transport-only test; signature authenticity
+        // is checked by the predeploy on-chain, not in this path.
+        world_chain_account: account(0),
+        session_verifier: account(1),
         to: TxKind::Call(Address::default()),
         value: U256::from(1),
         input: Bytes::new(),
         access_list: AccessList::default(),
-        world_id_account: account(0),
-        signature_type: Wip1001Signature::SECP256K1_TYPE,
-        session_key: Bytes::copy_from_slice(session_key.as_bytes()),
     };
 
     let signature = session_signer.sign_hash_sync(&tx.signing_hash())?;
     let envelope = WorldChainTxEnvelope::from(SignedWip1001::new_signed(
         tx,
-        Wip1001Signature::Secp256k1(signature),
+        Wip1001Signature::from(signature),
     ));
     let tx_hash = envelope.tx_hash();
 

--- a/e2e-tests/src/it/testsuite.rs
+++ b/e2e-tests/src/it/testsuite.rs
@@ -1,11 +1,9 @@
 use alloy_consensus::BlockHeader;
-use alloy_eips::eip2930::AccessList;
 use alloy_network::{Ethereum, EthereumWallet, NetworkTransactionBuilder, eip2718::Encodable2718};
 use alloy_primitives::{Bytes, b64};
 use alloy_provider::ProviderBuilder;
 use alloy_rpc_types::TransactionRequest;
 use alloy_rpc_types_engine::PayloadStatusEnum;
-use alloy_signer::SignerSync;
 use eyre::eyre::eyre;
 use op_alloy_consensus::OpTxEnvelope;
 use reth_chainspec::EthChainSpec;
@@ -14,7 +12,7 @@ use reth_network::{NetworkSyncUpdater, SyncState};
 use reth_node_api::PayloadAttributes;
 use reth_tasks::Runtime;
 use reth_transaction_pool::TransactionPool;
-use revm_primitives::{Address, B256, TxKind, U256};
+use revm_primitives::{Address, B256, U256};
 use std::{
     sync::{
         Arc,
@@ -60,10 +58,8 @@ use world_chain_primitives::{
     },
     payload_id::force_op_payload_id_v3,
     primitives::{ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, FlashblocksPayloadV1},
-    transaction::{SignedWip1001, TxWip1001, Wip1001Signature, WorldChainTxEnvelope},
 };
 use world_chain_test_utils::{
-    Wip1001NodeContext,
     e2e_harness::setup::{
         CHAIN_SPEC, WorldChainTestBuilder, create_test_transaction, encode_eip1559_params,
     },

--- a/e2e-tests/src/it/testsuite.rs
+++ b/e2e-tests/src/it/testsuite.rs
@@ -96,67 +96,6 @@ async fn create_priority_transaction(
     Ok((signed.encoded_2718().into(), *signed.tx_hash()))
 }
 
-fn create_wip1001_transaction() -> eyre::Result<(Bytes, B256)> {
-    let session_signer = signer(0);
-
-    let tx = TxWip1001 {
-        chain_id: CHAIN_SPEC.chain.id(),
-        nonce: 0,
-        max_priority_fee_per_gas: 1_000_000_000,
-        max_fee_per_gas: 2_000_000_000,
-        gas_limit: 21_000,
-        // The world chain account (protocol-level "from") and the on-chain
-        // session verifier address that authenticates the signature via
-        // EIP-1271 — see `wips/wip-1001.md`. The verifier address is a
-        // placeholder for this transport-only test; signature authenticity
-        // is checked by the predeploy on-chain, not in this path.
-        world_chain_account: account(0),
-        session_verifier: account(1),
-        to: TxKind::Call(Address::default()),
-        value: U256::from(1),
-        input: Bytes::new(),
-        access_list: AccessList::default(),
-    };
-
-    let signature = session_signer.sign_hash_sync(&tx.signing_hash())?;
-    let envelope = WorldChainTxEnvelope::from(SignedWip1001::new_signed(
-        tx,
-        Wip1001Signature::from(signature),
-    ));
-    let tx_hash = envelope.tx_hash();
-
-    Ok((envelope.encoded_2718().into(), tx_hash))
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_wip1001_node_accepts_wip1001_transaction() -> eyre::Result<()> {
-    reth_tracing::init_test_tracing();
-
-    let (_, mut nodes, _tasks, _, _) = WorldChainTestBuilder::builder()
-        .nodes(1)
-        .flashblocks(false)
-        .build()
-        .setup::<Wip1001NodeContext>()
-        .await?;
-    let node = &mut nodes[0].node;
-
-    let (raw_tx, tx_hash) = create_wip1001_transaction()?;
-    assert_eq!(node.rpc.inject_tx(raw_tx).await?, tx_hash);
-
-    let payload = node.advance_block().await?;
-    assert!(
-        payload
-            .block()
-            .body()
-            .transactions
-            .iter()
-            .any(|tx| tx.hash() == &tx_hash),
-        "WIP-1001 transaction should be included"
-    );
-
-    Ok(())
-}
-
 #[tokio::test(flavor = "multi_thread")]
 async fn test_can_build_pbh_payload() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -202,7 +202,7 @@ interface IWorldChainAccountRouter {
 
 The account router MUST dispatch admin validation only to its installed `admin.verifier`. It MUST dispatch session validation only to an installed session verifier address; unknown session verifier addresses MUST fail without executing verifier implementation code.
 
-`isValidSignatureForAdmin` and `isValidSignatureForVerifier` MUST dispatch using calldata `IERC1271.isValidSignature.selector || abi.encode(hash, signature)`. `evaluateSessionPolicyForVerifier` MUST dispatch using calldata `IWorldChainSessionVerifier.evaluateSessionPolicy.selector || abi.encode(context)`.
+When the account router handles a manager-issued admin signature check (`isValidSignatureForAdmin`) or session signature check (`isValidSignatureForVerifier`), it MUST `DELEGATECALL` the selected verifier implementation with calldata `IERC1271.isValidSignature.selector || abi.encode(hash, signature)`. When the router handles `evaluateSessionPolicyForVerifier`, it MUST `DELEGATECALL` the selected session verifier implementation with calldata `IWorldChainSessionVerifier.evaluateSessionPolicy.selector || abi.encode(context)`.
 
 Verifier implementations install scoped storage through the following installation hook:
 
@@ -394,9 +394,14 @@ Installing canonical account-router runtime bytecode is a native manager state t
 
 The protocol uses restricted validation frames for admin authorization, session signature verification, and session policy evaluation.
 
-For each EIP-1271 signature check, the protocol MUST perform a `STATICCALL` from `WORLD_CHAIN_ACCOUNT_MANAGER` to the signer with value `0`, gas exactly `EIP1271_VALIDATION_GAS_LIMIT`, and calldata `IERC1271.isValidSignature.selector || abi.encode(hash, signature)`. The call succeeds only if it returns `EIP1271_MAGIC_VALUE` and triggers no tracer rule violation.
+For each EIP-1271 signature check, the protocol MUST perform a `STATICCALL` from `WORLD_CHAIN_ACCOUNT_MANAGER` to the account router at `account` with value `0`, gas exactly `EIP1271_VALIDATION_GAS_LIMIT`, and calldata:
 
-For each session policy check, the protocol MUST perform a `STATICCALL` from `WORLD_CHAIN_ACCOUNT_MANAGER` to the session verifier with value `0`, gas exactly `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`, and calldata `IWorldChainSessionVerifier.evaluateSessionPolicy.selector || abi.encode(context)`. The call succeeds only if it returns `true` and triggers no tracer rule violation.
+- `IWorldChainAccountRouter.isValidSignatureForAdmin.selector || abi.encode(hash, signature)` for admin authorization checks; or
+- `IWorldChainAccountRouter.isValidSignatureForVerifier.selector || abi.encode(sessionVerifier, hash, signature)` for session signature checks.
+
+The call succeeds only if it returns `EIP1271_MAGIC_VALUE` and triggers no tracer rule violation. The account router is responsible for `DELEGATECALL`ing the configured verifier implementation per the dispatch rules in "Account Router and Verifier Interfaces"; the manager never calls a verifier implementation directly.
+
+For each session policy check, the protocol MUST perform a `STATICCALL` from `WORLD_CHAIN_ACCOUNT_MANAGER` to the account router at `account` with value `0`, gas exactly `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`, and calldata `IWorldChainAccountRouter.evaluateSessionPolicyForVerifier.selector || abi.encode(sessionVerifier, context)`. The call succeeds only if it returns `true` and triggers no tracer rule violation. The account router is responsible for `DELEGATECALL`ing the configured session verifier implementation.
 
 Failure, revert, out-of-gas, malformed return data, or a tracer violation MUST be treated as signature or policy failure.
 
@@ -506,13 +511,13 @@ To include a `0x1D` transaction, the protocol MUST:
 3. require `sessionVerifier` to be authorized for `account` in the current `sessionVerifiers` set and load the current `keyRingHash`;
 4. require the account balance to cover the worst-case payload gas charge and `MIN_VALIDATION_FAILURE_FEE`;
 5. compute `signingHash`;
-6. call `sessionVerifier.isValidSignature(signingHash, signature)` in a restricted validation frame;
+6. call `IWorldChainAccountRouter(account).isValidSignatureForVerifier(sessionVerifier, signingHash, signature)` in a restricted validation frame;
 7. if signature validation fails, apply validation-failure semantics and stop;
 8. increment `Account.transactionNonce` by one;
 9. execute the payload tentatively with `account` as the EVM sender and gas charged against envelope `gasLimit`;
 10. construct `ExecutionTraceContext` with `context.transaction.keyRingHash` set to the current account `keyRingHash`;
 11. if `abi.encode(context.trace).length > MAX_EXECUTION_TRACE_BYTES`, discard tentative payload state, apply trace-overflow semantics, and stop;
-12. call `sessionVerifier.evaluateSessionPolicy(context)` in a restricted validation frame;
+12. call `IWorldChainAccountRouter(account).evaluateSessionPolicyForVerifier(sessionVerifier, context)` in a restricted validation frame;
 13. if policy validation fails, discard tentative payload state, apply validation-failure semantics, and stop;
 14. otherwise commit the normal payload result, including a reverted payload result if the target call reverted.
 


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4641/transaction-envelope

This PR adds the wip1001 tx envelope. In particular it fixes the already present one that was stale and didn't reflect the spec anymore with the up to date and correct one.

### Next Steps

This PR doesn't add mempool validation / tx execution yet, it will be added in follow up PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes WIP-1001 transaction wire format, hashing/signature handling, and signer recovery semantics, which can affect tx propagation/validation and block building. It also removes custom tx-type handling from the node pool and drops the WIP-1001 e2e acceptance test, reducing coverage for these protocol-critical changes.
> 
> **Overview**
> Updates WIP-1001 transactions to match the latest spec by **making signatures opaque bytes validated via an on-chain EIP-1271 account-router call**, and by updating the envelope fields to use `world_chain_account` + `session_verifier` (removing `signature_type`/`session_key` and all local multi-scheme crypto verification).
> 
> `recover_signer` for WIP-1001 now returns the `world_chain_account` directly (no signature verification), and all tx hashing/encoding paths are updated to wrap a normal `Signature` into `Wip1001Signature` via `From`.
> 
> Renames/refactors keyring validation to `WorldChainAccountManager` + `SessionVerifier` (with new mocks), removes `p256`/`sha2`/`base64` deps and related tests, removes the txpool `.with_custom_tx_type(WIP_1001_TX_TYPE)` hook, and deletes the WIP-1001 node e2e test; the WIP-1001 markdown spec is updated to describe router-based restricted-frame calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aacccae188099703c7aefeaf56bffe1b8b17d3ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->