### PR TITLE
feat: precommit file size workflow

### DIFF
--- a/.github/workflows/large-files.yml
+++ b/.github/workflows/large-files.yml
@@ -1,0 +1,23 @@
+name: Large Files
+
+on:
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check-large-files:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+
+      - uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: check-added-large-files --from-ref ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || 'origin/main' }} --to-ref HEAD

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-added-large-files
+        args: [--enforce-all]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI and developer tooling only; no application runtime, auth, or data-path changes.
> 
> **Overview**
> Adds CI guardrails so **newly added large files** are blocked before merge.
> 
> A **Large Files** GitHub Actions workflow runs on pull requests, merge queues, and manual dispatch. It checks out full history, installs Python, and runs only the `check-added-large-files` pre-commit hook between the PR base (or `origin/main`) and `HEAD`.
> 
> A new **`.pre-commit-config.yaml`** registers `pre-commit-hooks` with `check-added-large-files` and `--enforce-all`, matching what CI runs and enabling the same check locally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 445de79898a3528a62b8529ef7f89e53de0b432a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->