### PR TITLE
feat(challenger): add retry list

### DIFF
--- a/proofs/challenger/src/challenger.rs
+++ b/proofs/challenger/src/challenger.rs
@@ -49,6 +49,11 @@ impl<E, C> WorldChainChallenger<E, C> {
     pub const fn config(&self) -> &ChallengerConfig {
         &self.config
     }
+
+    #[cfg(test)]
+    pub(crate) fn retry_games(&self) -> Vec<Address> {
+        self.retry_games.keys().copied().collect()
+    }
 }
 
 impl<E, C> WorldChainChallenger<E, C>

--- a/proofs/challenger/src/challenger.rs
+++ b/proofs/challenger/src/challenger.rs
@@ -1,8 +1,12 @@
 use crate::{
-    config::ChallengerConfig, error::ChallengerError, traits::ChallengerClient, types::RootState,
+    GameCreated, config::ChallengerConfig, error::ChallengerError, traits::ChallengerClient,
+    types::RootState,
 };
-use alloy_primitives::BlockNumber;
-use std::time::{SystemTime, UNIX_EPOCH};
+use alloy_primitives::{Address, BlockNumber};
+use std::{
+    collections::HashMap,
+    time::{SystemTime, UNIX_EPOCH},
+};
 use tracing::warn;
 use world_chain_proofs::ConsensusProvider;
 
@@ -11,6 +15,13 @@ const ONE_DAY_OF_L1_BLOCKS: u64 = 7_200;
 /// The safety margin of blocks.
 const MARGIN: u64 = 500;
 
+#[derive(Debug)]
+enum GameScanOutcome {
+    Valid,
+    Challenged,
+    Skip,
+}
+
 /// World Chain Challenger.
 #[derive(Debug)]
 pub struct WorldChainChallenger<E, C> {
@@ -18,20 +29,18 @@ pub struct WorldChainChallenger<E, C> {
     execution_provider: E,
     consensus_provider: C,
     cursor: BlockNumber,
+    retry_games: HashMap<Address, GameCreated>,
 }
 
 impl<E, C> WorldChainChallenger<E, C> {
     /// Creates a challenger from contract and output-root clients.
-    pub const fn new(
-        config: ChallengerConfig,
-        execution_provider: E,
-        consensus_provider: C,
-    ) -> Self {
+    pub fn new(config: ChallengerConfig, execution_provider: E, consensus_provider: C) -> Self {
         Self {
             config,
             execution_provider,
             consensus_provider,
             cursor: 0,
+            retry_games: HashMap::default(),
         }
     }
 
@@ -47,6 +56,55 @@ where
     E: ChallengerClient,
     C: ConsensusProvider,
 {
+    async fn process_game(
+        &self,
+        game_created: &GameCreated,
+        latest_finalized_l2_block: BlockNumber,
+    ) -> Result<GameScanOutcome, ChallengerError> {
+        let game = game_created.game;
+        let root_state = self.execution_provider.root_state(game).await?;
+        if root_state != RootState::Proposed {
+            // root state is not `Proposed` anymore, skip immediately
+            return Ok(GameScanOutcome::Skip);
+        }
+        let challenge_deadline = self.execution_provider.challenge_deadline(game).await?;
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_secs();
+
+        if now >= challenge_deadline {
+            // challenge deadline has expired, skip immediately
+            return Ok(GameScanOutcome::Skip);
+        }
+        // ensure that the l2 block is finalized
+        if game_created.l2_block_number > latest_finalized_l2_block {
+            return Err(ChallengerError::L2BlockNotFinalized {
+                game,
+                latest_finalized: latest_finalized_l2_block,
+                given_block: game_created.l2_block_number,
+            });
+        }
+
+        match self
+            .consensus_provider
+            .output_root_at_block(game_created.l2_block_number)
+            .await
+        {
+            Ok(root) if root != game_created.root_claim => {
+                self.execution_provider
+                    .submit_challenge(game, self.config.challenger_bond)
+                    .await?;
+                Ok(GameScanOutcome::Challenged)
+            }
+            Ok(_root) => {
+                // valid root, leave it
+                Ok(GameScanOutcome::Valid)
+            }
+            Err(err) => Err(ChallengerError::OutputRoot(err)),
+        }
+    }
+
     pub async fn scan_once(&mut self) -> Result<(), ChallengerError> {
         let target = self.execution_provider.finalized_l1_block_num().await?;
         let from = if self.cursor == 0 {
@@ -60,48 +118,35 @@ where
             return Ok(());
         }
         let games_created = self.execution_provider.games_created(from, target).await?;
-        for game_created in games_created {
-            let game = game_created.game;
-            let root_state = self.execution_provider.root_state(game).await?;
-            if root_state != RootState::Proposed {
-                // root state is not `Proposed` anymore, skip immediately
-                continue;
-            }
-            let challenge_deadline = self.execution_provider.challenge_deadline(game).await?;
-            let now = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("system time before unix epoch")
-                .as_secs();
+        let latest_finalized_l2_block = self.consensus_provider.latest_l2_finalized_block().await?;
 
-            if now >= challenge_deadline {
-                // challenge deadline has expired, skip immediately
-                continue;
-            }
-            // ensure that the l2 block is finalized
-            let latest_finalized_l2_block =
-                self.consensus_provider.latest_l2_finalized_block().await?;
-            if game_created.l2_block_number > latest_finalized_l2_block {
-                return Err(ChallengerError::L2BlockNotFinalized {
-                    game,
-                    latest_finalized: latest_finalized_l2_block,
-                    given_block: game_created.l2_block_number,
-                });
-            }
-
+        let retry_games: Vec<GameCreated> = self.retry_games.values().copied().collect();
+        for retry_game in retry_games {
             match self
-                .consensus_provider
-                .output_root_at_block(game_created.l2_block_number)
+                .process_game(&retry_game, latest_finalized_l2_block)
                 .await
             {
-                Ok(root) if root != game_created.root_claim => {
-                    self.execution_provider
-                        .submit_challenge(game, self.config.challenger_bond)
-                        .await?;
+                Ok(_) => {
+                    self.retry_games.remove(&retry_game.game);
                 }
-                Ok(_root) => {
-                    // valid root, leave it
+                Err(err) => {
+                    warn!(game = %retry_game.game, %err, "retry game failed");
                 }
-                Err(err) => return Err(ChallengerError::OutputRoot(err)),
+            }
+        }
+
+        for game_created in games_created {
+            match self
+                .process_game(&game_created, latest_finalized_l2_block)
+                .await
+            {
+                Ok(_) => {
+                    self.retry_games.remove(&game_created.game);
+                }
+                Err(err) => {
+                    warn!(game = %game_created.game, %err, "game scan failed; adding to retry list");
+                    self.retry_games.insert(game_created.game, game_created);
+                }
             }
         }
         // if the scan goes well, update the cursor

--- a/proofs/challenger/src/tests.rs
+++ b/proofs/challenger/src/tests.rs
@@ -158,6 +158,7 @@ async fn scan_once_leaves_valid_root() {
     challenger.scan_once().await.unwrap();
 
     assert!(submissions.lock().expect("not poisoned").is_empty());
+    assert!(challenger.retry_games().is_empty());
 }
 
 #[tokio::test]
@@ -182,6 +183,7 @@ async fn scan_once_skips_non_proposed_game() {
     challenger.scan_once().await.unwrap();
 
     assert!(submissions.lock().expect("not poisoned").is_empty());
+    assert!(challenger.retry_games().is_empty());
 }
 
 #[tokio::test]
@@ -206,6 +208,7 @@ async fn scan_once_skips_expired_challenge_deadline() {
     challenger.scan_once().await.unwrap();
 
     assert!(submissions.lock().expect("not poisoned").is_empty());
+    assert!(challenger.retry_games().is_empty());
 }
 
 #[tokio::test]
@@ -227,13 +230,11 @@ async fn scan_once_rejects_unfinalized_l2_block() {
     };
     let mut challenger = WorldChainChallenger::new(config(), client, output_roots);
 
-    assert!(matches!(
-        challenger.scan_once().await,
-        Err(ChallengerError::L2BlockNotFinalized {
-            game: GAME_1,
-            latest_finalized,
-            given_block: L2_BLOCK,
-        }) if latest_finalized == L2_BLOCK - 1
-    ));
+    // The game references an L2 block that is not finalized yet. This is a
+    // transient failure, so the game must not be challenged and instead be
+    // queued for a later retry, while the scan itself succeeds.
+    challenger.scan_once().await.unwrap();
+
     assert!(submissions.lock().expect("not poisoned").is_empty());
+    assert_eq!(challenger.retry_games(), [GAME_1]);
 }

--- a/proofs/challenger/src/types.rs
+++ b/proofs/challenger/src/types.rs
@@ -51,7 +51,7 @@ pub struct ChallengeSubmission {
 }
 
 /// The `GameCreated` event.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct GameCreated {
     pub proposal_key: B256,
     pub root_it: B256,


### PR DESCRIPTION
### Problem

The `scan_once` fn is early returning for every error happening in all games. This causes a random error in a single game to make the `scan_once` fn error out to its caller without advancing the cursor. This means that the next iteration will potentially re-scan a lot of already visited and processed games.

### Solution

Add a `retry_games` field to the challenger and add every game that fails in that list such that it can be re-tried in the next iteration but still keep working on next games and advance the cursor

### Next Steps

There are at least 2 follow up PRs I'll work on:

- make the `retry_games` list deadline aware such that we retry first the games with the closest deadline
- add async / parallelization to retry list and in general to processing of the games