### PR TITLE
chore: only smoke test on staging

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -57,7 +57,7 @@ jobs:
             environment: stage
             include_in_all: true
             rpc_url: https://wc-node-sepolia.worldcoin.dev
-            acceptance_profile: heavy
+            acceptance_profile: smoke
             bundler_rpc_url: https://rundler-sepolia.worldcoin.dev
             entry_point: "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
             safe_4337_module: "0x829Efdda958f06eA49f1F416e10b35C140bf45EF"
@@ -79,7 +79,7 @@ jobs:
             environment: dev-eu-central-2
             include_in_all: true
             rpc_url: https://tx-proxy-devnet-eu-central-2.worldcoin.dev
-            acceptance_profile: heavy
+            acceptance_profile: smoke
             bundler_rpc_url: https://rundler-devnet-eu-central-2.worldcoin.dev
             expected_chain_id: "69420"
             entry_point: ""

--- a/e2e-tests/src/it/acceptance_tests/README.md
+++ b/e2e-tests/src/it/acceptance_tests/README.md
@@ -26,7 +26,7 @@ The MVP checks:
 | `ACCEPTANCE_4337_ENTRY_POINT` | no on chain `69420`; yes otherwise | `0x0000000071727De22E5E9d8BAf0edAc6f37da032` on chain `69420` | ERC-4337 v0.7 EntryPoint address. |
 | `ACCEPTANCE_4337_MODULE` | no on chain `69420`; yes otherwise | `0x70673A08a5B1086585d39979Fb2d84FDC0bB6Aaf` on chain `69420` | Safe4337 module used to sign Safe user operations. |
 | `ACCEPTANCE_4337_WALLET_DEPLOYER` | no on chain `69420`; yes otherwise | `0xd1f0B51940DbD6e73891D2a41Ef14483fDC5Cb6e` on chain `69420` | Safe4337 wallet deployer used as the v0.7 factory. |
-| `ACCEPTANCE_4337_PROFILE` | no | unset | Named user-operation load profile. Supported values: `heavy`, `smoke`. Explicit per-knob env vars still override the profile. |
+| `ACCEPTANCE_4337_PROFILE` | no | unset | Named user-operation profile. Supported values: `heavy`, `smoke`. Explicit per-knob env vars still override the profile. |
 | `ACCEPTANCE_4337_WALLET_COUNT` | no | `20` | Number of ephemeral Safe wallets to deploy through sponsored user operations. |
 | `ACCEPTANCE_4337_DEPLOY_CONCURRENCY` | no | `10` | Max number of wallet-deploying user operations sent and awaited concurrently. Kept at Rundler's unstaked-factory in-flight limit because all deploy ops use the same Safe factory. |
 | `ACCEPTANCE_4337_OPS_PER_WALLET` | no | `3` | Number of post-deploy sponsored no-op user operations to send for each wallet. |
@@ -43,11 +43,11 @@ The ERC-4337 wallet owners are deterministic test mnemonic accounts and are only
 used to sign Safe user operations. They do not need ETH. Sponsored operations are
 paid by the configured Rundler instance.
 
-The GitHub Actions acceptance workflow sets `ACCEPTANCE_4337_PROFILE=heavy` for the current
-bundler-enabled stage and dev-eu-central-2 runs. That profile means 200 ephemeral Safe wallets,
-50 post-deploy sponsored no-op operations per wallet, and 200-way post-deploy operation
-concurrency. Deploy concurrency stays at 10 because all deployment operations use the same Safe
-factory.
+The GitHub Actions acceptance workflow sets `ACCEPTANCE_4337_PROFILE=smoke` for
+bundler-enabled runs. That profile means 20 ephemeral Safe wallets, 2 post-deploy
+sponsored no-op operations per wallet, and 20-way post-deploy operation
+concurrency. Deploy concurrency stays at 10 because all deployment operations use
+the same Safe factory.
 
 Example:
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only test profile changes with no production code or runtime behavior impact.
> 
> **Overview**
> Bundler-enabled **acceptance** matrix jobs for **stage** and **dev-eu-central-2** now use `acceptance_profile: smoke` instead of `heavy`, aligning them with **prod** and cutting ERC-4337 load in CI.
> 
> The acceptance tests README is updated to say the workflow sets `ACCEPTANCE_4337_PROFILE=smoke` for all bundler-enabled runs (20 wallets, 2 post-deploy ops per wallet, 20-way op concurrency) rather than the former **heavy** profile (200 wallets, 50 ops per wallet, 200-way concurrency).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 333070bbd8f62e3dba1851efdca16dbe7327b22c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->