### PR TITLE
fix: /deploy-alphanet

### DIFF
--- a/.github/actions/docker-build-push-digest/action.yml
+++ b/.github/actions/docker-build-push-digest/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: Git commit SHA to embed via VERGEN_GIT_SHA (defaults to the triggering commit).
     required: false
     default: ${{ github.sha }}
+  context:
+    description: Docker build context path.
+    required: false
+    default: .
   dockerfile:
     description: Path to the Dockerfile to build.
     required: false
@@ -29,6 +33,10 @@ inputs:
     description: Extra build args passed to docker build (newline-separated KEY=value).
     required: false
     default: ""
+  cache_scope:
+    description: BuildKit cache scope name.
+    required: false
+    default: ${{ github.ref_name }}
   digest_artifact_prefix:
     description: >-
       Prefix for the uploaded digest artifact name. Override when a workflow builds
@@ -41,12 +49,16 @@ runs:
   steps:
     - name: Prepare
       shell: bash
+      env:
+        CACHE_SCOPE_INPUT: ${{ inputs.cache_scope }}
+        IMAGE_NAME: ${{ inputs.image_name }}
+        PLATFORM: ${{ inputs.platform }}
       run: |
-        platform='${{ inputs.platform }}'
-        ref_name='${{ github.ref_name }}'
+        platform="${PLATFORM}"
+        cache_scope="${CACHE_SCOPE_INPUT}"
         echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
-        echo "CACHE_SCOPE=${ref_name//\//-}" >> "$GITHUB_ENV"
-        echo "BUILDKIT_CACHE_PREFIX=buildkit/${{ inputs.image_name }}/${platform//\//-}" >> "$GITHUB_ENV"
+        echo "CACHE_SCOPE=${cache_scope//\//-}" >> "$GITHUB_ENV"
+        echo "BUILDKIT_CACHE_PREFIX=buildkit/${IMAGE_NAME}/${platform//\//-}" >> "$GITHUB_ENV"
 
     - name: Log in to Registry
       uses: docker/login-action@v3
@@ -60,6 +72,8 @@ runs:
       uses: docker/metadata-action@v5
       with:
         images: ${{ inputs.registry }}/${{ inputs.image_name }}
+        labels: |
+          org.opencontainers.image.revision=${{ inputs.git_sha }}
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -74,7 +88,7 @@ runs:
       id: build
       uses: docker/build-push-action@v6
       with:
-        context: .
+        context: ${{ inputs.context }}
         file: ${{ inputs.dockerfile }}
         build-args: |
           VERGEN_GIT_SHA=${{ inputs.git_sha }}

--- a/.github/workflows/deploy-alphanet-build.yml
+++ b/.github/workflows/deploy-alphanet-build.yml
@@ -3,8 +3,9 @@ name: deploy-alphanet-build
 # Build + push a world-chain image for a pinned commit to the mutable `alphanet`
 # tag. Argo CD Image Updater watches that tag and handles the rollout.
 # Triggered (workflow_dispatch) by deploy-alphanet.yml after it has authorized
-# the commenter and resolved the PR head. It receives an immutable `sha` input,
-# so there is no time-of-check/time-of-use window.
+# the commenter and resolved the PR head. It receives the PR number plus an
+# immutable `sha` input, checks out trusted local actions from the workflow ref,
+# checks out the Docker source at that SHA, and verifies it before building.
 
 on:
   workflow_dispatch:
@@ -30,6 +31,7 @@ permissions:
   packages: write
   id-token: write
   pull-requests: write
+  issues: write
 
 jobs:
   prep:
@@ -57,19 +59,69 @@ jobs:
             platform: linux/arm64
     runs-on: ${{ matrix.runner }}
     steps:
-      - name: Check Out commit
+      - name: Resolve build target
+        id: target
+        env:
+          INPUT_SHA: ${{ inputs.sha }}
+          PR_NUMBER: ${{ inputs.pr }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          sha="${INPUT_SHA,,}"
+          if [[ ! "${sha}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Invalid sha input: ${INPUT_SHA}"
+            exit 1
+          fi
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+
+          if [[ -n "${PR_NUMBER}" ]]; then
+            if [[ ! "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
+              echo "::error::Invalid PR input: ${PR_NUMBER}"
+              exit 1
+            fi
+            echo "cache_scope=alphanet-pr-${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          else
+            echo "cache_scope=alphanet-${sha:0:12}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check Out workflow actions
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.sha }}
+          ref: ${{ github.sha }}
+          path: workflow
+
+      - name: Check Out PR source
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.target.outputs.sha }}
+          path: source
+
+      - name: Verify checked out commit
+        env:
+          EXPECTED_SHA: ${{ steps.target.outputs.sha }}
+        shell: bash
+        working-directory: source
+        run: |
+          set -euo pipefail
+          actual_sha="$(git rev-parse HEAD)"
+          if [[ "${actual_sha}" != "${EXPECTED_SHA}" ]]; then
+            echo "::error::Expected PR source ${EXPECTED_SHA}, checked out ${actual_sha}"
+            exit 1
+          fi
+          echo "Building PR source at ${actual_sha}"
+
       - name: Build and push digest
-        uses: ./.github/actions/docker-build-push-digest
+        uses: ./workflow/.github/actions/docker-build-push-digest
         with:
           platform: ${{ matrix.platform }}
           registry: ${{ env.REGISTRY }}
           image_name: ${{ env.IMAGE_NAME }}
           aws_region: ${{ env.AWS_REGION }}
           sccache_bucket: ${{ env.SCCACHE_BUCKET }}
-          git_sha: ${{ inputs.sha }}
+          git_sha: ${{ steps.target.outputs.sha }}
+          context: source
+          dockerfile: source/Dockerfile
+          cache_scope: ${{ steps.target.outputs.cache_scope }}
 
   merge:
     name: merge multi-arch manifest
@@ -78,10 +130,13 @@ jobs:
       - build-and-push
     runs-on: ubuntu-latest
     steps:
-      - name: Check Out Repo
+      - name: Check Out workflow actions
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          path: workflow
       - name: Merge multi-arch manifest
-        uses: ./.github/actions/docker-merge-manifest
+        uses: ./workflow/.github/actions/docker-merge-manifest
         with:
           registry: ${{ env.REGISTRY }}
           image_name: ${{ env.IMAGE_NAME }}
@@ -102,8 +157,9 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ inputs.pr }}
           TAG: ${{ needs.prep.outputs.tag }}
+          SHA: ${{ inputs.sha }}
         shell: bash
         run: |
           set -euo pipefail
           gh pr comment "${PR_NUMBER}" --repo "${REPO}" \
-            --body "Built \`${REGISTRY}/${IMAGE_NAME}:${TAG}\`. Argo CD Image Updater will detect the new digest and sync alphanet."
+            --body "Built \`${REGISTRY}/${IMAGE_NAME}:${TAG}\` from PR #${PR_NUMBER} at \`${SHA:0:12}\`. Argo CD Image Updater will detect the new digest and sync alphanet."

--- a/.github/workflows/deploy-alphanet.yml
+++ b/.github/workflows/deploy-alphanet.yml
@@ -78,6 +78,13 @@ jobs:
               --json headRefOid,headRepositoryOwner \
               --jq '[.headRefOid, .headRepositoryOwner.login] | @tsv'
           )
+          HEAD_SHA="${HEAD_SHA,,}"
+          if [[ ! "${HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            gh pr comment "${PR_NUMBER}" --repo "${REPO}" \
+              --body "Could not resolve a valid head SHA for PR #${PR_NUMBER}; deploy aborted."
+            echo "::error::Could not resolve valid PR head SHA: ${HEAD_SHA}"
+            exit 1
+          fi
           OWNER="${REPO%%/*}"
           if [[ "${HEAD_OWNER}" != "${OWNER}" ]]; then
             gh pr comment "${PR_NUMBER}" --repo "${REPO}" \
@@ -85,10 +92,9 @@ jobs:
             echo "::error::Refusing to build fork PR head owned by ${HEAD_OWNER}"
             exit 1
           fi
-          # Hand off to the build workflow. --ref main pins the build workflow + its local
-          # composite actions to the trusted default branch; the PR code is only consumed as
-          # an immutable SHA input to checkout/build. The build publishes the mutable alphanet
-          # image tag, so Image Updater can deploy it automatically.
+          # Hand off to the build workflow. --ref main selects the trusted workflow
+          # definition; deploy-alphanet-build checks out this immutable SHA as the
+          # Docker context while using trusted local actions from main.
           gh workflow run deploy-alphanet-build.yml \
             --repo "${REPO}" \
             --ref main \
@@ -96,4 +102,4 @@ jobs:
             -f pr="${PR_NUMBER}"
 
           gh pr comment "${PR_NUMBER}" --repo "${REPO}" \
-            --body "Building \`ghcr.io/${REPO}:alphanet\` and handing deployment to Argo CD Image Updater. Track it in the [deploy-alphanet-build runs](https://github.com/${REPO}/actions/workflows/deploy-alphanet-build.yml)."
+            --body "Building \`ghcr.io/${REPO}:alphanet\` from PR #${PR_NUMBER} at \`${HEAD_SHA:0:12}\` and handing deployment to Argo CD Image Updater. Track it in the [deploy-alphanet-build runs](https://github.com/${REPO}/actions/workflows/deploy-alphanet-build.yml)."


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes deploy pipeline trust boundaries and what gets built for alphanet; mistakes could build wrong code or break deploys, but inputs are validated and checkout is verified.
> 
> **Overview**
> Fixes **`/deploy-alphanet`** by separating **trusted CI** from **PR source** at build time and tightening validation.
> 
> The **`docker-build-push-digest`** composite action now accepts optional **`context`**, **`cache_scope`**, and sets **`org.opencontainers.image.revision`** from **`git_sha`**. BuildKit cache scope is driven by the new input instead of always using the ref name.
> 
> **`deploy-alphanet-build`** no longer checks out the target SHA as the job root (which would run PR-supplied workflow/actions). It checks out **`main`/workflow ref** under `workflow/` for local actions, checks out the pinned SHA under `source/` for the Docker build, **verifies** `git rev-parse HEAD` matches the expected SHA, and passes **`context: source`**, **`dockerfile: source/Dockerfile`**, and PR-scoped **`cache_scope`**. SHA and PR inputs are validated (40-char hex, numeric PR).
> 
> **`deploy-alphanet`** normalizes and validates the resolved PR head SHA before dispatch, updates handoff comments to include PR number and short SHA, and clarifies that the build workflow uses trusted actions from **main** while building immutable PR code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77553d2c29d6c73ced283ba99ad3daf47b49aa65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->