### PR TITLE
chore: add release workflow for world chain proof binaries

### DIFF
--- a/.github/actions/docker-build-push-digest/action.yml
+++ b/.github/actions/docker-build-push-digest/action.yml
@@ -21,6 +21,16 @@ inputs:
     description: Path to the Dockerfile to build.
     required: false
     default: Dockerfile
+  build_args:
+    description: Extra build args passed to docker build (newline-separated KEY=value).
+    required: false
+    default: ""
+  digest_artifact_prefix:
+    description: >-
+      Prefix for the uploaded digest artifact name. Override when a workflow builds
+      more than one image so their digest artifacts do not collide.
+    required: false
+    default: digests
 
 runs:
   using: composite
@@ -67,6 +77,7 @@ runs:
           SCCACHE_BUCKET=${{ inputs.sccache_bucket }}
           SCCACHE_REGION=${{ inputs.aws_region }}
           SCCACHE_S3_KEY_PREFIX=sccache/${{ github.repository }}/${{ env.PLATFORM_PAIR }}
+          ${{ inputs.build_args }}
         secrets: |
           aws_access_key_id=${{ env.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key=${{ env.AWS_SECRET_ACCESS_KEY }}
@@ -90,7 +101,7 @@ runs:
     - name: Upload digest
       uses: actions/upload-artifact@v4
       with:
-        name: digests-${{ env.PLATFORM_PAIR }}
+        name: ${{ inputs.digest_artifact_prefix }}-${{ env.PLATFORM_PAIR }}
         path: ${{ runner.temp }}/digests/*
         if-no-files-found: error
         retention-days: 1

--- a/.github/actions/docker-merge-manifest/action.yml
+++ b/.github/actions/docker-merge-manifest/action.yml
@@ -11,6 +11,17 @@ inputs:
   tags:
     description: Tag rules for docker/metadata-action (newline-separated).
     required: true
+  digest_artifact_prefix:
+    description: >-
+      Prefix of the digest artifacts to merge (must match the
+      digest_artifact_prefix given to docker-build-push-digest).
+    required: false
+    default: digests
+
+outputs:
+  digest:
+    description: Digest of the pushed multi-platform manifest.
+    value: ${{ steps.manifest-digest.outputs.digest }}
 
 runs:
   using: composite
@@ -19,7 +30,7 @@ runs:
       uses: actions/download-artifact@v4
       with:
         path: ${{ runner.temp }}/digests
-        pattern: digests-*
+        pattern: ${{ inputs.digest_artifact_prefix }}-*
         merge-multiple: true
 
     - name: Log in to Registry
@@ -50,3 +61,12 @@ runs:
       shell: bash
       run: |
         docker buildx imagetools inspect ${{ inputs.registry }}/${{ inputs.image_name }}:${{ steps.meta.outputs.version }}
+
+    - name: Export manifest digest
+      id: manifest-digest
+      shell: bash
+      run: |
+        digest=$(docker buildx imagetools inspect \
+          '${{ inputs.registry }}/${{ inputs.image_name }}:${{ steps.meta.outputs.version }}' \
+          --format '{{json .Manifest.Digest}}' | tr -d '"')
+        echo "digest=${digest}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-proof.yml
+++ b/.github/workflows/release-proof.yml
@@ -1,0 +1,346 @@
+# Versioned releases for the World Chain prover deployables.
+#
+# Triggered by `proof/vX.Y.Z` tags (kept separate from the node's `v*` tags so
+# prover releases — which are governance events whenever the vkeys or PCRs
+# change — advance on their own cadence).
+#
+# A release binds together every measurement the proof system registers
+# on-chain, in a single manifest.json:
+#   - SP1 guest ELF sha256s + range vkey commitment + aggregation vkey
+#   - Nitro enclave EIF PCR0/PCR1/PCR2
+#   - prover docker image digest
+# plus the deployable artifacts themselves (docker images, GPG-signed binary
+# tarballs, the guest ELFs, and the enclave EIF).
+#
+# Everything gates on verify-elfs: a release is only cut if the committed ELFs
+# are bit-for-bit reproducible from source.
+
+name: release-proof
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - proof/v*
+
+env:
+  CARGO_TERM_COLOR: always
+  REGISTRY: ghcr.io
+  PROOF_IMAGE_NAME: ${{ github.repository }}-proof
+  AWS_REGION: us-east-1
+  SCCACHE_BUCKET: crypto-dev-us-east-1-workflow-build-cache
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+jobs:
+  extract-version:
+    name: extract version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract version
+        id: extract_version
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/proof/* ]]; then
+            echo "VERSION=${GITHUB_REF#refs/tags/proof/}" >> "$GITHUB_OUTPUT"
+            echo "IS_RELEASE=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "VERSION=dev-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+            echo "IS_RELEASE=false" >> "$GITHUB_OUTPUT"
+          fi
+    outputs:
+      VERSION: ${{ steps.extract_version.outputs.VERSION }}
+      IS_RELEASE: ${{ steps.extract_version.outputs.IS_RELEASE }}
+
+  # Gate: the committed guest ELFs must be reproducible from source. Every
+  # other artifact embeds or ships these ELFs, so nothing builds if this fails.
+  verify-elfs:
+    name: verify ELFs
+    runs-on: arc-public-8xlarge-amd64-runner
+    steps:
+      - uses: actions/checkout@v6
+      - uses: taiki-e/install-action@just
+      - name: Install SP1 toolchain
+        run: |
+          curl -L https://sp1.succinct.xyz | bash
+          ~/.sp1/bin/sp1up --version v6.1.0
+          echo "$HOME/.sp1/bin" >> $GITHUB_PATH
+      - name: Build ELFs
+        run: just build-proof-elfs
+      - name: Verify ELFs unchanged
+        run: |
+          if [[ -n $(git diff proofs/succinct/elf/) ]]; then
+            echo "ELF files changed after rebuild — commit the updated ELFs"
+            git diff proofs/succinct/elf/
+            exit 1
+          fi
+
+  # Compute the on-chain verification keys for the committed ELFs.
+  vkeys:
+    name: compute vkeys
+    needs: [verify-elfs]
+    runs-on: arc-public-8xlarge-amd64-runner
+    steps:
+      - uses: actions/checkout@v6
+      - uses: taiki-e/install-action@just
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Compute vkeys
+        run: just proof-vkeys --output vkeys.json && cat vkeys.json
+      - name: Upload vkeys
+        uses: actions/upload-artifact@v4
+        with:
+          name: vkeys
+          path: vkeys.json
+          if-no-files-found: error
+
+  # Prover docker image (the `proof` CLI with sp1 + nitro backends).
+  # When the sp1-worker binary lands on main, add a second build/merge job pair
+  # with build_args:
+  #   PROVER_PACKAGE=world-chain-sp1-worker PROVER_BIN=sp1-worker FEATURES=
+  # and digest_artifact_prefix: digests-sp1-worker.
+  build-proof-image:
+    name: build proof image
+    environment: dev
+    needs: [verify-elfs]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: arc-public-8xlarge-amd64-runner
+            platform: linux/amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build and push digest
+        uses: ./.github/actions/docker-build-push-digest
+        with:
+          platform: ${{ matrix.platform }}
+          registry: ${{ env.REGISTRY }}
+          image_name: ${{ env.PROOF_IMAGE_NAME }}
+          aws_region: ${{ env.AWS_REGION }}
+          sccache_bucket: ${{ env.SCCACHE_BUCKET }}
+          dockerfile: Dockerfile.proof
+          digest_artifact_prefix: digests-proof
+
+  merge-proof-image:
+    name: merge proof image manifest
+    needs: [extract-version, build-proof-image]
+    runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.merge.outputs.digest }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Merge multi-arch manifest
+        id: merge
+        uses: ./.github/actions/docker-merge-manifest
+        with:
+          registry: ${{ env.REGISTRY }}
+          image_name: ${{ env.PROOF_IMAGE_NAME }}
+          digest_artifact_prefix: digests-proof
+          tags: |
+            type=raw,value=${{ needs.extract-version.outputs.VERSION }}
+            type=sha
+
+  # GPG-signed binary tarballs, mirroring the node release conventions.
+  build-binaries:
+    name: build binaries
+    needs: [extract-version, verify-elfs]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+    runs-on: ${{ matrix.runner }}
+    env:
+      VERSION: ${{ needs.extract-version.outputs.VERSION }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Cargo Build Release
+        run: cargo build --release --locked -p proof --bin proof --features sp1,nitro --target ${{ matrix.target }}
+
+      - name: Move binary
+        run: |
+          mkdir artifacts
+          mv "target/${{ matrix.target }}/release/proof" ./artifacts
+
+      - name: Configure GPG and create artifacts
+        env:
+          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          export GPG_TTY=$(tty)
+          echo -n "$GPG_SIGNING_KEY" | base64 --decode | gpg --batch --import
+          cd artifacts
+          tar -czf world-chain-proof-${{ env.VERSION }}-${{ matrix.target }}.tar.gz proof*
+          echo "$GPG_PASSPHRASE" | gpg --passphrase-fd 0 --pinentry-mode loopback --batch -ab world-chain-proof-${{ env.VERSION }}-${{ matrix.target }}.tar.gz
+          mv *tar.gz* ..
+        shell: bash
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: world-chain-proof-${{ env.VERSION }}-${{ matrix.target }}
+          path: world-chain-proof-${{ env.VERSION }}-${{ matrix.target }}.tar.gz*
+          if-no-files-found: error
+
+  # Nitro enclave EIF + PCR measurements. Does not require Nitro hardware.
+  build-eif:
+    name: build enclave EIF
+    needs: [verify-elfs]
+    runs-on: arc-public-8xlarge-amd64-runner
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build EIF
+        run: scripts/build-eif.sh target/eif
+      - name: Upload EIF and PCRs
+        uses: actions/upload-artifact@v4
+        with:
+          name: nitro-enclave
+          path: |
+            target/eif/world-chain-nitro-enclave.eif
+            target/eif/pcrs.json
+          if-no-files-found: error
+
+  # Assemble manifest.json and the draft release. Tag pushes only.
+  draft-release:
+    name: draft release
+    if: needs.extract-version.outputs.IS_RELEASE == 'true'
+    needs:
+      - extract-version
+      - vkeys
+      - merge-proof-image
+      - build-binaries
+      - build-eif
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      VERSION: ${{ needs.extract-version.outputs.VERSION }}
+      PROOF_IMAGE_DIGEST: ${{ needs.merge-proof-image.outputs.digest }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Stage release assets
+        run: |
+          mkdir -p assets
+          cp artifacts/vkeys/vkeys.json assets/
+          cp artifacts/nitro-enclave/pcrs.json assets/
+          cp artifacts/nitro-enclave/world-chain-nitro-enclave.eif assets/
+          cp artifacts/world-chain-proof-*/*.tar.gz* assets/
+          cp proofs/succinct/elf/world-chain-range-ethereum assets/
+          cp proofs/succinct/elf/world-chain-aggregation assets/
+
+      - name: Build manifest
+        run: |
+          jq -n \
+            --arg version "$VERSION" \
+            --arg git_sha "$GITHUB_SHA" \
+            --arg image "${REGISTRY}/${PROOF_IMAGE_NAME}:${VERSION}" \
+            --arg image_digest "$PROOF_IMAGE_DIGEST" \
+            --slurpfile vkeys assets/vkeys.json \
+            --slurpfile pcrs assets/pcrs.json \
+            '{
+              version: $version,
+              git_sha: $git_sha,
+              sp1: $vkeys[0],
+              nitro_enclave: { pcrs: $pcrs[0] },
+              images: { proof: { name: $image, digest: $image_digest } }
+            }' > assets/manifest.json
+          cat assets/manifest.json
+
+      - name: Compare measurements with previous release
+        id: measurements
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          prev_tag=$(gh release list --json tagName --jq '[.[].tagName | select(startswith("proof/v"))][0] // empty')
+          {
+            echo "MEASUREMENTS<<EOF"
+            echo '```json'
+            jq '{sp1: {range_vkey_commitment: .sp1.range_vkey_commitment, aggregation_vkey: .sp1.aggregation_vkey}, nitro_enclave: .nitro_enclave.pcrs}' assets/manifest.json
+            echo '```'
+            if [[ -n "$prev_tag" ]] && gh release download "$prev_tag" --pattern manifest.json --output prev-manifest.json 2>/dev/null; then
+              if diff <(jq -S '{sp1: {r: .sp1.range_vkey_commitment, a: .sp1.aggregation_vkey}, pcrs: .nitro_enclave.pcrs}' prev-manifest.json) \
+                      <(jq -S '{sp1: {r: .sp1.range_vkey_commitment, a: .sp1.aggregation_vkey}, pcrs: .nitro_enclave.pcrs}' assets/manifest.json) > /dev/null; then
+                echo "Unchanged since ${prev_tag}."
+              else
+                echo "> [!WARNING]"
+                echo "> Measurements CHANGED since ${prev_tag} — the on-chain verifier registrations (SP1 vkeys and/or TEE PCRs) must be updated before this release is deployed."
+              fi
+            else
+              echo "No previous proof release manifest found to compare against."
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Generate changelog
+        id: changelog
+        run: |
+          prev=$(git describe --tags --abbrev=0 --match 'proof/v*' "proof/${VERSION}^" 2>/dev/null || true)
+          {
+            echo "CHANGELOG<<EOF"
+            if [[ -n "$prev" ]]; then
+              git log --pretty=format:"- %s" "${prev}..proof/${VERSION}" -- proofs/ Dockerfile.proof scripts/build-eif.sh
+            else
+              echo "- Initial prover release"
+            fi
+            echo ""
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create release draft
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          body=$(cat <<- "ENDBODY"
+          ## Measurements
+
+          The values below are what the on-chain proof-lane registries must hold for this release (`manifest.json` is the machine-readable source of truth):
+
+          ${{ steps.measurements.outputs.MEASUREMENTS }}
+
+          ## Prover Changes
+
+          ${{ steps.changelog.outputs.CHANGELOG }}
+
+          ## Artifacts
+
+          | Artifact | Purpose |
+          |:---|:---|
+          | `manifest.json` | Binds git SHA, ELF hashes, vkeys, PCRs, and image digests for this release |
+          | `vkeys.json` | SP1 range vkey commitment + aggregation vkey |
+          | `pcrs.json` | Nitro enclave PCR0/PCR1/PCR2 |
+          | `world-chain-nitro-enclave.eif` | Enclave image (measurements in `pcrs.json`) |
+          | `world-chain-range-ethereum`, `world-chain-aggregation` | SP1 guest ELFs (reproducible via `just build-proof-elfs`) |
+          | `world-chain-proof-*.tar.gz` | `proof` CLI binaries, signed with PGP key `C75F BC64 E9D4 8E89 FB60 418B 8949 B352 D042 2E74` |
+          | Docker | `ghcr.io/${{ env.PROOF_IMAGE_NAME }}:${{ env.VERSION }}` |
+          ENDBODY
+          )
+          gh release create --draft -t "proof/${VERSION}" -F - "proof/${VERSION}" assets/* <<< "$body"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9108,6 +9108,7 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
+ "sha2 0.10.9",
  "sp1-sdk",
  "tokio",
  "world-chain-chainspec",

--- a/Dockerfile.proof
+++ b/Dockerfile.proof
@@ -1,5 +1,7 @@
 # syntax=docker/dockerfile:1.10
-# Image for the host-side prover CLI (proofs/bin), built with the sp1 + nitro backends.
+# Image for the host-side prover binaries (proofs/*). Defaults to the `proof` CLI built
+# with the sp1 + nitro backends; pass PROVER_PACKAGE/PROVER_BIN/FEATURES to build others
+# (e.g. PROVER_PACKAGE=world-chain-sp1-worker PROVER_BIN=sp1-worker FEATURES="").
 # Mirrors the caching strategy of the main Dockerfile (cargo-chef + sccache/S3).
 FROM public.ecr.aws/docker/library/rust:1.95.0-bookworm AS base
 
@@ -32,6 +34,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 FROM base AS builder
 WORKDIR /app
 
+ARG PROVER_PACKAGE="proof"
 ARG PROVER_BIN="proof"
 ARG PROFILE="maxperf"
 ARG FEATURES="sp1,nitro"
@@ -48,7 +51,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=secret,id=aws_secret_access_key,env=AWS_SECRET_ACCESS_KEY \
     --mount=type=secret,id=aws_session_token,env=AWS_SESSION_TOKEN \
     if [ -z "$SCCACHE_BUCKET" ]; then unset SCCACHE_BUCKET SCCACHE_REGION SCCACHE_S3_KEY_PREFIX; fi && \
-    cargo chef cook --locked --profile ${PROFILE} -p ${PROVER_BIN} --bin ${PROVER_BIN} --features ${FEATURES} --recipe-path recipe.json
+    cargo chef cook --locked --profile ${PROFILE} -p ${PROVER_PACKAGE} --bin ${PROVER_BIN} ${FEATURES:+--features ${FEATURES}} --recipe-path recipe.json
 
 ARG VERGEN_GIT_SHA
 COPY . .
@@ -60,7 +63,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=secret,id=aws_secret_access_key,env=AWS_SECRET_ACCESS_KEY \
     --mount=type=secret,id=aws_session_token,env=AWS_SESSION_TOKEN \
     if [ -z "$SCCACHE_BUCKET" ]; then unset SCCACHE_BUCKET SCCACHE_REGION SCCACHE_S3_KEY_PREFIX; fi && \
-    cargo build --locked --profile ${PROFILE} -p ${PROVER_BIN} --features ${FEATURES} --bin ${PROVER_BIN}
+    cargo build --locked --profile ${PROFILE} -p ${PROVER_PACKAGE} ${FEATURES:+--features ${FEATURES}} --bin ${PROVER_BIN}
 
 FROM public.ecr.aws/docker/library/debian:bookworm-slim
 WORKDIR /app
@@ -74,6 +77,16 @@ RUN apt-get update && \
 
 ARG PROVER_BIN="proof"
 ARG PROFILE="maxperf"
-COPY --from=builder /app/target/${PROFILE}/${PROVER_BIN} /usr/local/bin/proof
+COPY --from=builder /app/target/${PROFILE}/${PROVER_BIN} /usr/local/bin/${PROVER_BIN}
+RUN ln -s /usr/local/bin/${PROVER_BIN} /usr/local/bin/entrypoint
 
-ENTRYPOINT ["/usr/local/bin/proof"]
+# Committed SP1 guest ELFs, so prover binaries that load ELFs at runtime work
+# out of the box. The env vars are the canonical lookup used by the hosts.
+COPY proofs/succinct/elf/world-chain-range-ethereum /usr/local/share/world-chain/elf/world-chain-range-ethereum
+COPY proofs/succinct/elf/world-chain-aggregation /usr/local/share/world-chain/elf/world-chain-aggregation
+ENV WORLD_CHAIN_RANGE_ELF=/usr/local/share/world-chain/elf/world-chain-range-ethereum \
+    WORLD_CHAIN_AGGREGATION_ELF=/usr/local/share/world-chain/elf/world-chain-aggregation \
+    RANGE_ELF_PATH=/usr/local/share/world-chain/elf/world-chain-range-ethereum \
+    AGG_ELF_PATH=/usr/local/share/world-chain/elf/world-chain-aggregation
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]

--- a/Justfile
+++ b/Justfile
@@ -97,6 +97,10 @@ build-proof-aggregation-elf:
 # Build all World SP1 proof ELFs
 build-proof-elfs: build-proof-range-elf build-proof-aggregation-elf
 
+# Compute the on-chain verification keys for the committed SP1 proof ELFs
+proof-vkeys *args='':
+    cargo run --release -p proof --features sp1 -- sp1 vkeys $@
+
 # Generate CLI reference docs for the mdbook
 docs:
     cargo xtask docs

--- a/docs/proof/proof-cli.md
+++ b/docs/proof/proof-cli.md
@@ -237,6 +237,40 @@ proof sp1 prove \
   --output    ./proof.json
 ```
 
+### `sp1 vkeys`
+
+Computes the on-chain verification keys for the range and aggregation ELFs: the range vkey
+commitment (`multiBlockVKey` committed by the aggregation guest) and the aggregation vkey
+registered with the SP1 verifier. Runs SP1 setup locally — no proving, no RPC.
+
+```
+proof sp1 vkeys [--range-elf <FILE>] [--agg-elf <FILE>] [--output <FILE>]
+```
+
+| Flag | Env | Default | Description |
+|---|---|---|---|
+| `--range-elf <FILE>` | `RANGE_ELF_PATH` | `proofs/succinct/elf/world-chain-range-ethereum` | SP1 range ELF |
+| `--agg-elf <FILE>` | `AGG_ELF_PATH` | `proofs/succinct/elf/world-chain-aggregation` | SP1 aggregation ELF |
+| `--output <FILE>` | — | stdout | Write the JSON here instead of stdout |
+
+**Example**
+
+```bash
+# From the repo root, against the committed ELFs:
+just proof-vkeys
+```
+
+```json
+{
+  "range_vkey_commitment": "0x…",
+  "aggregation_vkey": "0x…",
+  "elfs": {
+    "world-chain-range-ethereum": { "path": "…", "sha256": "…" },
+    "world-chain-aggregation": { "path": "…", "sha256": "…" }
+  }
+}
+```
+
 ---
 
 ## Running the Nitro enclave

--- a/docs/proof/release.md
+++ b/docs/proof/release.md
@@ -1,0 +1,75 @@
+# Prover release process
+
+Prover deployables are released independently of the node via `proof/vX.Y.Z` tags, handled by
+[`.github/workflows/release-proof.yml`](../../.github/workflows/release-proof.yml). Node releases
+(`vX.Y.Z` tags, `release.yml`) are unaffected.
+
+## Why a separate tag namespace
+
+A prover release is a governance event whenever its measurements change: the SP1 vkeys and the
+Nitro enclave PCRs are registered on-chain (per WIP-1006's proof-lane registries), and a release
+that changes them requires a registry update before it can be deployed. Decoupling the tag
+namespaces lets prover releases follow proof-system iteration instead of node/hardfork cadence,
+and keeps measurement changes reviewable on their own.
+
+## What a release produces
+
+| Artifact | Notes |
+|:---|:---|
+| `manifest.json` | Single source of truth binding git SHA, ELF sha256s, vkeys, PCRs, and image digests |
+| `vkeys.json` | Range vkey commitment + aggregation vkey, computed from the committed ELFs |
+| `pcrs.json` | PCR0/PCR1/PCR2 of the enclave EIF |
+| `world-chain-nitro-enclave.eif` | Enclave image, built reproducibly (see below) |
+| `world-chain-range-ethereum`, `world-chain-aggregation` | The committed SP1 guest ELFs |
+| `world-chain-proof-<version>-<target>.tar.gz` (+ `.asc`) | GPG-signed `proof` CLI binaries (linux x86_64 / aarch64) |
+| `ghcr.io/worldcoin/world-chain-proof:<version>` | Multi-arch prover image (sp1 + nitro backends, ELFs baked in) |
+
+The draft release notes include a measurements section that diffs the vkeys/PCRs against the
+previous `proof/v*` release and flags when an on-chain registry update is required.
+
+## Cutting a release
+
+```bash
+git tag proof/v0.1.0 <sha-on-main>
+git push origin proof/v0.1.0
+```
+
+The workflow gates everything on ELF reproducibility (`just build-proof-elfs` must reproduce the
+committed ELFs bit-for-bit), then builds all artifacts and opens a **draft** release for human
+review. Review the measurements section, then publish.
+
+`workflow_dispatch` runs the same pipeline without creating a release (images are tagged
+`dev-<sha>`); use it to validate changes to the pipeline itself.
+
+## Reproducibility requirements
+
+- **SP1 ELFs** are built with `cargo prove build --docker` at a pinned SP1 toolchain tag and
+  committed under `proofs/succinct/elf/`. CI (`elf.yml` and the release gate) rebuilds and diffs
+  them.
+- **The enclave EIF** must be bit-for-bit reproducible so anyone can re-derive the registered
+  PCRs from source: `proofs/nitro/Dockerfile` pins base images by digest and apt packages to a
+  fixed snapshot.debian.org timestamp, and `scripts/build-eif.sh` pins the nitro-cli version that
+  assembles the EIF. Bumping any of these pins changes the PCRs — expect to re-register them.
+
+## Verifying a release locally
+
+```bash
+# Reproduce the guest ELFs and vkeys
+just build-proof-elfs
+just proof-vkeys
+
+# Reproduce the enclave EIF and PCRs (Linux x86_64 + Docker)
+scripts/build-eif.sh
+```
+
+Compare the output against the release's `manifest.json`.
+
+## Adding a prover binary to the release
+
+When a new prover deployable lands on `main` (e.g. the `sp1-worker`):
+
+1. Add a build/merge job pair in `release-proof.yml`, passing
+   `PROVER_PACKAGE`/`PROVER_BIN`/`FEATURES` build args to `Dockerfile.proof` and a unique
+   `digest_artifact_prefix`.
+2. Add a matrix entry to the `build-binaries` job for the signed tarball.
+3. Record the new image digest in the manifest step.

--- a/proofs/bin/Cargo.toml
+++ b/proofs/bin/Cargo.toml
@@ -34,6 +34,7 @@ world-chain-proof-succinct-host-utils.workspace = true
 alloy-consensus = { workspace = true, features = ["serde"], optional = true }
 bincode = { version = "1", optional = true }
 serde_cbor = { version = "0.11", optional = true }
+sha2 = { workspace = true, optional = true }
 sp1-sdk = { version = "=6.1.0", features = ["network"], optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -42,4 +43,10 @@ world-chain-proof-nitro = { workspace = true, optional = true }
 [features]
 default = []
 nitro = ["dep:world-chain-proof-nitro", "world-chain-proof-nitro/aws_nitro"]
-sp1 = ["dep:sp1-sdk", "dep:alloy-consensus", "dep:bincode", "dep:serde_cbor"]
+sp1 = [
+    "dep:sp1-sdk",
+    "dep:alloy-consensus",
+    "dep:bincode",
+    "dep:serde_cbor",
+    "dep:sha2",
+]

--- a/proofs/bin/src/main.rs
+++ b/proofs/bin/src/main.rs
@@ -105,6 +105,8 @@ enum Sp1Command {
     Execute(Sp1ExecuteArgs),
     /// Generate range + aggregation proofs end-to-end from RPC.
     Prove(Box<Sp1ProveArgs>),
+    /// Compute the on-chain verification keys for the range and aggregation ELFs.
+    Vkeys(Sp1VkeysArgs),
 }
 
 #[derive(Debug, Args)]
@@ -280,6 +282,30 @@ struct Sp1ProveArgs {
     output: Option<PathBuf>,
 }
 
+#[cfg(feature = "sp1")]
+#[derive(Debug, Args)]
+struct Sp1VkeysArgs {
+    /// Path to the SP1 range ELF binary.
+    #[arg(
+        long,
+        env = "RANGE_ELF_PATH",
+        default_value = "proofs/succinct/elf/world-chain-range-ethereum"
+    )]
+    range_elf: PathBuf,
+
+    /// Path to the SP1 aggregation ELF binary.
+    #[arg(
+        long,
+        env = "AGG_ELF_PATH",
+        default_value = "proofs/succinct/elf/world-chain-aggregation"
+    )]
+    agg_elf: PathBuf,
+
+    /// Output path for the vkeys JSON. Printed to stdout when unset.
+    #[arg(long)]
+    output: Option<PathBuf>,
+}
+
 struct RangeProofInput {
     metadata: RangeMetadata,
     witness: WorldRangeWitnessData,
@@ -384,6 +410,7 @@ fn main() -> eyre::Result<()> {
         Command::Sp1 { command } => match command {
             Sp1Command::Execute(args) => sp1_execute(args)?,
             Sp1Command::Prove(args) => sp1_prove(*args)?,
+            Sp1Command::Vkeys(args) => sp1_vkeys(args)?,
         },
     }
 
@@ -933,6 +960,63 @@ fn sp1_execute(args: Sp1ExecuteArgs) -> eyre::Result<()> {
         println!("public values: 0x{}", hex::encode(public_values.as_slice()));
         Ok(())
     })
+}
+
+#[cfg(feature = "sp1")]
+fn sp1_vkeys(args: Sp1VkeysArgs) -> eyre::Result<()> {
+    use sha2::{Digest, Sha256};
+    use sp1_sdk::{CpuProver, HashableKey, Prover, ProvingKey, env::EnvProver};
+    use world_chain_proof_core::types::u32_to_u8;
+
+    let range_elf = fs::read(&args.range_elf)
+        .wrap_err_with(|| format!("failed to read ELF {}", args.range_elf.display()))?;
+    let agg_elf = fs::read(&args.agg_elf)
+        .wrap_err_with(|| format!("failed to read ELF {}", args.agg_elf.display()))?;
+
+    let range_elf_sha256 = hex::encode(Sha256::digest(&range_elf));
+    let agg_elf_sha256 = hex::encode(Sha256::digest(&agg_elf));
+
+    let (range_vkey_commitment, aggregation_vkey) =
+        tokio::runtime::Runtime::new()?.block_on(async {
+            let client = EnvProver::Cpu(CpuProver::new().await);
+            let range_pk = client
+                .setup(range_elf.into())
+                .await
+                .map_err(|e| eyre!("range setup failed: {e}"))?;
+            let agg_pk = client
+                .setup(agg_elf.into())
+                .await
+                .map_err(|e| eyre!("aggregation setup failed: {e}"))?;
+            let range_vkey_commitment = B256::from(u32_to_u8(range_pk.verifying_key().hash_u32()));
+            let aggregation_vkey = agg_pk.verifying_key().bytes32();
+            Ok::<_, eyre::Report>((range_vkey_commitment, aggregation_vkey))
+        })?;
+
+    let out = serde_json::to_string_pretty(&json!({
+        "range_vkey_commitment": range_vkey_commitment,
+        "aggregation_vkey": aggregation_vkey,
+        "elfs": {
+            "world-chain-range-ethereum": {
+                "path": args.range_elf,
+                "sha256": range_elf_sha256,
+            },
+            "world-chain-aggregation": {
+                "path": args.agg_elf,
+                "sha256": agg_elf_sha256,
+            },
+        },
+    }))?;
+
+    match &args.output {
+        Some(path) => {
+            ensure_parent_dir(path)?;
+            fs::write(path, &out)
+                .wrap_err_with(|| format!("failed to write {}", path.display()))?;
+            println!("wrote vkeys to {}", path.display());
+        }
+        None => println!("{out}"),
+    }
+    Ok(())
 }
 
 #[cfg(feature = "sp1")]

--- a/proofs/nitro/Dockerfile
+++ b/proofs/nitro/Dockerfile
@@ -11,11 +11,25 @@
 #     --docker-uri world-chain-nitro-enclave:latest \
 #     --output-file world-chain-nitro-enclave.eif
 #
+# Or use scripts/build-eif.sh, which does both and emits the PCR measurements.
+#
 # The resulting EIF's PCR0/PCR1/PCR2 measurements must be copied into the verifier's
 # `ExpectedPcrs` (see `proofs/nitro/src/lib.rs`).
+#
+# REPRODUCIBILITY: the PCR measurements are a hash of the EIF contents, so this
+# build must be bit-for-bit reproducible for anyone to re-derive the registered
+# PCRs from source. Base images are pinned by digest and apt packages come from
+# a fixed snapshot.debian.org timestamp. When bumping either pin, expect the
+# PCRs to change and re-register them.
 
-ARG RUST_VERSION=1.95
-FROM rust:${RUST_VERSION}-bookworm AS builder
+# rust:1.95.0-bookworm
+FROM rust@sha256:6258907abe69656e41cd992e0b705cdcfabcbbe3db374f92ed2d47121282d4a1 AS builder
+
+# Pin apt to a fixed Debian snapshot so package versions cannot drift.
+ARG DEBIAN_SNAPSHOT=20260601T000000Z
+RUN rm -f /etc/apt/sources.list /etc/apt/sources.list.d/*.sources && \
+    printf 'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/%s bookworm main\ndeb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/%s bookworm-security main\n' \
+        "$DEBIAN_SNAPSHOT" "$DEBIAN_SNAPSHOT" > /etc/apt/sources.list
 
 # Dependencies for kona / rkyv / kzg-rs.
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -37,9 +51,14 @@ RUN cargo build \
         --features enclave-bin
 
 # ---- runtime image (kept minimal so PCR0 stays stable) ---------------------
-FROM debian:bookworm-slim
+# debian:bookworm-slim
+FROM debian@sha256:0104b334637a5f19aa9c983a91b54c89887c0984081f2068983107a6f6c21eeb
 
-# Install the NSM device tools required at runtime.
+ARG DEBIAN_SNAPSHOT=20260601T000000Z
+RUN rm -f /etc/apt/sources.list /etc/apt/sources.list.d/*.sources && \
+    printf 'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/%s bookworm main\ndeb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/%s bookworm-security main\n' \
+        "$DEBIAN_SNAPSHOT" "$DEBIAN_SNAPSHOT" > /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
     && rm -rf /var/lib/apt/lists/*

--- a/scripts/build-eif.sh
+++ b/scripts/build-eif.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build the world-chain-nitro-enclave EIF and emit its PCR measurements.
+#
+# Builds the enclave container image from proofs/nitro/Dockerfile, then converts
+# it to an EIF with nitro-cli (built from source at a pinned tag so the EIF
+# assembly itself is pinned). Runs on any Linux x86_64 host with Docker — Nitro
+# hardware is only needed to *run* the enclave, not to build it.
+#
+# Usage: scripts/build-eif.sh [output-dir]   (default: target/eif)
+#
+# Outputs in <output-dir>:
+#   world-chain-nitro-enclave.eif   the enclave image
+#   pcrs.json                       PCR0/PCR1/PCR2 measurements
+#
+# Env overrides:
+#   NITRO_CLI_VERSION   tag of aws/aws-nitro-enclaves-cli to build (default v1.4.2)
+#   ENCLAVE_IMAGE_TAG   docker tag for the intermediate container image
+
+if [ "$(uname -s)" != "Linux" ] || [ "$(uname -m)" != "x86_64" ]; then
+  echo "[ERROR] EIF builds require Linux x86_64 (got $(uname -s)/$(uname -m))." >&2
+  exit 1
+fi
+
+NITRO_CLI_VERSION="${NITRO_CLI_VERSION:-v1.4.2}"
+ENCLAVE_IMAGE_TAG="${ENCLAVE_IMAGE_TAG:-world-chain-nitro-enclave:local}"
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+out_dir="${1:-target/eif}"
+mkdir -p "$out_dir"
+out_dir="$(cd "$out_dir" && pwd)"
+
+echo "[1/3] Building enclave container image ($ENCLAVE_IMAGE_TAG)..."
+docker build -t "$ENCLAVE_IMAGE_TAG" -f proofs/nitro/Dockerfile .
+
+echo "[2/3] Building nitro-cli $NITRO_CLI_VERSION..."
+nitro_cli_dir="$out_dir/aws-nitro-enclaves-cli-$NITRO_CLI_VERSION"
+nitro_cli="$nitro_cli_dir/target/release/nitro-cli"
+if [ ! -x "$nitro_cli" ]; then
+  rm -rf "$nitro_cli_dir"
+  git clone --depth 1 --branch "$NITRO_CLI_VERSION" \
+    https://github.com/aws/aws-nitro-enclaves-cli "$nitro_cli_dir"
+  cargo build --release --bin nitro-cli --manifest-path "$nitro_cli_dir/Cargo.toml"
+fi
+
+echo "[3/3] Converting to EIF..."
+eif_path="$out_dir/world-chain-nitro-enclave.eif"
+build_json="$out_dir/build-enclave.json"
+NITRO_CLI_BLOBS="$nitro_cli_dir/blobs/x86_64" \
+NITRO_CLI_ARTIFACTS="$out_dir/artifacts" \
+  "$nitro_cli" build-enclave \
+    --docker-uri "$ENCLAVE_IMAGE_TAG" \
+    --output-file "$eif_path" | tee "$build_json"
+
+jq '.Measurements' "$build_json" > "$out_dir/pcrs.json"
+
+echo
+echo "EIF:  $eif_path"
+echo "PCRs: $out_dir/pcrs.json"
+jq . "$out_dir/pcrs.json"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches governance-critical measurements (on-chain vkeys/PCRs) and release automation with GPG/registry publishing; mistakes could ship wrong verifier bindings or skip registry-update warnings.
> 
> **Overview**
> Adds a **`proof/v*`-tagged release pipeline** (`release-proof.yml`) that gates on reproducible SP1 ELFs, then ships vkeys, multi-arch `Dockerfile.proof` images, GPG-signed `proof` binaries, Nitro EIF + PCRs, and a **`manifest.json`** binding git SHA, measurements, and image digests—opening a **draft** GitHub release with measurement diff vs the prior prover release.
> 
> **CLI & tooling:** new **`proof sp1 vkeys`** (local SP1 setup + ELF SHA256s), **`just proof-vkeys`**, and docs in `docs/proof/release.md` / `proof-cli.md`.
> 
> **Docker/CI:** composite actions gain optional **`build_args`** and **`digest_artifact_prefix`**; merge action **exports manifest digest**. **`Dockerfile.proof`** parameterizes package/bin/features, bakes guest ELFs and env paths. **Nitro** image pins digests + Debian snapshot; **`scripts/build-eif.sh`** builds pinned `nitro-cli` and emits `pcrs.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e41c6b2929cbe47558cb2f5496e470f2c18c56d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->