### PR TITLE
test(proof-system): add integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18554,7 +18554,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "world-chain-proof-kona-utils"
+name = "world-chain-proof-kona-client-utils"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus 2.0.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18537,7 +18537,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "world-chain-proof-kona-client-utils"
+name = "world-chain-proof-integration-tests"
+version = "2.2.0"
+dependencies = [
+ "alloy-primitives",
+ "anyhow",
+ "async-trait",
+ "tokio",
+ "tokio-util",
+ "world-chain-challenger",
+ "world-chain-defender",
+ "world-chain-proof-worker",
+ "world-chain-proofs",
+ "world-chain-proposer",
+ "world-chain-prover-service",
+]
+
+[[package]]
+name = "world-chain-proof-kona-utils"
 version = "2.2.0"
 dependencies = [
  "alloy-consensus 2.0.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ members = [
     "proofs/worker",
     "proofs/sp1-worker",
     "proofs/defender",
+    "proofs/integration-tests",
     "e2e-tests",
     "xtask",
 ]

--- a/proofs/integration-tests/Cargo.toml
+++ b/proofs/integration-tests/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "world-chain-proof-integration-tests"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+world-chain-challenger.workspace = true
+world-chain-defender.workspace = true
+world-chain-proof-worker.workspace = true
+world-chain-proofs.workspace = true
+world-chain-proposer.workspace = true
+world-chain-prover-service.workspace = true
+
+alloy-primitives.workspace = true
+anyhow.workspace = true
+async-trait.workspace = true
+
+[dev-dependencies]
+tokio.workspace = true
+tokio-util.workspace = true

--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -1,0 +1,603 @@
+//! Deterministic e2e harness for the World Chain proof services.
+//!
+//! The harness keeps the services under test real and replaces the external world with small,
+//! stateful fakes: execution/contracts, consensus roots, and proof backends. This lets tests
+//! exercise proposer -> challenger -> defender -> prover-service -> worker orchestration without
+//! depending on a live chain or expensive proof generation.
+
+use alloy_primitives::{Address, B256, BlockNumber, Bytes, U256, address};
+use async_trait::async_trait;
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+use world_chain_challenger::{ChallengeSubmission, ChallengerClient, ChallengerError};
+use world_chain_defender::{DefenderClient, DefenderError, DefenderSubmission};
+use world_chain_proof_worker::ProofJobBackend;
+use world_chain_proofs::{
+    ConsensusError, ConsensusProvider, GameCreated, PROOF_SYSTEM_VERSION, ProofDomain, ProofLane,
+    RootCommitment, RootState, has_threshold,
+};
+use world_chain_proposer::{
+    ParentRef, Proposal, ProposalSubmission, ProposerClient, ProposerError,
+};
+use world_chain_prover_service::{
+    ProofBackend, ProofData, ProofJobQueue, ProofJobQueueError, ProofRequest, ProofRequestError,
+    ProofRequestId, ProofRequester, ProofResponse, ProofStatus, ProverService, ProverServiceConfig,
+};
+
+pub const BLOCK_INTERVAL: u64 = 10;
+pub const INTERMEDIATE_BLOCK_INTERVAL: u64 = 5;
+pub const CHAIN_ID: u64 = 4801;
+pub const ANCHOR: Address = address!("0000000000000000000000000000000000001006");
+
+const STATE_NONE: u8 = 0;
+const STATE_PROPOSED: u8 = 1;
+const STATE_CHALLENGED: u8 = 2;
+const STATE_FINALIZED: u8 = 3;
+
+/// Domain used by the fake proof-system factory.
+#[must_use]
+pub fn test_domain() -> ProofDomain {
+    ProofDomain {
+        chain_id: CHAIN_ID,
+        proof_system_version: PROOF_SYSTEM_VERSION,
+        rollup_config_hash: B256::repeat_byte(0x99),
+        block_interval: BLOCK_INTERVAL,
+        intermediate_block_interval: INTERMEDIATE_BLOCK_INTERVAL,
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FakeConsensus {
+    state: Arc<Mutex<FakeConsensusState>>,
+}
+
+#[derive(Debug)]
+struct FakeConsensusState {
+    finalized_l2_block: BlockNumber,
+    roots: HashMap<BlockNumber, B256>,
+}
+
+impl FakeConsensus {
+    #[must_use]
+    pub fn new(finalized_l2_block: BlockNumber) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(FakeConsensusState {
+                finalized_l2_block,
+                roots: HashMap::new(),
+            })),
+        }
+    }
+
+    #[must_use]
+    pub fn with_root(self, l2_block_number: BlockNumber, root: B256) -> Self {
+        self.set_root(l2_block_number, root);
+        self
+    }
+
+    pub fn set_root(&self, l2_block_number: BlockNumber, root: B256) {
+        self.state
+            .lock()
+            .expect("fake consensus mutex poisoned")
+            .roots
+            .insert(l2_block_number, root);
+    }
+
+    pub fn set_finalized_l2_block(&self, finalized_l2_block: BlockNumber) {
+        self.state
+            .lock()
+            .expect("fake consensus mutex poisoned")
+            .finalized_l2_block = finalized_l2_block;
+    }
+}
+
+#[async_trait]
+impl ConsensusProvider for FakeConsensus {
+    async fn output_root_at_block(&self, l2_block_number: u64) -> Result<B256, ConsensusError> {
+        self.state
+            .lock()
+            .expect("fake consensus mutex poisoned")
+            .roots
+            .get(&l2_block_number)
+            .copied()
+            .ok_or(ConsensusError::MissingOutputRoot)
+    }
+
+    async fn latest_l2_finalized_block(&self) -> Result<BlockNumber, ConsensusError> {
+        Ok(self
+            .state
+            .lock()
+            .expect("fake consensus mutex poisoned")
+            .finalized_l2_block)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FakeExecution {
+    state: Arc<Mutex<FakeExecutionState>>,
+}
+
+#[derive(Debug)]
+struct FakeExecutionState {
+    domain_hash: B256,
+    anchor: ParentRef,
+    finalized_l1_block: BlockNumber,
+    next_game_nonce: u8,
+    games_by_key: HashMap<B256, Address>,
+    games_by_address: HashMap<Address, GameRecord>,
+    game_order: Vec<Address>,
+}
+
+#[derive(Debug, Clone)]
+struct GameRecord {
+    event: GameCreated,
+    state: u8,
+    challenge_deadline: u64,
+    proof_bitmap: u8,
+    challenge_count: u32,
+    submitted_lanes: Vec<ProofLane>,
+}
+
+impl Default for FakeExecution {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FakeExecution {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(FakeExecutionState {
+                domain_hash: test_domain().hash(),
+                anchor: ParentRef {
+                    address: ANCHOR,
+                    l2_block_number: 0,
+                },
+                finalized_l1_block: 10_000,
+                next_game_nonce: 1,
+                games_by_key: HashMap::new(),
+                games_by_address: HashMap::new(),
+                game_order: Vec::new(),
+            })),
+        }
+    }
+
+    #[must_use]
+    pub fn latest_game(&self) -> Option<GameCreated> {
+        let state = self.state.lock().expect("fake execution mutex poisoned");
+        state
+            .game_order
+            .last()
+            .and_then(|game| state.games_by_address.get(game))
+            .map(|record| record.event)
+    }
+
+    #[must_use]
+    pub fn game_state(&self, game: Address) -> RootState {
+        let raw = self
+            .state
+            .lock()
+            .expect("fake execution mutex poisoned")
+            .games_by_address
+            .get(&game)
+            .map_or(STATE_NONE, |record| record.state);
+        RootState::try_from(raw).expect("fake execution stores valid root states")
+    }
+
+    #[must_use]
+    pub fn proof_bitmap(&self, game: Address) -> u8 {
+        self.state
+            .lock()
+            .expect("fake execution mutex poisoned")
+            .games_by_address
+            .get(&game)
+            .map_or(0, |record| record.proof_bitmap)
+    }
+
+    #[must_use]
+    pub fn submitted_lanes(&self, game: Address) -> Vec<ProofLane> {
+        self.state
+            .lock()
+            .expect("fake execution mutex poisoned")
+            .games_by_address
+            .get(&game)
+            .map_or_else(Vec::new, |record| record.submitted_lanes.clone())
+    }
+
+    #[must_use]
+    pub fn challenge_count(&self, game: Address) -> u32 {
+        self.state
+            .lock()
+            .expect("fake execution mutex poisoned")
+            .games_by_address
+            .get(&game)
+            .map_or(0, |record| record.challenge_count)
+    }
+
+    pub fn challenge_game(&self, game: Address) {
+        let mut state = self.state.lock().expect("fake execution mutex poisoned");
+        challenge_record(state.games_by_address.get_mut(&game).expect("game exists"));
+    }
+
+    fn create_game(state: &mut FakeExecutionState, proposal: &Proposal) -> GameCreated {
+        let game = Address::with_last_byte(state.next_game_nonce);
+        state.next_game_nonce = state.next_game_nonce.saturating_add(1);
+
+        let l1_origin_number = state.finalized_l1_block.saturating_sub(1);
+        let l1_origin_hash = B256::with_last_byte(l1_origin_number as u8);
+        let root = RootCommitment {
+            proposal: proposal.commitment(),
+            l1_origin_hash,
+            l1_origin_number,
+        };
+        let event = GameCreated {
+            proposal_key: proposal.proposal_key,
+            root_id: root.root_id(state.domain_hash),
+            game,
+            proposer: Address::repeat_byte(0xa1),
+            root_claim: proposal.root_claim,
+            l2_block_number: proposal.l2_block_number,
+            parent_ref: proposal.parent_ref,
+            l1_origin_hash,
+            l1_origin_number,
+        };
+
+        state.games_by_key.insert(proposal.proposal_key, game);
+        state.game_order.push(game);
+        state.games_by_address.insert(
+            game,
+            GameRecord {
+                event,
+                state: STATE_PROPOSED,
+                challenge_deadline: u64::MAX,
+                proof_bitmap: 0,
+                challenge_count: 0,
+                submitted_lanes: Vec::new(),
+            },
+        );
+        event
+    }
+}
+
+fn challenge_record(record: &mut GameRecord) {
+    record.challenge_count = record.challenge_count.saturating_add(1);
+    if record.state == STATE_PROPOSED {
+        record.state = STATE_CHALLENGED;
+    }
+}
+
+fn proof_lane(lane: u8) -> Option<ProofLane> {
+    match lane {
+        0 => Some(ProofLane::ValidityProof),
+        1 => Some(ProofLane::TeeAttestation),
+        2 => Some(ProofLane::SecurityCouncil),
+        _ => None,
+    }
+}
+
+#[async_trait]
+impl ProposerClient for FakeExecution {
+    async fn anchor_parent(&self) -> Result<ParentRef, ProposerError> {
+        Ok(self
+            .state
+            .lock()
+            .expect("fake execution mutex poisoned")
+            .anchor)
+    }
+
+    async fn proposal_key(
+        &self,
+        commitment: world_chain_proofs::ProposalCommitment,
+    ) -> Result<B256, ProposerError> {
+        Ok(commitment.proposal_key(
+            self.state
+                .lock()
+                .expect("fake execution mutex poisoned")
+                .domain_hash,
+        ))
+    }
+
+    async fn game_for_proposal_key(
+        &self,
+        proposal_key: B256,
+    ) -> Result<Option<Address>, ProposerError> {
+        Ok(self
+            .state
+            .lock()
+            .expect("fake execution mutex poisoned")
+            .games_by_key
+            .get(&proposal_key)
+            .copied())
+    }
+
+    async fn submit_proposal(
+        &self,
+        proposal: &Proposal,
+        _proposer_bond: U256,
+    ) -> Result<ProposalSubmission, ProposerError> {
+        let mut state = self.state.lock().expect("fake execution mutex poisoned");
+        if let Some(existing) = state.games_by_key.get(&proposal.proposal_key) {
+            return Err(ProposerError::Contract(format!(
+                "game already exists for proposal key {} at {existing}",
+                proposal.proposal_key
+            )));
+        }
+        let event = Self::create_game(&mut state, proposal);
+        Ok(ProposalSubmission {
+            tx_hash: B256::with_last_byte(event.game.as_slice()[19]),
+        })
+    }
+}
+
+#[async_trait]
+impl ChallengerClient for FakeExecution {
+    async fn root_state(&self, game: Address) -> Result<RootState, ChallengerError> {
+        let raw = self
+            .state
+            .lock()
+            .expect("fake execution mutex poisoned")
+            .games_by_address
+            .get(&game)
+            .map_or(STATE_NONE, |record| record.state);
+        RootState::try_from(raw).map_err(Into::into)
+    }
+
+    async fn finalized_l1_block_num(&self) -> Result<BlockNumber, ChallengerError> {
+        Ok(self
+            .state
+            .lock()
+            .expect("fake execution mutex poisoned")
+            .finalized_l1_block)
+    }
+
+    async fn games_created(
+        &self,
+        _from: BlockNumber,
+        _to: BlockNumber,
+    ) -> Result<Vec<GameCreated>, ChallengerError> {
+        let state = self.state.lock().expect("fake execution mutex poisoned");
+        Ok(state
+            .game_order
+            .iter()
+            .filter_map(|game| state.games_by_address.get(game))
+            .map(|record| record.event)
+            .collect())
+    }
+
+    async fn challenge_deadline(&self, game: Address) -> Result<u64, ChallengerError> {
+        self.state
+            .lock()
+            .expect("fake execution mutex poisoned")
+            .games_by_address
+            .get(&game)
+            .map(|record| record.challenge_deadline)
+            .ok_or_else(|| ChallengerError::Contract(format!("unknown game {game}")))
+    }
+
+    async fn submit_challenge(
+        &self,
+        game: Address,
+        _challenger_bond: U256,
+    ) -> Result<ChallengeSubmission, ChallengerError> {
+        let mut state = self.state.lock().expect("fake execution mutex poisoned");
+        let record = state
+            .games_by_address
+            .get_mut(&game)
+            .ok_or_else(|| ChallengerError::Contract(format!("unknown game {game}")))?;
+        challenge_record(record);
+        Ok(ChallengeSubmission {
+            tx_hash: B256::with_last_byte(record.challenge_count as u8),
+        })
+    }
+}
+
+#[async_trait]
+impl DefenderClient for FakeExecution {
+    async fn root_state(&self, game: Address) -> Result<RootState, DefenderError> {
+        let raw = self
+            .state
+            .lock()
+            .expect("fake execution mutex poisoned")
+            .games_by_address
+            .get(&game)
+            .map_or(STATE_NONE, |record| record.state);
+        RootState::try_from(raw).map_err(Into::into)
+    }
+
+    async fn finalized_l1_block_num(&self) -> Result<BlockNumber, DefenderError> {
+        Ok(self
+            .state
+            .lock()
+            .expect("fake execution mutex poisoned")
+            .finalized_l1_block)
+    }
+
+    async fn games_created(
+        &self,
+        _from: BlockNumber,
+        _to: BlockNumber,
+    ) -> Result<Vec<GameCreated>, DefenderError> {
+        let state = self.state.lock().expect("fake execution mutex poisoned");
+        Ok(state
+            .game_order
+            .iter()
+            .filter_map(|game| state.games_by_address.get(game))
+            .map(|record| record.event)
+            .collect())
+    }
+
+    async fn challenge_deadline(&self, game: Address) -> Result<u64, DefenderError> {
+        self.state
+            .lock()
+            .expect("fake execution mutex poisoned")
+            .games_by_address
+            .get(&game)
+            .map(|record| record.challenge_deadline)
+            .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))
+    }
+
+    async fn proof_bitmap(&self, game: Address) -> Result<u8, DefenderError> {
+        self.state
+            .lock()
+            .expect("fake execution mutex poisoned")
+            .games_by_address
+            .get(&game)
+            .map(|record| record.proof_bitmap)
+            .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))
+    }
+
+    async fn submit_proof(
+        &self,
+        game: Address,
+        lane: u8,
+        proof: Bytes,
+    ) -> Result<DefenderSubmission, DefenderError> {
+        let lane =
+            proof_lane(lane).ok_or_else(|| DefenderError::Contract("invalid lane".into()))?;
+        if proof.is_empty() {
+            return Err(DefenderError::Contract("empty proof".into()));
+        }
+
+        let mut state = self.state.lock().expect("fake execution mutex poisoned");
+        let record = state
+            .games_by_address
+            .get_mut(&game)
+            .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))?;
+        if record.state != STATE_CHALLENGED {
+            return Err(DefenderError::Contract(format!(
+                "game {game} is not challenged"
+            )));
+        }
+
+        let mask = lane.mask();
+        if record.proof_bitmap & mask == 0 {
+            record.proof_bitmap |= mask;
+            record.submitted_lanes.push(lane);
+            if has_threshold(record.proof_bitmap) {
+                record.state = STATE_FINALIZED;
+            }
+        }
+
+        Ok(DefenderSubmission {
+            tx_hash: B256::with_last_byte(record.proof_bitmap),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FakeProofBackend {
+    lane: ProofBackend,
+    failures_before_success: u32,
+    attempts: Arc<Mutex<HashMap<ProofRequestId, u32>>>,
+}
+
+impl FakeProofBackend {
+    #[must_use]
+    pub fn new(lane: ProofBackend) -> Self {
+        Self {
+            lane,
+            failures_before_success: 0,
+            attempts: Arc::default(),
+        }
+    }
+
+    #[must_use]
+    pub fn flaky(lane: ProofBackend, failures_before_success: u32) -> Self {
+        Self {
+            lane,
+            failures_before_success,
+            attempts: Arc::default(),
+        }
+    }
+}
+
+impl ProofJobBackend for FakeProofBackend {
+    fn lane(&self) -> ProofBackend {
+        self.lane
+    }
+
+    fn prove(&self, request: &ProofRequest) -> anyhow::Result<ProofData> {
+        let id = request.id();
+        let mut attempts = self.attempts.lock().expect("fake backend mutex poisoned");
+        let count = attempts.entry(id).or_default();
+        if *count < self.failures_before_success {
+            *count += 1;
+            anyhow::bail!("configured fake proof failure for {id}");
+        }
+        *count += 1;
+
+        Ok(match self.lane {
+            ProofBackend::Sp1 => ProofData::Sp1 {
+                public_values: request.root_claim.as_slice().to_vec().into(),
+                proof: vec![0x51, request.l2_block_number as u8].into(), // mock proof
+            },
+            ProofBackend::Nitro => ProofData::Nitro {
+                attestation: request.l1_head.as_slice().to_vec().into(),
+                signature: vec![0x7e, request.l2_block_number as u8].into(), // mock signature
+            },
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SharedProverService {
+    service: Arc<ProverService>,
+}
+
+impl SharedProverService {
+    pub fn new(
+        config: ProverServiceConfig,
+    ) -> Result<Self, world_chain_prover_service::InvalidConfigError> {
+        Ok(Self {
+            service: Arc::new(ProverService::new(config)?),
+        })
+    }
+}
+
+#[async_trait]
+impl ProofRequester for SharedProverService {
+    async fn request_proof(
+        &self,
+        proof_request: ProofRequest,
+    ) -> Result<ProofRequestId, ProofRequestError> {
+        self.service.request_proof(proof_request).await
+    }
+
+    async fn proof_status(
+        &self,
+        proof_id: ProofRequestId,
+    ) -> Result<ProofStatus, ProofRequestError> {
+        self.service.proof_status(proof_id).await
+    }
+
+    async fn get_proof(
+        &self,
+        proof_id: ProofRequestId,
+    ) -> Result<ProofResponse, ProofRequestError> {
+        self.service.get_proof(proof_id).await
+    }
+}
+
+#[async_trait]
+impl ProofJobQueue for SharedProverService {
+    async fn get_next_proof(
+        &self,
+        backend: ProofBackend,
+    ) -> Result<Option<ProofRequest>, ProofJobQueueError> {
+        self.service.get_next_proof(backend).await
+    }
+
+    async fn submit_proof(&self, proof: ProofResponse) -> Result<(), ProofJobQueueError> {
+        self.service.submit_proof(proof).await
+    }
+
+    async fn fail_proof(
+        &self,
+        proof_id: ProofRequestId,
+        reason: String,
+    ) -> Result<(), ProofJobQueueError> {
+        self.service.fail_proof(proof_id, reason).await
+    }
+}

--- a/proofs/integration-tests/tests/orchestration.rs
+++ b/proofs/integration-tests/tests/orchestration.rs
@@ -1,0 +1,238 @@
+use std::time::Duration;
+
+use alloy_primitives::{B256, U256};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use world_chain_challenger::{ChallengerConfig, WorldChainChallenger};
+use world_chain_defender::{DefenderConfig, WorldChainDefender};
+use world_chain_proof_integration_tests::{
+    BLOCK_INTERVAL, FakeConsensus, FakeExecution, FakeProofBackend, SharedProverService,
+};
+use world_chain_proof_worker::{ProofWorker, ProofWorkerConfig};
+use world_chain_proofs::{ProofLane, RootState};
+use world_chain_proposer::{ProposerConfig, WorldChainProposer};
+use world_chain_prover_service::{ProofBackend, ProverServiceConfig};
+
+fn proposer_config() -> ProposerConfig {
+    ProposerConfig {
+        block_interval: BLOCK_INTERVAL,
+        proposer_bond: U256::from(1),
+        poll_interval: Duration::from_secs(1),
+    }
+}
+
+fn challenger_config() -> ChallengerConfig {
+    ChallengerConfig {
+        challenger_bond: U256::from(1),
+        poll_interval: Duration::from_secs(1),
+        ..ChallengerConfig::default()
+    }
+}
+
+fn defender_config() -> DefenderConfig {
+    DefenderConfig {
+        poll_interval: Duration::from_secs(1),
+        max_proof_attempts: 2,
+        ..DefenderConfig::default()
+    }
+}
+
+fn assert_defense_lanes(lanes: Vec<ProofLane>) {
+    assert_eq!(lanes.len(), 2);
+    assert!(lanes.contains(&ProofLane::ValidityProof));
+    assert!(lanes.contains(&ProofLane::TeeAttestation));
+}
+
+struct ProofStack {
+    service: SharedProverService,
+    tokens: Vec<CancellationToken>,
+    handles: Vec<JoinHandle<()>>,
+}
+
+fn start_proof_stack() -> ProofStack {
+    start_proof_stack_with(
+        FakeProofBackend::new(ProofBackend::Sp1),
+        FakeProofBackend::new(ProofBackend::Nitro),
+    )
+}
+
+fn start_proof_stack_with(
+    sp1_backend: FakeProofBackend,
+    nitro_backend: FakeProofBackend,
+) -> ProofStack {
+    let service = SharedProverService::new(ProverServiceConfig {
+        lease_timeout: Duration::from_secs(5),
+        max_attempts: 2,
+        max_queue_len: 16,
+        max_finished_jobs: 16,
+    })
+    .expect("valid prover-service config");
+
+    let sp1_worker = ProofWorker::new(
+        service.clone(),
+        sp1_backend,
+        ProofWorkerConfig {
+            poll_interval: Duration::from_millis(5),
+            max_concurrent_jobs: 1,
+        },
+    );
+    let sp1_cancel = sp1_worker.cancellation_token();
+    let sp1_handle = tokio::spawn(sp1_worker);
+
+    let nitro_worker = ProofWorker::new(
+        service.clone(),
+        nitro_backend,
+        ProofWorkerConfig {
+            poll_interval: Duration::from_millis(5),
+            max_concurrent_jobs: 1,
+        },
+    );
+    let nitro_cancel = nitro_worker.cancellation_token();
+    let nitro_handle = tokio::spawn(nitro_worker);
+
+    ProofStack {
+        service,
+        tokens: vec![sp1_cancel, nitro_cancel],
+        handles: vec![sp1_handle, nitro_handle],
+    }
+}
+
+async fn stop_proof_stack(stack: ProofStack) {
+    for token in stack.tokens {
+        token.cancel();
+    }
+    for handle in stack.handles {
+        handle.await.expect("worker shuts down");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn invalid_root_is_challenged_by_real_challenger() {
+    let chain = FakeExecution::new();
+    let canonical_root = B256::repeat_byte(0x20);
+    let bad_root = B256::repeat_byte(0x99);
+    let bad_proposer_consensus =
+        FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, bad_root);
+    let honest_consensus =
+        FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
+
+    let proposer =
+        WorldChainProposer::new(proposer_config(), chain.clone(), bad_proposer_consensus);
+    proposer.propose_once().await.expect("bad proposal posted");
+    let game = chain.latest_game().expect("game created").game;
+
+    let mut challenger =
+        WorldChainChallenger::new(challenger_config(), chain.clone(), honest_consensus);
+    challenger
+        .scan_once()
+        .await
+        .expect("challenger scan succeeds");
+
+    assert_eq!(chain.game_state(game), RootState::Challenged);
+    assert_eq!(chain.challenge_count(game), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn valid_challenged_root_is_defended_through_workers() {
+    let chain = FakeExecution::new();
+    let canonical_root = B256::repeat_byte(0x20);
+    let consensus = FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
+
+    let proposer = WorldChainProposer::new(proposer_config(), chain.clone(), consensus.clone());
+    proposer.propose_once().await.expect("proposal posted");
+    let game = chain.latest_game().expect("game created").game;
+    chain.challenge_game(game);
+
+    let stack = start_proof_stack();
+    let mut defender = WorldChainDefender::new(
+        defender_config(),
+        chain.clone(),
+        consensus,
+        stack.service.clone(),
+    );
+
+    for _ in 0..200 {
+        defender.scan_once().await.expect("defender scan succeeds");
+        if chain.game_state(game) == RootState::Finalized {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    assert_eq!(chain.game_state(game), RootState::Finalized);
+    assert_defense_lanes(chain.submitted_lanes(game));
+
+    stop_proof_stack(stack).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn valid_challenged_root_survives_transient_proof_failure() {
+    let chain = FakeExecution::new();
+    let canonical_root = B256::repeat_byte(0x20);
+    let consensus = FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
+
+    let proposer = WorldChainProposer::new(proposer_config(), chain.clone(), consensus.clone());
+    proposer.propose_once().await.expect("proposal posted");
+    let game = chain.latest_game().expect("game created").game;
+    chain.challenge_game(game);
+
+    let stack = start_proof_stack_with(
+        FakeProofBackend::flaky(ProofBackend::Sp1, 1),
+        FakeProofBackend::new(ProofBackend::Nitro),
+    );
+    let mut defender = WorldChainDefender::new(
+        defender_config(),
+        chain.clone(),
+        consensus,
+        stack.service.clone(),
+    );
+
+    for _ in 0..200 {
+        defender.scan_once().await.expect("defender scan succeeds");
+        if chain.game_state(game) == RootState::Finalized {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    assert_eq!(chain.game_state(game), RootState::Finalized);
+    assert_defense_lanes(chain.submitted_lanes(game));
+
+    stop_proof_stack(stack).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn defender_ignores_challenged_invalid_root() {
+    let chain = FakeExecution::new();
+    let canonical_root = B256::repeat_byte(0x20);
+    let bad_root = B256::repeat_byte(0x99);
+    let bad_proposer_consensus =
+        FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, bad_root);
+    let honest_consensus =
+        FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
+
+    let proposer =
+        WorldChainProposer::new(proposer_config(), chain.clone(), bad_proposer_consensus);
+    proposer.propose_once().await.expect("bad proposal posted");
+    let game = chain.latest_game().expect("game created").game;
+    chain.challenge_game(game);
+
+    let stack = start_proof_stack();
+    let mut defender = WorldChainDefender::new(
+        defender_config(),
+        chain.clone(),
+        honest_consensus,
+        stack.service.clone(),
+    );
+
+    for _ in 0..10 {
+        defender.scan_once().await.expect("defender scan succeeds");
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    assert_eq!(chain.game_state(game), RootState::Challenged);
+    assert_eq!(chain.proof_bitmap(game), 0);
+    assert!(chain.submitted_lanes(game).is_empty());
+
+    stop_proof_stack(stack).await;
+}


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4723/testing-create-rust-integration-testing-framework

This PR adds the integration tests framework for the proof-system. It also adds some initial tests to ensure services are working properly.

In these tests we only want to ensure proof system services (proposer, challenger, defender, prover-service) work as expected. We mock all the boundaries:

- proof backends
- execution client
- consensus client

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only crate and workspace membership; no production service or on-chain behavior changes.
> 
> **Overview**
> Adds a new **`world-chain-proof-integration-tests`** crate and wires it into the workspace so proof-system services can be exercised end-to-end without a live chain or real proof generation.
> 
> The harness keeps **real** `WorldChainProposer`, `WorldChainChallenger`, `WorldChainDefender`, `ProverService`, and `ProofWorker` instances and replaces boundaries with **stateful fakes**: `FakeExecution` (proposer/challenger/defender contract APIs, game lifecycle, proof bitmap / finalization), `FakeConsensus` (output roots), and `FakeProofBackend` (mock SP1/Nitro proofs, optional flaky failures). `SharedProverService` exposes the in-process prover service to both defender and workers.
> 
> **`tests/orchestration.rs`** adds four Tokio integration tests: invalid roots get challenged; valid challenged roots finalize after defender + workers submit both validity and TEE lanes; transient proof failures still finalize; defender does not submit proofs when the challenged root disagrees with honest consensus.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff89e4a58742777051bae6003de034cb03fb727c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->