### PR TITLE
test (prod): adapted prod acceptance tests

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -46,7 +46,6 @@ jobs:
             environment: prod
             include_in_all: false
             rpc_url: https://worldchain-mainnet.g.alchemy.com/public
-            bundler_checks_enabled: true
             acceptance_profile: smoke
             bundler_rpc_url: https://rundler-mainnet.worldcoin.dev
             entry_point: "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
@@ -58,7 +57,6 @@ jobs:
             environment: stage
             include_in_all: true
             rpc_url: https://wc-node-sepolia.worldcoin.dev
-            bundler_checks_enabled: true
             acceptance_profile: heavy
             bundler_rpc_url: https://rundler-sepolia.worldcoin.dev
             entry_point: "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
@@ -70,7 +68,6 @@ jobs:
             environment: dev
             include_in_all: true
             rpc_url: https://wc-node-devnet.worldcoin.dev
-            bundler_checks_enabled: false
             acceptance_profile: ""
             bundler_rpc_url: ""
             entry_point: ""
@@ -82,7 +79,6 @@ jobs:
             environment: dev-eu-central-2
             include_in_all: true
             rpc_url: https://tx-proxy-devnet-eu-central-2.worldcoin.dev
-            bundler_checks_enabled: true
             acceptance_profile: heavy
             bundler_rpc_url: https://rundler-devnet-eu-central-2.worldcoin.dev
             expected_chain_id: "69420"
@@ -133,7 +129,7 @@ jobs:
         env:
           ACCEPTANCE_NETWORK: ${{ matrix.network }}
           ACCEPTANCE_RPC_URL: ${{ matrix.rpc_url }}
-          ACCEPTANCE_BUNDLER_RPC_URL: ${{ matrix.bundler_checks_enabled && (matrix.network == 'dev-eu-central-2' && inputs.bundler_rpc_url || matrix.bundler_rpc_url) || '' }}
+          ACCEPTANCE_BUNDLER_RPC_URL: ${{ matrix.network == 'dev-eu-central-2' && inputs.bundler_rpc_url != '' && inputs.bundler_rpc_url || matrix.bundler_rpc_url }}
           ACCEPTANCE_CHAIN_ID: ${{ matrix.expected_chain_id }}
           ACCEPTANCE_4337_ENTRY_POINT: ${{ matrix.entry_point }}
           ACCEPTANCE_4337_MODULE: ${{ matrix.safe_4337_module }}

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -47,7 +47,7 @@ jobs:
             include_in_all: false
             rpc_url: https://worldchain-mainnet.g.alchemy.com/public
             bundler_checks_enabled: true
-            acceptance_profile: prod-smoke
+            acceptance_profile: smoke
             bundler_rpc_url: https://rundler-mainnet.worldcoin.dev
             entry_point: "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
             safe_4337_module: ""

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -10,6 +10,7 @@ on:
         type: choice
         options:
           - all
+          - prod
           - stage
           - dev-us-east-1
           - dev-eu-central-2
@@ -41,6 +42,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - network: prod
+            environment: prod
+            include_in_all: false
+            rpc_url: https://worldchain-mainnet.g.alchemy.com/public
+            bundler_checks_enabled: true
+            acceptance_profile: prod-smoke
+            bundler_rpc_url: https://rundler-mainnet.worldcoin.dev
+            entry_point: "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
+            safe_4337_module: ""
+            safe_4337_wallet_deployer: ""
+            expected_chain_id: "480"
+            allow_failure: false
           - network: stage
             environment: stage
             include_in_all: true

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -100,6 +100,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         if: ${{ (inputs.network == 'all' && matrix.include_in_all) || inputs.network == matrix.network }}
 
+      - uses: arduino/setup-protoc@v3
+        if: ${{ (inputs.network == 'all' && matrix.include_in_all) || inputs.network == matrix.network }}
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Cache
         if: ${{ (inputs.network == 'all' && matrix.include_in_all) || inputs.network == matrix.network }}
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.05

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -43,7 +43,10 @@ jobs:
         include:
           - network: stage
             environment: stage
+            include_in_all: true
             rpc_url: https://wc-node-sepolia.worldcoin.dev
+            bundler_checks_enabled: true
+            acceptance_profile: heavy
             bundler_rpc_url: https://rundler-sepolia.worldcoin.dev
             entry_point: "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
             safe_4337_module: "0x829Efdda958f06eA49f1F416e10b35C140bf45EF"
@@ -52,19 +55,31 @@ jobs:
             allow_failure: false
           - network: dev-us-east-1
             environment: dev
+            include_in_all: true
             rpc_url: https://wc-node-devnet.worldcoin.dev
+            bundler_checks_enabled: false
+            acceptance_profile: ""
             bundler_rpc_url: ""
+            entry_point: ""
+            safe_4337_module: ""
+            safe_4337_wallet_deployer: ""
             expected_chain_id: "4801222"
             allow_failure: true
           - network: dev-eu-central-2
             environment: dev-eu-central-2
+            include_in_all: true
             rpc_url: https://tx-proxy-devnet-eu-central-2.worldcoin.dev
+            bundler_checks_enabled: true
+            acceptance_profile: heavy
             bundler_rpc_url: https://rundler-devnet-eu-central-2.worldcoin.dev
             expected_chain_id: "69420"
+            entry_point: ""
+            safe_4337_module: ""
+            safe_4337_wallet_deployer: ""
             allow_failure: true
     steps:
       - name: Skip unselected network
-        if: ${{ inputs.network != 'all' && inputs.network != matrix.network }}
+        if: ${{ (inputs.network == 'all' && !matrix.include_in_all) || (inputs.network != 'all' && inputs.network != matrix.network) }}
         env:
           MATRIX_NETWORK: ${{ matrix.network }}
           SELECTED_NETWORK: ${{ inputs.network }}
@@ -105,7 +120,7 @@ jobs:
         env:
           ACCEPTANCE_NETWORK: ${{ matrix.network }}
           ACCEPTANCE_RPC_URL: ${{ matrix.rpc_url }}
-          ACCEPTANCE_BUNDLER_RPC_URL: ${{ matrix.network == 'dev-eu-central-2' && inputs.bundler_rpc_url || matrix.bundler_rpc_url }}
+          ACCEPTANCE_BUNDLER_RPC_URL: ${{ matrix.bundler_checks_enabled && (matrix.network == 'dev-eu-central-2' && inputs.bundler_rpc_url || matrix.bundler_rpc_url) || '' }}
           ACCEPTANCE_CHAIN_ID: ${{ matrix.expected_chain_id }}
           ACCEPTANCE_4337_ENTRY_POINT: ${{ matrix.entry_point }}
           ACCEPTANCE_4337_MODULE: ${{ matrix.safe_4337_module }}
@@ -116,10 +131,7 @@ jobs:
           ACCEPTANCE_BUNDLER_CF_ACCESS_CLIENT_SECRET: ${{ secrets.ACCEPTANCE_BUNDLER_CF_ACCESS_CLIENT_SECRET }}
           ACCEPTANCE_BLOCK_ADVANCE_TIMEOUT_SECS: "60"
           ACCEPTANCE_BLOCK_POLL_INTERVAL_SECS: "2"
-          ACCEPTANCE_4337_WALLET_COUNT: "200"
-          ACCEPTANCE_4337_DEPLOY_CONCURRENCY: "10"
-          ACCEPTANCE_4337_OPS_PER_WALLET: "50"
-          ACCEPTANCE_4337_OP_CONCURRENCY: "200"
+          ACCEPTANCE_4337_PROFILE: ${{ matrix.acceptance_profile }}
         run: cargo nextest run --profile ci -p world-chain-tests -E 'package(world-chain-tests) & binary(world-chain-tests) & test(/acceptance_tests::test_network/)' --no-capture
 
       - name: Report allowed build failure

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -95,13 +95,13 @@ jobs:
         run: printf 'Skipping %s because %s was selected.\n' "$MATRIX_NETWORK" "$SELECTED_NETWORK"
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.02
-        if: ${{ inputs.network == 'all' || inputs.network == matrix.network }}
+        if: ${{ (inputs.network == 'all' && matrix.include_in_all) || inputs.network == matrix.network }}
 
       - uses: dtolnay/rust-toolchain@stable
-        if: ${{ inputs.network == 'all' || inputs.network == matrix.network }}
+        if: ${{ (inputs.network == 'all' && matrix.include_in_all) || inputs.network == matrix.network }}
 
       - name: Cache
-        if: ${{ inputs.network == 'all' || inputs.network == matrix.network }}
+        if: ${{ (inputs.network == 'all' && matrix.include_in_all) || inputs.network == matrix.network }}
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.05
         with:
           path: |
@@ -112,19 +112,19 @@ jobs:
           restore-keys: cargo-acceptance-tests-
 
       - uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2.78.1
-        if: ${{ inputs.network == 'all' || inputs.network == matrix.network }}
+        if: ${{ (inputs.network == 'all' && matrix.include_in_all) || inputs.network == matrix.network }}
         with:
           tool: nextest@0.9.135
 
       - name: Build acceptance tests
         id: build
-        if: ${{ inputs.network == 'all' || inputs.network == matrix.network }}
+        if: ${{ (inputs.network == 'all' && matrix.include_in_all) || inputs.network == matrix.network }}
         continue-on-error: ${{ matrix.allow_failure }}
         run: cargo nextest run --profile ci -p world-chain-tests -E 'package(world-chain-tests) & binary(world-chain-tests) & test(/acceptance_tests::test_network/)' --no-run
 
       - name: Run acceptance tests
         id: run
-        if: ${{ (inputs.network == 'all' || inputs.network == matrix.network) && steps.build.outcome == 'success' }}
+        if: ${{ ((inputs.network == 'all' && matrix.include_in_all) || inputs.network == matrix.network) && steps.build.outcome == 'success' }}
         continue-on-error: ${{ matrix.allow_failure }}
         env:
           ACCEPTANCE_NETWORK: ${{ matrix.network }}
@@ -144,13 +144,13 @@ jobs:
         run: cargo nextest run --profile ci -p world-chain-tests -E 'package(world-chain-tests) & binary(world-chain-tests) & test(/acceptance_tests::test_network/)' --no-capture
 
       - name: Report allowed build failure
-        if: ${{ (inputs.network == 'all' || inputs.network == matrix.network) && matrix.allow_failure && steps.build.outcome == 'failure' }}
+        if: ${{ ((inputs.network == 'all' && matrix.include_in_all) || inputs.network == matrix.network) && matrix.allow_failure && steps.build.outcome == 'failure' }}
         env:
           NETWORK: ${{ matrix.network }}
         run: printf '::warning::Acceptance test build failed for %s, but this network is allowed to fail.\n' "$NETWORK"
 
       - name: Report allowed test failure
-        if: ${{ (inputs.network == 'all' || inputs.network == matrix.network) && matrix.allow_failure && steps.run.outcome == 'failure' }}
+        if: ${{ ((inputs.network == 'all' && matrix.include_in_all) || inputs.network == matrix.network) && matrix.allow_failure && steps.run.outcome == 'failure' }}
         env:
           NETWORK: ${{ matrix.network }}
         run: printf '::warning::Acceptance tests failed for %s, but this network is allowed to fail.\n' "$NETWORK"

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -49,8 +49,8 @@ jobs:
             acceptance_profile: smoke
             bundler_rpc_url: https://rundler-mainnet.worldcoin.dev
             entry_point: "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
-            safe_4337_module: ""
-            safe_4337_wallet_deployer: ""
+            safe_4337_module: "0x70673A08a5B1086585d39979Fb2d84FDC0bB6Aaf"
+            safe_4337_wallet_deployer: "0xd1f0B51940DbD6e73891D2a41Ef14483fDC5Cb6e"
             expected_chain_id: "480"
             allow_failure: false
           - network: stage

--- a/e2e-tests/src/it/acceptance_tests/README.md
+++ b/e2e-tests/src/it/acceptance_tests/README.md
@@ -26,6 +26,7 @@ The MVP checks:
 | `ACCEPTANCE_4337_ENTRY_POINT` | no on chain `69420`; yes otherwise | `0x0000000071727De22E5E9d8BAf0edAc6f37da032` on chain `69420` | ERC-4337 v0.7 EntryPoint address. |
 | `ACCEPTANCE_4337_MODULE` | no on chain `69420`; yes otherwise | `0x70673A08a5B1086585d39979Fb2d84FDC0bB6Aaf` on chain `69420` | Safe4337 module used to sign Safe user operations. |
 | `ACCEPTANCE_4337_WALLET_DEPLOYER` | no on chain `69420`; yes otherwise | `0xd1f0B51940DbD6e73891D2a41Ef14483fDC5Cb6e` on chain `69420` | Safe4337 wallet deployer used as the v0.7 factory. |
+| `ACCEPTANCE_4337_PROFILE` | no | unset | Named user-operation load profile. Supported values: `heavy`, `prod-smoke`. Explicit per-knob env vars still override the profile. |
 | `ACCEPTANCE_4337_WALLET_COUNT` | no | `20` | Number of ephemeral Safe wallets to deploy through sponsored user operations. |
 | `ACCEPTANCE_4337_DEPLOY_CONCURRENCY` | no | `10` | Max number of wallet-deploying user operations sent and awaited concurrently. Kept at Rundler's unstaked-factory in-flight limit because all deploy ops use the same Safe factory. |
 | `ACCEPTANCE_4337_OPS_PER_WALLET` | no | `3` | Number of post-deploy sponsored no-op user operations to send for each wallet. |
@@ -42,10 +43,11 @@ The ERC-4337 wallet owners are deterministic test mnemonic accounts and are only
 used to sign Safe user operations. They do not need ETH. Sponsored operations are
 paid by the configured Rundler instance.
 
-The GitHub Actions acceptance workflow overrides the local defaults for a small Rundler
-smoke-spike profile: 200 ephemeral Safe wallets, 50 post-deploy sponsored no-op operations per
-wallet, and 200-way post-deploy operation concurrency. Deploy concurrency stays at 10 because all
-deployment operations use the same Safe factory.
+The GitHub Actions acceptance workflow sets `ACCEPTANCE_4337_PROFILE=heavy` for the current
+bundler-enabled stage and dev-eu-central-2 runs. That profile means 200 ephemeral Safe wallets,
+50 post-deploy sponsored no-op operations per wallet, and 200-way post-deploy operation
+concurrency. Deploy concurrency stays at 10 because all deployment operations use the same Safe
+factory.
 
 Example:
 

--- a/e2e-tests/src/it/acceptance_tests/README.md
+++ b/e2e-tests/src/it/acceptance_tests/README.md
@@ -26,7 +26,7 @@ The MVP checks:
 | `ACCEPTANCE_4337_ENTRY_POINT` | no on chain `69420`; yes otherwise | `0x0000000071727De22E5E9d8BAf0edAc6f37da032` on chain `69420` | ERC-4337 v0.7 EntryPoint address. |
 | `ACCEPTANCE_4337_MODULE` | no on chain `69420`; yes otherwise | `0x70673A08a5B1086585d39979Fb2d84FDC0bB6Aaf` on chain `69420` | Safe4337 module used to sign Safe user operations. |
 | `ACCEPTANCE_4337_WALLET_DEPLOYER` | no on chain `69420`; yes otherwise | `0xd1f0B51940DbD6e73891D2a41Ef14483fDC5Cb6e` on chain `69420` | Safe4337 wallet deployer used as the v0.7 factory. |
-| `ACCEPTANCE_4337_PROFILE` | no | unset | Named user-operation load profile. Supported values: `heavy`, `prod-smoke`. Explicit per-knob env vars still override the profile. |
+| `ACCEPTANCE_4337_PROFILE` | no | unset | Named user-operation load profile. Supported values: `heavy`, `smoke`. Explicit per-knob env vars still override the profile. |
 | `ACCEPTANCE_4337_WALLET_COUNT` | no | `20` | Number of ephemeral Safe wallets to deploy through sponsored user operations. |
 | `ACCEPTANCE_4337_DEPLOY_CONCURRENCY` | no | `10` | Max number of wallet-deploying user operations sent and awaited concurrently. Kept at Rundler's unstaked-factory in-flight limit because all deploy ops use the same Safe factory. |
 | `ACCEPTANCE_4337_OPS_PER_WALLET` | no | `3` | Number of post-deploy sponsored no-op user operations to send for each wallet. |

--- a/e2e-tests/src/it/acceptance_tests/config.rs
+++ b/e2e-tests/src/it/acceptance_tests/config.rs
@@ -35,7 +35,7 @@ struct UserOperationProfileDefaults {
 
 enum UserOperationProfile {
     Heavy,
-    ProdSmoke,
+    Smoke,
 }
 
 #[derive(Clone)]
@@ -252,7 +252,7 @@ impl UserOperationProfile {
                 operations_per_wallet: 50,
                 operation_concurrency: 200,
             },
-            Self::ProdSmoke => UserOperationProfileDefaults {
+            Self::Smoke => UserOperationProfileDefaults {
                 wallet_count: 20,
                 deploy_concurrency: 10,
                 operations_per_wallet: 2,
@@ -266,9 +266,9 @@ fn user_operation_profile_from_env() -> eyre::Result<Option<UserOperationProfile
     optional_env("ACCEPTANCE_4337_PROFILE")
         .map(|value| match value.as_str() {
             "heavy" => Ok(UserOperationProfile::Heavy),
-            "prod-smoke" => Ok(UserOperationProfile::ProdSmoke),
+            "smoke" => Ok(UserOperationProfile::Smoke),
             _ => bail!(
-                "unsupported ACCEPTANCE_4337_PROFILE {value:?}; expected one of: heavy, prod-smoke"
+                "unsupported ACCEPTANCE_4337_PROFILE {value:?}; expected one of: heavy, smoke"
             ),
         })
         .transpose()

--- a/e2e-tests/src/it/acceptance_tests/config.rs
+++ b/e2e-tests/src/it/acceptance_tests/config.rs
@@ -26,6 +26,18 @@ const WORLD_CHAIN_DEVNET_SAFE_4337_WALLET_DEPLOYER: Address =
 const WORLD_CHAIN_DEVNET_ENTRY_POINT_V0_7: Address =
     address!("0000000071727De22E5E9d8BAf0edAc6f37da032");
 
+struct UserOperationProfileDefaults {
+    wallet_count: usize,
+    deploy_concurrency: usize,
+    operations_per_wallet: u64,
+    operation_concurrency: usize,
+}
+
+enum UserOperationProfile {
+    Heavy,
+    ProdSmoke,
+}
+
 #[derive(Clone)]
 pub(super) struct Config {
     pub(super) network: String,
@@ -132,6 +144,7 @@ fn bundler_config_from_env(
     let Some(rpc_url) = optional_env("ACCEPTANCE_BUNDLER_RPC_URL") else {
         return Ok(None);
     };
+    let profile_defaults = user_operation_profile_from_env()?.map(|profile| profile.defaults());
 
     Ok(Some(BundlerConfig {
         rpc_url: rpc_url
@@ -153,20 +166,30 @@ fn bundler_config_from_env(
             expected_chain_id,
             WORLD_CHAIN_DEVNET_SAFE_4337_WALLET_DEPLOYER,
         )?,
-        wallet_count: parse_optional_value(
+        wallet_count: parse_optional_profiled_value(
             "ACCEPTANCE_4337_WALLET_COUNT",
+            profile_defaults.as_ref().map(|defaults| defaults.wallet_count),
             DEFAULT_USER_OPERATION_WALLET_COUNT,
         )?,
-        deploy_concurrency: parse_optional_value(
+        deploy_concurrency: parse_optional_profiled_value(
             "ACCEPTANCE_4337_DEPLOY_CONCURRENCY",
+            profile_defaults
+                .as_ref()
+                .map(|defaults| defaults.deploy_concurrency),
             DEFAULT_USER_OPERATION_DEPLOY_CONCURRENCY,
         )?,
-        operations_per_wallet: parse_optional_value(
+        operations_per_wallet: parse_optional_profiled_value(
             "ACCEPTANCE_4337_OPS_PER_WALLET",
+            profile_defaults
+                .as_ref()
+                .map(|defaults| defaults.operations_per_wallet),
             DEFAULT_USER_OPERATION_OPS_PER_WALLET,
         )?,
-        operation_concurrency: parse_optional_value(
+        operation_concurrency: parse_optional_profiled_value(
             "ACCEPTANCE_4337_OP_CONCURRENCY",
+            profile_defaults
+                .as_ref()
+                .map(|defaults| defaults.operation_concurrency),
             DEFAULT_USER_OPERATION_OP_CONCURRENCY,
         )?,
         nonce_concurrency: parse_optional_value(
@@ -218,6 +241,37 @@ fn bundler_cloudflare_access_from_env(
     }
 }
 
+impl UserOperationProfile {
+    fn defaults(&self) -> UserOperationProfileDefaults {
+        match self {
+            Self::Heavy => UserOperationProfileDefaults {
+                wallet_count: 200,
+                deploy_concurrency: 10,
+                operations_per_wallet: 50,
+                operation_concurrency: 200,
+            },
+            Self::ProdSmoke => UserOperationProfileDefaults {
+                wallet_count: 20,
+                deploy_concurrency: 10,
+                operations_per_wallet: 2,
+                operation_concurrency: 20,
+            },
+        }
+    }
+}
+
+fn user_operation_profile_from_env() -> eyre::Result<Option<UserOperationProfile>> {
+    optional_env("ACCEPTANCE_4337_PROFILE")
+        .map(|value| match value.as_str() {
+            "heavy" => Ok(UserOperationProfile::Heavy),
+            "prod-smoke" => Ok(UserOperationProfile::ProdSmoke),
+            _ => bail!(
+                "unsupported ACCEPTANCE_4337_PROFILE {value:?}; expected one of: heavy, prod-smoke"
+            ),
+        })
+        .transpose()
+}
+
 fn parse_optional_address(
     name: &str,
     expected_chain_id: u64,
@@ -247,6 +301,21 @@ where
         .map(|value| parse_value(name, &value))
         .transpose()
         .map(|value| value.unwrap_or(default))
+}
+
+fn parse_optional_profiled_value<T>(
+    name: &str,
+    profile_default: Option<T>,
+    default: T,
+) -> eyre::Result<T>
+where
+    T: FromStr,
+    T::Err: std::error::Error + Send + Sync + 'static,
+{
+    optional_env(name)
+        .map(|value| parse_value(name, &value))
+        .transpose()
+        .map(|value| value.or(profile_default).unwrap_or(default))
 }
 
 fn parse_optional_value_from_str<T>(name: &str, default: &str) -> eyre::Result<T>

--- a/e2e-tests/src/it/acceptance_tests/config.rs
+++ b/e2e-tests/src/it/acceptance_tests/config.rs
@@ -168,7 +168,9 @@ fn bundler_config_from_env(
         )?,
         wallet_count: parse_optional_profiled_value(
             "ACCEPTANCE_4337_WALLET_COUNT",
-            profile_defaults.as_ref().map(|defaults| defaults.wallet_count),
+            profile_defaults
+                .as_ref()
+                .map(|defaults| defaults.wallet_count),
             DEFAULT_USER_OPERATION_WALLET_COUNT,
         )?,
         deploy_concurrency: parse_optional_profiled_value(


### PR DESCRIPTION
reduced non load test profile (smoke) tested on private prod rundler

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces optional CI runs against production mainnet and Rundler with sponsored user operations; blast radius is limited by prod-smoke sizing and excluding prod from the default “all” matrix.
> 
> **Overview**
> Adds **mainnet (`prod`)** to the acceptance-tests workflow as a **manual-only** target (`include_in_all: false`, so **“all”** still runs stage and devnets only). Prod uses public Alchemy RPC, mainnet Rundler, chain **480**, and **`prod-smoke`** ERC-4337 load (lighter than stage’s **`heavy`** profile).
> 
> Replaces workflow hardcoded **`ACCEPTANCE_4337_*`** load knobs with matrix-driven **`ACCEPTANCE_4337_PROFILE`**, **`bundler_checks_enabled`** (dev-us-east-1 skips bundler), and clearer per-network 4337 address fields. Acceptance test config gains named profiles **`heavy`** and **`prod-smoke`** that set wallet/op concurrency defaults; explicit per-knob env vars still win. README documents **`ACCEPTANCE_4337_PROFILE`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17851e54bb7364fc9090945b5e6dd7042d582b77. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->