### PR TITLE
feat: WIP-1001: Introduce Session Verifier Instances

### DIFF
--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -114,7 +114,7 @@ Verifier code is selected by verifier implementation address, not by a protocol-
 
 ```solidity
 sessionVerifierInstance = keccak256(abi.encode(
-    SESSION_VERIFIER_INSTANCE_DOMAIN,
+    WORLD_CHAIN_SESSION_VERIFIER_INSTANCE_DOMAIN,
     chainId,
     account,
     sessionVerifiers[i].verifier,

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -37,7 +37,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 | `WORLD_CHAIN_ACCOUNT_DOMAIN` | `bytes32` | `keccak256("WIP1001_ACCOUNT")` | Domain for account address derivation. |
 | `WORLD_CHAIN_ACCOUNT_CREATE_DOMAIN` | `bytes32` | `keccak256("WORLD_CHAIN_ACCOUNT_CREATE")` | Domain for account creation authorization. |
 | `WORLD_CHAIN_ACCOUNT_SET_DOMAIN` | `bytes32` | `keccak256("WORLD_CHAIN_ACCOUNT_SET")` | Domain for key ring replacement authorization. |
-| `SESSION_VERIFIER_INSTANCE_DOMAIN` | `bytes32` | `keccak256("WIP1001_SESSION_VERIFIER_INSTANCE")` | Domain for session verifier instance derivation. |
+| `WORLD_CHAIN_SESSION_VERIFIER_INSTANCE_DOMAIN` | `bytes32` | `keccak256("WORLD_CHAIN_SESSION_VERIFIER_INSTANCE")` | Domain for session verifier instance derivation. |
 
 ### Activation Parameters
 

--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -12,9 +12,9 @@ requires: EIP-1271, EIP-2718, EIP-1559, EIP-2930, ERC-7562, RIP-7212
 
 ## Abstract
 
-We define a native World Chain account type managed by the `WORLD_CHAIN_ACCOUNT_MANAGER` predeploy. Each account has one immutable [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) compliant admin signer and one active key ring of [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) compliant session verifiers.
+We define a native World Chain account type managed by the `WORLD_CHAIN_ACCOUNT_MANAGER` predeploy. Each account has one immutable [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) compliant admin signer and one active key ring of session verifier instances backed by [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) compliant verifier implementations.
 
-We extend [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) with a new typed transaction envelope with type flag `0x1D`. `0x1D` transactions are executed with the World Chain account *framed* as the sender. Session verifiers act as the transaction level signatories via programmable [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) smart contracts. Session verifiers dually function as signature verifiers, and session key policy evaluators.
+We extend [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) with a new typed transaction envelope with type flag `0x1D`. `0x1D` transactions are executed with the World Chain account *framed* as the sender. Session verifier instances act as the transaction level signatories via programmable [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) smart contracts. Session verifier implementations dually function as signature verifiers, and session key policy evaluators.
 
 We design with the principle of not defining signer-specific authentication as native execution paths. Signature schemes, proof systems, recovery policies, and spending policies are fully programmable. The protocol only prescribes deterministic transaction context, validation frames, and reusable precompiles for cryptographic operations.
 
@@ -33,10 +33,11 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 | Name | Type | Value | Meaning |
 | --- | --- | --- | --- |
 | `WORLD_TX_TYPE` | `uint8` | `0x1D` | EIP-2718 transaction type for World Chain account transactions. |
-| `MAX_SESSION_VERIFIERS` | `uint256` | `20` | Maximum active session verifiers per account. |
+| `MAX_SESSION_VERIFIERS` | `uint256` | `20` | Maximum active session verifier instances per account. |
 | `WORLD_CHAIN_ACCOUNT_DOMAIN` | `bytes32` | `keccak256("WIP1001_ACCOUNT")` | Domain for account address derivation. |
 | `WORLD_CHAIN_ACCOUNT_CREATE_DOMAIN` | `bytes32` | `keccak256("WORLD_CHAIN_ACCOUNT_CREATE")` | Domain for account creation authorization. |
 | `WORLD_CHAIN_ACCOUNT_SET_DOMAIN` | `bytes32` | `keccak256("WORLD_CHAIN_ACCOUNT_SET")` | Domain for key ring replacement authorization. |
+| `SESSION_VERIFIER_INSTANCE_DOMAIN` | `bytes32` | `keccak256("WIP1001_SESSION_VERIFIER_INSTANCE")` | Domain for session verifier instance derivation. |
 
 ### Activation Parameters
 
@@ -104,14 +105,26 @@ For every existing account:
 - `sessionVerifiers.length` MUST be in `[1, MAX_SESSION_VERIFIERS]`;
 - each `installation.length` in `admin` and `sessionVerifiers` MUST be at most `MAX_VERIFIER_INSTALL_DATA_BYTES`;
 - each `sessionVerifiers[i].verifier` MUST be a deployed EIP-1271 verifier implementation adhering to `IWorldChainSessionVerifier`;
-- `sessionVerifiers` MUST NOT contain duplicate verifier addresses;
+- `sessionVerifiers` MUST NOT contain duplicate session verifier instances;
 - `keyRingHash == keccak256(abi.encode(sessionVerifiers))`;
 - `adminNonce` is consumed only by admin operations;
 - `transactionNonce` is consumed only by successful `0x1D` transaction execution attempts;
 
-Verifier behavior is selected by verifier implementation address, not by a protocol-level enum. `installation` is opaque to the protocol and is interpreted only by the selected verifier implementation.
+Verifier code is selected by verifier implementation address, not by a protocol-level enum. Session verifier membership and configuration are selected by session verifier instance. For each active `sessionVerifiers[i]`, the corresponding instance identifier is:
 
-After account creation, `setKeyRing` is the only execution path that mutates `sessionVerifiers`, `keyRingHash`, or validation-affecting account storage for active session verifiers. WIP-1001 defines no operation that mutates `admin` or the account router runtime code.
+```solidity
+sessionVerifierInstance = keccak256(abi.encode(
+    SESSION_VERIFIER_INSTANCE_DOMAIN,
+    chainId,
+    account,
+    sessionVerifiers[i].verifier,
+    keccak256(sessionVerifiers[i].installation)
+));
+```
+
+A session verifier implementation is the contract address whose code is executed by the account router. A session verifier instance is one installed use of that implementation for a specific account and installation payload. Multiple session verifier instances MAY reference the same verifier implementation address, provided their installation hashes differ and therefore their `sessionVerifierInstance` identifiers are distinct. `installation` is opaque to the protocol and is interpreted only by the selected verifier implementation.
+
+After account creation, `setKeyRing` is the only execution path that mutates `sessionVerifiers`, `keyRingHash`, or validation-affecting account storage for active session verifier instances. WIP-1001 defines no operation that mutates `admin` or the account router runtime code.
 
 #### Address Derivation
 
@@ -186,13 +199,13 @@ interface IWorldChainAccountRouter {
     ) external view returns (bytes4 magicValue);
 
     function isValidSignatureForVerifier(
-        address verifier,
+        bytes32 sessionVerifierInstance,
         bytes32 hash,
         bytes calldata signature
     ) external view returns (bytes4 magicValue);
 
     function evaluateSessionPolicyForVerifier(
-        address verifier,
+        bytes32 sessionVerifierInstance,
         IWorldChainSessionVerifier.ExecutionTraceContext calldata context
     ) external view returns (bool allowed);
 }
@@ -200,9 +213,11 @@ interface IWorldChainAccountRouter {
 
 `installAdmin` and `installKeyRing` MUST reject any caller other than `WORLD_CHAIN_ACCOUNT_MANAGER`. The account router MUST expose no non-manager path that can mutate validation-affecting verifier storage. `isValidSignatureForAdmin`, `isValidSignatureForVerifier`, and `evaluateSessionPolicyForVerifier` MUST be callable by `WORLD_CHAIN_ACCOUNT_MANAGER` in restricted validation frames.
 
-The account router MUST dispatch admin validation only to its installed `admin.verifier`. It MUST dispatch session validation only to an installed session verifier address; unknown session verifier addresses MUST fail without executing verifier implementation code.
+The account router MUST dispatch admin validation only to its installed `admin.verifier`. It MUST dispatch session validation only to an installed session verifier instance; unknown session verifier instances MUST fail without executing verifier implementation code. For session validation, the router MUST resolve `sessionVerifierInstance` to the corresponding verifier implementation address before performing the controlled `DELEGATECALL`.
 
-When the account router handles a manager-issued admin signature check (`isValidSignatureForAdmin`) or session signature check (`isValidSignatureForVerifier`), it MUST `DELEGATECALL` the selected verifier implementation with calldata `IERC1271.isValidSignature.selector || abi.encode(hash, signature)`. When the router handles `evaluateSessionPolicyForVerifier`, it MUST `DELEGATECALL` the selected session verifier implementation with calldata `IWorldChainSessionVerifier.evaluateSessionPolicy.selector || abi.encode(context)`.
+When the account router handles a manager-issued admin signature check (`isValidSignatureForAdmin`), it MUST `DELEGATECALL` the selected admin verifier implementation with calldata `IERC1271.isValidSignature.selector || abi.encode(hash, signature)`. When the router handles a session signature check (`isValidSignatureForVerifier`), it MUST `DELEGATECALL` the selected session verifier implementation with calldata `IERC1271.isValidSignature.selector || abi.encode(hash, abi.encode(sessionVerifierInstance, signature))`. When the router handles `evaluateSessionPolicyForVerifier`, it MUST `DELEGATECALL` the selected session verifier implementation with calldata `IWorldChainSessionVerifier.evaluateSessionPolicy.selector || abi.encode(context)`.
+
+For session signature checks, the `signature` bytes visible to the session verifier's ERC-1271 entrypoint are router-encoded as `abi.encode(sessionVerifierInstance, signature)`, where the second field is the `0x1D` envelope's verifier-defined signature field. The `0x1D` transaction sender supplies only the envelope `sessionVerifierInstance` and verifier-defined `signature`; the account router performs this wrapping before dispatching to the verifier implementation.
 
 Verifier implementations install scoped storage through the following installation hook:
 
@@ -225,7 +240,7 @@ interface IWorldChainSessionVerifier is IERC1271, IWorldChainAccountHooks {
         bytes32 signingHash;
         uint256 chainId;
         address account;
-        address sessionVerifier;
+        bytes32 sessionVerifierInstance;
         uint64 nonce;
         uint256 maxPriorityFeePerGas;
         uint256 maxFeePerGas;
@@ -286,7 +301,7 @@ interface IWorldChainSessionVerifier is IERC1271, IWorldChainAccountHooks {
 }
 ```
 
-`installation` is verifier-defined. The protocol does not parse it, but it commits to it through `adminHash`, `createHash`, and `keyRingHash`. A verifier implementation's `install` function MUST fully write all validation-affecting state implied by `installation` into the verifier's own deterministic account-storage namespace. Removed verifier state MAY remain in account storage, but it MUST be unreachable unless that verifier address is installed again through a later `setKeyRing`.
+`installation` is verifier-defined. The protocol does not parse it, but it commits to it through `adminHash`, `createHash`, and `keyRingHash`. For session verifier installs, the account router MUST call `install` with `abi.encode(sessionVerifierInstance, installation)`. A session verifier implementation's `install` function MUST fully write all validation-affecting state implied by `installation` into a deterministic account-storage namespace derived from `sessionVerifierInstance`. Because `sessionVerifierInstance` includes `keccak256(installation)`, two installs of the same implementation with different installation bytes MUST use different validation-affecting storage slots. Removed verifier state MAY remain in account storage, but it MUST be unreachable unless the same session verifier instance is installed again through a later `setKeyRing`.
 
 Verifier implementations MUST NOT rely on validation-affecting state stored at the verifier implementation address. Validation-affecting state MUST live in account storage installed through the account router.
 
@@ -315,8 +330,8 @@ interface IWorldChainAccountManager {
     function getTransactionNonce(address account) external view returns (uint64);
     function getKeyRingHash(address account) external view returns (bytes32);
     function getSessionVerifiers(address account) external view returns (WorldChainAccountVerifier[] memory);
-    function isAuthorizedSessionVerifier(address account, address sessionVerifier) external view returns (bool);
-    function getAuthorizedSessionVerifier(address account, address sessionVerifier) external view returns (WorldChainAccountVerifier memory);
+    function isAuthorizedSessionVerifier(address account, bytes32 sessionVerifierInstance) external view returns (bool);
+    function getAuthorizedSessionVerifier(address account, bytes32 sessionVerifierInstance) external view returns (WorldChainAccountVerifier memory);
 }
 ```
 
@@ -358,18 +373,19 @@ Installing canonical account-router runtime bytecode is a native manager state t
 1. reject `admin.verifier == address(0)`;
 2. require `admin.verifier` and each initial session verifier to have deployed code;
 3. require `initialSessionVerifiers.length` to be in `[1, MAX_SESSION_VERIFIERS]`;
-4. reject duplicate or zero session verifier addresses;
+4. reject zero session verifier implementation addresses;
 5. reject oversized `admin.installation` or session verifier `installation`;
 6. compute `adminHash = keccak256(abi.encode(admin))`;
 7. derive `account`;
 8. reject if `account` already exists or already has deployed code;
-9. compute `keyRingHash = keccak256(abi.encode(initialSessionVerifiers))`;
-10. atomically install canonical account-router runtime bytecode at `account`;
-11. call `IWorldChainAccountRouter(account).installAdmin(admin)`;
-12. call `IWorldChainAccountRouter(account).installKeyRing(initialSessionVerifiers)`;
-13. verify `createHash` through the account router's admin validation path;
-14. initialize manager state with `admin`, `adminNonce = 0`, `transactionNonce = 0`, `sessionVerifiers = initialSessionVerifiers`, and `keyRingHash`;
-15. emit `AccountCreated(account, admin.verifier, adminHash, accountSalt, keyRingHash)`.
+9. reject duplicate session verifier instances for `account`;
+10. compute `keyRingHash = keccak256(abi.encode(initialSessionVerifiers))`;
+11. atomically install canonical account-router runtime bytecode at `account`;
+12. call `IWorldChainAccountRouter(account).installAdmin(admin)`;
+13. call `IWorldChainAccountRouter(account).installKeyRing(initialSessionVerifiers)`;
+14. verify `createHash` through the account router's admin validation path;
+15. initialize manager state with `admin`, `adminNonce = 0`, `transactionNonce = 0`, `sessionVerifiers = initialSessionVerifiers`, and `keyRingHash`;
+16. emit `AccountCreated(account, admin.verifier, adminHash, accountSalt, keyRingHash)`.
 
 #### `setKeyRing`
 
@@ -378,7 +394,7 @@ Installing canonical account-router runtime bytecode is a native manager state t
 1. require `account` to exist;
 2. require `expectedCurrentKeyRingHash == keyRingHash`;
 3. require `sessionVerifiers.length` to be in `[1, MAX_SESSION_VERIFIERS]`;
-4. reject duplicate, zero, undeployed, or oversized session verifier entries;
+4. reject duplicate session verifier instances and zero, undeployed, or oversized session verifier entries;
 5. compute `newKeyRingHash = keccak256(abi.encode(sessionVerifiers))`;
 6. reject `newKeyRingHash == keyRingHash`;
 7. compute `setKeyRingHash` using the current `adminNonce`;
@@ -394,14 +410,14 @@ Installing canonical account-router runtime bytecode is a native manager state t
 
 The protocol uses restricted validation frames for admin authorization, session signature verification, and session policy evaluation.
 
-For each EIP-1271 signature check, the protocol MUST perform a `STATICCALL` from `WORLD_CHAIN_ACCOUNT_MANAGER` to the account router at `account` with value `0`, gas exactly `EIP1271_VALIDATION_GAS_LIMIT`, and calldata:
+For each admin or session signature check, the protocol MUST perform a `STATICCALL` from `WORLD_CHAIN_ACCOUNT_MANAGER` to the account router at `account` with value `0`, gas exactly `EIP1271_VALIDATION_GAS_LIMIT`, and calldata:
 
 - `IWorldChainAccountRouter.isValidSignatureForAdmin.selector || abi.encode(hash, signature)` for admin authorization checks; or
-- `IWorldChainAccountRouter.isValidSignatureForVerifier.selector || abi.encode(sessionVerifier, hash, signature)` for session signature checks.
+- `IWorldChainAccountRouter.isValidSignatureForVerifier.selector || abi.encode(sessionVerifierInstance, hash, signature)` for session signature checks.
 
 The call succeeds only if it returns `EIP1271_MAGIC_VALUE` and triggers no tracer rule violation. The account router is responsible for `DELEGATECALL`ing the configured verifier implementation per the dispatch rules in "Account Router and Verifier Interfaces"; the manager never calls a verifier implementation directly.
 
-For each session policy check, the protocol MUST perform a `STATICCALL` from `WORLD_CHAIN_ACCOUNT_MANAGER` to the account router at `account` with value `0`, gas exactly `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`, and calldata `IWorldChainAccountRouter.evaluateSessionPolicyForVerifier.selector || abi.encode(sessionVerifier, context)`. The call succeeds only if it returns `true` and triggers no tracer rule violation. The account router is responsible for `DELEGATECALL`ing the configured session verifier implementation.
+For each session policy check, the protocol MUST perform a `STATICCALL` from `WORLD_CHAIN_ACCOUNT_MANAGER` to the account router at `account` with value `0`, gas exactly `EXECUTION_TRACE_VALIDATION_GAS_LIMIT`, and calldata `IWorldChainAccountRouter.evaluateSessionPolicyForVerifier.selector || abi.encode(sessionVerifierInstance, context)`. The call succeeds only if it returns `true` and triggers no tracer rule violation. The account router is responsible for `DELEGATECALL`ing the configured session verifier implementation.
 
 Failure, revert, out-of-gas, malformed return data, or a tracer violation MUST be treated as signature or policy failure.
 
@@ -437,7 +453,7 @@ The wire encoding is:
     maxFeePerGas,
     gasLimit,
     account,
-    sessionVerifier,
+    sessionVerifierInstance,
     to,
     value,
     data,
@@ -458,7 +474,7 @@ signingHash = keccak256(
         maxFeePerGas,
         gasLimit,
         account,
-        sessionVerifier,
+        sessionVerifierInstance,
         to,
         value,
         data,
@@ -479,7 +495,7 @@ txHash = keccak256(
         maxFeePerGas,
         gasLimit,
         account,
-        sessionVerifier,
+        sessionVerifierInstance,
         to,
         value,
         data,
@@ -497,6 +513,7 @@ Envelope validity requirements:
 - `data.length <= MAX_PAYLOAD_DATA_BYTES`;
 - `accessList.length <= MAX_ACCESS_LIST_ENTRIES`;
 - `signature.length <= MAX_SESSION_SIGNATURE_BYTES`;
+- `sessionVerifierInstance` MUST be exactly 32 bytes;
 - `accessList` MUST use EIP-2930 encoding;
 - `maxFeePerGas` and `maxPriorityFeePerGas` follow [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) validity rules.
 
@@ -508,16 +525,16 @@ To include a `0x1D` transaction, the protocol MUST:
 
 1. decode and validate the envelope;
 2. load `account` from `WORLD_CHAIN_ACCOUNT_MANAGER`;
-3. require `sessionVerifier` to be authorized for `account` in the current `sessionVerifiers` set and load the current `keyRingHash`;
+3. require `sessionVerifierInstance` to be authorized for `account` in the current `sessionVerifiers` set and load the current `keyRingHash`;
 4. require the account balance to cover the worst-case payload gas charge and `MIN_VALIDATION_FAILURE_FEE`;
 5. compute `signingHash`;
-6. call `IWorldChainAccountRouter(account).isValidSignatureForVerifier(sessionVerifier, signingHash, signature)` in a restricted validation frame;
+6. call `IWorldChainAccountRouter(account).isValidSignatureForVerifier(sessionVerifierInstance, signingHash, signature)` in a restricted validation frame;
 7. if signature validation fails, apply validation-failure semantics and stop;
 8. increment `Account.transactionNonce` by one;
 9. execute the payload tentatively with `account` as the EVM sender and gas charged against envelope `gasLimit`;
-10. construct `ExecutionTraceContext` with `context.transaction.keyRingHash` set to the current account `keyRingHash`;
+10. construct `ExecutionTraceContext` with `context.transaction.sessionVerifierInstance` set to the selected session verifier instance and `context.transaction.keyRingHash` set to the current account `keyRingHash`;
 11. if `abi.encode(context.trace).length > MAX_EXECUTION_TRACE_BYTES`, discard tentative payload state, apply trace-overflow semantics, and stop;
-12. call `IWorldChainAccountRouter(account).evaluateSessionPolicyForVerifier(sessionVerifier, context)` in a restricted validation frame;
+12. call `IWorldChainAccountRouter(account).evaluateSessionPolicyForVerifier(sessionVerifierInstance, context)` in a restricted validation frame;
 13. if policy validation fails, discard tentative payload state, apply validation-failure semantics, and stop;
 14. otherwise commit the normal payload result, including a reverted payload result if the target call reverted.
 
@@ -538,27 +555,27 @@ All validation gas consumed by signature and policy checks MUST count against `B
 
 World Chain clients MUST revalidate every pooled `0x1D` transaction at least once per block until inclusion or eviction.
 
-On pool admission or successful revalidation, the client MUST record `account`, `sessionVerifier`, `nonce`, `signingHash`, `signature`, and the account's active `keyRingHash`. A transaction is eligible to remain pooled only while all conditions hold:
+On pool admission or successful revalidation, the client MUST record `account`, `sessionVerifierInstance`, `nonce`, `signingHash`, `signature`, and the account's active `keyRingHash`. A transaction is eligible to remain pooled only while all conditions hold:
 
 - `account` exists;
 - the account balance can cover `MIN_VALIDATION_FAILURE_FEE` at the current `baseFee`;
 - the transaction nonce can still become executable under the account nonce ordering rules;
-- `sessionVerifier` is a member of the account's current `sessionVerifiers` set;
+- `sessionVerifierInstance` is a member of the account's current `sessionVerifiers` set;
 - the current account `keyRingHash` equals the hash recorded when the transaction was admitted or last revalidated.
 
-A client MAY reuse a prior successful signature-validation result only when the cached `(account, sessionVerifier, signingHash, signature, keyRingHash)` tuple exactly matches the current transaction and account state. Block builders MAY rely on such a cache to avoid repeating signature verification before block construction; if the active `keyRingHash` changes, the cached result MUST be discarded and the signature MUST be revalidated.
+A client MAY reuse a prior successful signature-validation result only when the cached `(account, sessionVerifierInstance, signingHash, signature, keyRingHash)` tuple exactly matches the current transaction and account state. Block builders MAY rely on such a cache to avoid repeating signature verification before block construction; if the active `keyRingHash` changes, the cached result MUST be discarded and the signature MUST be revalidated.
 
 The `keyRingHash` comparison is the deterministic anchor for block validation: a verifier MAY accept a cached signature result only if the active account hash equals the recorded hash; otherwise it MUST execute signature validation again.
 
 ### Signer-State Determinism
 
-Session verifier behavior that can change `isValidSignature` or `evaluateSessionPolicy` for already accepted transactions MUST be immutable for a verifier address. Validation-affecting updates MUST be represented by deploying or selecting a different session verifier address and installing a replacement set through `setKeyRing`, which updates `keyRingHash`.
+Session verifier behavior that can change `isValidSignature` or `evaluateSessionPolicy` for already accepted transactions MUST be immutable for a session verifier instance. Validation-affecting updates MUST be represented by selecting a different verifier implementation address or different installation bytes, deriving a different `sessionVerifierInstance`, and installing a replacement set through `setKeyRing`, which updates `keyRingHash`.
 
 This applies to root rotations, verification-key rotations, signer recovery changes, signer revocation lists, account binding changes, and policy configuration changes. State that cannot affect validation MAY update in place.
 
 ## Rationale
 
-EIP-1271 gives World Chain one protocol boundary for all authorization schemes. The protocol verifies a signer contract; the signer contract decides how to authenticate.
+EIP-1271 gives World Chain one protocol boundary for all authorization schemes. The protocol verifies a signer contract through the account router; the signer contract decides how to authenticate.
 
 Execution policy belongs inside the session verifier. The protocol supplies the canonical transaction context and execution trace, then asks the verifier for a boolean decision.
 
@@ -566,7 +583,7 @@ Validation gas limits are protocol constants, not signer-selected values. This g
 
 Validation gas is supplied from a per-block budget rather than the envelope `gasLimit`. This keeps the payload gas model close to EIP-1559 transactions while bounding validation work per block.
 
-Whole-set `setKeyRing` updates make the account's session authorization state a single ordered set with one deterministic `keyRingHash`. Clients can bind cached signature validation to that hash and must revalidate when it changes.
+Whole-set `setKeyRing` updates make the account's session authorization state a single ordered set with one deterministic `keyRingHash`. Session verifier instances allow that ordered set to contain multiple entries backed by the same verifier implementation while still giving clients a stable membership key for cached validation. Clients can bind cached signature validation to that hash and must revalidate when it changes.
 
 Restricted validation frames prevent validation from depending on mutable external state, block metadata, or arbitrary external contract calls.
 
@@ -581,17 +598,18 @@ Existing Safe accounts MAY deploy or delegate to EIP-1271 signer contracts that 
 Conforming implementations MUST pass vectors for:
 
 - address derivation across multiple `(chainId, manager, adminSigner, accountSalt)` tuples;
-- `keyRingHash = keccak256(abi.encode(sessionVerifiers))` for empty-forbidden, single-verifier, multi-verifier, and reordered verifier sets;
-- `create` validation, including deployed-code checks, duplicate and zero verifier rejection, account-exists rejection, initial nonce values, initial `keyRingHash`, `AccountCreated`, and default World ID admin signer account binding;
-- `setKeyRing` validation, including stale `expectedCurrentKeyRingHash`, duplicate, zero, undeployed, empty, oversized, and no-op verifier set rejection;
+- `keyRingHash = keccak256(abi.encode(sessionVerifiers))` for empty-forbidden, single-verifier, multi-verifier, repeated implementation with distinct installations, and reordered verifier sets;
+- `sessionVerifierInstance` derivation, including domain separation, chain ID binding, account binding, implementation-address binding, installation-hash binding, duplicate-instance rejection, and repeated implementation addresses with distinct installation bytes;
+- `create` validation, including deployed-code checks, duplicate instance and zero verifier rejection, account-exists rejection, initial nonce values, initial `keyRingHash`, `AccountCreated`, and default World ID admin signer account binding;
+- `setKeyRing` validation, including stale `expectedCurrentKeyRingHash`, duplicate instance, zero, undeployed, empty, oversized, and no-op verifier set rejection;
 - `setKeyRing` success behavior, including full-set replacement, `newKeyRingHash`, `adminNonce` increment, `KeyRingSet`, authorization lookup updates, and failure atomicity;
 - `createHash` and `setKeyRingHash` domain separation, parameter binding, nonce binding, and negative replay cases across accounts, chains, managers, hashes, and operation types;
 - `0x1D` RLP encoding, signing hash, and transaction hash;
 - malformed envelope rejection for `chainId`, `nonce`, `to`, `data`, `accessList`, `signature`, and EIP-1559 fee bounds;
-- transaction validation against the current verifier set, including unauthorized verifier rejection and `ExecutionTraceContext.transaction.keyRingHash`;
+- transaction validation against the current verifier set, including unauthorized session verifier instance rejection and `ExecutionTraceContext.transaction.keyRingHash`;
 - failure semantics for envelope/precheck failures, validation-budget exhaustion, signature failures, trace overflow, policy failures, and payload reverts;
-- txpool revalidation, signature-validation cache reuse, and cache invalidation when `keyRingHash`, verifier membership, account balance, or nonce eligibility changes;
-- signer-state determinism, including rejection of validation-affecting session verifier updates behind an unchanged verifier address;
+- txpool revalidation, signature-validation cache reuse, and cache invalidation when `keyRingHash`, session verifier instance membership, account balance, or nonce eligibility changes;
+- signer-state determinism, including rejection of validation-affecting session verifier updates behind an unchanged session verifier instance;
 - restricted-frame positive cases and each forbidden opcode or call target;
 - default signer factory `CREATE2` address computation, idempotency, metadata, and incompatible-code rejection;
 - World ID `worldIdField`, `worldIdAction`, admin proof, and session proof inputs;
@@ -604,18 +622,19 @@ Complete golden vectors and a conformance test suite MUST be published before th
 
 - Admin authorization hashes bind domain, chain ID, manager, account, operation parameters, and nonce where applicable. A signature valid for `create` MUST NOT be valid for `setKeyRing`, another account, another chain, another manager, or another key ring hash.
 - The admin signer is immutable in the account address. A broken or lost admin signer requires migrating assets to a new account; applications that need recovery SHOULD use admin signers with recovery or multisig logic from account creation.
-- `setKeyRing` is the only post-creation key ring mutation path. A compromised session verifier remains authorized until an admin-authorized replacement set is included.
+- `setKeyRing` is the only post-creation key ring mutation path. A compromised session verifier instance remains authorized until an admin-authorized replacement set is included.
 - `expectedCurrentKeyRingHash` protects `setKeyRing` authorizations from applying to an unexpected current set. Admin tooling SHOULD surface the complete replacement set before signing because omitted verifiers are removed atomically.
-- `keyRingHash` binds cached validation to the ordered `SessionVerifier[]` set. Clients MUST discard cached signature results when the active hash changes, even if the transaction's `sessionVerifier` remains present in the new set.
-- `keyRingHash` does not commit to mutable verifier behavior by itself. Session verifier state that can affect `isValidSignature` or `evaluateSessionPolicy` MUST be immutable for that verifier address; upgrades that affect validation require a new verifier address installed through `setKeyRing`.
-- The protocol MUST verify that `sessionVerifier` is authorized for `account` before calling EIP-1271. Unauthorized verifiers MUST fail as a precheck rather than receiving a validation call.
+- `keyRingHash` binds cached validation to the ordered `sessionVerifiers` set. Clients MUST discard cached signature results when the active hash changes, even if the transaction's `sessionVerifierInstance` remains present in the new set.
+- `keyRingHash` does not commit to mutable verifier behavior by itself. Session verifier state that can affect `isValidSignature` or `evaluateSessionPolicy` MUST be immutable for that verifier instance; upgrades that affect validation require a different verifier implementation address or different installation bytes installed through `setKeyRing`.
+- The protocol MUST verify that `sessionVerifierInstance` is authorized for `account` before calling verifier code. Unauthorized instances MUST fail as a precheck rather than receiving a validation call.
 - Fixed validation gas limits bound signer execution. Signers that exceed the limit fail validation, and all signature and policy validation gas counts against `BLOCK_VALIDATION_GAS_BUDGET`.
 - `BLOCK_VALIDATION_GAS_BUDGET` is scarce. `MIN_VALIDATION_FAILURE_FEE` MUST be tuned so validation spam is costly, and clients MUST reject pooled transactions that cannot pay it.
 - Builders may prefer transactions with cheaper validation profiles. Fixed validation gas bounds the worst-case bias but does not eliminate ordering incentives.
 - `MAX_EXECUTION_TRACE_BYTES`, `MAX_PAYLOAD_DATA_BYTES`, `MAX_ACCESS_LIST_ENTRIES`, `MAX_SESSION_SIGNATURE_BYTES`, and `MAX_ADMIN_AUTHORIZATION_BYTES` bound calldata, decoding, memory, and ABI-encoding costs.
 - Restricted frames forbid mutable external-state reads and block-context opcodes. Signers that need time, block, or external-state constraints MUST bind them into the signature or proof input.
 - `DELEGATECALL` inside restricted validation frames is safe only when the delegatee bytecode satisfies the same tracer rules recursively.
-- The `0x1D` envelope exposes `account` and `sessionVerifier`. Applications that need stronger privacy should use verifier contracts that aggregate or rotate credentials.
+- Because verifier implementations execute via `DELEGATECALL` against account storage, storage isolation is not enforced by the EVM. Session verifier implementations MUST use deterministic account-storage namespaces derived from `sessionVerifierInstance` and MUST NOT write outside their assigned namespace except through explicitly specified account-router storage APIs, if any. Protocol deployments SHOULD allow only audited or approved verifier implementations when verifier code is delegatecalled.
+- The `0x1D` envelope exposes `account` and `sessionVerifierInstance`. Applications that need stronger privacy should use verifier contracts that aggregate or rotate credentials.
 - World ID signers MUST bind `block.chainid` into `worldIdAction` or session nonce inputs to prevent cross-chain proof replay.
 - The default World ID admin signer self-reports `account()`. The manager checks this only for default-factory-deployed World ID admin signers; custom signers are responsible for their own consistency.
 - `create` does not bind `msg.sender`, so a copied call can be front-run. The resulting account state is identical because the authorization commits to all state-determining parameters.


### PR DESCRIPTION
solves issue of having duplicate session verifier addresses

if this is accepted also need to adapt: https://github.com/worldcoin/world-chain/pull/656

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Spec changes redefine session verifier identity from implementation address to a derived `sessionVerifierInstance`, affecting transaction encoding, router dispatch, and manager authorization rules. Medium risk because it is a cross-cutting protocol/interface change that would require coordinated client and contract updates.
> 
> **Overview**
> Updates WIP-1001 to introduce **session verifier instances**: a deterministic `sessionVerifierInstance` identifier derived from `(domain, chainId, account, verifierImplementation, keccak256(installation))`, allowing multiple installs of the same verifier implementation with different configurations.
> 
> This replaces uses of `sessionVerifier` addresses with `sessionVerifierInstance` across the spec, including `0x1D` envelope fields/hashes, manager authorization/duplicate checks, router interfaces/dispatch semantics, and verifier installation requirements (router wraps session signature bytes and passes `abi.encode(sessionVerifierInstance, installation)` to `install`). Test vectors and security considerations are updated to reflect instance-based membership, caching, and immutability rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e939f620db2afd986c8a3baa6a5365c626d6ac3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->