### PR TITLE
test: acceptance test with much higher load

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -33,7 +33,7 @@ jobs:
     name: acceptance-tests (${{ matrix.network }})
     runs-on: arc-public-8xlarge-amd64-runner
     environment: ${{ matrix.environment }}
-    timeout-minutes: 20
+    timeout-minutes: 45
     concurrency:
       group: ${{ github.workflow }}-${{ matrix.network }}
       cancel-in-progress: false
@@ -116,6 +116,10 @@ jobs:
           ACCEPTANCE_BUNDLER_CF_ACCESS_CLIENT_SECRET: ${{ secrets.ACCEPTANCE_BUNDLER_CF_ACCESS_CLIENT_SECRET }}
           ACCEPTANCE_BLOCK_ADVANCE_TIMEOUT_SECS: "60"
           ACCEPTANCE_BLOCK_POLL_INTERVAL_SECS: "2"
+          ACCEPTANCE_4337_WALLET_COUNT: "200"
+          ACCEPTANCE_4337_DEPLOY_CONCURRENCY: "10"
+          ACCEPTANCE_4337_OPS_PER_WALLET: "50"
+          ACCEPTANCE_4337_OP_CONCURRENCY: "200"
         run: cargo nextest run --profile ci -p world-chain-tests -E 'package(world-chain-tests) & binary(world-chain-tests) & test(/acceptance_tests::test_network/)' --no-capture
 
       - name: Report allowed build failure

--- a/e2e-tests/src/it/acceptance_tests/README.md
+++ b/e2e-tests/src/it/acceptance_tests/README.md
@@ -42,6 +42,11 @@ The ERC-4337 wallet owners are deterministic test mnemonic accounts and are only
 used to sign Safe user operations. They do not need ETH. Sponsored operations are
 paid by the configured Rundler instance.
 
+The GitHub Actions acceptance workflow overrides the local defaults for a small Rundler
+smoke-spike profile: 200 ephemeral Safe wallets, 50 post-deploy sponsored no-op operations per
+wallet, and 200-way post-deploy operation concurrency. Deploy concurrency stays at 10 because all
+deployment operations use the same Safe factory.
+
 Example:
 
 ```sh

--- a/e2e-tests/src/it/acceptance_tests/erc4337.rs
+++ b/e2e-tests/src/it/acceptance_tests/erc4337.rs
@@ -18,8 +18,8 @@ use alloy_sol_types::{SolCall, SolValue, sol};
 use eyre::eyre::{Context, OptionExt, bail, ensure};
 use futures::{StreamExt, TryStreamExt, stream};
 use serde::Serialize;
-use tokio::time::{sleep, timeout};
-use tracing::info;
+use tokio::time::{Instant, sleep, timeout};
+use tracing::{info, warn};
 use world_chain_test_utils::utils::signer;
 
 use super::{config::BundlerConfig, rpc::RpcEnv};
@@ -632,28 +632,42 @@ impl<'a> UserOperationHarness<'a> {
     }
 
     async fn wait_for_receipt(&self, hash: B256) -> eyre::Result<UserOperationReceipt> {
-        timeout(self.config.user_operation_timeout, async {
-            loop {
-                let receipt: Option<UserOperationReceipt> = self
-                    .bundler
-                    .raw_request(Cow::Borrowed("eth_getUserOperationReceipt"), (hash,))
-                    .await
-                    .context("failed to fetch user operation receipt")?;
+        let deadline = Instant::now() + self.config.user_operation_timeout;
+        let mut last_error = None;
 
-                if let Some(receipt) = receipt {
-                    return Ok(receipt);
+        loop {
+            let result: Result<Option<UserOperationReceipt>, _> = self
+                .bundler
+                .raw_request(Cow::Borrowed("eth_getUserOperationReceipt"), (hash,))
+                .await;
+
+            match result {
+                Ok(Some(receipt)) => return Ok(receipt),
+                Ok(None) => {}
+                Err(error) => {
+                    warn!(%hash, %error, "failed to fetch user operation receipt, retrying");
+                    last_error = Some(error.to_string());
+                }
+            }
+
+            let now = Instant::now();
+            if now >= deadline {
+                if let Some(error) = last_error {
+                    bail!(
+                        "timed out after {:?} waiting for user operation {hash:?}; last receipt fetch error: {error}",
+                        self.config.user_operation_timeout
+                    );
                 }
 
-                sleep(self.config.user_operation_poll_interval).await;
+                bail!(
+                    "timed out after {:?} waiting for user operation {hash:?}",
+                    self.config.user_operation_timeout
+                );
             }
-        })
-        .await
-        .with_context(|| {
-            format!(
-                "timed out after {:?} waiting for user operation {hash:?}",
-                self.config.user_operation_timeout
-            )
-        })?
+
+            let remaining = deadline.saturating_duration_since(now);
+            sleep(self.config.user_operation_poll_interval.min(remaining)).await;
+        }
     }
 
     async fn fresh_wallet(&self, offset: usize) -> eyre::Result<TestWallet> {


### PR DESCRIPTION
add retry rundler receipt polling errors

passes CI on stage

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect CI/e2e test configuration and polling behavior only, not production services or auth/data paths.
> 
> **Overview**
> Ramps **GitHub Actions** ERC-4337 acceptance tests to a high-load **Rundler smoke spike**: **200** ephemeral Safe wallets, **50** sponsored no-op ops per wallet after deploy, and **200**-way post-deploy concurrency (deploy concurrency stays **10**). Job **timeout** increases from **20** to **45** minutes to match the heavier run.
> 
> **`wait_for_receipt`** no longer fails on transient `eth_getUserOperationReceipt` errors; it **warns, retries** until the user-op timeout, and timeout messages can include the **last fetch error**. README documents the CI env overrides vs local defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54d0f5cbfc95434faedbaab9ca84c7fddd1f018a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->