### PR TITLE
feat(challenger): make retry list deadline aware

### DIFF
--- a/proofs/challenger/src/challenger.rs
+++ b/proofs/challenger/src/challenger.rs
@@ -49,6 +49,11 @@ impl<E, C> WorldChainChallenger<E, C> {
     pub const fn config(&self) -> &ChallengerConfig {
         &self.config
     }
+
+    #[cfg(test)]
+    pub(crate) fn retry_games(&self) -> Vec<Address> {
+        self.retry_games.keys().copied().collect()
+    }
 }
 
 impl<E, C> WorldChainChallenger<E, C>

--- a/proofs/challenger/src/challenger.rs
+++ b/proofs/challenger/src/challenger.rs
@@ -1,6 +1,9 @@
 use crate::{
-    GameCreated, config::ChallengerConfig, error::ChallengerError, traits::ChallengerClient,
-    types::RootState,
+    GameCreated,
+    config::ChallengerConfig,
+    error::{ChallengerError, GameScanError},
+    traits::ChallengerClient,
+    types::{GameScanOutcome, RetryGame, RootState},
 };
 use alloy_primitives::{Address, BlockNumber};
 use std::{
@@ -15,13 +18,6 @@ const ONE_DAY_OF_L1_BLOCKS: u64 = 7_200;
 /// The safety margin of blocks.
 const MARGIN: u64 = 500;
 
-#[derive(Debug)]
-enum GameScanOutcome {
-    Valid,
-    Challenged,
-    Skip,
-}
-
 /// World Chain Challenger.
 #[derive(Debug)]
 pub struct WorldChainChallenger<E, C> {
@@ -29,7 +25,7 @@ pub struct WorldChainChallenger<E, C> {
     execution_provider: E,
     consensus_provider: C,
     cursor: BlockNumber,
-    retry_games: HashMap<Address, GameCreated>,
+    retry_games: HashMap<Address, RetryGame>,
 }
 
 impl<E, C> WorldChainChallenger<E, C> {
@@ -54,6 +50,17 @@ impl<E, C> WorldChainChallenger<E, C> {
     pub(crate) fn retry_games(&self) -> Vec<Address> {
         self.retry_games.keys().copied().collect()
     }
+
+    fn queue_retry_game(&mut self, game_created: GameCreated, challenge_deadline: Option<u64>) {
+        let existing = self.retry_games.get(&game_created.game);
+        let retry_game = RetryGame {
+            game_created,
+            challenge_deadline: challenge_deadline
+                .or(existing.and_then(|retry| retry.challenge_deadline)),
+            attempts: existing.map_or(1, |retry| retry.attempts.saturating_add(1)),
+        };
+        self.retry_games.insert(game_created.game, retry_game);
+    }
 }
 
 impl<E, C> WorldChainChallenger<E, C>
@@ -65,29 +72,45 @@ where
         &self,
         game_created: &GameCreated,
         latest_finalized_l2_block: BlockNumber,
-    ) -> Result<GameScanOutcome, ChallengerError> {
+        now: u64,
+    ) -> Result<GameScanOutcome, GameScanError> {
         let game = game_created.game;
-        let root_state = self.execution_provider.root_state(game).await?;
+        let root_state = self
+            .execution_provider
+            .root_state(game)
+            .await
+            .map_err(|error| GameScanError {
+                error,
+                challenge_deadline: None,
+            })?;
         if root_state != RootState::Proposed {
             // root state is not `Proposed` anymore, skip immediately
             return Ok(GameScanOutcome::Skip);
         }
-        let challenge_deadline = self.execution_provider.challenge_deadline(game).await?;
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("system time before unix epoch")
-            .as_secs();
+        let challenge_deadline = self
+            .execution_provider
+            .challenge_deadline(game)
+            .await
+            .map_err(|error| GameScanError {
+                error,
+                challenge_deadline: None,
+            })?;
+        let challenge_deadline_value = challenge_deadline;
+        let challenge_deadline = Some(challenge_deadline_value);
 
-        if now >= challenge_deadline {
+        if now >= challenge_deadline_value {
             // challenge deadline has expired, skip immediately
             return Ok(GameScanOutcome::Skip);
         }
         // ensure that the l2 block is finalized
         if game_created.l2_block_number > latest_finalized_l2_block {
-            return Err(ChallengerError::L2BlockNotFinalized {
-                game,
-                latest_finalized: latest_finalized_l2_block,
-                given_block: game_created.l2_block_number,
+            return Err(GameScanError {
+                error: ChallengerError::L2BlockNotFinalized {
+                    game,
+                    latest_finalized: latest_finalized_l2_block,
+                    given_block: game_created.l2_block_number,
+                },
+                challenge_deadline,
             });
         }
 
@@ -99,14 +122,21 @@ where
             Ok(root) if root != game_created.root_claim => {
                 self.execution_provider
                     .submit_challenge(game, self.config.challenger_bond)
-                    .await?;
+                    .await
+                    .map_err(|error| GameScanError {
+                        error,
+                        challenge_deadline,
+                    })?;
                 Ok(GameScanOutcome::Challenged)
             }
             Ok(_root) => {
                 // valid root, leave it
                 Ok(GameScanOutcome::Valid)
             }
-            Err(err) => Err(ChallengerError::OutputRoot(err)),
+            Err(err) => Err(GameScanError {
+                error: ChallengerError::OutputRoot(err),
+                challenge_deadline,
+            }),
         }
     }
 
@@ -117,45 +147,69 @@ where
         } else {
             self.cursor
         };
-        // short circuit if from > target: it means that there are no
-        // new L1 finalized blocks compared to last scan
-        if from > target {
+        let has_new_l1_blocks = from <= target;
+        let games_created = if has_new_l1_blocks {
+            self.execution_provider.games_created(from, target).await?
+        } else {
+            Vec::new()
+        };
+
+        if games_created.is_empty() && self.retry_games.is_empty() {
+            if has_new_l1_blocks {
+                self.cursor = target + 1;
+            }
             return Ok(());
         }
-        let games_created = self.execution_provider.games_created(from, target).await?;
-        let latest_finalized_l2_block = self.consensus_provider.latest_l2_finalized_block().await?;
 
-        let retry_games: Vec<GameCreated> = self.retry_games.values().copied().collect();
+        let latest_finalized_l2_block = self.consensus_provider.latest_l2_finalized_block().await?;
+        let now = unix_now();
+
+        let mut retry_games: Vec<RetryGame> = self.retry_games.values().copied().collect();
+        // sort retry games by deadline with unknown deadlines first
+        retry_games.sort_by_key(|retry| retry.challenge_deadline.unwrap_or(0));
         for retry_game in retry_games {
+            let game = retry_game.game_created.game;
+            if retry_game
+                .challenge_deadline
+                .is_some_and(|challenge_deadline| now >= challenge_deadline)
+            {
+                warn!(game = %game, "dropping retry game after challenge deadline");
+                self.retry_games.remove(&game);
+                continue;
+            }
+
             match self
-                .process_game(&retry_game, latest_finalized_l2_block)
+                .process_game(&retry_game.game_created, latest_finalized_l2_block, now)
                 .await
             {
-                Ok(_) => {
-                    self.retry_games.remove(&retry_game.game);
+                Ok(_outcome) => {
+                    self.retry_games.remove(&game);
                 }
                 Err(err) => {
-                    warn!(game = %retry_game.game, %err, "retry game failed");
+                    warn!(game = %game, error = %err.error, "retry game failed");
+                    self.queue_retry_game(retry_game.game_created, err.challenge_deadline);
                 }
             }
         }
 
         for game_created in games_created {
             match self
-                .process_game(&game_created, latest_finalized_l2_block)
+                .process_game(&game_created, latest_finalized_l2_block, now)
                 .await
             {
-                Ok(_) => {
+                Ok(_outcome) => {
                     self.retry_games.remove(&game_created.game);
                 }
                 Err(err) => {
-                    warn!(game = %game_created.game, %err, "game scan failed; adding to retry list");
-                    self.retry_games.insert(game_created.game, game_created);
+                    warn!(game = %game_created.game, error = %err.error, "game scan failed; adding to retry list");
+                    self.queue_retry_game(game_created, err.challenge_deadline);
                 }
             }
         }
         // if the scan goes well, update the cursor
-        self.cursor = target + 1;
+        if has_new_l1_blocks {
+            self.cursor = target + 1;
+        }
         Ok(())
     }
 
@@ -171,4 +225,11 @@ where
             }
         }
     }
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time before unix epoch")
+        .as_secs()
 }

--- a/proofs/challenger/src/challenger.rs
+++ b/proofs/challenger/src/challenger.rs
@@ -1,8 +1,12 @@
 use crate::{
-    config::ChallengerConfig, error::ChallengerError, traits::ChallengerClient, types::RootState,
+    GameCreated, config::ChallengerConfig, error::ChallengerError, traits::ChallengerClient,
+    types::RootState,
 };
-use alloy_primitives::BlockNumber;
-use std::time::{SystemTime, UNIX_EPOCH};
+use alloy_primitives::{Address, BlockNumber};
+use std::{
+    collections::HashMap,
+    time::{SystemTime, UNIX_EPOCH},
+};
 use tracing::warn;
 use world_chain_proofs::ConsensusProvider;
 
@@ -11,6 +15,13 @@ const ONE_DAY_OF_L1_BLOCKS: u64 = 7_200;
 /// The safety margin of blocks.
 const MARGIN: u64 = 500;
 
+#[derive(Debug)]
+enum GameScanOutcome {
+    Valid,
+    Challenged,
+    Skip,
+}
+
 /// World Chain Challenger.
 #[derive(Debug)]
 pub struct WorldChainChallenger<E, C> {
@@ -18,20 +29,18 @@ pub struct WorldChainChallenger<E, C> {
     execution_provider: E,
     consensus_provider: C,
     cursor: BlockNumber,
+    retry_games: HashMap<Address, GameCreated>,
 }
 
 impl<E, C> WorldChainChallenger<E, C> {
     /// Creates a challenger from contract and output-root clients.
-    pub const fn new(
-        config: ChallengerConfig,
-        execution_provider: E,
-        consensus_provider: C,
-    ) -> Self {
+    pub fn new(config: ChallengerConfig, execution_provider: E, consensus_provider: C) -> Self {
         Self {
             config,
             execution_provider,
             consensus_provider,
             cursor: 0,
+            retry_games: HashMap::default(),
         }
     }
 
@@ -47,6 +56,55 @@ where
     E: ChallengerClient,
     C: ConsensusProvider,
 {
+    async fn process_game(
+        &self,
+        game_created: &GameCreated,
+        latest_finalized_l2_block: BlockNumber,
+    ) -> Result<GameScanOutcome, ChallengerError> {
+        let game = game_created.game;
+        let root_state = self.execution_provider.root_state(game).await?;
+        if root_state != RootState::Proposed {
+            // root state is not `Proposed` anymore, skip immediately
+            return Ok(GameScanOutcome::Skip);
+        }
+        let challenge_deadline = self.execution_provider.challenge_deadline(game).await?;
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_secs();
+
+        if now >= challenge_deadline {
+            // challenge deadline has expired, skip immediately
+            return Ok(GameScanOutcome::Skip);
+        }
+        // ensure that the l2 block is finalized
+        if game_created.l2_block_number > latest_finalized_l2_block {
+            return Err(ChallengerError::L2BlockNotFinalized {
+                game,
+                latest_finalized: latest_finalized_l2_block,
+                given_block: game_created.l2_block_number,
+            });
+        }
+
+        match self
+            .consensus_provider
+            .output_root_at_block(game_created.l2_block_number)
+            .await
+        {
+            Ok(root) if root != game_created.root_claim => {
+                self.execution_provider
+                    .submit_challenge(game, self.config.challenger_bond)
+                    .await?;
+                Ok(GameScanOutcome::Challenged)
+            }
+            Ok(_root) => {
+                // valid root, leave it
+                Ok(GameScanOutcome::Valid)
+            }
+            Err(err) => Err(ChallengerError::OutputRoot(err)),
+        }
+    }
+
     pub async fn scan_once(&mut self) -> Result<(), ChallengerError> {
         let target = self.execution_provider.finalized_l1_block_num().await?;
         let from = if self.cursor == 0 {
@@ -60,48 +118,35 @@ where
             return Ok(());
         }
         let games_created = self.execution_provider.games_created(from, target).await?;
-        for game_created in games_created {
-            let game = game_created.game;
-            let root_state = self.execution_provider.root_state(game).await?;
-            if root_state != RootState::Proposed {
-                // root state is not `Proposed` anymore, skip immediately
-                continue;
-            }
-            let challenge_deadline = self.execution_provider.challenge_deadline(game).await?;
-            let now = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("system time before unix epoch")
-                .as_secs();
+        let latest_finalized_l2_block = self.consensus_provider.latest_l2_finalized_block().await?;
 
-            if now >= challenge_deadline {
-                // challenge deadline has expired, skip immediately
-                continue;
-            }
-            // ensure that the l2 block is finalized
-            let latest_finalized_l2_block =
-                self.consensus_provider.latest_l2_finalized_block().await?;
-            if game_created.l2_block_number > latest_finalized_l2_block {
-                return Err(ChallengerError::L2BlockNotFinalized {
-                    game,
-                    latest_finalized: latest_finalized_l2_block,
-                    given_block: game_created.l2_block_number,
-                });
-            }
-
+        let retry_games: Vec<GameCreated> = self.retry_games.values().copied().collect();
+        for retry_game in retry_games {
             match self
-                .consensus_provider
-                .output_root_at_block(game_created.l2_block_number)
+                .process_game(&retry_game, latest_finalized_l2_block)
                 .await
             {
-                Ok(root) if root != game_created.root_claim => {
-                    self.execution_provider
-                        .submit_challenge(game, self.config.challenger_bond)
-                        .await?;
+                Ok(_) => {
+                    self.retry_games.remove(&retry_game.game);
                 }
-                Ok(_root) => {
-                    // valid root, leave it
+                Err(err) => {
+                    warn!(game = %retry_game.game, %err, "retry game failed");
                 }
-                Err(err) => return Err(ChallengerError::OutputRoot(err)),
+            }
+        }
+
+        for game_created in games_created {
+            match self
+                .process_game(&game_created, latest_finalized_l2_block)
+                .await
+            {
+                Ok(_) => {
+                    self.retry_games.remove(&game_created.game);
+                }
+                Err(err) => {
+                    warn!(game = %game_created.game, %err, "game scan failed; adding to retry list");
+                    self.retry_games.insert(game_created.game, game_created);
+                }
             }
         }
         // if the scan goes well, update the cursor

--- a/proofs/challenger/src/error.rs
+++ b/proofs/challenger/src/error.rs
@@ -41,3 +41,10 @@ pub enum ChallengerError {
         given_block: u64,
     },
 }
+
+/// Error returned while processing a single game.
+#[derive(Debug)]
+pub(crate) struct GameScanError {
+    pub error: ChallengerError,
+    pub challenge_deadline: Option<u64>,
+}

--- a/proofs/challenger/src/tests.rs
+++ b/proofs/challenger/src/tests.rs
@@ -158,6 +158,7 @@ async fn scan_once_leaves_valid_root() {
     challenger.scan_once().await.unwrap();
 
     assert!(submissions.lock().expect("not poisoned").is_empty());
+    assert!(challenger.retry_games().is_empty());
 }
 
 #[tokio::test]
@@ -182,6 +183,7 @@ async fn scan_once_skips_non_proposed_game() {
     challenger.scan_once().await.unwrap();
 
     assert!(submissions.lock().expect("not poisoned").is_empty());
+    assert!(challenger.retry_games().is_empty());
 }
 
 #[tokio::test]
@@ -206,6 +208,7 @@ async fn scan_once_skips_expired_challenge_deadline() {
     challenger.scan_once().await.unwrap();
 
     assert!(submissions.lock().expect("not poisoned").is_empty());
+    assert!(challenger.retry_games().is_empty());
 }
 
 #[tokio::test]
@@ -227,13 +230,11 @@ async fn scan_once_rejects_unfinalized_l2_block() {
     };
     let mut challenger = WorldChainChallenger::new(config(), client, output_roots);
 
-    assert!(matches!(
-        challenger.scan_once().await,
-        Err(ChallengerError::L2BlockNotFinalized {
-            game: GAME_1,
-            latest_finalized,
-            given_block: L2_BLOCK,
-        }) if latest_finalized == L2_BLOCK - 1
-    ));
+    // The game references an L2 block that is not finalized yet. This is a
+    // transient failure, so the game must not be challenged and instead be
+    // queued for a later retry, while the scan itself succeeds.
+    challenger.scan_once().await.unwrap();
+
     assert!(submissions.lock().expect("not poisoned").is_empty());
+    assert_eq!(challenger.retry_games(), [GAME_1]);
 }

--- a/proofs/challenger/src/tests.rs
+++ b/proofs/challenger/src/tests.rs
@@ -9,13 +9,17 @@ use alloy_primitives::{Address, B256, BlockNumber, U256, address};
 use async_trait::async_trait;
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
     time::Duration,
 };
 use world_chain_proofs::{ConsensusError, ConsensusProvider};
 
 const FACTORY: Address = address!("0000000000000000000000000000000000001006");
 const GAME_1: Address = address!("0000000000000000000000000000000000000001");
+const GAME_2: Address = address!("0000000000000000000000000000000000000002");
 const FINALIZED_L1_BLOCK: BlockNumber = 10_000;
 const L2_BLOCK: u64 = 100;
 
@@ -85,7 +89,7 @@ impl ChallengerClient for MockClient {
 #[derive(Debug, Clone)]
 struct MockOutputRoots {
     roots: HashMap<u64, B256>,
-    finalized_l2_block: BlockNumber,
+    finalized_l2_block: Arc<AtomicU64>,
 }
 
 #[async_trait]
@@ -98,8 +102,22 @@ impl ConsensusProvider for MockOutputRoots {
     }
 
     async fn latest_l2_finalized_block(&self) -> Result<BlockNumber, ConsensusError> {
-        Ok(self.finalized_l2_block)
+        Ok(self.finalized_l2_block.load(Ordering::SeqCst))
     }
+}
+
+fn mock_output_roots(
+    roots: HashMap<u64, B256>,
+    finalized_l2_block: BlockNumber,
+) -> (MockOutputRoots, Arc<AtomicU64>) {
+    let finalized_l2_block = Arc::new(AtomicU64::new(finalized_l2_block));
+    (
+        MockOutputRoots {
+            roots,
+            finalized_l2_block: Arc::clone(&finalized_l2_block),
+        },
+        finalized_l2_block,
+    )
 }
 
 fn config() -> ChallengerConfig {
@@ -123,10 +141,8 @@ async fn scan_once_challenges_invalid_root() {
         deadlines: HashMap::new(),
         submissions: Arc::clone(&submissions),
     };
-    let output_roots = MockOutputRoots {
-        roots: HashMap::from([(L2_BLOCK, canonical_root)]),
-        finalized_l2_block: L2_BLOCK,
-    };
+    let (output_roots, _finalized_l2_block) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
     let mut challenger = WorldChainChallenger::new(config(), client, output_roots);
 
     challenger.scan_once().await.unwrap();
@@ -149,10 +165,8 @@ async fn scan_once_leaves_valid_root() {
         deadlines: HashMap::new(),
         submissions: Arc::clone(&submissions),
     };
-    let output_roots = MockOutputRoots {
-        roots: HashMap::from([(L2_BLOCK, canonical_root)]),
-        finalized_l2_block: L2_BLOCK,
-    };
+    let (output_roots, _finalized_l2_block) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
     let mut challenger = WorldChainChallenger::new(config(), client, output_roots);
 
     challenger.scan_once().await.unwrap();
@@ -174,10 +188,8 @@ async fn scan_once_skips_non_proposed_game() {
         deadlines: HashMap::new(),
         submissions: Arc::clone(&submissions),
     };
-    let output_roots = MockOutputRoots {
-        roots: HashMap::from([(L2_BLOCK, canonical_root)]),
-        finalized_l2_block: L2_BLOCK,
-    };
+    let (output_roots, _finalized_l2_block) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
     let mut challenger = WorldChainChallenger::new(config(), client, output_roots);
 
     challenger.scan_once().await.unwrap();
@@ -199,10 +211,8 @@ async fn scan_once_skips_expired_challenge_deadline() {
         deadlines: HashMap::from([(GAME_1, 0)]),
         submissions: Arc::clone(&submissions),
     };
-    let output_roots = MockOutputRoots {
-        roots: HashMap::from([(L2_BLOCK, canonical_root)]),
-        finalized_l2_block: L2_BLOCK,
-    };
+    let (output_roots, _finalized_l2_block) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
     let mut challenger = WorldChainChallenger::new(config(), client, output_roots);
 
     challenger.scan_once().await.unwrap();
@@ -224,10 +234,8 @@ async fn scan_once_rejects_unfinalized_l2_block() {
         deadlines: HashMap::new(),
         submissions: Arc::clone(&submissions),
     };
-    let output_roots = MockOutputRoots {
-        roots: HashMap::from([(L2_BLOCK, canonical_root)]),
-        finalized_l2_block: L2_BLOCK - 1,
-    };
+    let (output_roots, _finalized_l2_block) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK - 1);
     let mut challenger = WorldChainChallenger::new(config(), client, output_roots);
 
     // The game references an L2 block that is not finalized yet. This is a
@@ -237,4 +245,71 @@ async fn scan_once_rejects_unfinalized_l2_block() {
 
     assert!(submissions.lock().expect("not poisoned").is_empty());
     assert_eq!(challenger.retry_games(), [GAME_1]);
+}
+
+#[tokio::test]
+async fn scan_once_processes_retry_games_without_new_l1_blocks() {
+    let proposed_root = B256::repeat_byte(0x10);
+    let canonical_root = B256::repeat_byte(0x20);
+
+    let submissions = Arc::default();
+    let client = MockClient {
+        finalized: FINALIZED_L1_BLOCK,
+        games: vec![(GAME_1, proposed_root, L2_BLOCK)],
+        states: HashMap::new(),
+        deadlines: HashMap::new(),
+        submissions: Arc::clone(&submissions),
+    };
+    let (output_roots, finalized_l2_block) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK - 1);
+    let mut challenger = WorldChainChallenger::new(config(), client, output_roots);
+
+    challenger.scan_once().await.unwrap();
+    assert_eq!(challenger.retry_games(), [GAME_1]);
+
+    finalized_l2_block.store(L2_BLOCK, Ordering::SeqCst);
+    challenger.scan_once().await.unwrap();
+
+    assert_eq!(
+        submissions.lock().expect("not poisoned").as_slice(),
+        &[GAME_1]
+    );
+    assert!(challenger.retry_games().is_empty());
+}
+
+#[tokio::test]
+async fn scan_once_processes_retry_games_by_challenge_deadline() {
+    let proposed_root_1 = B256::repeat_byte(0x10);
+    let proposed_root_2 = B256::repeat_byte(0x11);
+    let canonical_root_1 = B256::repeat_byte(0x20);
+    let canonical_root_2 = B256::repeat_byte(0x21);
+    let l2_block_2 = L2_BLOCK + 1;
+
+    let submissions = Arc::default();
+    let client = MockClient {
+        finalized: FINALIZED_L1_BLOCK,
+        games: vec![
+            (GAME_1, proposed_root_1, L2_BLOCK),
+            (GAME_2, proposed_root_2, l2_block_2),
+        ],
+        states: HashMap::new(),
+        deadlines: HashMap::from([(GAME_1, u64::MAX), (GAME_2, u64::MAX - 1)]),
+        submissions: Arc::clone(&submissions),
+    };
+    let (output_roots, finalized_l2_block) = mock_output_roots(
+        HashMap::from([(L2_BLOCK, canonical_root_1), (l2_block_2, canonical_root_2)]),
+        L2_BLOCK - 1,
+    );
+    let mut challenger = WorldChainChallenger::new(config(), client, output_roots);
+
+    challenger.scan_once().await.unwrap();
+
+    finalized_l2_block.store(l2_block_2, Ordering::SeqCst);
+    challenger.scan_once().await.unwrap();
+
+    assert_eq!(
+        submissions.lock().expect("not poisoned").as_slice(),
+        &[GAME_2, GAME_1]
+    );
+    assert!(challenger.retry_games().is_empty());
 }

--- a/proofs/challenger/src/types.rs
+++ b/proofs/challenger/src/types.rs
@@ -63,3 +63,19 @@ pub struct GameCreated {
     pub l1_origin_hash: B256,
     pub l1_origin_number: BlockNumber,
 }
+
+/// A game queued for retry after a transient scan failure.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RetryGame {
+    pub game_created: GameCreated,
+    pub challenge_deadline: Option<u64>,
+    pub attempts: u32,
+}
+
+/// Result of processing a single game.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum GameScanOutcome {
+    Valid,
+    Challenged,
+    Skip,
+}

--- a/proofs/challenger/src/types.rs
+++ b/proofs/challenger/src/types.rs
@@ -51,7 +51,7 @@ pub struct ChallengeSubmission {
 }
 
 /// The `GameCreated` event.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct GameCreated {
     pub proposal_key: B256,
     pub root_it: B256,


### PR DESCRIPTION
Stacked on top of https://github.com/worldcoin/world-chain/pull/710 - it needs that PR to be merged on `main` before merging this one.

### Problem

The `challenger` has a retry list for games that have failed for some reason. The retry list is not processed ordered by the each challenge deadline, so there is a risk we lose time processing first games with bigger deadlines.

### Solution

Make the retry list deadline aware by sorting it before processing.