### PR TITLE
perf(engine): block on pending flashblock execution in engine_newPayload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19388,6 +19388,7 @@ dependencies = [
  "tracing",
  "world-chain-evm",
  "world-chain-primitives",
+ "world-chain-validator",
 ]
 
 [[package]]
@@ -19601,6 +19602,7 @@ dependencies = [
  "revm",
  "revm-database",
  "tokio",
+ "tokio-stream",
  "tracing",
  "world-chain-chainspec",
  "world-chain-evm",

--- a/crates/node/src/context.rs
+++ b/crates/node/src/context.rs
@@ -332,6 +332,12 @@ where
                 .components_context
                 .as_ref()
                 .map(|flashblocks_components_ctx| flashblocks_components_ctx.authorizer_vk),
+            flashblocks_state: self
+                .components_context
+                .as_ref()
+                .map(|flashblocks_components_ctx| {
+                    flashblocks_components_ctx.flashblocks_state.clone()
+                }),
         };
         let op_eth_api_builder =
             OpEthApiBuilder::default().with_sequencer(self.config.args.rollup.sequencer.clone());

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -15,6 +15,7 @@ use reth_rpc_engine_api::{EngineApi, EngineCapabilities};
 use world_chain_p2p::protocol::handler::FlashblocksHandle;
 use world_chain_primitives::p2p::Authorization;
 use world_chain_rpc::engine::OpEngineApiExt;
+use world_chain_validator::coordinator::FlashblocksExecutionCoordinator;
 
 /// Builder for basic [`OpEngineApiExt`] implementation.
 pub struct FlashblocksEngineApiBuilder<EV> {
@@ -26,6 +27,9 @@ pub struct FlashblocksEngineApiBuilder<EV> {
     pub to_jobs_generator: Option<tokio::sync::watch::Sender<Option<Authorization>>>,
     /// Verifying key for authorizations.
     pub authorizer_vk: Option<VerifyingKey>,
+    /// The flashblocks execution coordinator, used to block `newPayload` on an
+    /// in-flight flashblock execution so the engine tree finalizes from cache.
+    pub flashblocks_state: Option<FlashblocksExecutionCoordinator>,
 }
 
 impl<EV: Default> Default for FlashblocksEngineApiBuilder<EV> {
@@ -35,6 +39,7 @@ impl<EV: Default> Default for FlashblocksEngineApiBuilder<EV> {
             flashblocks_handle: None,
             to_jobs_generator: None,
             authorizer_vk: None,
+            flashblocks_state: None,
         }
     }
 }
@@ -65,6 +70,7 @@ where
         let Self {
             engine_validator_builder,
             to_jobs_generator,
+            flashblocks_state,
             ..
         } = self;
 
@@ -99,7 +105,8 @@ where
         );
 
         let op_engine_api = OpEngineApi::new(inner);
-        let op_engine_api_ext = OpEngineApiExt::new(op_engine_api, to_jobs_generator);
+        let op_engine_api_ext =
+            OpEngineApiExt::new(op_engine_api, to_jobs_generator, flashblocks_state);
 
         Ok(op_engine_api_ext)
     }

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -27,8 +27,7 @@ pub struct FlashblocksEngineApiBuilder<EV> {
     pub to_jobs_generator: Option<tokio::sync::watch::Sender<Option<Authorization>>>,
     /// Verifying key for authorizations.
     pub authorizer_vk: Option<VerifyingKey>,
-    /// The flashblocks execution coordinator, used to block `newPayload` on an
-    /// in-flight flashblock execution so the engine tree finalizes from cache.
+    /// Pending flashblocks state.
     pub flashblocks_state: Option<FlashblocksExecutionCoordinator>,
 }
 

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 # internal
 world-chain-evm.workspace = true
 world-chain-primitives.workspace = true
+world-chain-validator.workspace = true
 
 # reth
 reth-chainspec.workspace = true

--- a/crates/rpc/src/engine.rs
+++ b/crates/rpc/src/engine.rs
@@ -2,7 +2,7 @@ use alloy_eips::eip7685::Requests;
 use alloy_primitives::{B256, BlockHash, U64};
 use alloy_rpc_types_engine::{
     ClientVersionV1, ExecutionPayloadBodiesV1, ExecutionPayloadInputV2, ExecutionPayloadV3,
-    ForkchoiceState, ForkchoiceUpdated, PayloadId, PayloadStatus,
+    ForkchoiceState, ForkchoiceUpdated, PayloadId, PayloadStatus, PayloadStatusEnum,
 };
 use jsonrpsee::{proc_macros::rpc, types::ErrorObject};
 use jsonrpsee_core::{RpcResult, async_trait, server::RpcModule};
@@ -48,15 +48,26 @@ impl<Provider, EngineT: EngineTypes, Pool, Validator, ChainSpec>
         }
     }
 
-    /// Blocks until the flashblock claiming `block_hash` has been executed and
-    /// cached in the engine tree (or a short timeout elapses), so the subsequent
-    /// `newPayload` finalizes from cache instead of re-executing.
-    fn resolve_pending(&self, block_hash: B256) -> impl Future<Output = ()> {
-        let pending_state = self.pending_state.clone();
-        async move {
-            if let Some(state) = pending_state {
-                state.resolve_pending(block_hash).await;
+    /// Races full payload validation against resolution of the pending flashblock
+    /// claiming `block_hash`, returning whichever finishes first. Both are started
+    /// together: if the flashblock's executed payload is broadcast (and thus cached
+    /// in the engine tree) first, it is already fully validated, so we return
+    /// `VALID` immediately; otherwise the engine's full validation result is used.
+    async fn resolve_or_validate(
+        &self,
+        block_hash: B256,
+        validate: impl Future<Output = RpcResult<PayloadStatus>>,
+    ) -> RpcResult<PayloadStatus> {
+        let Some(state) = &self.pending_state else {
+            return validate.await;
+        };
+
+        tokio::select! {
+            biased;
+            () = state.resolve_pending(block_hash) => {
+                Ok(PayloadStatus::new(PayloadStatusEnum::Valid, Some(block_hash)))
             }
+            result = validate => result,
         }
     }
 }
@@ -81,12 +92,12 @@ where
         versioned_hashes: Vec<B256>,
         parent_beacon_block_root: B256,
     ) -> RpcResult<PayloadStatus> {
-        self.resolve_pending(payload.payload_inner.payload_inner.block_hash)
-            .await;
-        Ok(self
-            .inner
-            .new_payload_v3(payload, versioned_hashes, parent_beacon_block_root)
-            .await?)
+        let block_hash = payload.payload_inner.payload_inner.block_hash;
+        let validate =
+            self.inner
+                .new_payload_v3(payload, versioned_hashes, parent_beacon_block_root);
+
+        self.resolve_or_validate(block_hash, validate).await
     }
 
     async fn new_payload_v4(
@@ -96,17 +107,14 @@ where
         parent_beacon_block_root: B256,
         execution_requests: Requests,
     ) -> RpcResult<PayloadStatus> {
-        self.resolve_pending(payload.payload_inner.payload_inner.payload_inner.block_hash)
-            .await;
-        Ok(self
-            .inner
-            .new_payload_v4(
-                payload,
-                versioned_hashes,
-                parent_beacon_block_root,
-                execution_requests,
-            )
-            .await?)
+        let block_hash = payload.payload_inner.payload_inner.payload_inner.block_hash;
+        let validate = self.inner.new_payload_v4(
+            payload,
+            versioned_hashes,
+            parent_beacon_block_root,
+            execution_requests,
+        );
+        self.resolve_or_validate(block_hash, validate).await
     }
 
     async fn fork_choice_updated_v1(

--- a/crates/rpc/src/engine.rs
+++ b/crates/rpc/src/engine.rs
@@ -2,7 +2,7 @@ use alloy_eips::eip7685::Requests;
 use alloy_primitives::{B256, BlockHash, U64};
 use alloy_rpc_types_engine::{
     ClientVersionV1, ExecutionPayloadBodiesV1, ExecutionPayloadInputV2, ExecutionPayloadV3,
-    ForkchoiceState, ForkchoiceUpdated, PayloadId, PayloadStatus, PayloadStatusEnum,
+    ForkchoiceState, ForkchoiceUpdated, PayloadId, PayloadStatus,
 };
 use jsonrpsee::{proc_macros::rpc, types::ErrorObject};
 use jsonrpsee_core::{RpcResult, async_trait, server::RpcModule};
@@ -49,7 +49,7 @@ impl<Provider, EngineT: EngineTypes, Pool, Validator, ChainSpec>
         }
     }
 
-    /// Races full payload validation against resolution of the pending flashblock.
+    /// Starts payload validation while waiting for a matching pending flashblock to resolve.
     async fn race_pending_payload(
         &self,
         block_hash: B256,
@@ -61,12 +61,13 @@ impl<Provider, EngineT: EngineTypes, Pool, Validator, ChainSpec>
 
         // Poll validation first: `resolve_pending` may never resolve, so it must
         // not short-circuit before the engine is handed the payload to validate.
+        tokio::pin!(validate);
         tokio::select! {
             biased;
-            result = validate => result,
-            () = state.resolve_pending(block_hash) => {
-                Ok(PayloadStatus::new(PayloadStatusEnum::Valid, Some(block_hash)))
-            }
+            result = &mut validate => result,
+            // Use the event to unblock/cache the pending payload path, but still return
+            // the engine's validation result for this `newPayload` request.
+            () = state.resolve_pending(block_hash) => validate.await,
         }
     }
 }

--- a/crates/rpc/src/engine.rs
+++ b/crates/rpc/src/engine.rs
@@ -48,12 +48,8 @@ impl<Provider, EngineT: EngineTypes, Pool, Validator, ChainSpec>
         }
     }
 
-    /// Races full payload validation against resolution of the pending flashblock
-    /// claiming `block_hash`, returning whichever finishes first. Both are started
-    /// together: if the flashblock's executed payload is broadcast (and thus cached
-    /// in the engine tree) first, it is already fully validated, so we return
-    /// `VALID` immediately; otherwise the engine's full validation result is used.
-    async fn resolve_or_validate(
+    /// Races full payload validation against resolution of the pending flashblock.
+    async fn race_pending_payload(
         &self,
         block_hash: B256,
         validate: impl Future<Output = RpcResult<PayloadStatus>>,
@@ -62,12 +58,14 @@ impl<Provider, EngineT: EngineTypes, Pool, Validator, ChainSpec>
             return validate.await;
         };
 
+        // Poll validation first: `resolve_pending` may never resolve, so it must
+        // not short-circuit before the engine is handed the payload to validate.
         tokio::select! {
             biased;
+            result = validate => result,
             () = state.resolve_pending(block_hash) => {
                 Ok(PayloadStatus::new(PayloadStatusEnum::Valid, Some(block_hash)))
             }
-            result = validate => result,
         }
     }
 }
@@ -97,7 +95,7 @@ where
             self.inner
                 .new_payload_v3(payload, versioned_hashes, parent_beacon_block_root);
 
-        self.resolve_or_validate(block_hash, validate).await
+        self.race_pending_payload(block_hash, validate).await
     }
 
     async fn new_payload_v4(
@@ -114,7 +112,7 @@ where
             parent_beacon_block_root,
             execution_requests,
         );
-        self.resolve_or_validate(block_hash, validate).await
+        self.race_pending_payload(block_hash, validate).await
     }
 
     async fn fork_choice_updated_v1(

--- a/crates/rpc/src/engine.rs
+++ b/crates/rpc/src/engine.rs
@@ -29,6 +29,7 @@ pub struct OpEngineApiExt<Provider, EngineT: EngineTypes, Pool, Validator, Chain
     /// A (optional) watch channel notifier to the jobs generator.
     to_jobs_generator: Option<tokio::sync::watch::Sender<Option<Authorization>>>,
     /// An (optional) handle to the [`FlashblocksExecutionCoordinator`]
+    ///  - `Some` when flashblocks is enabled, `None` otherwise.
     pending_state: Option<FlashblocksExecutionCoordinator>,
 }
 

--- a/crates/rpc/src/engine.rs
+++ b/crates/rpc/src/engine.rs
@@ -14,11 +14,13 @@ use reth_optimism_rpc::{OpEngineApi, OpEngineApiServer};
 use reth_provider::{BalProvider, BlockReader, HeaderProvider, StateProviderFactory};
 use reth_rpc_api::IntoEngineApiRpcModule;
 use reth_transaction_pool::TransactionPool;
+use std::future::Future;
 use tracing::trace;
 use world_chain_primitives::{
     p2p::Authorization,
     payload_id::{force_op_payload_id_v3, op_reth_payload_id_v4_lookup},
 };
+use world_chain_validator::coordinator::FlashblocksExecutionCoordinator;
 
 #[derive(Debug, Clone)]
 pub struct OpEngineApiExt<Provider, EngineT: EngineTypes, Pool, Validator, ChainSpec> {
@@ -26,6 +28,8 @@ pub struct OpEngineApiExt<Provider, EngineT: EngineTypes, Pool, Validator, Chain
     inner: OpEngineApi<Provider, EngineT, Pool, Validator, ChainSpec>,
     /// A (optional) watch channel notifier to the jobs generator.
     to_jobs_generator: Option<tokio::sync::watch::Sender<Option<Authorization>>>,
+    /// An (optional) handle to the [`FlashblocksExecutionCoordinator`]
+    pending_state: Option<FlashblocksExecutionCoordinator>,
 }
 
 impl<Provider, EngineT: EngineTypes, Pool, Validator, ChainSpec>
@@ -35,10 +39,24 @@ impl<Provider, EngineT: EngineTypes, Pool, Validator, ChainSpec>
     pub fn new(
         inner: OpEngineApi<Provider, EngineT, Pool, Validator, ChainSpec>,
         to_jobs_generator: Option<tokio::sync::watch::Sender<Option<Authorization>>>,
+        pending_state: Option<FlashblocksExecutionCoordinator>,
     ) -> Self {
         Self {
             inner,
             to_jobs_generator,
+            pending_state,
+        }
+    }
+
+    /// Blocks until the flashblock claiming `block_hash` has been executed and
+    /// cached in the engine tree (or a short timeout elapses), so the subsequent
+    /// `newPayload` finalizes from cache instead of re-executing.
+    fn resolve_pending(&self, block_hash: B256) -> impl Future<Output = ()> {
+        let pending_state = self.pending_state.clone();
+        async move {
+            if let Some(state) = pending_state {
+                state.resolve_pending(block_hash).await;
+            }
         }
     }
 }
@@ -63,6 +81,8 @@ where
         versioned_hashes: Vec<B256>,
         parent_beacon_block_root: B256,
     ) -> RpcResult<PayloadStatus> {
+        self.resolve_pending(payload.payload_inner.payload_inner.block_hash)
+            .await;
         Ok(self
             .inner
             .new_payload_v3(payload, versioned_hashes, parent_beacon_block_root)
@@ -76,6 +96,8 @@ where
         parent_beacon_block_root: B256,
         execution_requests: Requests,
     ) -> RpcResult<PayloadStatus> {
+        self.resolve_pending(payload.payload_inner.payload_inner.payload_inner.block_hash)
+            .await;
         Ok(self
             .inner
             .new_payload_v4(

--- a/crates/test-utils/src/e2e_harness/context.rs
+++ b/crates/test-utils/src/e2e_harness/context.rs
@@ -286,6 +286,12 @@ where
                 .components_context
                 .as_ref()
                 .map(|flashblocks_components_ctx| flashblocks_components_ctx.authorizer_vk),
+            flashblocks_state: self
+                .components_context
+                .as_ref()
+                .map(|flashblocks_components_ctx| {
+                    flashblocks_components_ctx.flashblocks_state.clone()
+                }),
         };
         let op_eth_api_builder = OpEthApiBuilder::<WorldRpcTypes>::default()
             .with_sequencer(self.config.args.rollup.sequencer.clone());

--- a/crates/validator/Cargo.toml
+++ b/crates/validator/Cargo.toml
@@ -41,6 +41,7 @@ revm-database.workspace = true
 
 # tokio
 tokio.workspace = true
+tokio-stream.workspace = true
 
 # misc
 crossbeam-channel.workspace = true

--- a/crates/validator/src/coordinator.rs
+++ b/crates/validator/src/coordinator.rs
@@ -50,10 +50,7 @@ use world_chain_primitives::flashblocks::{Flashblock, Flashblocks};
 static SEMAPHORE_TASK_PERMIT: LazyLock<Arc<Semaphore>> =
     LazyLock::new(|| Arc::new(Semaphore::const_new(1)));
 
-/// Max time `newPayload` waits for the matching flashblock's executed payload to
-/// land on the broadcast stream (and thus the engine tree cache) before falling
-/// through to normal execution. Bounded to roughly one flashblock interval so the
-/// engine is never stalled if the flashblock errors or never arrives.
+/// Max time `newPayload` waits for the matching flashblock's executed payload
 const RESOLVE_PENDING_TIMEOUT: Duration = Duration::from_millis(250);
 
 /// The current state of all known pre confirmations received over the P2P layer
@@ -100,15 +97,11 @@ impl FlashblocksExecutionCoordinator {
         }
     }
 
-    /// If the most recently streamed flashblock claims `hash`, blocks until its
-    /// executed payload is broadcast (and thus inserted into the engine tree
-    /// cache) or a short timeout elapses, so a subsequent `newPayload` for the
-    /// same block finalizes from cache instead of re-executing.
-    ///
-    /// Resolves immediately when no streamed flashblock claims `hash`.
+    /// Returns a future that resolves when either:
+    /// - `hash` does not match a flashblock pending execution resolution, or
+    /// - `hash` matches a pending flashblock and its executed payload has been
+    ///   broadcast (or `RESOLVE_PENDING_TIMEOUT` elapses before execution finishes).
     pub fn resolve_pending(&self, hash: B256) -> impl Future<Output = ()> {
-        // Synchronously gate on the last seen flashblock and subscribe; the
-        // returned future never holds the lock.
         let rx = {
             let inner = self.inner.read();
             (inner.flashblocks.last().diff().block_hash == hash)

--- a/crates/validator/src/coordinator.rs
+++ b/crates/validator/src/coordinator.rs
@@ -2,7 +2,7 @@ use alloy_consensus::BlockHeader;
 use alloy_op_evm::OpBlockExecutionCtx;
 use alloy_primitives::B256;
 use eyre::eyre::eyre;
-use futures::{FutureExt, StreamExt, future::OptionFuture};
+use futures::{StreamExt, future::OptionFuture};
 use parking_lot::RwLock;
 use reth_chain_state::ExecutedBlock;
 use reth_evm::ConfigureEvm;
@@ -24,7 +24,7 @@ use reth_provider::{
 use std::{
     future::Future,
     sync::{Arc, LazyLock},
-    time::{Duration, Instant},
+    time::Instant,
 };
 use tokio::{
     sync::{
@@ -49,9 +49,6 @@ use world_chain_primitives::flashblocks::{Flashblock, Flashblocks};
 /// Task-level permit to ensure only one flashblock is processed at a time.
 static SEMAPHORE_TASK_PERMIT: LazyLock<Arc<Semaphore>> =
     LazyLock::new(|| Arc::new(Semaphore::const_new(1)));
-
-/// Max time `newPayload` waits for the matching flashblock's executed payload
-const RESOLVE_PENDING_TIMEOUT: Duration = Duration::from_millis(250);
 
 /// The current state of all known pre confirmations received over the P2P layer
 /// or generated from the payload building job of this node.
@@ -97,10 +94,11 @@ impl FlashblocksExecutionCoordinator {
         }
     }
 
-    /// Returns a future that resolves when either:
-    /// - `hash` does not match a flashblock pending execution resolution, or
-    /// - `hash` matches a pending flashblock and its executed payload has been
-    ///   broadcast (or `RESOLVE_PENDING_TIMEOUT` elapses before execution finishes).
+    /// Returns a future that resolves once the pending flashblock claiming `hash`
+    /// has its executed payload broadcast (and thus inserted into the engine tree
+    /// cache). If no streamed flashblock claims `hash`, or its payload is never
+    /// broadcast, the future never resolves: callers race it against full payload
+    /// validation, so the unresolved arm simply loses.
     pub fn resolve_pending(&self, hash: B256) -> impl Future<Output = ()> {
         let rx = {
             let inner = self.inner.read();
@@ -109,18 +107,23 @@ impl FlashblocksExecutionCoordinator {
                 .flatten()
         };
 
-        OptionFuture::from(rx.map(|rx| {
-            tokio::time::timeout(
-                RESOLVE_PENDING_TIMEOUT,
+        async move {
+            let matched = OptionFuture::from(rx.map(|rx| {
                 BroadcastStream::new(rx).any(move |event| {
                     std::future::ready(matches!(
                         event,
                         Ok(Events::BuiltPayload(payload)) if payload.block().hash() == hash
                     ))
-                }),
-            )
-        }))
-        .map(drop)
+                })
+            }))
+            .await
+            .unwrap_or(false);
+
+            // Pend forever when unmatched so the caller's full validation wins the race.
+            if !matched {
+                std::future::pending::<()>().await;
+            }
+        }
     }
 
     /// Maps a closure over the [`WorldChainEventStream<T>`] from the P2P handle.
@@ -522,6 +525,8 @@ mod tests {
     use alloy_consensus::{Block, BlockBody, Header};
     use alloy_primitives::U256;
     use alloy_rpc_types_engine::PayloadId;
+    use std::time::Duration;
+
     use reth_optimism_primitives::OpTransactionSigned;
     use reth_primitives_traits::SealedBlock;
     use world_chain_primitives::{
@@ -578,12 +583,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolve_pending_gate_miss_returns_immediately() {
+    async fn resolve_pending_never_resolves_on_gate_miss() {
         let (coordinator, _events_tx) = test_coordinator();
-        // No streamed flashblock claims this hash → resolve without waiting.
-        let started = Instant::now();
-        coordinator.resolve_pending(B256::repeat_byte(7)).await;
-        assert!(started.elapsed() < RESOLVE_PENDING_TIMEOUT);
+        // No streamed flashblock claims this hash → never resolves.
+        let resolved = tokio::time::timeout(
+            Duration::from_millis(50),
+            coordinator.resolve_pending(B256::repeat_byte(7)),
+        )
+        .await;
+        assert!(resolved.is_err());
     }
 
     #[tokio::test]
@@ -592,29 +600,33 @@ mod tests {
         let (payload, hash) = built_payload(1);
         set_last_flashblock(&coordinator, hash);
 
-        let started = Instant::now();
         let task = {
             let coordinator = coordinator.clone();
             tokio::spawn(async move { coordinator.resolve_pending(hash).await })
         };
 
         // Let the task subscribe before the payload is broadcast.
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
         events_tx.send(Events::BuiltPayload(payload)).unwrap();
-        task.await.unwrap();
 
-        // Resolved by the broadcast, well before the timeout.
-        assert!(started.elapsed() < RESOLVE_PENDING_TIMEOUT);
+        // Resolves once the matching payload is broadcast.
+        assert!(
+            tokio::time::timeout(Duration::from_millis(200), task)
+                .await
+                .is_ok()
+        );
     }
 
     #[tokio::test]
-    async fn resolve_pending_times_out_without_broadcast() {
+    async fn resolve_pending_never_resolves_without_broadcast() {
         let (coordinator, _events_tx) = test_coordinator();
         let hash = B256::repeat_byte(9);
         set_last_flashblock(&coordinator, hash);
 
-        let started = Instant::now();
-        coordinator.resolve_pending(hash).await;
-        assert!(started.elapsed() >= RESOLVE_PENDING_TIMEOUT);
+        // Gate matches but nothing is broadcast → never resolves.
+        let resolved =
+            tokio::time::timeout(Duration::from_millis(50), coordinator.resolve_pending(hash))
+                .await;
+        assert!(resolved.is_err());
     }
 }

--- a/crates/validator/src/coordinator.rs
+++ b/crates/validator/src/coordinator.rs
@@ -94,18 +94,17 @@ impl FlashblocksExecutionCoordinator {
         }
     }
 
-    /// Returns a future that resolves once the pending flashblock claiming `hash`
-    /// has its executed payload broadcast (and thus inserted into the engine tree
-    /// cache). If no streamed flashblock claims `hash`, or its payload is never
-    /// broadcast, the future never resolves: callers race it against full payload
-    /// validation, so the unresolved arm simply loses.
+    /// Returns a future that resolves once the flashblock executing `hash` broadcasts
+    /// its executed payload. If `hash` was already executed and broadcast, the caller's
+    /// validation gets a full engine-tree cache hit and wins the race instead; if no
+    /// flashblock produces `hash`, this future never resolves and simply loses.
     pub fn resolve_pending(&self, hash: B256) -> impl Future<Output = ()> {
-        let rx = {
-            let inner = self.inner.read();
-            (inner.flashblocks.last().diff().block_hash == hash)
-                .then(|| inner.payload_events.as_ref().map(Sender::subscribe))
-                .flatten()
-        };
+        let rx = self
+            .inner
+            .read()
+            .payload_events
+            .as_ref()
+            .map(Sender::subscribe);
 
         async move {
             let matched = OptionFuture::from(rx.map(|rx| {
@@ -529,10 +528,7 @@ mod tests {
 
     use reth_optimism_primitives::OpTransactionSigned;
     use reth_primitives_traits::SealedBlock;
-    use world_chain_primitives::{
-        ed25519_dalek::SigningKey,
-        primitives::{ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1},
-    };
+    use world_chain_primitives::ed25519_dalek::SigningKey;
 
     fn test_coordinator() -> (
         FlashblocksExecutionCoordinator,
@@ -564,41 +560,10 @@ mod tests {
         (payload, hash)
     }
 
-    /// Sets the coordinator's last seen flashblock to claim `hash`, so the gate
-    /// in [`FlashblocksExecutionCoordinator::resolve_pending`] matches.
-    fn set_last_flashblock(coordinator: &FlashblocksExecutionCoordinator, hash: B256) {
-        let flashblock = Flashblock {
-            flashblock: FlashblocksPayloadV1 {
-                payload_id: PayloadId::new([0u8; 8]),
-                index: 0,
-                base: Some(ExecutionPayloadBaseV1::default()),
-                diff: ExecutionPayloadFlashblockDeltaV1 {
-                    block_hash: hash,
-                    ..Default::default()
-                },
-                metadata: Default::default(),
-            },
-        };
-        coordinator.inner.write().flashblocks.0 = vec![flashblock];
-    }
-
-    #[tokio::test]
-    async fn resolve_pending_never_resolves_on_gate_miss() {
-        let (coordinator, _events_tx) = test_coordinator();
-        // No streamed flashblock claims this hash → never resolves.
-        let resolved = tokio::time::timeout(
-            Duration::from_millis(50),
-            coordinator.resolve_pending(B256::repeat_byte(7)),
-        )
-        .await;
-        assert!(resolved.is_err());
-    }
-
     #[tokio::test]
     async fn resolve_pending_resolves_on_broadcast() {
         let (coordinator, events_tx) = test_coordinator();
         let (payload, hash) = built_payload(1);
-        set_last_flashblock(&coordinator, hash);
 
         let task = {
             let coordinator = coordinator.clone();
@@ -620,13 +585,31 @@ mod tests {
     #[tokio::test]
     async fn resolve_pending_never_resolves_without_broadcast() {
         let (coordinator, _events_tx) = test_coordinator();
-        let hash = B256::repeat_byte(9);
-        set_last_flashblock(&coordinator, hash);
 
-        // Gate matches but nothing is broadcast → never resolves.
-        let resolved =
-            tokio::time::timeout(Duration::from_millis(50), coordinator.resolve_pending(hash))
-                .await;
+        // Nothing is broadcast → never resolves, leaving validation to win the race.
+        let resolved = tokio::time::timeout(
+            Duration::from_millis(50),
+            coordinator.resolve_pending(B256::repeat_byte(9)),
+        )
+        .await;
+        assert!(resolved.is_err());
+    }
+
+    #[tokio::test]
+    async fn resolve_pending_ignores_nonmatching_broadcast() {
+        let (coordinator, events_tx) = test_coordinator();
+        let (other_payload, _other_hash) = built_payload(1);
+
+        let task = {
+            let coordinator = coordinator.clone();
+            tokio::spawn(async move { coordinator.resolve_pending(B256::repeat_byte(9)).await })
+        };
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        events_tx.send(Events::BuiltPayload(other_payload)).unwrap();
+
+        // A broadcast for a different block hash must not resolve the future.
+        let resolved = tokio::time::timeout(Duration::from_millis(50), task).await;
         assert!(resolved.is_err());
     }
 }

--- a/crates/validator/src/coordinator.rs
+++ b/crates/validator/src/coordinator.rs
@@ -1,7 +1,8 @@
 use alloy_consensus::BlockHeader;
 use alloy_op_evm::OpBlockExecutionCtx;
+use alloy_primitives::B256;
 use eyre::eyre::eyre;
-use futures::StreamExt;
+use futures::{FutureExt, StreamExt, future::OptionFuture};
 use parking_lot::RwLock;
 use reth_chain_state::ExecutedBlock;
 use reth_evm::ConfigureEvm;
@@ -21,8 +22,9 @@ use reth_provider::{
     StateProviderFactory,
 };
 use std::{
+    future::Future,
     sync::{Arc, LazyLock},
-    time::Instant,
+    time::{Duration, Instant},
 };
 use tokio::{
     sync::{
@@ -31,6 +33,7 @@ use tokio::{
     },
     task::JoinSet,
 };
+use tokio_stream::wrappers::BroadcastStream;
 use tracing::{error, trace};
 
 use crate::{
@@ -46,6 +49,12 @@ use world_chain_primitives::flashblocks::{Flashblock, Flashblocks};
 /// Task-level permit to ensure only one flashblock is processed at a time.
 static SEMAPHORE_TASK_PERMIT: LazyLock<Arc<Semaphore>> =
     LazyLock::new(|| Arc::new(Semaphore::const_new(1)));
+
+/// Max time `newPayload` waits for the matching flashblock's executed payload to
+/// land on the broadcast stream (and thus the engine tree cache) before falling
+/// through to normal execution. Bounded to roughly one flashblock interval so the
+/// engine is never stalled if the flashblock errors or never arrives.
+const RESOLVE_PENDING_TIMEOUT: Duration = Duration::from_millis(250);
 
 /// The current state of all known pre confirmations received over the P2P layer
 /// or generated from the payload building job of this node.
@@ -91,6 +100,36 @@ impl FlashblocksExecutionCoordinator {
         }
     }
 
+    /// If the most recently streamed flashblock claims `hash`, blocks until its
+    /// executed payload is broadcast (and thus inserted into the engine tree
+    /// cache) or a short timeout elapses, so a subsequent `newPayload` for the
+    /// same block finalizes from cache instead of re-executing.
+    ///
+    /// Resolves immediately when no streamed flashblock claims `hash`.
+    pub fn resolve_pending(&self, hash: B256) -> impl Future<Output = ()> {
+        // Synchronously gate on the last seen flashblock and subscribe; the
+        // returned future never holds the lock.
+        let rx = {
+            let inner = self.inner.read();
+            (inner.flashblocks.last().diff().block_hash == hash)
+                .then(|| inner.payload_events.as_ref().map(Sender::subscribe))
+                .flatten()
+        };
+
+        OptionFuture::from(rx.map(|rx| {
+            tokio::time::timeout(
+                RESOLVE_PENDING_TIMEOUT,
+                BroadcastStream::new(rx).any(move |event| {
+                    std::future::ready(matches!(
+                        event,
+                        Ok(Events::BuiltPayload(payload)) if payload.block().hash() == hash
+                    ))
+                }),
+            )
+        }))
+        .map(drop)
+    }
+
     /// Maps a closure over the [`WorldChainEventStream<T>`] from the P2P handle.
     pub fn map_worldchain_event_stream<N, P, T, F>(
         &self,
@@ -112,6 +151,7 @@ impl FlashblocksExecutionCoordinator {
         self.p2p_handle
             .event_stream(provider, move |event| f(event))
     }
+
     pub fn event_hook(
         event: &WorldChainEvent<()>,
         pending_block: &tokio::sync::watch::Sender<Option<ExecutedBlock<OpPrimitives>>>,
@@ -481,4 +521,107 @@ where
     flashblock_validation_metrics
         .record_full_process_flashblock(process_flashblock_started.elapsed());
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::{Block, BlockBody, Header};
+    use alloy_primitives::U256;
+    use alloy_rpc_types_engine::PayloadId;
+    use reth_optimism_primitives::OpTransactionSigned;
+    use reth_primitives_traits::SealedBlock;
+    use world_chain_primitives::{
+        ed25519_dalek::SigningKey,
+        primitives::{ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1},
+    };
+
+    fn test_coordinator() -> (
+        FlashblocksExecutionCoordinator,
+        broadcast::Sender<Events<OpEngineTypes>>,
+    ) {
+        let sk = SigningKey::from_bytes(&[1u8; 32]);
+        let handle = FlashblocksHandle::new(sk.verifying_key(), Some(sk));
+        let (pending_tx, _pending_rx) = tokio::sync::watch::channel(None);
+        let coordinator = FlashblocksExecutionCoordinator::new(handle, pending_tx);
+        let (events_tx, _events_rx) = broadcast::channel(16);
+        coordinator.register_payload_events(events_tx.clone());
+        (coordinator, events_tx)
+    }
+
+    /// Builds an [`OpBuiltPayload`] over an empty block; `number` seeds a distinct
+    /// block hash. Returns the payload and its block hash.
+    fn built_payload(number: u64) -> (OpBuiltPayload, B256) {
+        let header = Header {
+            number,
+            ..Default::default()
+        };
+        let block = SealedBlock::seal_slow(Block {
+            header,
+            body: BlockBody::<OpTransactionSigned>::default(),
+        });
+        let hash = block.hash();
+        let payload =
+            OpBuiltPayload::new(PayloadId::new([0u8; 8]), Arc::new(block), U256::ZERO, None);
+        (payload, hash)
+    }
+
+    /// Sets the coordinator's last seen flashblock to claim `hash`, so the gate
+    /// in [`FlashblocksExecutionCoordinator::resolve_pending`] matches.
+    fn set_last_flashblock(coordinator: &FlashblocksExecutionCoordinator, hash: B256) {
+        let flashblock = Flashblock {
+            flashblock: FlashblocksPayloadV1 {
+                payload_id: PayloadId::new([0u8; 8]),
+                index: 0,
+                base: Some(ExecutionPayloadBaseV1::default()),
+                diff: ExecutionPayloadFlashblockDeltaV1 {
+                    block_hash: hash,
+                    ..Default::default()
+                },
+                metadata: Default::default(),
+            },
+        };
+        coordinator.inner.write().flashblocks.0 = vec![flashblock];
+    }
+
+    #[tokio::test]
+    async fn resolve_pending_gate_miss_returns_immediately() {
+        let (coordinator, _events_tx) = test_coordinator();
+        // No streamed flashblock claims this hash → resolve without waiting.
+        let started = Instant::now();
+        coordinator.resolve_pending(B256::repeat_byte(7)).await;
+        assert!(started.elapsed() < RESOLVE_PENDING_TIMEOUT);
+    }
+
+    #[tokio::test]
+    async fn resolve_pending_resolves_on_broadcast() {
+        let (coordinator, events_tx) = test_coordinator();
+        let (payload, hash) = built_payload(1);
+        set_last_flashblock(&coordinator, hash);
+
+        let started = Instant::now();
+        let task = {
+            let coordinator = coordinator.clone();
+            tokio::spawn(async move { coordinator.resolve_pending(hash).await })
+        };
+
+        // Let the task subscribe before the payload is broadcast.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        events_tx.send(Events::BuiltPayload(payload)).unwrap();
+        task.await.unwrap();
+
+        // Resolved by the broadcast, well before the timeout.
+        assert!(started.elapsed() < RESOLVE_PENDING_TIMEOUT);
+    }
+
+    #[tokio::test]
+    async fn resolve_pending_times_out_without_broadcast() {
+        let (coordinator, _events_tx) = test_coordinator();
+        let hash = B256::repeat_byte(9);
+        set_last_flashblock(&coordinator, hash);
+
+        let started = Instant::now();
+        coordinator.resolve_pending(hash).await;
+        assert!(started.elapsed() >= RESOLVE_PENDING_TIMEOUT);
+    }
 }

--- a/crates/validator/src/state_root_strategy.rs
+++ b/crates/validator/src/state_root_strategy.rs
@@ -76,6 +76,7 @@ impl StateRootStrategy for AsyncStateRootStrategy {
                 let _ = sender.send(result);
             })
             .map_err(BlockExecutionError::other)?;
+
         Ok(ChannelStateRootHandle { receiver })
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes consensus/engine `newPayload` timing and async race behavior on a security-sensitive path; incorrect racing could affect cache hits or latency, though responses still come from inner validation.
> 
> **Overview**
> When flashblocks are enabled, **`engine_newPayload` v3/v4** no longer only runs the stock Op engine validation. **`OpEngineApiExt`** holds an optional **`FlashblocksExecutionCoordinator`** and uses **`race_pending_payload`** to run validation in parallel with waiting for a matching flashblock-built payload broadcast.
> 
> **`resolve_pending(block_hash)`** on the coordinator subscribes to built-payload events and completes when the hash matches; otherwise it never completes so the normal validation path still wins. The **`tokio::select!`** is **biased toward validation finishing first** so a stuck pending wait cannot block handing the payload to the engine; if the flashblock path fires first, the RPC still returns the engine’s validation result after it finishes.
> 
> Node and e2e wiring pass **`flashblocks_state`** through **`FlashblocksEngineApiBuilder`** into the extended engine API. **`world-chain-validator`** (and **`tokio-stream`**) are added where needed, with unit tests covering match, no broadcast, and wrong-hash broadcasts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18ad7dfbe2893e687fbd78365d1ae66d36e0af5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->