### PR TITLE
Add Docker Image CI workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)


### PR DESCRIPTION
How to make me richer ohhh..?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that runs a local `docker build`; no runtime, auth, or deployment behavior is modified.
> 
> **Overview**
> Adds a new GitHub Actions workflow **Docker Image CI** that runs on pushes and pull requests targeting `main`.
> 
> The job checks out the repo on `ubuntu-latest` and runs `docker build` against the root `Dockerfile`, tagging the result as `my-image-name:<unix timestamp>`. It does **not** push to a registry or reuse the existing `docker-proof` / `docker-build-push-digest` composite actions—it's a standalone build-only smoke check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0b76e129ca66dbfd691bb425c5018a61e2a9bf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->