### PR TITLE
chore: update docs

### DIFF
--- a/specs/cli/reference.md
+++ b/specs/cli/reference.md
@@ -35,11 +35,18 @@ Rollup:
       --rollup.enable-tx-conditional
           Enable transaction conditional support on sequencer
 
-      --rollup.supervisor-http <SUPERVISOR_HTTP_URL>
-          HTTP endpoint for the supervisor. When not set, interop transaction validation is disabled
+      --rollup.interop-http <INTEROP_HTTP_URL>
+          HTTP endpoint(s) for the interop filter, used to validate the interop messages referenced by incoming transactions. Repeat the flag to configure multiple endpoints; each check is fanned out to all of them and combined by quorum agreement (see `--rollup.interop-min-responses`). When none are set, interop transaction validation is disabled: a node that builds blocks will then include transactions carrying invalid interop messages, producing invalid blocks. It is only safe to leave this unset on nodes that do not build blocks
 
-      --rollup.supervisor-safety-level <SUPERVISOR_SAFETY_LEVEL>
-          Safety level for the supervisor
+      --rollup.interop-min-responses <INTEROP_MIN_RESPONSES>
+          Minimum number of definitive verdicts required to decide an interop check across the configured `--rollup.interop-http` endpoints. A transaction is accepted only when this many endpoints return a definitive verdict and all of them agree it is valid; if they disagree the transaction is rejected.
+          
+          Defaults to the number of endpoints (unanimity, fail-closed). Note this means any single unreachable or out-of-sync endpoint blocks ALL interop admission until it recovers, so adding endpoints under the default REDUCES availability. Set a majority quorum (e.g. N/2+1) to tolerate a degraded endpoint while still only accepting on unanimous agreement among responders.
+          
+          Disagreement detection is best-effort: once the quorum is reached the remaining endpoints are not awaited, so a slow dissenter beyond the quorum may go unseen.
+
+      --rollup.interop-safety-level <INTEROP_SAFETY_LEVEL>
+          Safety level for interop filter validation
           
           [default: CrossUnsafe]
 
@@ -53,6 +60,11 @@ Rollup:
           Minimum suggested priority fee (tip) in wei, default `1_000_000`
           
           [default: 1000000]
+
+      --rollup.max-uncompressed-block-size <MAX_UNCOMPRESSED_BLOCK_SIZE>
+          Maximum cumulative uncompressed (EIP-2718 encoded) block size in bytes.
+          
+          When set, the payload builder stops including mempool transactions once the block's total uncompressed transaction size would exceed this value. This bounds the size of the `engine_getPayload` response so it stays within the limits assumed by consensus-layer clients (e.g. the common 10 MiB JSON payload cap). Unset means no limit.
 
       --flashblocks-url <FLASHBLOCKS_URL>
           A URL pointing to a secure websocket subscription that streams out flashblocks.
@@ -68,23 +80,21 @@ Rollup:
           If true, initialize external-proofs exex to save and serve trie nodes to provide proofs faster
 
       --proofs-history.storage-path <PROOFS_HISTORY_STORAGE_PATH>
-          The path to the storage DB for proofs history
+          Path to the proofs-history storage DB. Defaults to `<reth-data-dir>/historical-proofs` (chain-namespaced via reth's `--datadir`)
+
+      --proofs-history.storage-version <PROOFS_HISTORY_STORAGE_VERSION>
+          Storage schema version. Must match the version used when starting the node
+
+          Possible values:
+          - v1: V1 storage schema (original single-table-per-domain layout). Default
+          - v2: V2 storage schema with changeset and history-bitmap tables, enabling history-aware reads at any block number within the proof window
+          
+          [default: v1]
 
       --proofs-history.window <PROOFS_HISTORY_WINDOW>
-          The window to span blocks for proofs history. Value is the number of blocks. Default is 1 month of blocks based on 2 seconds block time. 30 * 24 * 60 * 60 / 2 = `1_296_000`
+          The window to span blocks for proofs history. Value is the number of blocks. Default is 1 month of blocks based on 2 seconds block time (`30 * 24 * 60 * 60 / 2 = 1_296_000`)
           
           [default: 1296000]
-
-      --proofs-history.prune-interval <PROOFS_HISTORY_PRUNE_INTERVAL>
-          Interval between proof-storage prune runs. Accepts human-friendly durations like "100s", "5m", "1h". Defaults to 15s.
-          
-          - Shorter intervals prune smaller batches more often, so each prune run tends to be faster and the blocking pause for writes is shorter, at the cost of more frequent pauses. - Longer intervals prune larger batches less often, which reduces how often pruning runs, but each run can take longer and block writes for longer.
-          
-          A shorter interval is preferred so that prune runs stay small and don’t stall writes for too long.
-          
-          CLI: `--proofs-history.prune-interval 10m`
-          
-          [default: 15s]
 
       --proofs-history.verification-interval <PROOFS_HISTORY_VERIFICATION_INTERVAL>
           Verification interval: perform full block execution every N blocks for data integrity. - 0: Disabled (Default) (always use fast path with pre-computed data from notifications) - 1: Always verify (always execute blocks, slowest) - N: Verify every Nth block (e.g., 100 = every 100 blocks)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to `specs/cli/reference.md`; no runtime or config behavior is modified in this diff.
> 
> **Overview**
> Regenerates the auto-generated **`world-chain` CLI reference** so it matches current flags and help text.
> 
> **Interop / supervisor:** Documents renamed **`--rollup.interop-http`** (repeatable, quorum fan-out), new **`--rollup.interop-min-responses`**, and **`--rollup.interop-safety-level`** in place of the old supervisor HTTP/safety flags, including fail-closed behavior when endpoints are missing or disagree.
> 
> **Rollup payload:** Adds **`--rollup.max-uncompressed-block-size`** to cap cumulative EIP-2718 block size for `engine_getPayload` / CL JSON limits.
> 
> **Proofs history:** Updates storage path default wording, replaces **`--proofs-history.prune-interval`** with **`--proofs-history.storage-version`** (v1 vs v2 schema), and restores **`--proofs-history.window`** as its own entry with the 1_296_000 default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88cb87ff164bf35f1bdd46ac81a3b18357eed8b4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->