### PR TITLE
feat: better logs observability for devnet

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -53,6 +53,22 @@ devnet command='up' *args='':
     fi
     RUST_LOG="${RUST_LOG:-info,flashblocks=trace,engine_driver=info}" cargo run -p xtask -- devnet {{command}} {{args}}
 
+# Tail world-chain execution client logs from the running devnet (e.g. `just devnet-logs` or `just devnet-logs 0` for a specific sequencer).
+devnet-logs index='':
+    #!/usr/bin/env bash
+    set -uo pipefail
+    LOG_FILE="${WORLD_CHAIN_DEVNET_LOG_FILE:-target/devnet/logs/devnet.log}"
+    if [ ! -f "$LOG_FILE" ]; then
+        echo "no devnet log file at $LOG_FILE; is the devnet running?" >&2
+        exit 1
+    fi
+    if [ -n "{{index}}" ]; then
+        PATTERN="world-chain-el-{{index}} "
+    else
+        PATTERN="world-chain-el-"
+    fi
+    tail -n 200 -F "$LOG_FILE" | grep --line-buffered -- "$PATTERN"
+
 # Run stress tests against a live network
 stress *args='':
     RUST_LOG="info" cargo run -p xtask --release -- stress $@


### PR DESCRIPTION
### Problem

The new rust devnet works smoothly but it has a log observability issue:

- all binaries run into docker containers with the exception of world chain binaries. Those run natively.
- This makes it super easy to isolate logs of docker containers by just reading that docker containers logs
- but makes it harder to read world chain clients logs, which is what we usually care of during local devnet experiments.

### Solution

- add a `just devnet-logs` command that only prints world chain logs.
- you can run `just devnet-logs` and this will print logs from all world chain clients running (by default there are 3)
- or you can provide an index such as `just devnet-logs 0` and this will only show logs from world chain client index 0.

This is possible in a very easy way because all logs are written into a file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-only Justfile helper around tail/grep; no runtime, auth, or production behavior changes.
> 
> **Overview**
> Adds a **`just devnet-logs`** recipe so developers can follow **native world-chain execution client** output during local devnet runs, instead of digging through the combined `target/devnet/logs/devnet.log` file.
> 
> Running **`just devnet-logs`** tails the last 200 lines and follows the log, grepping lines tagged with **`world-chain-el-`** (all EL instances). **`just devnet-logs <index>`** narrows the filter to a single client (e.g. **`world-chain-el-0`**). The log path defaults to **`target/devnet/logs/devnet.log`** and can be overridden with **`WORLD_CHAIN_DEVNET_LOG_FILE`**, matching the existing devnet logging setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5e188c876b951720bfb481e6f7214dcf519c7ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->