### PR TITLE
feat(proof-system): add defender

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18082,6 +18082,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "world-chain-defender"
+version = "2.2.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-provider 2.0.4",
+ "alloy-rpc-types-eth 2.0.4",
+ "async-trait",
+ "thiserror 2.0.18",
+ "world-chain-proofs",
+]
+
+[[package]]
 name = "world-chain-devnet"
 version = "2.2.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18089,8 +18089,12 @@ dependencies = [
  "alloy-provider 2.0.4",
  "alloy-rpc-types-eth 2.0.4",
  "async-trait",
+ "futures-util",
  "thiserror 2.0.18",
+ "tokio",
+ "tracing",
  "world-chain-proofs",
+ "world-chain-prover-service",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ members = [
     "proofs/prover-service",
     "proofs/worker",
     "proofs/sp1-worker",
+    "proofs/defender",
     "e2e-tests",
     "xtask",
 ]
@@ -98,6 +99,7 @@ world-chain-challenger = { path = "proofs/challenger", default-features = false 
 world-chain-prover-service = { path = "proofs/prover-service", default-features = false }
 world-chain-proof-worker = { path = "proofs/worker", default-features = false }
 world-chain-sp1-worker = { path = "proofs/sp1-worker", default-features = false }
+world-chain-defender = { path = "proofs/defender", default-features = false }
 
 # reth crates.io
 reth-codecs = { version = "0.3.1", default-features = false }

--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -2394,7 +2394,6 @@ async fn start_world_chain_challenger(
     let output_roots = OptimismConsensusClient::new(output_root_rpc_url.to_string());
     let config = ChallengerConfig {
         challenger_bond: U256::from(WORLD_CHALLENGER_BOND_WEI),
-        factory_contract: factory_address,
         poll_interval: WORLD_CHALLENGER_POLL_INTERVAL,
         ..ChallengerConfig::default()
     };

--- a/proofs/challenger/src/alloy.rs
+++ b/proofs/challenger/src/alloy.rs
@@ -75,7 +75,7 @@ where
             .map(|(event, _log)| {
                 Ok(GameCreated {
                     proposal_key: event.proposalKey,
-                    root_it: event.rootId,
+                    root_id: event.rootId,
                     game: event.game,
                     proposer: event.proposer,
                     root_claim: event.rootClaim,

--- a/proofs/challenger/src/alloy.rs
+++ b/proofs/challenger/src/alloy.rs
@@ -1,13 +1,10 @@
+use crate::{error::ChallengerError, traits::ChallengerClient, types::ChallengeSubmission};
 use alloy_primitives::{Address, BlockNumber, U256};
 use alloy_provider::Provider;
 use alloy_rpc_types_eth::BlockId;
 use async_trait::async_trait;
-use world_chain_proofs::{IWorldChainProofSystemFactory, IWorldChainProofSystemGame};
-
-use crate::{
-    error::ChallengerError,
-    traits::ChallengerClient,
-    types::{ChallengeSubmission, GameCreated, RootState},
+use world_chain_proofs::{
+    GameCreated, IWorldChainProofSystemFactory, IWorldChainProofSystemGame, RootState,
 };
 
 /// Alloy-backed implementation of [`ChallengerClient`].

--- a/proofs/challenger/src/challenger.rs
+++ b/proofs/challenger/src/challenger.rs
@@ -1,9 +1,8 @@
 use crate::{
-    GameCreated,
     config::ChallengerConfig,
     error::{ChallengerError, GameScanError},
     traits::ChallengerClient,
-    types::{GameScanOutcome, RetryGame, RootState},
+    types::{GameScanOutcome, RetryGame},
 };
 use alloy_primitives::{Address, BlockNumber};
 use futures_util::{StreamExt, stream};
@@ -12,7 +11,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 use tracing::warn;
-use world_chain_proofs::ConsensusProvider;
+use world_chain_proofs::{ConsensusProvider, GameCreated, RootState};
 
 /// The number of L1 blocks published in 24h.
 const ONE_DAY_OF_L1_BLOCKS: u64 = 7_200;

--- a/proofs/challenger/src/config.rs
+++ b/proofs/challenger/src/config.rs
@@ -1,5 +1,5 @@
 use crate::error::ChallengerError;
-use alloy_primitives::{Address, U256};
+use alloy_primitives::U256;
 use std::time::Duration;
 
 /// Default number of games processed concurrently.
@@ -10,8 +10,6 @@ pub const DEFAULT_MAX_GAME_CONCURRENCY: usize = 10;
 pub struct ChallengerConfig {
     /// Bond sent with `WorldChainProofSystemGame.challenge`.
     pub challenger_bond: U256,
-    /// The `WorldChainProofSystemFactory` contract address.
-    pub factory_contract: Address,
     /// Delay between periodic scan attempts.
     pub poll_interval: Duration,
     /// Maximum number of games to process concurrently.
@@ -20,11 +18,6 @@ pub struct ChallengerConfig {
 
 impl ChallengerConfig {
     pub(crate) fn validate(&self) -> Result<(), ChallengerError> {
-        if self.factory_contract.is_zero() {
-            return Err(ChallengerError::InvalidConfig(
-                "factory contract cannot be zero",
-            ));
-        }
         if self.poll_interval.is_zero() {
             return Err(ChallengerError::InvalidConfig(
                 "poll_interval must be greater than zero",
@@ -43,7 +36,6 @@ impl Default for ChallengerConfig {
     fn default() -> Self {
         Self {
             challenger_bond: U256::ZERO,
-            factory_contract: Address::with_last_byte(1),
             poll_interval: Duration::from_mins(1),
             max_game_concurrency: DEFAULT_MAX_GAME_CONCURRENCY,
         }

--- a/proofs/challenger/src/error.rs
+++ b/proofs/challenger/src/error.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::{Address, TxHash};
 use thiserror::Error;
-use world_chain_proofs::ConsensusError;
+use world_chain_proofs::{ConsensusError, RootStateError};
 
 /// Errors returned by the proposer.
 #[derive(Debug, Error)]
@@ -23,8 +23,8 @@ pub enum ChallengerError {
     OutputRoot(#[from] ConsensusError),
     #[error("The challenge transaction didn't execute succesfully: {0}")]
     Revert(TxHash),
-    #[error("Invalid root state: {0}")]
-    InvalidRootState(u8),
+    #[error(transparent)]
+    InvalidRootState(#[from] RootStateError),
     #[error("RPC error: {0}")]
     Rpc(String),
     #[error("Latest L1 finalized block not found")]

--- a/proofs/challenger/src/lib.rs
+++ b/proofs/challenger/src/lib.rs
@@ -13,7 +13,7 @@ pub use challenger::WorldChainChallenger;
 pub use config::ChallengerConfig;
 pub use error::ChallengerError;
 pub use traits::ChallengerClient;
-pub use types::{ChallengeSubmission, Game, GameCreated, RootState};
+pub use types::ChallengeSubmission;
 
 #[cfg(test)]
 mod tests;

--- a/proofs/challenger/src/tests.rs
+++ b/proofs/challenger/src/tests.rs
@@ -1,9 +1,6 @@
 use crate::{
-    challenger::WorldChainChallenger,
-    config::ChallengerConfig,
-    error::ChallengerError,
-    traits::ChallengerClient,
-    types::{ChallengeSubmission, GameCreated, RootState},
+    challenger::WorldChainChallenger, config::ChallengerConfig, error::ChallengerError,
+    traits::ChallengerClient, types::ChallengeSubmission,
 };
 use alloy_primitives::{Address, B256, BlockNumber, U256, address};
 use async_trait::async_trait;
@@ -15,7 +12,7 @@ use std::{
     },
     time::Duration,
 };
-use world_chain_proofs::{ConsensusError, ConsensusProvider};
+use world_chain_proofs::{ConsensusError, ConsensusProvider, GameCreated, RootState};
 
 const GAME_1: Address = address!("0000000000000000000000000000000000000001");
 const GAME_2: Address = address!("0000000000000000000000000000000000000002");
@@ -40,7 +37,7 @@ struct MockClient {
 impl ChallengerClient for MockClient {
     async fn root_state(&self, game: Address) -> Result<RootState, ChallengerError> {
         let raw = self.states.get(&game).copied().unwrap_or(STATE_PROPOSED);
-        RootState::try_from(raw)
+        RootState::try_from(raw).map_err(Into::into)
     }
 
     async fn finalized_l1_block_num(&self) -> Result<BlockNumber, ChallengerError> {

--- a/proofs/challenger/src/tests.rs
+++ b/proofs/challenger/src/tests.rs
@@ -17,7 +17,6 @@ use std::{
 };
 use world_chain_proofs::{ConsensusError, ConsensusProvider};
 
-const FACTORY: Address = address!("0000000000000000000000000000000000001006");
 const GAME_1: Address = address!("0000000000000000000000000000000000000001");
 const GAME_2: Address = address!("0000000000000000000000000000000000000002");
 const FINALIZED_L1_BLOCK: BlockNumber = 10_000;
@@ -123,7 +122,6 @@ fn mock_output_roots(
 fn config() -> ChallengerConfig {
     ChallengerConfig {
         challenger_bond: U256::from(1),
-        factory_contract: FACTORY,
         poll_interval: Duration::from_secs(1),
         ..ChallengerConfig::default()
     }

--- a/proofs/challenger/src/tests.rs
+++ b/proofs/challenger/src/tests.rs
@@ -54,7 +54,7 @@ impl ChallengerClient for MockClient {
             .iter()
             .map(|&(game, root_claim, l2_block_number)| GameCreated {
                 proposal_key: B256::ZERO,
-                root_it: B256::ZERO,
+                root_id: B256::ZERO,
                 game,
                 proposer: Address::ZERO,
                 root_claim,

--- a/proofs/challenger/src/traits.rs
+++ b/proofs/challenger/src/traits.rs
@@ -1,9 +1,7 @@
-use crate::{
-    error::ChallengerError,
-    types::{ChallengeSubmission, GameCreated, RootState},
-};
+use crate::{error::ChallengerError, types::ChallengeSubmission};
 use alloy_primitives::{Address, BlockNumber, U256};
 use async_trait::async_trait;
+use world_chain_proofs::{GameCreated, RootState};
 
 #[async_trait]
 pub trait ChallengerClient {

--- a/proofs/challenger/src/types.rs
+++ b/proofs/challenger/src/types.rs
@@ -1,67 +1,11 @@
 use alloy_primitives::{Address, B256, BlockNumber, TxHash};
-
-use crate::error::ChallengerError;
-
-/// A game root state.
-#[derive(Debug, PartialEq, Eq)]
-pub enum RootState {
-    None,
-    Proposed,
-    Challenged,
-    Finalized,
-    Invalidated,
-}
-
-impl TryFrom<u8> for RootState {
-    type Error = ChallengerError;
-
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
-        match value {
-            0 => Ok(RootState::None),
-            1 => Ok(RootState::Proposed),
-            2 => Ok(RootState::Challenged),
-            3 => Ok(RootState::Finalized),
-            4 => Ok(RootState::Invalidated),
-            _ => Err(ChallengerError::InvalidRootState(value)),
-        }
-    }
-}
-
-/// A WorldChainProofSystemGame view for the challenger.
-#[derive(Debug)]
-pub struct Game {
-    /// The game contract address.
-    pub game: Address,
-    /// The output root claim contained in this game.
-    pub root_claim: B256,
-    /// The L2 block number the `root_claim` refers to.
-    pub l2_block_number: BlockNumber,
-    /// The root state of this game.
-    pub root_state: RootState,
-    /// The deadline in UNIX timestamp this game must be challenged
-    /// if `root_claim` is incorrect.
-    pub challenge_deadline: u64,
-}
+use world_chain_proofs::{GameCreated, RootState};
 
 /// Result of a submitted challenge transaction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ChallengeSubmission {
     /// Transaction hash for the challenge submission.
     pub tx_hash: TxHash,
-}
-
-/// The `GameCreated` event.
-#[derive(Debug, Clone, Copy)]
-pub struct GameCreated {
-    pub proposal_key: B256,
-    pub root_it: B256,
-    pub game: Address,
-    pub proposer: Address,
-    pub root_claim: B256,
-    pub l2_block_number: BlockNumber,
-    pub parent_ref: Address,
-    pub l1_origin_hash: B256,
-    pub l1_origin_number: BlockNumber,
 }
 
 /// A game queued for retry after a transient scan failure.

--- a/proofs/challenger/src/types.rs
+++ b/proofs/challenger/src/types.rs
@@ -1,5 +1,5 @@
-use alloy_primitives::{Address, B256, BlockNumber, TxHash};
-use world_chain_proofs::{GameCreated, RootState};
+use alloy_primitives::TxHash;
+use world_chain_proofs::GameCreated;
 
 /// Result of a submitted challenge transaction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/proofs/defender/Cargo.toml
+++ b/proofs/defender/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "world-chain-defender"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# workspace
+world-chain-proofs.workspace = true
+
+# alloy
+alloy-primitives.workspace = true
+alloy-provider.workspace = true
+alloy-rpc-types-eth.workspace = true
+
+# misc
+thiserror.workspace = true
+async-trait.workspace = true

--- a/proofs/defender/Cargo.toml
+++ b/proofs/defender/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 [dependencies]
 # workspace
 world-chain-proofs.workspace = true
+world-chain-prover-service.workspace = true
 
 # alloy
 alloy-primitives.workspace = true
@@ -22,3 +23,6 @@ alloy-rpc-types-eth.workspace = true
 # misc
 thiserror.workspace = true
 async-trait.workspace = true
+futures-util.workspace = true
+tokio = { workspace = true, features = ["time"] }
+tracing.workspace = true

--- a/proofs/defender/src/alloy.rs
+++ b/proofs/defender/src/alloy.rs
@@ -75,7 +75,7 @@ where
             .map(|(event, _log)| {
                 Ok(GameCreated {
                     proposal_key: event.proposalKey,
-                    root_it: event.rootId,
+                    root_id: event.rootId,
                     game: event.game,
                     proposer: event.proposer,
                     root_claim: event.rootClaim,
@@ -99,6 +99,19 @@ where
             .await
             .map_err(|err| DefenderError::Contract(err.to_string()))?;
         Ok(challenge_deadline)
+    }
+
+    async fn proof_bitmap(&self, game: Address) -> Result<u8, DefenderError> {
+        let game = IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance::new(
+            game,
+            self.provider.clone(),
+        );
+        let proof_bitmap = game
+            .proofBitmap()
+            .call()
+            .await
+            .map_err(|err| DefenderError::Contract(err.to_string()))?;
+        Ok(proof_bitmap)
     }
 
     async fn submit_proof(

--- a/proofs/defender/src/alloy.rs
+++ b/proofs/defender/src/alloy.rs
@@ -1,0 +1,135 @@
+use crate::{error::DefenderError, traits::DefenderClient, types::DefenderSubmission};
+use alloy_primitives::{Address, BlockNumber, Bytes, U256};
+use alloy_provider::Provider;
+use alloy_rpc_types_eth::BlockId;
+use async_trait::async_trait;
+use world_chain_proofs::{
+    GameCreated, IWorldChainProofSystemFactory, IWorldChainProofSystemGame, RootState,
+};
+
+/// Alloy-backed implementation of [`DefenderClient`].
+#[derive(Debug, Clone)]
+pub struct AlloyDefenderClient<P> {
+    factory: IWorldChainProofSystemFactory::IWorldChainProofSystemFactoryInstance<P>,
+    provider: P,
+}
+
+impl<P> AlloyDefenderClient<P>
+where
+    P: Provider + Clone,
+{
+    /// Creates a new Alloy-backed contract client.
+    pub fn new(provider: P, factory_address: Address) -> Self {
+        let factory = IWorldChainProofSystemFactory::IWorldChainProofSystemFactoryInstance::new(
+            factory_address,
+            provider.clone(),
+        );
+
+        Self { factory, provider }
+    }
+}
+
+#[async_trait]
+impl<P> DefenderClient for AlloyDefenderClient<P>
+where
+    P: Provider + Clone + Send + Sync + 'static,
+{
+    async fn root_state(&self, game: Address) -> Result<RootState, DefenderError> {
+        let game = IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance::new(
+            game,
+            self.provider.clone(),
+        );
+        let root_state_raw = game
+            .state()
+            .call()
+            .await
+            .map_err(|err| DefenderError::Contract(err.to_string()))?;
+        let root_state: RootState = root_state_raw.try_into()?;
+        Ok(root_state)
+    }
+
+    async fn finalized_l1_block_num(&self) -> Result<BlockNumber, DefenderError> {
+        self.provider
+            .get_block(BlockId::finalized())
+            .await
+            .map_err(|err| DefenderError::Rpc(err.to_string()))?
+            .map(|block| block.number())
+            .ok_or(DefenderError::L1FinalizedBlockNotFound)
+    }
+
+    async fn games_created(
+        &self,
+        from: BlockNumber,
+        to: BlockNumber,
+    ) -> Result<Vec<GameCreated>, DefenderError> {
+        let logs = self
+            .factory
+            .GameCreated_filter()
+            .from_block(from)
+            .to_block(to)
+            .query()
+            .await
+            .map_err(|err| DefenderError::Rpc(err.to_string()))?;
+
+        logs.into_iter()
+            .map(|(event, _log)| {
+                Ok(GameCreated {
+                    proposal_key: event.proposalKey,
+                    root_it: event.rootId,
+                    game: event.game,
+                    proposer: event.proposer,
+                    root_claim: event.rootClaim,
+                    l2_block_number: u256_to_u64(event.l2BlockNumber, "l2BlockNumber")?,
+                    parent_ref: event.parentRef,
+                    l1_origin_hash: event.l1OriginHash,
+                    l1_origin_number: u256_to_u64(event.l1OriginNumber, "l1OriginNumber")?,
+                })
+            })
+            .collect()
+    }
+
+    async fn challenge_deadline(&self, game: Address) -> Result<u64, DefenderError> {
+        let game = IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance::new(
+            game,
+            self.provider.clone(),
+        );
+        let challenge_deadline = game
+            .challengeDeadline()
+            .call()
+            .await
+            .map_err(|err| DefenderError::Contract(err.to_string()))?;
+        Ok(challenge_deadline)
+    }
+
+    async fn submit_proof(
+        &self,
+        game: Address,
+        lane: u8,
+        proof: Bytes,
+    ) -> Result<DefenderSubmission, DefenderError> {
+        let game = IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance::new(
+            game,
+            self.provider.clone(),
+        );
+        let pending = game
+            .submitProofLane(lane, proof)
+            .send()
+            .await
+            .map_err(|err| DefenderError::Contract(err.to_string()))?;
+        let tx_hash = *pending.tx_hash();
+        let receipt = pending
+            .get_receipt()
+            .await
+            .map_err(|err| DefenderError::Contract(err.to_string()))?;
+        if !receipt.status() {
+            return Err(DefenderError::Revert(tx_hash));
+        }
+        Ok(DefenderSubmission { tx_hash })
+    }
+}
+
+fn u256_to_u64(value: U256, field: &'static str) -> Result<u64, DefenderError> {
+    value
+        .try_into()
+        .map_err(|_| DefenderError::Contract(format!("{field} overflows u64")))
+}

--- a/proofs/defender/src/config.rs
+++ b/proofs/defender/src/config.rs
@@ -4,6 +4,9 @@ use std::time::Duration;
 /// Default number of games processed concurrently.
 pub const DEFAULT_MAX_GAME_CONCURRENCY: usize = 10;
 
+/// Default number of proving attempts per lane before abandoning it.
+pub const DEFAULT_MAX_PROOF_ATTEMPTS: u32 = 3;
+
 /// Configuration for the defender.
 #[derive(Debug, Clone)]
 pub struct DefenderConfig {
@@ -11,6 +14,8 @@ pub struct DefenderConfig {
     pub poll_interval: Duration,
     /// Maximum number of games to process concurrently.
     pub max_game_concurrency: usize,
+    /// Maximum number of proving attempts per lane before abandoning it.
+    pub max_proof_attempts: u32,
 }
 
 impl DefenderConfig {
@@ -25,6 +30,11 @@ impl DefenderConfig {
                 "max_game_concurrency must be greater than zero",
             ));
         }
+        if self.max_proof_attempts == 0 {
+            return Err(DefenderError::InvalidConfig(
+                "max_proof_attempts must be greater than zero",
+            ));
+        }
         Ok(())
     }
 }
@@ -34,6 +44,7 @@ impl Default for DefenderConfig {
         Self {
             poll_interval: Duration::from_mins(1),
             max_game_concurrency: DEFAULT_MAX_GAME_CONCURRENCY,
+            max_proof_attempts: DEFAULT_MAX_PROOF_ATTEMPTS,
         }
     }
 }

--- a/proofs/defender/src/config.rs
+++ b/proofs/defender/src/config.rs
@@ -1,0 +1,39 @@
+use crate::error::DefenderError;
+use std::time::Duration;
+
+/// Default number of games processed concurrently.
+pub const DEFAULT_MAX_GAME_CONCURRENCY: usize = 10;
+
+/// Configuration for the defender.
+#[derive(Debug, Clone)]
+pub struct DefenderConfig {
+    /// Delay between periodic scan attempts.
+    pub poll_interval: Duration,
+    /// Maximum number of games to process concurrently.
+    pub max_game_concurrency: usize,
+}
+
+impl DefenderConfig {
+    pub(crate) fn validate(&self) -> Result<(), DefenderError> {
+        if self.poll_interval.is_zero() {
+            return Err(DefenderError::InvalidConfig(
+                "poll_interval must be greater than zero",
+            ));
+        }
+        if self.max_game_concurrency == 0 {
+            return Err(DefenderError::InvalidConfig(
+                "max_game_concurrency must be greater than zero",
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Default for DefenderConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval: Duration::from_mins(1),
+            max_game_concurrency: DEFAULT_MAX_GAME_CONCURRENCY,
+        }
+    }
+}

--- a/proofs/defender/src/defender.rs
+++ b/proofs/defender/src/defender.rs
@@ -1,0 +1,422 @@
+use crate::{
+    config::DefenderConfig,
+    error::DefenderError,
+    traits::DefenderClient,
+    types::{ActiveDefense, DEFENDED_LANES, DefenseProgress, LaneState, WatchOutcome, WatchedGame},
+};
+use alloy_primitives::{Address, BlockNumber, Bytes};
+use futures_util::{StreamExt, stream};
+use std::{
+    collections::HashMap,
+    time::{SystemTime, UNIX_EPOCH},
+};
+use tracing::{error, info, warn};
+use world_chain_proofs::{ConsensusProvider, GameCreated, ProofLane, RootState};
+use world_chain_prover_service::{
+    ProofBackend, ProofData, ProofRequest, ProofRequester, ProofStatus,
+};
+
+/// The number of L1 blocks published in 24h.
+const ONE_DAY_OF_L1_BLOCKS: u64 = 7_200;
+/// The safety margin of blocks.
+const MARGIN: u64 = 500;
+
+/// World Chain Defender.
+///
+/// Watches every created game until it leaves the `Proposed` state. When a
+/// game is challenged and its root claim matches the canonical output root,
+/// the defender requests one proof per defended lane from the
+/// `prover-service` and submits each completed proof on-chain via
+/// `submitProofLane`.
+#[derive(Debug)]
+pub struct WorldChainDefender<E, C, P> {
+    config: DefenderConfig,
+    execution_provider: E,
+    consensus_provider: C,
+    proof_requester: P,
+    cursor: BlockNumber,
+    watched_games: HashMap<Address, WatchedGame>,
+    active_defenses: HashMap<Address, ActiveDefense>,
+}
+
+impl<E, C, P> WorldChainDefender<E, C, P> {
+    /// Creates a defender from execution, consensus and prover-requester clients.
+    pub fn new(
+        config: DefenderConfig,
+        execution_provider: E,
+        consensus_provider: C,
+        proof_requester: P,
+    ) -> Self {
+        Self {
+            config,
+            execution_provider,
+            consensus_provider,
+            proof_requester,
+            cursor: 0,
+            watched_games: HashMap::default(),
+            active_defenses: HashMap::default(),
+        }
+    }
+
+    /// Returns the defender configuration.
+    #[must_use]
+    pub const fn config(&self) -> &DefenderConfig {
+        &self.config
+    }
+
+    #[cfg(test)]
+    pub(crate) fn watched_games(&self) -> Vec<Address> {
+        self.watched_games.keys().copied().collect()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn active_defenses(&self) -> Vec<Address> {
+        self.active_defenses.keys().copied().collect()
+    }
+}
+
+impl<E, C, P> WorldChainDefender<E, C, P>
+where
+    E: DefenderClient,
+    C: ConsensusProvider,
+    P: ProofRequester + Sync,
+{
+    async fn watch_game(
+        &self,
+        watched: &WatchedGame,
+        latest_finalized_l2_block: BlockNumber,
+        now: u64,
+    ) -> Result<WatchOutcome, DefenderError> {
+        let game_created = &watched.game_created;
+        let game = game_created.game;
+        match self.execution_provider.root_state(game).await? {
+            RootState::Proposed => {
+                let challenge_deadline = match watched.challenge_deadline {
+                    Some(challenge_deadline) => challenge_deadline,
+                    None => self.execution_provider.challenge_deadline(game).await?,
+                };
+                if now >= challenge_deadline {
+                    // the game can no longer be challenged
+                    return Ok(WatchOutcome::Drop);
+                }
+                Ok(WatchOutcome::Keep {
+                    challenge_deadline: Some(challenge_deadline),
+                })
+            }
+            RootState::Challenged => {
+                // only judge the root against finalized L2 state
+                if game_created.l2_block_number > latest_finalized_l2_block {
+                    return Ok(WatchOutcome::Keep {
+                        challenge_deadline: watched.challenge_deadline,
+                    });
+                }
+                let root = self
+                    .consensus_provider
+                    .output_root_at_block(game_created.l2_block_number)
+                    .await?;
+                if root == game_created.root_claim {
+                    Ok(WatchOutcome::Defend)
+                } else {
+                    // invalid root, leave the game to the challenger
+                    Ok(WatchOutcome::Drop)
+                }
+            }
+            // the game already reached a terminal state
+            RootState::None | RootState::Finalized | RootState::Invalidated => {
+                Ok(WatchOutcome::Drop)
+            }
+        }
+    }
+
+    async fn scan_watched_games(
+        &self,
+        latest_finalized_l2_block: BlockNumber,
+        now: u64,
+    ) -> Vec<(WatchedGame, Result<WatchOutcome, DefenderError>)> {
+        stream::iter(self.watched_games.values().copied().collect::<Vec<_>>())
+            .map(|watched| async move {
+                let result = self
+                    .watch_game(&watched, latest_finalized_l2_block, now)
+                    .await;
+                (watched, result)
+            })
+            .buffer_unordered(self.config.max_game_concurrency)
+            .collect()
+            .await
+    }
+
+    fn handle_watch_outcomes(
+        &mut self,
+        results: Vec<(WatchedGame, Result<WatchOutcome, DefenderError>)>,
+    ) {
+        for (watched, result) in results {
+            let game = watched.game_created.game;
+            match result {
+                Ok(WatchOutcome::Defend) => {
+                    info!(%game, "challenged game has a valid root; starting defense");
+                    self.watched_games.remove(&game);
+                    self.active_defenses
+                        .insert(game, ActiveDefense::new(watched.game_created));
+                }
+                Ok(WatchOutcome::Drop) => {
+                    self.watched_games.remove(&game);
+                }
+                Ok(WatchOutcome::Keep { challenge_deadline }) => {
+                    if let Some(watched) = self.watched_games.get_mut(&game) {
+                        watched.challenge_deadline = challenge_deadline;
+                    }
+                }
+                Err(err) => {
+                    warn!(game = %game, error = %err, "game watch failed; retrying next tick");
+                }
+            }
+        }
+    }
+
+    async fn advance_lane(
+        &self,
+        game_created: &GameCreated,
+        lane: ProofLane,
+        backend: ProofBackend,
+        state: LaneState,
+    ) -> LaneState {
+        let game = game_created.game;
+        match state {
+            LaneState::Proven | LaneState::Abandoned => state,
+            LaneState::Pending => {
+                match self
+                    .proof_requester
+                    .request_proof(proof_request(game_created, backend))
+                    .await
+                {
+                    Ok(id) => LaneState::Requested { id, attempts: 1 },
+                    Err(error) => {
+                        warn!(%game, ?lane, %error, "proof request failed; retrying next tick");
+                        LaneState::Pending
+                    }
+                }
+            }
+            LaneState::Requested { id, attempts } => {
+                let status = match self.proof_requester.proof_status(id).await {
+                    Ok(status) => status,
+                    Err(error) => {
+                        warn!(%game, ?lane, %id, %error, "proof status check failed; retrying next tick");
+                        return state;
+                    }
+                };
+                match status {
+                    ProofStatus::Queued | ProofStatus::InProgress => state,
+                    ProofStatus::Completed => {
+                        let response = match self.proof_requester.get_proof(id).await {
+                            Ok(response) => response,
+                            Err(error) => {
+                                warn!(%game, ?lane, %id, %error, "proof retrieval failed; retrying next tick");
+                                return state;
+                            }
+                        };
+                        match self
+                            .execution_provider
+                            .submit_proof(game, lane as u8, encode_proof(&response.proof))
+                            .await
+                        {
+                            Ok(submission) => {
+                                info!(%game, ?lane, tx_hash = %submission.tx_hash, "proof lane submitted");
+                                LaneState::Proven
+                            }
+                            Err(error) => {
+                                // if the transaction actually landed, the
+                                // proof bitmap check resolves the lane on the
+                                // next tick
+                                warn!(%game, ?lane, %error, "proof submission failed; retrying next tick");
+                                state
+                            }
+                        }
+                    }
+                    ProofStatus::Failed => {
+                        if attempts >= self.config.max_proof_attempts {
+                            error!(%game, ?lane, attempts, "proving permanently failed; abandoning lane");
+                            return LaneState::Abandoned;
+                        }
+                        // re-requesting a failed proof re-queues it
+                        match self
+                            .proof_requester
+                            .request_proof(proof_request(game_created, backend))
+                            .await
+                        {
+                            Ok(id) => LaneState::Requested {
+                                id,
+                                attempts: attempts + 1,
+                            },
+                            Err(error) => {
+                                warn!(%game, ?lane, %error, "proof re-request failed; retrying next tick");
+                                state
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    async fn advance_defense(
+        &self,
+        defense: &ActiveDefense,
+    ) -> Result<DefenseProgress, DefenderError> {
+        let game_created = &defense.game_created;
+        let game = game_created.game;
+        if self.execution_provider.root_state(game).await? != RootState::Challenged {
+            return Ok(DefenseProgress::Resolved);
+        }
+        let proof_bitmap = self.execution_provider.proof_bitmap(game).await?;
+
+        let mut lanes = defense.lanes;
+        for (slot, (lane, backend)) in DEFENDED_LANES.into_iter().enumerate() {
+            // skip lanes already proven on-chain, by us or by anyone else
+            if proof_bitmap & lane.mask() != 0 {
+                lanes[slot] = LaneState::Proven;
+                continue;
+            }
+            lanes[slot] = self
+                .advance_lane(game_created, lane, backend, lanes[slot])
+                .await;
+        }
+        Ok(DefenseProgress::Lanes(lanes))
+    }
+
+    async fn scan_active_defenses(
+        &self,
+    ) -> Vec<(ActiveDefense, Result<DefenseProgress, DefenderError>)> {
+        stream::iter(self.active_defenses.values().copied().collect::<Vec<_>>())
+            .map(|defense| async move {
+                let result = self.advance_defense(&defense).await;
+                (defense, result)
+            })
+            .buffer_unordered(self.config.max_game_concurrency)
+            .collect()
+            .await
+    }
+
+    fn handle_defense_progress(
+        &mut self,
+        results: Vec<(ActiveDefense, Result<DefenseProgress, DefenderError>)>,
+    ) {
+        for (defense, result) in results {
+            let game = defense.game_created.game;
+            match result {
+                Ok(DefenseProgress::Resolved) => {
+                    info!(%game, "game left the challenged state; defense closed");
+                    self.active_defenses.remove(&game);
+                }
+                Ok(DefenseProgress::Lanes(lanes)) => {
+                    if lanes.iter().all(|lane| *lane == LaneState::Proven) {
+                        info!(%game, "all proof lanes submitted; defense completed");
+                        self.active_defenses.remove(&game);
+                    } else if lanes.iter().all(|lane| lane.is_terminal()) {
+                        error!(%game, "defense abandoned without proving all lanes");
+                        self.active_defenses.remove(&game);
+                    } else if let Some(defense) = self.active_defenses.get_mut(&game) {
+                        defense.lanes = lanes;
+                    }
+                }
+                Err(err) => {
+                    warn!(game = %game, error = %err, "defense scan failed; retrying next tick");
+                }
+            }
+        }
+    }
+
+    pub async fn scan_once(&mut self) -> Result<(), DefenderError> {
+        let target = self.execution_provider.finalized_l1_block_num().await?;
+        let from = if self.cursor == 0 {
+            target.saturating_sub(ONE_DAY_OF_L1_BLOCKS + MARGIN)
+        } else {
+            self.cursor
+        };
+        if from <= target {
+            let games_created = self.execution_provider.games_created(from, target).await?;
+            for game_created in games_created {
+                let game = game_created.game;
+                if self.watched_games.contains_key(&game)
+                    || self.active_defenses.contains_key(&game)
+                {
+                    continue;
+                }
+                self.watched_games.insert(
+                    game,
+                    WatchedGame {
+                        game_created,
+                        challenge_deadline: None,
+                    },
+                );
+            }
+            // games are tracked in memory from here on, so the cursor can advance
+            self.cursor = target + 1;
+        }
+
+        if self.watched_games.is_empty() && self.active_defenses.is_empty() {
+            return Ok(());
+        }
+
+        let latest_finalized_l2_block = self.consensus_provider.latest_l2_finalized_block().await?;
+        let now = unix_now();
+
+        let watch_results = self
+            .scan_watched_games(latest_finalized_l2_block, now)
+            .await;
+        self.handle_watch_outcomes(watch_results);
+
+        let defense_results = self.scan_active_defenses().await;
+        self.handle_defense_progress(defense_results);
+        Ok(())
+    }
+
+    /// Runs the defender forever, logging transient failures and retrying on each tick.
+    pub async fn run_forever(&mut self) -> Result<(), DefenderError> {
+        self.config.validate()?;
+
+        let mut interval = tokio::time::interval(self.config.poll_interval);
+        loop {
+            interval.tick().await;
+            if let Err(e) = self.scan_once().await {
+                warn!(%e, "scan attempt failed");
+            }
+        }
+    }
+}
+
+/// Builds the proof request for one lane of a defended game.
+fn proof_request(game_created: &GameCreated, backend: ProofBackend) -> ProofRequest {
+    ProofRequest {
+        backend,
+        game: game_created.game,
+        root_claim: game_created.root_claim,
+        l2_block_number: game_created.l2_block_number,
+        // pin the witness to the L1 origin committed at proposal time, so
+        // the request id stays stable across defender restarts
+        l1_head: game_created.l1_origin_hash,
+    }
+}
+
+/// Encode a proof payload into the `bytes` argument of `submitProofLane`.
+///
+/// TODO: the on-chain proof calldata format is not defined yet. Replace this
+/// placeholder encoding once the game contract specifies it.
+fn encode_proof(proof: &ProofData) -> Bytes {
+    match proof {
+        ProofData::Sp1 {
+            proof,
+            public_values,
+        } => [public_values.as_ref(), proof.as_ref()].concat().into(),
+        ProofData::Nitro {
+            attestation,
+            signature,
+        } => [attestation.as_ref(), signature.as_ref()].concat().into(),
+    }
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time before unix epoch")
+        .as_secs()
+}

--- a/proofs/defender/src/error.rs
+++ b/proofs/defender/src/error.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::TxHash;
 use thiserror::Error;
-use world_chain_proofs::RootStateError;
+use world_chain_proofs::{ConsensusError, RootStateError};
 
 /// Errors returned by the defender.
 #[derive(Debug, Error)]
@@ -17,6 +17,8 @@ pub enum DefenderError {
     L1FinalizedBlockNotFound,
     #[error(transparent)]
     InvalidRootState(#[from] RootStateError),
+    #[error(transparent)]
+    OutputRoot(#[from] ConsensusError),
     #[error("The submitProofLane transaction didn't execute succesfully: {0}")]
     Revert(TxHash),
 }

--- a/proofs/defender/src/error.rs
+++ b/proofs/defender/src/error.rs
@@ -1,0 +1,22 @@
+use alloy_primitives::TxHash;
+use thiserror::Error;
+use world_chain_proofs::RootStateError;
+
+/// Errors returned by the defender.
+#[derive(Debug, Error)]
+pub enum DefenderError {
+    /// Invalid defender configuration.
+    #[error("invalid defender config: {0}")]
+    InvalidConfig(&'static str),
+    /// Contract call or transaction failure.
+    #[error("contract error: {0}")]
+    Contract(String),
+    #[error("RPC error: {0}")]
+    Rpc(String),
+    #[error("Latest L1 finalized block not found")]
+    L1FinalizedBlockNotFound,
+    #[error(transparent)]
+    InvalidRootState(#[from] RootStateError),
+    #[error("The submitProofLane transaction didn't execute succesfully: {0}")]
+    Revert(TxHash),
+}

--- a/proofs/defender/src/lib.rs
+++ b/proofs/defender/src/lib.rs
@@ -1,0 +1,7 @@
+//! World Chain Defender.
+
+mod alloy;
+mod config;
+mod error;
+mod traits;
+mod types;

--- a/proofs/defender/src/lib.rs
+++ b/proofs/defender/src/lib.rs
@@ -5,3 +5,4 @@ mod config;
 mod error;
 mod traits;
 mod types;
+mod defender;

--- a/proofs/defender/src/lib.rs
+++ b/proofs/defender/src/lib.rs
@@ -2,7 +2,18 @@
 
 mod alloy;
 mod config;
+mod defender;
 mod error;
 mod traits;
 mod types;
-mod defender;
+
+// re-exports
+pub use alloy::AlloyDefenderClient;
+pub use config::DefenderConfig;
+pub use defender::WorldChainDefender;
+pub use error::DefenderError;
+pub use traits::DefenderClient;
+pub use types::DefenderSubmission;
+
+#[cfg(test)]
+mod tests;

--- a/proofs/defender/src/tests.rs
+++ b/proofs/defender/src/tests.rs
@@ -1,0 +1,450 @@
+use crate::{
+    config::DefenderConfig, defender::WorldChainDefender, error::DefenderError,
+    traits::DefenderClient, types::DefenderSubmission,
+};
+use alloy_primitives::{Address, B256, BlockNumber, Bytes, address};
+use async_trait::async_trait;
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
+};
+use world_chain_proofs::{ConsensusError, ConsensusProvider, GameCreated, ProofLane, RootState};
+use world_chain_prover_service::{
+    ProofBackend, ProofData, ProofRequest, ProofRequestError, ProofRequestId, ProofRequester,
+    ProofResponse, ProofStatus,
+};
+
+const GAME_1: Address = address!("0000000000000000000000000000000000000001");
+const FINALIZED_L1_BLOCK: BlockNumber = 10_000;
+const L2_BLOCK: u64 = 100;
+const L1_ORIGIN_HASH: B256 = B256::repeat_byte(0x42);
+
+/// State discriminant matching [`RootState::Proposed`].
+const STATE_PROPOSED: u8 = 1;
+/// State discriminant matching [`RootState::Challenged`].
+const STATE_CHALLENGED: u8 = 2;
+/// State discriminant matching [`RootState::Finalized`].
+const STATE_FINALIZED: u8 = 3;
+
+#[derive(Debug, Clone)]
+struct MockClient {
+    finalized: BlockNumber,
+    games: Vec<(Address, B256, u64)>,
+    states: Arc<Mutex<HashMap<Address, u8>>>,
+    deadlines: HashMap<Address, u64>,
+    bitmaps: HashMap<Address, u8>,
+    submissions: Arc<Mutex<Vec<(Address, u8)>>>,
+}
+
+impl MockClient {
+    fn new(games: Vec<(Address, B256, u64)>, states: HashMap<Address, u8>) -> Self {
+        Self {
+            finalized: FINALIZED_L1_BLOCK,
+            games,
+            states: Arc::new(Mutex::new(states)),
+            deadlines: HashMap::new(),
+            bitmaps: HashMap::new(),
+            submissions: Arc::default(),
+        }
+    }
+
+    fn set_state(&self, game: Address, state: u8) {
+        self.states
+            .lock()
+            .expect("not poisoned")
+            .insert(game, state);
+    }
+
+    fn submissions(&self) -> Vec<(Address, u8)> {
+        self.submissions.lock().expect("not poisoned").clone()
+    }
+}
+
+#[async_trait]
+impl DefenderClient for MockClient {
+    async fn root_state(&self, game: Address) -> Result<RootState, DefenderError> {
+        let raw = self
+            .states
+            .lock()
+            .expect("not poisoned")
+            .get(&game)
+            .copied()
+            .unwrap_or(STATE_PROPOSED);
+        RootState::try_from(raw).map_err(Into::into)
+    }
+
+    async fn finalized_l1_block_num(&self) -> Result<BlockNumber, DefenderError> {
+        Ok(self.finalized)
+    }
+
+    async fn games_created(
+        &self,
+        _from: BlockNumber,
+        _to: BlockNumber,
+    ) -> Result<Vec<GameCreated>, DefenderError> {
+        Ok(self
+            .games
+            .iter()
+            .map(|&(game, root_claim, l2_block_number)| GameCreated {
+                proposal_key: B256::ZERO,
+                root_id: B256::ZERO,
+                game,
+                proposer: Address::ZERO,
+                root_claim,
+                l2_block_number,
+                parent_ref: Address::ZERO,
+                l1_origin_hash: L1_ORIGIN_HASH,
+                l1_origin_number: 0,
+            })
+            .collect())
+    }
+
+    async fn challenge_deadline(&self, game: Address) -> Result<u64, DefenderError> {
+        Ok(self.deadlines.get(&game).copied().unwrap_or(u64::MAX))
+    }
+
+    async fn proof_bitmap(&self, game: Address) -> Result<u8, DefenderError> {
+        Ok(self.bitmaps.get(&game).copied().unwrap_or(0))
+    }
+
+    async fn submit_proof(
+        &self,
+        game: Address,
+        lane: u8,
+        _proof: Bytes,
+    ) -> Result<DefenderSubmission, DefenderError> {
+        self.submissions
+            .lock()
+            .expect("not poisoned")
+            .push((game, lane));
+        Ok(DefenderSubmission {
+            tx_hash: B256::repeat_byte(0xaa),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MockOutputRoots {
+    roots: HashMap<u64, B256>,
+    finalized_l2_block: Arc<AtomicU64>,
+}
+
+#[async_trait]
+impl ConsensusProvider for MockOutputRoots {
+    async fn output_root_at_block(&self, l2_block_number: u64) -> Result<B256, ConsensusError> {
+        self.roots
+            .get(&l2_block_number)
+            .copied()
+            .ok_or_else(|| ConsensusError::Rpc(format!("missing root for {l2_block_number}")))
+    }
+
+    async fn latest_l2_finalized_block(&self) -> Result<BlockNumber, ConsensusError> {
+        Ok(self.finalized_l2_block.load(Ordering::SeqCst))
+    }
+}
+
+fn mock_output_roots(
+    roots: HashMap<u64, B256>,
+    finalized_l2_block: BlockNumber,
+) -> (MockOutputRoots, Arc<AtomicU64>) {
+    let finalized_l2_block = Arc::new(AtomicU64::new(finalized_l2_block));
+    (
+        MockOutputRoots {
+            roots,
+            finalized_l2_block: Arc::clone(&finalized_l2_block),
+        },
+        finalized_l2_block,
+    )
+}
+
+#[derive(Debug, Clone, Default)]
+struct MockProver {
+    /// When true, every requested proof reports [`ProofStatus::Failed`].
+    fail: bool,
+    requests: Arc<Mutex<Vec<ProofRequest>>>,
+    by_id: Arc<Mutex<HashMap<ProofRequestId, ProofRequest>>>,
+}
+
+impl MockProver {
+    fn failing() -> Self {
+        Self {
+            fail: true,
+            ..Self::default()
+        }
+    }
+
+    fn requests(&self) -> Vec<ProofRequest> {
+        self.requests.lock().expect("not poisoned").clone()
+    }
+}
+
+#[async_trait]
+impl ProofRequester for MockProver {
+    async fn request_proof(
+        &self,
+        proof_request: ProofRequest,
+    ) -> Result<ProofRequestId, ProofRequestError> {
+        let id = proof_request.id();
+        self.requests
+            .lock()
+            .expect("not poisoned")
+            .push(proof_request.clone());
+        self.by_id
+            .lock()
+            .expect("not poisoned")
+            .insert(id, proof_request);
+        Ok(id)
+    }
+
+    async fn proof_status(
+        &self,
+        _proof_id: ProofRequestId,
+    ) -> Result<ProofStatus, ProofRequestError> {
+        Ok(if self.fail {
+            ProofStatus::Failed
+        } else {
+            ProofStatus::Completed
+        })
+    }
+
+    async fn get_proof(
+        &self,
+        proof_id: ProofRequestId,
+    ) -> Result<ProofResponse, ProofRequestError> {
+        let request = self
+            .by_id
+            .lock()
+            .expect("not poisoned")
+            .get(&proof_id)
+            .cloned()
+            .ok_or(ProofRequestError::NotFound(proof_id))?;
+        let proof = match request.backend {
+            ProofBackend::Sp1 => ProofData::Sp1 {
+                proof: Bytes::from_static(b"proof"),
+                public_values: Bytes::from_static(b"public values"),
+            },
+            ProofBackend::Nitro => ProofData::Nitro {
+                attestation: Bytes::from_static(b"attestation"),
+                signature: Bytes::from_static(b"signature"),
+            },
+        };
+        Ok(ProofResponse {
+            id: proof_id,
+            proof,
+        })
+    }
+}
+
+fn config() -> DefenderConfig {
+    DefenderConfig {
+        poll_interval: Duration::from_secs(1),
+        ..DefenderConfig::default()
+    }
+}
+
+#[tokio::test]
+async fn scan_once_defends_challenged_valid_root() {
+    let canonical_root = B256::repeat_byte(0x20);
+
+    let client = MockClient::new(
+        vec![(GAME_1, canonical_root, L2_BLOCK)],
+        HashMap::from([(GAME_1, STATE_CHALLENGED)]),
+    );
+    let (output_roots, _finalized_l2_block) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
+    let prover = MockProver::default();
+    let mut defender =
+        WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
+
+    // first tick: the challenged game is promoted to an active defense and
+    // both lane proofs are requested
+    defender.scan_once().await.unwrap();
+
+    let requests = prover.requests();
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[0].backend, ProofBackend::Sp1);
+    assert_eq!(requests[1].backend, ProofBackend::Nitro);
+    for request in &requests {
+        assert_eq!(request.game, GAME_1);
+        assert_eq!(request.root_claim, canonical_root);
+        assert_eq!(request.l2_block_number, L2_BLOCK);
+        assert_eq!(request.l1_head, L1_ORIGIN_HASH);
+    }
+    assert!(client.submissions().is_empty());
+
+    // second tick: both proofs are completed, fetched and submitted on-chain
+    defender.scan_once().await.unwrap();
+
+    assert_eq!(
+        client.submissions(),
+        vec![
+            (GAME_1, ProofLane::ValidityProof as u8),
+            (GAME_1, ProofLane::TeeAttestation as u8),
+        ]
+    );
+    assert!(defender.active_defenses().is_empty());
+    assert!(defender.watched_games().is_empty());
+}
+
+#[tokio::test]
+async fn scan_once_waits_for_proposed_game_to_be_challenged() {
+    let canonical_root = B256::repeat_byte(0x20);
+
+    let client = MockClient::new(vec![(GAME_1, canonical_root, L2_BLOCK)], HashMap::new());
+    let (output_roots, _finalized_l2_block) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
+    let prover = MockProver::default();
+    let mut defender =
+        WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
+
+    // the game is only proposed: keep watching, no proof requests
+    defender.scan_once().await.unwrap();
+    assert!(prover.requests().is_empty());
+    assert_eq!(defender.watched_games(), [GAME_1]);
+
+    client.set_state(GAME_1, STATE_CHALLENGED);
+    defender.scan_once().await.unwrap();
+
+    assert_eq!(prover.requests().len(), 2);
+    assert_eq!(defender.active_defenses(), [GAME_1]);
+}
+
+#[tokio::test]
+async fn scan_once_ignores_challenged_invalid_root() {
+    let proposed_root = B256::repeat_byte(0x10);
+    let canonical_root = B256::repeat_byte(0x20);
+
+    let client = MockClient::new(
+        vec![(GAME_1, proposed_root, L2_BLOCK)],
+        HashMap::from([(GAME_1, STATE_CHALLENGED)]),
+    );
+    let (output_roots, _finalized_l2_block) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
+    let prover = MockProver::default();
+    let mut defender =
+        WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
+
+    defender.scan_once().await.unwrap();
+
+    // an invalid root is the challenger's business, not ours
+    assert!(prover.requests().is_empty());
+    assert!(defender.watched_games().is_empty());
+    assert!(defender.active_defenses().is_empty());
+}
+
+#[tokio::test]
+async fn scan_once_defers_validity_check_until_l2_block_is_finalized() {
+    let canonical_root = B256::repeat_byte(0x20);
+
+    let client = MockClient::new(
+        vec![(GAME_1, canonical_root, L2_BLOCK)],
+        HashMap::from([(GAME_1, STATE_CHALLENGED)]),
+    );
+    let (output_roots, finalized_l2_block) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK - 1);
+    let prover = MockProver::default();
+    let mut defender =
+        WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
+
+    // the game's L2 block is not finalized yet, so the root cannot be judged
+    defender.scan_once().await.unwrap();
+    assert!(prover.requests().is_empty());
+    assert_eq!(defender.watched_games(), [GAME_1]);
+
+    finalized_l2_block.store(L2_BLOCK, Ordering::SeqCst);
+    defender.scan_once().await.unwrap();
+
+    assert_eq!(prover.requests().len(), 2);
+    assert_eq!(defender.active_defenses(), [GAME_1]);
+}
+
+#[tokio::test]
+async fn scan_once_skips_lane_already_proven() {
+    let canonical_root = B256::repeat_byte(0x20);
+
+    let mut client = MockClient::new(
+        vec![(GAME_1, canonical_root, L2_BLOCK)],
+        HashMap::from([(GAME_1, STATE_CHALLENGED)]),
+    );
+    client
+        .bitmaps
+        .insert(GAME_1, ProofLane::ValidityProof.mask());
+    let (output_roots, _finalized_l2_block) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
+    let prover = MockProver::default();
+    let mut defender =
+        WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
+
+    defender.scan_once().await.unwrap();
+    defender.scan_once().await.unwrap();
+
+    // the validity lane is already proven on-chain: only the TEE lane runs
+    let requests = prover.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].backend, ProofBackend::Nitro);
+    assert_eq!(
+        client.submissions(),
+        vec![(GAME_1, ProofLane::TeeAttestation as u8)]
+    );
+    assert!(defender.active_defenses().is_empty());
+}
+
+#[tokio::test]
+async fn failed_proofs_are_rerequested_up_to_the_attempt_bound() {
+    let canonical_root = B256::repeat_byte(0x20);
+
+    let client = MockClient::new(
+        vec![(GAME_1, canonical_root, L2_BLOCK)],
+        HashMap::from([(GAME_1, STATE_CHALLENGED)]),
+    );
+    let (output_roots, _finalized_l2_block) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
+    let prover = MockProver::failing();
+    let mut defender = WorldChainDefender::new(
+        DefenderConfig {
+            max_proof_attempts: 2,
+            ..config()
+        },
+        client.clone(),
+        output_roots,
+        prover.clone(),
+    );
+
+    // tick 1: first request per lane; tick 2: failed, re-requested once per
+    // lane; tick 3: failed again, attempts exhausted, lanes abandoned
+    defender.scan_once().await.unwrap();
+    defender.scan_once().await.unwrap();
+    defender.scan_once().await.unwrap();
+
+    assert_eq!(prover.requests().len(), 4);
+    assert!(client.submissions().is_empty());
+    assert!(defender.active_defenses().is_empty());
+}
+
+#[tokio::test]
+async fn defense_closes_when_game_leaves_challenged_state() {
+    let canonical_root = B256::repeat_byte(0x20);
+
+    let client = MockClient::new(
+        vec![(GAME_1, canonical_root, L2_BLOCK)],
+        HashMap::from([(GAME_1, STATE_CHALLENGED)]),
+    );
+    let (output_roots, _finalized_l2_block) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
+    let prover = MockProver::default();
+    let mut defender =
+        WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
+
+    defender.scan_once().await.unwrap();
+    assert_eq!(defender.active_defenses(), [GAME_1]);
+
+    client.set_state(GAME_1, STATE_FINALIZED);
+    defender.scan_once().await.unwrap();
+
+    assert!(client.submissions().is_empty());
+    assert!(defender.active_defenses().is_empty());
+}

--- a/proofs/defender/src/traits.rs
+++ b/proofs/defender/src/traits.rs
@@ -1,0 +1,27 @@
+use crate::{error::DefenderError, types::DefenderSubmission};
+use alloy_primitives::{Address, BlockNumber, Bytes};
+use async_trait::async_trait;
+use world_chain_proofs::{GameCreated, RootState};
+
+#[async_trait]
+pub trait DefenderClient {
+    /// Reads the root state of the provided game.
+    async fn root_state(&self, game: Address) -> Result<RootState, DefenderError>;
+    /// Get the last finalized L1 block number.
+    async fn finalized_l1_block_num(&self) -> Result<BlockNumber, DefenderError>;
+    /// Get all `GameCreated` events between the provided block numbers.
+    async fn games_created(
+        &self,
+        from: BlockNumber,
+        to: BlockNumber,
+    ) -> Result<Vec<GameCreated>, DefenderError>;
+    /// Get the challenge deadline of the provided game.
+    async fn challenge_deadline(&self, game: Address) -> Result<u64, DefenderError>;
+    /// Submit a proof to support a challenged game.
+    async fn submit_proof(
+        &self,
+        game: Address,
+        lane: u8,
+        proof: Bytes,
+    ) -> Result<DefenderSubmission, DefenderError>;
+}

--- a/proofs/defender/src/traits.rs
+++ b/proofs/defender/src/traits.rs
@@ -17,6 +17,8 @@ pub trait DefenderClient {
     ) -> Result<Vec<GameCreated>, DefenderError>;
     /// Get the challenge deadline of the provided game.
     async fn challenge_deadline(&self, game: Address) -> Result<u64, DefenderError>;
+    /// Get the bitmap of proof lanes already proven for the provided game.
+    async fn proof_bitmap(&self, game: Address) -> Result<u8, DefenderError>;
     /// Submit a proof to support a challenged game.
     async fn submit_proof(
         &self,

--- a/proofs/defender/src/types.rs
+++ b/proofs/defender/src/types.rs
@@ -1,8 +1,85 @@
 use alloy_primitives::TxHash;
+use world_chain_proofs::{GameCreated, ProofLane};
+use world_chain_prover_service::{ProofBackend, ProofRequestId};
 
 /// Result of a submitted `submitProofLane`` transaction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DefenderSubmission {
     /// Transaction hash for the challenge submission.
     pub tx_hash: TxHash,
+}
+
+/// Number of proof lanes the defender drives.
+pub(crate) const DEFENDED_LANE_COUNT: usize = 2;
+
+/// The proof lanes the defender drives, paired with the prover-service
+/// backend that generates each proof.
+pub(crate) const DEFENDED_LANES: [(ProofLane, ProofBackend); DEFENDED_LANE_COUNT] = [
+    (ProofLane::ValidityProof, ProofBackend::Sp1),
+    (ProofLane::TeeAttestation, ProofBackend::Nitro),
+];
+
+/// A game watched until it leaves the `Proposed` state.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct WatchedGame {
+    pub game_created: GameCreated,
+    /// Cached challenge deadline, fetched lazily on the first watch tick.
+    pub challenge_deadline: Option<u64>,
+}
+
+/// Result of watching a single game for one tick.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum WatchOutcome {
+    /// Keep watching the game.
+    Keep { challenge_deadline: Option<u64> },
+    /// The game was challenged and its root is valid: start a defense.
+    Defend,
+    /// The game no longer needs watching.
+    Drop,
+}
+
+/// Progress of a single proof lane within an active defense.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LaneState {
+    /// The proof has not been requested yet.
+    Pending,
+    /// The proof was requested from the prover-service.
+    Requested { id: ProofRequestId, attempts: u32 },
+    /// The lane is proven on-chain.
+    Proven,
+    /// Proving permanently failed after exhausting all attempts.
+    Abandoned,
+}
+
+impl LaneState {
+    /// Whether the lane needs no further work.
+    pub(crate) const fn is_terminal(self) -> bool {
+        matches!(self, Self::Proven | Self::Abandoned)
+    }
+}
+
+/// An active defense of a challenged game with a valid root.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ActiveDefense {
+    pub game_created: GameCreated,
+    /// Lane progress, indexed like [`DEFENDED_LANES`].
+    pub lanes: [LaneState; DEFENDED_LANE_COUNT],
+}
+
+impl ActiveDefense {
+    pub(crate) const fn new(game_created: GameCreated) -> Self {
+        Self {
+            game_created,
+            lanes: [LaneState::Pending; DEFENDED_LANE_COUNT],
+        }
+    }
+}
+
+/// Result of advancing a single defense for one tick.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum DefenseProgress {
+    /// The game left the `Challenged` state on-chain.
+    Resolved,
+    /// Lane progress after this tick.
+    Lanes([LaneState; DEFENDED_LANE_COUNT]),
 }

--- a/proofs/defender/src/types.rs
+++ b/proofs/defender/src/types.rs
@@ -1,0 +1,8 @@
+use alloy_primitives::TxHash;
+
+/// Result of a submitted `submitProofLane`` transaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DefenderSubmission {
+    /// Transaction hash for the challenge submission.
+    pub tx_hash: TxHash,
+}

--- a/proofs/primitives/Cargo.toml
+++ b/proofs/primitives/Cargo.toml
@@ -23,7 +23,7 @@ alloy-sol-types.workspace = true
 async-trait.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-reqwest.workspace = true
+reqwest = { workspace = true, features = ["json"] }
 thiserror.workspace = true
 
 [features]

--- a/proofs/primitives/src/lib.rs
+++ b/proofs/primitives/src/lib.rs
@@ -14,6 +14,6 @@ pub use bindings::{
 };
 pub use consensus_provider::{ConsensusError, ConsensusProvider, OptimismConsensusClient};
 pub use types::{
-    PROOF_LANE_COUNT, PROOF_SYSTEM_VERSION, PROOF_THRESHOLD, ProofDomain, ProofLane,
-    ProposalCommitment, RootCommitment, has_threshold, proof_count,
+    GameCreated, PROOF_LANE_COUNT, PROOF_SYSTEM_VERSION, PROOF_THRESHOLD, ProofDomain, ProofLane,
+    ProposalCommitment, RootCommitment, RootState, RootStateError, has_threshold, proof_count,
 };

--- a/proofs/primitives/src/types.rs
+++ b/proofs/primitives/src/types.rs
@@ -16,7 +16,7 @@ pub const PROOF_SYSTEM_VERSION: u64 = 1;
 #[derive(Debug, Clone, Copy)]
 pub struct GameCreated {
     pub proposal_key: B256,
-    pub root_it: B256,
+    pub root_id: B256,
     pub game: Address,
     pub proposer: Address,
     pub root_claim: B256,

--- a/proofs/primitives/src/types.rs
+++ b/proofs/primitives/src/types.rs
@@ -1,6 +1,7 @@
-use alloy_primitives::{Address, B256, U256, keccak256};
+use alloy_primitives::{Address, B256, BlockNumber, U256, keccak256};
 use alloy_sol_types::SolValue;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 /// Number of distinct lanes required by WIP-1006 for challenged finality.
 pub const PROOF_THRESHOLD: u8 = 2;
@@ -10,6 +11,51 @@ pub const PROOF_LANE_COUNT: u8 = 3;
 
 /// Version of the World Chain proof-domain encoding implemented here.
 pub const PROOF_SYSTEM_VERSION: u64 = 1;
+
+/// The `GameCreated` event.
+#[derive(Debug, Clone, Copy)]
+pub struct GameCreated {
+    pub proposal_key: B256,
+    pub root_it: B256,
+    pub game: Address,
+    pub proposer: Address,
+    pub root_claim: B256,
+    pub l2_block_number: BlockNumber,
+    pub parent_ref: Address,
+    pub l1_origin_hash: B256,
+    pub l1_origin_number: BlockNumber,
+}
+
+/// A game root state.
+#[derive(Debug, PartialEq, Eq)]
+pub enum RootState {
+    None,
+    Proposed,
+    Challenged,
+    Finalized,
+    Invalidated,
+}
+
+#[derive(Debug, Error)]
+pub enum RootStateError {
+    #[error("Invalid root state: {0}")]
+    InvalieRootState(u8),
+}
+
+impl TryFrom<u8> for RootState {
+    type Error = RootStateError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(RootState::None),
+            1 => Ok(RootState::Proposed),
+            2 => Ok(RootState::Challenged),
+            3 => Ok(RootState::Finalized),
+            4 => Ok(RootState::Invalidated),
+            _ => Err(RootStateError::InvalieRootState(value)),
+        }
+    }
+}
 
 /// Domain constants committed into every root id.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4712/defender-create-the-defender-monitoring-part

This PR adds the `world-chain-defender` service. It's responsible of monitoring active games that have been challenged but contain a valid root claim. Only for those games, it needs to start a defense process --> request 2 proofs (tee + zk) and then submits the respective transactions onchain to support the challenged game.

Right now the architecture is pretty similar to `world-chain-challenger` and `world-chain-proposer`: everything happens on a tick and it's stored in-memory. Future iterations may change this with a persistent db if needed (even though I don't think this is necessary).