### PR TITLE
fix(nitro): gate linux-only deps on target os

### DIFF
--- a/proofs/bin/Cargo.toml
+++ b/proofs/bin/Cargo.toml
@@ -31,11 +31,13 @@ world-chain-proof-protocol.workspace = true
 world-chain-proof-succinct-client-utils.workspace = true
 world-chain-proof-succinct-ethereum-client-utils.workspace = true
 world-chain-proof-succinct-host-utils.workspace = true
-world-chain-proof-nitro = { workspace = true, optional = true }
 alloy-consensus = { workspace = true, features = ["serde"], optional = true }
 bincode = { version = "1", optional = true }
 serde_cbor = { version = "0.11", optional = true }
 sp1-sdk = { version = "=6.1.0", features = ["network"], optional = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+world-chain-proof-nitro = { workspace = true, optional = true }
 
 [features]
 default = []

--- a/proofs/bin/src/main.rs
+++ b/proofs/bin/src/main.rs
@@ -78,7 +78,7 @@ enum Command {
     /// Build and write the witness to a file without proving.
     Witness(WitnessArgs),
     /// AWS Nitro TEE proving.
-    #[cfg(feature = "nitro")]
+    #[cfg(all(feature = "nitro", target_os = "linux"))]
     Nitro {
         #[command(subcommand)]
         command: NitroCommand,
@@ -91,7 +91,7 @@ enum Command {
     },
 }
 
-#[cfg(feature = "nitro")]
+#[cfg(all(feature = "nitro", target_os = "linux"))]
 #[derive(Debug, Subcommand)]
 enum NitroCommand {
     /// Generate witness and send to a running Nitro enclave for attested proving.
@@ -175,7 +175,7 @@ struct WitnessArgs {
     output: PathBuf,
 }
 
-#[cfg(feature = "nitro")]
+#[cfg(all(feature = "nitro", target_os = "linux"))]
 #[derive(Debug, Args)]
 struct NitroArgs {
     #[command(flatten)]
@@ -376,7 +376,7 @@ fn main() -> eyre::Result<()> {
             println!("witness bytes: {}", args.output.display());
             println!("metadata:      {}", metadata_path.display());
         }
-        #[cfg(feature = "nitro")]
+        #[cfg(all(feature = "nitro", target_os = "linux"))]
         Command::Nitro { command } => match command {
             NitroCommand::Prove(args) => nitro_prove(args)?,
         },
@@ -390,7 +390,7 @@ fn main() -> eyre::Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "nitro")]
+#[cfg(all(feature = "nitro", target_os = "linux"))]
 fn nitro_prove(args: NitroArgs) -> eyre::Result<()> {
     use world_chain_proof_nitro::{
         ExpectedPcrs, NitroRangeProofRequest,
@@ -468,7 +468,7 @@ fn nitro_prove(args: NitroArgs) -> eyre::Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "nitro")]
+#[cfg(all(feature = "nitro", target_os = "linux"))]
 fn hex_to_pcr(hex: &str) -> eyre::Result<[u8; 48]> {
     let bytes = hex::decode(hex).context("invalid PCR hex")?;
     bytes.try_into().map_err(|_| eyre!("PCR must be 48 bytes"))

--- a/proofs/nitro/Cargo.toml
+++ b/proofs/nitro/Cargo.toml
@@ -53,16 +53,24 @@ serde = { workspace = true, features = ["derive"] }
 sha2.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
-tokio-vsock = { version = "0.5", optional = true }
 tracing.workspace = true
 world-chain-proof-core.workspace = true
 
-# Enclave-only (gated by the `enclave` feature) -----------------------------
+# Linux-only host/enclave deps ----------------------------------------------
+#
+# Cargo features are target-independent, so `--all-features` on macOS still
+# enables `aws_nitro`/`enclave`. Keeping the platform-specific crates in this
+# target table prevents Cargo from trying to compile AF_VSOCK/NSM deps on
+# non-Linux hosts.
+[target.'cfg(target_os = "linux")'.dependencies]
+tokio-vsock = { version = "0.5", optional = true }
 aws-nitro-enclaves-nsm-api = { version = "0.4", optional = true }
 kona-proof = { workspace = true, optional = true }
 serde_bytes = { version = "0.11", optional = true }
 world-chain-proof-succinct-client-utils = { workspace = true, optional = true }
 world-chain-proof-succinct-ethereum-client-utils = { workspace = true, optional = true }
+
+# Feature-gated bin support -------------------------------------------------
 tracing-subscriber = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/proofs/nitro/src/bin/test_attestation.rs
+++ b/proofs/nitro/src/bin/test_attestation.rs
@@ -1,8 +1,11 @@
+#[cfg(target_os = "linux")]
 use anyhow::Context;
+#[cfg(target_os = "linux")]
 use world_chain_proof_core::{
     range::WorldRangeHardforkConfig,
     witness::{BlobData, WorldRangeWitnessData, preimage_store::PreimageStore},
 };
+#[cfg(target_os = "linux")]
 use world_chain_proof_nitro::{
     ExpectedPcrs, NitroRangeProofRequest,
     attestation::parse_and_check_pcrs,
@@ -10,6 +13,7 @@ use world_chain_proof_nitro::{
     protocol::range_user_data,
 };
 
+#[cfg(target_os = "linux")]
 fn hex_to_pcr(hex: &str) -> anyhow::Result<[u8; 48]> {
     let bytes = hex::decode(hex).context("invalid hex")?;
     bytes
@@ -17,6 +21,7 @@ fn hex_to_pcr(hex: &str) -> anyhow::Result<[u8; 48]> {
         .map_err(|_| anyhow::anyhow!("PCR must be 48 bytes"))
 }
 
+#[cfg(target_os = "linux")]
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
@@ -67,4 +72,9 @@ async fn main() -> anyhow::Result<()> {
 
     tracing::info!("attestation verified OK");
     Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("test-attestation is only supported on Linux");
 }

--- a/proofs/nitro/src/enclave.rs
+++ b/proofs/nitro/src/enclave.rs
@@ -17,10 +17,14 @@
 
 #![cfg(feature = "enclave-bin")]
 
+#[cfg(target_os = "linux")]
 use anyhow::Result;
+#[cfg(target_os = "linux")]
 use tracing_subscriber::EnvFilter;
+#[cfg(target_os = "linux")]
 use world_chain_proof_nitro::enclave_lib;
 
+#[cfg(target_os = "linux")]
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt()
@@ -32,4 +36,9 @@ async fn main() -> Result<()> {
         .init();
 
     enclave_lib::main_entry().await
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("world-chain-nitro-enclave is only supported on Linux");
 }

--- a/proofs/nitro/src/lib.rs
+++ b/proofs/nitro/src/lib.rs
@@ -39,19 +39,22 @@ use tracing as _;
 // `tracing-subscriber` is only used by the `enclave`/`test-attestation` bins, not the
 // lib; bind it here under the features that pull it in so the lib target doesn't trip
 // `unused_crate_dependencies`.
-#[cfg(any(feature = "aws_nitro", feature = "enclave-bin"))]
+#[cfg(all(
+    any(feature = "aws_nitro", feature = "enclave-bin"),
+    target_os = "linux"
+))]
 use tracing_subscriber as _;
 
 pub mod attestation;
 
-#[cfg(feature = "aws_nitro")]
+#[cfg(all(feature = "aws_nitro", target_os = "linux"))]
 pub mod host;
 pub mod protocol;
 
-#[cfg(feature = "enclave")]
+#[cfg(all(feature = "enclave", target_os = "linux"))]
 pub mod enclave_lib;
 
-#[cfg(feature = "aws_nitro")]
+#[cfg(all(feature = "aws_nitro", target_os = "linux"))]
 pub use host::{NitroProver, NitroProverError};
 
 /// Length, in bytes, of a Nitro PCR slot value (SHA-384 digest).
@@ -188,7 +191,7 @@ pub mod prelude {
         ExpectedPcrs, NitroAggregationProofArtifact, NitroAggregationProofRequest,
         NitroRangeProofArtifact, NitroRangeProofRequest, WorldTeeProver, range_user_data,
     };
-    #[cfg(feature = "aws_nitro")]
+    #[cfg(all(feature = "aws_nitro", target_os = "linux"))]
     pub use crate::{NitroProver, NitroProverError};
 }
 


### PR DESCRIPTION
### Problem

`just clippy` fails on macOS when `--all-features` enables Nitro features because Linux-only vsock dependencies are compiled on non-Linux targets.

You get errors like this:

```
error[E0432]: unresolved imports `libc::accept4`, `libc::SOCK_CLOEXEC`
  --> /Users/alessandro.mazza/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/vsock-0.4.0/src/lib.rs:21:5
   |
21 |     accept4, ioctl, sa_family_t, sockaddr, sockaddr_vm, socklen_t, suseconds_t, timeval, AF_VSOCK,
   |     ^^^^^^^ no `accept4` in the root
22 |     FIONBIO, SOCK_CLOEXEC,
   |              ^^^^^^^^^^^^ no `SOCK_CLOEXEC` in the root
   |
help: a similar name exists in the module
   |
21 -     accept4, ioctl, sa_family_t, sockaddr, sockaddr_vm, socklen_t, suseconds_t, timeval, AF_VSOCK,
21 +     accept, ioctl, sa_family_t, sockaddr, sockaddr_vm, socklen_t, suseconds_t, timeval, AF_VSOCK,
   |
help: a similar name exists in the module
   |
22 -     FIONBIO, SOCK_CLOEXEC,
22 +     FIONBIO, O_CLOEXEC,
   |

error[E0432]: unresolved import `libc::VMADDR_CID_LOCAL`
  --> /Users/alessandro.mazza/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/vsock-0.4.0/src/lib.rs:42:72
   |
42 | pub use libc::{VMADDR_CID_ANY, VMADDR_CID_HOST, VMADDR_CID_HYPERVISOR, VMADDR_CID_LOCAL};
   |                                                                        ^^^^^^^^^^^^^^^^ no `VMADDR_CID_LOCAL` in the root
   |
help: a similar name exists in the module
   |
42 - pub use libc::{VMADDR_CID_ANY, VMADDR_CID_HOST, VMADDR_CID_HYPERVISOR, VMADDR_CID_LOCAL};
42 + pub use libc::{VMADDR_CID_ANY, VMADDR_CID_HOST, VMADDR_CID_HYPERVISOR, VMADDR_CID_HOST};
   |

error[E0599]: no associated function or constant named `SOCK_CLOEXEC` found for struct `SockFlag` in the current scope
  --> /Users/alessandro.mazza/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/vsock-0.4.0/src/lib.rs:49:19
   |
49 |         SockFlag::SOCK_CLOEXEC,
   |                   ^^^^^^^^^^^^ associated function or constant not found in `SockFlag`

error[E0560]: struct `sockaddr_vm` has no field named `svm_zero`
   --> /Users/alessandro.mazza/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/vsock-0.4.0/src/lib.rs:118:13
    |
118 |             svm_zero: [0u8; 4],
    |             ^^^^^^^^ `sockaddr_vm` does not have this field
    |
    = note: available fields are: `svm_len`

error[E0599]: no associated function or constant named `MSG_NOSIGNAL` found for struct `MsgFlags` in the current scope
   --> /Users/alessandro.mazza/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/vsock-0.4.0/src/lib.rs:334:57
    |
334 |         Ok(send(self.socket.as_raw_fd(), buf, MsgFlags::MSG_NOSIGNAL)?)
    |                                                         ^^^^^^^^^^^^ associated function or constant not found in `MsgFlags`

Some errors have detailed explanations: E0432, E0560, E0599.
For more information about an error, try `rustc --explain E0432`.
error: could not compile `vsock` (lib) due to 5 previous errors
warning: build failed, waiting for other jobs to finish...
error: recipe `clippy` failed on line 34 with exit code 101
```

### Solution

Move Nitro vsock/enclave dependencies behind Linux target-specific dependency sections and gate Nitro host/enclave modules, exports, binaries, and CLI commands with `target_os = "linux"`.