### PR TITLE
feat(challenger): add L2 finality gate

### DIFF
--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -39,7 +39,7 @@ use tracing::{Instrument, debug, info, info_span, warn};
 use url::{Host, Url};
 use world_chain_chainspec::{WorldChainHardfork, WorldChainSpec};
 use world_chain_challenger::{AlloyChallengerClient, ChallengerConfig, WorldChainChallenger};
-use world_chain_proofs::{OptimismOutputRootClient, PROOF_SYSTEM_VERSION, PROOF_THRESHOLD};
+use world_chain_proofs::{OptimismConsensusClient, PROOF_SYSTEM_VERSION, PROOF_THRESHOLD};
 use world_chain_proposer::{AlloyProofSystemClient, ProposerConfig, WorldChainProposer};
 use world_chain_test_utils::DEV_CHAIN_ID;
 
@@ -2249,7 +2249,7 @@ async fn start_world_chain_proposer(
         .connect_http(Url::parse(l1_rpc_url)?);
 
     let contracts = AlloyProofSystemClient::new(provider, factory_address, anchor_address);
-    let output_roots = OptimismOutputRootClient::new(output_root_rpc_url.to_string());
+    let output_roots = OptimismConsensusClient::new(output_root_rpc_url.to_string());
     let config = ProposerConfig {
         block_interval: deployment.block_interval,
         proposer_bond: U256::from(WORLD_PROPOSER_BOND_WEI),
@@ -2309,7 +2309,7 @@ async fn start_world_chain_challenger(
         .connect_http(Url::parse(l1_rpc_url)?);
 
     let client = AlloyChallengerClient::new(provider, factory_address);
-    let output_roots = OptimismOutputRootClient::new(output_root_rpc_url.to_string());
+    let output_roots = OptimismConsensusClient::new(output_root_rpc_url.to_string());
     let config = ChallengerConfig {
         challenger_bond: U256::from(WORLD_CHALLENGER_BOND_WEI),
         factory_contract: factory_address,

--- a/proofs/challenger/src/alloy.rs
+++ b/proofs/challenger/src/alloy.rs
@@ -57,7 +57,7 @@ where
             .await
             .map_err(|err| ChallengerError::Rpc(err.to_string()))?
             .map(|block| block.number())
-            .ok_or(ChallengerError::L1FinalizedBlockNotFound())
+            .ok_or(ChallengerError::L1FinalizedBlockNotFound)
     }
 
     async fn games_created(

--- a/proofs/challenger/src/challenger.rs
+++ b/proofs/challenger/src/challenger.rs
@@ -4,7 +4,7 @@ use crate::{
 use alloy_primitives::BlockNumber;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::warn;
-use world_chain_proofs::OutputRootProvider;
+use world_chain_proofs::ConsensusProvider;
 
 /// The number of L1 blocks published in 24h.
 const ONE_DAY_OF_L1_BLOCKS: u64 = 7_200;
@@ -41,7 +41,7 @@ impl<P, O> WorldChainChallenger<P, O> {
 impl<P, O> WorldChainChallenger<P, O>
 where
     P: ChallengerClient,
-    O: OutputRootProvider,
+    O: ConsensusProvider,
 {
     pub async fn scan_once(&mut self) -> Result<(), ChallengerError> {
         let target = self.provider.finalized_l1_block_num().await?;

--- a/proofs/challenger/src/challenger.rs
+++ b/proofs/challenger/src/challenger.rs
@@ -59,8 +59,8 @@ where
         if from > target {
             return Ok(());
         }
-        let game_created = self.execution_provider.games_created(from, target).await?;
-        for game_created in game_created {
+        let games_created = self.execution_provider.games_created(from, target).await?;
+        for game_created in games_created {
             let game = game_created.game;
             let root_state = self.execution_provider.root_state(game).await?;
             if root_state != RootState::Proposed {

--- a/proofs/challenger/src/challenger.rs
+++ b/proofs/challenger/src/challenger.rs
@@ -13,20 +13,24 @@ const MARGIN: u64 = 500;
 
 /// World Chain Challenger.
 #[derive(Debug)]
-pub struct WorldChainChallenger<P, O> {
+pub struct WorldChainChallenger<E, C> {
     config: ChallengerConfig,
-    provider: P,
-    output_roots: O,
+    execution_provider: E,
+    consensus_provider: C,
     cursor: BlockNumber,
 }
 
-impl<P, O> WorldChainChallenger<P, O> {
+impl<E, C> WorldChainChallenger<E, C> {
     /// Creates a challenger from contract and output-root clients.
-    pub const fn new(config: ChallengerConfig, provider: P, output_roots: O) -> Self {
+    pub const fn new(
+        config: ChallengerConfig,
+        execution_provider: E,
+        consensus_provider: C,
+    ) -> Self {
         Self {
             config,
-            provider,
-            output_roots,
+            execution_provider,
+            consensus_provider,
             cursor: 0,
         }
     }
@@ -38,13 +42,13 @@ impl<P, O> WorldChainChallenger<P, O> {
     }
 }
 
-impl<P, O> WorldChainChallenger<P, O>
+impl<E, C> WorldChainChallenger<E, C>
 where
-    P: ChallengerClient,
-    O: ConsensusProvider,
+    E: ChallengerClient,
+    C: ConsensusProvider,
 {
     pub async fn scan_once(&mut self) -> Result<(), ChallengerError> {
-        let target = self.provider.finalized_l1_block_num().await?;
+        let target = self.execution_provider.finalized_l1_block_num().await?;
         let from = if self.cursor == 0 {
             target.saturating_sub(ONE_DAY_OF_L1_BLOCKS + MARGIN)
         } else {
@@ -55,15 +59,15 @@ where
         if from > target {
             return Ok(());
         }
-        let game_created = self.provider.games_created(from, target).await?;
+        let game_created = self.execution_provider.games_created(from, target).await?;
         for game_created in game_created {
             let game = game_created.game;
-            let root_state = self.provider.root_state(game).await?;
+            let root_state = self.execution_provider.root_state(game).await?;
             if root_state != RootState::Proposed {
                 // root state is not `Proposed` anymore, skip immediately
                 continue;
             }
-            let challenge_deadline = self.provider.challenge_deadline(game).await?;
+            let challenge_deadline = self.execution_provider.challenge_deadline(game).await?;
             let now = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .expect("system time before unix epoch")
@@ -73,15 +77,24 @@ where
                 // challenge deadline has expired, skip immediately
                 continue;
             }
-            // TODO finality gate on L2: ensure that the l2 block is finalized
+            // ensure that the l2 block is finalized
+            let latest_finalized_l2_block =
+                self.consensus_provider.latest_l2_finalized_block().await?;
+            if game_created.l2_block_number > latest_finalized_l2_block {
+                return Err(ChallengerError::L2BlockNotFinalized {
+                    game,
+                    latest_finalized: latest_finalized_l2_block,
+                    given_block: game_created.l2_block_number,
+                });
+            }
 
             match self
-                .output_roots
+                .consensus_provider
                 .output_root_at_block(game_created.l2_block_number)
                 .await
             {
                 Ok(root) if root != game_created.root_claim => {
-                    self.provider
+                    self.execution_provider
                         .submit_challenge(game, self.config.challenger_bond)
                         .await?;
                 }

--- a/proofs/challenger/src/error.rs
+++ b/proofs/challenger/src/error.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::TxHash;
+use alloy_primitives::{Address, TxHash};
 use thiserror::Error;
 use world_chain_proofs::ConsensusError;
 
@@ -28,5 +28,16 @@ pub enum ChallengerError {
     #[error("RPC error: {0}")]
     Rpc(String),
     #[error("Latest L1 finalized block not found")]
-    L1FinalizedBlockNotFound(),
+    L1FinalizedBlockNotFound,
+    #[error(
+        "L2 block included in the game {game} is not finalized yet. latest_finalized: {latest_finalized}, given_block: {given_block}"
+    )]
+    L2BlockNotFinalized {
+        /// Address of the game.
+        game: Address,
+        /// Latest L2 finalized block number.
+        latest_finalized: u64,
+        /// Block number included in the game.
+        given_block: u64,
+    },
 }

--- a/proofs/challenger/src/error.rs
+++ b/proofs/challenger/src/error.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::TxHash;
 use thiserror::Error;
-use world_chain_proofs::OutputRootError;
+use world_chain_proofs::ConsensusError;
 
 /// Errors returned by the proposer.
 #[derive(Debug, Error)]
@@ -20,7 +20,7 @@ pub enum ChallengerError {
     #[error("contract error: {0}")]
     Contract(String),
     #[error(transparent)]
-    OutputRoot(#[from] OutputRootError),
+    OutputRoot(#[from] ConsensusError),
     #[error("The challenge transaction didn't execute succesfully: {0}")]
     Revert(TxHash),
     #[error("Invalid root state: {0}")]

--- a/proofs/challenger/src/tests.rs
+++ b/proofs/challenger/src/tests.rs
@@ -85,6 +85,7 @@ impl ChallengerClient for MockClient {
 #[derive(Debug, Clone)]
 struct MockOutputRoots {
     roots: HashMap<u64, B256>,
+    finalized_l2_block: BlockNumber,
 }
 
 #[async_trait]
@@ -94,6 +95,10 @@ impl ConsensusProvider for MockOutputRoots {
             .get(&l2_block_number)
             .copied()
             .ok_or_else(|| ConsensusError::Rpc(format!("missing root for {l2_block_number}")))
+    }
+
+    async fn latest_l2_finalized_block(&self) -> Result<BlockNumber, ConsensusError> {
+        Ok(self.finalized_l2_block)
     }
 }
 
@@ -120,6 +125,7 @@ async fn scan_once_challenges_invalid_root() {
     };
     let output_roots = MockOutputRoots {
         roots: HashMap::from([(L2_BLOCK, canonical_root)]),
+        finalized_l2_block: L2_BLOCK,
     };
     let mut challenger = WorldChainChallenger::new(config(), client, output_roots);
 
@@ -145,6 +151,7 @@ async fn scan_once_leaves_valid_root() {
     };
     let output_roots = MockOutputRoots {
         roots: HashMap::from([(L2_BLOCK, canonical_root)]),
+        finalized_l2_block: L2_BLOCK,
     };
     let mut challenger = WorldChainChallenger::new(config(), client, output_roots);
 
@@ -168,6 +175,7 @@ async fn scan_once_skips_non_proposed_game() {
     };
     let output_roots = MockOutputRoots {
         roots: HashMap::from([(L2_BLOCK, canonical_root)]),
+        finalized_l2_block: L2_BLOCK,
     };
     let mut challenger = WorldChainChallenger::new(config(), client, output_roots);
 
@@ -191,10 +199,41 @@ async fn scan_once_skips_expired_challenge_deadline() {
     };
     let output_roots = MockOutputRoots {
         roots: HashMap::from([(L2_BLOCK, canonical_root)]),
+        finalized_l2_block: L2_BLOCK,
     };
     let mut challenger = WorldChainChallenger::new(config(), client, output_roots);
 
     challenger.scan_once().await.unwrap();
 
+    assert!(submissions.lock().expect("not poisoned").is_empty());
+}
+
+#[tokio::test]
+async fn scan_once_rejects_unfinalized_l2_block() {
+    let proposed_root = B256::repeat_byte(0x10);
+    let canonical_root = B256::repeat_byte(0x20);
+
+    let submissions = Arc::default();
+    let client = MockClient {
+        finalized: FINALIZED_L1_BLOCK,
+        games: vec![(GAME_1, proposed_root, L2_BLOCK)],
+        states: HashMap::new(),
+        deadlines: HashMap::new(),
+        submissions: Arc::clone(&submissions),
+    };
+    let output_roots = MockOutputRoots {
+        roots: HashMap::from([(L2_BLOCK, canonical_root)]),
+        finalized_l2_block: L2_BLOCK - 1,
+    };
+    let mut challenger = WorldChainChallenger::new(config(), client, output_roots);
+
+    assert!(matches!(
+        challenger.scan_once().await,
+        Err(ChallengerError::L2BlockNotFinalized {
+            game: GAME_1,
+            latest_finalized,
+            given_block: L2_BLOCK,
+        }) if latest_finalized == L2_BLOCK - 1
+    ));
     assert!(submissions.lock().expect("not poisoned").is_empty());
 }

--- a/proofs/challenger/src/tests.rs
+++ b/proofs/challenger/src/tests.rs
@@ -12,7 +12,7 @@ use std::{
     sync::{Arc, Mutex},
     time::Duration,
 };
-use world_chain_proofs::{OutputRootError, OutputRootProvider};
+use world_chain_proofs::{ConsensusError, ConsensusProvider};
 
 const FACTORY: Address = address!("0000000000000000000000000000000000001006");
 const GAME_1: Address = address!("0000000000000000000000000000000000000001");
@@ -88,12 +88,12 @@ struct MockOutputRoots {
 }
 
 #[async_trait]
-impl OutputRootProvider for MockOutputRoots {
-    async fn output_root_at_block(&self, l2_block_number: u64) -> Result<B256, OutputRootError> {
+impl ConsensusProvider for MockOutputRoots {
+    async fn output_root_at_block(&self, l2_block_number: u64) -> Result<B256, ConsensusError> {
         self.roots
             .get(&l2_block_number)
             .copied()
-            .ok_or_else(|| OutputRootError::Rpc(format!("missing root for {l2_block_number}")))
+            .ok_or_else(|| ConsensusError::Rpc(format!("missing root for {l2_block_number}")))
     }
 }
 

--- a/proofs/primitives/src/consensus_provider.rs
+++ b/proofs/primitives/src/consensus_provider.rs
@@ -27,12 +27,12 @@ pub enum ConsensusError {
 
 /// HTTP client for OP consensus clients.
 #[derive(Debug, Clone)]
-pub struct OptimismOutputRootClient {
+pub struct OptimismConsensusClient {
     client: reqwest::Client,
     rpc_url: String,
 }
 
-impl OptimismOutputRootClient {
+impl OptimismConsensusClient {
     /// Creates a new output-root client from the provided consensus client rpc endpoint.
     pub fn new(rpc_url: impl Into<String>) -> Self {
         Self {
@@ -43,7 +43,7 @@ impl OptimismOutputRootClient {
 }
 
 #[async_trait]
-impl ConsensusProvider for OptimismOutputRootClient {
+impl ConsensusProvider for OptimismConsensusClient {
     async fn output_root_at_block(&self, l2_block_number: u64) -> Result<B256, ConsensusError> {
         let block = format!("0x{l2_block_number:x}");
         let request = serde_json::json!({

--- a/proofs/primitives/src/lib.rs
+++ b/proofs/primitives/src/lib.rs
@@ -12,7 +12,7 @@ mod types;
 pub use bindings::{
     IWorldChainAnchorStateRegistry, IWorldChainProofSystemFactory, IWorldChainProofSystemGame,
 };
-pub use output_root::{OptimismOutputRootClient, OutputRootError, OutputRootProvider};
+pub use output_root::{ConsensusError, ConsensusProvider, OptimismOutputRootClient};
 pub use types::{
     PROOF_LANE_COUNT, PROOF_SYSTEM_VERSION, PROOF_THRESHOLD, ProofDomain, ProofLane,
     ProposalCommitment, RootCommitment, has_threshold, proof_count,

--- a/proofs/primitives/src/lib.rs
+++ b/proofs/primitives/src/lib.rs
@@ -5,14 +5,14 @@
 //! bitmaps, and lightweight ABI bindings for the local proof contracts.
 
 mod bindings;
-mod output_root;
+mod consensus_provider;
 mod types;
 
 // re-exports
 pub use bindings::{
     IWorldChainAnchorStateRegistry, IWorldChainProofSystemFactory, IWorldChainProofSystemGame,
 };
-pub use output_root::{ConsensusError, ConsensusProvider, OptimismOutputRootClient};
+pub use consensus_provider::{ConsensusError, ConsensusProvider, OptimismConsensusClient};
 pub use types::{
     PROOF_LANE_COUNT, PROOF_SYSTEM_VERSION, PROOF_THRESHOLD, ProofDomain, ProofLane,
     ProposalCommitment, RootCommitment, has_threshold, proof_count,

--- a/proofs/primitives/src/output_root.rs
+++ b/proofs/primitives/src/output_root.rs
@@ -1,36 +1,31 @@
-use alloy_primitives::B256;
+use alloy_primitives::{B256, BlockNumber};
 use async_trait::async_trait;
 use serde::Deserialize;
 use thiserror::Error;
 
-/// Source for OP Stack output roots.
+/// Source for all consensus clients requests.
 #[async_trait]
-pub trait OutputRootProvider: Send + Sync {
+pub trait ConsensusProvider: Send + Sync {
     /// Returns the output root for an L2 block number.
-    async fn output_root_at_block(&self, l2_block_number: u64) -> Result<B256, OutputRootError>;
+    async fn output_root_at_block(&self, l2_block_number: u64) -> Result<B256, ConsensusError>;
 
-    /// Returns the highest L2 block number for which an output root can be
-    /// served (the provider's current unsafe L2 head), or `None` when the head
-    /// is unknown and callers should not gate on it.
-    ///
-    /// The default implementation returns `None` so providers that cannot report
-    /// a head (e.g. tests) keep working without gating.
-    async fn latest_l2_block(&self) -> Result<Option<u64>, OutputRootError> {
-        Ok(None)
-    }
+    /// Returns the highest L2 finalized block number.
+    async fn latest_l2_finalized_block(&self) -> Result<BlockNumber, ConsensusError>;
 }
 
 #[derive(Error, Debug)]
-pub enum OutputRootError {
+pub enum ConsensusError {
     /// The output-root RPC response did not contain an output root.
     #[error("optimism_outputAtBlock response did not contain an output root")]
     MissingOutputRoot,
+    #[error("Latest L2 finalized block not found")]
+    FinalizedBlockNotFound,
     /// RPC transport or JSON-RPC failure.
     #[error("rpc error: {0}")]
     Rpc(String),
 }
 
-/// HTTP client for `optimism_outputAtBlock`.
+/// HTTP client for OP consensus clients.
 #[derive(Debug, Clone)]
 pub struct OptimismOutputRootClient {
     client: reqwest::Client,
@@ -48,8 +43,8 @@ impl OptimismOutputRootClient {
 }
 
 #[async_trait]
-impl OutputRootProvider for OptimismOutputRootClient {
-    async fn output_root_at_block(&self, l2_block_number: u64) -> Result<B256, OutputRootError> {
+impl ConsensusProvider for OptimismOutputRootClient {
+    async fn output_root_at_block(&self, l2_block_number: u64) -> Result<B256, ConsensusError> {
         let block = format!("0x{l2_block_number:x}");
         let request = serde_json::json!({
             "jsonrpc": "2.0",
@@ -64,28 +59,28 @@ impl OutputRootProvider for OptimismOutputRootClient {
             .json(&request)
             .send()
             .await
-            .map_err(|error| OutputRootError::Rpc(error.to_string()))?
+            .map_err(|error| ConsensusError::Rpc(error.to_string()))?
             .error_for_status()
-            .map_err(|error| OutputRootError::Rpc(error.to_string()))?
+            .map_err(|error| ConsensusError::Rpc(error.to_string()))?
             .json::<JsonRpcResponse<OutputAtBlockResponse>>()
             .await
-            .map_err(|error| OutputRootError::Rpc(error.to_string()))?;
+            .map_err(|error| ConsensusError::Rpc(error.to_string()))?;
 
         if let Some(error) = response.error {
-            return Err(OutputRootError::Rpc(format!(
+            return Err(ConsensusError::Rpc(format!(
                 "json-rpc error {}: {}",
                 error.code, error.message
             )));
         }
 
-        let output = response.result.ok_or(OutputRootError::MissingOutputRoot)?;
+        let output = response.result.ok_or(ConsensusError::MissingOutputRoot)?;
         output
             .output_root
             .parse()
-            .map_err(|error| OutputRootError::Rpc(format!("invalid outputRoot: {error}")))
+            .map_err(|error| ConsensusError::Rpc(format!("invalid outputRoot: {error}")))
     }
 
-    async fn latest_l2_block(&self) -> Result<Option<u64>, OutputRootError> {
+    async fn latest_l2_finalized_block(&self) -> Result<BlockNumber, ConsensusError> {
         let request = serde_json::json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -99,21 +94,24 @@ impl OutputRootProvider for OptimismOutputRootClient {
             .json(&request)
             .send()
             .await
-            .map_err(|error| OutputRootError::Rpc(error.to_string()))?
+            .map_err(|error| ConsensusError::Rpc(error.to_string()))?
             .error_for_status()
-            .map_err(|error| OutputRootError::Rpc(error.to_string()))?
+            .map_err(|error| ConsensusError::Rpc(error.to_string()))?
             .json::<JsonRpcResponse<SyncStatusResponse>>()
             .await
-            .map_err(|error| OutputRootError::Rpc(error.to_string()))?;
+            .map_err(|error| ConsensusError::Rpc(error.to_string()))?;
 
         if let Some(error) = response.error {
-            return Err(OutputRootError::Rpc(format!(
+            return Err(ConsensusError::Rpc(format!(
                 "json-rpc error {}: {}",
                 error.code, error.message
             )));
         }
+        let sync_status_response = response
+            .result
+            .ok_or(ConsensusError::FinalizedBlockNotFound)?;
 
-        Ok(response.result.map(|status| status.unsafe_l2.number))
+        Ok(sync_status_response.finalized_l2.number)
     }
 }
 
@@ -137,10 +135,10 @@ struct OutputAtBlockResponse {
 
 #[derive(Debug, Deserialize)]
 struct SyncStatusResponse {
-    unsafe_l2: L2BlockRef,
+    finalized_l2: L2BlockRef,
 }
 
 #[derive(Debug, Deserialize)]
 struct L2BlockRef {
-    number: u64,
+    number: BlockNumber,
 }

--- a/proofs/proposer/src/alloy.rs
+++ b/proofs/proposer/src/alloy.rs
@@ -6,7 +6,7 @@ use world_chain_proofs::{
     ProposalCommitment,
 };
 
-use crate::{ParentRef, ProofSystemClient, Proposal, ProposalSubmission, ProposerError};
+use crate::{ParentRef, Proposal, ProposalSubmission, ProposerClient, ProposerError};
 
 /// Alloy-backed implementation of [`ProofSystemClient`].
 #[derive(Debug, Clone)]
@@ -40,7 +40,7 @@ where
 }
 
 #[async_trait]
-impl<P> ProofSystemClient for AlloyProofSystemClient<P>
+impl<P> ProposerClient for AlloyProofSystemClient<P>
 where
     P: Provider + Clone + Send + Sync + 'static,
 {

--- a/proofs/proposer/src/error.rs
+++ b/proofs/proposer/src/error.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::TxHash;
 use thiserror::Error;
-use world_chain_proofs::OutputRootError;
+use world_chain_proofs::ConsensusError;
 
 /// Errors returned by the proposer.
 #[derive(Debug, Error)]
@@ -20,16 +20,17 @@ pub enum ProposerError {
     #[error("contract error: {0}")]
     Contract(String),
     #[error(transparent)]
-    OutputRoot(#[from] OutputRootError),
+    OutputRoot(#[from] ConsensusError),
     #[error("The proposal transaction didn't execute succesfully: {0}")]
     Revert(TxHash),
-    /// The next proposal target is ahead of the op-node L2 head, so no output
-    /// root is available yet. Transient and expected while the L2 catches up.
-    #[error("next proposal target {target_block} is ahead of the L2 head {l2_head}")]
+    /// The next proposal target is ahead of the op-node L2 finalized block.
+    #[error(
+        "next proposal target {target_block} is ahead of the finalized block {finalized_block}"
+    )]
     ProposalNotReady {
         /// L2 block number the proposer wants to propose next.
         target_block: u64,
         /// Current L2 head reported by the op-node.
-        l2_head: u64,
+        finalized_block: u64,
     },
 }

--- a/proofs/proposer/src/lib.rs
+++ b/proofs/proposer/src/lib.rs
@@ -15,7 +15,7 @@ pub use alloy::AlloyProofSystemClient;
 pub use config::ProposerConfig;
 pub use error::ProposerError;
 pub use proposer::WorldChainProposer;
-pub use traits::ProofSystemClient;
+pub use traits::ProposerClient;
 pub use types::{ParentRef, Proposal, ProposalSubmission};
 
 #[cfg(test)]

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -1,26 +1,26 @@
 use alloy_primitives::B256;
 use tracing::{debug, info, warn};
-use world_chain_proofs::OutputRootProvider;
+use world_chain_proofs::ConsensusProvider;
 
 use crate::{
-    ParentRef, ProofSystemClient, Proposal, ProposalSubmission, ProposerConfig, ProposerError,
+    ParentRef, Proposal, ProposalSubmission, ProposerClient, ProposerConfig, ProposerError,
 };
 
 /// World Chain Proposer.
 #[derive(Debug)]
-pub struct WorldChainProposer<C, O> {
+pub struct WorldChainProposer<E, C> {
     config: ProposerConfig,
-    contracts: C,
-    output_roots: O,
+    execution_provider: E,
+    consensus_provider: C,
 }
 
-impl<C, O> WorldChainProposer<C, O> {
-    /// Creates a proposer from contract and output-root clients.
-    pub const fn new(config: ProposerConfig, contracts: C, output_roots: O) -> Self {
+impl<E, C> WorldChainProposer<E, C> {
+    /// Creates a proposer from execution and consensus providers.
+    pub const fn new(config: ProposerConfig, execution_provider: E, consensus_provider: C) -> Self {
         Self {
             config,
-            contracts,
-            output_roots,
+            execution_provider,
+            consensus_provider,
         }
     }
 
@@ -31,16 +31,16 @@ impl<C, O> WorldChainProposer<C, O> {
     }
 }
 
-impl<C, O> WorldChainProposer<C, O>
+impl<E, C> WorldChainProposer<E, C>
 where
-    C: ProofSystemClient,
-    O: OutputRootProvider,
+    E: ProposerClient,
+    C: ConsensusProvider,
 {
     /// Finds the first missing proposal after the current anchor.
     pub async fn prepare_next_proposal(&self) -> Result<Proposal, ProposerError> {
         self.config.validate()?;
 
-        let mut parent = self.contracts.anchor_parent().await?;
+        let mut parent = self.execution_provider.anchor_parent().await?;
 
         loop {
             let l2_block_number = parent
@@ -51,19 +51,17 @@ where
                     block_interval: self.config.block_interval,
                 })?;
 
-            // Don't request an output root for a block the op-node hasn't
-            // produced yet: it would fail with an opaque internal RPC error.
-            if let Some(l2_head) = self.output_roots.latest_l2_block().await?
-                && l2_block_number > l2_head
-            {
+            let latest_finalized_l2_block =
+                self.consensus_provider.latest_l2_finalized_block().await?;
+            if l2_block_number > latest_finalized_l2_block {
                 return Err(ProposerError::ProposalNotReady {
                     target_block: l2_block_number,
-                    l2_head,
+                    finalized_block: latest_finalized_l2_block,
                 });
             }
 
             let root_claim = self
-                .output_roots
+                .consensus_provider
                 .output_root_at_block(l2_block_number)
                 .await?;
             let mut proposal = Proposal {
@@ -73,10 +71,13 @@ where
                 intermediate_roots_hash: B256::ZERO,
                 proposal_key: B256::ZERO,
             };
-            proposal.proposal_key = self.contracts.proposal_key(proposal.commitment()).await?;
+            proposal.proposal_key = self
+                .execution_provider
+                .proposal_key(proposal.commitment())
+                .await?;
 
             if let Some(game) = self
-                .contracts
+                .execution_provider
                 .game_for_proposal_key(proposal.proposal_key)
                 .await?
             {
@@ -95,7 +96,7 @@ where
     pub async fn propose_once(&self) -> Result<(Proposal, ProposalSubmission), ProposerError> {
         let proposal = self.prepare_next_proposal().await?;
         let submission = self
-            .contracts
+            .execution_provider
             .submit_proposal(&proposal, self.config.proposer_bond)
             .await?;
         Ok((proposal, submission))
@@ -120,11 +121,11 @@ where
                 }
                 Err(ProposerError::ProposalNotReady {
                     target_block,
-                    l2_head,
+                    finalized_block: l2_finalized_block,
                 }) => {
                     debug!(
                         target_block,
-                        l2_head, "waiting for L2 to reach the next proposal height"
+                        l2_finalized_block, "waiting for L2 to finalize the next proposal height"
                     );
                 }
                 Err(error) => {

--- a/proofs/proposer/src/tests.rs
+++ b/proofs/proposer/src/tests.rs
@@ -4,7 +4,7 @@ use std::{
     time::Duration,
 };
 
-use alloy_primitives::{Address, B256, U256, address, b256};
+use alloy_primitives::{Address, B256, BlockNumber, U256, address, b256};
 use async_trait::async_trait;
 use world_chain_proofs::{ConsensusError, ConsensusProvider, ProposalCommitment};
 
@@ -59,6 +59,7 @@ impl ProposerClient for MockContracts {
 #[derive(Debug, Clone)]
 struct MockOutputRoots {
     roots: HashMap<u64, B256>,
+    finalized_l2_block: BlockNumber,
 }
 
 #[async_trait]
@@ -68,6 +69,10 @@ impl ConsensusProvider for MockOutputRoots {
             .get(&l2_block_number)
             .copied()
             .ok_or_else(|| ConsensusError::Rpc(format!("missing root for {l2_block_number}")))
+    }
+
+    async fn latest_l2_finalized_block(&self) -> Result<BlockNumber, ConsensusError> {
+        Ok(self.finalized_l2_block)
     }
 }
 
@@ -106,6 +111,7 @@ async fn prepare_next_proposal_walks_existing_games_until_gap() {
     };
     let output_roots = MockOutputRoots {
         roots: HashMap::from([(10, root_10), (20, root_20)]),
+        finalized_l2_block: 20,
     };
     let proposer = WorldChainProposer::new(config(), contracts, output_roots);
 
@@ -131,6 +137,7 @@ async fn propose_once_submits_prepared_proposal() {
     };
     let output_roots = MockOutputRoots {
         roots: HashMap::from([(10, B256::repeat_byte(0x10))]),
+        finalized_l2_block: 10,
     };
     let proposer = WorldChainProposer::new(config(), contracts, output_roots);
 
@@ -161,11 +168,37 @@ async fn zero_block_interval_is_rejected() {
         contracts,
         MockOutputRoots {
             roots: HashMap::new(),
+            finalized_l2_block: 0,
         },
     );
 
     assert!(matches!(
         proposer.prepare_next_proposal().await,
         Err(ProposerError::InvalidConfig(_))
+    ));
+}
+
+#[tokio::test]
+async fn prepare_next_proposal_waits_for_finalized_l2_block() {
+    let contracts = MockContracts {
+        anchor: ParentRef {
+            address: ANCHOR,
+            l2_block_number: 0,
+        },
+        games: HashMap::new(),
+        submissions: Arc::default(),
+    };
+    let output_roots = MockOutputRoots {
+        roots: HashMap::from([(10, B256::repeat_byte(0x10))]),
+        finalized_l2_block: 9,
+    };
+    let proposer = WorldChainProposer::new(config(), contracts, output_roots);
+
+    assert!(matches!(
+        proposer.prepare_next_proposal().await,
+        Err(ProposerError::ProposalNotReady {
+            target_block: 10,
+            finalized_block: 9,
+        })
     ));
 }

--- a/proofs/proposer/src/tests.rs
+++ b/proofs/proposer/src/tests.rs
@@ -6,10 +6,10 @@ use std::{
 
 use alloy_primitives::{Address, B256, U256, address, b256};
 use async_trait::async_trait;
-use world_chain_proofs::{OutputRootError, OutputRootProvider, ProposalCommitment};
+use world_chain_proofs::{ConsensusError, ConsensusProvider, ProposalCommitment};
 
 use crate::{
-    ParentRef, ProofSystemClient, Proposal, ProposalSubmission, ProposerConfig, ProposerError,
+    ParentRef, Proposal, ProposalSubmission, ProposerClient, ProposerConfig, ProposerError,
     WorldChainProposer,
 };
 
@@ -25,7 +25,7 @@ struct MockContracts {
 }
 
 #[async_trait]
-impl ProofSystemClient for MockContracts {
+impl ProposerClient for MockContracts {
     async fn anchor_parent(&self) -> Result<ParentRef, ProposerError> {
         Ok(self.anchor)
     }
@@ -62,12 +62,12 @@ struct MockOutputRoots {
 }
 
 #[async_trait]
-impl OutputRootProvider for MockOutputRoots {
-    async fn output_root_at_block(&self, l2_block_number: u64) -> Result<B256, OutputRootError> {
+impl ConsensusProvider for MockOutputRoots {
+    async fn output_root_at_block(&self, l2_block_number: u64) -> Result<B256, ConsensusError> {
         self.roots
             .get(&l2_block_number)
             .copied()
-            .ok_or_else(|| OutputRootError::Rpc(format!("missing root for {l2_block_number}")))
+            .ok_or_else(|| ConsensusError::Rpc(format!("missing root for {l2_block_number}")))
     }
 }
 

--- a/proofs/proposer/src/traits.rs
+++ b/proofs/proposer/src/traits.rs
@@ -6,7 +6,7 @@ use crate::{ParentRef, Proposal, ProposalSubmission, ProposerError};
 
 /// Minimal contract surface needed by the proposer.
 #[async_trait]
-pub trait ProofSystemClient: Send + Sync {
+pub trait ProposerClient: Send + Sync {
     /// Reads the parent state from the anchor registry.
     async fn anchor_parent(&self) -> Result<ParentRef, ProposerError>;
 


### PR DESCRIPTION
This PR makes sure that:

- `world-chain-proposer` always uses a L2 finalized block when creating a new game and including the root claim.
- `world-chain-challenger` always ensures that the L2 game included in the game it's checking is a L2 finalized block. If not, return an Error and retry in the next iteration

This is done such that we don't risk L2 reorgs that may cause the root claim to change for the same L2 block number.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes when proposals and challenges are allowed relative to L2 finality—a security-sensitive correctness boundary for dispute games and root claims.
> 
> **Overview**
> Adds an **L2 finality gate** so proposer and challenger only use output roots for blocks at or below the op-node **finalized** L2 head, reducing risk from reorgs changing roots for the same block number.
> 
> **Consensus layer:** `OutputRootProvider` / `OptimismOutputRootClient` become `ConsensusProvider` / `OptimismConsensusClient`. Optional `latest_l2_block()` (unsafe head) is removed; `latest_l2_finalized_block()` is required and reads `optimism_syncStatus.finalized_l2` instead of `unsafe_l2`.
> 
> **Proposer:** Before fetching a root, it waits until the next proposal height is finalized (`ProposalNotReady` now compares against `finalized_block`, not L2 head).
> 
> **Challenger:** Before challenging, it errors with `L2BlockNotFinalized` if the game’s L2 block is above the latest finalized block (scan retries on the next poll).
> 
> **Wiring:** Devnet proposer/challenger use `OptimismConsensusClient`; structs split **execution** (L1 contracts) vs **consensus** (OP RPC) providers. `ProofSystemClient` is renamed to `ProposerClient`. Tests cover unfinalized-block behavior for both sides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbe0cacd94774856cde9b16c7aad7b22c56cb4fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->