### PR TITLE
fix: dockerfile

### DIFF
--- a/Dockerfile.proof
+++ b/Dockerfile.proof
@@ -8,9 +8,11 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
   cargo install --locked sccache --version ^0.9 \
   && cargo install --locked cargo-chef --version ^0.1
 
-# clang/llvm for C deps; protobuf-compiler for the sp1-sdk `network` (gRPC) client.
+# clang/llvm for C deps; protobuf-compiler + libprotobuf-dev for the sp1-sdk `network`
+# (gRPC) client — libprotobuf-dev provides the well-known type .proto files
+# (google/protobuf/*.proto) under /usr/include that protoc resolves imports against.
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends clang libclang-dev gcc curl protobuf-compiler \
+  && apt-get install -y --no-install-recommends clang libclang-dev gcc curl protobuf-compiler libprotobuf-dev \
   && rm -rf /var/lib/apt/lists/*
 
 ENV CARGO_HOME=/usr/local/cargo \


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Build-only dependency change for the proof Docker image; no runtime application or security logic affected.
> 
> **Overview**
> Updates **`Dockerfile.proof`** so the prover image build can compile protobuf/gRPC code for the sp1-sdk **`network`** feature.
> 
> The base stage now installs **`libprotobuf-dev`** alongside **`protobuf-compiler`**, supplying standard **`google/protobuf/*.proto`** headers under `/usr/include` that **`protoc`** needs when resolving imports. Comments in the Dockerfile explain why both packages are required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1251135987492dcad7bd31c4358ad3d9ef2dace9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->