### PR TITLE
fix: run contender stress tests agains rust local devnet

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -69,9 +69,9 @@ devnet-logs index='':
     fi
     tail -n 200 -F "$LOG_FILE" | grep --line-buffered -- "$PATTERN"
 
-# Run stress tests against a live network
+# Run Contender stress tests against a running native Rust devnet.
 stress *args='':
-    RUST_LOG="info" cargo run -p xtask --release -- stress $@
+    @scripts/stress/stress.sh $@
 
 # Prove a PBH transaction
 prove *args='':

--- a/pkg/devnet/README.md
+++ b/pkg/devnet/README.md
@@ -260,9 +260,14 @@ native `just devnet up` path for current local HA sequencing work.
 # Run E2E tests
 just e2e-test -n
 
-# Run stress tests with contender, if installed
-just stress-test <stress | stress-precompile>
+# Run Contender stress tests against a running native Rust devnet
+just devnet up -d
+just stress
+
+# Optional knobs
+TPS=100 DURATION=120 just stress
+just stress stress-precompile
 
 # Generate a performance report
-just stress-test report
+just stress report
 ```

--- a/scripts/stress/stress.sh
+++ b/scripts/stress/stress.sh
@@ -7,110 +7,156 @@ if [[ "${TRACE:-0}" == "1" ]]; then
 fi
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
 STRESS_SCENARIO="${SCRIPT_DIR}/scenarios/stress.toml"
 PRECOMPILE_STRESS_SCENARIO="${SCRIPT_DIR}/scenarios/precompileStress.toml"
-
-KURTOSIS_ENCLAVE="${KURTOSIS_ENCLAVE:-world-chain}"
-KURTOSIS_BUILDER_SERVICE="${KURTOSIS_BUILDER_SERVICE:-op-el-builder-2151908-1-custom-op-node-op-kurtosis}"
-KURTOSIS_TX_PROXY_SERVICE="${KURTOSIS_TX_PROXY_SERVICE:-tx-proxy}"
-
-LOCAL_BUILDER_FALLBACK="${LOCAL_BUILDER_FALLBACK:-http://localhost:8545}"
-LOCAL_TX_PROXY_FALLBACK="${LOCAL_TX_PROXY_FALLBACK:-http://localhost:8545}"
-
-resolve_kurtosis_url() {
-    local service_name="$1"
-    local port_name="$2"
-    local output
-    local url
-    local host_port
-
-    if ! command -v kurtosis >/dev/null 2>&1; then
-        return 1
-    fi
-
-    output="$(kurtosis port print "$KURTOSIS_ENCLAVE" "$service_name" "$port_name" 2>/dev/null || true)"
-    url="$(printf '%s\n' "$output" | sed -nE 's/.*(https?:\/\/127\.0\.0\.1:[0-9]+).*/\1/p' | head -n1)"
-    if [[ -n "$url" ]]; then
-        printf '%s\n' "$url"
-        return 0
-    fi
-
-    host_port="$(printf '%s\n' "$output" | sed -nE 's/.*(127\.0\.0\.1:[0-9]+).*/\1/p' | head -n1)"
-    if [[ -n "$host_port" ]]; then
-        printf 'http://%s\n' "$host_port"
-        return 0
-    fi
-
-    return 1
-}
-
-resolve_endpoint() {
-    local override="${1:-}"
-    local service_name="$2"
-    local port_name="$3"
-    local fallback="$4"
-    local resolved=""
-
-    if [[ -n "$override" ]]; then
-        printf '%s\n' "$override"
-        return 0
-    fi
-
-    resolved="$(resolve_kurtosis_url "$service_name" "$port_name" || true)"
-    if [[ -n "$resolved" ]]; then
-        printf '%s\n' "$resolved"
-        return 0
-    fi
-
-    printf '%s\n' "$fallback"
-}
-
-BUILDER="$(resolve_endpoint "${BUILDER:-}" "$KURTOSIS_BUILDER_SERVICE" "rpc" "$LOCAL_BUILDER_FALLBACK")"
-TX_PROXY="$(resolve_endpoint "${TX_PROXY:-}" "$KURTOSIS_TX_PROXY_SERVICE" "rpc" "$LOCAL_TX_PROXY_FALLBACK")"
+DEVNET_ENDPOINTS_FILE="${WORLD_CHAIN_DEVNET_ENDPOINTS_FILE:-${REPO_ROOT}/target/devnet/endpoints.json}"
+EXPECTED_CHAIN_ID="${DEVNET_CHAIN_ID:-2151908}"
+DEVNET_ENDPOINTS_TIMEOUT="${DEVNET_ENDPOINTS_TIMEOUT:-180}"
+DEVNET_RPC_TIMEOUT="${DEVNET_RPC_TIMEOUT:-60}"
 
 PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
-SEED="${SEED:-0x$(openssl rand -hex 32)}"
+
+die() {
+    echo "error: $*" >&2
+    exit 1
+}
+
+require_command() {
+    local command="$1"
+
+    command -v "$command" >/dev/null 2>&1 || die "required command not found: $command"
+}
+
+resolve_devnet_rpc() {
+    local elapsed=0
+    local resolved
+
+    if [[ -n "${RPC_URL:-}" ]]; then
+        printf '%s\n' "$RPC_URL"
+        return 0
+    fi
+
+    while ((elapsed <= DEVNET_ENDPOINTS_TIMEOUT)); do
+        if [[ -f "$DEVNET_ENDPOINTS_FILE" ]]; then
+            resolved="$(jq -er '.primary.sequencer_rpc_url // empty' "$DEVNET_ENDPOINTS_FILE" 2>/dev/null || true)"
+            if [[ -n "$resolved" ]]; then
+                printf '%s\n' "$resolved"
+                return 0
+            fi
+        fi
+
+        if ((elapsed == 0)); then
+            echo "Waiting for native devnet endpoints at ${DEVNET_ENDPOINTS_FILE}..." >&2
+        fi
+
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+
+    die "native devnet endpoints were not ready at ${DEVNET_ENDPOINTS_FILE}; start the devnet with 'just devnet' or 'just devnet up -d' and wait until it prints endpoints"
+}
+
+validate_rpc() {
+    local rpc_url="$1"
+    local elapsed=0
+    local response
+    local chain_hex
+    local chain_id
+    local last_error=""
+
+    while ((elapsed <= DEVNET_RPC_TIMEOUT)); do
+        response="$(curl -fsS --max-time "${RPC_CHECK_TIMEOUT:-2}" \
+            -H 'content-type: application/json' \
+            --data '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}' \
+            "$rpc_url" 2>&1)" && {
+            chain_hex="$(printf '%s\n' "$response" | jq -er '.result' 2>/dev/null)" \
+                || die "invalid eth_chainId response from ${rpc_url}: ${response}"
+            chain_id="$((chain_hex))"
+
+            [[ "$chain_id" -eq "$EXPECTED_CHAIN_ID" ]] \
+                || die "expected chain id ${EXPECTED_CHAIN_ID}, got ${chain_id} from ${rpc_url}"
+
+            return 0
+        }
+
+        last_error="$response"
+        if ((elapsed == 0)); then
+            echo "Waiting for native devnet RPC at ${rpc_url}..." >&2
+        fi
+
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+
+    die "could not reach native devnet RPC at ${rpc_url} after ${DEVNET_RPC_TIMEOUT}s; is 'just devnet' running? last error: ${last_error}"
+}
+
+DEVNET_RPC=""
+
+prepare_devnet_rpc() {
+    if [[ -n "$DEVNET_RPC" ]]; then
+        return 0
+    fi
+
+    require_command jq
+    require_command curl
+    DEVNET_RPC="$(resolve_devnet_rpc)"
+    validate_rpc "$DEVNET_RPC"
+    echo "Using native devnet RPC: ${DEVNET_RPC}" >&2
+}
 
 run_setup() {
     local scenario_file="$1"
 
+    require_command contender
     contender setup \
         -p "$PRIVATE_KEY" \
         "$scenario_file" \
-        -r "$TX_PROXY" \
+        -r "$DEVNET_RPC" \
         --optimism
 }
 
 run_spam() {
     local scenario_file="$1"
+    local seed="${SEED:-}"
 
+    if [[ -z "$seed" ]]; then
+        require_command openssl
+        seed="0x$(openssl rand -hex 32)"
+    fi
+
+    require_command contender
     contender spam \
-        --builder-url "$BUILDER" \
+        --builder-url "$DEVNET_RPC" \
         --txs-per-second "${TPS:-50}" \
-        --duration "${DURATION:-600}" \
-        --seed "$SEED" \
+        --duration "${DURATION:-60}" \
+        --seed "$seed" \
         -p "$PRIVATE_KEY" \
         "$scenario_file" \
-        -r "$TX_PROXY" \
+        -r "$DEVNET_RPC" \
         --optimism \
         --min-balance 0.7eth
 }
 
 stress() {
+    prepare_devnet_rpc
     run_setup "$STRESS_SCENARIO"
     run_spam "$STRESS_SCENARIO"
 }
 
 stress_precompile() {
+    prepare_devnet_rpc
     run_setup "$PRECOMPILE_STRESS_SCENARIO"
     run_spam "$PRECOMPILE_STRESS_SCENARIO"
 }
 
 generate_report() {
+    require_command contender
     contender report
 }
 
-case "${1:-}" in
+case "${1:-stress}" in
 stress-precompile)
     stress_precompile
     ;;
@@ -121,10 +167,10 @@ report)
     generate_report
     ;;
 *)
-    echo "Usage: $0 {stress-precompile|stress|report}"
+    echo "Usage: $0 [stress|stress-precompile|report]"
     echo "Commands:"
-    echo "  stress-precompile: Run the precompile stress test"
-    echo "  stress: Run the normal stress test"
+    echo "  stress: Run the normal stress test against the native Rust devnet"
+    echo "  stress-precompile: Run the precompile stress test against the native Rust devnet"
     echo "  report: Generate a report for the previous stress test"
     exit 1
     ;;


### PR DESCRIPTION
### Problem

The previous `just stress` command doesn't work with the new Rust local devnet. Further, it was testing pbh transactions as well. The new rust local devnet doesn't deploy pbh contracts, therefore it doesn't make sense to test pbh against it.

### Solution

Modify the `just stress` command so that it automatically interacts with the running rust local devnet. It calls a contender setup that defaults to 50 tps for 60 seconds.

Tested and it works fine.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local dev tooling and shell script only; no production runtime or auth/data-path changes.
> 
> **Overview**
> **`just stress`** now runs **`scripts/stress/stress.sh`** instead of the **`xtask`** stress path, so Contender targets a **running native Rust devnet** rather than Kurtosis builder/tx-proxy URLs.
> 
> The script **waits for** `target/devnet/endpoints.json` (or **`RPC_URL`**), reads **`primary.sequencer_rpc_url`**, and **polls `eth_chainId`** (default **2151908**) before **`contender setup`** / **`contender spam`**. Builder and RPC both use that same endpoint; defaults are **`TPS=50`** and **`DURATION=60`**. **`stress-precompile`** and **`report`** stay as subcommands, with **`stress`** as the default when no arg is passed.
> 
> **`pkg/devnet/README.md`** documents **`just devnet up -d`**, **`just stress`**, optional **`TPS`/`DURATION`**, and **`just stress report`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e044189e7c31bdb6705cffea54fa09353b5ca144. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->