### PR TITLE
refactor(prover-service): add worker_id logic 

### DIFF
--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -596,8 +596,9 @@ impl ProofJobQueue for SharedProverService {
     async fn get_next_proof(
         &self,
         backend: ProofBackend,
+        worker_id: String,
     ) -> Result<Option<LockedProofRequest>, ProofJobQueueError> {
-        self.service.get_next_proof(backend).await
+        self.service.get_next_proof(backend, worker_id).await
     }
 
     async fn submit_backend_proof_state(
@@ -605,9 +606,10 @@ impl ProofJobQueue for SharedProverService {
         proof_id: ProofRequestId,
         backend_proof_state: BackendProofState,
         lock_id: LockId,
+        worker_id: String,
     ) -> Result<(), ProofJobQueueError> {
         self.service
-            .submit_backend_proof_state(proof_id, backend_proof_state, lock_id)
+            .submit_backend_proof_state(proof_id, backend_proof_state, lock_id, worker_id)
             .await
     }
 
@@ -653,7 +655,10 @@ impl ProofJobQueue for SharedProverService {
         proof_id: ProofRequestId,
         reason: String,
         lock_id: LockId,
+        worker_id: String,
     ) -> Result<(), ProofJobQueueError> {
-        self.service.fail_proof(proof_id, reason, lock_id).await
+        self.service
+            .fail_proof(proof_id, reason, lock_id, worker_id)
+            .await
     }
 }

--- a/proofs/prover-service/migrations/20260619_proof_requests.sql
+++ b/proofs/prover-service/migrations/20260619_proof_requests.sql
@@ -43,8 +43,8 @@ create table proof_sessions (
     status              text not null,
     advance_attempts    integer not null default 0,
     next_poll_at        timestamptz not null,
-    lock_expires_at        timestamptz null,
-    lock_id         uuid null,
+    lock_expires_at     timestamptz null,
+    lock_id             uuid null,
 
     artifact            bytea null,
     failure_reason      text null,

--- a/proofs/prover-service/src/rpc.rs
+++ b/proofs/prover-service/src/rpc.rs
@@ -76,6 +76,7 @@ pub trait ProverServiceApi {
         proof_id: ProofRequestId,
         backend_proof_state: BackendProofState,
         lock_id: LockId,
+        worker_id: String,
     ) -> RpcResult<()>;
 
     /// Lock the next durable backend proof job for the given backend.
@@ -114,6 +115,7 @@ pub trait ProverServiceApi {
         proof_id: ProofRequestId,
         reason: String,
         lock_id: LockId,
+        worker_id: String,
     ) -> RpcResult<()>;
 }
 
@@ -211,10 +213,11 @@ impl ProverServiceApiServer for ProverServiceRpc {
         proof_id: ProofRequestId,
         backend_proof_state: BackendProofState,
         lock_id: LockId,
+        worker_id: String,
     ) -> RpcResult<()> {
         Ok(self
             .service
-            .submit_backend_proof_state(proof_id, backend_proof_state, lock_id)
+            .submit_backend_proof_state(proof_id, backend_proof_state, lock_id, worker_id)
             .await?)
     }
 
@@ -258,8 +261,12 @@ impl ProverServiceApiServer for ProverServiceRpc {
         proof_id: ProofRequestId,
         reason: String,
         lock_id: LockId,
+        worker_id: String,
     ) -> RpcResult<()> {
-        Ok(self.service.fail_proof(proof_id, reason, lock_id).await?)
+        Ok(self
+            .service
+            .fail_proof(proof_id, reason, lock_id, worker_id)
+            .await?)
     }
 }
 
@@ -416,12 +423,14 @@ impl ProofJobQueue for RpcProverServiceClient {
         proof_id: ProofRequestId,
         backend_proof_state: BackendProofState,
         lock_id: LockId,
+        worker_id: String,
     ) -> Result<(), ProofJobQueueError> {
         ProverServiceApiClient::submit_backend_proof_state(
             &self.client,
             proof_id,
             backend_proof_state,
             lock_id,
+            worker_id,
         )
         .await
         .map_err(|err| map_job_error(err, proof_id))
@@ -484,8 +493,9 @@ impl ProofJobQueue for RpcProverServiceClient {
         proof_id: ProofRequestId,
         reason: String,
         lock_id: LockId,
+        worker_id: String,
     ) -> Result<(), ProofJobQueueError> {
-        ProverServiceApiClient::fail_proof(&self.client, proof_id, reason, lock_id)
+        ProverServiceApiClient::fail_proof(&self.client, proof_id, reason, lock_id, worker_id)
             .await
             .map_err(|err| map_job_error(err, proof_id))
     }

--- a/proofs/prover-service/src/rpc.rs
+++ b/proofs/prover-service/src/rpc.rs
@@ -63,7 +63,11 @@ pub trait ProverServiceApi {
 
     /// Lock the next queued proof request for the given backend.
     #[method(name = "getNextProof")]
-    async fn get_next_proof(&self, backend: ProofBackend) -> RpcResult<Option<LockedProofRequest>>;
+    async fn get_next_proof(
+        &self,
+        backend: ProofBackend,
+        worker_id: String,
+    ) -> RpcResult<Option<LockedProofRequest>>;
 
     /// Persist durable backend work created while starting a proof job.
     #[method(name = "submitBackendProofState")]
@@ -194,8 +198,12 @@ impl ProverServiceApiServer for ProverServiceRpc {
         Ok(self.service.get_proof(proof_id).await?)
     }
 
-    async fn get_next_proof(&self, backend: ProofBackend) -> RpcResult<Option<LockedProofRequest>> {
-        Ok(self.service.get_next_proof(backend).await?)
+    async fn get_next_proof(
+        &self,
+        backend: ProofBackend,
+        worker_id: String,
+    ) -> RpcResult<Option<LockedProofRequest>> {
+        Ok(self.service.get_next_proof(backend, worker_id).await?)
     }
 
     async fn submit_backend_proof_state(
@@ -396,8 +404,9 @@ impl ProofJobQueue for RpcProverServiceClient {
     async fn get_next_proof(
         &self,
         backend: ProofBackend,
+        worker_id: String,
     ) -> Result<Option<LockedProofRequest>, ProofJobQueueError> {
-        ProverServiceApiClient::get_next_proof(&self.client, backend)
+        ProverServiceApiClient::get_next_proof(&self.client, backend, worker_id)
             .await
             .map_err(|err| ProofJobQueueError::Rpc(err.to_string()))
     }

--- a/proofs/prover-service/src/service.rs
+++ b/proofs/prover-service/src/service.rs
@@ -91,9 +91,10 @@ impl ProofJobQueue for ProverService {
         proof_id: ProofRequestId,
         backend_proof_state: BackendProofState,
         lock_id: LockId,
+        worker_id: String,
     ) -> Result<(), ProofJobQueueError> {
         self.store
-            .submit_backend_proof_state(proof_id, backend_proof_state, lock_id)
+            .submit_backend_proof_state(proof_id, backend_proof_state, lock_id, worker_id)
             .await
     }
 
@@ -166,7 +167,10 @@ impl ProofJobQueue for ProverService {
         proof_id: ProofRequestId,
         reason: String,
         lock_id: LockId,
+        worker_id: String,
     ) -> Result<(), ProofJobQueueError> {
-        self.store.fail_proof(proof_id, reason, lock_id).await
+        self.store
+            .fail_proof(proof_id, reason, lock_id, worker_id)
+            .await
     }
 }

--- a/proofs/prover-service/src/service.rs
+++ b/proofs/prover-service/src/service.rs
@@ -81,8 +81,9 @@ impl ProofJobQueue for ProverService {
     async fn get_next_proof(
         &self,
         backend: ProofBackend,
+        worker_id: String,
     ) -> Result<Option<LockedProofRequest>, ProofJobQueueError> {
-        self.store.get_next_proof(backend).await
+        self.store.get_next_proof(backend, worker_id).await
     }
 
     async fn submit_backend_proof_state(

--- a/proofs/prover-service/src/store.rs
+++ b/proofs/prover-service/src/store.rs
@@ -517,7 +517,6 @@ impl ProverServiceStore {
             "update proof_sessions
              set lock_expires_at = null,
                  lock_id = null,
-                 worker_id = null,
                  next_poll_at = $3,
                  updated_at = $4
              where id = $1

--- a/proofs/prover-service/src/store.rs
+++ b/proofs/prover-service/src/store.rs
@@ -211,6 +211,7 @@ impl ProverServiceStore {
     pub(crate) async fn get_next_proof(
         &self,
         backend: ProofBackend,
+        worker_id: String,
     ) -> Result<Option<LockedProofRequest>, ProofJobQueueError> {
         loop {
             let mut tx = self.begin_queue_tx().await?;
@@ -261,7 +262,8 @@ impl ProverServiceStore {
                      lock_expires_at = $3,
                      lock_id = $4,
                      start_attempts = start_attempts + 1,
-                     updated_at = $5
+                     updated_at = $5,
+                     worker_id = $6
                  where proof_id = $1",
             )
             .bind(proof_id_bytes(proof_id))
@@ -269,6 +271,7 @@ impl ProverServiceStore {
             .bind(lock_expires_at)
             .bind(lock_id.0)
             .bind(now)
+            .bind(worker_id)
             .execute(&mut *tx)
             .await
             .map_err(queue_db)?;

--- a/proofs/prover-service/src/store.rs
+++ b/proofs/prover-service/src/store.rs
@@ -103,6 +103,7 @@ impl ProverServiceStore {
                          start_attempts = 0,
                          lock_expires_at = null,
                          lock_id = null,
+                         worker_id = null,
                          updated_at = $3,
                          finished_at = null
                      where proof_id = $1",
@@ -287,6 +288,7 @@ impl ProverServiceStore {
         proof_id: ProofRequestId,
         backend_proof_state: BackendProofState,
         lock_id: LockId,
+        worker_id: String,
     ) -> Result<(), ProofJobQueueError> {
         let now = db_now();
         let mut tx = self.begin_queue_tx().await?;
@@ -295,10 +297,12 @@ impl ProverServiceStore {
              set status = $3,
                  lock_expires_at = null,
                  lock_id = null,
+                 worker_id = null,
                  updated_at = $4
              where proof_id = $1
                and lock_id = $2
                and status = $5
+               and worker_id = $6
              returning backend",
         )
         .bind(proof_id_bytes(proof_id))
@@ -306,6 +310,7 @@ impl ProverServiceStore {
         .bind(ProofStatus::BackendPending.as_str())
         .bind(now)
         .bind(ProofStatus::Starting.as_str())
+        .bind(worker_id)
         .fetch_optional(&mut *tx)
         .await
         .map_err(queue_db)?;
@@ -446,6 +451,7 @@ impl ProverServiceStore {
         proof_id: ProofRequestId,
         reason: String,
         lock_id: LockId,
+        worker_id: String,
     ) -> Result<(), ProofJobQueueError> {
         let mut tx = self.begin_queue_tx().await?;
         let row = sqlx::query(
@@ -454,11 +460,13 @@ impl ProverServiceStore {
              where proof_id = $1
                and lock_id = $2
                and status = $3
+               and worker_id = $4
              for update",
         )
         .bind(proof_id_bytes(proof_id))
         .bind(lock_id.0)
         .bind(ProofStatus::Starting.as_str())
+        .bind(worker_id)
         .fetch_optional(&mut *tx)
         .await
         .map_err(queue_db)?;
@@ -480,6 +488,7 @@ impl ProverServiceStore {
                  set status = $2,
                      lock_expires_at = null,
                      lock_id = null,
+                     worker_id = null,
                      updated_at = $3
                  where proof_id = $1",
             )
@@ -508,6 +517,7 @@ impl ProverServiceStore {
             "update proof_sessions
              set lock_expires_at = null,
                  lock_id = null,
+                 worker_id = null,
                  next_poll_at = $3,
                  updated_at = $4
              where id = $1
@@ -1059,6 +1069,7 @@ async fn mark_proof_failed(
              failure_reason = $3,
              lock_expires_at = null,
              lock_id = null,
+             worker_id = null,
              updated_at = $4,
              finished_at = $4
          where proof_id = $1",
@@ -1112,6 +1123,7 @@ async fn complete_proof(
              failure_reason = null,
              lock_expires_at = null,
              lock_id = null,
+             worker_id = null,
              updated_at = $4,
              finished_at = $4
          where proof_id = $1",

--- a/proofs/prover-service/src/tests.rs
+++ b/proofs/prover-service/src/tests.rs
@@ -80,6 +80,10 @@ fn backend_id(seed: u8) -> BackendProofId {
     BackendProofId(B256::with_last_byte(seed))
 }
 
+fn worker_id() -> String {
+    "test-worker".to_string()
+}
+
 #[test]
 fn request_id_is_deterministic() {
     let sp1 = request(ProofBackend::Sp1, 1);
@@ -100,7 +104,7 @@ async fn nitro_style_full_lifecycle() {
     assert_eq!(service.proof_status(id).await.unwrap(), ProofStatus::Queued);
 
     let locked = service
-        .get_next_proof(ProofBackend::Nitro)
+        .get_next_proof(ProofBackend::Nitro, worker_id())
         .await
         .unwrap()
         .expect("job available");
@@ -146,14 +150,19 @@ async fn backend_job_workflow_reaches_final_proof() {
         request: locked_req,
         lock_id,
     } = service
-        .get_next_proof(ProofBackend::Sp1)
+        .get_next_proof(ProofBackend::Sp1, worker_id())
         .await
         .unwrap()
         .expect("job available");
     assert_eq!(locked_req, req);
 
     service
-        .submit_backend_proof_state(id, BackendProofState::Range { id: backend_id(1) }, lock_id)
+        .submit_backend_proof_state(
+            id,
+            BackendProofState::Range { id: backend_id(1) },
+            lock_id,
+            worker_id(),
+        )
         .await
         .unwrap();
     assert_eq!(
@@ -240,13 +249,13 @@ async fn stale_start_lock_is_rejected() {
     let req = request(ProofBackend::Sp1, 3);
     let id = service.request_proof(req.clone()).await.unwrap();
     let first = service
-        .get_next_proof(ProofBackend::Sp1)
+        .get_next_proof(ProofBackend::Sp1, worker_id())
         .await
         .unwrap()
         .expect("first lock");
     tokio::time::sleep(Duration::from_millis(20)).await;
     let second = service
-        .get_next_proof(ProofBackend::Sp1)
+        .get_next_proof(ProofBackend::Sp1, worker_id())
         .await
         .unwrap()
         .expect("second lock");
@@ -288,23 +297,33 @@ async fn failed_attempts_retry_until_exhausted() {
     let id = service.request_proof(req.clone()).await.unwrap();
 
     let first = service
-        .get_next_proof(ProofBackend::Sp1)
+        .get_next_proof(ProofBackend::Sp1, worker_id())
         .await
         .unwrap()
         .expect("first lock");
     service
-        .fail_proof(id, "witness generation failed".to_string(), first.lock_id)
+        .fail_proof(
+            id,
+            "witness generation failed".to_string(),
+            first.lock_id,
+            worker_id(),
+        )
         .await
         .unwrap();
     assert_eq!(service.proof_status(id).await.unwrap(), ProofStatus::Queued);
 
     let second = service
-        .get_next_proof(ProofBackend::Sp1)
+        .get_next_proof(ProofBackend::Sp1, worker_id())
         .await
         .unwrap()
         .expect("second lock");
     service
-        .fail_proof(id, "backend rejected".to_string(), second.lock_id)
+        .fail_proof(
+            id,
+            "backend rejected".to_string(),
+            second.lock_id,
+            worker_id(),
+        )
         .await
         .unwrap();
     assert_eq!(service.proof_status(id).await.unwrap(), ProofStatus::Failed);
@@ -319,7 +338,7 @@ async fn backend_attempt_errors_retry_until_exhausted() {
     let req = request(ProofBackend::Sp1, 5);
     let id = service.request_proof(req.clone()).await.unwrap();
     let locked = service
-        .get_next_proof(ProofBackend::Sp1)
+        .get_next_proof(ProofBackend::Sp1, worker_id())
         .await
         .unwrap()
         .expect("start lock");
@@ -328,6 +347,7 @@ async fn backend_attempt_errors_retry_until_exhausted() {
             id,
             BackendProofState::Range { id: backend_id(1) },
             locked.lock_id,
+            worker_id(),
         )
         .await
         .unwrap();
@@ -384,7 +404,7 @@ async fn invalid_completed_backend_proof_fails_immediately() {
     let req = request(ProofBackend::Sp1, 6);
     let id = service.request_proof(req.clone()).await.unwrap();
     let locked = service
-        .get_next_proof(ProofBackend::Sp1)
+        .get_next_proof(ProofBackend::Sp1, worker_id())
         .await
         .unwrap()
         .expect("start lock");
@@ -393,6 +413,7 @@ async fn invalid_completed_backend_proof_fails_immediately() {
             id,
             BackendProofState::Range { id: backend_id(1) },
             locked.lock_id,
+            worker_id(),
         )
         .await
         .unwrap();
@@ -436,7 +457,7 @@ async fn failed_completed_backend_submission_relocks_lock() {
     let req = request(ProofBackend::Sp1, 7);
     let id = service.request_proof(req.clone()).await.unwrap();
     let locked = service
-        .get_next_proof(ProofBackend::Sp1)
+        .get_next_proof(ProofBackend::Sp1, worker_id())
         .await
         .unwrap()
         .expect("start lock");
@@ -445,6 +466,7 @@ async fn failed_completed_backend_submission_relocks_lock() {
             id,
             BackendProofState::Range { id: backend_id(1) },
             locked.lock_id,
+            worker_id(),
         )
         .await
         .unwrap();
@@ -496,7 +518,7 @@ async fn backend_noop_polling_does_not_exhaust_attempts() {
     let req = request(ProofBackend::Sp1, 8);
     let id = service.request_proof(req.clone()).await.unwrap();
     let locked = service
-        .get_next_proof(ProofBackend::Sp1)
+        .get_next_proof(ProofBackend::Sp1, worker_id())
         .await
         .unwrap()
         .expect("start lock");
@@ -505,6 +527,7 @@ async fn backend_noop_polling_does_not_exhaust_attempts() {
             id,
             BackendProofState::Range { id: backend_id(1) },
             locked.lock_id,
+            worker_id(),
         )
         .await
         .unwrap();
@@ -571,7 +594,7 @@ async fn expired_backend_locks_count_toward_attempts() {
     let req = request(ProofBackend::Sp1, 9);
     let id = service.request_proof(req.clone()).await.unwrap();
     let locked = service
-        .get_next_proof(ProofBackend::Sp1)
+        .get_next_proof(ProofBackend::Sp1, worker_id())
         .await
         .unwrap()
         .expect("start lock");
@@ -580,6 +603,7 @@ async fn expired_backend_locks_count_toward_attempts() {
             id,
             BackendProofState::Range { id: backend_id(1) },
             locked.lock_id,
+            worker_id(),
         )
         .await
         .unwrap();
@@ -628,7 +652,7 @@ async fn rpc_end_to_end() {
     assert_eq!(client.proof_status(id).await.unwrap(), ProofStatus::Queued);
 
     let locked = client
-        .get_next_proof(ProofBackend::Sp1)
+        .get_next_proof(ProofBackend::Sp1, worker_id())
         .await
         .unwrap()
         .expect("job available");
@@ -662,7 +686,7 @@ async fn rpc_backend_invalid_proof_maps_to_typed_error() {
     let req = request(ProofBackend::Sp1, 10);
     let id = client.request_proof(req.clone()).await.unwrap();
     let locked = client
-        .get_next_proof(ProofBackend::Sp1)
+        .get_next_proof(ProofBackend::Sp1, worker_id())
         .await
         .unwrap()
         .expect("start lock");
@@ -671,6 +695,7 @@ async fn rpc_backend_invalid_proof_maps_to_typed_error() {
             id,
             BackendProofState::Range { id: backend_id(1) },
             locked.lock_id,
+            worker_id(),
         )
         .await
         .unwrap();

--- a/proofs/prover-service/src/traits.rs
+++ b/proofs/prover-service/src/traits.rs
@@ -68,7 +68,6 @@ pub trait ProofJobQueue {
         &self,
         backend_job_id: i64,
         lock_id: LockId,
-        worker_id: String,
         next_update: BackendUpdate,
     ) -> Result<(), ProofJobQueueError>;
 
@@ -99,5 +98,6 @@ pub trait ProofJobQueue {
         proof_id: ProofRequestId,
         reason: String,
         lock_id: LockId,
+        worker_id: String,
     ) -> Result<(), ProofJobQueueError>;
 }

--- a/proofs/prover-service/src/traits.rs
+++ b/proofs/prover-service/src/traits.rs
@@ -45,6 +45,7 @@ pub trait ProofJobQueue {
     async fn get_next_proof(
         &self,
         backend: ProofBackend,
+        worker_id: String,
     ) -> Result<Option<LockedProofRequest>, ProofJobQueueError>;
 
     /// Persist durable backend work created while starting a proof job.
@@ -53,6 +54,7 @@ pub trait ProofJobQueue {
         proof_id: ProofRequestId,
         backend_proof_state: BackendProofState,
         lock_id: LockId,
+        worker_id: String,
     ) -> Result<(), ProofJobQueueError>;
 
     /// Lock durable backend work that is due for polling or advancement.
@@ -66,6 +68,7 @@ pub trait ProofJobQueue {
         &self,
         backend_job_id: i64,
         lock_id: LockId,
+        worker_id: String,
         next_update: BackendUpdate,
     ) -> Result<(), ProofJobQueueError>;
 

--- a/proofs/prover-service/src/types.rs
+++ b/proofs/prover-service/src/types.rs
@@ -368,7 +368,7 @@ pub struct LockedBackendProofWork {
 }
 
 /// Locked location for final proof submission.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ProofSubmissionLock {
     /// Final proof was produced while starting a user-facing proof job.
     ProofJob {

--- a/proofs/worker/src/worker.rs
+++ b/proofs/worker/src/worker.rs
@@ -220,7 +220,8 @@ where
         while let Poll::Ready(Some(joined)) = this.jobs.poll_join_next(cx) {
             match joined {
                 Ok(FinishedJob { lock, result }) => {
-                    this.reports.push(report(this.queue, lock, result));
+                    this.reports
+                        .push(report(this.queue, lock, this.worker_id.clone(), result));
                 }
                 Err(join_error) => warn!(%join_error, "proving task failed to join"),
             }
@@ -347,7 +348,12 @@ fn spawn_job<B>(
 }
 
 /// Builds the future that reports one finished job (submit or fail) and logs the outcome.
-fn report<Q>(queue: &Arc<Q>, lock: JobLock, result: anyhow::Result<BackendUpdate>) -> ReportFuture
+fn report<Q>(
+    queue: &Arc<Q>,
+    lock: JobLock,
+    worker_id: String,
+    result: anyhow::Result<BackendUpdate>,
+) -> ReportFuture
 where
     Q: ProofJobQueue + Send + Sync + 'static,
 {
@@ -361,24 +367,26 @@ where
 
     // `{:#}` renders the full anyhow context chain into the failure reason.
     match result.map_err(|error| format!("{error:#}")) {
-        Ok(update) => report_update(queue, lock, update).instrument(span).boxed(),
+        Ok(update) => report_update(queue, lock, worker_id, update)
+            .instrument(span)
+            .boxed(),
         Err(reason) => Box::pin(
             async move {
                 warn!(%reason, "proving failed");
-                report_failure(queue, lock, reason).await;
+                report_failure(queue, lock, worker_id, reason).await;
             }
             .instrument(span),
         ),
     }
 }
 
-async fn report_update<Q>(queue: Arc<Q>, lock: JobLock, update: BackendUpdate)
+async fn report_update<Q>(queue: Arc<Q>, lock: JobLock, worker_id: String, update: BackendUpdate)
 where
     Q: ProofJobQueue + Send + Sync + 'static,
 {
     match lock {
         JobLock::Start { request, lock_id } => {
-            report_start_update(queue, request, lock_id, update).await
+            report_start_update(queue, request, lock_id, worker_id, update).await
         }
         JobLock::Backend {
             backend_job_id,
@@ -392,6 +400,7 @@ async fn report_start_update<Q>(
     queue: Arc<Q>,
     request: ProofRequest,
     lock_id: LockId,
+    worker_id: String,
     update: BackendUpdate,
 ) where
     Q: ProofJobQueue + Send + Sync + 'static,
@@ -399,7 +408,9 @@ async fn report_start_update<Q>(
     let id = request.id();
     let result = match update {
         BackendUpdate::Pending { state } => {
-            queue.submit_backend_proof_state(id, state, lock_id).await
+            queue
+                .submit_backend_proof_state(id, state, lock_id, worker_id)
+                .await
         }
         BackendUpdate::Complete(proof) => {
             queue
@@ -409,13 +420,14 @@ async fn report_start_update<Q>(
                 )
                 .await
         }
-        BackendUpdate::Failed(reason) => queue.fail_proof(id, reason, lock_id).await,
+        BackendUpdate::Failed(reason) => queue.fail_proof(id, reason, lock_id, worker_id).await,
         BackendUpdate::Noop => {
             queue
                 .fail_proof(
                     id,
                     "backend start returned no state update".to_string(),
                     lock_id,
+                    worker_id,
                 )
                 .await
         }
@@ -496,13 +508,15 @@ fn should_release_backend_lock_after_report_error(
     should_retry_report_error(error) && !matches!(update, BackendUpdate::Failed(_))
 }
 
-async fn report_failure<Q>(queue: Arc<Q>, lock: JobLock, reason: String)
+async fn report_failure<Q>(queue: Arc<Q>, lock: JobLock, worker_id: String, reason: String)
 where
     Q: ProofJobQueue + Send + Sync + 'static,
 {
     let result = match lock {
         JobLock::Start { request, lock_id } => {
-            queue.fail_proof(request.id(), reason, lock_id).await
+            queue
+                .fail_proof(request.id(), reason, lock_id, worker_id)
+                .await
         }
         JobLock::Backend {
             backend_job_id,
@@ -624,6 +638,7 @@ mod tests {
             _proof_id: ProofRequestId,
             _backend_proof_state: BackendProofState,
             _lock_id: LockId,
+            _worker_id: String,
         ) -> Result<(), ProofJobQueueError> {
             Ok(())
         }
@@ -692,6 +707,7 @@ mod tests {
             proof_id: ProofRequestId,
             reason: String,
             _lock_id: LockId,
+            _worker_id: String,
         ) -> Result<(), ProofJobQueueError> {
             self.failed
                 .lock()

--- a/proofs/worker/src/worker.rs
+++ b/proofs/worker/src/worker.rs
@@ -115,7 +115,12 @@ impl WorkerState {
     }
 
     /// Transitions to leasing the next queued job for `lane`.
-    fn leasing<Q>(queue: &Arc<Q>, lane: ProofBackend, permit: OwnedSemaphorePermit) -> Self
+    fn leasing<Q>(
+        queue: &Arc<Q>,
+        lane: ProofBackend,
+        worker_id: String,
+        permit: OwnedSemaphorePermit,
+    ) -> Self
     where
         Q: ProofJobQueue + Send + Sync + 'static,
     {
@@ -125,7 +130,10 @@ impl WorkerState {
                 if let Some(work) = queue.get_next_backend_proof(lane).await? {
                     return Ok(Some(LeasedWork::Backend(work)));
                 }
-                Ok(queue.get_next_proof(lane).await?.map(LeasedWork::Start))
+                Ok(queue
+                    .get_next_proof(lane, worker_id)
+                    .await?
+                    .map(LeasedWork::Start))
             }),
             permit: Some(permit),
         }
@@ -159,6 +167,7 @@ pub struct ProofWorker<Q, B> {
     jobs: JoinSet<FinishedJob>,
     /// In-flight result reports to the `prover-service`.
     reports: FuturesUnordered<ReportFuture>,
+    worker_id: String,
 
     #[pin]
     lock: WorkerState,
@@ -183,6 +192,7 @@ where
             cancelled,
             jobs: JoinSet::new(),
             reports: FuturesUnordered::new(),
+            worker_id: config.worker_id,
             lock: WorkerState::Ready,
         }
     }
@@ -225,8 +235,12 @@ where
                     LeaseStateProj::Ready => match Arc::clone(this.concurrency).try_acquire_owned()
                     {
                         Ok(permit) => {
-                            this.lock
-                                .set(WorkerState::leasing(this.queue, *this.lane, permit));
+                            this.lock.set(WorkerState::leasing(
+                                this.queue,
+                                *this.lane,
+                                this.worker_id.clone(),
+                                permit,
+                            ));
                         }
                         // Every permit is proving. A finishing job wakes this task and frees
                         // its permit; the idle backoff is a safety net in case it does not.
@@ -600,6 +614,7 @@ mod tests {
         async fn get_next_proof(
             &self,
             _backend: ProofBackend,
+            _worker_id: String,
         ) -> Result<Option<LockedProofRequest>, ProofJobQueueError> {
             Ok(self.jobs.lock().expect("jobs poisoned").pop_front())
         }


### PR DESCRIPTION
Part of https://linear.app/worldcoin/issue/PROTO-4750/refactor-prover-service-logic

This PR adds the logic for `worker_id` so that both `lock_id` and `worker_id` must match when updating a row in `proof_requests` table.

This is not the final state yet, it's a step toward the final architecture. Next steps are:

- complete the refactor of the architecture by removing lots of unnecessary fields to the `proof_sessions` table that is going to become a much simpler table thanks to the new heartbeat system (that is not there yet, it'll be implemented in a even next step)
- at the same time, there will be a refactor of the traits because the workflow for the proof worker is going to slightly change and it needs a change on the api too