### PR TITLE
feat: enable karst per default new chains and local devnet

### DIFF
--- a/crates/chainspec/src/builder.rs
+++ b/crates/chainspec/src/builder.rs
@@ -166,9 +166,21 @@ impl WorldChainSpecBuilder {
         self
     }
 
+    /// Enable Karst at genesis.
+    pub fn karst_activated(mut self) -> Self {
+        self = self.jovian_activated();
+        self.inner = self
+            .inner
+            .with_fork(EthereumHardfork::Osaka, ForkCondition::Timestamp(0));
+        self.inner = self
+            .inner
+            .with_fork(WorldChainHardfork::Karst, ForkCondition::Timestamp(0));
+        self
+    }
+
     /// Enable Tropo at genesis.
     pub fn tropo_activated(mut self) -> Self {
-        self = self.jovian_activated();
+        self = self.karst_activated();
         self.inner = self
             .inner
             .with_fork(WorldChainHardfork::Tropo, ForkCondition::Timestamp(0));

--- a/crates/chainspec/src/hardfork.rs
+++ b/crates/chainspec/src/hardfork.rs
@@ -3,7 +3,7 @@ use reth_chainspec::{EthereumHardforks, ForkCondition, hardfork};
 hardfork!(
     /// The name of a World Chain hardfork.
     ///
-    /// World Chain follows the OP Stack upgrade sequence through Jovian, then uses
+    /// World Chain follows the OP Stack upgrade sequence through Karst, then uses
     /// World Chain specific upgrade names as the canonical schedule diverges.
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[derive(Default)]
@@ -27,9 +27,11 @@ hardfork!(
         /// Jovian: OP Stack Jovian upgrade. World Chain is already on this hardfork.
         #[default]
         Jovian,
-        /// Tropo: the first World Chain specific hardfork after Jovian.
+        /// Karst: OP Stack Karst upgrade.
+        Karst,
+        /// Tropo: the first World Chain specific hardfork after Karst.
         Tropo,
-        /// Strato: the second World Chain specific hardfork after Jovian.
+        /// Strato: the second World Chain specific hardfork after Karst.
         Strato,
     }
 );
@@ -102,6 +104,12 @@ pub trait WorldChainHardforks: EthereumHardforks {
             .active_at_timestamp(timestamp)
     }
 
+    /// Returns `true` if [`Karst`](WorldChainHardfork::Karst) is active.
+    fn is_karst_active_at_timestamp(&self, timestamp: u64) -> bool {
+        self.world_chain_fork_activation(WorldChainHardfork::Karst)
+            .active_at_timestamp(timestamp)
+    }
+
     /// Returns `true` if [`Tropo`](WorldChainHardfork::Tropo) is active.
     fn is_tropo_active_at_timestamp(&self, timestamp: u64) -> bool {
         self.world_chain_fork_activation(WorldChainHardfork::Tropo)
@@ -123,6 +131,10 @@ mod tests {
 
     #[test]
     fn parses_case_insensitive_hardfork_names() {
+        assert_eq!(
+            WorldChainHardfork::from_str("kArSt").unwrap(),
+            WorldChainHardfork::Karst
+        );
         assert_eq!(
             WorldChainHardfork::from_str("tRoPo").unwrap(),
             WorldChainHardfork::Tropo

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -31,7 +31,7 @@ pub const JOVIAN_UPGRADE_TIMESTAMP_MAINNET: u64 = 1_777_593_600;
 /// World Chain spec type.
 ///
 /// This wraps reth's generic [`ChainSpec`] the same way the OP stack spec does, while using World
-/// Chain hardfork names as the canonical post-Jovian schedule.
+/// Chain hardfork names as the canonical post-Karst schedule.
 #[derive(Debug, Clone, Deref, Into, Constructor, PartialEq, Eq)]
 pub struct WorldChainSpec {
     /// Inner reth chain spec.
@@ -215,7 +215,7 @@ impl OpHardforks for WorldChainSpec {
             OpHardfork::Holocene => self.fork(WorldChainHardfork::Holocene),
             OpHardfork::Isthmus => self.fork(WorldChainHardfork::Isthmus),
             OpHardfork::Jovian => self.fork(WorldChainHardfork::Jovian),
-            OpHardfork::Karst => ForkCondition::Never,
+            OpHardfork::Karst => self.fork(WorldChainHardfork::Karst),
             _ => ForkCondition::Never,
         }
     }
@@ -337,6 +337,7 @@ impl From<Genesis> for WorldChainSpec {
                 EthereumHardfork::Prague.boxed(),
                 op_genesis_info.isthmus_time,
             ),
+            (EthereumHardfork::Osaka.boxed(), op_genesis_info.karst_time),
             (
                 WorldChainHardfork::Regolith.boxed(),
                 op_genesis_info.regolith_time,
@@ -368,6 +369,10 @@ impl From<Genesis> for WorldChainSpec {
             (
                 WorldChainHardfork::Jovian.boxed(),
                 op_genesis_info.jovian_time,
+            ),
+            (
+                WorldChainHardfork::Karst.boxed(),
+                op_genesis_info.karst_time,
             ),
             (WorldChainHardfork::Tropo.boxed(), genesis_info.tropo_time),
             (WorldChainHardfork::Strato.boxed(), genesis_info.strato_time),
@@ -470,12 +475,14 @@ fn extra_timestamp(genesis: &Genesis, key: &str) -> Option<u64> {
 }
 
 pub(crate) fn convert_op_hardforks(hardforks: &ChainHardforks) -> ChainHardforks {
-    ChainHardforks::new(
-        hardforks
-            .forks_iter()
-            .filter_map(|(fork, condition)| convert_op_hardfork(fork).map(|fork| (fork, condition)))
-            .collect(),
-    )
+    let mut converted = ChainHardforks::default();
+    for (fork, condition) in hardforks.forks_iter() {
+        let Some(fork) = convert_op_hardfork(fork) else {
+            continue;
+        };
+        converted.insert(fork, condition);
+    }
+    converted
 }
 
 pub(crate) fn convert_op_hardfork(fork: &dyn Hardfork) -> Option<Box<dyn Hardfork>> {
@@ -489,7 +496,8 @@ pub(crate) fn convert_op_hardfork(fork: &dyn Hardfork) -> Option<Box<dyn Hardfor
         "Holocene" => Some(WorldChainHardfork::Holocene.boxed()),
         "Isthmus" => Some(WorldChainHardfork::Isthmus.boxed()),
         "Jovian" => Some(WorldChainHardfork::Jovian.boxed()),
-        "Karst" | "Interop" => None,
+        "Karst" => Some(WorldChainHardfork::Karst.boxed()),
+        "Interop" => None,
         other if other.eq_ignore_ascii_case("tropo") => Some(WorldChainHardfork::Tropo.boxed()),
         other if other.eq_ignore_ascii_case("strato") => Some(WorldChainHardfork::Strato.boxed()),
         _ => EthereumHardfork::VARIANTS
@@ -524,6 +532,7 @@ fn order_world_hardforks(
         WorldChainHardfork::Holocene.boxed(),
         WorldChainHardfork::Isthmus.boxed(),
         WorldChainHardfork::Jovian.boxed(),
+        WorldChainHardfork::Karst.boxed(),
         WorldChainHardfork::Tropo.boxed(),
         WorldChainHardfork::Strato.boxed(),
     ];
@@ -559,41 +568,55 @@ mod tests {
             spec.fork(WorldChainHardfork::Jovian),
             ForkCondition::Timestamp(JOVIAN_UPGRADE_TIMESTAMP_MAINNET)
         );
+        assert_eq!(spec.fork(WorldChainHardfork::Karst), ForkCondition::Never);
     }
 
     #[test]
-    fn world_specific_hardforks_default_inactive_for_custom_genesis() {
+    fn post_jovian_hardforks_default_inactive_for_custom_genesis() {
         let spec = WorldChainSpec::from_genesis(Genesis::default());
+        assert_eq!(spec.fork(WorldChainHardfork::Karst), ForkCondition::Never);
         assert_eq!(spec.fork(WorldChainHardfork::Tropo), ForkCondition::Never);
         assert_eq!(spec.fork(WorldChainHardfork::Strato), ForkCondition::Never);
     }
 
     #[test]
-    fn world_specific_hardforks_do_not_activate_post_jovian_op_forks() {
+    fn world_specific_hardforks_keep_karst_activation() {
         let spec = WorldChainSpecBuilder::mainnet()
             .jovian_activated()
+            .karst_activated()
             .tropo_activated()
             .strato_activated()
             .build();
 
         assert_eq!(
             spec.op_fork_activation(OpHardfork::Karst),
-            ForkCondition::Never
+            ForkCondition::Timestamp(0)
+        );
+        assert_eq!(
+            spec.fork(EthereumHardfork::Osaka),
+            ForkCondition::Timestamp(0)
         );
     }
 
     #[test]
-    fn converting_op_specs_drops_post_jovian_op_forks() {
+    fn converting_op_specs_preserves_karst() {
         let mut spec = WorldChainSpec::from_genesis(Genesis::default());
         spec.set_fork(OpHardfork::Karst, ForkCondition::Timestamp(10));
 
         let converted = WorldChainSpec::from(spec.inner);
 
-        assert_eq!(converted.fork(OpHardfork::Karst), ForkCondition::Never);
+        assert_eq!(
+            converted.fork(WorldChainHardfork::Karst),
+            ForkCondition::Timestamp(10)
+        );
+        assert_eq!(
+            converted.op_fork_activation(OpHardfork::Karst),
+            ForkCondition::Timestamp(10)
+        );
     }
 
     #[test]
-    fn world_hardfork_order_skips_post_jovian_op_forks() {
+    fn world_hardfork_order_places_karst_before_world_specific_forks() {
         let hardforks = order_world_hardforks(vec![
             (
                 WorldChainHardfork::Strato.boxed(),
@@ -607,23 +630,30 @@ mod tests {
                 WorldChainHardfork::Jovian.boxed(),
                 ForkCondition::Timestamp(10),
             ),
+            (
+                WorldChainHardfork::Karst.boxed(),
+                ForkCondition::Timestamp(15),
+            ),
         ]);
         let names = hardforks
             .forks_iter()
             .map(|(fork, _)| fork.name())
             .collect::<Vec<_>>();
 
-        assert_eq!(names, vec!["Jovian", "Tropo", "Strato"]);
+        assert_eq!(names, vec!["Jovian", "Karst", "Tropo", "Strato"]);
     }
 
     #[test]
-    fn builder_drops_post_jovian_op_forks_from_generic_inputs() {
+    fn builder_preserves_karst_from_generic_inputs() {
         let spec = WorldChainSpecBuilder::mainnet()
             .with_fork(OpHardfork::Karst, ForkCondition::Timestamp(10))
             .with_fork(OpHardfork::Jovian, ForkCondition::Timestamp(5))
             .build();
 
-        assert_eq!(spec.fork(OpHardfork::Karst), ForkCondition::Never);
+        assert_eq!(
+            spec.fork(WorldChainHardfork::Karst),
+            ForkCondition::Timestamp(10)
+        );
         assert_eq!(
             spec.fork(WorldChainHardfork::Jovian),
             ForkCondition::Timestamp(5)

--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -1176,6 +1176,11 @@ fn patch_l2_hardforks(
     );
     set_time(
         genesis_config,
+        "karstTime",
+        hardforks.is_active(WorldChainHardfork::Karst),
+    );
+    set_time(
+        genesis_config,
         "tropoTime",
         hardforks.is_active(WorldChainHardfork::Tropo),
     );
@@ -1239,6 +1244,11 @@ fn patch_l2_hardforks(
         rollup_config,
         "jovian_time",
         hardforks.is_active(WorldChainHardfork::Jovian),
+    );
+    set_time(
+        rollup_config,
+        "karst_time",
+        hardforks.is_active(WorldChainHardfork::Karst),
     );
     set_time(
         rollup_config,
@@ -3466,7 +3476,7 @@ mod tests {
                 "eip1559Elasticity": 10
             }
         });
-        let hardforks = WorldChainHardforkConfig::through(WorldChainHardfork::Jovian);
+        let hardforks = WorldChainHardforkConfig::through(WorldChainHardfork::Karst);
 
         patch_l2_genesis_base_fee_extra_data(&mut genesis, rollup.as_object().unwrap(), &hardforks)
             .unwrap();
@@ -3478,8 +3488,8 @@ mod tests {
     fn renders_op_deployer_intent_with_tagged_contract_locators() {
         let intent = render_intent(&HaSequencerConfig::default());
 
-        assert!(intent.contains("l1ContractsLocator = \"tag://op-contracts/v3.0.0-rc.2\""));
-        assert!(intent.contains("l2ContractsLocator = \"tag://op-contracts/v3.0.0-rc.2\""));
+        assert!(intent.contains("l1ContractsLocator = \"tag://op-contracts/v7.0.0-rc.4\""));
+        assert!(intent.contains("l2ContractsLocator = \"tag://op-contracts/v7.0.0-rc.4\""));
         assert!(!intent.contains("https://storage.googleapis.com/oplabs-contract-artifacts"));
     }
 }

--- a/crates/devnet/src/hardforks.rs
+++ b/crates/devnet/src/hardforks.rs
@@ -5,7 +5,7 @@ use reth_chainspec::{EthereumHardfork, ForkCondition};
 use world_chain_chainspec::{WorldChainHardfork, WorldChainSpec};
 
 /// Canonical hardfork order for local World Chain devnets.
-pub const WORLD_CHAIN_DEVNET_HARDFORK_ORDER: [WorldChainHardfork; 11] = [
+pub const WORLD_CHAIN_DEVNET_HARDFORK_ORDER: [WorldChainHardfork; 12] = [
     WorldChainHardfork::Bedrock,
     WorldChainHardfork::Regolith,
     WorldChainHardfork::Canyon,
@@ -15,14 +15,15 @@ pub const WORLD_CHAIN_DEVNET_HARDFORK_ORDER: [WorldChainHardfork; 11] = [
     WorldChainHardfork::Holocene,
     WorldChainHardfork::Isthmus,
     WorldChainHardfork::Jovian,
+    WorldChainHardfork::Karst,
     WorldChainHardfork::Tropo,
     WorldChainHardfork::Strato,
 ];
 
 /// Typed World Chain hardfork selection for local devnets.
 ///
-/// Defaults match current local-dev expectations: all OP/World hardforks
-/// through Jovian are active at genesis, while the World-specific Tropo and
+/// Defaults match the post-Karst local-dev baseline: all OP/World hardforks
+/// through Karst are active at genesis, while the World-specific Tropo and
 /// Strato forks are disabled until explicitly selected.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WorldChainHardforkConfig {
@@ -31,7 +32,7 @@ pub struct WorldChainHardforkConfig {
 
 impl Default for WorldChainHardforkConfig {
     fn default() -> Self {
-        Self::through(WorldChainHardfork::Jovian)
+        Self::through(WorldChainHardfork::Karst)
     }
 }
 
@@ -125,6 +126,14 @@ impl WorldChainHardforkConfig {
                 ForkCondition::Never
             },
         );
+        spec.set_fork(
+            EthereumHardfork::Osaka,
+            if self.active.contains(&WorldChainHardfork::Karst) {
+                ForkCondition::Timestamp(0)
+            } else {
+                ForkCondition::Never
+            },
+        );
 
         spec
     }
@@ -133,14 +142,33 @@ impl WorldChainHardforkConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use reth_chainspec::Hardforks;
 
     #[test]
-    fn default_local_devnet_hardforks_stop_at_jovian() {
+    fn default_local_devnet_hardforks_stop_at_karst() {
         let hardforks = WorldChainHardforkConfig::default();
 
         assert!(hardforks.is_active(WorldChainHardfork::Jovian));
+        assert!(hardforks.is_active(WorldChainHardfork::Karst));
         assert!(!hardforks.is_active(WorldChainHardfork::Tropo));
         assert!(!hardforks.is_active(WorldChainHardfork::Strato));
+    }
+
+    #[test]
+    fn karst_local_devnet_activates_osaka_without_world_specific_forks() {
+        let hardforks = WorldChainHardforkConfig::through(WorldChainHardfork::Karst);
+        let spec = hardforks.apply_to(WorldChainSpec::dev().as_ref().clone());
+
+        assert!(hardforks.is_active(WorldChainHardfork::Karst));
+        assert!(!hardforks.is_active(WorldChainHardfork::Tropo));
+        assert_eq!(
+            spec.fork(WorldChainHardfork::Karst),
+            ForkCondition::Timestamp(0)
+        );
+        assert_eq!(
+            spec.fork(EthereumHardfork::Osaka),
+            ForkCondition::Timestamp(0)
+        );
     }
 
     #[test]

--- a/crates/devnet/src/op_stack.rs
+++ b/crates/devnet/src/op_stack.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 /// OP contract artifacts supported by the pinned op-deployer image.
-pub const DEFAULT_OP_CONTRACT_ARTIFACTS_LOCATOR: &str = "tag://op-contracts/v3.0.0-rc.2";
+pub const DEFAULT_OP_CONTRACT_ARTIFACTS_LOCATOR: &str = "tag://op-contracts/v7.0.0-rc.4";
 
 const DEFAULT_DEVNET_PRIVATE_KEY: &str =
     "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
@@ -33,11 +33,11 @@ impl Default for OpStackImages {
         Self {
             op_node: ContainerImage::new(
                 "us-docker.pkg.dev/oplabs-tools-artifacts/images/kona-node",
-                "v1.5.0",
+                "v1.6.0",
             ),
             op_deployer: ContainerImage::new(
                 "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer",
-                "v0.4.0-rc.2",
+                "v0.7.0-rc.1",
             ),
             op_batcher: ContainerImage::new(
                 "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-batcher",
@@ -49,7 +49,7 @@ impl Default for OpStackImages {
             ),
             op_challenger: ContainerImage::new(
                 "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-challenger",
-                "develop",
+                "v1.9.3",
             ),
             op_conductor: ContainerImage::new(
                 "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-conductor",
@@ -567,11 +567,11 @@ mod tests {
     fn default_op_contract_locator_uses_supported_tag_scheme() {
         assert_eq!(
             OpContractDeploymentConfig::default().l1_artifacts_locator,
-            "tag://op-contracts/v3.0.0-rc.2"
+            "tag://op-contracts/v7.0.0-rc.4"
         );
         assert_eq!(
             OpContractDeploymentConfig::default().l2_artifacts_locator,
-            "tag://op-contracts/v3.0.0-rc.2"
+            "tag://op-contracts/v7.0.0-rc.4"
         );
     }
 

--- a/crates/rpc/src/engine.rs
+++ b/crates/rpc/src/engine.rs
@@ -155,9 +155,12 @@ where
 
     async fn get_payload_v5(
         &self,
-        _payload_id: PayloadId,
+        payload_id: PayloadId,
     ) -> RpcResult<EngineT::ExecutionPayloadEnvelopeV5> {
-        unimplemented!("get_payload_v5 is not yet supported by the flashblocks engine API")
+        Ok(self
+            .inner
+            .get_payload_v5(op_reth_payload_id_v4_lookup(payload_id))
+            .await?)
     }
 
     async fn get_payload_bodies_by_hash_v1(

--- a/crates/test-utils/src/builder.rs
+++ b/crates/test-utils/src/builder.rs
@@ -235,7 +235,7 @@ lazy_static::lazy_static! {
         WorldChainSpecBuilder::default()
             .chain(GENESIS.config.chain_id.into())
             .genesis(GENESIS.clone())
-            .isthmus_activated()
+            .karst_activated()
             .build()
     );
 

--- a/crates/test-utils/src/e2e_harness/actions.rs
+++ b/crates/test-utils/src/e2e_harness/actions.rs
@@ -1060,7 +1060,7 @@ where
 
             tokio::time::sleep(self.block_interval).await;
             let payload =
-                EngineApiClient::<OpEngineTypes>::get_payload_v4(&engine, payload_id).await?;
+                EngineApiClient::<OpEngineTypes>::get_payload_v5(&engine, payload_id).await?;
 
             info!(
                 "Mined block {} with {} txs",
@@ -1202,7 +1202,7 @@ pub type MidBuildCallback = Box<
 /// 1. Generates payload attributes for the next block
 /// 2. Sends `forkchoiceUpdatedV3` with attributes to start building
 /// 3. Waits for `block_interval` (the build deadline)
-/// 4. Calls `getPayloadV4` to retrieve the built payload
+/// 4. Calls `getPayloadV5` to retrieve the built payload
 /// 5. Sends `newPayloadV4` + `forkchoiceUpdated` on all follower nodes
 /// 6. Invokes the optional `on_block` callback
 /// 7. Advances to the next cycle with the new block as head
@@ -1325,9 +1325,9 @@ where
                     during_build(block_num).await?;
                 }
 
-                // 4. getPayloadV4
+                // 4. getPayloadV5
                 let payload =
-                    EngineApiClient::<OpEngineTypes>::get_payload_v4(&engine, payload_id).await?;
+                    EngineApiClient::<OpEngineTypes>::get_payload_v5(&engine, payload_id).await?;
 
                 let block_hash = payload
                     .execution_payload

--- a/crates/test-utils/src/e2e_harness/setup.rs
+++ b/crates/test-utils/src/e2e_harness/setup.rs
@@ -558,7 +558,7 @@ pub static CHAIN_SPEC: LazyLock<WorldChainSpec> = LazyLock::new(|| {
                 GenesisAccount::default().with_balance(U256::from(100_000_000_000_000_000u64)),
             )]),
         )
-        .jovian_activated()
+        .karst_activated()
         .build()
 });
 

--- a/e2e-tests/src/it/devnet_smoke.rs
+++ b/e2e-tests/src/it/devnet_smoke.rs
@@ -70,7 +70,9 @@ async fn direct_sequencer_devnet_smoke() -> eyre::Result<()> {
 
     let chain_spec = devnet.chain_spec();
     assert!(chain_spec.is_jovian_active_at_timestamp(0));
+    assert!(chain_spec.is_karst_active_at_timestamp(0));
     assert!(!chain_spec.is_tropo_active_at_timestamp(0));
+    assert!(devnet.hardforks().is_active(WorldChainHardfork::Karst));
     assert!(!devnet.hardforks().is_active(WorldChainHardfork::Tropo));
 
     Ok(())

--- a/proofs/core/src/range.rs
+++ b/proofs/core/src/range.rs
@@ -46,6 +46,9 @@ pub struct WorldRangeHardforkConfig {
     /// Jovian activation timestamp.
     #[serde(default, alias = "jovianTime")]
     pub jovian_time: Option<u64>,
+    /// Karst activation timestamp.
+    #[serde(default, alias = "karstTime")]
+    pub karst_time: Option<u64>,
     /// Tropo activation timestamp. This is a World-only fork.
     #[serde(default, alias = "tropoTime")]
     pub tropo_time: Option<u64>,
@@ -71,6 +74,7 @@ impl WorldRangeHardforkConfig {
             WorldRangeHardfork::Holocene => timestamp_active(self.holocene_time, timestamp),
             WorldRangeHardfork::Isthmus => timestamp_active(self.isthmus_time, timestamp),
             WorldRangeHardfork::Jovian => timestamp_active(self.jovian_time, timestamp),
+            WorldRangeHardfork::Karst => timestamp_active(self.karst_time, timestamp),
             WorldRangeHardfork::Tropo => timestamp_active(self.tropo_time, timestamp),
             WorldRangeHardfork::Strato => timestamp_active(self.strato_time, timestamp),
         }
@@ -81,6 +85,7 @@ impl WorldRangeHardforkConfig {
         [
             WorldRangeHardfork::Strato,
             WorldRangeHardfork::Tropo,
+            WorldRangeHardfork::Karst,
             WorldRangeHardfork::Jovian,
             WorldRangeHardfork::Isthmus,
             WorldRangeHardfork::Holocene,
@@ -130,6 +135,8 @@ pub enum WorldRangeHardfork {
     Isthmus,
     /// Jovian hardfork.
     Jovian,
+    /// Karst hardfork.
+    Karst,
     /// Tropo hardfork.
     Tropo,
     /// Strato hardfork.
@@ -159,6 +166,8 @@ pub enum WorldRangeSpecId {
     ISTHMUS,
     /// Jovian spec id.
     JOVIAN,
+    /// Karst spec id.
+    KARST,
     /// Tropo spec id.
     TROPO,
     /// Strato spec id.
@@ -178,6 +187,7 @@ impl WorldRangeSpecId {
             WorldRangeHardfork::Holocene => Self::HOLOCENE,
             WorldRangeHardfork::Isthmus => Self::ISTHMUS,
             WorldRangeHardfork::Jovian => Self::JOVIAN,
+            WorldRangeHardfork::Karst => Self::KARST,
             WorldRangeHardfork::Tropo => Self::TROPO,
             WorldRangeHardfork::Strato => Self::STRATO,
         }
@@ -196,6 +206,7 @@ impl From<WorldRangeSpecId> for &'static str {
             WorldRangeSpecId::HOLOCENE => "Holocene",
             WorldRangeSpecId::ISTHMUS => "Isthmus",
             WorldRangeSpecId::JOVIAN => "Jovian",
+            WorldRangeSpecId::KARST => "Karst",
             WorldRangeSpecId::TROPO => "Tropo",
             WorldRangeSpecId::STRATO => "Strato",
         }

--- a/proofs/kona-host/src/online.rs
+++ b/proofs/kona-host/src/online.rs
@@ -102,6 +102,7 @@ pub fn range_hardfork_config(config: &WorldHardforkConfig) -> WorldRangeHardfork
         holocene_time: config.holocene_time,
         isthmus_time: config.isthmus_time,
         jovian_time: config.jovian_time,
+        karst_time: config.karst_time,
         tropo_time: config.tropo_time,
         strato_time: config.strato_time,
     }

--- a/proofs/protocol/src/lib.rs
+++ b/proofs/protocol/src/lib.rs
@@ -1,8 +1,8 @@
 //! Proof protocol types for World Chain OP Succinct Lite fault proofs.
 //!
-//! The prover follows the OP Stack schedule through Jovian. Tropo and Strato are
+//! The prover follows the OP Stack schedule through Karst. Tropo and Strato are
 //! World-only hardforks and are carried in the proof config/hash instead of being
-//! represented as OP Karst or Interop activations.
+//! represented as later OP activations.
 
 use core::str::FromStr;
 
@@ -107,6 +107,9 @@ pub struct WorldHardforkConfig {
     /// Jovian activation timestamp.
     #[serde(default, alias = "jovianTime")]
     pub jovian_time: Option<u64>,
+    /// Karst activation timestamp.
+    #[serde(default, alias = "karstTime")]
+    pub karst_time: Option<u64>,
     /// Tropo activation timestamp. This is a World-only fork.
     #[serde(default, alias = "tropoTime")]
     pub tropo_time: Option<u64>,
@@ -131,6 +134,7 @@ impl WorldHardforkConfig {
             holocene_time: timestamp(chain_spec, WorldChainHardfork::Holocene),
             isthmus_time: timestamp(chain_spec, WorldChainHardfork::Isthmus),
             jovian_time: timestamp(chain_spec, WorldChainHardfork::Jovian),
+            karst_time: timestamp(chain_spec, WorldChainHardfork::Karst),
             tropo_time: timestamp(chain_spec, WorldChainHardfork::Tropo),
             strato_time: timestamp(chain_spec, WorldChainHardfork::Strato),
         }
@@ -153,13 +157,14 @@ impl WorldHardforkConfig {
             WorldChainHardfork::Holocene => timestamp_condition(self.holocene_time),
             WorldChainHardfork::Isthmus => timestamp_condition(self.isthmus_time),
             WorldChainHardfork::Jovian => timestamp_condition(self.jovian_time),
+            WorldChainHardfork::Karst => timestamp_condition(self.karst_time),
             WorldChainHardfork::Tropo => timestamp_condition(self.tropo_time),
             WorldChainHardfork::Strato => timestamp_condition(self.strato_time),
             _ => ForkCondition::Never,
         }
     }
 
-    /// Returns the OP-compatible activation condition through Jovian only.
+    /// Returns the OP-compatible activation condition through Karst.
     pub fn op_activation(&self, fork: OpHardfork) -> ForkCondition {
         match fork {
             OpHardfork::Bedrock => self.activation(WorldChainHardfork::Bedrock),
@@ -171,7 +176,7 @@ impl WorldHardforkConfig {
             OpHardfork::Holocene => self.activation(WorldChainHardfork::Holocene),
             OpHardfork::Isthmus => self.activation(WorldChainHardfork::Isthmus),
             OpHardfork::Jovian => self.activation(WorldChainHardfork::Jovian),
-            OpHardfork::Karst => ForkCondition::Never,
+            OpHardfork::Karst => self.activation(WorldChainHardfork::Karst),
             _ => ForkCondition::Never,
         }
     }
@@ -187,6 +192,7 @@ impl WorldHardforkConfig {
         [
             WorldChainHardfork::Strato,
             WorldChainHardfork::Tropo,
+            WorldChainHardfork::Karst,
             WorldChainHardfork::Jovian,
             WorldChainHardfork::Isthmus,
             WorldChainHardfork::Holocene,
@@ -227,9 +233,9 @@ fn timestamp_condition(timestamp: Option<u64>) -> ForkCondition {
 
 /// World-specific proof spec id.
 ///
-/// This mirrors OP `OpSpecId` through Jovian. Tropo and Strato intentionally do not map to OP
-/// Karst/Interop schedule activations, but they do use the Osaka EVM revision like the Base
-/// post-Jovian proof implementation.
+/// This mirrors OP `OpSpecId` through Karst. Tropo and Strato intentionally do not introduce
+/// additional OP schedule activations, but they do use the Osaka EVM revision like the Base
+/// post-Karst proof implementation.
 #[repr(u8)]
 #[derive(
     Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Serialize, Deserialize,
@@ -255,6 +261,8 @@ pub enum WorldSpecId {
     /// Jovian spec id.
     #[default]
     JOVIAN,
+    /// Karst spec id.
+    KARST,
     /// Tropo spec id.
     TROPO,
     /// Strato spec id.
@@ -277,6 +285,7 @@ impl WorldSpecId {
             WorldChainHardfork::Holocene => Self::HOLOCENE,
             WorldChainHardfork::Isthmus => Self::ISTHMUS,
             WorldChainHardfork::Jovian => Self::JOVIAN,
+            WorldChainHardfork::Karst => Self::KARST,
             WorldChainHardfork::Tropo => Self::TROPO,
             WorldChainHardfork::Strato => Self::STRATO,
             _ => Self::LATEST,
@@ -290,14 +299,14 @@ impl WorldSpecId {
             Self::CANYON => SpecId::SHANGHAI,
             Self::ECOTONE | Self::FJORD | Self::GRANITE | Self::HOLOCENE => SpecId::CANCUN,
             Self::ISTHMUS | Self::JOVIAN => SpecId::PRAGUE,
-            Self::TROPO | Self::STRATO => SpecId::OSAKA,
+            Self::KARST | Self::TROPO | Self::STRATO => SpecId::OSAKA,
         }
     }
 
     /// Compatibility bridge for EVM factories that still accept `OpSpecId`.
     ///
-    /// Returning `KARST` for Tropo/Strato selects the Osaka EVM revision in `op-revm`; it must not
-    /// be used as evidence that OP Karst is active in the World hardfork schedule.
+    /// Returning `KARST` for Tropo/Strato selects the Osaka EVM revision in `op-revm`; the World
+    /// fork schedule still distinguishes those forks from the OP Karst activation.
     pub const fn into_op_revm_spec(self) -> OpSpecId {
         match self {
             Self::BEDROCK => OpSpecId::BEDROCK,
@@ -309,7 +318,7 @@ impl WorldSpecId {
             Self::HOLOCENE => OpSpecId::HOLOCENE,
             Self::ISTHMUS => OpSpecId::ISTHMUS,
             Self::JOVIAN => OpSpecId::JOVIAN,
-            Self::TROPO | Self::STRATO => OpSpecId::KARST,
+            Self::KARST | Self::TROPO | Self::STRATO => OpSpecId::KARST,
         }
     }
 
@@ -345,6 +354,7 @@ impl FromStr for WorldSpecId {
             name::HOLOCENE => Ok(Self::HOLOCENE),
             name::ISTHMUS => Ok(Self::ISTHMUS),
             name::JOVIAN => Ok(Self::JOVIAN),
+            name::KARST => Ok(Self::KARST),
             name::TROPO => Ok(Self::TROPO),
             name::STRATO => Ok(Self::STRATO),
             _ => Err(UnknownHardfork),
@@ -364,6 +374,7 @@ impl From<WorldSpecId> for &'static str {
             WorldSpecId::HOLOCENE => name::HOLOCENE,
             WorldSpecId::ISTHMUS => name::ISTHMUS,
             WorldSpecId::JOVIAN => name::JOVIAN,
+            WorldSpecId::KARST => name::KARST,
             WorldSpecId::TROPO => name::TROPO,
             WorldSpecId::STRATO => name::STRATO,
         }
@@ -390,6 +401,8 @@ pub mod name {
     pub const ISTHMUS: &str = "Isthmus";
     /// Jovian spec name.
     pub const JOVIAN: &str = "Jovian";
+    /// Karst spec name.
+    pub const KARST: &str = "Karst";
     /// Tropo spec name.
     pub const TROPO: &str = "Tropo";
     /// Strato spec name.
@@ -407,43 +420,50 @@ mod tests {
     fn parses_snake_and_camel_world_fork_times() {
         let snake: WorldHardforkConfig = serde_json::from_value(json!({
             "jovian_time": 10,
-            "tropo_time": 20,
-            "strato_time": 30
+            "karst_time": 20,
+            "tropo_time": 30,
+            "strato_time": 40
         }))
         .unwrap();
         let camel: WorldHardforkConfig = serde_json::from_value(json!({
             "jovianTime": 10,
-            "tropoTime": 20,
-            "stratoTime": 30
+            "karstTime": 20,
+            "tropoTime": 30,
+            "stratoTime": 40
         }))
         .unwrap();
 
         assert_eq!(snake, camel);
-        assert_eq!(snake.tropo_time, Some(20));
-        assert_eq!(snake.strato_time, Some(30));
+        assert_eq!(snake.karst_time, Some(20));
+        assert_eq!(snake.tropo_time, Some(30));
+        assert_eq!(snake.strato_time, Some(40));
     }
 
     #[test]
-    fn world_schedule_activates_tropo_and_strato() {
+    fn world_schedule_activates_karst_tropo_and_strato() {
         let config = WorldHardforkConfig {
             jovian_time: Some(10),
-            tropo_time: Some(20),
-            strato_time: Some(30),
+            karst_time: Some(20),
+            tropo_time: Some(30),
+            strato_time: Some(40),
             ..Default::default()
         };
 
         assert_eq!(config.active_fork_at(1, 19), WorldChainHardfork::Jovian);
-        assert_eq!(config.active_fork_at(1, 20), WorldChainHardfork::Tropo);
-        assert_eq!(config.active_fork_at(1, 30), WorldChainHardfork::Strato);
-        assert_eq!(config.proof_spec_at(1, 30), WorldSpecId::STRATO);
+        assert_eq!(config.active_fork_at(1, 20), WorldChainHardfork::Karst);
+        assert_eq!(config.active_fork_at(1, 30), WorldChainHardfork::Tropo);
+        assert_eq!(config.active_fork_at(1, 40), WorldChainHardfork::Strato);
+        assert_eq!(config.proof_spec_at(1, 20), WorldSpecId::KARST);
+        assert_eq!(config.proof_spec_at(1, 40), WorldSpecId::STRATO);
     }
 
     #[test]
-    fn op_schedule_stops_at_jovian_for_world() {
+    fn op_schedule_includes_karst_for_world() {
         let config = WorldHardforkConfig {
             jovian_time: Some(10),
-            tropo_time: Some(20),
-            strato_time: Some(30),
+            karst_time: Some(20),
+            tropo_time: Some(30),
+            strato_time: Some(40),
             ..Default::default()
         };
 
@@ -453,14 +473,16 @@ mod tests {
         );
         assert_eq!(
             config.op_activation(OpHardfork::Karst),
-            ForkCondition::Never
+            ForkCondition::Timestamp(20)
         );
     }
 
     #[test]
-    fn world_specs_map_post_jovian_to_osaka_without_activating_op_karst() {
+    fn world_specs_map_karst_and_world_specific_forks_to_osaka() {
+        assert_eq!(WorldSpecId::KARST.into_eth_spec(), SpecId::OSAKA);
         assert_eq!(WorldSpecId::TROPO.into_eth_spec(), SpecId::OSAKA);
         assert_eq!(WorldSpecId::STRATO.into_eth_spec(), SpecId::OSAKA);
+        assert_eq!(WorldSpecId::KARST.into_op_revm_spec(), OpSpecId::KARST);
         assert_eq!(WorldSpecId::TROPO.into_op_revm_spec(), OpSpecId::KARST);
         assert!(WorldSpecId::STRATO.is_enabled_in(WorldSpecId::TROPO));
     }

--- a/proofs/prover/src/lib.rs
+++ b/proofs/prover/src/lib.rs
@@ -226,6 +226,7 @@ fn range_hardfork_config(config: &ProtocolHardforkConfig) -> WorldRangeHardforkC
         holocene_time: config.holocene_time,
         isthmus_time: config.isthmus_time,
         jovian_time: config.jovian_time,
+        karst_time: config.karst_time,
         tropo_time: config.tropo_time,
         strato_time: config.strato_time,
     }


### PR DESCRIPTION
Harness to enable Karst on new chains / activate based on activation in genesis etc.

This is fine for local devnet, next steps are importing and creating relevant acceptance tests and test this on candidate networks

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Touches consensus-critical hardfork ordering, genesis/rollup derivation, Engine API payload versioning, and fault-proof schedules; mis-activation or schedule drift could break sync, devnets, or proving relative to OP Karst/Osaka expectations.
> 
> **Overview**
> Adds **Karst** as a first-class World Chain hardfork (between Jovian and Tropo/Strato), wires **Ethereum Osaka** to `karst_time`, and stops treating OP Karst as dropped after Jovian—genesis, rollup conversion, devnet defaults, and proof schedules now preserve and activate Karst where configured.
> 
> **Local dev and new-chain baselines** default to forks through Karst at genesis (`karst_activated`, devnet `WorldChainHardforkConfig::through(Karst)`), with `karstTime` / `karst_time` patched into L2 genesis and rollup. OP Stack devnet images and contract locators move to **v7**-family tags (`op-contracts/v7.0.0-rc.4`, kona-node v1.6.0, op-deployer v0.7.0-rc.1, op-challenger v1.9.3).
> 
> **Engine API and tests** implement `get_payload_v5` (replacing the previous stub) and switch e2e block mining to **getPayloadV5**; shared test chain specs use `karst_activated` instead of stopping at Isthmus/Jovian.
> 
> **Proof stack** extends range/protocol types with Karst timestamps and `WorldSpecId::KARST` (Osaka EVM), and updates OP schedule helpers so Karst is included through Karst rather than `Never`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ee9a9e55f963bed41d7149d04cfadb535451d92. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->