### PR TITLE
feat: argocd image updater alpha/betanet deployments

### DIFF
--- a/.github/workflows/deploy-alphanet-build.yml
+++ b/.github/workflows/deploy-alphanet-build.yml
@@ -1,13 +1,10 @@
 name: deploy-alphanet-build
 
-# Build + push a world-chain image for a pinned commit and dispatch an alphanet tag bump to
-# worldcoin/crypto-apps. Triggered (workflow_dispatch) by deploy-alphanet.yml after it has
-# authorized the commenter and resolved the PR head. It receives an immutable `sha` input, so
-# there is no time-of-check/time-of-use window.
-#
-# This mirrors docker.yml's devnet build/push/merge, but builds an arbitrary (PR) commit and
-# bumps the alphanet apps instead of devnet. Run it only via the /deploy-alphanet command (or
-# a manual dispatch by a maintainer with a known-good SHA).
+# Build + push a world-chain image for a pinned commit to the mutable `alphanet`
+# tag. Argo CD Image Updater watches that tag and handles the rollout.
+# Triggered (workflow_dispatch) by deploy-alphanet.yml after it has authorized
+# the commenter and resolved the PR head. It receives an immutable `sha` input,
+# so there is no time-of-check/time-of-use window.
 
 on:
   workflow_dispatch:
@@ -44,9 +41,7 @@ jobs:
       - name: Resolve tag
         id: tag
         shell: bash
-        env:
-          SHA: ${{ inputs.sha }}
-        run: echo "tag=sha-${SHA:0:7}" >> "$GITHUB_OUTPUT"
+        run: echo "tag=alphanet" >> "$GITHUB_OUTPUT"
 
   build-and-push:
     name: build and push docker
@@ -93,46 +88,15 @@ jobs:
           tags: |
             type=raw,value=${{ needs.prep.outputs.tag }}
 
-  dispatch:
-    name: dispatch alphanet bump to crypto-apps
+  comment-result:
+    name: comment result
     needs:
       - prep
       - merge
+    if: ${{ inputs.pr != '' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Mint app token
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ vars.DEVNET_DEPLOYMENT_APPID }}
-          private-key: ${{ secrets.DEVNET_DEPLOYMENT_SECRET }}
-          owner: worldcoin
-          repositories: crypto-apps
-
-      - name: Send repository_dispatch
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          TAG: ${{ needs.prep.outputs.tag }}
-          SHA: ${{ inputs.sha }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          PR_NUMBER: ${{ inputs.pr }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          args=(
-            -f "event_type=bump-world-chain-alphanet"
-            -f "client_payload[tag]=${TAG}"
-            -f "client_payload[sha]=${SHA}"
-            -f "client_payload[issuer]=${RUN_URL}"
-          )
-          if [[ -n "${PR_NUMBER}" ]]; then
-            args+=(-f "client_payload[pr]=${PR_NUMBER}")
-          fi
-          gh api repos/worldcoin/crypto-apps/dispatches "${args[@]}"
-          echo "Dispatched bump-world-chain-alphanet with tag ${TAG}"
-
-      - name: Comment dispatch result
-        if: ${{ inputs.pr != '' }}
+      - name: Comment build result
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -142,4 +106,4 @@ jobs:
         run: |
           set -euo pipefail
           gh pr comment "${PR_NUMBER}" --repo "${REPO}" \
-            --body "🚀 Built \`${REGISTRY}/${IMAGE_NAME}:${TAG}\` and dispatched an **alphanet** deploy to [worldcoin/crypto-apps](https://github.com/worldcoin/crypto-apps/actions/workflows/bump-world-chain-alphanet.yaml). A bump PR will open there and auto-merge once checks pass."
+            --body "Built \`${REGISTRY}/${IMAGE_NAME}:${TAG}\`. Argo CD Image Updater will detect the new digest and sync alphanet."

--- a/.github/workflows/deploy-alphanet.yml
+++ b/.github/workflows/deploy-alphanet.yml
@@ -2,7 +2,7 @@ name: deploy-alphanet
 
 # Maintainer-triggered deploy of a PR's code to the world-chain-alphanet devnet.
 # Comment `/deploy-alphanet` on a PR to build that PR's HEAD into a tagged image and
-# dispatch a tag bump to worldcoin/crypto-apps (alphanet apps).
+# publish it to the mutable `alphanet` image tag watched by Argo CD Image Updater.
 #
 # This workflow is privileged (issue_comment runs the copy on the DEFAULT branch with
 # write tokens + secrets). It therefore does NOT check out or execute any PR code; it only
@@ -85,12 +85,10 @@ jobs:
             echo "::error::Refusing to build fork PR head owned by ${HEAD_OWNER}"
             exit 1
           fi
-          TAG="sha-${HEAD_SHA:0:7}"
-
           # Hand off to the build workflow. --ref main pins the build workflow + its local
           # composite actions to the trusted default branch; the PR code is only consumed as
-          # an immutable SHA input to checkout/build. The build derives the image tag from the
-          # SHA, so we only pass the SHA and the PR number to comment on.
+          # an immutable SHA input to checkout/build. The build publishes the mutable alphanet
+          # image tag, so Image Updater can deploy it automatically.
           gh workflow run deploy-alphanet-build.yml \
             --repo "${REPO}" \
             --ref main \
@@ -98,4 +96,4 @@ jobs:
             -f pr="${PR_NUMBER}"
 
           gh pr comment "${PR_NUMBER}" --repo "${REPO}" \
-            --body "🛠️ Building \`${TAG}\` and dispatching an **alphanet** deploy. Track it in the [deploy-alphanet-build runs](https://github.com/${REPO}/actions/workflows/deploy-alphanet-build.yml)."
+            --body "Building \`ghcr.io/${REPO}:alphanet\` and handing deployment to Argo CD Image Updater. Track it in the [deploy-alphanet-build runs](https://github.com/${REPO}/actions/workflows/deploy-alphanet-build.yml)."

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -69,34 +69,3 @@ jobs:
           tags: |
             type=raw,value=${{ inputs.image_tag || 'nightly' }}
             type=sha
-
-  dispatch-devnet-bump:
-    name: dispatch devnet bump to crypto-apps
-    needs: merge
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Mint app token
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ vars.DEVNET_DEPLOYMENT_APPID }}
-          private-key: ${{ secrets.DEVNET_DEPLOYMENT_SECRET }}
-          owner: worldcoin
-          repositories: crypto-apps
-
-      - name: Send repository_dispatch
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          SHA: ${{ github.sha }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          SHORT=${SHA::7}
-          gh api repos/worldcoin/crypto-apps/dispatches \
-            -f event_type=bump-world-chain-dev \
-            -f "client_payload[tag]=sha-${SHORT}" \
-            -f "client_payload[sha]=${SHA}" \
-            -f "client_payload[issuer]=${RUN_URL}"
-          echo "Dispatched bump-world-chain-dev with tag sha-${SHORT}"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how alphanet and main-branch devnet images reach clusters; misconfigured Image Updater or tag wiring could block deploys, though the change removes privileged cross-repo dispatch secrets from these workflows.
> 
> **Overview**
> Replaces **crypto-apps** `repository_dispatch` bump flows with publishing **mutable image tags** that **Argo CD Image Updater** is expected to roll out.
> 
> For **`/deploy-alphanet`**, `deploy-alphanet-build.yml` now always tags images as **`alphanet`** (instead of `sha-<short>`), drops the job that minted a GitHub App token and dispatched `bump-world-chain-alphanet` to `worldcoin/crypto-apps`, and only posts a PR comment when a build finishes. `deploy-alphanet.yml` comments were updated to describe **`ghcr.io/...:alphanet`** and Image Updater instead of a crypto-apps bump PR.
> 
> On **`main` pushes**, `docker.yml` no longer runs **`dispatch-devnet-bump`** (`bump-world-chain-dev` to crypto-apps); devnet rollout is likewise assumed to be handled outside this repo via Image Updater (or equivalent) watching the published tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e28cea4fa67b14de734e73d73bfba066ac087ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->