### PR TITLE
fix: WIP-1001: Store Verifier Address in instance look up to enable easy validation

### DIFF
--- a/wips/wip-1001.md
+++ b/wips/wip-1001.md
@@ -87,6 +87,7 @@ struct Account {
     WorldChainAccountVerifier admin;
     bytes32 accountSalt;
     WorldChainAccountVerifier[] sessionVerifiers;
+    mapping(bytes32 sessionVerifierInstance => InstalledSessionVerifier) sessionVerifierInstances;
     bytes32 keyRingHash;
     uint64 adminNonce;
     uint64 transactionNonce;
@@ -95,6 +96,11 @@ struct Account {
 struct WorldChainAccountVerifier {
     address verifier;
     bytes installation;
+}
+
+struct InstalledSessionVerifier {
+    address verifier;
+    bytes32 keyRingHash;
 }
 ```
 
@@ -106,6 +112,7 @@ For every existing account:
 - each `installation.length` in `admin` and `sessionVerifiers` MUST be at most `MAX_VERIFIER_INSTALL_DATA_BYTES`;
 - each `sessionVerifiers[i].verifier` MUST be a deployed EIP-1271 verifier implementation adhering to `IWorldChainSessionVerifier`;
 - `sessionVerifiers` MUST NOT contain duplicate session verifier instances;
+- for each active `sessionVerifiers[i]`, the corresponding derived `sessionVerifierInstance` MUST resolve to `sessionVerifiers[i].verifier` and the current `keyRingHash`;
 - `keyRingHash == keccak256(abi.encode(sessionVerifiers))`;
 - `adminNonce` is consumed only by admin operations;
 - `transactionNonce` is consumed only by successful `0x1D` transaction execution attempts;
@@ -124,7 +131,9 @@ sessionVerifierInstance = keccak256(abi.encode(
 
 A session verifier implementation is the contract address whose code is executed by the account router. A session verifier instance is one installed use of that implementation for a specific account and installation payload. Multiple session verifier instances MAY reference the same verifier implementation address, provided their installation hashes differ and therefore their `sessionVerifierInstance` identifiers are distinct. `installation` is opaque to the protocol and is interpreted only by the selected verifier implementation.
 
-After account creation, `setKeyRing` is the only execution path that mutates `sessionVerifiers`, `keyRingHash`, or validation-affecting account storage for active session verifier instances. WIP-1001 defines no operation that mutates `admin` or the account router runtime code.
+`sessionVerifierInstances` is account-router resolver state. It maps each installed session verifier instance to the verifier implementation address to `DELEGATECALL` and the `keyRingHash` for which that resolver entry is active. A session verifier instance is active iff `sessionVerifierInstances[sessionVerifierInstance].keyRingHash == keyRingHash != 0` and `sessionVerifierInstances[sessionVerifierInstance].verifier != address(0)`. Entries from previous key rings MAY remain in storage, but MUST NOT authorize after `keyRingHash` changes.
+
+After account creation, `setKeyRing` is the only execution path that mutates `sessionVerifiers`, `sessionVerifierInstances`, `keyRingHash`, or validation-affecting account storage for active session verifier instances. WIP-1001 defines no operation that mutates `admin` or the account router runtime code.
 
 #### Address Derivation
 
@@ -213,7 +222,7 @@ interface IWorldChainAccountRouter {
 
 `installAdmin` and `installKeyRing` MUST reject any caller other than `WORLD_CHAIN_ACCOUNT_MANAGER`. The account router MUST expose no non-manager path that can mutate validation-affecting verifier storage. `isValidSignatureForAdmin`, `isValidSignatureForVerifier`, and `evaluateSessionPolicyForVerifier` MUST be callable by `WORLD_CHAIN_ACCOUNT_MANAGER` in restricted validation frames.
 
-The account router MUST dispatch admin validation only to its installed `admin.verifier`. It MUST dispatch session validation only to an installed session verifier instance; unknown session verifier instances MUST fail without executing verifier implementation code. For session validation, the router MUST resolve `sessionVerifierInstance` to the corresponding verifier implementation address before performing the controlled `DELEGATECALL`.
+The account router MUST dispatch admin validation only to its installed `admin.verifier`. It MUST dispatch session validation only to an active session verifier instance; unknown or stale session verifier instances MUST fail without executing verifier implementation code. For session validation, the router MUST resolve `sessionVerifierInstance` through `sessionVerifierInstances`, require the stored `keyRingHash` to equal the account's current `keyRingHash`, and then use the stored `verifier` address for the controlled `DELEGATECALL`.
 
 When the account router handles a manager-issued admin signature check (`isValidSignatureForAdmin`), it MUST `DELEGATECALL` the selected admin verifier implementation with calldata `IERC1271.isValidSignature.selector || abi.encode(hash, signature)`. When the router handles a session signature check (`isValidSignatureForVerifier`), it MUST `DELEGATECALL` the selected session verifier implementation with calldata `IERC1271.isValidSignature.selector || abi.encode(hash, abi.encode(sessionVerifierInstance, signature))`. When the router handles `evaluateSessionPolicyForVerifier`, it MUST `DELEGATECALL` the selected session verifier implementation with calldata `IWorldChainSessionVerifier.evaluateSessionPolicy.selector || abi.encode(context)`.
 
@@ -301,7 +310,7 @@ interface IWorldChainSessionVerifier is IERC1271, IWorldChainAccountHooks {
 }
 ```
 
-`installation` is verifier-defined. The protocol does not parse it, but it commits to it through `adminHash`, `createHash`, and `keyRingHash`. For session verifier installs, the account router MUST call `install` with `abi.encode(sessionVerifierInstance, installation)`. A session verifier implementation's `install` function MUST fully write all validation-affecting state implied by `installation` into a deterministic account-storage namespace derived from `sessionVerifierInstance`. Because `sessionVerifierInstance` includes `keccak256(installation)`, two installs of the same implementation with different installation bytes MUST use different validation-affecting storage slots. Removed verifier state MAY remain in account storage, but it MUST be unreachable unless the same session verifier instance is installed again through a later `setKeyRing`.
+`installation` is verifier-defined. The protocol does not parse it, but it commits to it through `adminHash`, `createHash`, and `keyRingHash`. For session verifier installs, the account router MUST derive each `sessionVerifierInstance`, store `sessionVerifierInstances[sessionVerifierInstance] = InstalledSessionVerifier(verifier, keyRingHash)`, and call `install` with `abi.encode(sessionVerifierInstance, installation)`. A session verifier implementation's `install` function MUST fully write all validation-affecting state implied by `installation` into a deterministic account-storage namespace derived from `sessionVerifierInstance`. Because `sessionVerifierInstance` includes `keccak256(installation)`, two installs of the same implementation with different installation bytes MUST use different validation-affecting storage slots. Removed verifier state MAY remain in account storage, but it MUST be unreachable unless the same session verifier instance is installed again through a later `setKeyRing`.
 
 Verifier implementations MUST NOT rely on validation-affecting state stored at the verifier implementation address. Validation-affecting state MUST live in account storage installed through the account router.
 
@@ -334,6 +343,8 @@ interface IWorldChainAccountManager {
     function getAuthorizedSessionVerifier(address account, bytes32 sessionVerifierInstance) external view returns (WorldChainAccountVerifier memory);
 }
 ```
+
+`isAuthorizedSessionVerifier` MUST return `true` only when `sessionVerifierInstance` resolves to an `InstalledSessionVerifier` whose `keyRingHash` equals the account's current `keyRingHash`. `getAuthorizedSessionVerifier` MUST return the matching current `sessionVerifiers` entry and MUST fail for an absent or stale `sessionVerifierInstance`.
 
 ### Manager Events
 
@@ -384,7 +395,7 @@ Installing canonical account-router runtime bytecode is a native manager state t
 12. call `IWorldChainAccountRouter(account).installAdmin(admin)`;
 13. call `IWorldChainAccountRouter(account).installKeyRing(initialSessionVerifiers)`;
 14. verify `createHash` through the account router's admin validation path;
-15. initialize manager state with `admin`, `adminNonce = 0`, `transactionNonce = 0`, `sessionVerifiers = initialSessionVerifiers`, and `keyRingHash`;
+15. initialize manager state with `admin`, `adminNonce = 0`, `transactionNonce = 0`, `sessionVerifiers = initialSessionVerifiers`, active `sessionVerifierInstances`, and `keyRingHash`;
 16. emit `AccountCreated(account, admin.verifier, adminHash, accountSalt, keyRingHash)`.
 
 #### `setKeyRing`
@@ -402,9 +413,10 @@ Installing canonical account-router runtime bytecode is a native manager state t
 9. call `IWorldChainAccountRouter(account).installKeyRing(sessionVerifiers)`;
 10. set `previousKeyRingHash = keyRingHash`;
 11. replace the account's full `sessionVerifiers` set with the supplied `sessionVerifiers`;
-12. set `keyRingHash = newKeyRingHash`;
-13. increment `adminNonce` by one;
-14. emit `KeyRingSet(account, previousKeyRingHash, newKeyRingHash, adminNonce)`.
+12. write active `sessionVerifierInstances` entries for the supplied set under `newKeyRingHash`;
+13. set `keyRingHash = newKeyRingHash`;
+14. increment `adminNonce` by one;
+15. emit `KeyRingSet(account, previousKeyRingHash, newKeyRingHash, adminNonce)`.
 
 ### Restricted Validation Frames
 
@@ -525,7 +537,7 @@ To include a `0x1D` transaction, the protocol MUST:
 
 1. decode and validate the envelope;
 2. load `account` from `WORLD_CHAIN_ACCOUNT_MANAGER`;
-3. require `sessionVerifierInstance` to be authorized for `account` in the current `sessionVerifiers` set and load the current `keyRingHash`;
+3. load the current `keyRingHash`, resolve `sessionVerifierInstance` through `sessionVerifierInstances`, require `verifier != address(0)` and require the stored `keyRingHash` to equal the current `keyRingHash`, and load the resolved verifier implementation address;
 4. require the account balance to cover the worst-case payload gas charge and `MIN_VALIDATION_FAILURE_FEE`;
 5. compute `signingHash`;
 6. call `IWorldChainAccountRouter(account).isValidSignatureForVerifier(sessionVerifierInstance, signingHash, signature)` in a restricted validation frame;
@@ -560,7 +572,7 @@ On pool admission or successful revalidation, the client MUST record `account`, 
 - `account` exists;
 - the account balance can cover `MIN_VALIDATION_FAILURE_FEE` at the current `baseFee`;
 - the transaction nonce can still become executable under the account nonce ordering rules;
-- `sessionVerifierInstance` is a member of the account's current `sessionVerifiers` set;
+- `sessionVerifierInstance` resolves to a nonzero verifier in `sessionVerifierInstances` with the account's current `keyRingHash`;
 - the current account `keyRingHash` equals the hash recorded when the transaction was admitted or last revalidated.
 
 A client MAY reuse a prior successful signature-validation result only when the cached `(account, sessionVerifierInstance, signingHash, signature, keyRingHash)` tuple exactly matches the current transaction and account state. Block builders MAY rely on such a cache to avoid repeating signature verification before block construction; if the active `keyRingHash` changes, the cached result MUST be discarded and the signature MUST be revalidated.
@@ -583,7 +595,7 @@ Validation gas limits are protocol constants, not signer-selected values. This g
 
 Validation gas is supplied from a per-block budget rather than the envelope `gasLimit`. This keeps the payload gas model close to EIP-1559 transactions while bounding validation work per block.
 
-Whole-set `setKeyRing` updates make the account's session authorization state a single ordered set with one deterministic `keyRingHash`. Session verifier instances allow that ordered set to contain multiple entries backed by the same verifier implementation while still giving clients a stable membership key for cached validation. Clients can bind cached signature validation to that hash and must revalidate when it changes.
+Whole-set `setKeyRing` updates make the account's session authorization state a single ordered set with one deterministic `keyRingHash`. Session verifier instances allow that ordered set to contain multiple entries backed by the same verifier implementation while still giving clients a stable membership key for cached validation. The account-router resolver stores the verifier implementation address beside the key-ring generation so validation can dispatch from `sessionVerifierInstance` without accepting a verifier address from transaction calldata. Clients can bind cached signature validation to that hash and must revalidate when it changes.
 
 Restricted validation frames prevent validation from depending on mutable external state, block metadata, or arbitrary external contract calls.
 
@@ -600,15 +612,16 @@ Conforming implementations MUST pass vectors for:
 - address derivation across multiple `(chainId, manager, adminSigner, accountSalt)` tuples;
 - `keyRingHash = keccak256(abi.encode(sessionVerifiers))` for empty-forbidden, single-verifier, multi-verifier, repeated implementation with distinct installations, and reordered verifier sets;
 - `sessionVerifierInstance` derivation, including domain separation, chain ID binding, account binding, implementation-address binding, installation-hash binding, duplicate-instance rejection, and repeated implementation addresses with distinct installation bytes;
+- `sessionVerifierInstances` resolution, including verifier address lookup, stale key-ring hash rejection, zero verifier rejection, and repeated implementation addresses with distinct instance IDs;
 - `create` validation, including deployed-code checks, duplicate instance and zero verifier rejection, account-exists rejection, initial nonce values, initial `keyRingHash`, `AccountCreated`, and default World ID admin signer account binding;
 - `setKeyRing` validation, including stale `expectedCurrentKeyRingHash`, duplicate instance, zero, undeployed, empty, oversized, and no-op verifier set rejection;
 - `setKeyRing` success behavior, including full-set replacement, `newKeyRingHash`, `adminNonce` increment, `KeyRingSet`, authorization lookup updates, and failure atomicity;
 - `createHash` and `setKeyRingHash` domain separation, parameter binding, nonce binding, and negative replay cases across accounts, chains, managers, hashes, and operation types;
 - `0x1D` RLP encoding, signing hash, and transaction hash;
 - malformed envelope rejection for `chainId`, `nonce`, `to`, `data`, `accessList`, `signature`, and EIP-1559 fee bounds;
-- transaction validation against the current verifier set, including unauthorized session verifier instance rejection and `ExecutionTraceContext.transaction.keyRingHash`;
+- transaction validation against the current session verifier instance resolver, including unauthorized session verifier instance rejection and `ExecutionTraceContext.transaction.keyRingHash`;
 - failure semantics for envelope/precheck failures, validation-budget exhaustion, signature failures, trace overflow, policy failures, and payload reverts;
-- txpool revalidation, signature-validation cache reuse, and cache invalidation when `keyRingHash`, session verifier instance membership, account balance, or nonce eligibility changes;
+- txpool revalidation, signature-validation cache reuse, and cache invalidation when `keyRingHash`, session verifier instance authorization, account balance, or nonce eligibility changes;
 - signer-state determinism, including rejection of validation-affecting session verifier updates behind an unchanged session verifier instance;
 - restricted-frame positive cases and each forbidden opcode or call target;
 - default signer factory `CREATE2` address computation, idempotency, metadata, and incompatible-code rejection;
@@ -627,6 +640,7 @@ Complete golden vectors and a conformance test suite MUST be published before th
 - `keyRingHash` binds cached validation to the ordered `sessionVerifiers` set. Clients MUST discard cached signature results when the active hash changes, even if the transaction's `sessionVerifierInstance` remains present in the new set.
 - `keyRingHash` does not commit to mutable verifier behavior by itself. Session verifier state that can affect `isValidSignature` or `evaluateSessionPolicy` MUST be immutable for that verifier instance; upgrades that affect validation require a different verifier implementation address or different installation bytes installed through `setKeyRing`.
 - The protocol MUST verify that `sessionVerifierInstance` is authorized for `account` before calling verifier code. Unauthorized instances MUST fail as a precheck rather than receiving a validation call.
+- `sessionVerifierInstances` entries from prior key rings MAY remain in storage. They MUST NOT authorize unless their stored `keyRingHash` equals the account's current `keyRingHash`.
 - Fixed validation gas limits bound signer execution. Signers that exceed the limit fail validation, and all signature and policy validation gas counts against `BLOCK_VALIDATION_GAS_BUDGET`.
 - `BLOCK_VALIDATION_GAS_BUDGET` is scarce. `MIN_VALIDATION_FAILURE_FEE` MUST be tuned so validation spam is costly, and clients MUST reject pooled transactions that cannot pay it.
 - Builders may prefer transactions with cheaper validation profiles. Fixed validation gas bounds the worst-case bias but does not eliminate ordering incentives.


### PR DESCRIPTION
otherwise it would not have been possible with just instance -> keyRingHash lookup mapping

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the WIP-1001 spec’s session-verifier authorization/dispatch rules, which impacts how clients and the account router validate and route `0x1D` transactions. Risk is moderate because it changes core validation semantics, though it is documentation/spec-only in this PR.
> 
> **Overview**
> Clarifies and extends WIP-1001 to require an on-chain resolver mapping `sessionVerifierInstance -> (verifier, keyRingHash)` (`InstalledSessionVerifier`) so the account router can dispatch session validation without trusting any verifier address from transaction calldata.
> 
> Updates the spec to treat session verifier instances as **active only when their stored `keyRingHash` matches the current account `keyRingHash`**, and propagates this resolver requirement through router dispatch rules, `create`/`setKeyRing` state transition steps, manager authorization helpers (`isAuthorizedSessionVerifier`/`getAuthorizedSessionVerifier`), tx inclusion prechecks, txpool revalidation conditions, and test vector expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a73b8faef895cc8ac2392e900277a5921bc00e6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->