### PR TITLE
fix: record incremental metrics correctly

### DIFF
--- a/crates/builder/src/payload_builder_metrics.rs
+++ b/crates/builder/src/payload_builder_metrics.rs
@@ -375,9 +375,10 @@ pub struct PayloadBuildMetrics {
     pub committed_payload_transaction_count: Histogram,
     /// Latest committed payload transaction count.
     pub committed_payload_transaction_count_latest: Gauge,
-    /// Histogram of committed payload fees in wei.
+    /// Histogram of marginal fees in wei added by each committed flashblock. Summing this
+    /// over a window yields true per-block revenue (records the delta, not the running total).
     pub committed_payload_fees_wei: Histogram,
-    /// Latest committed payload fees in wei.
+    /// Latest committed payload cumulative fees in wei (full block value at last commit).
     pub committed_payload_fees_wei_latest: Gauge,
     /// Histogram of committed flashblock index values.
     pub committed_flashblock_index: Histogram,
@@ -547,7 +548,8 @@ impl PayloadBuildMetrics {
         size_bytes: u64,
         gas_used: u64,
         tx_count: u64,
-        fees_wei: f64,
+        incremental_fees_wei: f64,
+        cumulative_fees_wei: f64,
         flashblock_index: u64,
     ) {
         self.committed_payloads_total.increment(1);
@@ -560,8 +562,9 @@ impl PayloadBuildMetrics {
             .record(tx_count as f64);
         self.committed_payload_transaction_count_latest
             .set(tx_count as f64);
-        self.committed_payload_fees_wei.record(fees_wei);
-        self.committed_payload_fees_wei_latest.set(fees_wei);
+        self.committed_payload_fees_wei.record(incremental_fees_wei);
+        self.committed_payload_fees_wei_latest
+            .set(cumulative_fees_wei);
         self.committed_flashblock_index
             .record(flashblock_index as f64);
         self.committed_flashblock_index_latest

--- a/crates/builder/src/payload_builder_metrics.rs
+++ b/crates/builder/src/payload_builder_metrics.rs
@@ -365,24 +365,14 @@ pub struct PayloadBuildMetrics {
     pub committed_payloads_total: Counter,
     /// Histogram of committed payload size in bytes.
     pub committed_payload_size_bytes: Histogram,
-    /// Latest committed payload size in bytes.
-    pub committed_payload_size_bytes_latest: Gauge,
     /// Histogram of committed payload gas used.
     pub committed_payload_gas_used: Histogram,
-    /// Latest committed payload gas used.
-    pub committed_payload_gas_used_latest: Gauge,
     /// Histogram of committed payload transaction count.
     pub committed_payload_transaction_count: Histogram,
-    /// Latest committed payload transaction count.
-    pub committed_payload_transaction_count_latest: Gauge,
     /// Histogram of committed payload fees in wei.
     pub committed_payload_fees_wei: Histogram,
-    /// Latest committed payload fees in wei.
-    pub committed_payload_fees_wei_latest: Gauge,
     /// Histogram of committed flashblock index values.
     pub committed_flashblock_index: Histogram,
-    /// Latest committed flashblock index value.
-    pub committed_flashblock_index_latest: Gauge,
 }
 
 impl PayloadBuildMetrics {
@@ -542,39 +532,24 @@ impl PayloadBuildMetrics {
             .set(count as f64);
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn record_committed_payload(
         &self,
         incremental_size_bytes: u64,
-        cumulative_size_bytes: u64,
         incremental_gas_used: u64,
-        cumulative_gas_used: u64,
         incremental_tx_count: u64,
-        cumulative_tx_count: u64,
         incremental_fees_wei: f64,
-        cumulative_fees_wei: f64,
         flashblock_index: u64,
     ) {
         self.committed_payloads_total.increment(1);
         self.committed_payload_size_bytes
             .record(incremental_size_bytes as f64);
-        self.committed_payload_size_bytes_latest
-            .set(cumulative_size_bytes as f64);
         self.committed_payload_gas_used
             .record(incremental_gas_used as f64);
-        self.committed_payload_gas_used_latest
-            .set(cumulative_gas_used as f64);
         self.committed_payload_transaction_count
             .record(incremental_tx_count as f64);
-        self.committed_payload_transaction_count_latest
-            .set(cumulative_tx_count as f64);
         self.committed_payload_fees_wei.record(incremental_fees_wei);
-        self.committed_payload_fees_wei_latest
-            .set(cumulative_fees_wei);
         self.committed_flashblock_index
             .record(flashblock_index as f64);
-        self.committed_flashblock_index_latest
-            .set(flashblock_index as f64);
     }
 }
 

--- a/crates/builder/src/payload_builder_metrics.rs
+++ b/crates/builder/src/payload_builder_metrics.rs
@@ -375,10 +375,9 @@ pub struct PayloadBuildMetrics {
     pub committed_payload_transaction_count: Histogram,
     /// Latest committed payload transaction count.
     pub committed_payload_transaction_count_latest: Gauge,
-    /// Histogram of marginal fees in wei added by each committed flashblock. Summing this
-    /// over a window yields true per-block revenue (records the delta, not the running total).
+    /// Histogram of committed payload fees in wei.
     pub committed_payload_fees_wei: Histogram,
-    /// Latest committed payload cumulative fees in wei (full block value at last commit).
+    /// Latest committed payload fees in wei.
     pub committed_payload_fees_wei_latest: Gauge,
     /// Histogram of committed flashblock index values.
     pub committed_flashblock_index: Histogram,
@@ -543,25 +542,32 @@ impl PayloadBuildMetrics {
             .set(count as f64);
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn record_committed_payload(
         &self,
-        size_bytes: u64,
-        gas_used: u64,
-        tx_count: u64,
+        incremental_size_bytes: u64,
+        cumulative_size_bytes: u64,
+        incremental_gas_used: u64,
+        cumulative_gas_used: u64,
+        incremental_tx_count: u64,
+        cumulative_tx_count: u64,
         incremental_fees_wei: f64,
         cumulative_fees_wei: f64,
         flashblock_index: u64,
     ) {
         self.committed_payloads_total.increment(1);
-        self.committed_payload_size_bytes.record(size_bytes as f64);
+        self.committed_payload_size_bytes
+            .record(incremental_size_bytes as f64);
         self.committed_payload_size_bytes_latest
-            .set(size_bytes as f64);
-        self.committed_payload_gas_used.record(gas_used as f64);
-        self.committed_payload_gas_used_latest.set(gas_used as f64);
+            .set(cumulative_size_bytes as f64);
+        self.committed_payload_gas_used
+            .record(incremental_gas_used as f64);
+        self.committed_payload_gas_used_latest
+            .set(cumulative_gas_used as f64);
         self.committed_payload_transaction_count
-            .record(tx_count as f64);
+            .record(incremental_tx_count as f64);
         self.committed_payload_transaction_count_latest
-            .set(tx_count as f64);
+            .set(cumulative_tx_count as f64);
         self.committed_payload_fees_wei.record(incremental_fees_wei);
         self.committed_payload_fees_wei_latest
             .set(cumulative_fees_wei);

--- a/crates/payload/src/job.rs
+++ b/crates/payload/src/job.rs
@@ -386,13 +386,9 @@ where
             .payload_build_metrics()
             .record_committed_payload(
                 cum_bytes.saturating_sub(prev_bytes),
-                cum_bytes,
                 cum_gas.saturating_sub(prev_gas),
-                cum_gas,
                 cum_tx.saturating_sub(prev_tx),
-                cum_tx,
                 cum_fees.saturating_sub(prev_fees).saturating_to::<u128>() as f64,
-                cum_fees.saturating_to::<u128>() as f64,
                 flashblock_index,
             );
     }

--- a/crates/payload/src/job.rs
+++ b/crates/payload/src/job.rs
@@ -376,34 +376,43 @@ where
     pub(crate) fn record_payload_metrics(
         &self,
         payload: &OpBuiltPayload<OpPrimitives>,
-        prev_fees: U256,
+        prev_totals: Option<(u64, u64, u64, U256)>,
         flashblock_index: u64,
     ) {
-        let block = payload.block();
-        let payload_bytes: usize = block
-            .body()
-            .transactions()
-            .map(|tx| tx.encoded_2718().len())
-            .sum();
-        let gas_used = block.header().gas_used;
-        let tx_count = block.body().transactions().count();
-        // `fees()` is the cumulative block value at this flashblock. Record only the
-        // marginal fees added since the previously committed payload so that summing the
-        // histogram over a window yields true per-block revenue rather than counting each
-        // block's running total once per flashblock commit.
-        let cumulative_fees = payload.fees();
-        let incremental_fees = cumulative_fees.saturating_sub(prev_fees);
+        let (cum_bytes, cum_gas, cum_tx, cum_fees) = payload_totals(payload);
+        let (prev_bytes, prev_gas, prev_tx, prev_fees) =
+            prev_totals.unwrap_or((0, 0, 0, U256::ZERO));
         self.builder
             .payload_build_metrics()
             .record_committed_payload(
-                payload_bytes as u64,
-                gas_used,
-                tx_count as u64,
-                incremental_fees.saturating_to::<u128>() as f64,
-                cumulative_fees.saturating_to::<u128>() as f64,
+                cum_bytes.saturating_sub(prev_bytes),
+                cum_bytes,
+                cum_gas.saturating_sub(prev_gas),
+                cum_gas,
+                cum_tx.saturating_sub(prev_tx),
+                cum_tx,
+                cum_fees.saturating_sub(prev_fees).saturating_to::<u128>() as f64,
+                cum_fees.saturating_to::<u128>() as f64,
                 flashblock_index,
             );
     }
+}
+
+fn payload_totals(payload: &OpBuiltPayload<OpPrimitives>) -> (u64, u64, u64, U256) {
+    let block = payload.block();
+    let payload_bytes: usize = block
+        .body()
+        .transactions()
+        .map(|tx| tx.encoded_2718().len())
+        .sum();
+    let gas_used = block.header().gas_used;
+    let tx_count = block.body().transactions().count();
+    (
+        payload_bytes as u64,
+        gas_used,
+        tx_count as u64,
+        payload.fees(),
+    )
 }
 
 impl<Builder> Future for FlashblocksPayloadJob<Builder>
@@ -524,14 +533,12 @@ where
                     }
                 }
 
-                // Capture the previously committed cumulative fees before overwriting, so
-                // the metric can record only this flashblock's marginal contribution.
-                let prev_committed_fees = this.committed_payload.fees().unwrap_or_default();
+                let prev_totals = this.committed_payload.payload().map(payload_totals);
 
                 // commit to the best payload
                 this.committed_payload =
                     CommittedPayloadState::from((this.best_payload.0.clone(), access_list));
-                this.record_payload_metrics(&payload, prev_committed_fees, this.block_index);
+                this.record_payload_metrics(&payload, prev_totals, this.block_index);
 
                 // increment the pre-confirmation index
                 this.block_index += 1;

--- a/crates/payload/src/job.rs
+++ b/crates/payload/src/job.rs
@@ -376,6 +376,7 @@ where
     pub(crate) fn record_payload_metrics(
         &self,
         payload: &OpBuiltPayload<OpPrimitives>,
+        prev_fees: U256,
         flashblock_index: u64,
     ) {
         let block = payload.block();
@@ -386,13 +387,20 @@ where
             .sum();
         let gas_used = block.header().gas_used;
         let tx_count = block.body().transactions().count();
+        // `fees()` is the cumulative block value at this flashblock. Record only the
+        // marginal fees added since the previously committed payload so that summing the
+        // histogram over a window yields true per-block revenue rather than counting each
+        // block's running total once per flashblock commit.
+        let cumulative_fees = payload.fees();
+        let incremental_fees = cumulative_fees.saturating_sub(prev_fees);
         self.builder
             .payload_build_metrics()
             .record_committed_payload(
                 payload_bytes as u64,
                 gas_used,
                 tx_count as u64,
-                payload.fees().saturating_to::<u128>() as f64,
+                incremental_fees.saturating_to::<u128>() as f64,
+                cumulative_fees.saturating_to::<u128>() as f64,
                 flashblock_index,
             );
     }
@@ -516,10 +524,14 @@ where
                     }
                 }
 
+                // Capture the previously committed cumulative fees before overwriting, so
+                // the metric can record only this flashblock's marginal contribution.
+                let prev_committed_fees = this.committed_payload.fees().unwrap_or_default();
+
                 // commit to the best payload
                 this.committed_payload =
                     CommittedPayloadState::from((this.best_payload.0.clone(), access_list));
-                this.record_payload_metrics(&payload, this.block_index);
+                this.record_payload_metrics(&payload, prev_committed_fees, this.block_index);
 
                 // increment the pre-confirmation index
                 this.block_index += 1;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Observability-only change to how fee values are derived and labeled; no payload building, publishing, or fee calculation logic is altered.
> 
> **Overview**
> **Fixes committed payload fee metrics** so per-block revenue can be computed correctly when a block is built across multiple flashblock commits.
> 
> Previously each commit recorded the **cumulative** `payload.fees()` into `committed_payload_fees_wei`, so aggregating the histogram counted the running block total once per flashblock and overstated revenue. The histogram now records **marginal** fees (`cumulative_fees - prev_committed_fees`), captured from `committed_payload` before the state is overwritten on commit. The **`committed_payload_fees_wei_latest`** gauge still reflects the full cumulative block fees at the last commit.
> 
> `record_committed_payload` takes separate `incremental_fees_wei` and `cumulative_fees_wei` arguments; metric doc comments were updated to describe this behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eeba33e02f02a35587794fd0fe228fdb0971fc3e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->