### PR TITLE
chore: Rename Rundler stage URL

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -58,7 +58,7 @@ jobs:
             include_in_all: true
             rpc_url: https://wc-node-sepolia.worldcoin.dev
             acceptance_profile: smoke
-            bundler_rpc_url: https://rundler-sepolia.worldcoin.dev
+            bundler_rpc_url: https://rundler-stage.worldcoin.dev
             entry_point: "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
             safe_4337_module: "0x829Efdda958f06eA49f1F416e10b35C140bf45EF"
             safe_4337_wallet_deployer: "0x6966cAE939Cbbb2DE66E1e7c67Ddb9143fDbA36c"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single CI matrix URL swap; no application or auth logic changes, though stage 4337 smoke tests will fail if the new endpoint is wrong or unreachable.
> 
> **Overview**
> Updates the **stage** acceptance-test matrix so ERC-4337 bundler checks use **`https://rundler-stage.worldcoin.dev`** instead of **`https://rundler-sepolia.worldcoin.dev`**.
> 
> No other networks, RPC URLs, or test env wiring change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6822ed8fa5c9f19dc0d87d957c8cca82d3c9381. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->