### PR TITLE
refactor(prover-service): change some db fields

### DIFF
--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -2689,6 +2689,7 @@ async fn start_sp1_worker(
         queue,
         backend,
         ProofWorkerConfig {
+            worker_id: "devnet-sp1-worker".to_string(),
             poll_interval: SP1_WORKER_POLL_INTERVAL,
             max_concurrent_jobs: 1,
         },

--- a/docs/proof/prover-service-postgres-workflow.md
+++ b/docs/proof/prover-service-postgres-workflow.md
@@ -16,7 +16,7 @@ job table can be extended with a `phase_index` column.
 - Keep SP1-specific range and aggregation logic inside the SP1 backend, not inside the
   `prover-service`.
 - Prevent duplicate workers from advancing the same proof state concurrently.
-- Reject stale updates from workers whose lease expired and was taken over by another worker.
+- Reject stale updates from workers whose lock expired and was taken over by another worker.
 
 ## New Types
 
@@ -71,15 +71,15 @@ impl BackendProofPhase {
     }
 }
 
-/// Opaque token returned by the `prover-service` when a worker leases a DB row.
+/// Opaque id returned by the `prover-service` when a worker locks a DB row.
 ///
-/// Every update for that leased row must include the same token. This prevents an old worker from
-/// overwriting state after its lease expired and another worker reclaimed the row.
-struct LeaseToken(uuid::Uuid);
+/// Every update for that locked row must include the same id. This prevents an old worker from
+/// overwriting state after its lock expired and another worker reclaimed the row.
+struct LockId(uuid::Uuid);
 
-struct LeasedProofRequest {
+struct LockedProofRequest {
     request: ProofRequest,
-    lease_token: LeaseToken,
+    lock_id: LockId,
 }
 
 struct BackendProofWork {
@@ -87,23 +87,23 @@ struct BackendProofWork {
     state: BackendProofState,
 }
 
-struct LeasedBackendProofWork {
+struct LockedBackendProofWork {
     backend_job_id: i64,
     work: BackendProofWork,
-    lease_token: LeaseToken,
+    lock_id: LockId,
 }
 
-enum ProofSubmissionLease {
+enum ProofSubmissionLock {
     /// Final proof was produced while starting the user-facing proof job.
     ///
     /// This is the current Nitro path.
-    ProofJob { lease_token: LeaseToken },
+    ProofJob { lock_id: LockId },
     /// Final proof was produced while advancing a durable backend job.
     ///
     /// This is the SP1 aggregation path.
     BackendJob {
         backend_job_id: i64,
-        lease_token: LeaseToken,
+        lock_id: LockId,
     },
 }
 
@@ -162,13 +162,13 @@ overloading the simple status enum.
 
 ### Worker API - `ProofJobQueue`
 
-- `get_next_proof(ProofBackend) -> Option<LeasedProofRequest>`
-- `submit_backend_proof_state(proof_id, backend_proof_state, lease_token)`
-- `get_next_backend_proof(ProofBackend) -> Option<LeasedBackendProofWork>`
-- `complete_backend_proof_job(backend_job_id, lease_token, next_update)`
-- `fail_backend_proof_job(backend_job_id, reason, lease_token)`
-- `submit_proof(ProofResponse, ProofSubmissionLease)`
-- `fail_proof(proof_id, reason, lease_token)`
+- `get_next_proof(ProofBackend) -> Option<LockedProofRequest>`
+- `submit_backend_proof_state(proof_id, backend_proof_state, lock_id)`
+- `get_next_backend_proof(ProofBackend) -> Option<LockedBackendProofWork>`
+- `complete_backend_proof_job(backend_job_id, lock_id, next_update)`
+- `fail_backend_proof_job(backend_job_id, reason, lock_id)`
+- `submit_proof(ProofResponse, ProofSubmissionLock)`
+- `fail_proof(proof_id, reason, lock_id)`
 
 `submit_backend_proof_state` is used after `backend.start` successfully launches external backend
 work. For SP1 this stores `BackendProofState::Range { id }`, where `id` is the range proof id
@@ -177,27 +177,27 @@ returned by the SP1 network, and transitions the user-facing proof job to `Backe
 `complete_backend_proof_job` is a generic name for applying a `BackendUpdate` produced by
 `backend.advance`. It can:
 
-- clear the backend job lease and schedule another poll for `Noop`;
+- clear the backend job lock and schedule another poll for `Noop`;
 - mark the current backend job complete and insert the next backend job for `Pending`;
 - mark the backend job and proof job failed for `Failed`;
 - mark the backend job complete and store the final proof for `Complete`.
 
 `fail_backend_proof_job` reports that a worker failed to advance a durable backend job during this
-attempt. It mirrors `fail_proof` for the start phase: the service clears the lease, schedules the
+attempt. It mirrors `fail_proof` for the start phase: the service clears the lock, schedules the
 backend job for another poll, and only marks the backend job plus parent proof job `Failed` once
 `advance_attempts` reaches the configured maximum. This is for worker or transient backend errors;
 `BackendUpdate::Failed` remains a terminal backend result.
 
 `submit_proof` stores the final proof and marks the user-facing proof job `Completed`. It accepts a
-`ProofSubmissionLease` because final proofs can come from two places:
+`ProofSubmissionLock` because final proofs can come from two places:
 
 - Nitro currently completes directly from `backend.start`, so submission must validate the
-  `proof_requests.lease_token`.
+  `proof_requests.lock_id`.
 - SP1 completes from `backend.advance` on the aggregation backend job, so submission must validate
-  the `proof_sessions.lease_token` for the aggregation row and mark that row `Completed`. The
+  the `proof_sessions.lock_id` for the aggregation row and mark that row `Completed`. The
   worker reports that path through `complete_backend_proof_job(..., BackendUpdate::Complete(_))`.
 
-The final method names can be adjusted, but every worker update should carry the lease token for
+The final method names can be adjusted, but every worker update should carry the lock id for
 the row being updated.
 
 ### Worker Backend API - `ProofJobBackend`
@@ -206,7 +206,7 @@ the row being updated.
 - `start(request: &ProofRequest) -> BackendUpdate`
 - `advance(request: &ProofRequest, state: BackendProofState) -> BackendUpdate`
 
-`start` is called once a user-facing proof request is leased from `proof_requests`.
+`start` is called once a user-facing proof request is locked from `proof_requests`.
 
 `advance` is called for already-created external backend work stored in `proof_sessions`.
 
@@ -220,8 +220,8 @@ an intermediate proof or a final proof.
 
 1. `ProofWorker` calls `get_next_proof(Sp1)` to get the next SP1 proof request to satisfy.
 2. `prover-service` claims one queued SP1 `proof_requests` row, sets it to `Starting`, writes
-   `locked_until`, writes a fresh `lease_token`, increments `start_attempts`, and returns
-   `LeasedProofRequest`.
+   `lock_expires_at`, writes a fresh `lock_id`, increments `start_attempts`, and returns
+   `LockedProofRequest`.
 3. Worker calls `sp1_backend.start(request)`.
 4. SP1 backend builds the witness for the entire block range.
 5. SP1 backend calls SP1 network `.request()` for the compressed range proof.
@@ -235,20 +235,20 @@ an intermediate proof or a final proof.
    }
    ```
 
-7. Worker calls `submit_backend_proof_state(proof_id, Range { id }, lease_token)`.
-8. `prover-service` accepts the update only if the `proof_requests.lease_token` still matches.
+7. Worker calls `submit_backend_proof_state(proof_id, Range { id }, lock_id)`.
+8. `prover-service` accepts the update only if the `proof_requests.lock_id` still matches.
 9. `prover-service` inserts a `proof_sessions` row for the SP1 range proof and transitions the
    proof job to:
 
    ```text
    status = BackendPending
-   locked_until = null
-   lease_token = null
+   lock_expires_at = null
+   lock_id = null
    ```
 
 10. Later, any SP1 `ProofWorker` calls `get_next_backend_proof(Sp1)`.
-11. `prover-service` claims a due `proof_sessions` row, writes `locked_until`, writes a fresh
-    `lease_token`, and returns the original request plus `BackendProofState::Range { id }`.
+11. `prover-service` claims a due `proof_sessions` row, writes `lock_expires_at`, writes a fresh
+    `lock_id`, and returns the original request plus `BackendProofState::Range { id }`.
 12. Worker calls `sp1_backend.advance(request, BackendProofState::Range { id })`.
 13. SP1 backend polls SP1 network for the range proof status.
 14. If the range proof is still pending, SP1 backend returns:
@@ -257,7 +257,7 @@ an intermediate proof or a final proof.
     BackendUpdate::Noop
     ```
 
-15. Worker reports the `Noop` update. `prover-service` clears the backend job lease and sets
+15. Worker reports the `Noop` update. `prover-service` clears the backend job lock and sets
     `next_poll_at` to a future timestamp.
 16. If the range proof is complete, SP1 backend fetches the range proof, builds the aggregation
     proof request, and calls SP1 network `.request()` for the aggregation proof.
@@ -271,7 +271,7 @@ an intermediate proof or a final proof.
     }
     ```
 
-18. Worker reports the `Pending` update for the leased range backend job.
+18. Worker reports the `Pending` update for the locked range backend job.
 19. `prover-service` marks the range backend job `Completed` and inserts a new
     `proof_sessions` row for the aggregation proof.
 20. Later, any SP1 worker calls `get_next_backend_proof(Sp1)` again.
@@ -286,30 +286,30 @@ an intermediate proof or a final proof.
     BackendUpdate::Complete(proof_data)
     ```
 
-26. Worker reports the final update for the leased aggregation backend job:
+26. Worker reports the final update for the locked aggregation backend job:
 
     ```rust
     complete_backend_proof_job(
         backend_job_id,
-        lease_token,
+        lock_id,
         BackendUpdate::Complete(proof_data),
     )
     ```
 
-    Here `backend_job_id` and `lease_token` are the values returned by
+    Here `backend_job_id` and `lock_id` are the values returned by
     `get_next_backend_proof(Sp1)` for the aggregation backend job.
 
 27. `prover-service` accepts the submission only if the aggregation
-    `proof_sessions.lease_token` still matches.
-28. `prover-service` marks the aggregation backend job `Completed`, clears its lease, stores the
+    `proof_sessions.lock_id` still matches.
+28. `prover-service` marks the aggregation backend job `Completed`, clears its lock, stores the
     final proof in `proof_requests.proof_data`, and marks the proof job `Completed`.
 
 ### Nitro TEE
 
 1. `ProofWorker` calls `get_next_proof(Nitro)` to get the next Nitro proof request to satisfy.
 2. `prover-service` claims one queued Nitro `proof_requests` row, sets it to `Starting`, writes
-   `locked_until`, writes a fresh `lease_token`, increments `start_attempts`, and returns
-   `LeasedProofRequest`.
+   `lock_expires_at`, writes a fresh `lock_id`, increments `start_attempts`, and returns
+   `LockedProofRequest`.
 3. Worker calls `nitro_backend.start(request)`.
 4. Nitro backend builds the witness for the entire block range and immediately produces the proof.
 5. Nitro backend returns:
@@ -323,11 +323,11 @@ an intermediate proof or a final proof.
    ```rust
    submit_proof(
        proof_response,
-       ProofSubmissionLease::ProofJob { lease_token },
+       ProofSubmissionLock::ProofJob { lock_id },
    )
    ```
 
-7. `prover-service` accepts the update only if the `proof_requests.lease_token` still matches, stores
+7. `prover-service` accepts the update only if the `proof_requests.lock_id` still matches, stores
    the proof, and marks the proof job `Completed`.
 
 Nitro does not need `proof_sessions` today. If Nitro later becomes async, `nitro_backend.start`
@@ -353,15 +353,20 @@ create table proof_requests (
     proof_data          bytea null,
     failure_reason      text null,
 
+    worker_id           text null,
+    lock_id             uuid null,
+
     start_attempts      integer not null default 0,
-    locked_until        timestamptz null,
-    lease_token         uuid null,
+    lock_expires_at     timestamptz null,
 
     created_at          timestamptz not null,
     updated_at          timestamptz not null,
     finished_at         timestamptz null
 );
 ```
+
+`worker_id` is reserved for worker attribution and observability. In the current implementation it
+is not written by the store yet, so existing rows keep it `null`.
 
 Recommended constraints:
 
@@ -374,8 +379,8 @@ create index proof_requests_queued_idx
     on proof_requests (backend, created_at)
     where status = 'queued';
 
-create index proof_requests_starting_lease_idx
-    on proof_requests (locked_until)
+create index proof_requests_starting_lock_idx
+    on proof_requests (lock_expires_at)
     where status = 'starting';
 ```
 
@@ -400,8 +405,8 @@ create table proof_sessions (
     status              text not null,
     advance_attempts    integer not null default 0,
     next_poll_at        timestamptz not null,
-    locked_until        timestamptz null,
-    lease_token         uuid null,
+    lock_expires_at     timestamptz null,
+    lock_id             uuid null,
 
     artifact            bytea null,
     failure_reason      text null,
@@ -430,8 +435,8 @@ create index proof_sessions_due_idx
     on proof_sessions (backend, next_poll_at)
     where status = 'requested';
 
-create index proof_sessions_lease_idx
-    on proof_sessions (locked_until)
+create index proof_sessions_lock_idx
+    on proof_sessions (lock_expires_at)
     where status = 'requested';
 ```
 
@@ -451,25 +456,25 @@ unique (proof_id, phase, phase_index)
 
 and remove or replace `unique (proof_id, phase)`.
 
-## How `locked_until` Works
+## How `lock_expires_at` Works
 
-`locked_until` is a durable lease timestamp. A row is available to claim when:
+`lock_expires_at` is a durable lock timestamp. A row is available to claim when:
 
 ```sql
-locked_until is null or locked_until < $now
+lock_expires_at is null or lock_expires_at < $now
 ```
 
-`$now`, `$locked_until`, and `$next_poll_at` should be computed in Rust, for example from
-`chrono::Utc::now()` plus the configured lease or poll duration. Runtime status values should be
+`$now`, `$lock_expires_at`, and `$next_poll_at` should be computed in Rust, for example from
+`chrono::Utc::now()` plus the configured lock or poll duration. Runtime status values should be
 bound from the Rust enums, such as `ProofStatus::Queued.as_str()` and
 `BackendProofJobStatus::Requested.as_str()`, rather than embedded as SQL literals.
 
 It prevents two workers from owning the same state transition after the database transaction that
 claimed the row has committed.
 
-### `proof_requests.locked_until`
+### `proof_requests.lock_expires_at`
 
-`proof_requests.locked_until` protects only the short initial start phase.
+`proof_requests.lock_expires_at` protects only the short initial start phase.
 
 It is used when a worker claims a queued proof via `get_next_proof`. The worker owns the row while
 it calls `backend.start(request)`.
@@ -484,7 +489,7 @@ from proof_requests
 where backend = $1
   and (
     status = $queued_status
-    or (status = $starting_status and locked_until < $now)
+    or (status = $starting_status and lock_expires_at < $now)
   )
 order by created_at
 for update skip locked
@@ -496,36 +501,36 @@ Then:
 ```sql
 update proof_requests
 set status = $starting_status,
-    locked_until = $locked_until,
-    lease_token = $lease_token,
+    lock_expires_at = $lock_expires_at,
+    lock_id = $lock_id,
     start_attempts = start_attempts + 1,
     updated_at = $now
 where proof_id = $proof_id;
 ```
 
 If the selected row was an expired `Starting` row and `start_attempts` has already reached the
-configured maximum, the service should mark it `Failed` instead of leasing it again.
+configured maximum, the service should mark it `Failed` instead of locking it again.
 
-For SP1, this lease should cover witness generation and the SP1 network `.request()` call. It should
+For SP1, this lock should cover witness generation and the SP1 network `.request()` call. It should
 not cover the time spent waiting for SP1 network proof generation.
 
 Once SP1 `start()` successfully returns a range backend id, the proof job moves to:
 
 ```text
 status = BackendPending
-locked_until = null
-lease_token = null
+lock_expires_at = null
+lock_id = null
 ```
 
 At that point, the long-running proof generation is represented by `proof_sessions`, and the
-original proof job must not be leased by `get_next_proof` again.
+original proof job must not be locked by `get_next_proof` again.
 
-If the worker dies during `start()`, `locked_until` eventually expires. The job can then be retried
+If the worker dies during `start()`, `lock_expires_at` eventually expires. The job can then be retried
 by another worker.
 
-### `proof_sessions.locked_until`
+### `proof_sessions.lock_expires_at`
 
-`proof_sessions.locked_until` protects backend polling and phase advancement.
+`proof_sessions.lock_expires_at` protects backend polling and phase advancement.
 
 It is used when a worker claims backend work via `get_next_backend_proof`. This prevents duplicate
 workers from polling the same completed SP1 range proof and both requesting aggregation proofs.
@@ -538,7 +543,7 @@ from proof_sessions
 where backend = $1
   and status = $requested_status
   and next_poll_at <= $now
-  and (locked_until is null or locked_until < $now)
+  and (lock_expires_at is null or lock_expires_at < $now)
 order by next_poll_at
 for update skip locked
 limit 1;
@@ -548,30 +553,30 @@ Then:
 
 ```sql
 update proof_sessions
-set locked_until = $locked_until,
-    lease_token = $lease_token,
+set lock_expires_at = $lock_expires_at,
+    lock_id = $lock_id,
     updated_at = $now
 where id = $backend_job_id;
 ```
 
-If `advance()` returns `Noop`, clear the lease and schedule the next poll:
+If `advance()` returns `Noop`, clear the lock and schedule the next poll:
 
 ```sql
 update proof_sessions
-set locked_until = null,
-    lease_token = null,
+set lock_expires_at = null,
+    lock_id = null,
     next_poll_at = $next_poll_at,
     updated_at = $now
 where id = $backend_job_id
-  and lease_token = $lease_token;
+  and lock_id = $lock_id;
 ```
 
-If the worker dies while advancing backend work, it never clears the lease. After
-`locked_until < $now`, another worker can claim and retry that backend job.
+If the worker dies while advancing backend work, it never clears the lock. After
+`lock_expires_at < $now`, another worker can claim and retry that backend job.
 
-## Why Lease Tokens Are Needed
+## Why Lock IDs Are Needed
 
-`locked_until` alone prevents simultaneous claims, but it does not protect against stale updates
+`lock_expires_at` alone prevents simultaneous claims, but it does not protect against stale updates
 from slow workers.
 
 Example:
@@ -580,39 +585,39 @@ Example:
 
    ```text
    status = Starting
-   locked_until = $now + 10 minutes
-   lease_token = A
+   lock_expires_at = $now + 10 minutes
+   lock_id = A
    ```
 
-2. Worker A is slow and the lease expires.
+2. Worker A is slow and the lock expires.
 3. Worker B claims the same proof:
 
    ```text
    status = Starting
-   locked_until = $now + 10 minutes
-   lease_token = B
+   lock_expires_at = $now + 10 minutes
+   lock_id = B
    ```
 
 4. Worker A returns a failure.
 
-The service must ignore Worker A's update because it carries stale token `A`.
+The service must ignore Worker A's update because it carries stale lock id `A`.
 
-Every update should therefore include the lease token, and the SQL update should check it:
+Every update should therefore include the lock id, and the SQL update should check it:
 
 ```sql
 update proof_requests
 set status = $failed_status,
     failure_reason = $reason,
-    locked_until = null,
-    lease_token = null,
+    lock_expires_at = null,
+    lock_id = null,
     finished_at = $now,
     updated_at = $now
 where proof_id = $proof_id
   and status = $starting_status
-  and lease_token = $lease_token;
+  and lock_id = $lock_id;
 ```
 
-If this update affects zero rows, the lease is stale. The service should return a stale lease error
+If this update affects zero rows, the lock is stale. The service should return a stale lock error
 or treat it as a no-op. It must not overwrite the newer owner.
 
 The same rule applies to `proof_sessions`. A stale worker must not be able to:
@@ -630,7 +635,7 @@ The two attempts counters measure different retry layers.
 `start_attempts` counts how many times workers tried to start backend work for the user-facing proof
 request.
 
-It increments when `get_next_proof` successfully leases a queued proof job and transitions it to
+It increments when `get_next_proof` successfully locks a queued proof job and transitions it to
 `Starting`.
 
 It covers failures before durable external backend work has been persisted:
@@ -639,7 +644,7 @@ It covers failures before durable external backend work has been persisted:
 - SP1 network `.request()` fails before returning an SP1 proof id;
 - Nitro enclave proving fails;
 - worker dies while the proof job is `Starting`;
-- the proof job start lease expires before the worker reports an update.
+- the proof job start lock expires before the worker reports an update.
 
 For SP1, once `start()` succeeds and the range `backend_proof_id` is persisted,
 `start_attempts` should stop changing. Further progress is tracked by `proof_sessions`.
@@ -653,8 +658,8 @@ instead of requeueing it.
 must not count healthy polls where the backend is still working.
 
 It increments when a worker reports an advance error through `fail_backend_proof_job`, or when
-`get_next_backend_proof` reclaims an expired backend lease from a worker that died or stopped
-responding. A normal lease does not increment it, and `BackendUpdate::Noop` does not increment it.
+`get_next_backend_proof` reclaims an expired backend lock from a worker that died or stopped
+responding. A normal lock does not increment it, and `BackendUpdate::Noop` does not increment it.
 
 It covers failures after the external backend id is known:
 
@@ -662,7 +667,7 @@ It covers failures after the external backend id is known:
 - worker dies while polling or fetching the completed SP1 proof;
 - range proof completes, but requesting the aggregation proof fails;
 - transient serialization or validation errors while building the next phase;
-- stale backend job lease expiry.
+- stale backend job lock expiry.
 
 An SP1 range backend job and an SP1 aggregation backend job each have their own
 `advance_attempts`.
@@ -735,7 +740,7 @@ BackendPending
 
 proof_sessions:
 Range Requested
-  locked_until = null
+  lock_expires_at = null
   next_poll_at = future timestamp
 ```
 
@@ -743,7 +748,7 @@ Range Requested
 
 ```text
 proof_requests:
-Starting with expired locked_until
+Starting with expired lock_expires_at
   -> claimed again as Starting by another worker, or requeued by a background reaper
 
 proof_sessions:
@@ -761,7 +766,7 @@ proof_requests:
 BackendPending
 
 proof_sessions:
-Requested with expired locked_until
+Requested with expired lock_expires_at
   -> claimed by another worker
 ```
 

--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -22,10 +22,10 @@ use world_chain_proposer::{
     ParentRef, Proposal, ProposalSubmission, ProposerClient, ProposerError,
 };
 use world_chain_prover_service::{
-    BackendProofState, BackendUpdate, LeaseToken, LeasedBackendProofWork, LeasedProofRequest,
+    BackendProofState, BackendUpdate, LockId, LockedBackendProofWork, LockedProofRequest,
     ProofBackend, ProofData, ProofJobQueue, ProofJobQueueError, ProofRequest, ProofRequestError,
-    ProofRequestId, ProofRequester, ProofResponse, ProofStatus, ProofSubmissionLease,
-    ProverService, ProverServiceConfig,
+    ProofRequestId, ProofRequester, ProofResponse, ProofStatus, ProofSubmissionLock, ProverService,
+    ProverServiceConfig,
 };
 
 pub const BLOCK_INTERVAL: u64 = 10;
@@ -596,7 +596,7 @@ impl ProofJobQueue for SharedProverService {
     async fn get_next_proof(
         &self,
         backend: ProofBackend,
-    ) -> Result<Option<LeasedProofRequest>, ProofJobQueueError> {
+    ) -> Result<Option<LockedProofRequest>, ProofJobQueueError> {
         self.service.get_next_proof(backend).await
     }
 
@@ -604,7 +604,7 @@ impl ProofJobQueue for SharedProverService {
         &self,
         proof_id: ProofRequestId,
         backend_proof_state: BackendProofState,
-        lease_token: LeaseToken,
+        lease_token: LockId,
     ) -> Result<(), ProofJobQueueError> {
         self.service
             .submit_backend_proof_state(proof_id, backend_proof_state, lease_token)
@@ -614,14 +614,14 @@ impl ProofJobQueue for SharedProverService {
     async fn get_next_backend_proof(
         &self,
         backend: ProofBackend,
-    ) -> Result<Option<LeasedBackendProofWork>, ProofJobQueueError> {
+    ) -> Result<Option<LockedBackendProofWork>, ProofJobQueueError> {
         self.service.get_next_backend_proof(backend).await
     }
 
     async fn complete_backend_proof_job(
         &self,
         backend_job_id: i64,
-        lease_token: LeaseToken,
+        lease_token: LockId,
         next_update: BackendUpdate,
     ) -> Result<(), ProofJobQueueError> {
         self.service
@@ -633,7 +633,7 @@ impl ProofJobQueue for SharedProverService {
         &self,
         backend_job_id: i64,
         reason: String,
-        lease_token: LeaseToken,
+        lease_token: LockId,
     ) -> Result<(), ProofJobQueueError> {
         self.service
             .fail_backend_proof_job(backend_job_id, reason, lease_token)
@@ -643,7 +643,7 @@ impl ProofJobQueue for SharedProverService {
     async fn submit_proof(
         &self,
         proof: ProofResponse,
-        lease: ProofSubmissionLease,
+        lease: ProofSubmissionLock,
     ) -> Result<(), ProofJobQueueError> {
         self.service.submit_proof(proof, lease).await
     }
@@ -652,7 +652,7 @@ impl ProofJobQueue for SharedProverService {
         &self,
         proof_id: ProofRequestId,
         reason: String,
-        lease_token: LeaseToken,
+        lease_token: LockId,
     ) -> Result<(), ProofJobQueueError> {
         self.service.fail_proof(proof_id, reason, lease_token).await
     }

--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -604,10 +604,10 @@ impl ProofJobQueue for SharedProverService {
         &self,
         proof_id: ProofRequestId,
         backend_proof_state: BackendProofState,
-        lease_token: LockId,
+        lock_id: LockId,
     ) -> Result<(), ProofJobQueueError> {
         self.service
-            .submit_backend_proof_state(proof_id, backend_proof_state, lease_token)
+            .submit_backend_proof_state(proof_id, backend_proof_state, lock_id)
             .await
     }
 
@@ -621,11 +621,11 @@ impl ProofJobQueue for SharedProverService {
     async fn complete_backend_proof_job(
         &self,
         backend_job_id: i64,
-        lease_token: LockId,
+        lock_id: LockId,
         next_update: BackendUpdate,
     ) -> Result<(), ProofJobQueueError> {
         self.service
-            .complete_backend_proof_job(backend_job_id, lease_token, next_update)
+            .complete_backend_proof_job(backend_job_id, lock_id, next_update)
             .await
     }
 
@@ -633,10 +633,10 @@ impl ProofJobQueue for SharedProverService {
         &self,
         backend_job_id: i64,
         reason: String,
-        lease_token: LockId,
+        lock_id: LockId,
     ) -> Result<(), ProofJobQueueError> {
         self.service
-            .fail_backend_proof_job(backend_job_id, reason, lease_token)
+            .fail_backend_proof_job(backend_job_id, reason, lock_id)
             .await
     }
 
@@ -652,8 +652,8 @@ impl ProofJobQueue for SharedProverService {
         &self,
         proof_id: ProofRequestId,
         reason: String,
-        lease_token: LockId,
+        lock_id: LockId,
     ) -> Result<(), ProofJobQueueError> {
-        self.service.fail_proof(proof_id, reason, lease_token).await
+        self.service.fail_proof(proof_id, reason, lock_id).await
     }
 }

--- a/proofs/integration-tests/tests/orchestration.rs
+++ b/proofs/integration-tests/tests/orchestration.rs
@@ -82,7 +82,7 @@ async fn start_proof_stack_with(
     let service = SharedProverService::connect(
         &database_url,
         ProverServiceConfig {
-            lease_timeout: Duration::from_secs(5),
+            lock_timeout: Duration::from_secs(5),
             max_attempts: 2,
             max_queue_len: 16,
             backend_poll_interval: Duration::from_millis(5),

--- a/proofs/integration-tests/tests/orchestration.rs
+++ b/proofs/integration-tests/tests/orchestration.rs
@@ -95,6 +95,7 @@ async fn start_proof_stack_with(
         service.clone(),
         sp1_backend,
         ProofWorkerConfig {
+            worker_id: "orchestration-sp1-worker".to_string(),
             poll_interval: Duration::from_millis(5),
             max_concurrent_jobs: 1,
         },
@@ -106,6 +107,7 @@ async fn start_proof_stack_with(
         service.clone(),
         nitro_backend,
         ProofWorkerConfig {
+            worker_id: "orchestration-nitro-worker".to_string(),
             poll_interval: Duration::from_millis(5),
             max_concurrent_jobs: 1,
         },

--- a/proofs/nitro/worker/src/lib.rs
+++ b/proofs/nitro/worker/src/lib.rs
@@ -260,6 +260,10 @@ struct Cli {
     /// proving, so this can be higher than for SP1 workers.
     #[arg(long, default_value_t = 1)]
     max_concurrent_jobs: usize,
+
+    /// The unique worker id.
+    #[arg(long)]
+    worker_id: String,
 }
 
 // ──────────────────────────────────────────────────────────────────────────────────────
@@ -320,10 +324,12 @@ pub fn run() -> Result<()> {
     let queue = RpcProverServiceClient::new(&cli.prover_service_url)
         .with_context(|| format!("failed to connect to {}", cli.prover_service_url))?;
 
+    let worker_id = format!("{}-nitro-worker", cli.worker_id);
     let worker = ProofWorker::new(
         queue,
         backend,
         ProofWorkerConfig {
+            worker_id,
             poll_interval: Duration::from_secs(cli.poll_interval_seconds),
             max_concurrent_jobs: cli.max_concurrent_jobs,
         },

--- a/proofs/prover-service/migrations/20260619_proof_requests.sql
+++ b/proofs/prover-service/migrations/20260619_proof_requests.sql
@@ -10,9 +10,11 @@ create table proof_requests (
     proof_data          bytea null,
     failure_reason      text null,
 
+    worker_id           text null,
+    lock_id             uuid null,
+
     start_attempts      integer not null default 0,
-    locked_until        timestamptz null,
-    lease_token         uuid null,
+    lock_expires_at     timestamp with time zone null,
 
     created_at          timestamptz not null,
     updated_at          timestamptz not null,
@@ -26,8 +28,8 @@ create index proof_requests_queued_idx
     on proof_requests (backend, created_at)
     where status = 'queued';
 
-create index proof_requests_starting_lease_idx
-    on proof_requests (locked_until)
+create index proof_requests_starting_lock_idx
+    on proof_requests (lock_expires_at)
     where status = 'starting';
 
 create table proof_sessions (
@@ -41,8 +43,8 @@ create table proof_sessions (
     status              text not null,
     advance_attempts    integer not null default 0,
     next_poll_at        timestamptz not null,
-    locked_until        timestamptz null,
-    lease_token         uuid null,
+    lock_expires_at        timestamptz null,
+    lock_id         uuid null,
 
     artifact            bytea null,
     failure_reason      text null,
@@ -64,6 +66,6 @@ create index proof_sessions_due_idx
     on proof_sessions (backend, next_poll_at)
     where status = 'requested';
 
-create index proof_sessions_lease_idx
-    on proof_sessions (locked_until)
+create index proof_sessions_lock_idx
+    on proof_sessions (lock_expires_at)
     where status = 'requested';

--- a/proofs/prover-service/src/config.rs
+++ b/proofs/prover-service/src/config.rs
@@ -1,8 +1,8 @@
 use crate::error::InvalidConfigError;
 use std::time::Duration;
 
-/// Default lease duration granted to a worker for a single proving attempt.
-pub const DEFAULT_LEASE_TIMEOUT: Duration = Duration::from_mins(30);
+/// Default lock duration granted to a worker for a single proving attempt.
+pub const DEFAULT_LOCK_TIMEOUT: Duration = Duration::from_mins(30);
 
 /// Default maximum number of proving attempts per request.
 pub const DEFAULT_MAX_ATTEMPTS: u32 = 3;
@@ -16,10 +16,10 @@ pub const DEFAULT_BACKEND_POLL_INTERVAL: Duration = Duration::from_secs(30);
 /// Configuration for the `prover-service`.
 #[derive(Debug, Clone)]
 pub struct ProverServiceConfig {
-    /// How long a worker holds a job lease before the job is
+    /// How long a worker holds a job lock before the job is
     /// considered abandoned and re-queued.
-    pub lease_timeout: Duration,
-    /// Maximum number of proving attempts (leases) per request before
+    pub lock_timeout: Duration,
+    /// Maximum number of proving attempts (locks) per request before
     /// it is marked as failed.
     pub max_attempts: u32,
     /// Maximum number of requests queued per backend.
@@ -30,10 +30,8 @@ pub struct ProverServiceConfig {
 
 impl ProverServiceConfig {
     pub(crate) fn validate(&self) -> Result<(), InvalidConfigError> {
-        if self.lease_timeout.is_zero() {
-            return Err(InvalidConfigError(
-                "lease_timeout must be greater than zero",
-            ));
+        if self.lock_timeout.is_zero() {
+            return Err(InvalidConfigError("lock_timeout must be greater than zero"));
         }
         if self.max_attempts == 0 {
             return Err(InvalidConfigError("max_attempts must be greater than zero"));
@@ -55,7 +53,7 @@ impl ProverServiceConfig {
 impl Default for ProverServiceConfig {
     fn default() -> Self {
         Self {
-            lease_timeout: DEFAULT_LEASE_TIMEOUT,
+            lock_timeout: DEFAULT_LOCK_TIMEOUT,
             max_attempts: DEFAULT_MAX_ATTEMPTS,
             max_queue_len: DEFAULT_MAX_QUEUE_LEN,
             backend_poll_interval: DEFAULT_BACKEND_POLL_INTERVAL,

--- a/proofs/prover-service/src/error.rs
+++ b/proofs/prover-service/src/error.rs
@@ -63,9 +63,9 @@ pub enum ProofJobQueueError {
     /// No backend proof job with the given id is known.
     #[error("unknown backend proof job {0}")]
     UnknownBackendJob(i64),
-    /// The lease token no longer owns the row being updated.
-    #[error("stale lease for proof job update")]
-    StaleLease,
+    /// The lock token no longer owns the row being updated.
+    #[error("stale lock for proof job update")]
+    StaleLocked,
     /// The submitted proof does not match the requested job.
     #[error("invalid proof for job {id}: {reason}")]
     InvalidProof {

--- a/proofs/prover-service/src/lib.rs
+++ b/proofs/prover-service/src/lib.rs
@@ -78,7 +78,7 @@ mod types;
 
 // re-exports
 pub use config::{
-    DEFAULT_BACKEND_POLL_INTERVAL, DEFAULT_LEASE_TIMEOUT, DEFAULT_MAX_ATTEMPTS,
+    DEFAULT_BACKEND_POLL_INTERVAL, DEFAULT_LOCK_TIMEOUT, DEFAULT_MAX_ATTEMPTS,
     DEFAULT_MAX_QUEUE_LEN, ProverServiceConfig,
 };
 pub use error::{
@@ -92,8 +92,8 @@ pub use service::ProverService;
 pub use traits::{ProofJobQueue, ProofRequester};
 pub use types::{
     BackendProofId, BackendProofJobStatus, BackendProofPhase, BackendProofState, BackendProofWork,
-    BackendUpdate, LeaseToken, LeasedBackendProofWork, LeasedProofRequest, ProofBackend, ProofData,
-    ProofRequest, ProofRequestId, ProofResponse, ProofStatus, ProofSubmissionLease,
+    BackendUpdate, LockId, LockedBackendProofWork, LockedProofRequest, ProofBackend, ProofData,
+    ProofRequest, ProofRequestId, ProofResponse, ProofStatus, ProofSubmissionLock,
 };
 
 #[cfg(test)]

--- a/proofs/prover-service/src/main.rs
+++ b/proofs/prover-service/src/main.rs
@@ -54,7 +54,7 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     let config = ProverServiceConfig {
-        lease_timeout: Duration::from_secs(cli.lease_timeout_seconds),
+        lock_timeout: Duration::from_secs(cli.lease_timeout_seconds),
         max_attempts: cli.max_attempts,
         max_queue_len: cli.max_queue_len,
         backend_poll_interval: Duration::from_secs(cli.backend_poll_interval_seconds),

--- a/proofs/prover-service/src/rpc.rs
+++ b/proofs/prover-service/src/rpc.rs
@@ -32,8 +32,8 @@ pub mod error_code {
     pub const UNKNOWN_JOB: i32 = -32011;
     /// No backend proof job with the given id is known.
     pub const UNKNOWN_BACKEND_JOB: i32 = -32013;
-    /// A worker tried to update a row using an expired or superseded lease.
-    pub const STALE_LEASE: i32 = -32014;
+    /// A worker tried to update a row using an expired or superseded lock.
+    pub const STALE_LOCK: i32 = -32014;
     /// The submitted proof does not match the requested job;
     /// the error data holds the proof id and reason.
     pub const INVALID_PROOF: i32 = -32012;
@@ -61,7 +61,7 @@ pub trait ProverServiceApi {
     #[method(name = "getProof")]
     async fn get_proof(&self, proof_id: ProofRequestId) -> RpcResult<ProofResponse>;
 
-    /// Lease the next queued proof request for the given backend.
+    /// Lock the next queued proof request for the given backend.
     #[method(name = "getNextProof")]
     async fn get_next_proof(&self, backend: ProofBackend) -> RpcResult<Option<LockedProofRequest>>;
 
@@ -71,10 +71,10 @@ pub trait ProverServiceApi {
         &self,
         proof_id: ProofRequestId,
         backend_proof_state: BackendProofState,
-        lease_token: LockId,
+        lock_id: LockId,
     ) -> RpcResult<()>;
 
-    /// Lease the next durable backend proof job for the given backend.
+    /// Lock the next durable backend proof job for the given backend.
     #[method(name = "getNextBackendProof")]
     async fn get_next_backend_proof(
         &self,
@@ -86,7 +86,7 @@ pub trait ProverServiceApi {
     async fn complete_backend_proof_job(
         &self,
         backend_job_id: i64,
-        lease_token: LockId,
+        lock_id: LockId,
         next_update: BackendUpdate,
     ) -> RpcResult<()>;
 
@@ -96,13 +96,12 @@ pub trait ProverServiceApi {
         &self,
         backend_job_id: i64,
         reason: String,
-        lease_token: LockId,
+        lock_id: LockId,
     ) -> RpcResult<()>;
 
     /// Submit a generated proof.
     #[method(name = "submitProof")]
-    async fn submit_proof(&self, proof: ProofResponse, lease: ProofSubmissionLock)
-    -> RpcResult<()>;
+    async fn submit_proof(&self, proof: ProofResponse, lock: ProofSubmissionLock) -> RpcResult<()>;
 
     /// Report that proving failed for the given job.
     #[method(name = "failProof")]
@@ -110,7 +109,7 @@ pub trait ProverServiceApi {
         &self,
         proof_id: ProofRequestId,
         reason: String,
-        lease_token: LockId,
+        lock_id: LockId,
     ) -> RpcResult<()>;
 }
 
@@ -151,7 +150,7 @@ impl From<ProofJobQueueError> for ErrorObjectOwned {
                 ErrorObject::owned(error_code::UNKNOWN_BACKEND_JOB, message, None::<()>)
             }
             ProofJobQueueError::StaleLocked => {
-                ErrorObject::owned(error_code::STALE_LEASE, message, None::<()>)
+                ErrorObject::owned(error_code::STALE_LOCK, message, None::<()>)
             }
             ProofJobQueueError::InvalidProof { id, reason } => ErrorObject::owned(
                 error_code::INVALID_PROOF,
@@ -203,11 +202,11 @@ impl ProverServiceApiServer for ProverServiceRpc {
         &self,
         proof_id: ProofRequestId,
         backend_proof_state: BackendProofState,
-        lease_token: LockId,
+        lock_id: LockId,
     ) -> RpcResult<()> {
         Ok(self
             .service
-            .submit_backend_proof_state(proof_id, backend_proof_state, lease_token)
+            .submit_backend_proof_state(proof_id, backend_proof_state, lock_id)
             .await?)
     }
 
@@ -221,12 +220,12 @@ impl ProverServiceApiServer for ProverServiceRpc {
     async fn complete_backend_proof_job(
         &self,
         backend_job_id: i64,
-        lease_token: LockId,
+        lock_id: LockId,
         next_update: BackendUpdate,
     ) -> RpcResult<()> {
         Ok(self
             .service
-            .complete_backend_proof_job(backend_job_id, lease_token, next_update)
+            .complete_backend_proof_job(backend_job_id, lock_id, next_update)
             .await?)
     }
 
@@ -234,32 +233,25 @@ impl ProverServiceApiServer for ProverServiceRpc {
         &self,
         backend_job_id: i64,
         reason: String,
-        lease_token: LockId,
+        lock_id: LockId,
     ) -> RpcResult<()> {
         Ok(self
             .service
-            .fail_backend_proof_job(backend_job_id, reason, lease_token)
+            .fail_backend_proof_job(backend_job_id, reason, lock_id)
             .await?)
     }
 
-    async fn submit_proof(
-        &self,
-        proof: ProofResponse,
-        lease: ProofSubmissionLock,
-    ) -> RpcResult<()> {
-        Ok(self.service.submit_proof(proof, lease).await?)
+    async fn submit_proof(&self, proof: ProofResponse, lock: ProofSubmissionLock) -> RpcResult<()> {
+        Ok(self.service.submit_proof(proof, lock).await?)
     }
 
     async fn fail_proof(
         &self,
         proof_id: ProofRequestId,
         reason: String,
-        lease_token: LockId,
+        lock_id: LockId,
     ) -> RpcResult<()> {
-        Ok(self
-            .service
-            .fail_proof(proof_id, reason, lease_token)
-            .await?)
+        Ok(self.service.fail_proof(proof_id, reason, lock_id).await?)
     }
 }
 
@@ -337,7 +329,7 @@ fn map_job_error(err: ClientError, id: ProofRequestId) -> ProofJobQueueError {
     };
     match err.code() {
         error_code::UNKNOWN_JOB => ProofJobQueueError::UnknownJob(id),
-        error_code::STALE_LEASE => ProofJobQueueError::StaleLocked,
+        error_code::STALE_LOCK => ProofJobQueueError::StaleLocked,
         error_code::INVALID_PROOF => ProofJobQueueError::InvalidProof {
             id,
             reason: invalid_proof_reason(&err).unwrap_or_else(|| err.message().to_string()),
@@ -352,7 +344,7 @@ fn map_backend_job_error(err: ClientError, backend_job_id: i64) -> ProofJobQueue
     };
     match err.code() {
         error_code::UNKNOWN_BACKEND_JOB => ProofJobQueueError::UnknownBackendJob(backend_job_id),
-        error_code::STALE_LEASE => ProofJobQueueError::StaleLocked,
+        error_code::STALE_LOCK => ProofJobQueueError::StaleLocked,
         error_code::INVALID_PROOF => {
             if let Some(data) = error_data::<InvalidProofErrorData>(&err) {
                 ProofJobQueueError::InvalidProof {
@@ -414,13 +406,13 @@ impl ProofJobQueue for RpcProverServiceClient {
         &self,
         proof_id: ProofRequestId,
         backend_proof_state: BackendProofState,
-        lease_token: LockId,
+        lock_id: LockId,
     ) -> Result<(), ProofJobQueueError> {
         ProverServiceApiClient::submit_backend_proof_state(
             &self.client,
             proof_id,
             backend_proof_state,
-            lease_token,
+            lock_id,
         )
         .await
         .map_err(|err| map_job_error(err, proof_id))
@@ -438,13 +430,13 @@ impl ProofJobQueue for RpcProverServiceClient {
     async fn complete_backend_proof_job(
         &self,
         backend_job_id: i64,
-        lease_token: LockId,
+        lock_id: LockId,
         next_update: BackendUpdate,
     ) -> Result<(), ProofJobQueueError> {
         ProverServiceApiClient::complete_backend_proof_job(
             &self.client,
             backend_job_id,
-            lease_token,
+            lock_id,
             next_update,
         )
         .await
@@ -455,13 +447,13 @@ impl ProofJobQueue for RpcProverServiceClient {
         &self,
         backend_job_id: i64,
         reason: String,
-        lease_token: LockId,
+        lock_id: LockId,
     ) -> Result<(), ProofJobQueueError> {
         ProverServiceApiClient::fail_backend_proof_job(
             &self.client,
             backend_job_id,
             reason,
-            lease_token,
+            lock_id,
         )
         .await
         .map_err(|err| map_backend_job_error(err, backend_job_id))
@@ -470,10 +462,10 @@ impl ProofJobQueue for RpcProverServiceClient {
     async fn submit_proof(
         &self,
         proof: ProofResponse,
-        lease: ProofSubmissionLock,
+        lock: ProofSubmissionLock,
     ) -> Result<(), ProofJobQueueError> {
         let id = proof.id;
-        ProverServiceApiClient::submit_proof(&self.client, proof, lease)
+        ProverServiceApiClient::submit_proof(&self.client, proof, lock)
             .await
             .map_err(|err| map_job_error(err, id))
     }
@@ -482,9 +474,9 @@ impl ProofJobQueue for RpcProverServiceClient {
         &self,
         proof_id: ProofRequestId,
         reason: String,
-        lease_token: LockId,
+        lock_id: LockId,
     ) -> Result<(), ProofJobQueueError> {
-        ProverServiceApiClient::fail_proof(&self.client, proof_id, reason, lease_token)
+        ProverServiceApiClient::fail_proof(&self.client, proof_id, reason, lock_id)
             .await
             .map_err(|err| map_job_error(err, proof_id))
     }

--- a/proofs/prover-service/src/rpc.rs
+++ b/proofs/prover-service/src/rpc.rs
@@ -3,9 +3,9 @@ use crate::{
     service::ProverService,
     traits::{ProofJobQueue, ProofRequester},
     types::{
-        BackendProofState, BackendUpdate, LeaseToken, LeasedBackendProofWork, LeasedProofRequest,
+        BackendProofState, BackendUpdate, LockId, LockedBackendProofWork, LockedProofRequest,
         ProofBackend, ProofRequest, ProofRequestId, ProofResponse, ProofStatus,
-        ProofSubmissionLease,
+        ProofSubmissionLock,
     },
 };
 use jsonrpsee::{
@@ -63,7 +63,7 @@ pub trait ProverServiceApi {
 
     /// Lease the next queued proof request for the given backend.
     #[method(name = "getNextProof")]
-    async fn get_next_proof(&self, backend: ProofBackend) -> RpcResult<Option<LeasedProofRequest>>;
+    async fn get_next_proof(&self, backend: ProofBackend) -> RpcResult<Option<LockedProofRequest>>;
 
     /// Persist durable backend work created while starting a proof job.
     #[method(name = "submitBackendProofState")]
@@ -71,7 +71,7 @@ pub trait ProverServiceApi {
         &self,
         proof_id: ProofRequestId,
         backend_proof_state: BackendProofState,
-        lease_token: LeaseToken,
+        lease_token: LockId,
     ) -> RpcResult<()>;
 
     /// Lease the next durable backend proof job for the given backend.
@@ -79,14 +79,14 @@ pub trait ProverServiceApi {
     async fn get_next_backend_proof(
         &self,
         backend: ProofBackend,
-    ) -> RpcResult<Option<LeasedBackendProofWork>>;
+    ) -> RpcResult<Option<LockedBackendProofWork>>;
 
     /// Apply a durable backend proof update.
     #[method(name = "completeBackendProofJob")]
     async fn complete_backend_proof_job(
         &self,
         backend_job_id: i64,
-        lease_token: LeaseToken,
+        lease_token: LockId,
         next_update: BackendUpdate,
     ) -> RpcResult<()>;
 
@@ -96,16 +96,13 @@ pub trait ProverServiceApi {
         &self,
         backend_job_id: i64,
         reason: String,
-        lease_token: LeaseToken,
+        lease_token: LockId,
     ) -> RpcResult<()>;
 
     /// Submit a generated proof.
     #[method(name = "submitProof")]
-    async fn submit_proof(
-        &self,
-        proof: ProofResponse,
-        lease: ProofSubmissionLease,
-    ) -> RpcResult<()>;
+    async fn submit_proof(&self, proof: ProofResponse, lease: ProofSubmissionLock)
+    -> RpcResult<()>;
 
     /// Report that proving failed for the given job.
     #[method(name = "failProof")]
@@ -113,7 +110,7 @@ pub trait ProverServiceApi {
         &self,
         proof_id: ProofRequestId,
         reason: String,
-        lease_token: LeaseToken,
+        lease_token: LockId,
     ) -> RpcResult<()>;
 }
 
@@ -153,7 +150,7 @@ impl From<ProofJobQueueError> for ErrorObjectOwned {
             ProofJobQueueError::UnknownBackendJob(_) => {
                 ErrorObject::owned(error_code::UNKNOWN_BACKEND_JOB, message, None::<()>)
             }
-            ProofJobQueueError::StaleLease => {
+            ProofJobQueueError::StaleLocked => {
                 ErrorObject::owned(error_code::STALE_LEASE, message, None::<()>)
             }
             ProofJobQueueError::InvalidProof { id, reason } => ErrorObject::owned(
@@ -198,7 +195,7 @@ impl ProverServiceApiServer for ProverServiceRpc {
         Ok(self.service.get_proof(proof_id).await?)
     }
 
-    async fn get_next_proof(&self, backend: ProofBackend) -> RpcResult<Option<LeasedProofRequest>> {
+    async fn get_next_proof(&self, backend: ProofBackend) -> RpcResult<Option<LockedProofRequest>> {
         Ok(self.service.get_next_proof(backend).await?)
     }
 
@@ -206,7 +203,7 @@ impl ProverServiceApiServer for ProverServiceRpc {
         &self,
         proof_id: ProofRequestId,
         backend_proof_state: BackendProofState,
-        lease_token: LeaseToken,
+        lease_token: LockId,
     ) -> RpcResult<()> {
         Ok(self
             .service
@@ -217,14 +214,14 @@ impl ProverServiceApiServer for ProverServiceRpc {
     async fn get_next_backend_proof(
         &self,
         backend: ProofBackend,
-    ) -> RpcResult<Option<LeasedBackendProofWork>> {
+    ) -> RpcResult<Option<LockedBackendProofWork>> {
         Ok(self.service.get_next_backend_proof(backend).await?)
     }
 
     async fn complete_backend_proof_job(
         &self,
         backend_job_id: i64,
-        lease_token: LeaseToken,
+        lease_token: LockId,
         next_update: BackendUpdate,
     ) -> RpcResult<()> {
         Ok(self
@@ -237,7 +234,7 @@ impl ProverServiceApiServer for ProverServiceRpc {
         &self,
         backend_job_id: i64,
         reason: String,
-        lease_token: LeaseToken,
+        lease_token: LockId,
     ) -> RpcResult<()> {
         Ok(self
             .service
@@ -248,7 +245,7 @@ impl ProverServiceApiServer for ProverServiceRpc {
     async fn submit_proof(
         &self,
         proof: ProofResponse,
-        lease: ProofSubmissionLease,
+        lease: ProofSubmissionLock,
     ) -> RpcResult<()> {
         Ok(self.service.submit_proof(proof, lease).await?)
     }
@@ -257,7 +254,7 @@ impl ProverServiceApiServer for ProverServiceRpc {
         &self,
         proof_id: ProofRequestId,
         reason: String,
-        lease_token: LeaseToken,
+        lease_token: LockId,
     ) -> RpcResult<()> {
         Ok(self
             .service
@@ -340,7 +337,7 @@ fn map_job_error(err: ClientError, id: ProofRequestId) -> ProofJobQueueError {
     };
     match err.code() {
         error_code::UNKNOWN_JOB => ProofJobQueueError::UnknownJob(id),
-        error_code::STALE_LEASE => ProofJobQueueError::StaleLease,
+        error_code::STALE_LEASE => ProofJobQueueError::StaleLocked,
         error_code::INVALID_PROOF => ProofJobQueueError::InvalidProof {
             id,
             reason: invalid_proof_reason(&err).unwrap_or_else(|| err.message().to_string()),
@@ -355,7 +352,7 @@ fn map_backend_job_error(err: ClientError, backend_job_id: i64) -> ProofJobQueue
     };
     match err.code() {
         error_code::UNKNOWN_BACKEND_JOB => ProofJobQueueError::UnknownBackendJob(backend_job_id),
-        error_code::STALE_LEASE => ProofJobQueueError::StaleLease,
+        error_code::STALE_LEASE => ProofJobQueueError::StaleLocked,
         error_code::INVALID_PROOF => {
             if let Some(data) = error_data::<InvalidProofErrorData>(&err) {
                 ProofJobQueueError::InvalidProof {
@@ -407,7 +404,7 @@ impl ProofJobQueue for RpcProverServiceClient {
     async fn get_next_proof(
         &self,
         backend: ProofBackend,
-    ) -> Result<Option<LeasedProofRequest>, ProofJobQueueError> {
+    ) -> Result<Option<LockedProofRequest>, ProofJobQueueError> {
         ProverServiceApiClient::get_next_proof(&self.client, backend)
             .await
             .map_err(|err| ProofJobQueueError::Rpc(err.to_string()))
@@ -417,7 +414,7 @@ impl ProofJobQueue for RpcProverServiceClient {
         &self,
         proof_id: ProofRequestId,
         backend_proof_state: BackendProofState,
-        lease_token: LeaseToken,
+        lease_token: LockId,
     ) -> Result<(), ProofJobQueueError> {
         ProverServiceApiClient::submit_backend_proof_state(
             &self.client,
@@ -432,7 +429,7 @@ impl ProofJobQueue for RpcProverServiceClient {
     async fn get_next_backend_proof(
         &self,
         backend: ProofBackend,
-    ) -> Result<Option<LeasedBackendProofWork>, ProofJobQueueError> {
+    ) -> Result<Option<LockedBackendProofWork>, ProofJobQueueError> {
         ProverServiceApiClient::get_next_backend_proof(&self.client, backend)
             .await
             .map_err(|err| ProofJobQueueError::Rpc(err.to_string()))
@@ -441,7 +438,7 @@ impl ProofJobQueue for RpcProverServiceClient {
     async fn complete_backend_proof_job(
         &self,
         backend_job_id: i64,
-        lease_token: LeaseToken,
+        lease_token: LockId,
         next_update: BackendUpdate,
     ) -> Result<(), ProofJobQueueError> {
         ProverServiceApiClient::complete_backend_proof_job(
@@ -458,7 +455,7 @@ impl ProofJobQueue for RpcProverServiceClient {
         &self,
         backend_job_id: i64,
         reason: String,
-        lease_token: LeaseToken,
+        lease_token: LockId,
     ) -> Result<(), ProofJobQueueError> {
         ProverServiceApiClient::fail_backend_proof_job(
             &self.client,
@@ -473,7 +470,7 @@ impl ProofJobQueue for RpcProverServiceClient {
     async fn submit_proof(
         &self,
         proof: ProofResponse,
-        lease: ProofSubmissionLease,
+        lease: ProofSubmissionLock,
     ) -> Result<(), ProofJobQueueError> {
         let id = proof.id;
         ProverServiceApiClient::submit_proof(&self.client, proof, lease)
@@ -485,7 +482,7 @@ impl ProofJobQueue for RpcProverServiceClient {
         &self,
         proof_id: ProofRequestId,
         reason: String,
-        lease_token: LeaseToken,
+        lease_token: LockId,
     ) -> Result<(), ProofJobQueueError> {
         ProverServiceApiClient::fail_proof(&self.client, proof_id, reason, lease_token)
             .await

--- a/proofs/prover-service/src/service.rs
+++ b/proofs/prover-service/src/service.rs
@@ -4,9 +4,9 @@ use crate::{
     store::ProverServiceStore,
     traits::{ProofJobQueue, ProofRequester},
     types::{
-        BackendProofState, BackendUpdate, LeaseToken, LeasedBackendProofWork, LeasedProofRequest,
+        BackendProofState, BackendUpdate, LockId, LockedBackendProofWork, LockedProofRequest,
         ProofBackend, ProofRequest, ProofRequestId, ProofResponse, ProofStatus,
-        ProofSubmissionLease,
+        ProofSubmissionLock,
     },
 };
 use async_trait::async_trait;
@@ -81,7 +81,7 @@ impl ProofJobQueue for ProverService {
     async fn get_next_proof(
         &self,
         backend: ProofBackend,
-    ) -> Result<Option<LeasedProofRequest>, ProofJobQueueError> {
+    ) -> Result<Option<LockedProofRequest>, ProofJobQueueError> {
         self.store.get_next_proof(backend).await
     }
 
@@ -89,7 +89,7 @@ impl ProofJobQueue for ProverService {
         &self,
         proof_id: ProofRequestId,
         backend_proof_state: BackendProofState,
-        lease_token: LeaseToken,
+        lease_token: LockId,
     ) -> Result<(), ProofJobQueueError> {
         self.store
             .submit_backend_proof_state(proof_id, backend_proof_state, lease_token)
@@ -99,14 +99,14 @@ impl ProofJobQueue for ProverService {
     async fn get_next_backend_proof(
         &self,
         backend: ProofBackend,
-    ) -> Result<Option<LeasedBackendProofWork>, ProofJobQueueError> {
+    ) -> Result<Option<LockedBackendProofWork>, ProofJobQueueError> {
         self.store.get_next_backend_proof(backend).await
     }
 
     async fn complete_backend_proof_job(
         &self,
         backend_job_id: i64,
-        lease_token: LeaseToken,
+        lease_token: LockId,
         next_update: BackendUpdate,
     ) -> Result<(), ProofJobQueueError> {
         match next_update {
@@ -137,7 +137,7 @@ impl ProofJobQueue for ProverService {
         &self,
         backend_job_id: i64,
         reason: String,
-        lease_token: LeaseToken,
+        lease_token: LockId,
     ) -> Result<(), ProofJobQueueError> {
         self.store
             .fail_backend_proof_job(backend_job_id, reason, lease_token)
@@ -147,20 +147,18 @@ impl ProofJobQueue for ProverService {
     async fn submit_proof(
         &self,
         proof: ProofResponse,
-        lease: ProofSubmissionLease,
+        lock: ProofSubmissionLock,
     ) -> Result<(), ProofJobQueueError> {
-        match lease {
-            ProofSubmissionLease::ProofJob { lease_token } => {
-                self.store
-                    .submit_proof_from_proof_job(proof, lease_token)
-                    .await
+        match lock {
+            ProofSubmissionLock::ProofJob { lock_id } => {
+                self.store.submit_proof_from_proof_job(proof, lock_id).await
             }
-            ProofSubmissionLease::BackendJob {
+            ProofSubmissionLock::BackendJob {
                 backend_job_id,
-                lease_token,
+                lock_id,
             } => {
                 self.store
-                    .submit_proof_from_backend_job(proof, backend_job_id, lease_token)
+                    .submit_proof_from_backend_job(proof, backend_job_id, lock_id)
                     .await
             }
         }
@@ -170,7 +168,7 @@ impl ProofJobQueue for ProverService {
         &self,
         proof_id: ProofRequestId,
         reason: String,
-        lease_token: LeaseToken,
+        lease_token: LockId,
     ) -> Result<(), ProofJobQueueError> {
         self.store.fail_proof(proof_id, reason, lease_token).await
     }

--- a/proofs/prover-service/src/service.rs
+++ b/proofs/prover-service/src/service.rs
@@ -14,8 +14,8 @@ use sqlx::{PgPool, migrate::MigrateError};
 
 /// The central orchestration service between defenders and proof generation backends.
 ///
-/// State is durable in Postgres. All worker-facing mutations validate the lease token returned
-/// by the corresponding claim method, so stale workers cannot overwrite rows after their lease
+/// State is durable in Postgres. All worker-facing mutations validate the lock token returned
+/// by the corresponding claim method, so stale workers cannot overwrite rows after their lock
 /// expires and another worker takes over.
 #[derive(Debug, Clone)]
 pub struct ProverService {
@@ -89,10 +89,10 @@ impl ProofJobQueue for ProverService {
         &self,
         proof_id: ProofRequestId,
         backend_proof_state: BackendProofState,
-        lease_token: LockId,
+        lock_id: LockId,
     ) -> Result<(), ProofJobQueueError> {
         self.store
-            .submit_backend_proof_state(proof_id, backend_proof_state, lease_token)
+            .submit_backend_proof_state(proof_id, backend_proof_state, lock_id)
             .await
     }
 
@@ -106,28 +106,24 @@ impl ProofJobQueue for ProverService {
     async fn complete_backend_proof_job(
         &self,
         backend_job_id: i64,
-        lease_token: LockId,
+        lock_id: LockId,
         next_update: BackendUpdate,
     ) -> Result<(), ProofJobQueueError> {
         match next_update {
-            BackendUpdate::Noop => {
-                self.store
-                    .noop_backend_job(backend_job_id, lease_token)
-                    .await
-            }
+            BackendUpdate::Noop => self.store.noop_backend_job(backend_job_id, lock_id).await,
             BackendUpdate::Pending { state } => {
                 self.store
-                    .advance_backend_job(backend_job_id, lease_token, state)
+                    .advance_backend_job(backend_job_id, lock_id, state)
                     .await
             }
             BackendUpdate::Failed(reason) => {
                 self.store
-                    .fail_backend_job(backend_job_id, lease_token, &reason)
+                    .fail_backend_job(backend_job_id, lock_id, &reason)
                     .await
             }
             BackendUpdate::Complete(proof) => {
                 self.store
-                    .submit_completed_backend_proof(backend_job_id, lease_token, proof)
+                    .submit_completed_backend_proof(backend_job_id, lock_id, proof)
                     .await
             }
         }
@@ -137,10 +133,10 @@ impl ProofJobQueue for ProverService {
         &self,
         backend_job_id: i64,
         reason: String,
-        lease_token: LockId,
+        lock_id: LockId,
     ) -> Result<(), ProofJobQueueError> {
         self.store
-            .fail_backend_proof_job(backend_job_id, reason, lease_token)
+            .fail_backend_proof_job(backend_job_id, reason, lock_id)
             .await
     }
 
@@ -168,8 +164,8 @@ impl ProofJobQueue for ProverService {
         &self,
         proof_id: ProofRequestId,
         reason: String,
-        lease_token: LockId,
+        lock_id: LockId,
     ) -> Result<(), ProofJobQueueError> {
-        self.store.fail_proof(proof_id, reason, lease_token).await
+        self.store.fail_proof(proof_id, reason, lock_id).await
     }
 }

--- a/proofs/prover-service/src/store.rs
+++ b/proofs/prover-service/src/store.rs
@@ -3,7 +3,7 @@ use crate::{
     error::{InvalidConfigError, ProofJobQueueError, ProofRequestError, ProverServiceInitError},
     types::{
         BackendProofId, BackendProofJobStatus, BackendProofPhase, BackendProofState,
-        BackendProofWork, LeaseToken, LeasedBackendProofWork, LeasedProofRequest, ProofBackend,
+        BackendProofWork, LockId, LockedBackendProofWork, LockedProofRequest, ProofBackend,
         ProofData, ProofRequest, ProofRequestId, ProofResponse, ProofStatus,
     },
 };
@@ -101,8 +101,8 @@ impl ProverServiceStore {
                          proof_data = null,
                          failure_reason = null,
                          start_attempts = 0,
-                         locked_until = null,
-                         lease_token = null,
+                         lock_expires_at = null,
+                         lock_id = null,
                          updated_at = $3,
                          finished_at = null
                      where proof_id = $1",
@@ -211,7 +211,7 @@ impl ProverServiceStore {
     pub(crate) async fn get_next_proof(
         &self,
         backend: ProofBackend,
-    ) -> Result<Option<LeasedProofRequest>, ProofJobQueueError> {
+    ) -> Result<Option<LockedProofRequest>, ProofJobQueueError> {
         loop {
             let mut tx = self.begin_queue_tx().await?;
             let now = db_now();
@@ -222,7 +222,7 @@ impl ProverServiceStore {
                  where backend = $1
                    and (
                      status = $2
-                     or (status = $3 and locked_until < $4)
+                     or (status = $3 and lock_expires_at < $4)
                    )
                  order by created_at
                  for update skip locked
@@ -243,7 +243,7 @@ impl ProverServiceStore {
             let proof_id = proof_id_from_row(&row).map_err(ProofJobQueueError::Internal)?;
             let attempts: i32 = row.try_get("start_attempts").map_err(queue_db)?;
             if attempts as u32 >= self.config.max_attempts {
-                let reason = format!("start lease expired after {attempts} attempts");
+                let reason = format!("start lock expired after {attempts} attempts");
                 mark_proof_failed(&mut tx, proof_id, &reason, db_now())
                     .await
                     .map_err(queue_db)?;
@@ -253,32 +253,29 @@ impl ProverServiceStore {
             }
 
             let request = request_from_row(&row).map_err(ProofJobQueueError::Internal)?;
-            let lease_token = LeaseToken::new();
-            let locked_until = timestamp_after(now, self.config.lease_timeout);
+            let lock_id = LockId::new();
+            let lock_expires_at = timestamp_after(now, self.config.lock_timeout);
             sqlx::query(
                 "update proof_requests
                  set status = $2,
-                     locked_until = $3,
-                     lease_token = $4,
+                     lock_expires_at = $3,
+                     lock_id = $4,
                      start_attempts = start_attempts + 1,
                      updated_at = $5
                  where proof_id = $1",
             )
             .bind(proof_id_bytes(proof_id))
             .bind(ProofStatus::Starting.as_str())
-            .bind(locked_until)
-            .bind(lease_token.0)
+            .bind(lock_expires_at)
+            .bind(lock_id.0)
             .bind(now)
             .execute(&mut *tx)
             .await
             .map_err(queue_db)?;
 
             tx.commit().await.map_err(queue_db)?;
-            debug!(%proof_id, %backend, attempts = attempts + 1, "proof job leased");
-            return Ok(Some(LeasedProofRequest {
-                request,
-                lease_token,
-            }));
+            debug!(%proof_id, %backend, attempts = attempts + 1, "proof job locked");
+            return Ok(Some(LockedProofRequest { request, lock_id }));
         }
     }
 
@@ -286,23 +283,23 @@ impl ProverServiceStore {
         &self,
         proof_id: ProofRequestId,
         backend_proof_state: BackendProofState,
-        lease_token: LeaseToken,
+        lock_id: LockId,
     ) -> Result<(), ProofJobQueueError> {
         let now = db_now();
         let mut tx = self.begin_queue_tx().await?;
         let backend: Option<String> = sqlx::query_scalar(
             "update proof_requests
              set status = $3,
-                 locked_until = null,
-                 lease_token = null,
+                 lock_expires_at = null,
+                 lock_id = null,
                  updated_at = $4
              where proof_id = $1
-               and lease_token = $2
+               and lock_id = $2
                and status = $5
              returning backend",
         )
         .bind(proof_id_bytes(proof_id))
-        .bind(lease_token.0)
+        .bind(lock_id.0)
         .bind(ProofStatus::BackendPending.as_str())
         .bind(now)
         .bind(ProofStatus::Starting.as_str())
@@ -339,7 +336,7 @@ impl ProverServiceStore {
     pub(crate) async fn get_next_backend_proof(
         &self,
         backend: ProofBackend,
-    ) -> Result<Option<LeasedBackendProofWork>, ProofJobQueueError> {
+    ) -> Result<Option<LockedBackendProofWork>, ProofJobQueueError> {
         loop {
             let mut tx = self.begin_queue_tx().await?;
             let now = db_now();
@@ -349,7 +346,7 @@ impl ProverServiceStore {
                      bj.phase,
                      bj.backend_proof_id,
                      bj.advance_attempts,
-                     (bj.locked_until is not null and bj.locked_until < $3) as lease_expired,
+                     (bj.lock_expires_at is not null and bj.lock_expires_at < $3) as lock_expired,
                      pj.proof_id,
                      pj.backend,
                      pj.game,
@@ -361,7 +358,7 @@ impl ProverServiceStore {
                  where bj.backend = $1
                    and bj.status = $2
                    and bj.next_poll_at <= $3
-                   and (bj.locked_until is null or bj.locked_until < $3)
+                   and (bj.lock_expires_at is null or bj.lock_expires_at < $3)
                  order by bj.next_poll_at
                  for update of bj skip locked
                  limit 1",
@@ -380,14 +377,14 @@ impl ProverServiceStore {
             let backend_job_id: i64 = row.try_get("backend_job_id").map_err(queue_db)?;
             let proof_id = proof_id_from_row(&row).map_err(ProofJobQueueError::Internal)?;
             let attempts: i32 = row.try_get("advance_attempts").map_err(queue_db)?;
-            let lease_expired: bool = row.try_get("lease_expired").map_err(queue_db)?;
-            let attempts = if lease_expired {
+            let lock_expired: bool = row.try_get("lock_expired").map_err(queue_db)?;
+            let attempts = if lock_expired {
                 attempts.saturating_add(1)
             } else {
                 attempts
             };
-            if lease_expired && attempts as u32 >= self.config.max_attempts {
-                let reason = format!("backend lease expired after {attempts} attempts");
+            if lock_expired && attempts as u32 >= self.config.max_attempts {
+                let reason = format!("backend lock expired after {attempts} attempts");
                 mark_backend_failed(&mut tx, backend_job_id, proof_id, &reason, db_now())
                     .await
                     .map_err(queue_db)?;
@@ -409,19 +406,19 @@ impl ProverServiceStore {
                 ),
             );
 
-            let lease_token = LeaseToken::new();
-            let locked_until = timestamp_after(now, self.config.lease_timeout);
+            let lock_id = LockId::new();
+            let lock_expires_at = timestamp_after(now, self.config.lock_timeout);
             sqlx::query(
                 "update proof_sessions
-                 set locked_until = $2,
-                     lease_token = $3,
+                 set lock_expires_at = $2,
+                     lock_id = $3,
                      advance_attempts = $4,
                      updated_at = $5
                  where id = $1",
             )
             .bind(backend_job_id)
-            .bind(locked_until)
-            .bind(lease_token.0)
+            .bind(lock_expires_at)
+            .bind(lock_id.0)
             .bind(attempts)
             .bind(now)
             .execute(&mut *tx)
@@ -429,14 +426,14 @@ impl ProverServiceStore {
             .map_err(queue_db)?;
 
             tx.commit().await.map_err(queue_db)?;
-            debug!(%proof_id, backend_job_id, %backend, failed_attempts = attempts, "backend proof job leased");
-            return Ok(Some(LeasedBackendProofWork {
+            debug!(%proof_id, backend_job_id, %backend, failed_attempts = attempts, "backend proof job locked");
+            return Ok(Some(LockedBackendProofWork {
                 backend_job_id,
                 work: BackendProofWork {
                     proof_request: request,
                     state,
                 },
-                lease_token,
+                lock_id,
             }));
         }
     }
@@ -445,19 +442,19 @@ impl ProverServiceStore {
         &self,
         proof_id: ProofRequestId,
         reason: String,
-        lease_token: LeaseToken,
+        lock_id: LockId,
     ) -> Result<(), ProofJobQueueError> {
         let mut tx = self.begin_queue_tx().await?;
         let row = sqlx::query(
             "select start_attempts, backend
              from proof_requests
              where proof_id = $1
-               and lease_token = $2
+               and lock_id = $2
                and status = $3
              for update",
         )
         .bind(proof_id_bytes(proof_id))
-        .bind(lease_token.0)
+        .bind(lock_id.0)
         .bind(ProofStatus::Starting.as_str())
         .fetch_optional(&mut *tx)
         .await
@@ -478,8 +475,8 @@ impl ProverServiceStore {
             sqlx::query(
                 "update proof_requests
                  set status = $2,
-                     locked_until = null,
-                     lease_token = null,
+                     lock_expires_at = null,
+                     lock_id = null,
                      updated_at = $3
                  where proof_id = $1",
             )
@@ -499,23 +496,23 @@ impl ProverServiceStore {
     pub(crate) async fn noop_backend_job(
         &self,
         backend_job_id: i64,
-        lease_token: LeaseToken,
+        lock_id: LockId,
     ) -> Result<(), ProofJobQueueError> {
         let now = db_now();
         let next_poll_at = timestamp_after(now, self.config.backend_poll_interval);
         let mut tx = self.begin_queue_tx().await?;
         let result = sqlx::query(
             "update proof_sessions
-             set locked_until = null,
-                 lease_token = null,
+             set lock_expires_at = null,
+                 lock_id = null,
                  next_poll_at = $3,
                  updated_at = $4
              where id = $1
-               and lease_token = $2
+               and lock_id = $2
                and status = $5",
         )
         .bind(backend_job_id)
-        .bind(lease_token.0)
+        .bind(lock_id.0)
         .bind(next_poll_at)
         .bind(now)
         .bind(BackendProofJobStatus::Requested.as_str())
@@ -533,7 +530,7 @@ impl ProverServiceStore {
     pub(crate) async fn advance_backend_job(
         &self,
         backend_job_id: i64,
-        lease_token: LeaseToken,
+        lock_id: LockId,
         state: BackendProofState,
     ) -> Result<(), ProofJobQueueError> {
         let now = db_now();
@@ -541,17 +538,17 @@ impl ProverServiceStore {
         let row = sqlx::query(
             "update proof_sessions
              set status = $3,
-                 locked_until = null,
-                 lease_token = null,
+                 lock_expires_at = null,
+                 lock_id = null,
                  updated_at = $4,
                  completed_at = $4
              where id = $1
-               and lease_token = $2
+               and lock_id = $2
                and status = $5
              returning proof_id, backend",
         )
         .bind(backend_job_id)
-        .bind(lease_token.0)
+        .bind(lock_id.0)
         .bind(BackendProofJobStatus::Completed.as_str())
         .bind(now)
         .bind(BackendProofJobStatus::Requested.as_str())
@@ -590,19 +587,19 @@ impl ProverServiceStore {
         &self,
         backend_job_id: i64,
         reason: String,
-        lease_token: LeaseToken,
+        lock_id: LockId,
     ) -> Result<(), ProofJobQueueError> {
         let mut tx = self.begin_queue_tx().await?;
         let row = sqlx::query(
             "select proof_id, advance_attempts
              from proof_sessions
              where id = $1
-               and lease_token = $2
+               and lock_id = $2
                and status = $3
              for update",
         )
         .bind(backend_job_id)
-        .bind(lease_token.0)
+        .bind(lock_id.0)
         .bind(BackendProofJobStatus::Requested.as_str())
         .fetch_optional(&mut *tx)
         .await
@@ -625,17 +622,17 @@ impl ProverServiceStore {
             let next_poll_at = timestamp_after(now, self.config.backend_poll_interval);
             sqlx::query(
                 "update proof_sessions
-                 set locked_until = null,
-                     lease_token = null,
+                 set lock_expires_at = null,
+                     lock_id = null,
                      next_poll_at = $3,
                      advance_attempts = $4,
                      updated_at = $5
                  where id = $1
-                   and lease_token = $2
+                   and lock_id = $2
                    and status = $6",
             )
             .bind(backend_job_id)
-            .bind(lease_token.0)
+            .bind(lock_id.0)
             .bind(next_poll_at)
             .bind(attempts)
             .bind(now)
@@ -653,7 +650,7 @@ impl ProverServiceStore {
     pub(crate) async fn fail_backend_job(
         &self,
         backend_job_id: i64,
-        lease_token: LeaseToken,
+        lock_id: LockId,
         reason: &str,
     ) -> Result<(), ProofJobQueueError> {
         let now = db_now();
@@ -662,17 +659,17 @@ impl ProverServiceStore {
             "update proof_sessions
              set status = $3,
                  failure_reason = $4,
-                 locked_until = null,
-                 lease_token = null,
+                 lock_expires_at = null,
+                 lock_id = null,
                  updated_at = $5,
                  completed_at = $5
              where id = $1
-               and lease_token = $2
+               and lock_id = $2
                and status = $6
              returning proof_id",
         )
         .bind(backend_job_id)
-        .bind(lease_token.0)
+        .bind(lock_id.0)
         .bind(BackendProofJobStatus::Failed.as_str())
         .bind(reason)
         .bind(now)
@@ -696,19 +693,17 @@ impl ProverServiceStore {
     pub(crate) async fn submit_completed_backend_proof(
         &self,
         backend_job_id: i64,
-        lease_token: LeaseToken,
+        lock_id: LockId,
         proof: ProofData,
     ) -> Result<(), ProofJobQueueError> {
-        let proof_id = self
-            .backend_job_proof_id(backend_job_id, lease_token)
-            .await?;
+        let proof_id = self.backend_job_proof_id(backend_job_id, lock_id).await?;
         self.submit_proof_from_backend_job(
             ProofResponse {
                 id: proof_id,
                 proof,
             },
             backend_job_id,
-            lease_token,
+            lock_id,
         )
         .await
     }
@@ -716,18 +711,18 @@ impl ProverServiceStore {
     async fn backend_job_proof_id(
         &self,
         backend_job_id: i64,
-        lease_token: LeaseToken,
+        lock_id: LockId,
     ) -> Result<ProofRequestId, ProofJobQueueError> {
         let mut tx = self.begin_queue_tx().await?;
         let row = sqlx::query(
             "select proof_id
              from proof_sessions
              where id = $1
-               and lease_token = $2
+               and lock_id = $2
                and status = $3",
         )
         .bind(backend_job_id)
-        .bind(lease_token.0)
+        .bind(lock_id.0)
         .bind(BackendProofJobStatus::Requested.as_str())
         .fetch_optional(&mut *tx)
         .await
@@ -744,19 +739,19 @@ impl ProverServiceStore {
     pub(crate) async fn submit_proof_from_proof_job(
         &self,
         proof: ProofResponse,
-        lease_token: LeaseToken,
+        lock_id: LockId,
     ) -> Result<(), ProofJobQueueError> {
         let mut tx = self.begin_queue_tx().await?;
         let row = sqlx::query(
             "select backend
              from proof_requests
              where proof_id = $1
-               and lease_token = $2
+               and lock_id = $2
                and status = $3
              for update",
         )
         .bind(proof_id_bytes(proof.id))
-        .bind(lease_token.0)
+        .bind(lock_id.0)
         .bind(ProofStatus::Starting.as_str())
         .fetch_optional(&mut *tx)
         .await
@@ -778,17 +773,17 @@ impl ProverServiceStore {
         &self,
         proof: ProofResponse,
         backend_job_id: i64,
-        lease_token: LeaseToken,
+        lock_id: LockId,
     ) -> Result<(), ProofJobQueueError> {
         match self
-            .try_submit_proof_from_backend_job(proof, backend_job_id, lease_token)
+            .try_submit_proof_from_backend_job(proof, backend_job_id, lock_id)
             .await
         {
             Ok(()) => Ok(()),
             Err(error) => {
                 if let Some(action) = backend_submission_failure_action(&error)
                     && let Err(cleanup_error) = self
-                        .handle_failed_backend_submission(backend_job_id, lease_token, action)
+                        .handle_failed_backend_submission(backend_job_id, lock_id, action)
                         .await
                 {
                     warn!(
@@ -807,7 +802,7 @@ impl ProverServiceStore {
         &self,
         proof: ProofResponse,
         backend_job_id: i64,
-        lease_token: LeaseToken,
+        lock_id: LockId,
     ) -> Result<(), ProofJobQueueError> {
         let mut tx = self.begin_queue_tx().await?;
         let row = sqlx::query(
@@ -815,12 +810,12 @@ impl ProverServiceStore {
              from proof_sessions bj
              join proof_requests pj on pj.proof_id = bj.proof_id
              where bj.id = $1
-               and bj.lease_token = $2
+               and bj.lock_id = $2
                and bj.status = $3
              for update of bj, pj",
         )
         .bind(backend_job_id)
-        .bind(lease_token.0)
+        .bind(lock_id.0)
         .bind(BackendProofJobStatus::Requested.as_str())
         .fetch_optional(&mut *tx)
         .await
@@ -844,8 +839,8 @@ impl ProverServiceStore {
         sqlx::query(
             "update proof_sessions
              set status = $2,
-                 locked_until = null,
-                 lease_token = null,
+                 lock_expires_at = null,
+                 lock_id = null,
                  updated_at = $3,
                  completed_at = $3
              where id = $1",
@@ -866,16 +861,16 @@ impl ProverServiceStore {
     async fn handle_failed_backend_submission(
         &self,
         backend_job_id: i64,
-        lease_token: LeaseToken,
+        lock_id: LockId,
         action: BackendSubmissionFailureAction,
     ) -> Result<(), ProofJobQueueError> {
         match action {
             BackendSubmissionFailureAction::Terminal(reason) => {
-                self.fail_backend_job(backend_job_id, lease_token, &reason)
+                self.fail_backend_job(backend_job_id, lock_id, &reason)
                     .await
             }
             BackendSubmissionFailureAction::Retry(reason) => {
-                self.fail_backend_proof_job(backend_job_id, reason, lease_token)
+                self.fail_backend_proof_job(backend_job_id, reason, lock_id)
                     .await
             }
         }
@@ -999,7 +994,7 @@ fn backend_submission_failure_action(
     error: &ProofJobQueueError,
 ) -> Option<BackendSubmissionFailureAction> {
     match error {
-        ProofJobQueueError::StaleLease
+        ProofJobQueueError::StaleLocked
         | ProofJobQueueError::UnknownBackendJob(_)
         | ProofJobQueueError::UnknownJob(_) => None,
         ProofJobQueueError::InvalidProof { .. } => {
@@ -1025,7 +1020,7 @@ async fn classify_proof_update(
     .await
     .unwrap_or(false);
     if exists {
-        ProofJobQueueError::StaleLease
+        ProofJobQueueError::StaleLocked
     } else {
         ProofJobQueueError::UnknownJob(proof_id)
     }
@@ -1042,7 +1037,7 @@ async fn classify_backend_update(
             .await
             .unwrap_or(false);
     if exists {
-        ProofJobQueueError::StaleLease
+        ProofJobQueueError::StaleLocked
     } else {
         ProofJobQueueError::UnknownBackendJob(backend_job_id)
     }
@@ -1059,8 +1054,8 @@ async fn mark_proof_failed(
          set status = $2,
              proof_data = null,
              failure_reason = $3,
-             locked_until = null,
-             lease_token = null,
+             lock_expires_at = null,
+             lock_id = null,
              updated_at = $4,
              finished_at = $4
          where proof_id = $1",
@@ -1085,8 +1080,8 @@ async fn mark_backend_failed(
         "update proof_sessions
          set status = $2,
              failure_reason = $3,
-             locked_until = null,
-             lease_token = null,
+             lock_expires_at = null,
+             lock_id = null,
              updated_at = $4,
              completed_at = $4
          where id = $1",
@@ -1112,8 +1107,8 @@ async fn complete_proof(
          set status = $2,
              proof_data = $3,
              failure_reason = null,
-             locked_until = null,
-             lease_token = null,
+             lock_expires_at = null,
+             lock_id = null,
              updated_at = $4,
              finished_at = $4
          where proof_id = $1",

--- a/proofs/prover-service/src/tests.rs
+++ b/proofs/prover-service/src/tests.rs
@@ -1,7 +1,7 @@
 use crate::{
-    BackendProofId, BackendProofState, BackendUpdate, LeasedProofRequest, ProofBackend, ProofData,
+    BackendProofId, BackendProofState, BackendUpdate, LockedProofRequest, ProofBackend, ProofData,
     ProofJobQueue, ProofJobQueueError, ProofRequest, ProofRequestError, ProofRequester,
-    ProofResponse, ProofStatus, ProofSubmissionLease, ProverService, ProverServiceConfig,
+    ProofResponse, ProofStatus, ProofSubmissionLock, ProverService, ProverServiceConfig,
     RpcProverServiceClient, start_rpc_server,
 };
 use alloy_primitives::{Address, B256, Bytes};
@@ -12,7 +12,7 @@ use testcontainers_modules::postgres;
 
 fn test_config() -> ProverServiceConfig {
     ProverServiceConfig {
-        lease_timeout: Duration::from_secs(60),
+        lock_timeout: Duration::from_secs(60),
         max_attempts: 2,
         max_queue_len: 4,
         backend_poll_interval: Duration::from_millis(25),
@@ -99,12 +99,12 @@ async fn nitro_style_full_lifecycle() {
     let id = service.request_proof(req.clone()).await.unwrap();
     assert_eq!(service.proof_status(id).await.unwrap(), ProofStatus::Queued);
 
-    let leased = service
+    let locked = service
         .get_next_proof(ProofBackend::Nitro)
         .await
         .unwrap()
         .expect("job available");
-    assert_eq!(leased.request, req);
+    assert_eq!(locked.request, req);
     assert_eq!(
         service.proof_status(id).await.unwrap(),
         ProofStatus::Starting
@@ -121,8 +121,8 @@ async fn nitro_style_full_lifecycle() {
     service
         .submit_proof(
             response.clone(),
-            ProofSubmissionLease::ProofJob {
-                lease_token: leased.lease_token,
+            ProofSubmissionLock::ProofJob {
+                lock_id: locked.lock_id,
             },
         )
         .await
@@ -142,22 +142,18 @@ async fn backend_job_workflow_reaches_final_proof() {
     let service = ctx.service;
     let req = request(ProofBackend::Sp1, 2);
     let id = service.request_proof(req.clone()).await.unwrap();
-    let LeasedProofRequest {
-        request: leased_req,
-        lease_token,
+    let LockedProofRequest {
+        request: locked_req,
+        lock_id,
     } = service
         .get_next_proof(ProofBackend::Sp1)
         .await
         .unwrap()
         .expect("job available");
-    assert_eq!(leased_req, req);
+    assert_eq!(locked_req, req);
 
     service
-        .submit_backend_proof_state(
-            id,
-            BackendProofState::Range { id: backend_id(1) },
-            lease_token,
-        )
+        .submit_backend_proof_state(id, BackendProofState::Range { id: backend_id(1) }, lock_id)
         .await
         .unwrap();
     assert_eq!(
@@ -177,7 +173,7 @@ async fn backend_job_workflow_reaches_final_proof() {
     );
 
     service
-        .complete_backend_proof_job(range.backend_job_id, range.lease_token, BackendUpdate::Noop)
+        .complete_backend_proof_job(range.backend_job_id, range.lock_id, BackendUpdate::Noop)
         .await
         .unwrap();
     assert!(
@@ -197,7 +193,7 @@ async fn backend_job_workflow_reaches_final_proof() {
     service
         .complete_backend_proof_job(
             range.backend_job_id,
-            range.lease_token,
+            range.lock_id,
             BackendUpdate::Pending {
                 state: BackendProofState::Aggregation { id: backend_id(2) },
             },
@@ -217,9 +213,9 @@ async fn backend_job_workflow_reaches_final_proof() {
     service
         .submit_proof(
             proof_for(&req),
-            ProofSubmissionLease::BackendJob {
+            ProofSubmissionLock::BackendJob {
                 backend_job_id: aggregation.backend_job_id,
-                lease_token: aggregation.lease_token,
+                lock_id: aggregation.lock_id,
             },
         )
         .await
@@ -231,9 +227,9 @@ async fn backend_job_workflow_reaches_final_proof() {
 }
 
 #[tokio::test]
-async fn stale_start_lease_is_rejected() {
+async fn stale_start_lock_is_rejected() {
     let Some(ctx) = service(ProverServiceConfig {
-        lease_timeout: Duration::from_millis(10),
+        lock_timeout: Duration::from_millis(10),
         ..test_config()
     })
     .await
@@ -247,31 +243,31 @@ async fn stale_start_lease_is_rejected() {
         .get_next_proof(ProofBackend::Sp1)
         .await
         .unwrap()
-        .expect("first lease");
+        .expect("first lock");
     tokio::time::sleep(Duration::from_millis(20)).await;
     let second = service
         .get_next_proof(ProofBackend::Sp1)
         .await
         .unwrap()
-        .expect("second lease");
+        .expect("second lock");
 
     assert!(matches!(
         service
             .submit_proof(
                 proof_for(&req),
-                ProofSubmissionLease::ProofJob {
-                    lease_token: first.lease_token,
+                ProofSubmissionLock::ProofJob {
+                    lock_id: first.lock_id,
                 },
             )
             .await,
-        Err(ProofJobQueueError::StaleLease)
+        Err(ProofJobQueueError::StaleLocked)
     ));
 
     service
         .submit_proof(
             proof_for(&req),
-            ProofSubmissionLease::ProofJob {
-                lease_token: second.lease_token,
+            ProofSubmissionLock::ProofJob {
+                lock_id: second.lock_id,
             },
         )
         .await
@@ -295,13 +291,9 @@ async fn failed_attempts_retry_until_exhausted() {
         .get_next_proof(ProofBackend::Sp1)
         .await
         .unwrap()
-        .expect("first lease");
+        .expect("first lock");
     service
-        .fail_proof(
-            id,
-            "witness generation failed".to_string(),
-            first.lease_token,
-        )
+        .fail_proof(id, "witness generation failed".to_string(), first.lock_id)
         .await
         .unwrap();
     assert_eq!(service.proof_status(id).await.unwrap(), ProofStatus::Queued);
@@ -310,9 +302,9 @@ async fn failed_attempts_retry_until_exhausted() {
         .get_next_proof(ProofBackend::Sp1)
         .await
         .unwrap()
-        .expect("second lease");
+        .expect("second lock");
     service
-        .fail_proof(id, "backend rejected".to_string(), second.lease_token)
+        .fail_proof(id, "backend rejected".to_string(), second.lock_id)
         .await
         .unwrap();
     assert_eq!(service.proof_status(id).await.unwrap(), ProofStatus::Failed);
@@ -326,16 +318,16 @@ async fn backend_attempt_errors_retry_until_exhausted() {
     let service = ctx.service;
     let req = request(ProofBackend::Sp1, 5);
     let id = service.request_proof(req.clone()).await.unwrap();
-    let leased = service
+    let locked = service
         .get_next_proof(ProofBackend::Sp1)
         .await
         .unwrap()
-        .expect("start lease");
+        .expect("start lock");
     service
         .submit_backend_proof_state(
             id,
             BackendProofState::Range { id: backend_id(1) },
-            leased.lease_token,
+            locked.lock_id,
         )
         .await
         .unwrap();
@@ -344,12 +336,12 @@ async fn backend_attempt_errors_retry_until_exhausted() {
         .get_next_backend_proof(ProofBackend::Sp1)
         .await
         .unwrap()
-        .expect("first backend lease");
+        .expect("first backend lock");
     service
         .fail_backend_proof_job(
             first.backend_job_id,
             "temporary SP1 poll failure".to_string(),
-            first.lease_token,
+            first.lock_id,
         )
         .await
         .unwrap();
@@ -370,13 +362,13 @@ async fn backend_attempt_errors_retry_until_exhausted() {
         .get_next_backend_proof(ProofBackend::Sp1)
         .await
         .unwrap()
-        .expect("second backend lease");
+        .expect("second backend lock");
     assert_eq!(second.backend_job_id, first.backend_job_id);
     service
         .fail_backend_proof_job(
             second.backend_job_id,
             "temporary SP1 poll failure".to_string(),
-            second.lease_token,
+            second.lock_id,
         )
         .await
         .unwrap();
@@ -391,16 +383,16 @@ async fn invalid_completed_backend_proof_fails_immediately() {
     let service = ctx.service;
     let req = request(ProofBackend::Sp1, 6);
     let id = service.request_proof(req.clone()).await.unwrap();
-    let leased = service
+    let locked = service
         .get_next_proof(ProofBackend::Sp1)
         .await
         .unwrap()
-        .expect("start lease");
+        .expect("start lock");
     service
         .submit_backend_proof_state(
             id,
             BackendProofState::Range { id: backend_id(1) },
-            leased.lease_token,
+            locked.lock_id,
         )
         .await
         .unwrap();
@@ -409,7 +401,7 @@ async fn invalid_completed_backend_proof_fails_immediately() {
         .get_next_backend_proof(ProofBackend::Sp1)
         .await
         .unwrap()
-        .expect("backend lease");
+        .expect("backend lock");
     let invalid_proof = ProofData::Nitro {
         attestation: Bytes::from(vec![0xcc]),
         signature: Bytes::from(vec![0xdd]),
@@ -418,7 +410,7 @@ async fn invalid_completed_backend_proof_fails_immediately() {
         service
             .complete_backend_proof_job(
                 backend.backend_job_id,
-                backend.lease_token,
+                backend.lock_id,
                 BackendUpdate::Complete(invalid_proof),
             )
             .await,
@@ -436,23 +428,23 @@ async fn invalid_completed_backend_proof_fails_immediately() {
 }
 
 #[tokio::test]
-async fn failed_completed_backend_submission_releases_lease() {
+async fn failed_completed_backend_submission_relocks_lock() {
     let Some(ctx) = service(test_config()).await else {
         return;
     };
     let service = ctx.service;
     let req = request(ProofBackend::Sp1, 7);
     let id = service.request_proof(req.clone()).await.unwrap();
-    let leased = service
+    let locked = service
         .get_next_proof(ProofBackend::Sp1)
         .await
         .unwrap()
-        .expect("start lease");
+        .expect("start lock");
     service
         .submit_backend_proof_state(
             id,
             BackendProofState::Range { id: backend_id(1) },
-            leased.lease_token,
+            locked.lock_id,
         )
         .await
         .unwrap();
@@ -460,7 +452,7 @@ async fn failed_completed_backend_submission_releases_lease() {
         .get_next_backend_proof(ProofBackend::Sp1)
         .await
         .unwrap()
-        .expect("backend lease");
+        .expect("backend lock");
 
     sqlx::query("update proof_requests set backend = 'corrupt' where proof_id = $1")
         .bind(id.0.as_slice())
@@ -472,7 +464,7 @@ async fn failed_completed_backend_submission_releases_lease() {
         service
             .complete_backend_proof_job(
                 backend.backend_job_id,
-                backend.lease_token,
+                backend.lock_id,
                 BackendUpdate::Complete(proof_for(&req).proof),
             )
             .await,
@@ -480,8 +472,8 @@ async fn failed_completed_backend_submission_releases_lease() {
     ));
 
     let row = sqlx::query(
-        "select status, advance_attempts, locked_until is null as unlocked,
-                lease_token is null as lease_cleared
+        "select status, advance_attempts, lock_expires_at is null as unlocked,
+                lock_id is null as lock_cleared
          from proof_sessions
          where id = $1",
     )
@@ -492,7 +484,7 @@ async fn failed_completed_backend_submission_releases_lease() {
     assert_eq!(row.get::<String, _>("status"), "requested");
     assert_eq!(row.get::<i32, _>("advance_attempts"), 1);
     assert!(row.get::<bool, _>("unlocked"));
-    assert!(row.get::<bool, _>("lease_cleared"));
+    assert!(row.get::<bool, _>("lock_cleared"));
 }
 
 #[tokio::test]
@@ -503,16 +495,16 @@ async fn backend_noop_polling_does_not_exhaust_attempts() {
     let service = ctx.service;
     let req = request(ProofBackend::Sp1, 8);
     let id = service.request_proof(req.clone()).await.unwrap();
-    let leased = service
+    let locked = service
         .get_next_proof(ProofBackend::Sp1)
         .await
         .unwrap()
-        .expect("start lease");
+        .expect("start lock");
     service
         .submit_backend_proof_state(
             id,
             BackendProofState::Range { id: backend_id(1) },
-            leased.lease_token,
+            locked.lock_id,
         )
         .await
         .unwrap();
@@ -523,7 +515,7 @@ async fn backend_noop_polling_does_not_exhaust_attempts() {
             .get_next_backend_proof(ProofBackend::Sp1)
             .await
             .unwrap()
-            .expect("backend lease");
+            .expect("backend lock");
         if let Some(previous) = backend_job_id {
             assert_eq!(backend.backend_job_id, previous);
         } else {
@@ -532,7 +524,7 @@ async fn backend_noop_polling_does_not_exhaust_attempts() {
         service
             .complete_backend_proof_job(
                 backend.backend_job_id,
-                backend.lease_token,
+                backend.lock_id,
                 BackendUpdate::Noop,
             )
             .await
@@ -548,11 +540,11 @@ async fn backend_noop_polling_does_not_exhaust_attempts() {
         .get_next_backend_proof(ProofBackend::Sp1)
         .await
         .unwrap()
-        .expect("backend lease after repeated noops");
+        .expect("backend lock after repeated noops");
     service
         .complete_backend_proof_job(
             backend.backend_job_id,
-            backend.lease_token,
+            backend.lock_id,
             BackendUpdate::Pending {
                 state: BackendProofState::Aggregation { id: backend_id(2) },
             },
@@ -566,9 +558,9 @@ async fn backend_noop_polling_does_not_exhaust_attempts() {
 }
 
 #[tokio::test]
-async fn expired_backend_leases_count_toward_attempts() {
+async fn expired_backend_locks_count_toward_attempts() {
     let Some(ctx) = service(ProverServiceConfig {
-        lease_timeout: Duration::from_millis(10),
+        lock_timeout: Duration::from_millis(10),
         ..test_config()
     })
     .await
@@ -578,16 +570,16 @@ async fn expired_backend_leases_count_toward_attempts() {
     let service = ctx.service;
     let req = request(ProofBackend::Sp1, 9);
     let id = service.request_proof(req.clone()).await.unwrap();
-    let leased = service
+    let locked = service
         .get_next_proof(ProofBackend::Sp1)
         .await
         .unwrap()
-        .expect("start lease");
+        .expect("start lock");
     service
         .submit_backend_proof_state(
             id,
             BackendProofState::Range { id: backend_id(1) },
-            leased.lease_token,
+            locked.lock_id,
         )
         .await
         .unwrap();
@@ -596,13 +588,13 @@ async fn expired_backend_leases_count_toward_attempts() {
         .get_next_backend_proof(ProofBackend::Sp1)
         .await
         .unwrap()
-        .expect("first backend lease");
+        .expect("first backend lock");
     tokio::time::sleep(Duration::from_millis(20)).await;
     let second = service
         .get_next_backend_proof(ProofBackend::Sp1)
         .await
         .unwrap()
-        .expect("second backend lease");
+        .expect("second backend lock");
     assert_eq!(second.backend_job_id, first.backend_job_id);
     assert_eq!(
         service.proof_status(id).await.unwrap(),
@@ -635,17 +627,17 @@ async fn rpc_end_to_end() {
     let id = client.request_proof(req.clone()).await.unwrap();
     assert_eq!(client.proof_status(id).await.unwrap(), ProofStatus::Queued);
 
-    let leased = client
+    let locked = client
         .get_next_proof(ProofBackend::Sp1)
         .await
         .unwrap()
         .expect("job available");
-    assert_eq!(leased.request, req);
+    assert_eq!(locked.request, req);
     client
         .submit_proof(
             proof_for(&req),
-            ProofSubmissionLease::ProofJob {
-                lease_token: leased.lease_token,
+            ProofSubmissionLock::ProofJob {
+                lock_id: locked.lock_id,
             },
         )
         .await
@@ -669,16 +661,16 @@ async fn rpc_backend_invalid_proof_maps_to_typed_error() {
 
     let req = request(ProofBackend::Sp1, 10);
     let id = client.request_proof(req.clone()).await.unwrap();
-    let leased = client
+    let locked = client
         .get_next_proof(ProofBackend::Sp1)
         .await
         .unwrap()
-        .expect("start lease");
+        .expect("start lock");
     client
         .submit_backend_proof_state(
             id,
             BackendProofState::Range { id: backend_id(1) },
-            leased.lease_token,
+            locked.lock_id,
         )
         .await
         .unwrap();
@@ -686,7 +678,7 @@ async fn rpc_backend_invalid_proof_maps_to_typed_error() {
         .get_next_backend_proof(ProofBackend::Sp1)
         .await
         .unwrap()
-        .expect("backend lease");
+        .expect("backend lock");
 
     let invalid_proof = ProofData::Nitro {
         attestation: Bytes::from(vec![0xcc]),
@@ -696,7 +688,7 @@ async fn rpc_backend_invalid_proof_maps_to_typed_error() {
         client
             .complete_backend_proof_job(
                 backend.backend_job_id,
-                backend.lease_token,
+                backend.lock_id,
                 BackendUpdate::Complete(invalid_proof),
             )
             .await,

--- a/proofs/prover-service/src/traits.rs
+++ b/proofs/prover-service/src/traits.rs
@@ -1,9 +1,9 @@
 use crate::{
     error::{ProofJobQueueError, ProofRequestError},
     types::{
-        BackendProofState, BackendUpdate, LeaseToken, LeasedBackendProofWork, LeasedProofRequest,
+        BackendProofState, BackendUpdate, LockId, LockedBackendProofWork, LockedProofRequest,
         ProofBackend, ProofRequest, ProofRequestId, ProofResponse, ProofStatus,
-        ProofSubmissionLease,
+        ProofSubmissionLock,
     },
 };
 use async_trait::async_trait;
@@ -45,27 +45,27 @@ pub trait ProofJobQueue {
     async fn get_next_proof(
         &self,
         backend: ProofBackend,
-    ) -> Result<Option<LeasedProofRequest>, ProofJobQueueError>;
+    ) -> Result<Option<LockedProofRequest>, ProofJobQueueError>;
 
     /// Persist durable backend work created while starting a proof job.
     async fn submit_backend_proof_state(
         &self,
         proof_id: ProofRequestId,
         backend_proof_state: BackendProofState,
-        lease_token: LeaseToken,
+        lease_token: LockId,
     ) -> Result<(), ProofJobQueueError>;
 
     /// Lease durable backend work that is due for polling or advancement.
     async fn get_next_backend_proof(
         &self,
         backend: ProofBackend,
-    ) -> Result<Option<LeasedBackendProofWork>, ProofJobQueueError>;
+    ) -> Result<Option<LockedBackendProofWork>, ProofJobQueueError>;
 
     /// Apply an update produced while advancing a durable backend job.
     async fn complete_backend_proof_job(
         &self,
         backend_job_id: i64,
-        lease_token: LeaseToken,
+        lease_token: LockId,
         next_update: BackendUpdate,
     ) -> Result<(), ProofJobQueueError>;
 
@@ -77,14 +77,14 @@ pub trait ProofJobQueue {
         &self,
         backend_job_id: i64,
         reason: String,
-        lease_token: LeaseToken,
+        lease_token: LockId,
     ) -> Result<(), ProofJobQueueError>;
 
     /// Submit a final proof response to the `prover-service`.
     async fn submit_proof(
         &self,
         proof: ProofResponse,
-        lease: ProofSubmissionLease,
+        lease: ProofSubmissionLock,
     ) -> Result<(), ProofJobQueueError>;
 
     /// Report that proving failed for the given job.
@@ -95,6 +95,6 @@ pub trait ProofJobQueue {
         &self,
         proof_id: ProofRequestId,
         reason: String,
-        lease_token: LeaseToken,
+        lease_token: LockId,
     ) -> Result<(), ProofJobQueueError>;
 }

--- a/proofs/prover-service/src/traits.rs
+++ b/proofs/prover-service/src/traits.rs
@@ -39,8 +39,8 @@ pub trait ProofRequester {
 pub trait ProofJobQueue {
     /// Look for a new proof request to start on the given backend.
     ///
-    /// Returns `None` when no work is available. Returned jobs are leased:
-    /// a job that is neither submitted nor failed before the lease expires
+    /// Returns `None` when no work is available. Returned jobs are locked:
+    /// a job that is neither submitted nor failed before the lock expires
     /// is re-queued.
     async fn get_next_proof(
         &self,
@@ -52,10 +52,10 @@ pub trait ProofJobQueue {
         &self,
         proof_id: ProofRequestId,
         backend_proof_state: BackendProofState,
-        lease_token: LockId,
+        lock_id: LockId,
     ) -> Result<(), ProofJobQueueError>;
 
-    /// Lease durable backend work that is due for polling or advancement.
+    /// Lock durable backend work that is due for polling or advancement.
     async fn get_next_backend_proof(
         &self,
         backend: ProofBackend,
@@ -65,7 +65,7 @@ pub trait ProofJobQueue {
     async fn complete_backend_proof_job(
         &self,
         backend_job_id: i64,
-        lease_token: LockId,
+        lock_id: LockId,
         next_update: BackendUpdate,
     ) -> Result<(), ProofJobQueueError>;
 
@@ -77,14 +77,14 @@ pub trait ProofJobQueue {
         &self,
         backend_job_id: i64,
         reason: String,
-        lease_token: LockId,
+        lock_id: LockId,
     ) -> Result<(), ProofJobQueueError>;
 
     /// Submit a final proof response to the `prover-service`.
     async fn submit_proof(
         &self,
         proof: ProofResponse,
-        lease: ProofSubmissionLock,
+        lock: ProofSubmissionLock,
     ) -> Result<(), ProofJobQueueError>;
 
     /// Report that proving failed for the given job.
@@ -95,6 +95,6 @@ pub trait ProofJobQueue {
         &self,
         proof_id: ProofRequestId,
         reason: String,
-        lease_token: LockId,
+        lock_id: LockId,
     ) -> Result<(), ProofJobQueueError>;
 }

--- a/proofs/prover-service/src/types.rs
+++ b/proofs/prover-service/src/types.rs
@@ -264,37 +264,37 @@ impl TryFrom<&str> for BackendProofPhase {
     }
 }
 
-/// Opaque token proving ownership of a leased row.
+/// Opaque token proving ownership of a locked row.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct LeaseToken(pub Uuid);
+pub struct LockId(pub Uuid);
 
-impl LeaseToken {
-    /// Generate a fresh lease token.
+impl LockId {
+    /// Generate a fresh lock id.
     #[must_use]
     pub fn new() -> Self {
         Self(Uuid::new_v4())
     }
 }
 
-impl Default for LeaseToken {
+impl Default for LockId {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl std::fmt::Display for LeaseToken {
+impl std::fmt::Display for LockId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
-/// Initial proof request leased from `proof_requests`.
+/// Initial proof request locked from `proof_requests`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct LeasedProofRequest {
+pub struct LockedProofRequest {
     /// The user-facing proof request.
     pub request: ProofRequest,
-    /// Token required for updates to the leased proof job.
-    pub lease_token: LeaseToken,
+    /// Token required for updates to the locked proof job.
+    pub lock_id: LockId,
 }
 
 /// Durable external backend state.
@@ -356,31 +356,31 @@ pub struct BackendProofWork {
     pub state: BackendProofState,
 }
 
-/// Durable backend job leased from `proof_sessions`.
+/// Durable backend job locked from `proof_sessions`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct LeasedBackendProofWork {
+pub struct LockedBackendProofWork {
     /// Database identifier of the backend job row.
     pub backend_job_id: i64,
     /// Backend work to advance.
     pub work: BackendProofWork,
-    /// Token required for updates to the leased backend job.
-    pub lease_token: LeaseToken,
+    /// Token required for updates to the locked backend job.
+    pub lock_id: LockId,
 }
 
-/// Lease location for final proof submission.
+/// Locked location for final proof submission.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum ProofSubmissionLease {
+pub enum ProofSubmissionLock {
     /// Final proof was produced while starting a user-facing proof job.
     ProofJob {
-        /// Token for the leased `proof_requests` row.
-        lease_token: LeaseToken,
+        /// Token for the locked `proof_requests` row.
+        lock_id: LockId,
     },
     /// Final proof was produced while advancing a durable backend job.
     BackendJob {
         /// Database identifier of the backend job row.
         backend_job_id: i64,
-        /// Token for the leased `proof_sessions` row.
-        lease_token: LeaseToken,
+        /// Token for the locked `proof_sessions` row.
+        lock_id: LockId,
     },
 }
 

--- a/proofs/sp1-worker/src/main.rs
+++ b/proofs/sp1-worker/src/main.rs
@@ -107,6 +107,10 @@ struct Cli {
     /// the Succinct proving network.
     #[arg(long, default_value_t = 1)]
     max_concurrent_jobs: usize,
+
+    /// The unique worker id.
+    #[arg(long)]
+    worker_id: String,
 }
 
 fn main() -> Result<()> {
@@ -148,10 +152,12 @@ fn main() -> Result<()> {
 
     let queue = RpcProverServiceClient::new(&cli.prover_service_url)
         .with_context(|| format!("failed to connect to {}", cli.prover_service_url))?;
+    let worker_id = cli.worker_id;
     let worker = ProofWorker::new(
         queue,
         backend,
         ProofWorkerConfig {
+            worker_id,
             poll_interval: Duration::from_secs(cli.poll_interval_seconds),
             max_concurrent_jobs: cli.max_concurrent_jobs,
         },

--- a/proofs/sp1-worker/src/main.rs
+++ b/proofs/sp1-worker/src/main.rs
@@ -152,7 +152,7 @@ fn main() -> Result<()> {
 
     let queue = RpcProverServiceClient::new(&cli.prover_service_url)
         .with_context(|| format!("failed to connect to {}", cli.prover_service_url))?;
-    let worker_id = cli.worker_id;
+    let worker_id = format!("{}-sp1-worker", cli.worker_id);
     let worker = ProofWorker::new(
         queue,
         backend,

--- a/proofs/sp1-worker/tests/e2e_proving.rs
+++ b/proofs/sp1-worker/tests/e2e_proving.rs
@@ -187,6 +187,7 @@ async fn worker_proves_real_range_end_to_end() {
         RpcProverServiceClient::new(&url).expect("client"),
         backend,
         ProofWorkerConfig {
+            worker_id: "test-worker".to_string(),
             poll_interval: Duration::from_millis(500),
             max_concurrent_jobs: 1,
         },

--- a/proofs/sp1-worker/tests/rpc_roundtrip.rs
+++ b/proofs/sp1-worker/tests/rpc_roundtrip.rs
@@ -89,6 +89,7 @@ async fn worker_completes_requested_proof_over_rpc() {
         queue,
         MockBackend,
         ProofWorkerConfig {
+            worker_id: "test-worker".to_string(),
             poll_interval: Duration::from_millis(10),
             max_concurrent_jobs: 1,
         },

--- a/proofs/worker/src/worker.rs
+++ b/proofs/worker/src/worker.rs
@@ -30,7 +30,7 @@ use crate::backend::ProofJobBackend;
 /// Succinct proving network) or that are cheap and local (TEE attestation).
 pub const DEFAULT_MAX_CONCURRENT_JOBS: usize = 1;
 
-/// Default sleep between lease attempts when no work is available.
+/// Default sleep between lock attempts when no work is available.
 pub const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(10);
 
 const REPORT_UPDATE_MAX_RETRIES: usize = 2;
@@ -53,7 +53,7 @@ enum LeasedWork {
 pub struct ProofWorkerConfig {
     /// The worker id.
     pub worker_id: String,
-    /// Sleep between lease attempts when no work is available.
+    /// Sleep between lock attempts when no work is available.
     pub poll_interval: Duration,
     /// Maximum number of jobs this worker proves concurrently. Per-worker, not global, so an
     /// SP1 worker and a TEE worker in the same process throttle independently.
@@ -72,32 +72,32 @@ impl ProofWorkerConfig {
     }
 }
 
-/// A backend update paired with the lease it answers.
+/// A backend update paired with the lock it answers.
 struct FinishedJob {
-    lease: JobLease,
+    lock: JobLock,
     result: anyhow::Result<BackendUpdate>,
 }
 
-/// The leased row that must be used when reporting a finished task.
-enum JobLease {
+/// The locked row that must be used when reporting a finished task.
+enum JobLock {
     Start {
         request: ProofRequest,
-        lease_token: LockId,
+        lock_id: LockId,
     },
     Backend {
         backend_job_id: i64,
         request: ProofRequest,
-        lease_token: LockId,
+        lock_id: LockId,
     },
 }
 
-/// Lease sub-state: at most one `getNextProof` request is in flight at a time, and a lease is
+/// Locked sub-state: at most one `getNextProof` request is in flight at a time, and a lock is
 /// only started once a concurrency permit is held for the job it may return.
 #[pin_project(project = LeaseStateProj)]
 enum WorkerState {
-    /// Acquire a permit and start a lease on the next poll.
+    /// Acquire a permit and start a lock on the next poll.
     Ready,
-    /// Sleeping out the poll interval after an empty or failed lease attempt.
+    /// Sleeping out the poll interval after an empty or failed lock attempt.
     Idle(Pin<Box<Sleep>>),
     /// Waiting on `getNextProof`, holding the permit for the prospective job.
     Leasing {
@@ -109,7 +109,7 @@ enum WorkerState {
 }
 
 impl WorkerState {
-    /// Transitions to sleeping out the poll interval before the next lease attempt.
+    /// Transitions to sleeping out the poll interval before the next lock attempt.
     fn idle(poll_interval: Duration) -> Self {
         Self::Idle(Box::pin(tokio::time::sleep(poll_interval)))
     }
@@ -135,7 +135,7 @@ impl WorkerState {
 /// Worker that leases proof jobs for one backend lane from the `prover-service`, proves them
 /// with a [`ProofJobBackend`], and submits the results back.
 ///
-/// The worker is a [`Future`] driving three sources concurrently: a lease loop throttled by a
+/// The worker is a [`Future`] driving three sources concurrently: a lock loop throttled by a
 /// per-worker concurrency semaphore, a [`JoinSet`] of proving tasks on the blocking pool, and
 /// the in-flight result reports. It is generic over the backend, so a process can run one
 /// instance per lane (an SP1 worker, a TEE worker) — each its own future with independent
@@ -161,7 +161,7 @@ pub struct ProofWorker<Q, B> {
     reports: FuturesUnordered<ReportFuture>,
 
     #[pin]
-    lease: WorkerState,
+    lock: WorkerState,
 }
 
 impl<Q, B> ProofWorker<Q, B>
@@ -183,7 +183,7 @@ where
             cancelled,
             jobs: JoinSet::new(),
             reports: FuturesUnordered::new(),
-            lease: WorkerState::Ready,
+            lock: WorkerState::Ready,
         }
     }
 
@@ -209,34 +209,34 @@ where
         // pushed ones register their wakers in this same pass.
         while let Poll::Ready(Some(joined)) = this.jobs.poll_join_next(cx) {
             match joined {
-                Ok(FinishedJob { lease, result }) => {
-                    this.reports.push(report(this.queue, lease, result));
+                Ok(FinishedJob { lock, result }) => {
+                    this.reports.push(report(this.queue, lock, result));
                 }
                 Err(join_error) => warn!(%join_error, "proving task failed to join"),
             }
         }
         while let Poll::Ready(Some(())) = this.reports.poll_next_unpin(cx) {}
 
-        // Lease new work while concurrency permits are available. The loop only exits through
+        // Lock new work while concurrency permits are available. The loop only exits through
         // a `break` once an inner future returns `Pending`.
         if !shutting_down {
             loop {
-                match this.lease.as_mut().project() {
+                match this.lock.as_mut().project() {
                     LeaseStateProj::Ready => match Arc::clone(this.concurrency).try_acquire_owned()
                     {
                         Ok(permit) => {
-                            this.lease
+                            this.lock
                                 .set(WorkerState::leasing(this.queue, *this.lane, permit));
                         }
                         // Every permit is proving. A finishing job wakes this task and frees
                         // its permit; the idle backoff is a safety net in case it does not.
-                        Err(_) => this.lease.set(WorkerState::idle(*this.poll_interval)),
+                        Err(_) => this.lock.set(WorkerState::idle(*this.poll_interval)),
                     },
                     LeaseStateProj::Idle(sleep) => {
                         if sleep.as_mut().poll(cx).is_pending() {
                             break;
                         }
-                        this.lease.set(WorkerState::Ready);
+                        this.lock.set(WorkerState::Ready);
                     }
                     LeaseStateProj::Leasing { future, permit } => match future.as_mut().poll(cx) {
                         Poll::Pending => break,
@@ -245,14 +245,14 @@ where
                                 .take()
                                 .expect("leasing state holds its permit until the job spawns");
                             spawn_job(this.jobs, this.backend, work, permit);
-                            this.lease.set(WorkerState::Ready);
+                            this.lock.set(WorkerState::Ready);
                         }
                         Poll::Ready(Ok(None)) => {
-                            this.lease.set(WorkerState::idle(*this.poll_interval));
+                            this.lock.set(WorkerState::idle(*this.poll_interval));
                         }
                         Poll::Ready(Err(error)) => {
-                            warn!(%error, "failed to lease next proof job");
-                            this.lease.set(WorkerState::idle(*this.poll_interval));
+                            warn!(%error, "failed to lock next proof job");
+                            this.lock.set(WorkerState::idle(*this.poll_interval));
                         }
                     },
                 }
@@ -276,7 +276,7 @@ where
 /// Dispatches a leased job to the blocking pool under a per-job tracing span, holding its
 /// concurrency permit until the proof completes.
 ///
-/// Panics are contained so a crashed job is failed promptly instead of waiting out its lease.
+/// Panics are contained so a crashed job is failed promptly instead of waiting out its lock.
 /// The task is not interruptible once started: on worker shutdown it is abandoned and its
 /// result discarded.
 fn spawn_job<B>(
@@ -304,20 +304,20 @@ fn spawn_job<B>(
     jobs.spawn_blocking(move || {
         let _guard = span.enter();
         let _permit = permit;
-        let lease = match work {
-            LeasedWork::Start(leased) => JobLease::Start {
+        let lock = match work {
+            LeasedWork::Start(leased) => JobLock::Start {
                 request: leased.request,
-                lease_token: leased.lock_id,
+                lock_id: leased.lock_id,
             },
-            LeasedWork::Backend(leased) => JobLease::Backend {
+            LeasedWork::Backend(leased) => JobLock::Backend {
                 backend_job_id: leased.backend_job_id,
                 request: leased.work.proof_request,
-                lease_token: leased.lock_id,
+                lock_id: leased.lock_id,
             },
         };
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| match &lease {
-            JobLease::Start { request, .. } => backend.start(request),
-            JobLease::Backend { request, .. } => {
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| match &lock {
+            JobLock::Start { request, .. } => backend.start(request),
+            JobLock::Backend { request, .. } => {
                 let state = backend_state.expect("backend work has state");
                 backend.advance(request, state)
             }
@@ -328,17 +328,17 @@ fn spawn_job<B>(
                 panic_message(&*panic)
             ))
         });
-        FinishedJob { lease, result }
+        FinishedJob { lock, result }
     });
 }
 
 /// Builds the future that reports one finished job (submit or fail) and logs the outcome.
-fn report<Q>(queue: &Arc<Q>, lease: JobLease, result: anyhow::Result<BackendUpdate>) -> ReportFuture
+fn report<Q>(queue: &Arc<Q>, lock: JobLock, result: anyhow::Result<BackendUpdate>) -> ReportFuture
 where
     Q: ProofJobQueue + Send + Sync + 'static,
 {
-    let (id, lane) = match &lease {
-        JobLease::Start { request, .. } | JobLease::Backend { request, .. } => {
+    let (id, lane) = match &lock {
+        JobLock::Start { request, .. } | JobLock::Backend { request, .. } => {
             (request.id(), request.backend)
         }
     };
@@ -347,38 +347,37 @@ where
 
     // `{:#}` renders the full anyhow context chain into the failure reason.
     match result.map_err(|error| format!("{error:#}")) {
-        Ok(update) => report_update(queue, lease, update).instrument(span).boxed(),
+        Ok(update) => report_update(queue, lock, update).instrument(span).boxed(),
         Err(reason) => Box::pin(
             async move {
                 warn!(%reason, "proving failed");
-                report_failure(queue, lease, reason).await;
+                report_failure(queue, lock, reason).await;
             }
             .instrument(span),
         ),
     }
 }
 
-async fn report_update<Q>(queue: Arc<Q>, lease: JobLease, update: BackendUpdate)
+async fn report_update<Q>(queue: Arc<Q>, lock: JobLock, update: BackendUpdate)
 where
     Q: ProofJobQueue + Send + Sync + 'static,
 {
-    match lease {
-        JobLease::Start {
-            request,
-            lease_token,
-        } => report_start_update(queue, request, lease_token, update).await,
-        JobLease::Backend {
+    match lock {
+        JobLock::Start { request, lock_id } => {
+            report_start_update(queue, request, lock_id, update).await
+        }
+        JobLock::Backend {
             backend_job_id,
-            lease_token,
+            lock_id,
             ..
-        } => report_backend_update(queue, backend_job_id, lease_token, update).await,
+        } => report_backend_update(queue, backend_job_id, lock_id, update).await,
     }
 }
 
 async fn report_start_update<Q>(
     queue: Arc<Q>,
     request: ProofRequest,
-    lease_token: LockId,
+    lock_id: LockId,
     update: BackendUpdate,
 ) where
     Q: ProofJobQueue + Send + Sync + 'static,
@@ -386,27 +385,23 @@ async fn report_start_update<Q>(
     let id = request.id();
     let result = match update {
         BackendUpdate::Pending { state } => {
-            queue
-                .submit_backend_proof_state(id, state, lease_token)
-                .await
+            queue.submit_backend_proof_state(id, state, lock_id).await
         }
         BackendUpdate::Complete(proof) => {
             queue
                 .submit_proof(
                     ProofResponse { id, proof },
-                    ProofSubmissionLock::ProofJob {
-                        lock_id: lease_token,
-                    },
+                    ProofSubmissionLock::ProofJob { lock_id: lock_id },
                 )
                 .await
         }
-        BackendUpdate::Failed(reason) => queue.fail_proof(id, reason, lease_token).await,
+        BackendUpdate::Failed(reason) => queue.fail_proof(id, reason, lock_id).await,
         BackendUpdate::Noop => {
             queue
                 .fail_proof(
                     id,
                     "backend start returned no state update".to_string(),
-                    lease_token,
+                    lock_id,
                 )
                 .await
         }
@@ -421,7 +416,7 @@ async fn report_start_update<Q>(
 async fn report_backend_update<Q>(
     queue: Arc<Q>,
     backend_job_id: i64,
-    lease_token: LockId,
+    lock_id: LockId,
     update: BackendUpdate,
 ) where
     Q: ProofJobQueue + Send + Sync + 'static,
@@ -431,7 +426,7 @@ async fn report_backend_update<Q>(
         let update = update.clone();
         async move {
             queue
-                .complete_backend_proof_job(backend_job_id, lease_token, update)
+                .complete_backend_proof_job(backend_job_id, lock_id, update)
                 .await
         }
     };
@@ -458,10 +453,10 @@ async fn report_backend_update<Q>(
 
     warn!(%error, backend_job_id, "failed to submit backend proof job update");
 
-    if should_release_backend_lease_after_report_error(&update, &error) {
+    if should_release_backend_lock_after_report_error(&update, &error) {
         let reason = format!("failed to submit backend proof job update: {error}");
         if let Err(fail_error) = queue
-            .fail_backend_proof_job(backend_job_id, reason, lease_token)
+            .fail_backend_proof_job(backend_job_id, reason, lock_id)
             .await
         {
             warn!(
@@ -480,29 +475,28 @@ fn should_retry_report_error(error: &ProofJobQueueError) -> bool {
     )
 }
 
-fn should_release_backend_lease_after_report_error(
+fn should_release_backend_lock_after_report_error(
     update: &BackendUpdate,
     error: &ProofJobQueueError,
 ) -> bool {
     should_retry_report_error(error) && !matches!(update, BackendUpdate::Failed(_))
 }
 
-async fn report_failure<Q>(queue: Arc<Q>, lease: JobLease, reason: String)
+async fn report_failure<Q>(queue: Arc<Q>, lock: JobLock, reason: String)
 where
     Q: ProofJobQueue + Send + Sync + 'static,
 {
-    let result = match lease {
-        JobLease::Start {
-            request,
-            lease_token,
-        } => queue.fail_proof(request.id(), reason, lease_token).await,
-        JobLease::Backend {
+    let result = match lock {
+        JobLock::Start { request, lock_id } => {
+            queue.fail_proof(request.id(), reason, lock_id).await
+        }
+        JobLock::Backend {
             backend_job_id,
-            lease_token,
+            lock_id,
             ..
         } => {
             queue
-                .fail_backend_proof_job(backend_job_id, reason, lease_token)
+                .fail_backend_proof_job(backend_job_id, reason, lock_id)
                 .await
         }
     };
@@ -614,7 +608,7 @@ mod tests {
             &self,
             _proof_id: ProofRequestId,
             _backend_proof_state: BackendProofState,
-            _lease_token: LockId,
+            _lock_id: LockId,
         ) -> Result<(), ProofJobQueueError> {
             Ok(())
         }
@@ -633,7 +627,7 @@ mod tests {
         async fn complete_backend_proof_job(
             &self,
             backend_job_id: i64,
-            _lease_token: LockId,
+            _lock_id: LockId,
             next_update: BackendUpdate,
         ) -> Result<(), ProofJobQueueError> {
             let mut failures = self
@@ -657,7 +651,7 @@ mod tests {
             &self,
             backend_job_id: i64,
             reason: String,
-            _lease_token: LockId,
+            _lock_id: LockId,
         ) -> Result<(), ProofJobQueueError> {
             self.backend_failures
                 .lock()
@@ -669,7 +663,7 @@ mod tests {
         async fn submit_proof(
             &self,
             proof: ProofResponse,
-            _lease: ProofSubmissionLock,
+            _lock: ProofSubmissionLock,
         ) -> Result<(), ProofJobQueueError> {
             self.submitted
                 .lock()
@@ -682,7 +676,7 @@ mod tests {
             &self,
             proof_id: ProofRequestId,
             reason: String,
-            _lease_token: LockId,
+            _lock_id: LockId,
         ) -> Result<(), ProofJobQueueError> {
             self.failed
                 .lock()
@@ -842,7 +836,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn releases_backend_lease_after_exhausted_report_retries() {
+    async fn releases_backend_lock_after_exhausted_report_retries() {
         let request = request();
         let backend_job_id = 43;
         let next_state = BackendProofState::Aggregation {

--- a/proofs/worker/src/worker.rs
+++ b/proofs/worker/src/worker.rs
@@ -19,8 +19,8 @@ use tokio::{
 use tokio_util::sync::{CancellationToken, WaitForCancellationFutureOwned};
 use tracing::{Instrument, info, info_span, warn};
 use world_chain_prover_service::{
-    BackendUpdate, LeaseToken, LeasedBackendProofWork, LeasedProofRequest, ProofBackend,
-    ProofJobQueue, ProofJobQueueError, ProofRequest, ProofResponse, ProofSubmissionLease,
+    BackendUpdate, LockId, LockedBackendProofWork, LockedProofRequest, ProofBackend, ProofJobQueue,
+    ProofJobQueueError, ProofRequest, ProofResponse, ProofSubmissionLock,
 };
 
 use crate::backend::ProofJobBackend;
@@ -44,13 +44,15 @@ type ReportFuture = BoxFuture<'static, ()>;
 
 /// Work leased from either the user-facing proof queue or the durable backend-job queue.
 enum LeasedWork {
-    Start(LeasedProofRequest),
-    Backend(LeasedBackendProofWork),
+    Start(LockedProofRequest),
+    Backend(LockedBackendProofWork),
 }
 
 /// Configuration for a [`ProofWorker`].
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct ProofWorkerConfig {
+    /// The worker id.
+    pub worker_id: String,
     /// Sleep between lease attempts when no work is available.
     pub poll_interval: Duration,
     /// Maximum number of jobs this worker proves concurrently. Per-worker, not global, so an
@@ -58,11 +60,14 @@ pub struct ProofWorkerConfig {
     pub max_concurrent_jobs: usize,
 }
 
-impl Default for ProofWorkerConfig {
-    fn default() -> Self {
+impl ProofWorkerConfig {
+    /// Create a new `ProofWorkerConfig` with the provided `worker_id`
+    /// `poll_interval` and `max_concurrent_jobs`.
+    pub fn new(worker_id: String, poll_interval: Duration, max_concurrent_jobs: usize) -> Self {
         Self {
-            poll_interval: DEFAULT_POLL_INTERVAL,
-            max_concurrent_jobs: DEFAULT_MAX_CONCURRENT_JOBS,
+            worker_id,
+            poll_interval,
+            max_concurrent_jobs,
         }
     }
 }
@@ -77,12 +82,12 @@ struct FinishedJob {
 enum JobLease {
     Start {
         request: ProofRequest,
-        lease_token: LeaseToken,
+        lease_token: LockId,
     },
     Backend {
         backend_job_id: i64,
         request: ProofRequest,
-        lease_token: LeaseToken,
+        lease_token: LockId,
     },
 }
 
@@ -302,12 +307,12 @@ fn spawn_job<B>(
         let lease = match work {
             LeasedWork::Start(leased) => JobLease::Start {
                 request: leased.request,
-                lease_token: leased.lease_token,
+                lease_token: leased.lock_id,
             },
             LeasedWork::Backend(leased) => JobLease::Backend {
                 backend_job_id: leased.backend_job_id,
                 request: leased.work.proof_request,
-                lease_token: leased.lease_token,
+                lease_token: leased.lock_id,
             },
         };
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| match &lease {
@@ -373,7 +378,7 @@ where
 async fn report_start_update<Q>(
     queue: Arc<Q>,
     request: ProofRequest,
-    lease_token: LeaseToken,
+    lease_token: LockId,
     update: BackendUpdate,
 ) where
     Q: ProofJobQueue + Send + Sync + 'static,
@@ -389,7 +394,9 @@ async fn report_start_update<Q>(
             queue
                 .submit_proof(
                     ProofResponse { id, proof },
-                    ProofSubmissionLease::ProofJob { lease_token },
+                    ProofSubmissionLock::ProofJob {
+                        lock_id: lease_token,
+                    },
                 )
                 .await
         }
@@ -414,7 +421,7 @@ async fn report_start_update<Q>(
 async fn report_backend_update<Q>(
     queue: Arc<Q>,
     backend_job_id: i64,
-    lease_token: LeaseToken,
+    lease_token: LockId,
     update: BackendUpdate,
 ) where
     Q: ProofJobQueue + Send + Sync + 'static,
@@ -533,8 +540,8 @@ mod tests {
     /// In-memory queue with shared interior so tests keep a handle for assertions.
     #[derive(Clone, Default)]
     struct MockQueue {
-        jobs: Arc<Mutex<VecDeque<LeasedProofRequest>>>,
-        backend_jobs: Arc<Mutex<VecDeque<LeasedBackendProofWork>>>,
+        jobs: Arc<Mutex<VecDeque<LockedProofRequest>>>,
+        backend_jobs: Arc<Mutex<VecDeque<LockedBackendProofWork>>>,
         backend_updates: Arc<Mutex<Vec<(i64, BackendUpdate)>>>,
         backend_failures: Arc<Mutex<Vec<(i64, String)>>>,
         backend_complete_failures: Arc<Mutex<usize>>,
@@ -547,9 +554,9 @@ mod tests {
             Self {
                 jobs: Arc::new(Mutex::new(
                     jobs.into_iter()
-                        .map(|request| LeasedProofRequest {
+                        .map(|request| LockedProofRequest {
                             request,
-                            lease_token: LeaseToken::new(),
+                            lock_id: LockId::new(),
                         })
                         .collect(),
                 )),
@@ -557,7 +564,7 @@ mod tests {
             }
         }
 
-        fn with_backend_jobs(jobs: impl IntoIterator<Item = LeasedBackendProofWork>) -> Self {
+        fn with_backend_jobs(jobs: impl IntoIterator<Item = LockedBackendProofWork>) -> Self {
             Self {
                 backend_jobs: Arc::new(Mutex::new(jobs.into_iter().collect())),
                 ..Self::default()
@@ -599,7 +606,7 @@ mod tests {
         async fn get_next_proof(
             &self,
             _backend: ProofBackend,
-        ) -> Result<Option<LeasedProofRequest>, ProofJobQueueError> {
+        ) -> Result<Option<LockedProofRequest>, ProofJobQueueError> {
             Ok(self.jobs.lock().expect("jobs poisoned").pop_front())
         }
 
@@ -607,7 +614,7 @@ mod tests {
             &self,
             _proof_id: ProofRequestId,
             _backend_proof_state: BackendProofState,
-            _lease_token: LeaseToken,
+            _lease_token: LockId,
         ) -> Result<(), ProofJobQueueError> {
             Ok(())
         }
@@ -615,7 +622,7 @@ mod tests {
         async fn get_next_backend_proof(
             &self,
             _backend: ProofBackend,
-        ) -> Result<Option<LeasedBackendProofWork>, ProofJobQueueError> {
+        ) -> Result<Option<LockedBackendProofWork>, ProofJobQueueError> {
             Ok(self
                 .backend_jobs
                 .lock()
@@ -626,7 +633,7 @@ mod tests {
         async fn complete_backend_proof_job(
             &self,
             backend_job_id: i64,
-            _lease_token: LeaseToken,
+            _lease_token: LockId,
             next_update: BackendUpdate,
         ) -> Result<(), ProofJobQueueError> {
             let mut failures = self
@@ -650,7 +657,7 @@ mod tests {
             &self,
             backend_job_id: i64,
             reason: String,
-            _lease_token: LeaseToken,
+            _lease_token: LockId,
         ) -> Result<(), ProofJobQueueError> {
             self.backend_failures
                 .lock()
@@ -662,7 +669,7 @@ mod tests {
         async fn submit_proof(
             &self,
             proof: ProofResponse,
-            _lease: ProofSubmissionLease,
+            _lease: ProofSubmissionLock,
         ) -> Result<(), ProofJobQueueError> {
             self.submitted
                 .lock()
@@ -675,7 +682,7 @@ mod tests {
             &self,
             proof_id: ProofRequestId,
             reason: String,
-            _lease_token: LeaseToken,
+            _lease_token: LockId,
         ) -> Result<(), ProofJobQueueError> {
             self.failed
                 .lock()
@@ -746,14 +753,14 @@ mod tests {
         backend_job_id: i64,
         request: ProofRequest,
         state: BackendProofState,
-    ) -> LeasedBackendProofWork {
-        LeasedBackendProofWork {
+    ) -> LockedBackendProofWork {
+        LockedBackendProofWork {
             backend_job_id,
             work: BackendProofWork {
                 proof_request: request,
                 state,
             },
-            lease_token: LeaseToken::new(),
+            lock_id: LockId::new(),
         }
     }
 
@@ -773,6 +780,7 @@ mod tests {
 
     fn config() -> ProofWorkerConfig {
         ProofWorkerConfig {
+            worker_id: "test-worker".to_string(),
             poll_interval: Duration::from_millis(10),
             max_concurrent_jobs: 1,
         }

--- a/proofs/worker/src/worker.rs
+++ b/proofs/worker/src/worker.rs
@@ -391,7 +391,7 @@ async fn report_start_update<Q>(
             queue
                 .submit_proof(
                     ProofResponse { id, proof },
-                    ProofSubmissionLock::ProofJob { lock_id: lock_id },
+                    ProofSubmissionLock::ProofJob { lock_id },
                 )
                 .await
         }


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4745/add-worker-id-lock-id-lock-expires-at-and-refactor-tables-and-logic-to

### Notes

- this PR changes some fields in preparation of the change of architecture of the `prover-service`.
- in particular, besides some renaming, this PR adds the `worker_id` field. For now this is never used, so it is always a `NULL` value in the db. Follow up PRs will handle the logic related to it.
- I change the migration db file. There is no need to take care of backwards compatibility because the `prover-service` is not deployed anywhere yet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core prover-service queue locking and a breaking rename across RPC/types/migrations; logic is mostly mechanical but any missed call site or deployed schema mismatch would break workers.
> 
> **Overview**
> Renames the Postgres-backed prover job **lease** model to **lock** terminology end-to-end: DB columns (`locked_until` / `lease_token` → `lock_expires_at` / `lock_id`), Rust types (`LeaseToken` → `LockId`, `Leased*` → `Locked*`, `ProofSubmissionLease` → `ProofSubmissionLock`), config (`lease_timeout` → `lock_timeout`), and RPC/errors (`StaleLease` → `StaleLocked`). Queue claim and update SQL in the store follows the new names; behavior is unchanged.
> 
> Adds nullable `worker_id` on `proof_requests` in the migration and docs, plus a required `worker_id` on `ProofWorkerConfig` and CLI flags for SP1/Nitro workers (devnet and tests set fixed ids). **The store does not persist `worker_id` yet**—rows stay `NULL` until follow-up work.
> 
> `ProofWorkerConfig` no longer has a `Default`; callers must pass `worker_id` explicitly (or use `ProofWorkerConfig::new`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ac4ae4458d958528f041da86d341af8248eb835. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->