### PR TITLE
feat: integrate proposer into devnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13972,8 +13972,10 @@ dependencies = [
  "alloy-eips 2.0.4",
  "alloy-genesis",
  "alloy-hardforks",
+ "alloy-network 2.0.4",
  "alloy-primitives",
  "alloy-provider 2.0.4",
+ "alloy-signer-local",
  "base64 0.22.1",
  "color-eyre",
  "ed25519-dalek",
@@ -14002,6 +14004,7 @@ dependencies = [
  "world-chain-node",
  "world-chain-primitives",
  "world-chain-proofs",
+ "world-chain-proposer",
  "world-chain-rpc",
  "world-chain-test-utils",
 ]

--- a/crates/devnet/Cargo.toml
+++ b/crates/devnet/Cargo.toml
@@ -15,6 +15,7 @@ world-chain-chainspec.workspace = true
 world-chain-node.workspace = true
 world-chain-primitives.workspace = true
 world-chain-proofs.workspace = true
+world-chain-proposer.workspace = true
 world-chain-rpc.workspace = true
 world-chain-test-utils.workspace = true
 
@@ -22,7 +23,9 @@ alloy-provider.workspace = true
 alloy-eips.workspace = true
 alloy-genesis.workspace = true
 alloy-hardforks.workspace = true
+alloy-network.workspace = true
 alloy-primitives.workspace = true
+alloy-signer-local.workspace = true
 
 base64.workspace = true
 ed25519-dalek.workspace = true

--- a/crates/devnet/src/component.rs
+++ b/crates/devnet/src/component.rs
@@ -57,6 +57,8 @@ pub enum DevnetComponentKind {
     WorldContractsDeployer,
     /// World Chain WIP-1006 proof-system contracts on L1.
     WorldProofSystem,
+    /// World Chain WIP-1006 proof-system proposer.
+    WorldChainProposer,
     /// Flashblocks capability on the World Chain execution node.
     Flashblocks,
     /// Deprecated/removed legacy component.
@@ -79,6 +81,7 @@ impl DevnetComponentKind {
             Self::Grafana => "grafana",
             Self::WorldContractsDeployer => "world-contracts-deployer",
             Self::WorldProofSystem => "world-proof-system",
+            Self::WorldChainProposer => "world-chain-proposer",
             Self::Flashblocks => "flashblocks",
             Self::RemovedLegacyService => "removed-legacy-service",
         }

--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -9,8 +9,10 @@ use std::{
 
 use alloy_eips::{BlockNumberOrTag, eip1559::BaseFeeParams};
 use alloy_genesis::Genesis;
-use alloy_primitives::{B64, hex, keccak256};
+use alloy_network::EthereumWallet;
+use alloy_primitives::{Address, B64, U256, hex, keccak256};
 use alloy_provider::{Provider, ProviderBuilder};
+use alloy_signer_local::PrivateKeySigner;
 use base64::prelude::{BASE64_STANDARD, Engine};
 use eyre::eyre::{Context, Result, bail, eyre};
 use flate2::read::GzDecoder;
@@ -33,10 +35,13 @@ use tokio::{
     process::{Child, Command},
     task::JoinHandle,
 };
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 use url::{Host, Url};
 use world_chain_chainspec::{WorldChainHardfork, WorldChainSpec};
 use world_chain_proofs::{PROOF_SYSTEM_VERSION, PROOF_THRESHOLD};
+use world_chain_proposer::{
+    AlloyProofSystemClient, OptimismOutputRootClient, ProposerConfig, WorldChainProposer,
+};
 use world_chain_test_utils::DEV_CHAIN_ID;
 
 use crate::{
@@ -65,6 +70,11 @@ const SERVICE_RPC_PORT: u16 = 8545;
 const SERVICE_METRICS_PORT: u16 = 7300;
 const PROOF_SYSTEM_BLOCK_INTERVAL: u64 = 10;
 const PROOF_SYSTEM_INTERMEDIATE_BLOCK_INTERVAL: u64 = 5;
+/// Bond, in wei, sent with every `WorldChainProofSystemFactory.propose`.
+/// Matches `PROPOSER_BOND` (1 ether) in `scripts/devnet/DeployProofSystem.s.sol`.
+const WORLD_PROPOSER_BOND_WEI: u128 = 1_000_000_000_000_000_000;
+/// Delay between World Chain proof-system proposal attempts.
+const WORLD_PROPOSER_POLL_INTERVAL: Duration = Duration::from_secs(2);
 
 const DEVNET_PRIVATE_KEY: &str =
     "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
@@ -95,6 +105,7 @@ pub struct FullStackWorldDevnet {
     _proposer: Option<ContainerService>,
     _challenger: Option<ContainerService>,
     _proof_system: Option<WorldProofSystemDeployment>,
+    _world_proposer: Option<ProposerTask>,
     _conductors: Vec<ConductorService>,
     _op_nodes: Vec<OpNodeService>,
     sequencers: Vec<SequencerService>,
@@ -198,6 +209,18 @@ struct WorldProofSystemDeployment {
     proof_system_version: u64,
     block_interval: u64,
     intermediate_block_interval: u64,
+}
+
+/// In-process World Chain proof-system proposer task. Aborted on devnet drop.
+#[derive(Debug)]
+struct ProposerTask {
+    handle: JoinHandle<()>,
+}
+
+impl Drop for ProposerTask {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
 }
 
 #[derive(Debug)]
@@ -412,6 +435,18 @@ impl FullStackWorldDevnet {
             (Some(batcher), Some(proposer), None)
         };
 
+        let world_proposer = if let Some(deployment) = proof_system.as_ref() {
+            let output_root_rpc = op_nodes
+                .first()
+                .map(|node| node.rpc_url.clone())
+                .ok_or_else(|| {
+                    eyre!("full-stack devnet has no op-node for the World Chain proposer")
+                })?;
+            Some(start_world_chain_proposer(&l1_public_rpc, &output_root_rpc, deployment).await?)
+        } else {
+            None
+        };
+
         let mut metrics_targets = Vec::new();
         metrics_targets.extend(
             sequencers
@@ -458,6 +493,7 @@ impl FullStackWorldDevnet {
             _proposer: proposer,
             _challenger: challenger,
             _proof_system: proof_system,
+            _world_proposer: world_proposer,
             _conductors: conductors,
             _op_nodes: op_nodes,
             sequencers,
@@ -2103,6 +2139,62 @@ async fn start_challenger(
     .await
 }
 
+/// Spawns the in-process World Chain proof-system proposer.
+///
+/// The proposer signs with the dev proposer key (Anvil account #1), which
+/// `DeployProofSystem.s.sol` stakes in the `MockStakingRegistry` and funds via
+/// `fundDevAccounts`. Output roots are read from the op-node rollup RPC and
+/// proposals are submitted to `WorldChainProofSystemFactory.propose` on L1.
+async fn start_world_chain_proposer(
+    l1_rpc_url: &str,
+    output_root_rpc_url: &str,
+    deployment: &WorldProofSystemDeployment,
+) -> Result<ProposerTask> {
+    let factory_address: Address = deployment
+        .proof_system_factory
+        .parse()
+        .wrap_err("invalid proof-system factory address")?;
+    let anchor_address: Address = deployment
+        .anchor_state_registry
+        .parse()
+        .wrap_err("invalid anchor-state-registry address")?;
+
+    let signer: PrivateKeySigner = DEVNET_PRIVATE_KEY
+        .parse()
+        .wrap_err("invalid World Chain proposer signing key")?;
+    let proposer_address = signer.address();
+    let provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(signer))
+        .connect_http(Url::parse(l1_rpc_url)?);
+
+    let contracts = AlloyProofSystemClient::new(provider, factory_address, anchor_address);
+    let output_roots = OptimismOutputRootClient::new(output_root_rpc_url.to_string());
+    let config = ProposerConfig {
+        block_interval: deployment.block_interval,
+        proposer_bond: U256::from(WORLD_PROPOSER_BOND_WEI),
+        poll_interval: WORLD_PROPOSER_POLL_INTERVAL,
+    };
+    let proposer = WorldChainProposer::new(config, contracts, output_roots);
+
+    info!(
+        l1_rpc_url,
+        output_root_rpc_url,
+        factory = %deployment.proof_system_factory,
+        anchor = %deployment.anchor_state_registry,
+        proposer = %proposer_address,
+        block_interval = deployment.block_interval,
+        "starting native World Chain proof-system proposer"
+    );
+
+    let handle = tokio::spawn(async move {
+        if let Err(error) = proposer.run_forever().await {
+            warn!(%error, "World Chain proof-system proposer stopped");
+        }
+    });
+
+    Ok(ProposerTask { handle })
+}
+
 async fn start_aux_service(
     id: &str,
     kind: DevnetComponentKind,
@@ -2482,6 +2574,20 @@ fn build_components(
                 "rollup_config_hash={}",
                 deployment.rollup_config_hash
             )),
+        );
+        components.push(
+            DevnetComponent::new(
+                "world-chain-proposer",
+                DevnetComponentKind::WorldChainProposer,
+                DevnetComponentStatus::Running,
+            )
+            .with_endpoint("factory", deployment.proof_system_factory.clone())
+            .with_endpoint("anchor", deployment.anchor_state_registry.clone())
+            .with_note(format!(
+                "native in-process proposer posting OP output roots every {} L2 blocks via WorldChainProofSystemFactory.propose",
+                deployment.block_interval
+            ))
+            .with_note("signs with the dev proposer key staked in the MockStakingRegistry"),
         );
     }
 

--- a/crates/devnet/src/op_stack.rs
+++ b/crates/devnet/src/op_stack.rs
@@ -425,6 +425,14 @@ impl HaSequencerTopology {
                 )
                 .with_note("deploys WIP-1006 proof-system contracts to the local L1"),
             );
+            components.push(
+                DevnetComponent::new(
+                    "world-chain-proposer",
+                    DevnetComponentKind::WorldChainProposer,
+                    DevnetComponentStatus::Planned,
+                )
+                .with_note("native proposer posting OP output roots to the WIP-1006 proof system"),
+            );
         }
 
         let challenger_config = config.op_challenger.then(OpChallengerConfig::local);
@@ -536,6 +544,7 @@ mod tests {
         assert_eq!(count(DevnetComponentKind::Grafana), 1);
         assert_eq!(count(DevnetComponentKind::WorldContractsDeployer), 1);
         assert_eq!(count(DevnetComponentKind::WorldProofSystem), 1);
+        assert_eq!(count(DevnetComponentKind::WorldChainProposer), 1);
         assert!(topology.components.iter().any(|component| component.kind
             == DevnetComponentKind::WorldContractsDeployer
             && component.status == DevnetComponentStatus::Planned));


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches L1 proposal/finality and devnet defaults (Forge deploy, funded dev keys); scoped to local devnet and mocks, not production mainnet paths yet.
> 
> **Overview**
> Adds **WIP-1006** end-to-end: new `world-chain-proofs` (domain hashing, `proposalKey`/`rootId`, lane bitmaps, Alloy bindings) and `world-chain-proposer` (walks anchor → existing games, fetches `optimism_outputAtBlock`, submits `WorldChainProofSystemFactory.propose` with bond).
> 
> On **L1 contracts**, introduces anchor registry, proof factory/game, mock verifiers/staking, `DeployProofSystem.s.sol`, and Foundry tests. **WIP-1006** doc is updated to separate `proposalKey` (factory lookup) from `rootId` (proof-bound, includes L1 origin).
> 
> The **native HA devnet** now defaults to deploying that suite via Forge and running an in-process proposer (`WorldProofSystem` / `WorldChainProposer` components); opt out with `--no-proof-system` / `xtask` flag. `WorldContractsDeploymentConfig` gains `proof_system: true` by default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 057b46381356a54096f438b62a71430e3334aaf8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->