### PR TITLE
feat(devnet): add block access lists deployment to the devnet

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -48,13 +48,18 @@ playground *args='':
     RUST_LOG="info" cargo run -p xtask --release -- launch-node $@
 
 # Manage the native Rust HA devnet. Use `just devnet up -d` to run in the background and `just devnet down` to stop it.
+# Set BAL=1 to enable flashblocks block access lists on the sequencer nodes.
 devnet command='up' *args='':
     #!/usr/bin/env bash
     set -euo pipefail
+    EXTRA_ARGS=()
     if [ "{{command}}" = "up" ]; then
         cargo build -p world-chain
+        if [ "${BAL:-0}" = "1" ]; then
+            EXTRA_ARGS+=(--bal-enabled)
+        fi
     fi
-    RUST_LOG="${RUST_LOG:-info,flashblocks=trace,engine_driver=info}" cargo run -p xtask -- devnet {{command}} {{args}}
+    RUST_LOG="${RUST_LOG:-info,flashblocks=trace,engine_driver=info}" cargo run -p xtask -- devnet {{command}} {{args}} ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}
 
 # Tail world-chain execution client logs from the running devnet (e.g. `just devnet-logs` or `just devnet-logs 0` for a specific sequencer).
 devnet-logs index='':

--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -212,6 +212,7 @@ impl FullStackWorldDevnet {
         hardforks: WorldChainHardforkConfig,
         port_mode: DevnetPortMode,
         block_time: Duration,
+        access_list: bool,
     ) -> Result<Self> {
         let topology = HaSequencerTopology::from_config(config.clone());
         let artifacts = generate_op_artifacts(&config, &hardforks).await?;
@@ -257,7 +258,13 @@ impl FullStackWorldDevnet {
                 .enumerate()
                 .filter_map(|(peer_index, peer)| (peer_index != index).then_some(peer.clone()))
                 .collect::<Vec<_>>();
-            start_world_chain_el(index, &workdir_path, &sequencer_plans[index], trusted_peers)
+            start_world_chain_el(
+                index,
+                &workdir_path,
+                &sequencer_plans[index],
+                trusted_peers,
+                access_list,
+            )
         }))
         .await?;
         connect_execution_peers(&sequencers).await?;
@@ -960,6 +967,7 @@ async fn start_world_chain_el(
     workdir: &Path,
     plan: &SequencerPlan,
     trusted_peers: Vec<String>,
+    access_list: bool,
 ) -> Result<SequencerService> {
     let data_dir = workdir.join(format!("l2data-{index}"));
     fs::create_dir_all(&data_dir).wrap_err("failed to create L2 data dir")?;
@@ -1068,6 +1076,9 @@ async fn start_world_chain_el(
         "log-fmt".to_string(),
         "-vvv".to_string(),
     ]);
+    if access_list {
+        args.push("--flashblocks.access-list".to_string());
+    }
 
     let mut process = spawn_native_process(&format!("world-chain-el-{index}"), &binary, &args)
         .wrap_err_with(|| format!("failed to spawn native world-chain EL process {index}"))?;

--- a/crates/devnet/src/lib.rs
+++ b/crates/devnet/src/lib.rs
@@ -98,6 +98,7 @@ pub struct WorldDevnetBuilder {
     preset: WorldDevnetPreset,
     hardforks: WorldChainHardforkConfig,
     flashblocks: bool,
+    access_list: bool,
     nodes: u8,
     block_time: Duration,
     port_mode: DevnetPortMode,
@@ -112,6 +113,7 @@ impl Default for WorldDevnetBuilder {
             preset: WorldDevnetPreset::DirectSequencer,
             hardforks: WorldChainHardforkConfig::default(),
             flashblocks: true,
+            access_list: false,
             nodes: 1,
             block_time: Duration::from_secs(2),
             port_mode: DevnetPortMode::Dynamic,
@@ -161,6 +163,13 @@ impl WorldDevnetBuilder {
     /// Enable or disable flashblocks. Presets enable it by default.
     pub fn flashblocks(mut self, enabled: bool) -> Self {
         self.flashblocks = enabled;
+        self
+    }
+
+    /// Enable or disable flashblocks block access lists (BAL). Disabled by
+    /// default; only takes effect when flashblocks is enabled.
+    pub fn flashblocks_access_list(mut self, enabled: bool) -> Self {
+        self.access_list = enabled;
         self
     }
 
@@ -248,6 +257,7 @@ impl WorldDevnetBuilder {
             preset = ?self.preset,
             nodes = self.nodes,
             flashblocks = self.flashblocks,
+            access_list = self.access_list,
             block_time_ms = self.block_time.as_millis(),
             hardforks = %active_hardforks,
             l1_enabled = self.l1.is_some(),
@@ -270,6 +280,7 @@ impl WorldDevnetBuilder {
                 self.hardforks.clone(),
                 self.port_mode,
                 self.block_time,
+                self.access_list,
             )
             .await?;
             let components = full_stack.components();
@@ -308,6 +319,7 @@ impl WorldDevnetBuilder {
         let (_, nodes, tasks, env, tx_spammer) = WorldChainTestBuilder::builder()
             .nodes(self.nodes)
             .flashblocks(self.flashblocks)
+            .access_list(self.access_list)
             .chain_spec(chain_spec.clone())
             .build()
             .setup_with::<WorldChainDefaultContext, _>(optimism_payload_attributes)

--- a/crates/test-utils/src/e2e_harness/setup.rs
+++ b/crates/test-utils/src/e2e_harness/setup.rs
@@ -177,6 +177,8 @@ pub struct WorldChainTestBuilder {
     nodes: u8,
     #[builder(default)]
     flashblocks: bool,
+    #[builder(default = true)]
+    access_list: bool,
     #[builder(default)]
     tx_peers: bool,
     #[builder(default)]
@@ -233,6 +235,7 @@ impl WorldChainTestBuilder {
             self.tx_peers,
             self.disable_gossip,
             self.flashblocks,
+            self.access_list,
             self.block_uncompressed_size_limit,
             self.chain_spec,
         )
@@ -326,6 +329,7 @@ async fn setup_inner<T, G>(
     enable_tx_peers: bool,
     disable_gossip: bool,
     flashblocks_enabled: bool,
+    access_list: bool,
     block_uncompressed_size_limit: Option<u64>,
     chain_spec: Arc<WorldChainSpec>,
 ) -> eyre::Result<(
@@ -402,9 +406,15 @@ where
                 Some(previous_peer_ids),
                 disable_gossip,
                 flashblocks_enabled,
+                access_list,
             )
         } else {
-            test_config_with_peers_and_gossip(None, disable_gossip, flashblocks_enabled)
+            test_config_with_peers_and_gossip(
+                None,
+                disable_gossip,
+                flashblocks_enabled,
+                access_list,
+            )
         };
         let mut config = config;
         config.args.builder.block_uncompressed_size_limit = block_uncompressed_size_limit;

--- a/crates/test-utils/src/node.rs
+++ b/crates/test-utils/src/node.rs
@@ -69,7 +69,7 @@ use world_chain_pool::{
 use world_chain_primitives::ed25519_dalek::SigningKey;
 
 pub fn test_config() -> WorldChainNodeConfig {
-    test_config_with_peers_and_gossip(None, false, true)
+    test_config_with_peers_and_gossip(None, false, true, true)
 }
 
 /// Creates a test config with optional transaction propagation peers and gossip control
@@ -77,6 +77,7 @@ pub fn test_config_with_peers_and_gossip(
     tx_peers: Option<Vec<PeerId>>,
     disable_txpool_gossip: bool,
     flashblocks_enabled: bool,
+    access_list: bool,
 ) -> WorldChainNodeConfig {
     use reth_optimism_node::args::RollupArgs;
 
@@ -102,7 +103,7 @@ pub fn test_config_with_peers_and_gossip(
             force_publish: false,
             recommit_interval: 200,
             flashblocks_interval: 200,
-            access_list: true,
+            access_list,
             store: false,
             store_path: None,
             fanout: FanoutArgs::default(),
@@ -128,7 +129,7 @@ pub fn test_config_with_peers_and_gossip(
         },
         builder_config: FlashblocksPayloadBuilderConfig {
             inner: OpBuilderConfig::default(),
-            bal_enabled: true,
+            bal_enabled: access_list,
         },
         flashblocks_store: None,
     }

--- a/xtask/src/devnet.rs
+++ b/xtask/src/devnet.rs
@@ -53,6 +53,10 @@ struct UpArgs {
     #[arg(long)]
     no_flashblocks: bool,
 
+    /// Enable flashblocks block access lists (BAL) on the sequencer nodes.
+    #[arg(long)]
+    bal_enabled: bool,
+
     /// Disable the containerized L1 dependency.
     #[arg(long)]
     no_l1: bool,
@@ -196,6 +200,7 @@ async fn up(args: UpArgs) -> Result<()> {
         .observability(observability)
         .hardforks(hardforks)
         .flashblocks(!args.no_flashblocks)
+        .flashblocks_access_list(args.bal_enabled)
         .block_time(Duration::from_millis(args.block_time_ms))
         .port_mode(if args.stable_ports {
             DevnetPortMode::Stable
@@ -221,6 +226,7 @@ async fn up(args: UpArgs) -> Result<()> {
         preset = ?args.preset,
         block_time_ms = args.block_time_ms,
         flashblocks = !args.no_flashblocks,
+        bal_enabled = args.bal_enabled,
         stable_ports = args.stable_ports,
         l1 = !args.no_l1,
         observability = !args.no_observability && (args.observability || preset == WorldDevnetPreset::HaSequencer),
@@ -356,6 +362,9 @@ fn background_args(args: &UpArgs) -> Vec<String> {
     }
     if args.no_flashblocks {
         argv.push("--no-flashblocks".to_string());
+    }
+    if args.bal_enabled {
+        argv.push("--bal-enabled".to_string());
     }
     if args.no_l1 {
         argv.push("--no-l1".to_string());

--- a/xtask/src/devnet.rs
+++ b/xtask/src/devnet.rs
@@ -57,6 +57,19 @@ struct UpArgs {
     #[arg(long)]
     bal_enabled: bool,
 
+    /// Automatically run a Contender stress test against the live nodes once
+    /// the devnet is ready. The devnet keeps running until Ctrl-C.
+    #[arg(long)]
+    stress: bool,
+
+    /// Target transactions per second for the automated stress run.
+    #[arg(long, default_value_t = 50, requires = "stress")]
+    stress_tps: u64,
+
+    /// Duration in seconds to sustain the automated stress run.
+    #[arg(long, default_value_t = 60, requires = "stress")]
+    stress_duration: u64,
+
     /// Disable the containerized L1 dependency.
     #[arg(long)]
     no_l1: bool,
@@ -227,6 +240,7 @@ async fn up(args: UpArgs) -> Result<()> {
         block_time_ms = args.block_time_ms,
         flashblocks = !args.no_flashblocks,
         bal_enabled = args.bal_enabled,
+        stress = args.stress,
         stable_ports = args.stable_ports,
         l1 = !args.no_l1,
         observability = !args.no_observability && (args.observability || preset == WorldDevnetPreset::HaSequencer),
@@ -247,6 +261,14 @@ async fn up(args: UpArgs) -> Result<()> {
     };
     write_endpoints_file(&devnet, &devnet_endpoints_path())?;
 
+    let stress_task = args.stress.then(|| {
+        spawn_stress_run(
+            devnet.sequencer_rpc_url(),
+            args.stress_tps,
+            args.stress_duration,
+        )
+    });
+
     let signal_task = tokio::spawn(async move {
         match ctrl_c.await {
             Ok(()) => {
@@ -258,7 +280,54 @@ async fn up(args: UpArgs) -> Result<()> {
 
     let result = devnet.run_until_shutdown(shutdown_rx).await;
     signal_task.abort();
+    if let Some(task) = stress_task {
+        // Dropping the join handle's future kills the stress child via
+        // `kill_on_drop` if it is still running.
+        task.abort();
+    }
     result
+}
+
+/// Spawn a background task that drives `scripts/stress/stress.sh` against the
+/// live devnet. The script is responsible for `contender setup` + `spam`; we
+/// just point it at the primary sequencer and pass the rate/duration through.
+fn spawn_stress_run(rpc_url: String, tps: u64, duration: u64) -> tokio::task::JoinHandle<()> {
+    let script = stress_script_path();
+    tokio::spawn(async move {
+        info!(
+            rpc_url = %rpc_url,
+            tps,
+            duration_secs = duration,
+            script = %script.display(),
+            "starting automated stress run against live devnet"
+        );
+
+        let status = tokio::process::Command::new("bash")
+            .arg(&script)
+            .arg("stress")
+            .env("RPC_URL", &rpc_url)
+            .env("TPS", tps.to_string())
+            .env("DURATION", duration.to_string())
+            .kill_on_drop(true)
+            .status()
+            .await;
+
+        match status {
+            Ok(status) if status.success() => info!("automated stress run completed"),
+            Ok(status) => warn!(
+                ?status,
+                "automated stress run exited with a non-zero status"
+            ),
+            Err(err) => warn!(
+                %err,
+                "failed to launch automated stress run; is `contender` installed and on PATH?"
+            ),
+        }
+    })
+}
+
+fn stress_script_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../scripts/stress/stress.sh")
 }
 
 async fn spawn_background(args: UpArgs) -> Result<()> {
@@ -365,6 +434,13 @@ fn background_args(args: &UpArgs) -> Vec<String> {
     }
     if args.bal_enabled {
         argv.push("--bal-enabled".to_string());
+    }
+    if args.stress {
+        argv.push("--stress".to_string());
+        argv.push("--stress-tps".to_string());
+        argv.push(args.stress_tps.to_string());
+        argv.push("--stress-duration".to_string());
+        argv.push(args.stress_duration.to_string());
     }
     if args.no_l1 {
         argv.push("--no-l1".to_string());

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -7,6 +7,7 @@ use tracing::{
     field::{Field, Visit},
 };
 use tracing_subscriber::{
+    Layer,
     fmt::{FmtContext, FormatEvent, FormatFields, format::Writer},
     layer::SubscriberExt,
     registry::LookupSpan,
@@ -69,11 +70,33 @@ async fn main() -> eyre::Result<()> {
     }
 }
 
+/// Tracing targets used for the auxiliary devnet services, i.e. everything that
+/// is not a World Chain execution node. These are suppressed on stdout so the
+/// main terminal only shows the World Chain nodes (and the devnet harness's own
+/// lifecycle), but they are still written to the devnet log file for debugging.
+///
+/// Set `DEVNET_LOG_ALL=1` to keep these on stdout as well.
+const AUX_SERVICE_TARGETS: &[&str] = &[
+    "l1_dev_chain",
+    "op_deployer",
+    "op_node",
+    "op_conductor",
+    "op_batcher",
+    "op_proposer",
+    "op_challenger",
+    "op_stack_service",
+    "prometheus",
+    "grafana",
+];
+
+fn devnet_env_filter() -> tracing_subscriber::EnvFilter {
+    tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"))
+}
+
 fn init_devnet_tracing(
     reset_log: bool,
 ) -> eyre::Result<tracing_appender::non_blocking::WorkerGuard> {
-    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
     let log_path = devnet_log_path();
     if let Some(parent) = log_path.parent() {
         std::fs::create_dir_all(parent)
@@ -90,16 +113,31 @@ fn init_devnet_tracing(
         .wrap_err_with(|| format!("failed to open {}", log_path.display()))?;
     let (file_writer, guard) = tracing_appender::non_blocking(file);
 
+    // The file keeps the full firehose; stdout is filtered down to the World
+    // Chain nodes unless DEVNET_LOG_ALL is set.
+    let file_filter = devnet_env_filter();
+    let mut stdout_filter = devnet_env_filter();
+    if std::env::var_os("DEVNET_LOG_ALL").is_none() {
+        for target in AUX_SERVICE_TARGETS {
+            stdout_filter = stdout_filter.add_directive(
+                format!("{target}=off")
+                    .parse()
+                    .expect("valid tracing directive"),
+            );
+        }
+    }
+
     let stdout_layer = tracing_subscriber::fmt::layer()
         .event_format(DevnetLogFormatter)
-        .with_ansi(true);
+        .with_ansi(true)
+        .with_filter(stdout_filter);
     let file_layer = tracing_subscriber::fmt::layer()
         .event_format(DevnetLogFormatter)
         .with_ansi(false)
-        .with_writer(file_writer);
+        .with_writer(file_writer)
+        .with_filter(file_filter);
 
     tracing_subscriber::registry()
-        .with(env_filter)
         .with(stdout_layer)
         .with(file_layer)
         .init();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Devnet and test wiring only; BAL stays disabled by default for devnet runs, with no auth or production deployment changes.
> 
> **Overview**
> Adds an **opt-in** path to turn on flashblocks **block access lists (BAL)** when running the native devnet, instead of always hard-coding BAL on in test configs only.
> 
> **Devnet / CLI:** `WorldDevnetBuilder` gains `flashblocks_access_list` (default **off**). HA full-stack startup threads that flag into native sequencer args as `--flashblocks.access-list` when enabled. `xtask devnet` exposes `--bal-enabled`; `just devnet` can pass it via **`BAL=1`**.
> 
> **Tests:** In-process harness setup plumbs a single `access_list` toggle through `WorldChainTestBuilder` into flashblocks args and `bal_enabled` on the payload builder config (replacing always-on BAL in `test_config_with_peers_and_gossip`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a631f3945c9fa0cfbb393bd7416d63196ff3a4a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->