### PR TITLE
chore: rename prover-service tables

### DIFF
--- a/docs/proof/prover-service-postgres-workflow.md
+++ b/docs/proof/prover-service-postgres-workflow.md
@@ -61,7 +61,7 @@ enum BackendProofPhase {
 }
 
 impl BackendProofPhase {
-    /// Stable database representation stored in `proof_backend_jobs.phase`.
+    /// Stable database representation stored in `proof_sessions.phase`.
     fn as_str(self) -> &'static str {
         match self {
             Self::Range => "range",
@@ -130,7 +130,7 @@ enum BackendUpdate {
     Pending {
         state: BackendProofState,
     },
-    /// Final proof is complete and can be stored in `proof_jobs.proof_data`.
+    /// Final proof is complete and can be stored in `proof_requests.proof_data`.
     ///
     /// Intermediate SP1 range proofs must not be returned as `Complete`. The SP1 backend consumes
     /// completed range proofs internally and returns
@@ -156,7 +156,7 @@ The defender-facing API stays unchanged:
 - `proof_status(ProofRequestId) -> ProofStatus`
 - `get_proof(ProofRequestId) -> ProofResponse`
 
-`proof_status` returns the high-level `proof_jobs.status`. It should not expose backend polling
+`proof_status` returns the high-level `proof_requests.status`. It should not expose backend polling
 details by default. If operators need more detail later, add a separate detail API instead of
 overloading the simple status enum.
 
@@ -192,9 +192,9 @@ backend job for another poll, and only marks the backend job plus parent proof j
 `ProofSubmissionLease` because final proofs can come from two places:
 
 - Nitro currently completes directly from `backend.start`, so submission must validate the
-  `proof_jobs.lease_token`.
+  `proof_requests.lease_token`.
 - SP1 completes from `backend.advance` on the aggregation backend job, so submission must validate
-  the `proof_backend_jobs.lease_token` for the aggregation row and mark that row `Completed`. The
+  the `proof_sessions.lease_token` for the aggregation row and mark that row `Completed`. The
   worker reports that path through `complete_backend_proof_job(..., BackendUpdate::Complete(_))`.
 
 The final method names can be adjusted, but every worker update should carry the lease token for
@@ -206,9 +206,9 @@ the row being updated.
 - `start(request: &ProofRequest) -> BackendUpdate`
 - `advance(request: &ProofRequest, state: BackendProofState) -> BackendUpdate`
 
-`start` is called once a user-facing proof request is leased from `proof_jobs`.
+`start` is called once a user-facing proof request is leased from `proof_requests`.
 
-`advance` is called for already-created external backend work stored in `proof_backend_jobs`.
+`advance` is called for already-created external backend work stored in `proof_sessions`.
 
 The generic worker does not understand SP1 range or aggregation internals. It only applies
 `BackendUpdate` values. The concrete backend decides whether a completed external backend request is
@@ -219,7 +219,7 @@ an intermediate proof or a final proof.
 ### SP1
 
 1. `ProofWorker` calls `get_next_proof(Sp1)` to get the next SP1 proof request to satisfy.
-2. `prover-service` claims one queued SP1 `proof_jobs` row, sets it to `Starting`, writes
+2. `prover-service` claims one queued SP1 `proof_requests` row, sets it to `Starting`, writes
    `locked_until`, writes a fresh `lease_token`, increments `start_attempts`, and returns
    `LeasedProofRequest`.
 3. Worker calls `sp1_backend.start(request)`.
@@ -236,8 +236,8 @@ an intermediate proof or a final proof.
    ```
 
 7. Worker calls `submit_backend_proof_state(proof_id, Range { id }, lease_token)`.
-8. `prover-service` accepts the update only if the `proof_jobs.lease_token` still matches.
-9. `prover-service` inserts a `proof_backend_jobs` row for the SP1 range proof and transitions the
+8. `prover-service` accepts the update only if the `proof_requests.lease_token` still matches.
+9. `prover-service` inserts a `proof_sessions` row for the SP1 range proof and transitions the
    proof job to:
 
    ```text
@@ -247,7 +247,7 @@ an intermediate proof or a final proof.
    ```
 
 10. Later, any SP1 `ProofWorker` calls `get_next_backend_proof(Sp1)`.
-11. `prover-service` claims a due `proof_backend_jobs` row, writes `locked_until`, writes a fresh
+11. `prover-service` claims a due `proof_sessions` row, writes `locked_until`, writes a fresh
     `lease_token`, and returns the original request plus `BackendProofState::Range { id }`.
 12. Worker calls `sp1_backend.advance(request, BackendProofState::Range { id })`.
 13. SP1 backend polls SP1 network for the range proof status.
@@ -273,7 +273,7 @@ an intermediate proof or a final proof.
 
 18. Worker reports the `Pending` update for the leased range backend job.
 19. `prover-service` marks the range backend job `Completed` and inserts a new
-    `proof_backend_jobs` row for the aggregation proof.
+    `proof_sessions` row for the aggregation proof.
 20. Later, any SP1 worker calls `get_next_backend_proof(Sp1)` again.
 21. `prover-service` returns the original request plus `BackendProofState::Aggregation { id }`.
 22. SP1 backend polls SP1 network for the aggregation proof status.
@@ -300,14 +300,14 @@ an intermediate proof or a final proof.
     `get_next_backend_proof(Sp1)` for the aggregation backend job.
 
 27. `prover-service` accepts the submission only if the aggregation
-    `proof_backend_jobs.lease_token` still matches.
+    `proof_sessions.lease_token` still matches.
 28. `prover-service` marks the aggregation backend job `Completed`, clears its lease, stores the
-    final proof in `proof_jobs.proof_data`, and marks the proof job `Completed`.
+    final proof in `proof_requests.proof_data`, and marks the proof job `Completed`.
 
 ### Nitro TEE
 
 1. `ProofWorker` calls `get_next_proof(Nitro)` to get the next Nitro proof request to satisfy.
-2. `prover-service` claims one queued Nitro `proof_jobs` row, sets it to `Starting`, writes
+2. `prover-service` claims one queued Nitro `proof_requests` row, sets it to `Starting`, writes
    `locked_until`, writes a fresh `lease_token`, increments `start_attempts`, and returns
    `LeasedProofRequest`.
 3. Worker calls `nitro_backend.start(request)`.
@@ -327,21 +327,21 @@ an intermediate proof or a final proof.
    )
    ```
 
-7. `prover-service` accepts the update only if the `proof_jobs.lease_token` still matches, stores
+7. `prover-service` accepts the update only if the `proof_requests.lease_token` still matches, stores
    the proof, and marks the proof job `Completed`.
 
-Nitro does not need `proof_backend_jobs` today. If Nitro later becomes async, `nitro_backend.start`
+Nitro does not need `proof_sessions` today. If Nitro later becomes async, `nitro_backend.start`
 can return `Pending { state: BackendProofState::Single { id } }`, and the same backend job polling
 machinery can resume it.
 
 ## Postgres Tables
 
-### `proof_jobs`
+### `proof_requests`
 
 One row per user-facing proof request.
 
 ```sql
-create table proof_jobs (
+create table proof_requests (
     proof_id            bytea primary key,
     backend             text not null,
     game                bytea not null,
@@ -366,20 +366,20 @@ create table proof_jobs (
 Recommended constraints:
 
 ```sql
-alter table proof_jobs
-    add constraint proof_jobs_status_check
+alter table proof_requests
+    add constraint proof_requests_status_check
     check (status in ('queued', 'starting', 'backend_pending', 'completed', 'failed'));
 
-create index proof_jobs_queued_idx
-    on proof_jobs (backend, created_at)
+create index proof_requests_queued_idx
+    on proof_requests (backend, created_at)
     where status = 'queued';
 
-create index proof_jobs_starting_lease_idx
-    on proof_jobs (locked_until)
+create index proof_requests_starting_lease_idx
+    on proof_requests (locked_until)
     where status = 'starting';
 ```
 
-### `proof_backend_jobs`
+### `proof_sessions`
 
 Durable external backend work.
 
@@ -389,9 +389,9 @@ id. Keeping `phase` in SQL makes the state queryable and lets Postgres enforce u
 `unique (proof_id, phase)`.
 
 ```sql
-create table proof_backend_jobs (
+create table proof_sessions (
     id                  bigserial primary key,
-    proof_id            bytea not null references proof_jobs(proof_id),
+    proof_id            bytea not null references proof_requests(proof_id),
 
     backend             text not null,
     phase               text not null,
@@ -418,20 +418,20 @@ create table proof_backend_jobs (
 Recommended constraints:
 
 ```sql
-alter table proof_backend_jobs
-    add constraint proof_backend_jobs_status_check
+alter table proof_sessions
+    add constraint proof_sessions_status_check
     check (status in ('requested', 'completed', 'failed'));
 
-alter table proof_backend_jobs
-    add constraint proof_backend_jobs_phase_check
+alter table proof_sessions
+    add constraint proof_sessions_phase_check
     check (phase in ('single', 'range', 'aggregation'));
 
-create index proof_backend_jobs_due_idx
-    on proof_backend_jobs (backend, next_poll_at)
+create index proof_sessions_due_idx
+    on proof_sessions (backend, next_poll_at)
     where status = 'requested';
 
-create index proof_backend_jobs_lease_idx
-    on proof_backend_jobs (locked_until)
+create index proof_sessions_lease_idx
+    on proof_sessions (locked_until)
     where status = 'requested';
 ```
 
@@ -467,9 +467,9 @@ bound from the Rust enums, such as `ProofStatus::Queued.as_str()` and
 It prevents two workers from owning the same state transition after the database transaction that
 claimed the row has committed.
 
-### `proof_jobs.locked_until`
+### `proof_requests.locked_until`
 
-`proof_jobs.locked_until` protects only the short initial start phase.
+`proof_requests.locked_until` protects only the short initial start phase.
 
 It is used when a worker claims a queued proof via `get_next_proof`. The worker owns the row while
 it calls `backend.start(request)`.
@@ -480,7 +480,7 @@ back to `Queued`, or directly in the claim query. The direct approach looks like
 
 ```sql
 select proof_id
-from proof_jobs
+from proof_requests
 where backend = $1
   and (
     status = $queued_status
@@ -494,7 +494,7 @@ limit 1;
 Then:
 
 ```sql
-update proof_jobs
+update proof_requests
 set status = $starting_status,
     locked_until = $locked_until,
     lease_token = $lease_token,
@@ -517,15 +517,15 @@ locked_until = null
 lease_token = null
 ```
 
-At that point, the long-running proof generation is represented by `proof_backend_jobs`, and the
+At that point, the long-running proof generation is represented by `proof_sessions`, and the
 original proof job must not be leased by `get_next_proof` again.
 
 If the worker dies during `start()`, `locked_until` eventually expires. The job can then be retried
 by another worker.
 
-### `proof_backend_jobs.locked_until`
+### `proof_sessions.locked_until`
 
-`proof_backend_jobs.locked_until` protects backend polling and phase advancement.
+`proof_sessions.locked_until` protects backend polling and phase advancement.
 
 It is used when a worker claims backend work via `get_next_backend_proof`. This prevents duplicate
 workers from polling the same completed SP1 range proof and both requesting aggregation proofs.
@@ -534,7 +534,7 @@ Claiming backend work should happen inside a transaction:
 
 ```sql
 select id
-from proof_backend_jobs
+from proof_sessions
 where backend = $1
   and status = $requested_status
   and next_poll_at <= $now
@@ -547,7 +547,7 @@ limit 1;
 Then:
 
 ```sql
-update proof_backend_jobs
+update proof_sessions
 set locked_until = $locked_until,
     lease_token = $lease_token,
     updated_at = $now
@@ -557,7 +557,7 @@ where id = $backend_job_id;
 If `advance()` returns `Noop`, clear the lease and schedule the next poll:
 
 ```sql
-update proof_backend_jobs
+update proof_sessions
 set locked_until = null,
     lease_token = null,
     next_poll_at = $next_poll_at,
@@ -600,7 +600,7 @@ The service must ignore Worker A's update because it carries stale token `A`.
 Every update should therefore include the lease token, and the SQL update should check it:
 
 ```sql
-update proof_jobs
+update proof_requests
 set status = $failed_status,
     failure_reason = $reason,
     locked_until = null,
@@ -615,7 +615,7 @@ where proof_id = $proof_id
 If this update affects zero rows, the lease is stale. The service should return a stale lease error
 or treat it as a no-op. It must not overwrite the newer owner.
 
-The same rule applies to `proof_backend_jobs`. A stale worker must not be able to:
+The same rule applies to `proof_sessions`. A stale worker must not be able to:
 
 - mark a backend job failed after another worker reclaimed it;
 - request and persist a duplicate next phase;
@@ -625,7 +625,7 @@ The same rule applies to `proof_backend_jobs`. A stale worker must not be able t
 
 The two attempts counters measure different retry layers.
 
-### `proof_jobs.start_attempts`
+### `proof_requests.start_attempts`
 
 `start_attempts` counts how many times workers tried to start backend work for the user-facing proof
 request.
@@ -642,12 +642,12 @@ It covers failures before durable external backend work has been persisted:
 - the proof job start lease expires before the worker reports an update.
 
 For SP1, once `start()` succeeds and the range `backend_proof_id` is persisted,
-`start_attempts` should stop changing. Further progress is tracked by `proof_backend_jobs`.
+`start_attempts` should stop changing. Further progress is tracked by `proof_sessions`.
 
 If `start_attempts` reaches the configured maximum, the service should mark the proof job `Failed`
 instead of requeueing it.
 
-### `proof_backend_jobs.advance_attempts`
+### `proof_sessions.advance_attempts`
 
 `advance_attempts` counts failed attempts to advance an already-created external backend job. It
 must not count healthy polls where the backend is still working.
@@ -702,13 +702,13 @@ With `next_poll_at`:
 ### SP1 success path
 
 ```text
-proof_jobs:
+proof_requests:
 Queued
   -> Starting
   -> BackendPending
   -> Completed
 
-proof_backend_jobs:
+proof_sessions:
 Range Requested
   -> Range Completed
   -> Aggregation Requested
@@ -718,22 +718,22 @@ Range Requested
 ### Nitro success path
 
 ```text
-proof_jobs:
+proof_requests:
 Queued
   -> Starting
   -> Completed
 
-proof_backend_jobs:
+proof_sessions:
 no rows
 ```
 
 ### SP1 range still pending
 
 ```text
-proof_jobs:
+proof_requests:
 BackendPending
 
-proof_backend_jobs:
+proof_sessions:
 Range Requested
   locked_until = null
   next_poll_at = future timestamp
@@ -742,11 +742,11 @@ Range Requested
 ### Worker dies during SP1 `start`
 
 ```text
-proof_jobs:
+proof_requests:
 Starting with expired locked_until
   -> claimed again as Starting by another worker, or requeued by a background reaper
 
-proof_backend_jobs:
+proof_sessions:
 no row unless the first worker successfully persisted a backend id
 ```
 
@@ -757,10 +757,10 @@ pre-submission record. For a first version, this is an acceptable tradeoff to do
 ### Worker dies while polling SP1 backend work
 
 ```text
-proof_jobs:
+proof_requests:
 BackendPending
 
-proof_backend_jobs:
+proof_sessions:
 Requested with expired locked_until
   -> claimed by another worker
 ```

--- a/proofs/prover-service/migrations/20260619_proof_requests.sql
+++ b/proofs/prover-service/migrations/20260619_proof_requests.sql
@@ -1,4 +1,4 @@
-create table proof_jobs (
+create table proof_requests (
     proof_id            bytea primary key,
     backend             text not null,
     game                bytea not null,
@@ -18,21 +18,21 @@ create table proof_jobs (
     updated_at          timestamptz not null,
     finished_at         timestamptz null,
 
-    constraint proof_jobs_status_check
+    constraint proof_requests_status_check
         check (status in ('queued', 'starting', 'backend_pending', 'completed', 'failed'))
 );
 
-create index proof_jobs_queued_idx
-    on proof_jobs (backend, created_at)
+create index proof_requests_queued_idx
+    on proof_requests (backend, created_at)
     where status = 'queued';
 
-create index proof_jobs_starting_lease_idx
-    on proof_jobs (locked_until)
+create index proof_requests_starting_lease_idx
+    on proof_requests (locked_until)
     where status = 'starting';
 
-create table proof_backend_jobs (
+create table proof_sessions (
     id                  bigserial primary key,
-    proof_id            bytea not null references proof_jobs(proof_id),
+    proof_id            bytea not null references proof_requests(proof_id),
 
     backend             text not null,
     phase               text not null,
@@ -54,16 +54,16 @@ create table proof_backend_jobs (
     unique (backend, backend_proof_id),
     unique (proof_id, phase),
 
-    constraint proof_backend_jobs_status_check
+    constraint proof_sessions_status_check
         check (status in ('requested', 'completed', 'failed')),
-    constraint proof_backend_jobs_phase_check
+    constraint proof_sessions_phase_check
         check (phase in ('single', 'range', 'aggregation'))
 );
 
-create index proof_backend_jobs_due_idx
-    on proof_backend_jobs (backend, next_poll_at)
+create index proof_sessions_due_idx
+    on proof_sessions (backend, next_poll_at)
     where status = 'requested';
 
-create index proof_backend_jobs_lease_idx
-    on proof_backend_jobs (locked_until)
+create index proof_sessions_lease_idx
+    on proof_sessions (locked_until)
     where status = 'requested';

--- a/proofs/prover-service/src/store.rs
+++ b/proofs/prover-service/src/store.rs
@@ -82,7 +82,7 @@ impl ProverServiceStore {
         let mut tx = self.begin_request_tx().await?;
 
         if let Some(row) =
-            sqlx::query("select status from proof_jobs where proof_id = $1 for update")
+            sqlx::query("select status from proof_requests where proof_id = $1 for update")
                 .bind(&proof_id)
                 .fetch_optional(&mut *tx)
                 .await
@@ -90,13 +90,13 @@ impl ProverServiceStore {
         {
             let status = parse_status(row.try_get("status").map_err(request_db)?)?;
             if status == ProofStatus::Failed {
-                sqlx::query("delete from proof_backend_jobs where proof_id = $1")
+                sqlx::query("delete from proof_sessions where proof_id = $1")
                     .bind(&proof_id)
                     .execute(&mut *tx)
                     .await
                     .map_err(request_db)?;
                 sqlx::query(
-                    "update proof_jobs
+                    "update proof_requests
                      set status = $2,
                          proof_data = null,
                          failure_reason = null,
@@ -120,7 +120,7 @@ impl ProverServiceStore {
         }
 
         let queued: i64 = sqlx::query_scalar(
-            "select count(*) from proof_jobs where backend = $1 and status = $2",
+            "select count(*) from proof_requests where backend = $1 and status = $2",
         )
         .bind(backend.as_str())
         .bind(ProofStatus::Queued.as_str())
@@ -132,7 +132,7 @@ impl ProverServiceStore {
         }
 
         sqlx::query(
-            "insert into proof_jobs (
+            "insert into proof_requests (
                 proof_id, backend, game, root_claim, l2_block_number, l1_head,
                 status, created_at, updated_at
              )
@@ -159,7 +159,7 @@ impl ProverServiceStore {
         &self,
         proof_id: ProofRequestId,
     ) -> Result<ProofStatus, ProofRequestError> {
-        let row = sqlx::query("select status from proof_jobs where proof_id = $1")
+        let row = sqlx::query("select status from proof_requests where proof_id = $1")
             .bind(proof_id_bytes(proof_id))
             .fetch_optional(&self.pool)
             .await
@@ -173,7 +173,7 @@ impl ProverServiceStore {
         proof_id: ProofRequestId,
     ) -> Result<ProofResponse, ProofRequestError> {
         let row = sqlx::query(
-            "select status, proof_data, failure_reason from proof_jobs where proof_id = $1",
+            "select status, proof_data, failure_reason from proof_requests where proof_id = $1",
         )
         .bind(proof_id_bytes(proof_id))
         .fetch_optional(&self.pool)
@@ -218,7 +218,7 @@ impl ProverServiceStore {
             let Some(row) = sqlx::query(
                 "select proof_id, backend, game, root_claim, l2_block_number, l1_head,
                         start_attempts
-                 from proof_jobs
+                 from proof_requests
                  where backend = $1
                    and (
                      status = $2
@@ -256,7 +256,7 @@ impl ProverServiceStore {
             let lease_token = LeaseToken::new();
             let locked_until = timestamp_after(now, self.config.lease_timeout);
             sqlx::query(
-                "update proof_jobs
+                "update proof_requests
                  set status = $2,
                      locked_until = $3,
                      lease_token = $4,
@@ -291,7 +291,7 @@ impl ProverServiceStore {
         let now = db_now();
         let mut tx = self.begin_queue_tx().await?;
         let backend: Option<String> = sqlx::query_scalar(
-            "update proof_jobs
+            "update proof_requests
              set status = $3,
                  locked_until = null,
                  lease_token = null,
@@ -315,7 +315,7 @@ impl ProverServiceStore {
         };
 
         sqlx::query(
-            "insert into proof_backend_jobs (
+            "insert into proof_sessions (
                 proof_id, backend, phase, backend_proof_id, status,
                 next_poll_at, created_at, updated_at
              )
@@ -356,8 +356,8 @@ impl ProverServiceStore {
                      pj.root_claim,
                      pj.l2_block_number,
                      pj.l1_head
-                 from proof_backend_jobs bj
-                 join proof_jobs pj on pj.proof_id = bj.proof_id
+                 from proof_sessions bj
+                 join proof_requests pj on pj.proof_id = bj.proof_id
                  where bj.backend = $1
                    and bj.status = $2
                    and bj.next_poll_at <= $3
@@ -412,7 +412,7 @@ impl ProverServiceStore {
             let lease_token = LeaseToken::new();
             let locked_until = timestamp_after(now, self.config.lease_timeout);
             sqlx::query(
-                "update proof_backend_jobs
+                "update proof_sessions
                  set locked_until = $2,
                      lease_token = $3,
                      advance_attempts = $4,
@@ -450,7 +450,7 @@ impl ProverServiceStore {
         let mut tx = self.begin_queue_tx().await?;
         let row = sqlx::query(
             "select start_attempts, backend
-             from proof_jobs
+             from proof_requests
              where proof_id = $1
                and lease_token = $2
                and status = $3
@@ -476,7 +476,7 @@ impl ProverServiceStore {
         } else {
             let now = db_now();
             sqlx::query(
-                "update proof_jobs
+                "update proof_requests
                  set status = $2,
                      locked_until = null,
                      lease_token = null,
@@ -505,7 +505,7 @@ impl ProverServiceStore {
         let next_poll_at = timestamp_after(now, self.config.backend_poll_interval);
         let mut tx = self.begin_queue_tx().await?;
         let result = sqlx::query(
-            "update proof_backend_jobs
+            "update proof_sessions
              set locked_until = null,
                  lease_token = null,
                  next_poll_at = $3,
@@ -539,7 +539,7 @@ impl ProverServiceStore {
         let now = db_now();
         let mut tx = self.begin_queue_tx().await?;
         let row = sqlx::query(
-            "update proof_backend_jobs
+            "update proof_sessions
              set status = $3,
                  locked_until = null,
                  lease_token = null,
@@ -566,7 +566,7 @@ impl ProverServiceStore {
         let backend: String = row.try_get("backend").map_err(queue_db)?;
 
         sqlx::query(
-            "insert into proof_backend_jobs (
+            "insert into proof_sessions (
                 proof_id, backend, phase, backend_proof_id, status,
                 next_poll_at, created_at, updated_at
              )
@@ -595,7 +595,7 @@ impl ProverServiceStore {
         let mut tx = self.begin_queue_tx().await?;
         let row = sqlx::query(
             "select proof_id, advance_attempts
-             from proof_backend_jobs
+             from proof_sessions
              where id = $1
                and lease_token = $2
                and status = $3
@@ -624,7 +624,7 @@ impl ProverServiceStore {
             let now = db_now();
             let next_poll_at = timestamp_after(now, self.config.backend_poll_interval);
             sqlx::query(
-                "update proof_backend_jobs
+                "update proof_sessions
                  set locked_until = null,
                      lease_token = null,
                      next_poll_at = $3,
@@ -659,7 +659,7 @@ impl ProverServiceStore {
         let now = db_now();
         let mut tx = self.begin_queue_tx().await?;
         let row = sqlx::query(
-            "update proof_backend_jobs
+            "update proof_sessions
              set status = $3,
                  failure_reason = $4,
                  locked_until = null,
@@ -721,7 +721,7 @@ impl ProverServiceStore {
         let mut tx = self.begin_queue_tx().await?;
         let row = sqlx::query(
             "select proof_id
-             from proof_backend_jobs
+             from proof_sessions
              where id = $1
                and lease_token = $2
                and status = $3",
@@ -749,7 +749,7 @@ impl ProverServiceStore {
         let mut tx = self.begin_queue_tx().await?;
         let row = sqlx::query(
             "select backend
-             from proof_jobs
+             from proof_requests
              where proof_id = $1
                and lease_token = $2
                and status = $3
@@ -812,8 +812,8 @@ impl ProverServiceStore {
         let mut tx = self.begin_queue_tx().await?;
         let row = sqlx::query(
             "select bj.proof_id, pj.backend
-             from proof_backend_jobs bj
-             join proof_jobs pj on pj.proof_id = bj.proof_id
+             from proof_sessions bj
+             join proof_requests pj on pj.proof_id = bj.proof_id
              where bj.id = $1
                and bj.lease_token = $2
                and bj.status = $3
@@ -842,7 +842,7 @@ impl ProverServiceStore {
 
         let now = db_now();
         sqlx::query(
-            "update proof_backend_jobs
+            "update proof_sessions
              set status = $2,
                  locked_until = null,
                  lease_token = null,
@@ -1018,7 +1018,7 @@ async fn classify_proof_update(
     proof_id: ProofRequestId,
 ) -> ProofJobQueueError {
     let exists = sqlx::query_scalar::<_, bool>(
-        "select exists(select 1 from proof_jobs where proof_id = $1)",
+        "select exists(select 1 from proof_requests where proof_id = $1)",
     )
     .bind(proof_id_bytes(proof_id))
     .fetch_one(&mut **tx)
@@ -1036,7 +1036,7 @@ async fn classify_backend_update(
     backend_job_id: i64,
 ) -> ProofJobQueueError {
     let exists = sqlx::query_scalar::<_, bool>(
-        "select exists(select 1 from proof_backend_jobs where id = $1)",
+        "select exists(select 1 from proof_sessions where id = $1)",
     )
     .bind(backend_job_id)
     .fetch_one(&mut **tx)
@@ -1056,7 +1056,7 @@ async fn mark_proof_failed(
     now: DbTimestamp,
 ) -> Result<(), sqlx::Error> {
     sqlx::query(
-        "update proof_jobs
+        "update proof_requests
          set status = $2,
              proof_data = null,
              failure_reason = $3,
@@ -1083,7 +1083,7 @@ async fn mark_backend_failed(
     now: DbTimestamp,
 ) -> Result<(), sqlx::Error> {
     sqlx::query(
-        "update proof_backend_jobs
+        "update proof_sessions
          set status = $2,
              failure_reason = $3,
              locked_until = null,
@@ -1109,7 +1109,7 @@ async fn complete_proof(
     let proof_data =
         serde_json::to_vec(&proof.proof).map_err(|err| sqlx::Error::Decode(Box::new(err)))?;
     sqlx::query(
-        "update proof_jobs
+        "update proof_requests
          set status = $2,
              proof_data = $3,
              failure_reason = null,

--- a/proofs/prover-service/src/store.rs
+++ b/proofs/prover-service/src/store.rs
@@ -1035,13 +1035,12 @@ async fn classify_backend_update(
     tx: &mut Transaction<'_, Postgres>,
     backend_job_id: i64,
 ) -> ProofJobQueueError {
-    let exists = sqlx::query_scalar::<_, bool>(
-        "select exists(select 1 from proof_sessions where id = $1)",
-    )
-    .bind(backend_job_id)
-    .fetch_one(&mut **tx)
-    .await
-    .unwrap_or(false);
+    let exists =
+        sqlx::query_scalar::<_, bool>("select exists(select 1 from proof_sessions where id = $1)")
+            .bind(backend_job_id)
+            .fetch_one(&mut **tx)
+            .await
+            .unwrap_or(false);
     if exists {
         ProofJobQueueError::StaleLease
     } else {

--- a/proofs/prover-service/src/tests.rs
+++ b/proofs/prover-service/src/tests.rs
@@ -462,7 +462,7 @@ async fn failed_completed_backend_submission_releases_lease() {
         .unwrap()
         .expect("backend lease");
 
-    sqlx::query("update proof_jobs set backend = 'corrupt' where proof_id = $1")
+    sqlx::query("update proof_requests set backend = 'corrupt' where proof_id = $1")
         .bind(id.0.as_slice())
         .execute(service.pool())
         .await
@@ -482,7 +482,7 @@ async fn failed_completed_backend_submission_releases_lease() {
     let row = sqlx::query(
         "select status, advance_attempts, locked_until is null as unlocked,
                 lease_token is null as lease_cleared
-         from proof_backend_jobs
+         from proof_sessions
          where id = $1",
     )
     .bind(backend.backend_job_id)

--- a/proofs/prover-service/src/types.rs
+++ b/proofs/prover-service/src/types.rs
@@ -288,7 +288,7 @@ impl std::fmt::Display for LeaseToken {
     }
 }
 
-/// Initial proof request leased from `proof_jobs`.
+/// Initial proof request leased from `proof_requests`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LeasedProofRequest {
     /// The user-facing proof request.
@@ -356,7 +356,7 @@ pub struct BackendProofWork {
     pub state: BackendProofState,
 }
 
-/// Durable backend job leased from `proof_backend_jobs`.
+/// Durable backend job leased from `proof_sessions`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LeasedBackendProofWork {
     /// Database identifier of the backend job row.
@@ -372,14 +372,14 @@ pub struct LeasedBackendProofWork {
 pub enum ProofSubmissionLease {
     /// Final proof was produced while starting a user-facing proof job.
     ProofJob {
-        /// Token for the leased `proof_jobs` row.
+        /// Token for the leased `proof_requests` row.
         lease_token: LeaseToken,
     },
     /// Final proof was produced while advancing a durable backend job.
     BackendJob {
         /// Database identifier of the backend job row.
         backend_job_id: i64,
-        /// Token for the leased `proof_backend_jobs` row.
+        /// Token for the leased `proof_sessions` row.
         lease_token: LeaseToken,
     },
 }


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4744/rename-tables

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical identifier rename with no logic changes; risk is limited to environments that still expect the old table names without a separate migration path.
> 
> **Overview**
> Renames the prover-service Postgres schema and all references from **`proof_jobs`** → **`proof_requests`** and **`proof_backend_jobs`** → **`proof_sessions`**, including table definitions, constraints, indexes, and foreign keys in the migration.
> 
> **`store.rs`** SQL is updated throughout (queueing, leasing, backend polling, completion/failure paths); **`types.rs`** doc comments and the workflow doc are aligned with the new names. Tests that touch tables directly use the new table names. **No API or queue/lease behavior changes**—this is a naming-only refactor for fresh deployments using the updated migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92e1ac116b774c30353a338f4c1c495c9275c8fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->