### PR TITLE
feat: approval for releases

### DIFF
--- a/.github/workflows/release-proof.yml
+++ b/.github/workflows/release-proof.yml
@@ -36,8 +36,16 @@ permissions:
   id-token: write
 
 jobs:
+  approve-release:
+    name: approve release
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - run: true
+
   extract-version:
     name: extract version
+    needs: approve-release
     runs-on: ubuntu-latest
     steps:
       - name: Extract version
@@ -58,6 +66,7 @@ jobs:
   # other artifact embeds or ships these ELFs, so nothing builds if this fails.
   verify-elfs:
     name: verify ELFs
+    needs: approve-release
     runs-on: arc-public-8xlarge-amd64-runner
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,16 @@ permissions:
   id-token: write
 
 jobs:
+  approve-release:
+    name: approve release
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - run: true
+
   extract-version:
     name: extract version
+    needs: approve-release
     runs-on: ubuntu-latest
     steps:
       - name: Extract version


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Workflow-only change that adds a manual gate; it does not alter build logic or artifact contents, but misconfigured environment rules could block or delay releases.
> 
> **Overview**
> Both **`release.yml`** and **`release-proof.yml`** now start with an **`approve-release`** job bound to the GitHub **`release`** environment (no-op `run: true`), so tag-triggered runs wait for environment reviewers before anything else proceeds.
> 
> **`extract-version`** depends on **`approve-release`** in both workflows. In **`release-proof.yml`**, **`verify-elfs`** also **`needs: approve-release`**, so ELF reproducibility checks cannot run until release is approved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b49c50764dffd6f2973147660ff87a9325fbd278. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->