### PR TITLE
fix: edit wip1006

### DIFF
--- a/wips/wip-1006.md
+++ b/wips/wip-1006.md
@@ -132,8 +132,6 @@ stateDiagram-v2
     PROPOSED --> FINALIZED: challenge deadline elapsed & no challenge
     PROPOSED --> CHALLENGED: staked challenge before challenge deadline
     CHALLENGED --> FINALIZED: PROOF_THRESHOLD distinct lanes verified before proof deadline
-    PROPOSED --> INVALIDATED: conclusive invalidity evidence
-    CHALLENGED --> INVALIDATED: conclusive invalidity evidence
     CHALLENGED --> INVALIDATED: proof deadline elapsed without PROOF_THRESHOLD
     FINALIZED --> [*]
     INVALIDATED --> [*]
@@ -197,13 +195,15 @@ For each lane submission, the contract MUST:
 
 A lane submission at or after `proofDeadline` MUST revert. Finalization of a challenged root is permissionless once the threshold is met.
 
-If `block.timestamp >= proofDeadline` and the root's proof bitmap contains fewer than `PROOF_THRESHOLD` distinct lanes, anyone MAY call `invalidate(rootId)`. The contract MUST move the root to `INVALIDATED`. Failure to assemble `PROOF_THRESHOLD` distinct lanes within `PROOF_PERIOD` is treated as conclusive invalidity for the purposes of [Invalidity and Conflicts](#invalidity-and-conflicts), and the proposer bond is forfeited per [Proposal Lifecycle](#proposal-lifecycle).
+If `block.timestamp >= proofDeadline` and the root's proof bitmap contains fewer than `PROOF_THRESHOLD` distinct lanes, anyone MAY call `invalidate(rootId)`. The contract MUST move the root to `INVALIDATED` and forfeit `PROPOSER_BOND` per [Proposal Lifecycle](#proposal-lifecycle). This is the only path to `INVALIDATED`; see [Invalidity and Conflicts](#invalidity-and-conflicts).
 
 ### Invalidity and Conflicts
 
-Before finalization, conclusive invalidity evidence from any configured lane MUST move the root to `INVALIDATED`. An invalidated root MUST NOT finalize, and descendants of an invalidated root MUST NOT become accepted anchors.
+Invalidation occurs only via the `CHALLENGED → INVALIDATED` transition described in [Challenged Finality](#challenged-finality): a challenged root that has not assembled `PROOF_THRESHOLD` distinct supporting lanes by `proofDeadline` MUST be invalidated. There is no fast-path invalidation from `PROPOSED`. A party in possession of evidence that a proposed root is incorrect MUST challenge the root; absence of supporting proofs within `PROOF_PERIOD` is the protocol's sole in-band signal of invalidity.
 
-After a root has finalized, conclusive invalidity evidence MUST NOT silently roll back finalized state. The evidence MUST trigger the configured safety process — pausing the proof game type, blacklisting the game, or routing the incident to governance.
+An invalidated root MUST NOT finalize, and descendants of an invalidated root MUST NOT become accepted anchors.
+
+If invalidity of a finalized root is discovered after the fact — for example, via an offchain proof exhibiting a conflicting `(parent, l2BlockNumber) → rootId'` — the protocol MUST NOT silently roll back finalized state. The configured safety process MUST be triggered: pausing the proof game type, blacklisting the game, or routing the incident to governance.
 
 ### Lane-Specific Requirements
 

--- a/wips/wip-1006.md
+++ b/wips/wip-1006.md
@@ -79,8 +79,8 @@ This matches the OP Stack and Base proposer surface field-for-field. Any OP Stac
 [op-output-root]: https://specs.optimism.io/protocol/proposals.html#l2-output-commitment-construction
 [op-proposals]: https://specs.optimism.io/protocol/proposals.html
 [op-fdg]: https://specs.optimism.io/fault-proof/stage-one/fault-dispute-game.html
-[base-azul-extradata]: https://docs.base.org/specs/protocol/proofs/contracts#game-extra-data
-[base-azul-l1head]: https://docs.base.org/specs/protocol/proofs/contracts#clone-arguments
+[base-azul-extradata]: https://docs.base.org/base-chain/specs/protocol/proofs/contracts#game-extra-data
+[base-azul-l1head]: https://docs.base.org/base-chain/specs/protocol/proofs/contracts#clone-arguments
 [eip-2935]: https://eips.ethereum.org/EIPS/eip-2935
 
 #### Domain (verifier-immutable)
@@ -244,13 +244,13 @@ This WIP specifies interfaces only. Implementation details — storage layouts, 
 | `ISecurityCouncil` | Submits and verifies `SECURITY_COUNCIL` attestations bound to `rootId`. | World Chain Security Council multisig. |
 | `IStakingRegistry` | Checks challenger eligibility and locks, forfeits, or refunds `BOND_AMOUNT`. | World Chain–specific; no Base analogue. |
 
-[base-contracts]: https://docs.base.org/specs/protocol/proofs/contracts
-[base-factory]: https://docs.base.org/specs/protocol/proofs/contracts#disputegamefactory
-[base-aggregate]: https://docs.base.org/specs/protocol/proofs/contracts#aggregateverifier
-[base-anchor]: https://docs.base.org/specs/protocol/proofs/contracts#anchorstateregistry
-[base-zk]: https://docs.base.org/specs/protocol/proofs/contracts#zkverifier
-[base-tee]: https://docs.base.org/specs/protocol/proofs/contracts#teeverifier
-[base-tee-registry]: https://docs.base.org/specs/protocol/proofs/contracts#teeproverregistry
+[base-contracts]: https://docs.base.org/base-chain/specs/protocol/proofs/contracts
+[base-factory]: https://docs.base.org/base-chain/specs/protocol/proofs/contracts#disputegamefactory
+[base-aggregate]: https://docs.base.org/base-chain/specs/protocol/proofs/contracts#aggregateverifier
+[base-anchor]: https://docs.base.org/base-chain/specs/protocol/proofs/contracts#anchorstateregistry
+[base-zk]: https://docs.base.org/base-chain/specs/protocol/proofs/contracts#zkverifier
+[base-tee]: https://docs.base.org/base-chain/specs/protocol/proofs/contracts#teeverifier
+[base-tee-registry]: https://docs.base.org/base-chain/specs/protocol/proofs/contracts#teeproverregistry
 
 ## Backwards Compatibility
 

--- a/wips/wip-1006.md
+++ b/wips/wip-1006.md
@@ -44,6 +44,7 @@ Activation parameters are set at hardfork activation and held as immutable value
 | Name | Initial Value | Meaning |
 | --- | --- | --- |
 | `CHALLENGE_PERIOD` | `1 day` | Duration after proposal creation during which a staked participant MAY challenge a root without submitting proof material. Per-proposal `challengeDeadline = createdAt + CHALLENGE_PERIOD`. |
+| `PROOF_PERIOD` | `7 days` | Duration after a root is challenged during which lane submissions MAY be accepted toward `PROOF_THRESHOLD`. Per-proposal `proofDeadline = challengedAt + PROOF_PERIOD`. A challenged root that has not reached `PROOF_THRESHOLD` by `proofDeadline` MUST be invalidated. |
 | `PROPOSER_BOND` | TBD | Slashable stake required of the proposer. Locked at proposal time, refunded if the root reaches `FINALIZED`, and forfeited if the root reaches `INVALIDATED`. |
 | `CHALLENGER_BOND` | TBD | Slashable stake required of each challenger. Locked at challenge time and forfeited if the challenged root finalizes; refunded if the root is invalidated. |
 
@@ -128,11 +129,12 @@ A root moves through four states:
 ```mermaid
 stateDiagram-v2
     [*] --> PROPOSED: propose(root)
-    PROPOSED --> FINALIZED: deadline elapsed & no challenge
-    PROPOSED --> CHALLENGED: staked challenge before deadline
-    CHALLENGED --> FINALIZED: second distinct lane verified
+    PROPOSED --> FINALIZED: challenge deadline elapsed & no challenge
+    PROPOSED --> CHALLENGED: staked challenge before challenge deadline
+    CHALLENGED --> FINALIZED: PROOF_THRESHOLD distinct lanes verified before proof deadline
     PROPOSED --> INVALIDATED: conclusive invalidity evidence
     CHALLENGED --> INVALIDATED: conclusive invalidity evidence
+    CHALLENGED --> INVALIDATED: proof deadline elapsed without PROOF_THRESHOLD
     FINALIZED --> [*]
     INVALIDATED --> [*]
 ```
@@ -159,6 +161,7 @@ The challenge transaction:
 - MUST NOT require the caller to submit proof material.
 - MUST lock `CHALLENGER_BOND` of the caller's stake as slashable collateral against the challenged root.
 - MUST mark the root as `CHALLENGED`.
+- MUST record `challengedAt = block.timestamp` and `proofDeadline = challengedAt + PROOF_PERIOD` on the root, the first time it transitions to `CHALLENGED`. Subsequent challenges MUST NOT extend `proofDeadline`.
 
 If the challenged root finalizes through the proof-lane threshold, the locked `CHALLENGER_BOND` is forfeited. If the root is invalidated, the locked `CHALLENGER_BOND` is refunded to the challenger.
 
@@ -181,17 +184,20 @@ An unchallenged root finalizes without any proof-lane submissions.
 
 ### Challenged Finality
 
-A challenged root MUST NOT finalize merely because time has elapsed. It finalizes only when at least `PROOF_THRESHOLD` distinct proof lanes support the root.
+A challenged root MUST NOT finalize merely because time has elapsed. It finalizes only when at least `PROOF_THRESHOLD` distinct proof lanes support the root, and only if the threshold is met before `proofDeadline`.
 
 For each lane submission, the contract MUST:
 
 1. Verify that the root is in `CHALLENGED`.
-2. Verify that the proof or attestation binds to `rootId`.
-3. Verify the proof or attestation according to the lane-specific verifier.
-4. Set the lane's bit in the root's proof bitmap.
-5. Finalize the root when the bitmap contains at least `PROOF_THRESHOLD` distinct lanes.
+2. Verify that `block.timestamp < proofDeadline`.
+3. Verify that the proof or attestation binds to `rootId`.
+4. Verify the proof or attestation according to the lane-specific verifier.
+5. Set the lane's bit in the root's proof bitmap.
+6. Finalize the root when the bitmap contains at least `PROOF_THRESHOLD` distinct lanes.
 
-Finalization of a challenged root is permissionless once the threshold is met.
+A lane submission at or after `proofDeadline` MUST revert. Finalization of a challenged root is permissionless once the threshold is met.
+
+If `block.timestamp >= proofDeadline` and the root's proof bitmap contains fewer than `PROOF_THRESHOLD` distinct lanes, anyone MAY call `invalidate(rootId)`. The contract MUST move the root to `INVALIDATED`. Failure to assemble `PROOF_THRESHOLD` distinct lanes within `PROOF_PERIOD` is treated as conclusive invalidity for the purposes of [Invalidity and Conflicts](#invalidity-and-conflicts), and the proposer bond is forfeited per [Proposal Lifecycle](#proposal-lifecycle).
 
 ### Invalidity and Conflicts
 
@@ -270,6 +276,9 @@ Before this WIP can move beyond Draft, implementations SHOULD cover at least:
 - a challenge at or after the deadline reverts;
 - a challenged root with one supporting lane does not finalize;
 - a challenged root with two distinct supporting lanes finalizes;
+- a challenged root with fewer than `PROOF_THRESHOLD` lanes at `proofDeadline` invalidates and forfeits `PROPOSER_BOND`;
+- a lane submission at or after `proofDeadline` reverts and does not affect the proof bitmap;
+- subsequent challenges on an already-challenged root do not extend `proofDeadline`;
 - duplicate submissions from the same lane do not increase the threshold count;
 - every proof lane rejects material that does not bind to `rootId`;
 - anchor updates reject non-finalized, invalidated, paused, retired, or non-monotonic roots.

--- a/wips/wip-1006.md
+++ b/wips/wip-1006.md
@@ -11,7 +11,7 @@ created: 2026-05-27
 
 ## Abstract
 
-We outline an architecture for an optimistic fault proof system. A proposer posts a root optimistically without any proof. If no staked participant challenges the root within a one-day window, the foot finalizes purely on the basis of elapsed time. If the root is challenged via a claimed dispute. This initiates a 7 day challenge window where n / m proofs are required to prove the root invalid.
+We outline an architecture for an optimistic fault proof system. A proposer posts a root optimistically without any proof. If no staked participant challenges the root within a one-day window, the root finalizes purely on the basis of elapsed time. If the root is challenged via a claimed dispute. This initiates a 7 day challenge window where n / m proofs are required to prove the root invalid.
 
 ## Motivation
 
@@ -44,7 +44,8 @@ Activation parameters are set at hardfork activation and held as immutable value
 | Name | Initial Value | Meaning |
 | --- | --- | --- |
 | `CHALLENGE_PERIOD` | `1 day` | Duration after proposal creation during which a staked participant MAY challenge a root without submitting proof material. Per-proposal `challengeDeadline = createdAt + CHALLENGE_PERIOD`. |
-| `BOND_AMOUNT` | TBD | Slashable stake required of each challenger. Locked at challenge time and forfeited if the challenged root finalizes; refunded if the root is invalidated. |
+| `PROPOSER_BOND` | TBD | Slashable stake required of the proposer. Locked at proposal time, refunded if the root reaches `FINALIZED`, and forfeited if the root reaches `INVALIDATED`. |
+| `CHALLENGER_BOND` | TBD | Slashable stake required of each challenger. Locked at challenge time and forfeited if the challenged root finalizes; refunded if the root is invalidated. |
 
 ### Proof Lanes
 
@@ -140,11 +141,13 @@ stateDiagram-v2
 
 A root enters the system in the `PROPOSED` state.
 
-1. The proposer submits the root commitment and the required proposal bond.
+1. The proposer submits the root commitment and locks `PROPOSER_BOND` as slashable collateral against the proposal.
 2. The contract records `createdAt = block.timestamp` and `challengeDeadline = createdAt + CHALLENGE_PERIOD`.
 3. The root remains open to challenges until `challengeDeadline`.
 
 The proposer MUST NOT be required to submit material from any proof lane when creating the proposal, however they may choose to do so.
+
+If the root reaches `FINALIZED`, the locked `PROPOSER_BOND` MUST be refunded to the proposer. If the root reaches `INVALIDATED`, the locked `PROPOSER_BOND` MUST be forfeited.
 
 ### Challenge Lifecycle
 
@@ -154,12 +157,12 @@ The challenge transaction:
 
 - MUST verify that the caller is currently staked according to the configured staking registry.
 - MUST NOT require the caller to submit proof material.
-- MUST lock `BOND_AMOUNT` of the caller's stake as slashable collateral against the challenged root.
+- MUST lock `CHALLENGER_BOND` of the caller's stake as slashable collateral against the challenged root.
 - MUST mark the root as `CHALLENGED`.
 
-If the challenged root finalizes through the proof-lane threshold, the locked `BOND_AMOUNT` is forfeited. If the root is invalidated, the locked `BOND_AMOUNT` is refunded to the challenger.
+If the challenged root finalizes through the proof-lane threshold, the locked `CHALLENGER_BOND` is forfeited. If the root is invalidated, the locked `CHALLENGER_BOND` is refunded to the challenger.
 
-Multiple challenges MAY be recorded for accounting, but only the existence of at least one valid challenge affects the finality path. Each additional challenger locks their own `BOND_AMOUNT`.
+Multiple challenges MAY be recorded for accounting, but only the existence of at least one valid challenge affects the finality path. Each additional challenger locks their own `CHALLENGER_BOND`.
 
 A challenge submitted at or after `challengeDeadline` MUST revert.
 
@@ -234,7 +237,7 @@ This WIP specifies interfaces only. Implementation details — storage layouts, 
 | `ITEEVerifier` | Verifies the `TEE_ATTESTATION` lane against `rootId`. | [`TEEVerifier`][base-tee] |
 | `ITEEProverRegistry` | Maintains accepted TEE signer identities, image hashes, and proposer allowlisting. | [`TEEProverRegistry`][base-tee-registry] |
 | `ISecurityCouncil` | Submits and verifies `SECURITY_COUNCIL` attestations bound to `rootId`. | World Chain Security Council multisig. |
-| `IStakingRegistry` | Checks challenger eligibility and locks, forfeits, or refunds `BOND_AMOUNT`. | World Chain–specific; no Base analogue. |
+| `IStakingRegistry` | Checks challenger eligibility and locks, forfeits, or refunds `PROPOSER_BOND` and `CHALLENGER_BOND`. | World Chain–specific; no Base analogue. |
 
 [base-contracts]: https://docs.base.org/base-chain/specs/protocol/proofs/contracts
 [base-factory]: https://docs.base.org/base-chain/specs/protocol/proofs/contracts#disputegamefactory
@@ -283,7 +286,7 @@ Before this WIP can move beyond Draft, implementations SHOULD cover at least:
 
 **`rootId` domain separation is critical.** Every lane MUST bind to the same `rootId`, and `rootId` itself MUST commit to `chainId`, `proofSystemVersion`, `rollupConfigHash`, and the parent/child block range. Missing domain separation allows replay across chains, hardfork schedules, game types, proof-system versions, or block ranges.
 
-**Bond and stake calibration are security-critical.** If challenges are too cheap, attackers can grief honest roots into the slow path. If challenges are too expensive, honest watchers may fail to challenge invalid roots. Exact economic parameters are out of scope for this WIP but MUST be tuned before mainnet deployment.
+**Bond and stake calibration are security-critical.** If `CHALLENGER_BOND` is too cheap, attackers can grief honest roots into the slow path. If `CHALLENGER_BOND` is too expensive, honest watchers may fail to challenge invalid roots. If `PROPOSER_BOND` is too cheap, invalid-proposal spam is cheap and forces honest watchers to lock capital per challenge; if `PROPOSER_BOND` is too expensive, only well-capitalized actors can propose, which centralizes the role. Exact economic parameters are out of scope for this WIP but MUST be tuned before mainnet deployment.
 
 ## Copyright
 

--- a/wips/wip-1006.md
+++ b/wips/wip-1006.md
@@ -1,7 +1,7 @@
 ---
 wip: 1006
 title: Proof System Architecture
-description: Optimistic one-day challenge period followed by a 2-of-4 proof-lane threshold for finalizing challenged World Chain output roots.
+description: Optimistic one-day challenge period followed by a 2-of-3 proof-lane threshold for finalizing challenged World Chain output roots.
 author: 0xOsiris
 status: Draft
 type: Standards Track
@@ -35,7 +35,7 @@ Protocol constants are fixed by this WIP and MUST NOT be changed without a new W
 | Name | Value | Meaning |
 | --- | --- | --- |
 | `PROOF_THRESHOLD` | `2` | Number of distinct proof lanes that MUST support a challenged root before it finalizes. |
-| `PROOF_LANE_COUNT` | `4` | Number of configured proof lanes. |
+| `PROOF_LANE_COUNT` | `3` | Number of configured proof lanes. |
 
 ### Activation Parameters
 
@@ -53,7 +53,6 @@ A challenged root finalizes only when at least `PROOF_THRESHOLD` distinct lanes 
 | Lane | Source | Submission |
 | --- | --- | --- |
 | `VALIDITY_PROOF` | A configured validity proof verifier (zkVM or SNARK). | Permissionless. |
-| `FAULT_PROOF_GAME` | A resolved fault proof game for the same root commitment. | Permissionless submission of the resolved game reference. |
 | `TEE_ATTESTATION` | A registered TEE signer attesting to the transition. | Anyone MAY relay a valid signed attestation. |
 | `SECURITY_COUNCIL` | A Security Council threshold signature or multisig action. | Council-controlled attestation. |
 
@@ -203,12 +202,6 @@ After a root has finalized, conclusive invalidity evidence MUST NOT silently rol
 
 The validity proof lane verifies that the transition from `parentRoot` at `parentL2BlockNumber` to `rootClaim` at `l2BlockNumber` is valid under `rollupConfigHash`. The verifier MAY be implemented with a zkVM, a SNARK, or another cryptographic proof system. The proof MUST bind to `rootId` and MUST be verified onchain or by an onchain verifier gateway.
 
-#### Fault Proof Game
-
-The fault proof lane accepts the result of a configured fault proof game. The submitted game reference MUST prove that the game was created for the same `rootClaim`, parent, L2 block number, and root commitment; that the game is resolved and finalized according to its own rules; and that the game result supports the proposed root.
-
-A finalized fault proof game in which the defender wins counts as one supporting lane. A finalized fault proof game in which the challenger wins MUST invalidate the root.
-
 #### TEE Attestation
 
 The TEE lane accepts an attestation from a registered TEE signer over `rootId`. The verifier MUST check that the signer is registered, that the signer is valid for the active TEE image or measurement, that the attestation binds to `rootId`, and that the attestation has not expired or been revoked.
@@ -238,7 +231,6 @@ This WIP specifies interfaces only. Implementation details — storage layouts, 
 | `IProofSystemGame` | Per-proposal game: holds state, accepts lane submissions, finalizes, advances anchor. World Chain analogue of Base's `AggregateVerifier`. | [`AggregateVerifier`][base-aggregate] |
 | `IAnchorStateRegistry` | Tracks the current anchor, finalized roots, blacklist, retirement, and pause. | [`AnchorStateRegistry`][base-anchor] |
 | `IValidityProofVerifier` | Verifies the `VALIDITY_PROOF` lane against `rootId`. | [`ZKVerifier`][base-zk] |
-| `IFaultProofGame` | Configured fault proof game implementation accepted by the `FAULT_PROOF_GAME` lane. | [OP Stack `FaultDisputeGame`][op-fdg] |
 | `ITEEVerifier` | Verifies the `TEE_ATTESTATION` lane against `rootId`. | [`TEEVerifier`][base-tee] |
 | `ITEEProverRegistry` | Maintains accepted TEE signer identities, image hashes, and proposer allowlisting. | [`TEEProverRegistry`][base-tee-registry] |
 | `ISecurityCouncil` | Submits and verifies `SECURITY_COUNCIL` attestations bound to `rootId`. | World Chain Security Council multisig. |
@@ -277,7 +269,6 @@ Before this WIP can move beyond Draft, implementations SHOULD cover at least:
 - a challenged root with two distinct supporting lanes finalizes;
 - duplicate submissions from the same lane do not increase the threshold count;
 - every proof lane rejects material that does not bind to `rootId`;
-- a fault proof game that resolves against the proposed root prevents finalization; and
 - anchor updates reject non-finalized, invalidated, paused, retired, or non-monotonic roots.
 
 ## Security Considerations

--- a/wips/wip-1006.md
+++ b/wips/wip-1006.md
@@ -11,7 +11,7 @@ created: 2026-05-27
 
 ## Abstract
 
-We outline an architecture for an optimistic fault proof system. A proposer posts a root optimistically without any proof. If no staked participant challenges the root within a one-day window, the root finalizes purely on the basis of elapsed time. If the root is challenged via a claimed dispute, this initiates a 7 day challenge window where n / m proofs are required to prove the root invalid.
+We outline an architecture for an optimistic fault proof system. A proposer posts a root optimistically without any proof. If no staked participant challenges the root within a one-day window, the root finalizes purely on the basis of elapsed time. If the root is challenged, this initiates a 7 day challenge window where n / m proofs are required to prove the actual validity of the root.
 
 ## Motivation
 

--- a/wips/wip-1006.md
+++ b/wips/wip-1006.md
@@ -11,7 +11,7 @@ created: 2026-05-27
 
 ## Abstract
 
-We outline an architecture for an optimistic fault proof system. A proposer posts a root optimistically without any proof. If no staked participant challenges the root within a one-day window, the root finalizes purely on the basis of elapsed time. If the root is challenged via a claimed dispute. This initiates a 7 day challenge window where n / m proofs are required to prove the root invalid.
+We outline an architecture for an optimistic fault proof system. A proposer posts a root optimistically without any proof. If no staked participant challenges the root within a one-day window, the root finalizes purely on the basis of elapsed time. If the root is challenged via a claimed dispute, this initiates a 7 day challenge window where n / m proofs are required to prove the root invalid.
 
 ## Motivation
 


### PR DESCRIPTION
This PR edits a bit wip1006

Should be merged into https://github.com/worldcoin/world-chain/pull/675


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to a draft WIP; no runtime code or deployed contracts are modified in this PR.
> 
> **Overview**
> **WIP-1006** is revised to describe a **2-of-3** disputed finality model (down from 2-of-4) by dropping the **`FAULT_PROOF_GAME`** lane and related contract interfaces, tests, and security notes tied to interactive fault games.
> 
> The spec now defines a **`PROOF_PERIOD`** (7 days) with **`proofDeadline`**: challenged roots must reach **`PROOF_THRESHOLD`** before that deadline or move to **`INVALIDATED`** via permissionless **`invalidate`**. Lane submissions after the deadline revert. **Subsequent challenges do not extend** the proof window.
> 
> Economics and lifecycle wording split a single **`BOND_AMOUNT`** into **`PROPOSER_BOND`** and **`CHALLENGER_BOND`**, with explicit refund/forfeit rules on finalize vs invalidate. The state machine and **Invalidity and Conflicts** sections remove fast-path invalidation from **`PROPOSED`** and lane-driven “conclusive invalidity” before finalization; in-band invalidity is framed as failing to assemble enough supporting lanes by **`proofDeadline`** after a challenge.
> 
> Minor edits fix abstract typos, tighten challenged-finality steps, update Base Azul doc links to **`docs.base.org/base-chain/...`**, and extend recommended test cases and bond-calibration security text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b182dfc5d3b20a929a666624a4a244de7a141c6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->