### PR TITLE
fix: pre-flight tx validation

### DIFF
--- a/crates/builder/src/execution_context.rs
+++ b/crates/builder/src/execution_context.rs
@@ -5,6 +5,7 @@ use crate::{
 use alloy_consensus::{Block, SignableTransaction, Transaction, transaction::SignerRecoverable};
 use alloy_eips::{Encodable2718, Typed2718};
 use alloy_network::{TransactionBuilder, TxSignerSync};
+use alloy_op_evm::block::PreRefundGasUsed;
 use alloy_primitives::{Address, U256};
 use alloy_signer_local::PrivateKeySigner;
 use eyre::eyre::eyre;
@@ -83,12 +84,15 @@ where
         info: &mut ExecutionInfo,
         base_fee: u64,
         gas_used: u64,
+        evm_gas_used: u64,
         tx_da_size: u64,
         tx: Recovered<OpTransactionSigned>,
     ) {
         // add gas used by the transaction to cumulative gas used, before creating the
         // receipt
         info.cumulative_gas_used += gas_used;
+
+        info.cumulative_evm_gas_used += evm_gas_used;
         info.cumulative_da_bytes_used += tx_da_size;
 
         // update add to total fees
@@ -229,6 +233,7 @@ where
                         DB: reth_evm::block::StateDB + reth_evm::Database,
                         BlockEnv = BlockEnv,
                     >,
+                    Result: PreRefundGasUsed,
                 >,
             >,
         Txs: PayloadTransactions<
@@ -339,7 +344,12 @@ where
             }
 
             let tx_execution_started = Instant::now();
-            let execution_result = builder.execute_transaction(tx.clone());
+
+            let mut evm_gas_used = 0u64;
+            let execution_result =
+                builder.execute_transaction_with_result_closure(tx.clone(), |result| {
+                    evm_gas_used = result.evm_gas_used();
+                });
             attempt_metrics.record_transaction_execution_duration(tx_execution_started.elapsed());
             let gas_used = match execution_result {
                 Ok(res) => {
@@ -387,7 +397,7 @@ where
             let gas_used = gas_used.tx_gas_used();
             attempt_metrics.record_transaction_gas_used(gas_used);
             transactions_executed += 1;
-            self.commit_changes(info, base_fee, gas_used, tx_da_size, tx);
+            self.commit_changes(info, base_fee, gas_used, evm_gas_used, tx_da_size, tx);
         }
 
         if !spent_nullifier_hashes.is_empty() {
@@ -409,11 +419,14 @@ where
             // insufficient funds, continue with the built payload. This ensures that
             // PBH transactions still receive priority inclusion, even if the PBH nullifier
             // is not spent rather than sitting in the default execution client's mempool.
-            match builder.execute_transaction(tx.clone()) {
+            let mut evm_gas_used = 0u64;
+            match builder.execute_transaction_with_result_closure(tx.clone(), |result| {
+                evm_gas_used = result.evm_gas_used();
+            }) {
                 Ok(gas_used) => {
                     let gas_used = gas_used.tx_gas_used();
                     let tx_da_size = estimated_da_size_bytes(&tx);
-                    self.commit_changes(info, base_fee, gas_used, tx_da_size, tx);
+                    self.commit_changes(info, base_fee, gas_used, evm_gas_used, tx_da_size, tx);
                     attempt_metrics
                         .record_spend_nullifiers_outcome(PayloadBuildTaskOutcome::Success);
                 }

--- a/crates/builder/src/payload_builder.rs
+++ b/crates/builder/src/payload_builder.rs
@@ -369,13 +369,14 @@ where
 
     let effective_gas_limit = ctx
         .effective_gas_limit()
-        .saturating_sub(committed_state.gas_used);
+        .saturating_sub(committed_state.evm_gas_used);
 
     trace!(
         target: "flashblocks::payload_builder",
         gas_limit = attributes.gas_limit,
         effective_gas_limit,
         committed_gas_used = committed_state.gas_used,
+        committed_evm_gas_used = committed_state.evm_gas_used,
         timestamp = ctx.attributes().timestamp(),
         "building new payload"
     );
@@ -539,7 +540,8 @@ where
         committed_payload.map_or(ExecutionInfo::default(), |p| ExecutionInfo {
             total_fees: p.fees(),
             cumulative_gas_used: p.block().gas_used(),
-            // The amount of EVM gas used gas_used() + gas_refunded() for an individual flashblock.
+            // `effective_gas_limit` already excludes committed pre-refund gas, so this tracks only
+            // new transactions executed in the continuation build.
             cumulative_evm_gas_used: 0,
             cumulative_da_bytes_used: committed_state
                 .transactions_iter()
@@ -694,6 +696,7 @@ where
         R::default(),
     );
     executor.gas_used = committed_state.gas_used;
+    executor.evm_gas_used = committed_state.evm_gas_used;
     executor.da_footprint_used = committed_state.blob_gas_used;
     executor.receipts = committed_state.receipts_iter().cloned().collect();
 
@@ -744,6 +747,7 @@ where
     );
 
     executor.gas_used = committed_state.gas_used;
+    executor.evm_gas_used = committed_state.evm_gas_used;
     executor.da_footprint_used = committed_state.blob_gas_used;
     executor.receipts = committed_state.receipts_iter().cloned().collect();
 

--- a/crates/builder/src/payload_builder.rs
+++ b/crates/builder/src/payload_builder.rs
@@ -481,6 +481,7 @@ fn build_inner<'a, Txs, Ctx, Pool, R>(
             Evm: Evm<DB: reth_evm::block::StateDB + Database + 'a, BlockEnv = BlockEnv>,
             Receipt = R::Receipt,
             Transaction = R::Transaction,
+            Result: alloy_op_evm::block::PreRefundGasUsed,
         >,
     >,
     mut attempt_metrics: &mut PayloadBuildAttemptMetrics,
@@ -538,7 +539,8 @@ where
         committed_payload.map_or(ExecutionInfo::default(), |p| ExecutionInfo {
             total_fees: p.fees(),
             cumulative_gas_used: p.block().gas_used(),
-            cumulative_evm_gas_used: p.block().gas_used(),
+            // The amount of EVM gas used gas_used() + gas_refunded() for an individual flashblock.
+            cumulative_evm_gas_used: 0,
             cumulative_da_bytes_used: committed_state
                 .transactions_iter()
                 .filter(|tx| !tx.tx().is_deposit())

--- a/crates/builder/src/traits/context.rs
+++ b/crates/builder/src/traits/context.rs
@@ -1,5 +1,6 @@
 use crate::payload_builder_metrics::PayloadBuildAttemptMetrics;
 use alloy_eips::eip4895::Withdrawals;
+use alloy_op_evm::block::PreRefundGasUsed;
 use alloy_primitives::U256;
 use alloy_rpc_types_engine::PayloadId;
 use op_alloy_consensus::EIP1559ParamError;
@@ -159,6 +160,7 @@ pub trait PayloadBuilderCtx: Send + Sync {
                         DB: reth_evm::block::StateDB + reth_evm::Database,
                         BlockEnv = BlockEnv,
                     >,
+                    Result: PreRefundGasUsed,
                 >,
             >,
         Txs: PayloadTransactions<Transaction = Self::Transaction>;

--- a/crates/evm/src/execution/bal.rs
+++ b/crates/evm/src/execution/bal.rs
@@ -13,7 +13,7 @@ use op_revm::{
     },
 };
 use reth_evm::{
-    Database, Evm,
+    Database, Evm, RecoveredTx,
     block::{BlockExecutionError, BlockExecutor, InternalBlockExecutionError},
 };
 use reth_node_api::NodePrimitives;
@@ -71,6 +71,24 @@ pub fn record_op_l1_block_bal_reads<DB>(db: &mut State<DB>) -> Result<(), BlockE
     }
 
     Ok(())
+}
+
+/// Reconstructs pre-refund EVM gas for committed transactions.
+///
+/// The block header and receipts carry canonical gas after SDM/post-exec refunds. The matching
+/// post-exec transaction carries the refund entries, so adding them back gives the executor's
+/// pre-refund gas counter for the committed payload.
+pub fn pre_refund_gas_used<'a>(
+    gas_used: u64,
+    transactions: impl IntoIterator<Item = &'a Recovered<OpTransactionSigned>>,
+) -> u64 {
+    let gas_refunded = transactions
+        .into_iter()
+        .filter_map(|tx| tx.tx().as_post_exec())
+        .flat_map(|tx| tx.inner().payload.gas_refund_entries.iter())
+        .fold(0u64, |sum, entry| sum.saturating_add(entry.gas_refund));
+
+    gas_used.saturating_add(gas_refunded)
 }
 
 #[derive(thiserror::Error, Debug, serde::Serialize)]
@@ -408,8 +426,10 @@ impl BlockAccessIndexCounter {
 pub struct CommittedState<R: OpReceiptBuilder + Default = OpRethReceiptBuilder> {
     /// True when there is no prior committed payload (i.e. this is the first flashblock).
     pub is_first: bool,
-    /// The total gas used in previous committed transactions.
+    /// The total canonical gas used in previous committed transactions.
     pub gas_used: u64,
+    /// The total pre-refund EVM gas used in previous committed transactions.
+    pub evm_gas_used: u64,
     /// The total DA footprint in previous committed transactions.
     ///
     /// Post-Jovian this is stored in the block header's `blob_gas_used` field.
@@ -483,6 +503,7 @@ where
                 .enumerate()
                 .map(|(index, tx)| (index as u64, tx))
                 .collect();
+            let evm_gas_used = pre_refund_gas_used(gas_used, transactions.iter().map(|(_, tx)| tx));
 
             let receipts: Vec<_> = executed_block
                 .execution_output
@@ -499,6 +520,7 @@ where
                 transactions,
                 receipts,
                 gas_used,
+                evm_gas_used,
                 blob_gas_used,
                 fees,
                 bundle,
@@ -509,6 +531,7 @@ where
                 transactions: vec![],
                 receipts: vec![],
                 gas_used: 0,
+                evm_gas_used: 0,
                 blob_gas_used: 0,
                 fees: U256::ZERO,
                 bundle: BundleState::default(),
@@ -519,7 +542,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::BlockAccessIndexCounter;
+    use super::{BlockAccessIndexCounter, pre_refund_gas_used};
+    use alloy_consensus::Sealable;
+    use alloy_primitives::Address;
+    use op_alloy_consensus::{SDMGasEntry, build_post_exec_tx};
+    use reth_optimism_primitives::OpTransactionSigned;
+    use reth_primitives_traits::Recovered;
 
     #[test]
     fn test_block_access_index_counter_finish() {
@@ -535,5 +563,28 @@ mod tests {
         let (start, end) = counter.finish();
         assert_eq!(start, 5);
         assert_eq!(end, 8);
+    }
+
+    #[test]
+    fn pre_refund_gas_used_adds_post_exec_refunds() {
+        let post_exec = OpTransactionSigned::from(
+            build_post_exec_tx(
+                42,
+                vec![
+                    SDMGasEntry {
+                        index: 0,
+                        gas_refund: 7,
+                    },
+                    SDMGasEntry {
+                        index: 1,
+                        gas_refund: 11,
+                    },
+                ],
+            )
+            .seal_slow(),
+        );
+        let transactions = [Recovered::new_unchecked(post_exec, Address::ZERO)];
+
+        assert_eq!(pre_refund_gas_used(100, transactions.iter()), 118);
     }
 }

--- a/crates/test-utils/src/builder.rs
+++ b/crates/test-utils/src/builder.rs
@@ -5,16 +5,16 @@
 //! from `world-chain-builder`'s internal `test_utils` module so that
 //! downstream test and fuzz crates can depend on `world-chain-test-utils` alone.
 
-use alloy_consensus::{BlockHeader, TxEip1559, constants::KECCAK_EMPTY};
-use alloy_eips::{BlockNumHash, eip2718::Encodable2718};
+use alloy_consensus::{constants::KECCAK_EMPTY, BlockHeader, TxEip1559};
+use alloy_eips::{eip2718::Encodable2718, BlockNumHash};
 use alloy_genesis::{Genesis, GenesisAccount};
 use alloy_op_evm::{OpBlockExecutionCtx, OpBlockExecutor, OpEvmFactory};
 use alloy_primitives::{
-    Address, B256, Bytes, FixedBytes, StorageKey, TxKind, U256, bytes, hex, keccak256,
+    bytes, hex, keccak256, Address, Bytes, FixedBytes, StorageKey, TxKind, B256, U256,
 };
 use alloy_rpc_types_engine::PayloadId;
 use alloy_signer_local::PrivateKeySigner;
-use alloy_sol_types::{SolCall, sol};
+use alloy_sol_types::{sol, SolCall};
 use alloy_trie::TrieAccount;
 use crossbeam_channel::bounded;
 use op_alloy_consensus::{OpTxEnvelope, OpTypedTransaction};
@@ -22,8 +22,8 @@ use op_alloy_network::TxSignerSync;
 use op_revm::OpSpecId;
 use reth_chainspec::ChainInfo;
 use reth_evm::{
-    ConfigureEvm, EvmEnv, EvmFactory,
     execute::{BlockBuilder, BlockBuilderOutcome},
+    ConfigureEvm, EvmEnv, EvmFactory,
 };
 use reth_optimism_evm::OpNextBlockEnvAttributes;
 use reth_optimism_primitives::{OpPrimitives, OpTransactionSigned};
@@ -33,12 +33,12 @@ use reth_provider::{
     HeaderProvider, NodePrimitivesProvider, ProviderResult, StateProvider, StateProviderBox,
     StateProviderFactory,
 };
-use reth_revm::{State, database::StateProviderDatabase};
+use reth_revm::{database::StateProviderDatabase, State};
 use reth_trie_common::{ExecutionWitnessMode, HashedPostState};
 use revm::{
-    DatabaseRef,
     database::{BundleState, InMemoryDB},
     state::AccountInfo,
+    DatabaseRef,
 };
 use std::{
     collections::{BTreeMap, HashMap},
@@ -49,12 +49,12 @@ use tracing::error;
 use world_chain_builder::payload_builder_metrics::PayloadBuildAttemptMetrics;
 use world_chain_chainspec::{WorldChainSpec, WorldChainSpecBuilder};
 use world_chain_evm::{
-    BlockBuilderExt, OpRethReceiptBuilder, WorldChainEvmConfig,
-    execution::bal::{BalBlockBuilder, CommittedState, pre_refund_gas_used},
+    execution::bal::{pre_refund_gas_used, BalBlockBuilder, CommittedState},
     utils::cache_prestate_from_bundle,
+    BlockBuilderExt, OpRethReceiptBuilder, WorldChainEvmConfig,
 };
 use world_chain_primitives::{
-    access_list::{FlashblockAccessListData, access_list_hash},
+    access_list::{access_list_hash, FlashblockAccessListData},
     primitives::{ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, FlashblocksPayloadV1},
 };
 
@@ -464,13 +464,25 @@ impl TxOp {
 
     /// Creates a signed transaction from this operation
     pub fn to_signed_tx(&self, nonce: u64) -> Recovered<OpTransactionSigned> {
+        self.to_signed_tx_with_gas_limit(nonce, self.gas_limit())
+    }
+
+    /// Creates a signed transaction from this operation with an explicit gas limit.
+    ///
+    /// Used by gas-limit fuzzing to set the transaction's `gas_limit` field independently of the
+    /// operation's estimated cost.
+    pub fn to_signed_tx_with_gas_limit(
+        &self,
+        nonce: u64,
+        gas_limit: u64,
+    ) -> Recovered<OpTransactionSigned> {
         let mut tx = TxEip1559 {
             chain_id: CHAIN_SPEC.chain().id(),
             nonce,
             max_fee_per_gas: CHAIN_SPEC.genesis_header().base_fee_per_gas.unwrap_or(1) as u128 * 2,
             max_priority_fee_per_gas: 1,
             to: self.target(),
-            gas_limit: self.gas_limit(),
+            gas_limit,
             value: self.value(),
             input: self.encode_calldata(),
             access_list: Default::default(),
@@ -486,7 +498,12 @@ impl TxOp {
 
     /// Encodes transaction to bytes
     pub fn to_encoded_bytes(&self, nonce: u64) -> Bytes {
-        let tx = self.to_signed_tx(nonce);
+        self.to_encoded_bytes_with_gas_limit(nonce, self.gas_limit())
+    }
+
+    /// Encodes transaction to bytes with an explicit gas limit.
+    pub fn to_encoded_bytes_with_gas_limit(&self, nonce: u64, gas_limit: u64) -> Bytes {
+        let tx = self.to_signed_tx_with_gas_limit(nonce, gas_limit);
         let mut buf = Vec::new();
         tx.inner().encode_2718(&mut buf);
         Bytes::from(buf)
@@ -551,6 +568,60 @@ pub fn build_chained_payloads_with_provider<P>(
 where
     P: StateProvider + ?Sized,
 {
+    // Default each transaction's gas limit to the operation's estimate.
+    let sequence = sequence
+        .into_iter()
+        .map(|(op, nonce)| {
+            let gas_limit = op.gas_limit();
+            (op, nonce, gas_limit)
+        })
+        .collect();
+    build_chained_payloads_with_provider_and_gas(state_provider, sequence, max_flashblocks, bal)
+}
+
+/// Builds chained payloads using an explicit per-transaction gas limit.
+///
+/// Mirrors [`build_chained_payloads`] but lets callers fuzz each transaction's `gas_limit` field
+/// independently of the operation's estimated cost. Uses a mock [`TestStateProvider`] as the
+/// backing database.
+pub fn build_chained_payloads_with_gas_limits(
+    sequence: Vec<(TxOp, u64, u64)>,
+    max_flashblocks: usize,
+    bal: bool,
+) -> Result<
+    Vec<(
+        ExecutionPayloadFlashblockDeltaV1,
+        Option<CommittedState<OpRethReceiptBuilder>>,
+    )>,
+    Box<dyn std::error::Error + Send + Sync>,
+> {
+    let state_provider = create_test_state_provider();
+    build_chained_payloads_with_provider_and_gas(
+        state_provider.as_ref(),
+        sequence,
+        max_flashblocks,
+        bal,
+    )
+}
+
+/// Backing implementation for the `build_chained_payloads*` family.
+///
+/// Each sequence entry is `(operation, nonce, gas_limit)`.
+fn build_chained_payloads_with_provider_and_gas<P>(
+    state_provider: &P,
+    sequence: Vec<(TxOp, u64, u64)>,
+    max_flashblocks: usize,
+    bal: bool,
+) -> Result<
+    Vec<(
+        ExecutionPayloadFlashblockDeltaV1,
+        Option<CommittedState<OpRethReceiptBuilder>>,
+    )>,
+    Box<dyn std::error::Error + Send + Sync>,
+>
+where
+    P: StateProvider + ?Sized,
+{
     let mut payloads = Vec::with_capacity(max_flashblocks);
     let mut prev_outcome: Option<(BlockBuilderOutcome<OpPrimitives>, BundleState)> = None;
 
@@ -559,8 +630,11 @@ where
     let sequences = sequence.chunks(chunk_size).collect::<Vec<_>>();
 
     for sequence in sequences.into_iter() {
-        // Convert transaction ops to signed transactions
-        let transactions = transaction_op_sequence_to_transactions(sequence);
+        // Convert transaction ops to signed transactions, honoring the explicit gas limit.
+        let transactions: Vec<_> = sequence
+            .iter()
+            .map(|(op, nonce, gas_limit)| op.to_signed_tx_with_gas_limit(*nonce, *gas_limit))
+            .collect();
 
         // Execute over the previous outcome, if any
         let (outcome, bal_data, bundle_state) =
@@ -580,8 +654,11 @@ where
                 .into());
             }
         }
-        // Encode transactions for the payload
-        let encoded_txs = transaction_sequence_to_encoded(sequence);
+        // Encode transactions for the payload, honoring the explicit gas limit.
+        let encoded_txs: Vec<_> = sequence
+            .iter()
+            .map(|(op, nonce, gas_limit)| op.to_encoded_bytes_with_gas_limit(*nonce, *gas_limit))
+            .collect();
 
         // Construct the payload
         let payload = ExecutionPayloadFlashblockDeltaV1 {

--- a/crates/test-utils/src/builder.rs
+++ b/crates/test-utils/src/builder.rs
@@ -5,16 +5,16 @@
 //! from `world-chain-builder`'s internal `test_utils` module so that
 //! downstream test and fuzz crates can depend on `world-chain-test-utils` alone.
 
-use alloy_consensus::{constants::KECCAK_EMPTY, BlockHeader, TxEip1559};
-use alloy_eips::{eip2718::Encodable2718, BlockNumHash};
+use alloy_consensus::{BlockHeader, TxEip1559, constants::KECCAK_EMPTY};
+use alloy_eips::{BlockNumHash, eip2718::Encodable2718};
 use alloy_genesis::{Genesis, GenesisAccount};
 use alloy_op_evm::{OpBlockExecutionCtx, OpBlockExecutor, OpEvmFactory};
 use alloy_primitives::{
-    bytes, hex, keccak256, Address, Bytes, FixedBytes, StorageKey, TxKind, B256, U256,
+    Address, B256, Bytes, FixedBytes, StorageKey, TxKind, U256, bytes, hex, keccak256,
 };
 use alloy_rpc_types_engine::PayloadId;
 use alloy_signer_local::PrivateKeySigner;
-use alloy_sol_types::{sol, SolCall};
+use alloy_sol_types::{SolCall, sol};
 use alloy_trie::TrieAccount;
 use crossbeam_channel::bounded;
 use op_alloy_consensus::{OpTxEnvelope, OpTypedTransaction};
@@ -22,8 +22,8 @@ use op_alloy_network::TxSignerSync;
 use op_revm::OpSpecId;
 use reth_chainspec::ChainInfo;
 use reth_evm::{
-    execute::{BlockBuilder, BlockBuilderOutcome},
     ConfigureEvm, EvmEnv, EvmFactory,
+    execute::{BlockBuilder, BlockBuilderOutcome},
 };
 use reth_optimism_evm::OpNextBlockEnvAttributes;
 use reth_optimism_primitives::{OpPrimitives, OpTransactionSigned};
@@ -33,12 +33,12 @@ use reth_provider::{
     HeaderProvider, NodePrimitivesProvider, ProviderResult, StateProvider, StateProviderBox,
     StateProviderFactory,
 };
-use reth_revm::{database::StateProviderDatabase, State};
+use reth_revm::{State, database::StateProviderDatabase};
 use reth_trie_common::{ExecutionWitnessMode, HashedPostState};
 use revm::{
+    DatabaseRef,
     database::{BundleState, InMemoryDB},
     state::AccountInfo,
-    DatabaseRef,
 };
 use std::{
     collections::{BTreeMap, HashMap},
@@ -49,12 +49,12 @@ use tracing::error;
 use world_chain_builder::payload_builder_metrics::PayloadBuildAttemptMetrics;
 use world_chain_chainspec::{WorldChainSpec, WorldChainSpecBuilder};
 use world_chain_evm::{
-    execution::bal::{pre_refund_gas_used, BalBlockBuilder, CommittedState},
-    utils::cache_prestate_from_bundle,
     BlockBuilderExt, OpRethReceiptBuilder, WorldChainEvmConfig,
+    execution::bal::{BalBlockBuilder, CommittedState, pre_refund_gas_used},
+    utils::cache_prestate_from_bundle,
 };
 use world_chain_primitives::{
-    access_list::{access_list_hash, FlashblockAccessListData},
+    access_list::{FlashblockAccessListData, access_list_hash},
     primitives::{ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, FlashblocksPayloadV1},
 };
 

--- a/crates/test-utils/src/builder.rs
+++ b/crates/test-utils/src/builder.rs
@@ -50,7 +50,7 @@ use world_chain_builder::payload_builder_metrics::PayloadBuildAttemptMetrics;
 use world_chain_chainspec::{WorldChainSpec, WorldChainSpecBuilder};
 use world_chain_evm::{
     BlockBuilderExt, OpRethReceiptBuilder, WorldChainEvmConfig,
-    execution::bal::{BalBlockBuilder, CommittedState},
+    execution::bal::{BalBlockBuilder, CommittedState, pre_refund_gas_used},
     utils::cache_prestate_from_bundle,
 };
 use world_chain_primitives::{
@@ -598,26 +598,34 @@ where
 
         payloads.push((
             payload,
-            prev_outcome.as_ref().map(|(o, state)| CommittedState {
-                is_first: false,
-                gas_used: o.block.gas_used(),
-                blob_gas_used: o.block.blob_gas_used().unwrap_or_default(),
-                fees: U256::ZERO,
-                bundle: state.clone(),
-                receipts: o
-                    .execution_result
-                    .receipts
-                    .clone()
-                    .iter()
-                    .enumerate()
-                    .map(|(idx, r)| (idx as u64, r.clone()))
-                    .collect(),
-                transactions: o
+            prev_outcome.as_ref().map(|(o, state)| {
+                let gas_used = o.block.gas_used();
+                let transactions: Vec<_> = o
                     .block
                     .clone_transactions_recovered()
                     .enumerate()
                     .map(|(idx, tx)| (idx as u64, tx.clone()))
-                    .collect(),
+                    .collect();
+                let evm_gas_used =
+                    pre_refund_gas_used(gas_used, transactions.iter().map(|(_, tx)| tx));
+
+                CommittedState {
+                    is_first: false,
+                    gas_used,
+                    evm_gas_used,
+                    blob_gas_used: o.block.blob_gas_used().unwrap_or_default(),
+                    fees: U256::ZERO,
+                    bundle: state.clone(),
+                    receipts: o
+                        .execution_result
+                        .receipts
+                        .clone()
+                        .iter()
+                        .enumerate()
+                        .map(|(idx, r)| (idx as u64, r.clone()))
+                        .collect(),
+                    transactions,
+                }
             }),
         ));
 

--- a/crates/validator/src/execution_strategy.rs
+++ b/crates/validator/src/execution_strategy.rs
@@ -312,6 +312,7 @@ impl<'a, S: StateRootStrategy> BalBlockValidator<'a, S> {
             executor_factory.create_executor(evm, self.ctx.execution_context.clone());
 
         canonical_executor.gas_used = committed_state.gas_used;
+        canonical_executor.evm_gas_used = committed_state.evm_gas_used;
         canonical_executor.da_footprint_used = committed_state.blob_gas_used;
         canonical_executor.receipts = committed_state.receipts_iter().cloned().collect();
 
@@ -560,6 +561,7 @@ impl<S: StateRootStrategy> ExecutionStrategy<WorldChainEvmConfig, S>
         );
 
         executor.gas_used = committed_state.gas_used;
+        executor.evm_gas_used = committed_state.evm_gas_used;
         executor.da_footprint_used = committed_state.blob_gas_used;
         executor.receipts = committed_state.receipts_iter().cloned().collect();
 

--- a/e2e-tests/src/fuzz/fixtures.rs
+++ b/e2e-tests/src/fuzz/fixtures.rs
@@ -82,3 +82,50 @@ pub fn arb_execution_payload_sequence(
         },
     )
 }
+
+/// Strategy for generating a transaction sequence where each transaction's `gas_limit` field is
+/// fuzzed by over-provisioning the operation's estimate by a random amount.
+///
+/// The estimate is a lower bound (transactions never run out of gas), while the extra headroom
+/// drives the EVM's gas-refund accounting that the builder must track across chained flashblocks.
+pub fn arb_transaction_sequence_with_fuzzed_gas(
+    max_ops: usize,
+) -> impl Strategy<Value = Vec<(TxOp, u64, u64)>> {
+    arb_transaction_sequence(max_ops).prop_flat_map(|sequence| {
+        // One extra-gas value per transaction, up to ~5M gas of headroom.
+        let extras = prop::collection::vec(0u64..5_000_000u64, sequence.len());
+        extras.prop_map(move |extras| {
+            sequence
+                .iter()
+                .cloned()
+                .zip(extras)
+                .map(|((op, nonce), extra)| {
+                    let gas_limit = op.gas_limit().saturating_add(extra);
+                    (op, nonce, gas_limit)
+                })
+                .collect()
+        })
+    })
+}
+
+/// Strategy for generating a chained payload sequence whose transactions carry fuzzed gas limits.
+pub fn arb_execution_payload_sequence_with_fuzzed_gas(
+    transactions: usize,
+    max_flashblocks: usize,
+) -> impl Strategy<
+    Value = Vec<(
+        world_chain_primitives::primitives::ExecutionPayloadFlashblockDeltaV1,
+        Option<
+            world_chain_evm::execution::bal::CommittedState<
+                reth_optimism_evm::OpRethReceiptBuilder,
+            >,
+        >,
+    )>,
+> {
+    arb_transaction_sequence_with_fuzzed_gas(transactions).prop_filter_map(
+        "execution must succeed",
+        move |sequence: Vec<(TxOp, u64, u64)>| {
+            build_chained_payloads_with_gas_limits(sequence, max_flashblocks, true).ok()
+        },
+    )
+}

--- a/e2e-tests/src/fuzz/proptest.rs
+++ b/e2e-tests/src/fuzz/proptest.rs
@@ -54,6 +54,7 @@ fn unwrap_committed_state(
     state.unwrap_or_else(|| CommittedState {
         is_first: true,
         gas_used: 0,
+        evm_gas_used: 0,
         fees: U256::ZERO,
         receipts: vec![],
         transactions: vec![],

--- a/e2e-tests/src/fuzz/proptest.rs
+++ b/e2e-tests/src/fuzz/proptest.rs
@@ -76,7 +76,7 @@ mod property_tests {
     use crate::fuzz::{
         fixtures::{
             ALICE, BOB, ChaosTarget, TxOp, arb_execution_payload, arb_execution_payload_sequence,
-            build_chained_payloads,
+            arb_execution_payload_sequence_with_fuzzed_gas, build_chained_payloads,
         },
         proptest::{unwrap_committed_state, validate},
     };
@@ -295,6 +295,26 @@ mod property_tests {
                             debug_output(e);
                         }
                     prop_assert!(payload.is_ok(), "Parallel execution failed: {:#?}", payload.err());
+                }
+
+                /// Fuzz the per-transaction `gas_limit` field across chained flashblocks.
+                ///
+                /// Over-provisioning gas exercises the EVM gas-refund accounting that the builder
+                /// tracks via `CommittedState::evm_gas_used`: each committed flashblock's pre-refund
+                /// gas must flow into the next flashblock's validation. This guards against the
+                /// builder mis-accounting the effective gas limit when continuation builds inherit
+                /// committed state. Validation of every flashblock must succeed.
+                #[test]
+                fn prop_validate_fuzzed_gas_limits(payloads in (1usize..200, 1usize..20).prop_flat_map(|(max_txs, max_flashblocks)| { arb_execution_payload_sequence_with_fuzzed_gas(max_txs, max_flashblocks) })) {
+                    for (diff, committed_state) in payloads.into_iter() {
+                        let committed = unwrap_committed_state(committed_state);
+                        let payload = validate(&diff, committed);
+                        if let Err(err) = &payload
+                            && let Some(e) = err.downcast_ref::<BalExecutorError>() {
+                                debug_output(e);
+                            }
+                        prop_assert!(payload.is_ok(), "Parallel execution failed: {:#?}", payload.err());
+                    }
                 }
     }
 }

--- a/e2e-tests/src/it/testsuite.rs
+++ b/e2e-tests/src/it/testsuite.rs
@@ -33,11 +33,15 @@ use alloy_provider::{Provider, RootProvider};
 use alloy_rpc_client::RpcClient;
 use alloy_rpc_types_engine::PayloadId;
 use ed25519_dalek::SigningKey;
+use proptest::{
+    strategy::{Strategy, ValueTree},
+    test_runner::TestRunner,
+};
 use reth_network::{Peers, PeersInfo};
 use reth_network_peers::PeerId;
 use reth_tracing::tracing_subscriber::{self, util::SubscriberInitExt};
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fmt,
     io::Write,
     time::{SystemTime, UNIX_EPOCH},
@@ -323,6 +327,242 @@ async fn test_without_block_uncompressed_size_limit_includes_all_transactions() 
             .iter()
             .any(|tx| *tx.tx_hash() == tx3_hash),
         "tx3 should be included"
+    );
+
+    Ok(())
+}
+
+/// Sign a transaction that burns real gas via non-zero calldata, carrying an explicit `gas_limit`.
+///
+/// Under Prague (EIP-7623, active at Karst) every non-zero calldata byte costs a flat 40 gas, so
+/// `calldata_len` deterministically dials the transaction's *actual* (pre-refund) gas consumption,
+/// while `gas_limit` is what the builder reserves against the block limit. Accumulating real gas is
+/// what makes the reservation gate in `WorldChainPayloadBuilderCtx::execute_best_transactions`
+/// actually engage — a plain transfer (21k) never grows `cumulative_evm_gas_used` enough to matter.
+async fn signed_gas_burner(
+    signer_index: u32,
+    nonce: u64,
+    calldata_len: usize,
+    gas_limit: u64,
+) -> eyre::Result<(Bytes, B256)> {
+    let mut tx_request = tx(
+        CHAIN_SPEC.chain.id(),
+        Some(Bytes::from(vec![1u8; calldata_len])),
+        nonce,
+        Address::random(),
+        gas_limit,
+    );
+    tx_request.value = Some(U256::from(1));
+
+    let wallet = EthereumWallet::from(signer(signer_index));
+    let signed =
+        <TransactionRequest as NetworkTransactionBuilder<Ethereum>>::build(tx_request, &wallet)
+            .await?;
+
+    Ok((signed.encoded_2718().into(), *signed.tx_hash()))
+}
+
+/// Fuzz transaction gas through the real `WorldChainPayloadBuilder` / `WorldChainPayloadBuilderCtx`
+/// payload-building path **with flashblocks enabled**, deliberately overcommitting a block so the
+/// gas-limit overflow is caught at *validation* time (the reservation gate) rather than surfacing
+/// during the critical execution path.
+///
+/// The validator-side prop tests in `crate::fuzz` fuzz gas limits against the parallel BAL execution
+/// strategy. This is the producer-side counterpart: it drives gas-heavy transactions through the
+/// flashblocks builder via [`EngineDriver`], so `execute_best_transactions`' reservation logic is
+/// stressed *across* the chained flashblocks that make up each block (the continuation-build
+/// accounting that carries `cumulative_evm_gas_used` forward — the focus of this branch's fix).
+///
+/// Each transaction burns a fuzzed amount of real gas via non-zero calldata and carries a fuzzed,
+/// over-provisioned `gas_limit`. The total real gas injected far exceeds one block, forcing the
+/// builder to stop including transactions before the block overflows. Invariants:
+///
+/// 1. **Caps at validation, never overflows** – every built block reports `gas_used <= gas_limit`.
+///    The builder must reject the over-the-limit transaction at the `is_tx_over_limits` gate, not by
+///    failing mid-execution.
+/// 2. **Validator accepts every block** – the driver canonicalizes each block via `newPayload`; a
+///    block that overflowed (or a builder that mis-accounted gas) would be rejected there. Reaching
+///    the end means the builder produced only valid blocks.
+/// 3. **The gate actually engaged** – the load spills across multiple blocks and at least one block
+///    fills close to the limit, proving the overflow path was exercised rather than trivially fitting.
+/// 4. **No transaction is wrongly dropped** – deferred transactions drain over subsequent blocks.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_payload_builder_fuzzed_gas_limits_flashblocks() -> eyre::Result<()> {
+    use std::sync::Mutex;
+
+    reth_tracing::init_test_tracing();
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Constrain the built block to the genesis gas limit (30M, an unchanged value FCU accepts) so a
+    // modest number of gas-heavy transactions overcommits it and forces the reservation gate to fire.
+    const BLOCK_GAS_LIMIT: u64 = 30_000_000;
+    // Distinct funded senders (res/genesis.json funds 20 test-mnemonic accounts); signer 0 is skipped
+    // because the e2e chain spec funds it with only 0.1 ETH. Each sends one nonce-0 transaction.
+    const SENDERS: u32 = 12;
+    // Cycles to fully drain the overcommitted load.
+    const NUM_BLOCKS: usize = 5;
+    const BLOCK_INTERVAL: Duration = Duration::from_millis(2000);
+
+    let (_, nodes, _tasks, mut env, _spammer) = WorldChainTestBuilder::builder()
+        .nodes(1)
+        .flashblocks(true)
+        .build()
+        .setup::<WorldChainDefaultContext>()
+        .await?;
+
+    let builder_context = nodes[0].ext_context.clone().unwrap();
+    let block_hash = nodes[0].node.block_hash(0);
+    let chain_spec = nodes[0].node.inner.chain_spec().clone();
+
+    for node in &nodes {
+        node.node.update_forkchoice(block_hash, block_hash).await?;
+    }
+
+    // Deterministic runner so a failure reproduces from the same seed.
+    let mut runner = TestRunner::deterministic();
+    // Fuzz the real gas burned (via calldata length) and the over-provisioned headroom independently.
+    // At 40 gas/non-zero-byte each tx burns ~3.2M–4.4M real gas, so SENDERS of them (~46M) overcommit
+    // the 30M block; declared gas_limit always covers the floor cost (21k + 40*len) and stays below
+    // the block limit so the pool accepts every tx.
+    let calldata_len_strategy = 80_000usize..=110_000usize;
+    let headroom_strategy = 0u64..=3_000_000u64;
+
+    let mut injected: HashSet<Bytes> = HashSet::new();
+    for signer_index in 1..=SENDERS {
+        let calldata_len = calldata_len_strategy
+            .new_tree(&mut runner)
+            .expect("calldata strategy should produce a value")
+            .current();
+        let headroom = headroom_strategy
+            .new_tree(&mut runner)
+            .expect("headroom strategy should produce a value")
+            .current();
+        // Floor cost (21k + 40*len) plus slack, plus fuzzed over-provisioning.
+        let gas_limit = 40 * calldata_len as u64 + 100_000 + headroom;
+        let (raw, _hash) = signed_gas_burner(signer_index, 0, calldata_len, gas_limit).await?;
+        nodes[0].node.rpc.inject_tx(raw.clone()).await?;
+        injected.insert(raw);
+    }
+
+    let injected = Arc::new(injected);
+    // Every user tx observed across all built blocks.
+    let included: Arc<Mutex<HashSet<Bytes>>> = Arc::new(Mutex::new(HashSet::new()));
+    // Per-block (gas_used, gas_limit, user_tx_count).
+    let stats: Arc<Mutex<Vec<(u64, u64, usize)>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let builder_vk = builder_context
+        .flashblocks_handle
+        .builder_sk()
+        .unwrap()
+        .verifying_key();
+
+    let authorization_gen =
+        move |parent_hash: B256, attrs: reth_optimism_payload_builder::OpPayloadAttrs| {
+            let authorizer_sk = ed25519_dalek::SigningKey::from_bytes(&[0; 32]);
+            let payload_id = force_op_payload_id_v3(attrs.payload_id(&parent_hash));
+            world_chain_primitives::p2p::Authorization::new(
+                payload_id,
+                attrs.payload_attributes.timestamp,
+                &authorizer_sk,
+                builder_vk,
+            )
+        };
+
+    let mut driver = world_chain_test_utils::e2e_harness::actions::EngineDriver {
+        builder_idx: 0,
+        follower_idxs: vec![],
+        initial_parent_hash: Some(block_hash),
+        num_blocks: NUM_BLOCKS,
+        block_interval: BLOCK_INTERVAL,
+        flashblocks: true,
+        authorization_gen,
+        attributes_gen: Box::new({
+            let chain_spec = chain_spec.clone();
+            move |_block_number, timestamp| {
+                let eip1559 = encode_eip1559_params(chain_spec.as_ref(), timestamp)?;
+                let mut attrs = build_payload_attributes(
+                    timestamp,
+                    eip1559,
+                    Some(vec![TX_SET_L1_BLOCK.clone()]),
+                );
+                attrs.0.gas_limit = Some(BLOCK_GAS_LIMIT);
+                Ok(attrs)
+            }
+        }),
+        during_build: None,
+        on_block: Some(Box::new({
+            let injected = injected.clone();
+            let included = included.clone();
+            let stats = stats.clone();
+            move |_block_num, payload| {
+                let injected = injected.clone();
+                let included = included.clone();
+                let stats = stats.clone();
+
+                let inner = &payload
+                    .execution_payload
+                    .payload_inner
+                    .payload_inner
+                    .payload_inner;
+                let gas_used = inner.gas_used;
+                let gas_limit = inner.gas_limit;
+                let transactions = inner.transactions.clone();
+
+                Box::pin(async move {
+                    let mut included = included.lock().unwrap();
+                    let mut user_txs = 0;
+                    for raw in &transactions {
+                        if injected.contains(raw) {
+                            included.insert(raw.clone());
+                            user_txs += 1;
+                        }
+                    }
+                    stats.lock().unwrap().push((gas_used, gas_limit, user_txs));
+                    Ok(())
+                })
+            }
+        })),
+    };
+
+    driver.execute(&mut env).await?;
+
+    let stats = stats.lock().unwrap();
+
+    // Invariant 1: the builder caps every block at its gas limit. A correct reservation gate stops
+    // including transactions *before* the block overflows; it never produces gas_used > gas_limit.
+    for (i, (gas_used, gas_limit, _)) in stats.iter().enumerate() {
+        assert!(
+            gas_used <= gas_limit,
+            "block {i}: gas_used {gas_used} exceeds gas_limit {gas_limit}",
+        );
+    }
+
+    // Invariant 2: the driver canonicalized every block via newPayload, so reaching here means the
+    // validator accepted each block — an overflow would have surfaced as an Invalid status, i.e. it
+    // is caught at validation time rather than crashing the critical execution path.
+
+    // Invariant 3: the fuzzed load genuinely overcommitted a single block, so the gate had to defer
+    // transactions across blocks and at least one block filled close to the limit.
+    let block_gas_limit = stats.first().map(|(_, l, _)| *l).unwrap_or(BLOCK_GAS_LIMIT);
+    let blocks_with_user_txs = stats.iter().filter(|(_, _, n)| *n > 0).count();
+    assert!(
+        blocks_with_user_txs >= 2,
+        "expected the overcommitted load to spill across >= 2 blocks, got {blocks_with_user_txs}",
+    );
+    let max_gas_used = stats.iter().map(|(g, _, _)| *g).max().unwrap_or(0);
+    assert!(
+        max_gas_used > block_gas_limit / 2,
+        "expected at least one block to fill past half its gas limit; max gas_used was {max_gas_used} of {block_gas_limit}",
+    );
+
+    // Invariant 4: deferred transactions are never dropped — they all drain across the driven blocks.
+    let included = included.lock().unwrap();
+    assert_eq!(
+        included.len(),
+        injected.len(),
+        "{} of {} fuzzed transactions were never included across {NUM_BLOCKS} blocks",
+        injected.len() - included.len(),
+        injected.len(),
     );
 
     Ok(())


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core payload building and flashblock validation gas accounting; incorrect refund math could reject valid txs or over-include, but scope is focused and covered by a unit test for `pre_refund_gas_used`.
> 
> **Overview**
> Fixes **pre-flight transaction validation** when continuing a flashblock build on top of a committed payload: block header **gas used** is canonical (after SDM/post-exec refunds), but the executor enforces limits against **pre-refund** gas.
> 
> Adds **`evm_gas_used`** on **`CommittedState`**, reconstructed via **`pre_refund_gas_used`** from post-exec **`gas_refund_entries`**. **`effective_gas_limit`** now subtracts committed **`evm_gas_used`** instead of **`gas_used`**. Pool execution records pre-refund gas through **`execute_transaction_with_result_closure`** and **`PreRefundGasUsed`**, and continuation builds reset **`cumulative_evm_gas_used`** to zero while seeding block executors with committed **`evm_gas_used`**. Builder, validator, and test fixtures are updated consistently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 162da9ffe05f81642cdbee10f7b58a23620872c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->