### PR TITLE
fix: push ci on main

### DIFF
--- a/.github/workflows/docker-proof.yml
+++ b/.github/workflows/docker-proof.yml
@@ -34,41 +34,14 @@ permissions:
   id-token: write
 
 jobs:
-  # Build the SP1 guest ELFs ONCE, reproducibly, via the SP1 Docker
-  # reproducibility builder (`cargo prove build --docker`, pinned v6.1.0). The
-  # prover-sp1 / sp1-worker image builds cannot do this themselves (no
-  # Docker-in-Docker inside the image build), and a local build would not be
-  # reproducible, so the ELFs are produced here and downloaded into those image
-  # builds as the `proof-elfs` artifact. One build => one canonical vkey shared
-  # by every arch of the multi-arch image.
-  build-elfs:
-    name: build ELFs
-    runs-on: arc-public-8xlarge-amd64-runner
-    steps:
-      - name: Check Out Repo
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.ref }}
-      - uses: taiki-e/install-action@just
-      - name: Install SP1 toolchain
-        run: |
-          curl -L https://sp1.succinct.xyz | bash
-          ~/.sp1/bin/sp1up --version v6.1.0
-          echo "$HOME/.sp1/bin" >> $GITHUB_PATH
-      - name: Build ELFs
-        run: just build-proof-elfs
-      - name: Upload ELFs
-        uses: actions/upload-artifact@v4
-        with:
-          name: proof-elfs
-          path: |
-            proofs/succinct/elf/world-chain-proof-succinct-range-ethereum
-            proofs/succinct/elf/world-chain-proof-succinct-aggregation
-          if-no-files-found: error
-
+  # Non-release images: the SP1 guest ELFs are compiled locally inside the image
+  # build (Dockerfile.prover, SP1_BUILD_DOCKER=false) rather than built once
+  # reproducibly and shared as an artifact. Nightly/dev images don't need the
+  # canonical, vkey-matching ELFs — that reproducibility (build-elfs job +
+  # `proof-elfs` artifact) is reserved for release-proof.yml. Passing
+  # `SP1_PREBUILT_ELF_DIR=` opts out of the Dockerfile's default prebuilt path.
   build-sp1-prover-image:
     name: build world-chain-prover-sp1 image
-    needs: [build-elfs]
     environment: dev
     strategy:
       fail-fast: false
@@ -84,11 +57,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
-      - name: Download ELFs
-        uses: actions/download-artifact@v4
-        with:
-          name: proof-elfs
-          path: proofs/succinct/elf
       - name: Build and push digest
         uses: ./.github/actions/docker-build-push-digest
         with:
@@ -102,6 +70,7 @@ jobs:
             PROVER_PACKAGE=world-chain-prover-sp1
             PROVER_BIN=world-chain-prover-sp1
             FEATURES=
+            SP1_PREBUILT_ELF_DIR=
           digest_artifact_prefix: digests-prover-sp1
 
   build-nitro-prover-image:
@@ -138,10 +107,10 @@ jobs:
 
   # Each prover's merge depends ONLY on its own build jobs. docker-build-push-digest
   # pushes untagged (by-digest) manifests, which GHCR garbage-collects within minutes.
-  # The nitro build has no build-elfs dependency and finishes ~13 min before sp1, so a
-  # single merge gated on both builds let nitro's digests be collected before it ran
-  # ("manifest ... not found"). Splitting mirrors release-proof.yml and keeps each merge
-  # running right after its own builds.
+  # The nitro and sp1 builds finish at different times, so a single merge gated on both
+  # builds could let the faster prover's digests be collected before it ran ("manifest
+  # ... not found"). Splitting mirrors release-proof.yml and keeps each merge running
+  # right after its own builds.
   merge-sp1-prover-image:
     name: merge world-chain-prover-sp1 image manifest
     needs: [build-sp1-prover-image]
@@ -181,7 +150,6 @@ jobs:
   # `<repo>-<service>` image so tags do not collide with the `proof` image.
   build-service-images:
     name: build ${{ matrix.service.bin }} image
-    needs: [build-elfs]
     environment: dev
     strategy:
       fail-fast: false
@@ -201,14 +169,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
-      # Only sp1-worker embeds the SP1 guest ELFs; the other services don't
-      # depend on the elfs crate, so they need no ELF artifact.
-      - name: Download ELFs
-        if: matrix.service.bin == 'sp1-worker'
-        uses: actions/download-artifact@v4
-        with:
-          name: proof-elfs
-          path: proofs/succinct/elf
+      # Only sp1-worker embeds the SP1 guest ELFs; it compiles them locally
+      # in-image (SP1_PREBUILT_ELF_DIR= opts out of the Dockerfile's prebuilt
+      # default). The other services don't depend on the elfs crate, so the
+      # empty value is simply ignored for them.
       - name: Build and push digest
         uses: ./.github/actions/docker-build-push-digest
         with:
@@ -221,6 +185,7 @@ jobs:
           build_args: |
             PROVER_PACKAGE=${{ matrix.service.package }}
             PROVER_BIN=${{ matrix.service.bin }}
+            SP1_PREBUILT_ELF_DIR=
           digest_artifact_prefix: ${{ matrix.service.prefix }}
 
   merge-service-images:

--- a/.github/workflows/docker-proof.yml
+++ b/.github/workflows/docker-proof.yml
@@ -34,8 +34,41 @@ permissions:
   id-token: write
 
 jobs:
+  # Build the SP1 guest ELFs ONCE, reproducibly, via the SP1 Docker
+  # reproducibility builder (`cargo prove build --docker`, pinned v6.1.0). The
+  # prover-sp1 / sp1-worker image builds cannot do this themselves (no
+  # Docker-in-Docker inside the image build), and a local build would not be
+  # reproducible, so the ELFs are produced here and downloaded into those image
+  # builds as the `proof-elfs` artifact. One build => one canonical vkey shared
+  # by every arch of the multi-arch image.
+  build-elfs:
+    name: build ELFs
+    runs-on: arc-public-8xlarge-amd64-runner
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: taiki-e/install-action@just
+      - name: Install SP1 toolchain
+        run: |
+          curl -L https://sp1.succinct.xyz | bash
+          ~/.sp1/bin/sp1up --version v6.1.0
+          echo "$HOME/.sp1/bin" >> $GITHUB_PATH
+      - name: Build ELFs
+        run: just build-proof-elfs
+      - name: Upload ELFs
+        uses: actions/upload-artifact@v4
+        with:
+          name: proof-elfs
+          path: |
+            proofs/succinct/elf/world-chain-proof-succinct-range-ethereum
+            proofs/succinct/elf/world-chain-proof-succinct-aggregation
+          if-no-files-found: error
+
   build-sp1-prover-image:
     name: build world-chain-prover-sp1 image
+    needs: [build-elfs]
     environment: dev
     strategy:
       fail-fast: false
@@ -51,6 +84,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
+      - name: Download ELFs
+        uses: actions/download-artifact@v4
+        with:
+          name: proof-elfs
+          path: proofs/succinct/elf
       - name: Build and push digest
         uses: ./.github/actions/docker-build-push-digest
         with:
@@ -143,6 +181,7 @@ jobs:
   # `<repo>-<service>` image so tags do not collide with the `proof` image.
   build-service-images:
     name: build ${{ matrix.service.bin }} image
+    needs: [build-elfs]
     environment: dev
     strategy:
       fail-fast: false
@@ -162,6 +201,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
+      # Only sp1-worker embeds the SP1 guest ELFs; the other services don't
+      # depend on the elfs crate, so they need no ELF artifact.
+      - name: Download ELFs
+        if: matrix.service.bin == 'sp1-worker'
+        uses: actions/download-artifact@v4
+        with:
+          name: proof-elfs
+          path: proofs/succinct/elf
       - name: Build and push digest
         uses: ./.github/actions/docker-build-push-digest
         with:

--- a/.github/workflows/release-proof.yml
+++ b/.github/workflows/release-proof.yml
@@ -59,19 +59,47 @@ jobs:
       VERSION: ${{ steps.extract_version.outputs.VERSION }}
       IS_RELEASE: ${{ steps.extract_version.outputs.IS_RELEASE }}
 
-  # Compute the on-chain verification keys. The SP1 guest ELFs are compiled
-  # inline via sp1_build (include_elf!()) — no separate build step required.
-  vkeys:
-    name: compute vkeys
+  # Build the SP1 guest ELFs ONCE, reproducibly, via the SP1 Docker
+  # reproducibility builder (`cargo prove build --docker`, pinned v6.1.0). Every
+  # downstream consumer (vkeys manifest, prover images, signed binaries) embeds
+  # these exact bytes via SP1_PREBUILT_ELF_DIR, so the released vkey is a single
+  # canonical value derived from one build — no per-job rebuilds, no arch drift.
+  build-elfs:
+    name: build ELFs
     needs: approve-release
     runs-on: arc-public-8xlarge-amd64-runner
     steps:
       - uses: actions/checkout@v6
+      - uses: taiki-e/install-action@just
       - name: Install SP1 toolchain
         run: |
           curl -L https://sp1.succinct.xyz | bash
           ~/.sp1/bin/sp1up --version v6.1.0
           echo "$HOME/.sp1/bin" >> $GITHUB_PATH
+      - name: Build ELFs
+        run: just build-proof-elfs
+      - name: Upload ELFs
+        uses: actions/upload-artifact@v4
+        with:
+          name: proof-elfs
+          path: |
+            proofs/succinct/elf/world-chain-proof-succinct-range-ethereum
+            proofs/succinct/elf/world-chain-proof-succinct-aggregation
+          if-no-files-found: error
+
+  # Compute the on-chain verification keys from the prebuilt reproducible ELFs,
+  # so the manifest vkey matches exactly what the prover images embed.
+  vkeys:
+    name: compute vkeys
+    needs: [approve-release, build-elfs]
+    runs-on: arc-public-8xlarge-amd64-runner
+    steps:
+      - uses: actions/checkout@v6
+      - name: Download ELFs
+        uses: actions/download-artifact@v4
+        with:
+          name: proof-elfs
+          path: proofs/succinct/elf
       - uses: taiki-e/install-action@just
       - uses: dtolnay/rust-toolchain@stable
       - uses: arduino/setup-protoc@v3
@@ -80,7 +108,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Compute vkeys
         env:
-          SP1_BUILD_DOCKER: "false"
+          SP1_PREBUILT_ELF_DIR: ${{ github.workspace }}/proofs/succinct/elf
         run: just proof-vkeys --output vkeys.json && cat vkeys.json
       - name: Upload vkeys
         uses: actions/upload-artifact@v4
@@ -92,7 +120,7 @@ jobs:
   build-sp1-prover-image:
     name: build world-chain-prover-sp1 image
     environment: dev
-    needs: approve-release
+    needs: [approve-release, build-elfs]
     strategy:
       fail-fast: false
       matrix:
@@ -104,6 +132,11 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6
+      - name: Download ELFs
+        uses: actions/download-artifact@v4
+        with:
+          name: proof-elfs
+          path: proofs/succinct/elf
       - name: Build and push digest
         uses: ./.github/actions/docker-build-push-digest
         with:
@@ -193,7 +226,7 @@ jobs:
   build-service-images:
     name: build ${{ matrix.service.bin }} image
     environment: dev
-    needs: approve-release
+    needs: [approve-release, build-elfs]
     strategy:
       fail-fast: false
       matrix:
@@ -209,6 +242,14 @@ jobs:
     runs-on: ${{ matrix.platform.runner }}
     steps:
       - uses: actions/checkout@v6
+      # Only sp1-worker embeds the SP1 guest ELFs; other services don't depend
+      # on the elfs crate, so they need no ELF artifact.
+      - name: Download ELFs
+        if: matrix.service.bin == 'sp1-worker'
+        uses: actions/download-artifact@v4
+        with:
+          name: proof-elfs
+          path: proofs/succinct/elf
       - name: Build and push digest
         uses: ./.github/actions/docker-build-push-digest
         with:
@@ -250,7 +291,7 @@ jobs:
 
   build-binaries:
     name: build binaries
-    needs: [extract-version]
+    needs: [extract-version, build-elfs]
     strategy:
       fail-fast: false
       matrix:
@@ -264,11 +305,11 @@ jobs:
       VERSION: ${{ needs.extract-version.outputs.VERSION }}
     steps:
       - uses: actions/checkout@v6
-      - name: Install SP1 toolchain
-        run: |
-          curl -L https://sp1.succinct.xyz | bash
-          ~/.sp1/bin/sp1up --version v6.1.0
-          echo "$HOME/.sp1/bin" >> $GITHUB_PATH
+      - name: Download ELFs
+        uses: actions/download-artifact@v4
+        with:
+          name: proof-elfs
+          path: proofs/succinct/elf
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -277,9 +318,11 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: Swatinem/rust-cache@v2
+      # Embed the prebuilt reproducible ELFs (no in-build SP1 compile), so the
+      # signed prover-sp1 binary carries the same canonical vkey as the images.
       - name: Cargo Build Release
         env:
-          SP1_BUILD_DOCKER: "false"
+          SP1_PREBUILT_ELF_DIR: ${{ github.workspace }}/proofs/succinct/elf
         run: |
           cargo build --release --locked -p world-chain-prover-sp1 --target ${{ matrix.target }}
           cargo build --release --locked -p world-chain-prover-nitro --target ${{ matrix.target }}

--- a/.github/workflows/release-proof.yml
+++ b/.github/workflows/release-proof.yml
@@ -60,10 +60,12 @@ jobs:
       IS_RELEASE: ${{ steps.extract_version.outputs.IS_RELEASE }}
 
   # Build the SP1 guest ELFs ONCE, reproducibly, via the SP1 Docker
-  # reproducibility builder (`cargo prove build --docker`, pinned v6.1.0). Every
-  # downstream consumer (vkeys manifest, prover images, signed binaries) embeds
-  # these exact bytes via SP1_PREBUILT_ELF_DIR, so the released vkey is a single
-  # canonical value derived from one build — no per-job rebuilds, no arch drift.
+  # reproducibility builder (`cargo prove build --docker`, pinned v6.1.0), and
+  # publish them as the `proof-elfs` artifact. Consumed by the builds that
+  # can't (or shouldn't) run the Docker builder in place: the prover images
+  # (no Docker-in-Docker) and the release binaries (the arm runner would
+  # otherwise emulate the amd64 SP1 builder). The vkeys job builds via
+  # `docker: true` directly — reproducible, so it yields the same bytes.
   build-elfs:
     name: build ELFs
     needs: approve-release
@@ -87,19 +89,15 @@ jobs:
             proofs/succinct/elf/world-chain-proof-succinct-aggregation
           if-no-files-found: error
 
-  # Compute the on-chain verification keys from the prebuilt reproducible ELFs,
-  # so the manifest vkey matches exactly what the prover images embed.
+  # Compute the on-chain verification keys. Builds the guest ELFs via the SP1
+  # Docker reproducibility builder (the runner has Docker), so the manifest vkey
+  # matches the reproducible ELFs embedded in the prover images by `build-elfs`.
   vkeys:
     name: compute vkeys
-    needs: [approve-release, build-elfs]
+    needs: approve-release
     runs-on: arc-public-8xlarge-amd64-runner
     steps:
       - uses: actions/checkout@v6
-      - name: Download ELFs
-        uses: actions/download-artifact@v4
-        with:
-          name: proof-elfs
-          path: proofs/succinct/elf
       - uses: taiki-e/install-action@just
       - uses: dtolnay/rust-toolchain@stable
       - uses: arduino/setup-protoc@v3
@@ -107,8 +105,6 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: Swatinem/rust-cache@v2
       - name: Compute vkeys
-        env:
-          SP1_PREBUILT_ELF_DIR: ${{ github.workspace }}/proofs/succinct/elf
         run: just proof-vkeys --output vkeys.json && cat vkeys.json
       - name: Upload vkeys
         uses: actions/upload-artifact@v4

--- a/.github/workflows/vkeys.yml
+++ b/.github/workflows/vkeys.yml
@@ -42,7 +42,9 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      # No SP1_BUILD_DOCKER override: build the guest ELFs via the SP1 Docker
+      # reproducibility builder (the runner has a Docker daemon), so the vkeys
+      # derived here match the committed vkeys.json and the reproducible ELFs
+      # embedded in the prover image by the `build-elfs` job.
       - name: Verify vkeys
-        env:
-          SP1_BUILD_DOCKER: "false"
         run: just verify-proof-vkeys

--- a/.github/workflows/vkeys.yml
+++ b/.github/workflows/vkeys.yml
@@ -26,12 +26,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install SP1 toolchain
-        run: |
-          curl -L https://sp1.succinct.xyz | bash
-          ~/.sp1/bin/sp1up --version v6.1.0
-          echo "$HOME/.sp1/bin" >> $GITHUB_PATH
-
       - uses: taiki-e/install-action@just
 
       - uses: dtolnay/rust-toolchain@stable

--- a/Dockerfile.prover
+++ b/Dockerfile.prover
@@ -20,17 +20,13 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends clang libclang-dev gcc curl protobuf-compiler libprotobuf-dev git \
   && rm -rf /var/lib/apt/lists/*
 
-# Install the SP1 toolchain (cargo-prove + risc-v target). The host-utils
-# `build.rs` invokes `sp1_build::build_program_with_args` to compile the
-# guest ELFs at `cargo build` time and embed them with
-# `sp1_sdk::include_elf!()`. Inside this Dockerfile we use the locally
-# installed toolchain rather than the docker:true reproducibility builder
-# (the Docker daemon isn't reachable from inside a docker build).
-# `SP1_BUILD_DOCKER=false` is set in the builder stage below to switch.
-ENV PATH=/root/.sp1/bin:$PATH
-RUN curl -L https://sp1.succinct.xyz | bash \
-  && /root/.sp1/bin/sp1up --version v6.1.0
-
+# No SP1 toolchain is installed here: the guest ELFs are NOT compiled inside
+# this image (the Docker daemon isn't reachable from inside a docker build, and
+# a local cargo-prove build would not be reproducible). Instead the prover
+# image consumes prebuilt, reproducibly-built ELFs produced once by the
+# `build-elfs` CI job (`docker: true`) and injected via SP1_PREBUILT_ELF_DIR in
+# the builder stage below, which `proofs/succinct/elfs/build.rs` embeds with
+# `sp1_sdk::include_elf!()`.
 ENV CARGO_HOME=/usr/local/cargo \
     RUSTC_WRAPPER=sccache \
     SCCACHE_DIR=/sccache
@@ -61,13 +57,15 @@ ARG SCCACHE_S3_KEY_PREFIX
 RUN test -n "${PROVER_PACKAGE}" || (echo "ERROR: PROVER_PACKAGE build arg is required" && exit 1)
 RUN test -n "${PROVER_BIN}" || (echo "ERROR: PROVER_BIN build arg is required" && exit 1)
 
-# Use the locally-installed SP1 toolchain (installed in the `base` stage)
-# instead of `docker: true` since the Docker daemon isn't reachable from
-# inside this image build. The `vkeys` CI step also sets
-# SP1_BUILD_DOCKER=false with the same pinned v6.1.0 toolchain, so the
-# ELFs embedded in this image and the committed vkeys.json are always
-# produced by the same toolchain invocation.
-ENV SP1_BUILD_DOCKER=false
+# Embed the prebuilt, reproducibly-built guest ELFs instead of compiling them
+# in-image. The `build-elfs` CI job builds them once via the SP1 Docker
+# reproducibility builder and the prover-sp1 / sp1-worker image jobs download
+# them into `proofs/succinct/elf/`, which `COPY . .` (below) brings in at this
+# path. `proofs/succinct/elfs/build.rs` reads this var and points
+# `include_elf!()` at those bytes; for non-SP1 binaries (which don't depend on
+# the elfs crate) it is simply ignored. The path must be absolute so
+# `include_bytes!` resolves it independently of the source file location.
+ENV SP1_PREBUILT_ELF_DIR=/app/proofs/succinct/elf
 
 COPY --from=planner /app/recipe.json recipe.json
 
@@ -108,11 +106,10 @@ ARG PROFILE="maxperf"
 COPY --from=builder /app/target/${PROFILE}/${PROVER_BIN} /usr/local/bin/${PROVER_BIN}
 RUN ln -s /usr/local/bin/${PROVER_BIN} /usr/local/bin/entrypoint
 
-# SP1 guest ELFs are compiled at `cargo build` time by
-# `proofs/succinct/utils/host/build.rs` (sp1_build::build_program_with_args)
-# and embedded into the prover binary at compile time via
-# `sp1_sdk::include_elf!()` (see `proofs/succinct/utils/host/src/env_prover.rs`).
-# This image therefore needs no extra ELF files baked in — the bytes ship
-# inside the binary itself, matching the OP Succinct upstream pattern.
+# SP1 guest ELFs are embedded into the prover binary at compile time via
+# `sp1_sdk::include_elf!()` (see `proofs/succinct/elfs/`). The bytes come from
+# the prebuilt, reproducibly-built ELFs injected via SP1_PREBUILT_ELF_DIR in
+# the builder stage, so they ship inside the binary itself — this final image
+# needs no extra ELF files baked in.
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]

--- a/Dockerfile.prover
+++ b/Dockerfile.prover
@@ -20,13 +20,18 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends clang libclang-dev gcc curl protobuf-compiler libprotobuf-dev git \
   && rm -rf /var/lib/apt/lists/*
 
-# No SP1 toolchain is installed here: the guest ELFs are NOT compiled inside
-# this image (the Docker daemon isn't reachable from inside a docker build, and
-# a local cargo-prove build would not be reproducible). Instead the prover
-# image consumes prebuilt, reproducibly-built ELFs produced once by the
-# `build-elfs` CI job (`docker: true`) and injected via SP1_PREBUILT_ELF_DIR in
-# the builder stage below, which `proofs/succinct/elfs/build.rs` embeds with
-# `sp1_sdk::include_elf!()`.
+# Install the SP1 toolchain (cargo-prove + risc-v target) for the in-image
+# guest build used by the non-release prover images. The Docker daemon isn't
+# reachable from inside a docker build, so `proofs/succinct/elfs/build.rs` runs
+# a *local* SP1 build (SP1_BUILD_DOCKER=false, set in the builder stage) at the
+# fixed /app WORKDIR with the pinned tag — consistent across the image-build
+# matrix. Release images instead embed prebuilt, reproducibly-built ELFs via
+# SP1_PREBUILT_ELF_DIR (which takes precedence and skips this toolchain). Only
+# in the build layers, not the final runtime image.
+ENV PATH=/root/.sp1/bin:$PATH
+RUN curl -L https://sp1.succinct.xyz | bash \
+  && /root/.sp1/bin/sp1up --version v6.1.0
+
 ENV CARGO_HOME=/usr/local/cargo \
     RUSTC_WRAPPER=sccache \
     SCCACHE_DIR=/sccache
@@ -57,15 +62,25 @@ ARG SCCACHE_S3_KEY_PREFIX
 RUN test -n "${PROVER_PACKAGE}" || (echo "ERROR: PROVER_PACKAGE build arg is required" && exit 1)
 RUN test -n "${PROVER_BIN}" || (echo "ERROR: PROVER_BIN build arg is required" && exit 1)
 
-# Embed the prebuilt, reproducibly-built guest ELFs instead of compiling them
-# in-image. The `build-elfs` CI job builds them once via the SP1 Docker
-# reproducibility builder and the prover-sp1 / sp1-worker image jobs download
-# them into `proofs/succinct/elf/`, which `COPY . .` (below) brings in at this
-# path. `proofs/succinct/elfs/build.rs` reads this var and points
-# `include_elf!()` at those bytes; for non-SP1 binaries (which don't depend on
-# the elfs crate) it is simply ignored. The path must be absolute so
-# `include_bytes!` resolves it independently of the source file location.
-ENV SP1_PREBUILT_ELF_DIR=/app/proofs/succinct/elf
+# Guest-ELF source, resolved by `proofs/succinct/elfs/build.rs`:
+#
+# - Release (default): embed prebuilt, reproducibly-built ELFs. The release
+#   `build-elfs` CI job builds them once via the SP1 Docker reproducibility
+#   builder and the prover-sp1 / sp1-worker jobs download them into
+#   `proofs/succinct/elf/`, which `COPY . .` brings in at this absolute path.
+#   build.rs points `include_elf!()` at those bytes (no in-image compile) and
+#   fails loudly if a file is missing. The path takes precedence over
+#   SP1_BUILD_DOCKER, so the in-image toolchain is unused on this path.
+# - Non-release: the image jobs override this to empty (`SP1_PREBUILT_ELF_DIR=`),
+#   which makes build.rs compile the guests locally via the in-image toolchain
+#   (SP1_BUILD_DOCKER=false) — no reproducible artifact required for nightly/dev.
+#
+# For non-SP1 binaries (which don't depend on the elfs crate) both are ignored.
+ARG SP1_PREBUILT_ELF_DIR=/app/proofs/succinct/elf
+ENV SP1_PREBUILT_ELF_DIR=${SP1_PREBUILT_ELF_DIR}
+# Local in-image guest build when no prebuilt ELFs are supplied (non-release).
+ARG SP1_BUILD_DOCKER=false
+ENV SP1_BUILD_DOCKER=${SP1_BUILD_DOCKER}
 
 COPY --from=planner /app/recipe.json recipe.json
 
@@ -108,8 +123,8 @@ RUN ln -s /usr/local/bin/${PROVER_BIN} /usr/local/bin/entrypoint
 
 # SP1 guest ELFs are embedded into the prover binary at compile time via
 # `sp1_sdk::include_elf!()` (see `proofs/succinct/elfs/`). The bytes come from
-# the prebuilt, reproducibly-built ELFs injected via SP1_PREBUILT_ELF_DIR in
-# the builder stage, so they ship inside the binary itself — this final image
-# needs no extra ELF files baked in.
+# either the prebuilt ELFs (release) or the local in-image guest build
+# (non-release) selected in the builder stage, so they ship inside the binary
+# itself — this final image needs no extra ELF files baked in.
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]

--- a/Justfile
+++ b/Justfile
@@ -100,6 +100,18 @@ update-proof-vkeys:
     cargo run -p world-chain-prover-sp1 -- vkeys --output /tmp/vkeys-update.json
     jq -S . /tmp/vkeys-update.json > proofs/succinct/elf/vkeys.json
 
+# Build the SP1 guest ELFs reproducibly (docker:true, pinned v6.1.0) into
+# proofs/succinct/elf/ so the prover image build can embed them via
+# SP1_PREBUILT_ELF_DIR. The --elf-name values match the include_elf!() args in
+# proofs/succinct/elfs/src/lib.rs (and SP1_ELF_<name> emitted by build.rs), and
+# `cargo prove build --docker` produces bytes identical to the elfs crate's
+# build.rs (same sp1_build/docker/tag), so the embedded ELF matches the vkey
+# computed by `verify-proof-vkeys`. Requires a reachable Docker daemon + sp1up
+# v6.1.0. Run by the `build-elfs` CI job and usable locally.
+build-proof-elfs:
+    cd proofs/succinct/programs/range-ethereum && cargo prove build --docker --workspace-directory ../../../.. --tag v6.1.0 --ignore-rust-version --elf-name world-chain-proof-succinct-range-ethereum --output-directory ../../elf
+    cd proofs/succinct/programs/aggregation && cargo prove build --docker --workspace-directory ../../../.. --tag v6.1.0 --ignore-rust-version --elf-name world-chain-proof-succinct-aggregation --output-directory ../../elf
+
 # Verify that the committed vkeys.json matches what the current source produces.
 # Uses jq -S to normalize key ordering before comparing, so the diff is not
 # sensitive to JSON insertion order. Used by CI. Fails if they differ.

--- a/proofs/succinct/elfs/build.rs
+++ b/proofs/succinct/elfs/build.rs
@@ -8,13 +8,19 @@
 //! `fs::read` of an ELF file.
 //!
 //! Behaviour:
-//! - Always uses `docker: true` with the pinned SP1 toolchain tag
+//! - Defaults to `docker: true` with the pinned SP1 toolchain tag
 //!   (matches the `=6.1.0` version of `sp1-sdk` / `sp1-zkvm` the workspace
 //!   pins to) for bit-for-bit reproducible ELFs. This is the ecosystem
 //!   standard used by op-succinct, sp1-helios, and all other SP1 adopters.
 //!   Docker provides reproducibility by fixing the build environment path
-//!   layout inside the container. The only exception is `Dockerfile.prover`
-//!   where Docker-in-Docker is genuinely unavailable.
+//!   layout inside the container.
+//! - Honours `SP1_BUILD_DOCKER=false` to fall back to the locally-installed
+//!   `cargo-prove` toolchain instead of the Docker reproducibility builder.
+//!   This is required wherever the Docker daemon is unreachable from inside
+//!   the build — notably `Dockerfile.prover` (no Docker-in-Docker) and the
+//!   `vkeys` CI step, both of which install the pinned `v6.1.0` toolchain via
+//!   `sp1up` and set this variable. `sp1_build` does not read this variable
+//!   itself, so we map it onto `BuildArgs.docker` here.
 //! - Honours `SP1_SKIP_PROGRAM_BUILD=true` for fast iteration: `sp1_build`
 //!   checks this variable internally — when set, it skips the Docker/local
 //!   guest compilation but **still emits** the `SP1_ELF_*` cargo env-vars so
@@ -30,6 +36,15 @@
 
 fn main() {
     println!("cargo:rerun-if-env-changed=SP1_SKIP_PROGRAM_BUILD");
+    println!("cargo:rerun-if-env-changed=SP1_BUILD_DOCKER");
+
+    // Use the Docker reproducibility builder by default; allow opting out via
+    // `SP1_BUILD_DOCKER=false` for environments where the Docker daemon is
+    // unreachable (Dockerfile.prover, vkeys CI). Any value other than an
+    // explicit "false" keeps the default Docker build.
+    let use_docker = std::env::var("SP1_BUILD_DOCKER")
+        .map(|v| !v.eq_ignore_ascii_case("false"))
+        .unwrap_or(true);
 
     // The SP1 guest programs live in their own nested cargo workspace at
     // `proofs/succinct/programs/`, but they have path dependencies that
@@ -71,7 +86,7 @@ fn main() {
         sp1_build::build_program_with_args(
             program_dir,
             sp1_build::BuildArgs {
-                docker: true,
+                docker: use_docker,
                 tag: "v6.1.0".to_string(),
                 ignore_rust_version: true,
                 workspace_directory: Some(workspace_root.clone()),

--- a/proofs/succinct/elfs/build.rs
+++ b/proofs/succinct/elfs/build.rs
@@ -8,26 +8,30 @@
 //! binary at link time via `include_elf!()` — there is no runtime
 //! `fs::read` of an ELF file.
 //!
-//! ELFs MUST be bit-for-bit reproducible, because their SHA-256 and the
-//! derived on-chain verification keys are governance-tracked and must be
-//! identical across every build (including each arch of a multi-arch image).
-//! Two mutually exclusive modes provide that:
+//! The release-tracked vkey (governance-tracked SHA-256 of each ELF) MUST come
+//! from a bit-for-bit reproducible build. Three modes are supported, selected
+//! by environment, in priority order:
 //!
-//! - **Build via the SP1 Docker reproducibility builder** (`docker: true`,
-//!   pinned tag `v6.1.0` matching the `=6.1.0` `sp1-sdk` pin). The container
-//!   fixes the toolchain and path layout, so the ELF is identical regardless
-//!   of host. This is the default and is used wherever a Docker daemon is
-//!   reachable (CI runners, dev machines, the `build-elfs` job). A *local*
-//!   `cargo-prove` build is deliberately NOT offered as a fallback: local
-//!   builds are not reproducible (host arch / paths leak into the ELF), which
-//!   would diverge the vkey.
+//! - **Embed prebuilt ELFs** via `SP1_PREBUILT_ELF_DIR=<dir>` (highest
+//!   priority). When set, this script points `include_elf!()` at
+//!   `<dir>/<program>` and does NOT compile anything. This is the *release*
+//!   path: the ELFs are produced once by the reproducible `build-elfs` CI job
+//!   (`docker: true`) and injected so every release image/binary embeds the
+//!   same canonical, vkey-matching bytes. The files must exist at link time;
+//!   `include_bytes!` fails loudly if one is missing (no silent fallback).
 //!
-//! - **Embed prebuilt ELFs** via `SP1_PREBUILT_ELF_DIR=<dir>`. When set, this
-//!   script points `include_elf!()` at `<dir>/<program>` and does NOT compile
-//!   anything. This is for environments without a Docker daemon — notably the
-//!   prover image build (`Dockerfile.prover`, no Docker-in-Docker) — where the
-//!   ELFs produced once by the `build-elfs` CI job (`docker: true`) are
-//!   downloaded and injected, so every image embeds the same canonical bytes.
+//! - **Local (non-Docker) in-image build** via `SP1_BUILD_DOCKER=false`. Used
+//!   by the non-release prover image builds (`Dockerfile.prover`): the guest is
+//!   compiled by the in-image SP1 toolchain at the fixed `/app` WORKDIR with
+//!   the pinned tag, so it is consistent across the image-build matrix without
+//!   needing a Docker daemon or the artifact plumbing. These nightly/dev images
+//!   are NOT vkey-canonical — releases use the prebuilt path above.
+//!
+//! - **SP1 Docker reproducibility builder** (`docker: true`, default). The
+//!   container fixes the toolchain and path layout, so the ELF is identical
+//!   regardless of host. Used wherever a Docker daemon is reachable and no
+//!   prebuilt ELFs were supplied (dev machines, the `vkeys` / `build-elfs` CI
+//!   jobs).
 //!
 //! Under `cargo clippy`, the `#[cfg(clippy)]` guards in `src/lib.rs` prevent
 //! `include_elf!()` from expanding, so no ELF files need to exist.
@@ -41,18 +45,32 @@ const PROGRAMS: [&str; 2] = [
 
 fn main() {
     println!("cargo:rerun-if-env-changed=SP1_PREBUILT_ELF_DIR");
+    println!("cargo:rerun-if-env-changed=SP1_BUILD_DOCKER");
 
     // Fast path for environments without a Docker daemon: embed prebuilt,
     // reproducibly-built ELFs instead of compiling. `include_elf!(name)` reads
     // `SP1_ELF_<name>`, so emitting an absolute path here makes it embed those
     // exact bytes with no guest compile. The files must exist at link time;
     // `include_bytes!` fails loudly if one is missing (no silent fallback).
+    // Treat an empty value as unset so callers can opt out with `KEY=`.
     if let Ok(dir) = std::env::var("SP1_PREBUILT_ELF_DIR") {
-        for program in PROGRAMS {
-            println!("cargo:rustc-env=SP1_ELF_{program}={dir}/{program}");
+        if !dir.trim().is_empty() {
+            for program in PROGRAMS {
+                println!("cargo:rustc-env=SP1_ELF_{program}={dir}/{program}");
+            }
+            return;
         }
-        return;
     }
+
+    // No prebuilt ELFs supplied: compile the guests. Use the SP1 Docker
+    // reproducibility builder by default; `SP1_BUILD_DOCKER=false` switches to a
+    // local in-image build (sp1-build does not read this var itself, so we honor
+    // it here). The non-release prover image build sets it to compile the guests
+    // with the in-image toolchain.
+    let docker = !matches!(
+        std::env::var("SP1_BUILD_DOCKER").as_deref(),
+        Ok("false") | Ok("0")
+    );
 
     // The SP1 guest programs live in their own nested cargo workspace at
     // `proofs/succinct/programs/`, but they have path dependencies that
@@ -94,9 +112,11 @@ fn main() {
         sp1_build::build_program_with_args(
             program_dir,
             sp1_build::BuildArgs {
-                docker: true,
+                docker,
                 tag: "v6.1.0".to_string(),
                 ignore_rust_version: true,
+                // Only consumed by the Docker builder (mounts the repo root so
+                // out-of-workspace path deps resolve); ignored by a local build.
                 workspace_directory: Some(workspace_root.clone()),
                 ..Default::default()
             },

--- a/proofs/succinct/elfs/build.rs
+++ b/proofs/succinct/elfs/build.rs
@@ -1,50 +1,58 @@
-//! Build script: compile the World Chain SP1 guest programs and emit
-//! `SP1_ELF_<crate>` environment variables for `sp1_sdk::include_elf!()`.
+//! Build script: make the World Chain SP1 guest program ELFs available to
+//! `sp1_sdk::include_elf!()` by emitting the `SP1_ELF_<crate>` environment
+//! variables it reads (`include_elf!(name)` expands to
+//! `include_bytes!(env!("SP1_ELF_<name>"))`).
 //!
 //! This is the OP Succinct upstream pattern (see `utils/build/` in
-//! `succinctlabs/op-succinct`): the ELF bytes live entirely as compile-time
-//! build artifacts, embedded into the host binary at link time via
-//! `include_elf!()`. There are no committed ELF blobs and no runtime
+//! `succinctlabs/op-succinct`): the ELF bytes are embedded into the host
+//! binary at link time via `include_elf!()` — there is no runtime
 //! `fs::read` of an ELF file.
 //!
-//! Behaviour:
-//! - Defaults to `docker: true` with the pinned SP1 toolchain tag
-//!   (matches the `=6.1.0` version of `sp1-sdk` / `sp1-zkvm` the workspace
-//!   pins to) for bit-for-bit reproducible ELFs. This is the ecosystem
-//!   standard used by op-succinct, sp1-helios, and all other SP1 adopters.
-//!   Docker provides reproducibility by fixing the build environment path
-//!   layout inside the container.
-//! - Honours `SP1_BUILD_DOCKER=false` to fall back to the locally-installed
-//!   `cargo-prove` toolchain instead of the Docker reproducibility builder.
-//!   This is required wherever the Docker daemon is unreachable from inside
-//!   the build — notably `Dockerfile.prover` (no Docker-in-Docker) and the
-//!   `vkeys` CI step, both of which install the pinned `v6.1.0` toolchain via
-//!   `sp1up` and set this variable. `sp1_build` does not read this variable
-//!   itself, so we map it onto `BuildArgs.docker` here.
-//! - Honours `SP1_SKIP_PROGRAM_BUILD=true` for fast iteration: `sp1_build`
-//!   checks this variable internally — when set, it skips the Docker/local
-//!   guest compilation but **still emits** the `SP1_ELF_*` cargo env-vars so
-//!   `include_elf!()` resolves against previously-cached ELFs in
-//!   `target/elf-compilation/...`. Our `main` does not need a separate
-//!   early-return for this flag; the delegation to `sp1_build` is sufficient.
-//!   Useful for `cargo check` once a single full build has populated the
-//!   target directory. (Under `cargo clippy` the `#[cfg(clippy)]` guards in
-//!   `src/lib.rs` already prevent `include_elf!()` from expanding, so no
-//!   build is needed at all.)
-//! - Under `cargo clippy`, the `#[cfg(clippy)]` guards in `src/lib.rs`
-//!   prevent `include_elf!()` from expanding, so no ELF files need to exist.
+//! ELFs MUST be bit-for-bit reproducible, because their SHA-256 and the
+//! derived on-chain verification keys are governance-tracked and must be
+//! identical across every build (including each arch of a multi-arch image).
+//! Two mutually exclusive modes provide that:
+//!
+//! - **Build via the SP1 Docker reproducibility builder** (`docker: true`,
+//!   pinned tag `v6.1.0` matching the `=6.1.0` `sp1-sdk` pin). The container
+//!   fixes the toolchain and path layout, so the ELF is identical regardless
+//!   of host. This is the default and is used wherever a Docker daemon is
+//!   reachable (CI runners, dev machines, the `build-elfs` job). A *local*
+//!   `cargo-prove` build is deliberately NOT offered as a fallback: local
+//!   builds are not reproducible (host arch / paths leak into the ELF), which
+//!   would diverge the vkey.
+//!
+//! - **Embed prebuilt ELFs** via `SP1_PREBUILT_ELF_DIR=<dir>`. When set, this
+//!   script points `include_elf!()` at `<dir>/<program>` and does NOT compile
+//!   anything. This is for environments without a Docker daemon — notably the
+//!   prover image build (`Dockerfile.prover`, no Docker-in-Docker) — where the
+//!   ELFs produced once by the `build-elfs` CI job (`docker: true`) are
+//!   downloaded and injected, so every image embeds the same canonical bytes.
+//!
+//! Under `cargo clippy`, the `#[cfg(clippy)]` guards in `src/lib.rs` prevent
+//! `include_elf!()` from expanding, so no ELF files need to exist.
+
+/// Guest program bin-target names, matching the `include_elf!(...)` arguments
+/// in `src/lib.rs` and the file names produced/consumed by the build-elfs job.
+const PROGRAMS: [&str; 2] = [
+    "world-chain-proof-succinct-range-ethereum",
+    "world-chain-proof-succinct-aggregation",
+];
 
 fn main() {
-    println!("cargo:rerun-if-env-changed=SP1_SKIP_PROGRAM_BUILD");
-    println!("cargo:rerun-if-env-changed=SP1_BUILD_DOCKER");
+    println!("cargo:rerun-if-env-changed=SP1_PREBUILT_ELF_DIR");
 
-    // Use the Docker reproducibility builder by default; allow opting out via
-    // `SP1_BUILD_DOCKER=false` for environments where the Docker daemon is
-    // unreachable (Dockerfile.prover, vkeys CI). Any value other than an
-    // explicit "false" keeps the default Docker build.
-    let use_docker = std::env::var("SP1_BUILD_DOCKER")
-        .map(|v| !v.eq_ignore_ascii_case("false"))
-        .unwrap_or(true);
+    // Fast path for environments without a Docker daemon: embed prebuilt,
+    // reproducibly-built ELFs instead of compiling. `include_elf!(name)` reads
+    // `SP1_ELF_<name>`, so emitting an absolute path here makes it embed those
+    // exact bytes with no guest compile. The files must exist at link time;
+    // `include_bytes!` fails loudly if one is missing (no silent fallback).
+    if let Ok(dir) = std::env::var("SP1_PREBUILT_ELF_DIR") {
+        for program in PROGRAMS {
+            println!("cargo:rustc-env=SP1_ELF_{program}={dir}/{program}");
+        }
+        return;
+    }
 
     // The SP1 guest programs live in their own nested cargo workspace at
     // `proofs/succinct/programs/`, but they have path dependencies that
@@ -86,7 +94,7 @@ fn main() {
         sp1_build::build_program_with_args(
             program_dir,
             sp1_build::BuildArgs {
-                docker: use_docker,
+                docker: true,
                 tag: "v6.1.0".to_string(),
                 ignore_rust_version: true,
                 workspace_directory: Some(workspace_root.clone()),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Build-time-only behavior change with an explicit opt-out; default reproducible Docker builds are unchanged.
> 
> **Overview**
> The SP1 guest ELF **build script** no longer always forces Docker for `sp1_build`. It still defaults to the pinned **v6.1.0** Docker reproducibility path, but **`SP1_BUILD_DOCKER=false`** (case-insensitive) switches `BuildArgs.docker` off so builds use the locally installed **`cargo-prove`** toolchain instead.
> 
> Cargo is told to **rebuild when that env var changes**, and the module docs describe using this in **`Dockerfile.prover`** and the **vkeys CI** step where Docker-in-Docker is not available and **`sp1up`** supplies the toolchain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 235f9a7a186903da5db0584a4c80577046a7836d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->