### PR TITLE
feat: add retry to proof submissions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19217,6 +19217,7 @@ dependencies = [
  "alloy-primitives",
  "anyhow",
  "async-trait",
+ "backon",
  "tokio",
  "tokio-util",
  "tracing",

--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -44,7 +44,7 @@ use world_chain_challenger::{AlloyChallengerClient, ChallengerConfig, WorldChain
 use world_chain_defender::{AlloyDefenderClient, DefenderConfig, WorldChainDefender};
 use world_chain_proof_kona_host_utils::online::OnlineHostConfig;
 use world_chain_proof_succinct_host_utils::prover::{SP1ProofMode, Sp1ProverKind, SuccinctProver};
-use world_chain_proof_worker::{ProofWorker, ProofWorkerConfig};
+use world_chain_proof_worker::{ProofWorker, ProofWorkerConfig, RetryConfig};
 use world_chain_proofs::{OptimismConsensusClient, PROOF_SYSTEM_VERSION, PROOF_THRESHOLD};
 use world_chain_proposer::{AlloyProofSystemClient, ProposerConfig, WorldChainProposer};
 use world_chain_prover_service::{
@@ -2697,6 +2697,7 @@ async fn start_sp1_worker(
 
     let queue = RpcProverServiceClient::new(prover_service_url)
         .map_err(|error| eyre!("failed to connect SP1 worker to prover-service: {error}"))?;
+    let retry_config = RetryConfig::default();
     let worker = ProofWorker::new(
         queue,
         backend,
@@ -2704,6 +2705,7 @@ async fn start_sp1_worker(
             worker_id: "devnet-sp1-worker".to_string(),
             poll_interval: SP1_WORKER_POLL_INTERVAL,
             max_concurrent_jobs: 1,
+            retry_config,
         },
     );
 
@@ -2711,6 +2713,10 @@ async fn start_sp1_worker(
         prover_service = %prover_service_url,
         block_interval = deployment.block_interval,
         prover = ?kind,
+        submit_proof_retry_max_retries = retry_config.max_attempts.unwrap_or_default(),
+        submit_proof_retry_unbounded = retry_config.max_attempts.is_none(),
+        submit_proof_retry_initial_delay_ms = retry_config.initial_delay.as_millis(),
+        submit_proof_retry_max_delay_ms = retry_config.max_delay.as_millis(),
         "starting native defender SP1 worker"
     );
 

--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -2713,8 +2713,7 @@ async fn start_sp1_worker(
         prover_service = %prover_service_url,
         block_interval = deployment.block_interval,
         prover = ?kind,
-        submit_proof_retry_max_retries = retry_config.max_attempts.unwrap_or_default(),
-        submit_proof_retry_unbounded = retry_config.max_attempts.is_none(),
+        submit_proof_retry_max_retries = retry_config.max_attempts,
         submit_proof_retry_initial_delay_ms = retry_config.initial_delay.as_millis(),
         submit_proof_retry_max_delay_ms = retry_config.max_delay.as_millis(),
         "starting native defender SP1 worker"

--- a/proofs/integration-tests/tests/orchestration.rs
+++ b/proofs/integration-tests/tests/orchestration.rs
@@ -10,7 +10,7 @@ use world_chain_defender::{DefenderConfig, WorldChainDefender};
 use world_chain_proof_integration_tests::{
     BLOCK_INTERVAL, FakeConsensus, FakeExecution, FakeProofBackend, SharedProverService,
 };
-use world_chain_proof_worker::{ProofWorker, ProofWorkerConfig};
+use world_chain_proof_worker::{ProofWorker, ProofWorkerConfig, RetryConfig};
 use world_chain_proofs::{ProofLane, RootState};
 use world_chain_proposer::{ProposerConfig, WorldChainProposer};
 use world_chain_prover_service::{ProofBackend, ProverServiceConfig};
@@ -101,6 +101,7 @@ async fn start_proof_stack_with(
             worker_id: "orchestration-sp1-worker".to_string(),
             poll_interval: Duration::from_millis(5),
             max_concurrent_jobs: 1,
+            retry_config: RetryConfig::default(),
         },
     );
     let sp1_cancel = sp1_worker.cancellation_token();
@@ -113,6 +114,7 @@ async fn start_proof_stack_with(
             worker_id: "orchestration-nitro-worker".to_string(),
             poll_interval: Duration::from_millis(5),
             max_concurrent_jobs: 1,
+            retry_config: RetryConfig::default(),
         },
     );
     let nitro_cancel = nitro_worker.cancellation_token();

--- a/proofs/nitro/worker/src/lib.rs
+++ b/proofs/nitro/worker/src/lib.rs
@@ -42,7 +42,7 @@ use world_chain_proof_worker::{
 };
 use world_chain_prover_service::{ProofBackend, ProofData, RpcProverServiceClient};
 
-const DEFAULT_SUBMIT_PROOF_RETRY_MAX_RETRIES: u32 = 5;
+const DEFAULT_SUBMIT_PROOF_RETRY_MAX_RETRIES: u32 = 10;
 const DEFAULT_SUBMIT_PROOF_RETRY_INITIAL_DELAY_MS: u64 = 100;
 const DEFAULT_SUBMIT_PROOF_RETRY_MAX_DELAY_MS: u64 = 10_000;
 

--- a/proofs/nitro/worker/src/lib.rs
+++ b/proofs/nitro/worker/src/lib.rs
@@ -42,7 +42,7 @@ use world_chain_proof_worker::{
 };
 use world_chain_prover_service::{ProofBackend, ProofData, RpcProverServiceClient};
 
-const DEFAULT_SUBMIT_PROOF_RETRY_MAX_RETRIES: u32 = 10;
+const DEFAULT_SUBMIT_PROOF_RETRY_MAX_RETRIES: usize = 10;
 const DEFAULT_SUBMIT_PROOF_RETRY_INITIAL_DELAY_MS: u64 = 100;
 const DEFAULT_SUBMIT_PROOF_RETRY_MAX_DELAY_MS: u64 = 10_000;
 
@@ -269,11 +269,7 @@ struct Cli {
         env = "SUBMIT_PROOF_RETRY_MAX_RETRIES",
         default_value_t = DEFAULT_SUBMIT_PROOF_RETRY_MAX_RETRIES
     )]
-    submit_proof_retry_max_retries: u32,
-
-    /// Retry submitProof without an attempt limit while errors remain retryable.
-    #[arg(long, env = "SUBMIT_PROOF_RETRY_UNBOUNDED", default_value_t = false)]
-    submit_proof_retry_unbounded: bool,
+    submit_proof_retry_max_retries: usize,
 
     /// Initial delay in milliseconds before retrying submitProof.
     #[arg(
@@ -331,7 +327,6 @@ pub fn run() -> Result<()> {
         enclave_cid = cli.enclave_cid,
         block_interval = cli.block_interval,
         submit_proof_retry_max_retries = cli.submit_proof_retry_max_retries,
-        submit_proof_retry_unbounded = cli.submit_proof_retry_unbounded,
         submit_proof_retry_initial_delay_ms = cli.submit_proof_retry_initial_delay_ms,
         submit_proof_retry_max_delay_ms = cli.submit_proof_retry_max_delay_ms,
         "nitro-worker starting"
@@ -361,15 +356,11 @@ pub fn run() -> Result<()> {
     let worker_id = format!("{}-nitro-worker", cli.worker_id);
     let retry_initial_delay = Duration::from_millis(cli.submit_proof_retry_initial_delay_ms);
     let retry_max_delay = Duration::from_millis(cli.submit_proof_retry_max_delay_ms);
-    let retry_config = if cli.submit_proof_retry_unbounded {
-        RetryConfig::unbounded(retry_initial_delay, retry_max_delay)
-    } else {
-        RetryConfig::new(
-            cli.submit_proof_retry_max_retries,
-            retry_initial_delay,
-            retry_max_delay,
-        )
-    };
+    let retry_config = RetryConfig::new(
+        cli.submit_proof_retry_max_retries,
+        retry_initial_delay,
+        retry_max_delay,
+    );
     let worker = ProofWorker::new(
         queue,
         backend,

--- a/proofs/nitro/worker/src/lib.rs
+++ b/proofs/nitro/worker/src/lib.rs
@@ -37,8 +37,14 @@ use world_chain_proof_nitro::{
     host::{EnclaveEndpoint, NitroProver},
 };
 use world_chain_proof_protocol::WorldHardforkConfig as ProtocolHardforkConfig;
-use world_chain_proof_worker::{ClaimedProofJobHandler, ProofJob, ProofWorker, ProofWorkerConfig};
+use world_chain_proof_worker::{
+    ClaimedProofJobHandler, ProofJob, ProofWorker, ProofWorkerConfig, RetryConfig,
+};
 use world_chain_prover_service::{ProofBackend, ProofData, RpcProverServiceClient};
+
+const DEFAULT_SUBMIT_PROOF_RETRY_MAX_RETRIES: u32 = 5;
+const DEFAULT_SUBMIT_PROOF_RETRY_INITIAL_DELAY_MS: u64 = 100;
+const DEFAULT_SUBMIT_PROOF_RETRY_MAX_DELAY_MS: u64 = 10_000;
 
 // ──────────────────────────────────────────────────────────────────────────────────────
 // NitroBackend — ClaimedProofJobHandler implementation for the Nitro TEE lane
@@ -257,6 +263,34 @@ struct Cli {
     #[arg(long, default_value_t = 1)]
     max_concurrent_jobs: usize,
 
+    /// Maximum retries after a retryable submitProof failure.
+    #[arg(
+        long,
+        env = "SUBMIT_PROOF_RETRY_MAX_RETRIES",
+        default_value_t = DEFAULT_SUBMIT_PROOF_RETRY_MAX_RETRIES
+    )]
+    submit_proof_retry_max_retries: u32,
+
+    /// Retry submitProof without an attempt limit while errors remain retryable.
+    #[arg(long, env = "SUBMIT_PROOF_RETRY_UNBOUNDED", default_value_t = false)]
+    submit_proof_retry_unbounded: bool,
+
+    /// Initial delay in milliseconds before retrying submitProof.
+    #[arg(
+        long,
+        env = "SUBMIT_PROOF_RETRY_INITIAL_DELAY_MS",
+        default_value_t = DEFAULT_SUBMIT_PROOF_RETRY_INITIAL_DELAY_MS
+    )]
+    submit_proof_retry_initial_delay_ms: u64,
+
+    /// Maximum delay in milliseconds between submitProof retries.
+    #[arg(
+        long,
+        env = "SUBMIT_PROOF_RETRY_MAX_DELAY_MS",
+        default_value_t = DEFAULT_SUBMIT_PROOF_RETRY_MAX_DELAY_MS
+    )]
+    submit_proof_retry_max_delay_ms: u64,
+
     /// The unique worker id.
     #[arg(long)]
     worker_id: String,
@@ -296,6 +330,10 @@ pub fn run() -> Result<()> {
         prover_service = %cli.prover_service_url,
         enclave_cid = cli.enclave_cid,
         block_interval = cli.block_interval,
+        submit_proof_retry_max_retries = cli.submit_proof_retry_max_retries,
+        submit_proof_retry_unbounded = cli.submit_proof_retry_unbounded,
+        submit_proof_retry_initial_delay_ms = cli.submit_proof_retry_initial_delay_ms,
+        submit_proof_retry_max_delay_ms = cli.submit_proof_retry_max_delay_ms,
         "nitro-worker starting"
     );
 
@@ -321,6 +359,17 @@ pub fn run() -> Result<()> {
         .with_context(|| format!("failed to connect to {}", cli.prover_service_url))?;
 
     let worker_id = format!("{}-nitro-worker", cli.worker_id);
+    let retry_initial_delay = Duration::from_millis(cli.submit_proof_retry_initial_delay_ms);
+    let retry_max_delay = Duration::from_millis(cli.submit_proof_retry_max_delay_ms);
+    let retry_config = if cli.submit_proof_retry_unbounded {
+        RetryConfig::unbounded(retry_initial_delay, retry_max_delay)
+    } else {
+        RetryConfig::new(
+            cli.submit_proof_retry_max_retries,
+            retry_initial_delay,
+            retry_max_delay,
+        )
+    };
     let worker = ProofWorker::new(
         queue,
         backend,
@@ -328,6 +377,7 @@ pub fn run() -> Result<()> {
             worker_id,
             poll_interval: Duration::from_secs(cli.poll_interval_seconds),
             max_concurrent_jobs: cli.max_concurrent_jobs,
+            retry_config,
         },
     );
 

--- a/proofs/prover-service/src/error.rs
+++ b/proofs/prover-service/src/error.rs
@@ -62,6 +62,69 @@ pub enum ProofRequestError {
     Rpc(String),
 }
 
+/// Data describing a proof job status mismatch.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct ProofJobStatusErrorData {
+    /// The proof request id.
+    pub proof_id: ProofRequestId,
+    /// The expected job status.
+    pub expected: ProofJobStatus,
+    /// The actual stored job status.
+    pub actual: ProofJobStatus,
+}
+
+impl std::fmt::Display for ProofJobStatusErrorData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Invalid proof job status for proof id {}: expected {}, got {}.",
+            self.proof_id, self.expected, self.actual
+        )
+    }
+}
+
+/// Data describing a submitted proof backend mismatch.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct BackendMismatchErrorData {
+    /// The proof request id.
+    pub proof_id: ProofRequestId,
+    /// The backend expected by the stored proof request.
+    pub expected: ProofBackend,
+    /// The backend that produced the submitted proof.
+    pub actual: ProofBackend,
+}
+
+impl std::fmt::Display for BackendMismatchErrorData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "proof job {} backend mismatch: expected {}, got {}.",
+            self.proof_id, self.expected, self.actual
+        )
+    }
+}
+
+/// Data describing a repeated proof submission with different proof data.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct ProofMismatchErrorData {
+    /// The proof request id.
+    pub proof_id: ProofRequestId,
+    /// The proof data already stored by the prover-service.
+    pub expected: ProofData,
+    /// The proof data submitted by the worker.
+    pub actual: ProofData,
+}
+
+impl std::fmt::Display for ProofMismatchErrorData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "proof {} proof data mismatch: expected {:?}, got {:?}.",
+            self.proof_id, self.expected, self.actual
+        )
+    }
+}
+
 /// Error returned to a prover worker by the `prover-service`.
 #[derive(Error, Debug)]
 pub enum ProofJobQueueError {
@@ -81,34 +144,30 @@ pub enum ProofJobQueueError {
     MalformedB256(usize),
     #[error("Proof request {0} not found.")]
     ProofIdNotFound(ProofRequestId),
-    #[error("Invalid proof job status for proof id {proof_id}: expected {expected}, got {actual}.")]
-    ProofJobStatusNotClaimed {
-        proof_id: ProofRequestId,
-        expected: ProofJobStatus,
-        actual: ProofJobStatus,
-    },
+    #[error("{0}")]
+    ProofJobStatusNotClaimed(ProofJobStatusErrorData),
     #[error("Stale lock for given proof id: {0}.")]
     StaleLock(ProofRequestId),
     #[error("Expired lock for given proof id: {0}.")]
     LockExpired(ProofRequestId),
-    #[error("proof job {proof_id} backend mismatch: expected {expected}, got {actual}.")]
-    BackendMismatch {
-        proof_id: ProofRequestId,
-        expected: ProofBackend,
-        actual: ProofBackend,
-    },
+    #[error("{0}")]
+    BackendMismatch(BackendMismatchErrorData),
     #[error("The proof {0} has already reached a terminal job status.")]
     AlreadyTerminal(ProofRequestId),
     #[error(transparent)]
     ProofEncoding(#[from] serde_json::Error),
-    #[error("proof {proof_id} proof data mismatch: expected {expected:?}, got {actual:?}.")]
-    ProofMismatch {
-        proof_id: ProofRequestId,
-        expected: ProofData,
-        actual: ProofData,
-    },
+    #[error("{0}")]
+    ProofMismatch(ProofMismatchErrorData),
     #[error(
         "proof {0}: the diagnostic read did not identify a stable reason for the proof submission failure."
     )]
     Unknown(ProofRequestId),
+    #[error("remote prover-service internal error.")]
+    RemoteInternal,
+    #[error("RPC request timed out.")]
+    RpcRequestTimeout,
+    #[error("RPC transport error: {0}.")]
+    RpcTransport(#[from] jsonrpsee::core::BoxError),
+    #[error("RPC client error: {0}.")]
+    RpcClient(#[source] jsonrpsee::core::client::Error),
 }

--- a/proofs/prover-service/src/error.rs
+++ b/proofs/prover-service/src/error.rs
@@ -1,4 +1,7 @@
-use crate::types::{ProofRequestId, ProofStatus};
+use crate::{
+    ProofBackend, ProofJobStatus,
+    types::{ProofRequestId, ProofStatus},
+};
 use sqlx::migrate::MigrateError;
 use thiserror::Error;
 
@@ -62,32 +65,40 @@ pub enum ProofRequestError {
 /// Error returned to a prover worker by the `prover-service`.
 #[derive(Error, Debug)]
 pub enum ProofJobQueueError {
-    /// No proof request with the given id is known.
-    #[error("unknown proof job {0}")]
-    UnknownJob(ProofRequestId),
-    /// No backend proof job with the given id is known.
-    #[error("unknown backend proof job {0}")]
-    UnknownBackendJob(i64),
-    /// The lock token no longer owns the row being updated.
-    #[error("stale lock for proof job update")]
-    StaleLocked,
-    /// The submitted proof does not match the requested job.
-    #[error("invalid proof for job {id}: {reason}")]
-    InvalidProof {
-        /// The proof request id.
-        id: ProofRequestId,
-        /// Why the proof was rejected.
-        reason: String,
+    #[error(transparent)]
+    Sqlx(#[from] sqlx::Error),
+    #[error("block number is negative: {0}.")]
+    NegativeBlockNumber(i64),
+    #[error("{0}")]
+    UnknownProofBackend(String),
+    #[error("{0}")]
+    UnknownBackendSessionStatus(String),
+    #[error("{0}")]
+    UnknownProofJobStatus(String),
+    #[error("The provided value has {0} bytes, expected 20.")]
+    MalformedAddress(usize),
+    #[error("The provided value has {0} bytes, expected 32.")]
+    MalformedB256(usize),
+    #[error("Proof request {0} not found.")]
+    ProofIdNotFound(ProofRequestId),
+    #[error("Invalid proof job status for proof id {proof_id}: expected {expected}, got {actual}.")]
+    ProofJobStatusNotClaimed {
+        proof_id: ProofRequestId,
+        expected: ProofJobStatus,
+        actual: ProofJobStatus,
     },
-    /// Internal service or storage error.
-    #[error("prover-service error: {0}")]
-    Internal(String),
-    /// RPC transport error.
-    #[error("RPC error: {0}")]
-    Rpc(String),
-    /// No proof request with the given id is known.
-    #[error("proof request {0} not found")]
-    NotFound(ProofRequestId),
-    #[error("validation error: {0}")]
-    Validation(String),
+    #[error("Stale lock for given proof id: {0}.")]
+    StaleLock(ProofRequestId),
+    #[error("Expired lock for given proof id: {0}.")]
+    LockExpired(ProofRequestId),
+    #[error("proof job {proof_id} backend mismatch: expected {expected}, got {actual}.")]
+    BackendMismatch {
+        proof_id: ProofRequestId,
+        expected: ProofBackend,
+        actual: ProofBackend,
+    },
+    #[error("The proof {0} has already reached a terminal job status.")]
+    AlreadyTerminal(ProofRequestId),
+    #[error(transparent)]
+    ProofEncoding(#[from] serde_json::Error),
 }

--- a/proofs/prover-service/src/error.rs
+++ b/proofs/prover-service/src/error.rs
@@ -159,7 +159,7 @@ pub enum ProofJobQueueError {
     #[error(transparent)]
     ProofEncoding(#[from] serde_json::Error),
     #[error("{0}")]
-    ProofMismatch(ProofMismatchErrorData),
+    ProofMismatch(Box<ProofMismatchErrorData>),
     #[error(
         "proof {0}: the diagnostic read did not identify a stable reason for the proof submission failure."
     )]

--- a/proofs/prover-service/src/error.rs
+++ b/proofs/prover-service/src/error.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ProofBackend, ProofJobStatus,
+    ProofBackend, ProofData, ProofJobStatus,
     types::{ProofRequestId, ProofStatus},
 };
 use sqlx::migrate::MigrateError;
@@ -101,4 +101,14 @@ pub enum ProofJobQueueError {
     AlreadyTerminal(ProofRequestId),
     #[error(transparent)]
     ProofEncoding(#[from] serde_json::Error),
+    #[error("proof {proof_id} proof data mismatch: expected {expected:?}, got {actual:?}.")]
+    ProofMismatch {
+        proof_id: ProofRequestId,
+        expected: ProofData,
+        actual: ProofData,
+    },
+    #[error(
+        "proof {0}: the diagnostic read did not identify a stable reason for the proof submission failure."
+    )]
+    Unknown(ProofRequestId),
 }

--- a/proofs/prover-service/src/error.rs
+++ b/proofs/prover-service/src/error.rs
@@ -2,7 +2,9 @@ use crate::{
     ProofBackend, ProofData, ProofJobStatus,
     types::{ProofRequestId, ProofStatus},
 };
+use jsonrpsee::core::client::Error as JsonRpseeError;
 use sqlx::migrate::MigrateError;
+use std::sync::Arc;
 use thiserror::Error;
 
 /// Invalid `prover-service` configuration.
@@ -164,10 +166,31 @@ pub enum ProofJobQueueError {
     Unknown(ProofRequestId),
     #[error("remote prover-service internal error.")]
     RemoteInternal,
+    #[error("remote prover-service storage error.")]
+    RemoteSqlx,
     #[error("RPC request timed out.")]
     RpcRequestTimeout,
     #[error("RPC transport error: {0}.")]
     RpcTransport(#[from] jsonrpsee::core::BoxError),
+    #[error("RPC client restart needed: {0}.")]
+    RpcRestartNeeded(#[source] Arc<JsonRpseeError>),
+    #[error("RPC service disconnected.")]
+    RpcServiceDisconnected,
     #[error("RPC client error: {0}.")]
-    RpcClient(#[source] jsonrpsee::core::client::Error),
+    RpcClient(#[source] JsonRpseeError),
+}
+
+impl ProofJobQueueError {
+    /// Whether retrying the same operation can plausibly succeed.
+    pub const fn is_retryable(&self) -> bool {
+        matches!(
+            self,
+            Self::Sqlx(_)
+                | Self::RemoteSqlx
+                | Self::RpcRequestTimeout
+                | Self::RpcTransport(_)
+                | Self::RpcRestartNeeded(_)
+                | Self::RpcServiceDisconnected
+        )
+    }
 }

--- a/proofs/prover-service/src/lib.rs
+++ b/proofs/prover-service/src/lib.rs
@@ -81,7 +81,8 @@ pub use config::{
     DEFAULT_BACKEND_POLL_INTERVAL, DEFAULT_LOCK_TIMEOUT, DEFAULT_MAX_ATTEMPTS, ProverServiceConfig,
 };
 pub use error::{
-    InvalidConfigError, ProofJobQueueError, ProofRequestError, ProverServiceInitError,
+    BackendMismatchErrorData, InvalidConfigError, ProofJobQueueError, ProofJobStatusErrorData,
+    ProofMismatchErrorData, ProofRequestError, ProverServiceInitError,
 };
 pub use rpc::{
     ProverServiceApiClient, ProverServiceApiServer, ProverServiceRpc, RpcProverServiceClient,

--- a/proofs/prover-service/src/rpc.rs
+++ b/proofs/prover-service/src/rpc.rs
@@ -46,6 +46,8 @@ pub mod error_code {
     pub const ALREADY_TERMINAL: i32 = -32017;
     /// A replayed submit carried proof data that differs from the stored proof.
     pub const PROOF_MISMATCH: i32 = -32018;
+    /// Temporary prover-service storage failure.
+    pub const SQLX: i32 = -32019;
 }
 
 /// The `prover-service` JSON-RPC API, covering both the defender-facing
@@ -158,8 +160,10 @@ impl From<ProofJobQueueError> for ErrorObjectOwned {
             ProofJobQueueError::ProofMismatch(data) => {
                 ErrorObject::owned(error_code::PROOF_MISMATCH, message, Some(data))
             }
-            ProofJobQueueError::Sqlx(_)
-            | ProofJobQueueError::NegativeBlockNumber(_)
+            ProofJobQueueError::Sqlx(_) => {
+                ErrorObject::owned(error_code::SQLX, message, None::<()>)
+            }
+            ProofJobQueueError::NegativeBlockNumber(_)
             | ProofJobQueueError::UnknownProofBackend(_)
             | ProofJobQueueError::UnknownBackendSessionStatus(_)
             | ProofJobQueueError::UnknownProofJobStatus(_)
@@ -168,8 +172,11 @@ impl From<ProofJobQueueError> for ErrorObjectOwned {
             | ProofJobQueueError::ProofEncoding(_)
             | ProofJobQueueError::Unknown(_)
             | ProofJobQueueError::RemoteInternal
+            | ProofJobQueueError::RemoteSqlx
             | ProofJobQueueError::RpcRequestTimeout
             | ProofJobQueueError::RpcTransport(_)
+            | ProofJobQueueError::RpcRestartNeeded(_)
+            | ProofJobQueueError::RpcServiceDisconnected
             | ProofJobQueueError::RpcClient(_) => {
                 ErrorObject::owned(INTERNAL_ERROR_CODE, message, None::<()>)
             }
@@ -322,6 +329,8 @@ fn map_job_error(err: ClientError, id: ProofRequestId) -> ProofJobQueueError {
     match err {
         ClientError::RequestTimeout => ProofJobQueueError::RpcRequestTimeout,
         ClientError::Transport(err) => ProofJobQueueError::RpcTransport(err),
+        ClientError::RestartNeeded(err) => ProofJobQueueError::RpcRestartNeeded(err),
+        ClientError::ServiceDisconnect => ProofJobQueueError::RpcServiceDisconnected,
         ClientError::Call(err) => map_job_call_error(err, id),
         err => ProofJobQueueError::RpcClient(err),
     }
@@ -362,6 +371,7 @@ fn map_job_call_error(err: ErrorObjectOwned, fallback_id: ProofRequestId) -> Pro
                 ProofJobQueueError::RemoteInternal
             }
         }
+        error_code::SQLX => ProofJobQueueError::RemoteSqlx,
         INTERNAL_ERROR_CODE => ProofJobQueueError::RemoteInternal,
         _ => ProofJobQueueError::RpcClient(ClientError::Call(err)),
     }

--- a/proofs/prover-service/src/rpc.rs
+++ b/proofs/prover-service/src/rpc.rs
@@ -1,5 +1,8 @@
 use crate::{
-    error::{ProofJobQueueError, ProofRequestError},
+    error::{
+        BackendMismatchErrorData, ProofJobQueueError, ProofJobStatusErrorData,
+        ProofMismatchErrorData, ProofRequestError,
+    },
     service::ProverService,
     traits::{ProofJobQueue, ProofRequester},
     types::{
@@ -12,10 +15,7 @@ use jsonrpsee::{
     http_client::{HttpClient, HttpClientBuilder},
     proc_macros::rpc,
     server::{Server, ServerHandle},
-    types::{
-        ErrorObject, ErrorObjectOwned,
-        error::{INTERNAL_ERROR_CODE, INVALID_PARAMS_CODE},
-    },
+    types::{ErrorObject, ErrorObjectOwned, error::INTERNAL_ERROR_CODE},
 };
 use std::{net::SocketAddr, sync::Arc};
 use tracing::info;
@@ -32,21 +32,20 @@ pub mod error_code {
     pub const TOO_MANY_RETRIES: i32 = -32005;
     /// A conflicting row vanished after an insert conflict; the request is safe to retry.
     pub const RETRYABLE_CONFLICT: i32 = -32006;
-    /// No proof job with the given id is known.
-    pub const UNKNOWN_JOB: i32 = -32011;
-    /// No backend proof job with the given id is known.
-    pub const UNKNOWN_BACKEND_JOB: i32 = -32013;
+    /// No proof job with the given proof request id is known.
+    pub const PROOF_ID_NOT_FOUND: i32 = -32011;
+    /// The proof job was not in the expected claimed status.
+    pub const PROOF_JOB_STATUS_NOT_CLAIMED: i32 = -32012;
     /// A worker tried to update a row using an expired or superseded lock.
     pub const STALE_LOCK: i32 = -32014;
-    /// The submitted proof does not match the requested job;
-    /// the error data holds the proof id and reason.
-    pub const INVALID_PROOF: i32 = -32012;
-}
-
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
-struct InvalidProofErrorData {
-    id: ProofRequestId,
-    reason: String,
+    /// A worker tried to update a row using an expired lock.
+    pub const LOCK_EXPIRED: i32 = -32015;
+    /// The submitted proof was produced by a different backend than the job expects.
+    pub const BACKEND_MISMATCH: i32 = -32016;
+    /// The proof job has already reached a terminal status.
+    pub const ALREADY_TERMINAL: i32 = -32017;
+    /// A replayed submit carried proof data that differs from the stored proof.
+    pub const PROOF_MISMATCH: i32 = -32018;
 }
 
 /// The `prover-service` JSON-RPC API, covering both the defender-facing
@@ -136,31 +135,43 @@ impl From<ProofJobQueueError> for ErrorObjectOwned {
     fn from(err: ProofJobQueueError) -> Self {
         let message = err.to_string();
         match err {
-            ProofJobQueueError::UnknownJob(_) => {
-                ErrorObject::owned(error_code::UNKNOWN_JOB, message, None::<()>)
+            ProofJobQueueError::ProofIdNotFound(proof_id) => {
+                ErrorObject::owned(error_code::PROOF_ID_NOT_FOUND, message, Some(proof_id))
             }
-            ProofJobQueueError::UnknownBackendJob(_) => {
-                ErrorObject::owned(error_code::UNKNOWN_BACKEND_JOB, message, None::<()>)
-            }
-            ProofJobQueueError::StaleLocked => {
-                ErrorObject::owned(error_code::STALE_LOCK, message, None::<()>)
-            }
-            ProofJobQueueError::InvalidProof { id, reason } => ErrorObject::owned(
-                error_code::INVALID_PROOF,
+            ProofJobQueueError::ProofJobStatusNotClaimed(data) => ErrorObject::owned(
+                error_code::PROOF_JOB_STATUS_NOT_CLAIMED,
                 message,
-                Some(InvalidProofErrorData { id, reason }),
+                Some(data),
             ),
-            ProofJobQueueError::Internal(_) => {
+            ProofJobQueueError::StaleLock(proof_id) => {
+                ErrorObject::owned(error_code::STALE_LOCK, message, Some(proof_id))
+            }
+            ProofJobQueueError::LockExpired(proof_id) => {
+                ErrorObject::owned(error_code::LOCK_EXPIRED, message, Some(proof_id))
+            }
+            ProofJobQueueError::BackendMismatch(data) => {
+                ErrorObject::owned(error_code::BACKEND_MISMATCH, message, Some(data))
+            }
+            ProofJobQueueError::AlreadyTerminal(proof_id) => {
+                ErrorObject::owned(error_code::ALREADY_TERMINAL, message, Some(proof_id))
+            }
+            ProofJobQueueError::ProofMismatch(data) => {
+                ErrorObject::owned(error_code::PROOF_MISMATCH, message, Some(data))
+            }
+            ProofJobQueueError::Sqlx(_)
+            | ProofJobQueueError::NegativeBlockNumber(_)
+            | ProofJobQueueError::UnknownProofBackend(_)
+            | ProofJobQueueError::UnknownBackendSessionStatus(_)
+            | ProofJobQueueError::UnknownProofJobStatus(_)
+            | ProofJobQueueError::MalformedAddress(_)
+            | ProofJobQueueError::MalformedB256(_)
+            | ProofJobQueueError::ProofEncoding(_)
+            | ProofJobQueueError::Unknown(_)
+            | ProofJobQueueError::RemoteInternal
+            | ProofJobQueueError::RpcRequestTimeout
+            | ProofJobQueueError::RpcTransport(_)
+            | ProofJobQueueError::RpcClient(_) => {
                 ErrorObject::owned(INTERNAL_ERROR_CODE, message, None::<()>)
-            }
-            ProofJobQueueError::Rpc(_) => {
-                ErrorObject::owned(INTERNAL_ERROR_CODE, message, None::<()>)
-            }
-            ProofJobQueueError::NotFound(_) => {
-                ErrorObject::owned(error_code::NOT_FOUND, message, None::<()>)
-            }
-            ProofJobQueueError::Validation(_) => {
-                ErrorObject::owned(INVALID_PARAMS_CODE, message, None::<()>)
             }
         }
     }
@@ -283,12 +294,6 @@ fn error_data<T: serde::de::DeserializeOwned>(err: &ErrorObjectOwned) -> Option<
         .and_then(|raw| serde_json::from_str(raw.get()).ok())
 }
 
-fn invalid_proof_reason(err: &ErrorObjectOwned) -> Option<String> {
-    error_data::<InvalidProofErrorData>(err)
-        .map(|data| data.reason)
-        .or_else(|| error_data(err))
-}
-
 fn map_request_error(
     err: ClientError,
     id: ProofRequestId,
@@ -314,17 +319,51 @@ fn map_request_error(
 }
 
 fn map_job_error(err: ClientError, id: ProofRequestId) -> ProofJobQueueError {
-    let ClientError::Call(err) = err else {
-        return ProofJobQueueError::Rpc(err.to_string());
-    };
+    match err {
+        ClientError::RequestTimeout => ProofJobQueueError::RpcRequestTimeout,
+        ClientError::Transport(err) => ProofJobQueueError::RpcTransport(err),
+        ClientError::Call(err) => map_job_call_error(err, id),
+        err => ProofJobQueueError::RpcClient(err),
+    }
+}
+
+fn map_job_call_error(err: ErrorObjectOwned, fallback_id: ProofRequestId) -> ProofJobQueueError {
     match err.code() {
-        error_code::UNKNOWN_JOB => ProofJobQueueError::UnknownJob(id),
-        error_code::STALE_LOCK => ProofJobQueueError::StaleLocked,
-        error_code::INVALID_PROOF => ProofJobQueueError::InvalidProof {
-            id,
-            reason: invalid_proof_reason(&err).unwrap_or_else(|| err.message().to_string()),
-        },
-        _ => ProofJobQueueError::Rpc(format!("{} (code {})", err.message(), err.code())),
+        error_code::PROOF_ID_NOT_FOUND => {
+            ProofJobQueueError::ProofIdNotFound(error_data(&err).unwrap_or(fallback_id))
+        }
+        error_code::PROOF_JOB_STATUS_NOT_CLAIMED => {
+            if let Some(data) = error_data::<ProofJobStatusErrorData>(&err) {
+                ProofJobQueueError::ProofJobStatusNotClaimed(data)
+            } else {
+                ProofJobQueueError::RemoteInternal
+            }
+        }
+        error_code::STALE_LOCK => {
+            ProofJobQueueError::StaleLock(error_data(&err).unwrap_or(fallback_id))
+        }
+        error_code::LOCK_EXPIRED => {
+            ProofJobQueueError::LockExpired(error_data(&err).unwrap_or(fallback_id))
+        }
+        error_code::BACKEND_MISMATCH => {
+            if let Some(data) = error_data::<BackendMismatchErrorData>(&err) {
+                ProofJobQueueError::BackendMismatch(data)
+            } else {
+                ProofJobQueueError::RemoteInternal
+            }
+        }
+        error_code::ALREADY_TERMINAL => {
+            ProofJobQueueError::AlreadyTerminal(error_data(&err).unwrap_or(fallback_id))
+        }
+        error_code::PROOF_MISMATCH => {
+            if let Some(data) = error_data::<ProofMismatchErrorData>(&err) {
+                ProofJobQueueError::ProofMismatch(data)
+            } else {
+                ProofJobQueueError::RemoteInternal
+            }
+        }
+        INTERNAL_ERROR_CODE => ProofJobQueueError::RemoteInternal,
+        _ => ProofJobQueueError::RpcClient(ClientError::Call(err)),
     }
 }
 
@@ -369,7 +408,7 @@ impl ProofJobQueue for RpcProverServiceClient {
     ) -> Result<Option<LockedProofRequest>, ProofJobQueueError> {
         ProverServiceApiClient::get_next_proof(&self.client, backend, worker_id)
             .await
-            .map_err(|err| ProofJobQueueError::Rpc(err.to_string()))
+            .map_err(|err| map_job_error(err, ProofRequestId(Default::default())))
     }
 
     async fn submit_proof(

--- a/proofs/prover-service/src/rpc.rs
+++ b/proofs/prover-service/src/rpc.rs
@@ -365,7 +365,7 @@ fn map_job_call_error(err: ErrorObjectOwned, fallback_id: ProofRequestId) -> Pro
             ProofJobQueueError::AlreadyTerminal(error_data(&err).unwrap_or(fallback_id))
         }
         error_code::PROOF_MISMATCH => {
-            if let Some(data) = error_data::<ProofMismatchErrorData>(&err) {
+            if let Some(data) = error_data::<Box<ProofMismatchErrorData>>(&err) {
                 ProofJobQueueError::ProofMismatch(data)
             } else {
                 ProofJobQueueError::RemoteInternal

--- a/proofs/prover-service/src/store.rs
+++ b/proofs/prover-service/src/store.rs
@@ -509,8 +509,8 @@ impl ProverServiceStore {
         if stored_proof_request.backend != proof.proof.backend() {
             return Err(ProofJobQueueError::BackendMismatch {
                 proof_id: proof.id,
-                expected: proof.proof.backend(),
-                actual: stored_proof_request.backend,
+                expected: stored_proof_request.backend,
+                actual: proof.proof.backend(),
             });
         }
         if stored_lock_id != Some(lock_id.0) || stored_worker_id != Some(worker_id.clone()) {

--- a/proofs/prover-service/src/store.rs
+++ b/proofs/prover-service/src/store.rs
@@ -1,7 +1,10 @@
 use crate::{
     ProofData,
     config::ProverServiceConfig,
-    error::{InvalidConfigError, ProofJobQueueError, ProofRequestError, ProverServiceInitError},
+    error::{
+        BackendMismatchErrorData, InvalidConfigError, ProofJobQueueError, ProofJobStatusErrorData,
+        ProofMismatchErrorData, ProofRequestError, ProverServiceInitError,
+    },
     types::{
         BackendSession, BackendSessionStatus, LockId, LockedProofRequest, ProofBackend,
         ProofJobStatus, ProofRequest, ProofRequestId, ProofResponse, ProofStatus, SessionType,
@@ -360,11 +363,13 @@ impl ProverServiceStore {
         // - lock_id and worker_id must match
         // - lock_expires_at shoult not be expired
         if stored_job_status != ProofJobStatus::Claimed {
-            return Err(ProofJobQueueError::ProofJobStatusNotClaimed {
-                proof_id,
-                expected: ProofJobStatus::Claimed,
-                actual: stored_job_status,
-            });
+            return Err(ProofJobQueueError::ProofJobStatusNotClaimed(
+                ProofJobStatusErrorData {
+                    proof_id,
+                    expected: ProofJobStatus::Claimed,
+                    actual: stored_job_status,
+                },
+            ));
         }
         if stored_lock_id != Some(lock_id.0) || stored_worker_id != Some(worker_id.clone()) {
             return Err(ProofJobQueueError::StaleLock(proof_id));
@@ -507,11 +512,13 @@ impl ProverServiceStore {
             .map_err(|err| ProofJobQueueError::UnknownProofJobStatus(err))?;
         // validation
         if stored_proof_request.backend != proof.proof.backend() {
-            return Err(ProofJobQueueError::BackendMismatch {
-                proof_id: proof.id,
-                expected: stored_proof_request.backend,
-                actual: proof.proof.backend(),
-            });
+            return Err(ProofJobQueueError::BackendMismatch(
+                BackendMismatchErrorData {
+                    proof_id: proof.id,
+                    expected: stored_proof_request.backend,
+                    actual: proof.proof.backend(),
+                },
+            ));
         }
         if stored_lock_id != Some(lock_id.0) || stored_worker_id != Some(worker_id.clone()) {
             return Err(ProofJobQueueError::StaleLock(proof.id));
@@ -604,11 +611,11 @@ impl ProverServiceStore {
                     // proof has already been submitted - no op
                     return Ok(());
                 } else {
-                    return Err(ProofJobQueueError::ProofMismatch {
+                    return Err(ProofJobQueueError::ProofMismatch(ProofMismatchErrorData {
                         proof_id: proof.id,
                         expected: stored_proof_data,
                         actual: proof.proof,
-                    });
+                    }));
                 }
             }
             if matches!(
@@ -618,11 +625,13 @@ impl ProverServiceStore {
                 return Err(ProofJobQueueError::AlreadyTerminal(proof.id));
             }
             if stored_job_status != ProofJobStatus::Claimed {
-                return Err(ProofJobQueueError::ProofJobStatusNotClaimed {
-                    proof_id: proof.id,
-                    expected: ProofJobStatus::Claimed,
-                    actual: stored_job_status,
-                });
+                return Err(ProofJobQueueError::ProofJobStatusNotClaimed(
+                    ProofJobStatusErrorData {
+                        proof_id: proof.id,
+                        expected: ProofJobStatus::Claimed,
+                        actual: stored_job_status,
+                    },
+                ));
             }
             if stored_lock_id != Some(lock_id.0) || stored_worker_id != Some(worker_id) {
                 return Err(ProofJobQueueError::StaleLock(proof.id));

--- a/proofs/prover-service/src/store.rs
+++ b/proofs/prover-service/src/store.rs
@@ -310,7 +310,7 @@ impl ProverServiceStore {
             let backend_session_id: String = row.try_get("backend_session_id")?;
             let status_str: String = row.try_get("status")?;
             let state = BackendSessionStatus::try_from(status_str.as_str())
-                .map_err(|e| ProofJobQueueError::UnknownBackendSessionStatus(e))?;
+                .map_err(ProofJobQueueError::UnknownBackendSessionStatus)?;
 
             Some(BackendSession {
                 backend_session_id,
@@ -352,7 +352,7 @@ impl ProverServiceStore {
 
         let stored_job_status_str: &str = claim.get("job_status");
         let stored_job_status = ProofJobStatus::try_from(stored_job_status_str)
-            .map_err(|e| ProofJobQueueError::UnknownProofJobStatus(e))?;
+            .map_err(ProofJobQueueError::UnknownProofJobStatus)?;
 
         let stored_lock_id: Option<Uuid> = claim.get("lock_id");
         let stored_worker_id: Option<String> = claim.get("worker_id");
@@ -401,7 +401,7 @@ impl ProverServiceStore {
         for row in existing_backend_sessions {
             let status_str: &str = row.get("status");
             let status = BackendSessionStatus::try_from(status_str)
-                .map_err(|err| ProofJobQueueError::UnknownBackendSessionStatus(err))?;
+                .map_err(ProofJobQueueError::UnknownBackendSessionStatus)?;
             if status.is_terminal() {
                 // return this proof session
                 // TODO: do it
@@ -509,7 +509,7 @@ impl ProverServiceStore {
         let stored_lock_expires_at: Option<chrono::DateTime<Utc>> = existing.get("lock_expires_at");
         let stored_job_status_str: String = existing.get("job_status");
         let stored_job_status = ProofJobStatus::try_from(stored_job_status_str.as_str())
-            .map_err(|err| ProofJobQueueError::UnknownProofJobStatus(err))?;
+            .map_err(ProofJobQueueError::UnknownProofJobStatus)?;
         // validation
         if stored_proof_request.backend != proof.proof.backend() {
             return Err(ProofJobQueueError::BackendMismatch(
@@ -592,7 +592,7 @@ impl ProverServiceStore {
                 existing.get("lock_expires_at");
             let stored_job_status_str: String = existing.get("job_status");
             let stored_job_status = ProofJobStatus::try_from(stored_job_status_str.as_str())
-                .map_err(|err| ProofJobQueueError::UnknownProofJobStatus(err))?;
+                .map_err(ProofJobQueueError::UnknownProofJobStatus)?;
             // validation
             if stored_job_status == ProofJobStatus::Succeeded
                 && stored_worker_id == Some(worker_id.clone())
@@ -604,11 +604,13 @@ impl ProverServiceStore {
                     // proof has already been submitted - no op
                     return Ok(());
                 } else {
-                    return Err(ProofJobQueueError::ProofMismatch(ProofMismatchErrorData {
-                        proof_id: proof.id,
-                        expected: stored_proof_data,
-                        actual: proof.proof,
-                    }));
+                    return Err(ProofJobQueueError::ProofMismatch(Box::new(
+                        ProofMismatchErrorData {
+                            proof_id: proof.id,
+                            expected: stored_proof_data,
+                            actual: proof.proof,
+                        },
+                    )));
                 }
             }
             if matches!(
@@ -632,7 +634,7 @@ impl ProverServiceStore {
             if stored_lock_expires_at.is_none() || stored_lock_expires_at.unwrap() <= Utc::now() {
                 return Err(ProofJobQueueError::LockExpired(proof.id));
             }
-            return Err(ProofJobQueueError::Unknown(proof.id));
+            Err(ProofJobQueueError::Unknown(proof.id))
         }
     }
 
@@ -686,7 +688,7 @@ fn request_from_row(row: &PgRow) -> Result<ProofRequest, ProofJobQueueError> {
 
     Ok(ProofRequest {
         backend: ProofBackend::try_from(row.try_get::<String, _>("backend")?.as_str())
-            .map_err(|err| ProofJobQueueError::UnknownProofBackend(err))?,
+            .map_err(ProofJobQueueError::UnknownProofBackend)?,
         game: address_from_bytes(row.try_get("game")?)?,
         root_claim: b256_from_bytes(row.try_get("root_claim")?)?,
         l2_block_number: l2_block_number as u64,

--- a/proofs/prover-service/src/store.rs
+++ b/proofs/prover-service/src/store.rs
@@ -570,19 +570,12 @@ impl ProverServiceStore {
             // db is updated, return successfully
             Ok(())
         } else {
-            // TODO: to do a better analysis of the error, we should try to
-            // read the row again (equal to start of this fn) and perform
-            // validation again. This makes the error more clear and callers
-            // of this fn may handle the specific error better.
-            // Err(ProofJobQueueError::Validation(
-            //     "submit_proof is failing because there is no row to update!".to_string(),
-            // ))
-            // re-read the row to anaylize the error or return `AlreadySubmitted` if the proof
+            // re-read the row to anaylize the error or return Ok(()) if the proof
             // has already been submitted (idempotency).
             let row = sqlx::query(
                 r#"
                 SELECT backend, game, root_claim, l2_block_number, l1_head, proof_status,
-                    lock_id, worker_id, lock_expires_at, job_status
+                    lock_id, worker_id, lock_expires_at, job_status, proof_data
                 FROM proof_requests
                 WHERE proof_id = $1
                 "#,

--- a/proofs/prover-service/src/store.rs
+++ b/proofs/prover-service/src/store.rs
@@ -270,11 +270,10 @@ impl ProverServiceStore {
         .bind(now)
         .bind(self.config.max_attempts as i32)
         .fetch_optional(&self.pool)
-        .await
-        .map_err(queue_db)?;
+        .await?;
 
         if let Some(row) = query {
-            let request = request_from_row(&row).map_err(ProofJobQueueError::Internal)?;
+            let request = request_from_row(&row)?;
             Ok(Some(LockedProofRequest { request, lock_id }))
         } else {
             Ok(None)
@@ -301,15 +300,13 @@ impl ProverServiceStore {
         .bind(BackendSessionStatus::Submitting.as_str())
         .bind(BackendSessionStatus::Running.as_str())
         .fetch_optional(&self.pool)
-        .await
-        .map_err(queue_db)?;
+        .await?;
 
         let session = if let Some(row) = row {
-            let backend_session_id: String = row.try_get("backend_session_id").map_err(queue_db)?;
-            let status_str: String = row.try_get("status").map_err(queue_db)?;
-            let state = BackendSessionStatus::try_from(status_str.as_str()).map_err(|e| {
-                ProofJobQueueError::Internal(format!("unknown proof_sessions.status value {e:?}"))
-            })?;
+            let backend_session_id: String = row.try_get("backend_session_id")?;
+            let status_str: String = row.try_get("status")?;
+            let state = BackendSessionStatus::try_from(status_str.as_str())
+                .map_err(|e| ProofJobQueueError::UnknownBackendSessionStatus(e))?;
 
             Some(BackendSession {
                 backend_session_id,
@@ -343,19 +340,15 @@ impl ProverServiceStore {
         )
         .bind(proof_id_bytes(proof_id))
         .fetch_optional(&mut *tx)
-        .await
-        .map_err(queue_db)?;
+        .await?;
 
         let Some(claim) = claim else {
-            return Err(ProofJobQueueError::NotFound(proof_id));
+            return Err(ProofJobQueueError::ProofIdNotFound(proof_id));
         };
 
         let stored_job_status_str: &str = claim.get("job_status");
-        let stored_job_status = ProofJobStatus::try_from(stored_job_status_str).map_err(|e| {
-            ProofJobQueueError::Internal(format!(
-                "Unknown job_status '{stored_job_status_str}': {e}"
-            ))
-        })?;
+        let stored_job_status = ProofJobStatus::try_from(stored_job_status_str)
+            .map_err(|e| ProofJobQueueError::UnknownProofJobStatus(e))?;
 
         let stored_lock_id: Option<Uuid> = claim.get("lock_id");
         let stored_worker_id: Option<String> = claim.get("worker_id");
@@ -366,23 +359,21 @@ impl ProverServiceStore {
         // - lock_id and worker_id must match
         // - lock_expires_at shoult not be expired
         if stored_job_status != ProofJobStatus::Claimed {
-            return Err(ProofJobQueueError::Internal(format!(
-                "Invalid status for proof {proof_id}: expected Queued, got {stored_job_status:?}"
-            )));
+            return Err(ProofJobQueueError::ProofJobStatusNotClaimed {
+                proof_id,
+                expected: ProofJobStatus::Claimed,
+                actual: stored_job_status,
+            });
         }
         if stored_lock_id != Some(lock_id.0) || stored_worker_id != Some(worker_id.clone()) {
-            return Err(ProofJobQueueError::Internal(format!(
-                "Not authorized for proof {proof_id}: lock_id or worker_id mismatch"
-            )));
+            return Err(ProofJobQueueError::StaleLock(proof_id));
         }
         if stored_lock_expires_at.is_none()
             || stored_lock_expires_at
                 .as_ref()
                 .is_none_or(|expires_at| *expires_at <= now)
         {
-            return Err(ProofJobQueueError::Internal(format!(
-                "Lock expired for proof {proof_id}"
-            )));
+            return Err(ProofJobQueueError::LockExpired(proof_id));
         }
 
         let existing_backend_sessions = sqlx::query(
@@ -399,16 +390,12 @@ impl ProverServiceStore {
         .bind(session_type.as_str())
         .bind(backend_session_id.clone())
         .fetch_all(&mut *tx)
-        .await
-        .map_err(queue_db)?;
+        .await?;
 
         for row in existing_backend_sessions {
             let status_str: &str = row.get("status");
-            let status = BackendSessionStatus::try_from(status_str).map_err(|err| {
-                ProofJobQueueError::Internal(format!(
-                    "invalid session status '{status_str}': {err}"
-                ))
-            })?;
+            let status = BackendSessionStatus::try_from(status_str)
+                .map_err(|err| ProofJobQueueError::UnknownBackendSessionStatus(err))?;
             if status.is_terminal() {
                 // return this proof session
                 // TODO: do it
@@ -433,8 +420,7 @@ impl ProverServiceStore {
         .bind(BackendSessionStatus::Submitting.as_str())
         .bind(BackendSessionStatus::Running.as_str())
         .fetch_optional(&mut *tx)
-        .await
-        .map_err(queue_db)?
+        .await?
         .map(|r| r.get("id"));
 
         let _row = if let Some(active_id) = active_id {
@@ -456,13 +442,12 @@ impl ProverServiceStore {
             .bind(BackendSessionStatus::Submitting.as_str())
             .bind(BackendSessionStatus::Running.as_str())
             .fetch_optional(&mut *tx)
-            .await
-            .map_err(queue_db)?
+            .await?
             .ok_or_else(|| {
-                ProofJobQueueError::Internal(
+                ProofJobQueueError::Sqlx(sqlx::Error::Protocol(
                     "active proof session status changed between SELECT FOR UPDATE and UPDATE"
-                        .to_string(),
-                )
+                        .into(),
+                ))
             })?
         } else {
             sqlx::query(
@@ -483,11 +468,10 @@ impl ProverServiceStore {
             .bind(status.as_str())
             .bind(now)
             .fetch_one(&mut *tx)
-            .await
-            .map_err(queue_db)?
+            .await?
         };
 
-        tx.commit().await.map_err(queue_db)?;
+        tx.commit().await?;
 
         Ok(())
     }
@@ -509,51 +493,43 @@ impl ProverServiceStore {
         )
         .bind(proof_id_bytes(proof.id))
         .fetch_optional(&self.pool)
-        .await
-        .map_err(queue_db)?;
+        .await?;
         let Some(existing) = row else {
-            return Err(ProofJobQueueError::NotFound(proof.id));
+            return Err(ProofJobQueueError::ProofIdNotFound(proof.id));
         };
-        let stored_proof_request =
-            request_from_row(&existing).map_err(ProofJobQueueError::Internal)?;
+        let stored_proof_request = request_from_row(&existing)?;
         let stored_lock_id: Option<Uuid> = existing.get("lock_id");
         let stored_worker_id: Option<String> = existing.get("worker_id");
         let stored_lock_expires_at: Option<chrono::DateTime<Utc>> = existing.get("lock_expires_at");
         let stored_job_status_str: String = existing.get("job_status");
         let stored_job_status = ProofJobStatus::try_from(stored_job_status_str.as_str())
-            .map_err(ProofJobQueueError::Internal)?;
+            .map_err(|err| ProofJobQueueError::UnknownProofJobStatus(err))?;
         // validation
         if stored_proof_request.backend != proof.proof.backend() {
-            return Err(ProofJobQueueError::Validation(format!(
-                "stored backend is {} but provided proof is for {}",
-                stored_proof_request.backend,
-                proof.proof.backend()
-            )));
+            return Err(ProofJobQueueError::BackendMismatch {
+                proof_id: proof.id,
+                expected: proof.proof.backend(),
+                actual: stored_proof_request.backend,
+            });
         }
         if stored_lock_id != Some(lock_id.0) || stored_worker_id != Some(worker_id.clone()) {
-            return Err(ProofJobQueueError::StaleLocked);
+            return Err(ProofJobQueueError::StaleLock(proof.id));
         }
         if stored_lock_expires_at.is_none()
             || stored_lock_expires_at
                 .as_ref()
                 .is_none_or(|expires_at| *expires_at <= now)
         {
-            return Err(ProofJobQueueError::Validation(format!(
-                "Lock expired for proof {}",
-                stored_proof_request.id()
-            )));
+            return Err(ProofJobQueueError::LockExpired(proof.id));
         }
         if matches!(
             stored_job_status,
             ProofJobStatus::Succeeded | ProofJobStatus::Failed
         ) {
-            return Err(ProofJobQueueError::Validation(
-                "The proof has alredy reached a terminal job status.".to_string(),
-            ));
+            return Err(ProofJobQueueError::AlreadyTerminal(proof.id));
         }
         // now update the table with the proof
-        let proof_data = serde_json::to_vec(&proof.proof)
-            .map_err(|err| ProofJobQueueError::Internal(err.to_string()))?;
+        let proof_data = serde_json::to_vec(&proof.proof)?;
         let row = sqlx::query(
             r#"
             UPDATE proof_requests
@@ -580,8 +556,7 @@ impl ProverServiceStore {
         .bind(lock_id.0)
         .bind(now)
         .fetch_optional(&self.pool)
-        .await
-        .map_err(queue_db)?;
+        .await?;
 
         if let Some(_row) = row {
             // db is updated, return successfully
@@ -591,9 +566,10 @@ impl ProverServiceStore {
             // read the row again (equal to start of this fn) and perform
             // validation again. This makes the error more clear and callers
             // of this fn may handle the specific error better.
-            Err(ProofJobQueueError::Validation(
-                "submit_proof is failing because there is no row to update!".to_string(),
-            ))
+            // Err(ProofJobQueueError::Validation(
+            //     "submit_proof is failing because there is no row to update!".to_string(),
+            // ))
+            todo!()
         }
     }
 
@@ -617,7 +593,7 @@ impl ProverServiceStore {
     async fn begin_queue_tx(&self) -> Result<Transaction<'_, Postgres>, ProofJobQueueError> {
         self.begin_tx(PostgresIsolationLevel::ReadCommitted)
             .await
-            .map_err(queue_db)
+            .map_err(ProofJobQueueError::Sqlx)
     }
 }
 
@@ -625,44 +601,33 @@ fn proof_id_bytes(id: ProofRequestId) -> Vec<u8> {
     id.0.as_slice().to_vec()
 }
 
-fn b256_from_bytes(field: &str, bytes: Vec<u8>) -> Result<B256, String> {
+fn b256_from_bytes(bytes: Vec<u8>) -> Result<B256, ProofJobQueueError> {
     if bytes.len() != 32 {
-        return Err(format!("{field} has {} bytes, expected 32", bytes.len()));
+        return Err(ProofJobQueueError::MalformedB256(bytes.len()));
     }
     Ok(B256::from_slice(&bytes))
 }
 
-fn address_from_bytes(field: &str, bytes: Vec<u8>) -> Result<Address, String> {
+fn address_from_bytes(bytes: Vec<u8>) -> Result<Address, ProofJobQueueError> {
     if bytes.len() != 20 {
-        return Err(format!("{field} has {} bytes, expected 20", bytes.len()));
+        return Err(ProofJobQueueError::MalformedAddress(bytes.len()));
     }
     Ok(Address::from_slice(&bytes))
 }
 
-fn request_from_row(row: &PgRow) -> Result<ProofRequest, String> {
-    let l2_block_number: i64 = row
-        .try_get("l2_block_number")
-        .map_err(|err| err.to_string())?;
+fn request_from_row(row: &PgRow) -> Result<ProofRequest, ProofJobQueueError> {
+    let l2_block_number: i64 = row.try_get("l2_block_number")?;
     if l2_block_number < 0 {
-        return Err(format!("l2_block_number is negative: {l2_block_number}"));
+        return Err(ProofJobQueueError::NegativeBlockNumber(l2_block_number));
     }
 
     Ok(ProofRequest {
-        backend: ProofBackend::try_from(
-            row.try_get::<String, _>("backend")
-                .map_err(|err| err.to_string())?
-                .as_str(),
-        )?,
-        game: address_from_bytes("game", row.try_get("game").map_err(|err| err.to_string())?)?,
-        root_claim: b256_from_bytes(
-            "root_claim",
-            row.try_get("root_claim").map_err(|err| err.to_string())?,
-        )?,
+        backend: ProofBackend::try_from(row.try_get::<String, _>("backend")?.as_str())
+            .map_err(|err| ProofJobQueueError::UnknownProofBackend(err))?,
+        game: address_from_bytes(row.try_get("game")?)?,
+        root_claim: b256_from_bytes(row.try_get("root_claim")?)?,
         l2_block_number: l2_block_number as u64,
-        l1_head: b256_from_bytes(
-            "l1_head",
-            row.try_get("l1_head").map_err(|err| err.to_string())?,
-        )?,
+        l1_head: b256_from_bytes(row.try_get("l1_head")?)?,
     })
 }
 
@@ -677,8 +642,4 @@ fn l2_to_i64(value: u64) -> Result<i64, ProofRequestError> {
 
 fn request_db(err: sqlx::Error) -> ProofRequestError {
     ProofRequestError::Internal(err.to_string())
-}
-
-fn queue_db(err: sqlx::Error) -> ProofJobQueueError {
-    ProofJobQueueError::Internal(err.to_string())
 }

--- a/proofs/prover-service/src/store.rs
+++ b/proofs/prover-service/src/store.rs
@@ -1,4 +1,5 @@
 use crate::{
+    ProofData,
     config::ProverServiceConfig,
     error::{InvalidConfigError, ProofJobQueueError, ProofRequestError, ProverServiceInitError},
     types::{
@@ -552,7 +553,7 @@ impl ProverServiceStore {
         .bind(now)
         .bind(proof_id_bytes(proof.id))
         .bind(ProofJobStatus::Claimed.as_str())
-        .bind(worker_id)
+        .bind(worker_id.clone())
         .bind(lock_id.0)
         .bind(now)
         .fetch_optional(&self.pool)
@@ -569,7 +570,67 @@ impl ProverServiceStore {
             // Err(ProofJobQueueError::Validation(
             //     "submit_proof is failing because there is no row to update!".to_string(),
             // ))
-            todo!()
+            // re-read the row to anaylize the error or return `AlreadySubmitted` if the proof
+            // has already been submitted (idempotency).
+            let row = sqlx::query(
+                r#"
+                SELECT backend, game, root_claim, l2_block_number, l1_head, proof_status,
+                    lock_id, worker_id, lock_expires_at, job_status
+                FROM proof_requests
+                WHERE proof_id = $1
+                "#,
+            )
+            .bind(proof_id_bytes(proof.id))
+            .fetch_optional(&self.pool)
+            .await?;
+            let Some(existing) = row else {
+                return Err(ProofJobQueueError::ProofIdNotFound(proof.id));
+            };
+            let stored_lock_id: Option<Uuid> = existing.get("lock_id");
+            let stored_worker_id: Option<String> = existing.get("worker_id");
+            let stored_lock_expires_at: Option<chrono::DateTime<Utc>> =
+                existing.get("lock_expires_at");
+            let stored_job_status_str: String = existing.get("job_status");
+            let stored_job_status = ProofJobStatus::try_from(stored_job_status_str.as_str())
+                .map_err(|err| ProofJobQueueError::UnknownProofJobStatus(err))?;
+            // validation
+            if stored_job_status == ProofJobStatus::Succeeded
+                && stored_worker_id == Some(worker_id.clone())
+                && stored_lock_id == Some(lock_id.0)
+            {
+                let stored_proof_data_vec: Vec<u8> = existing.get("proof_data");
+                let stored_proof_data: ProofData = serde_json::from_slice(&stored_proof_data_vec)?;
+                if stored_proof_data == proof.proof {
+                    // proof has already been submitted - no op
+                    return Ok(());
+                } else {
+                    return Err(ProofJobQueueError::ProofMismatch {
+                        proof_id: proof.id,
+                        expected: stored_proof_data,
+                        actual: proof.proof,
+                    });
+                }
+            }
+            if matches!(
+                stored_job_status,
+                ProofJobStatus::Succeeded | ProofJobStatus::Failed
+            ) {
+                return Err(ProofJobQueueError::AlreadyTerminal(proof.id));
+            }
+            if stored_job_status != ProofJobStatus::Claimed {
+                return Err(ProofJobQueueError::ProofJobStatusNotClaimed {
+                    proof_id: proof.id,
+                    expected: ProofJobStatus::Claimed,
+                    actual: stored_job_status,
+                });
+            }
+            if stored_lock_id != Some(lock_id.0) || stored_worker_id != Some(worker_id) {
+                return Err(ProofJobQueueError::StaleLock(proof.id));
+            }
+            if stored_lock_expires_at.is_none() || stored_lock_expires_at.unwrap() <= Utc::now() {
+                return Err(ProofJobQueueError::LockExpired(proof.id));
+            }
+            return Err(ProofJobQueueError::Unknown(proof.id));
         }
     }
 

--- a/proofs/prover-service/src/tests.rs
+++ b/proofs/prover-service/src/tests.rs
@@ -209,7 +209,7 @@ async fn stale_lock_is_rejected_and_reclaim_succeeds() {
         service
             .submit_proof(proof_for(&req), worker_id(), first.lock_id)
             .await,
-        Err(ProofJobQueueError::StaleLocked)
+        Err(ProofJobQueueError::StaleLock(_))
     ));
 
     // The current lock owner can submit successfully.
@@ -248,7 +248,7 @@ async fn submit_proof_with_wrong_backend_is_rejected() {
         service
             .submit_proof(mismatched, worker_id(), locked.lock_id)
             .await,
-        Err(ProofJobQueueError::Validation(_))
+        Err(ProofJobQueueError::BackendMismatch { .. })
     ));
     assert_eq!(
         service.proof_status(id).await.unwrap(),

--- a/proofs/prover-service/src/tests.rs
+++ b/proofs/prover-service/src/tests.rs
@@ -248,7 +248,7 @@ async fn submit_proof_with_wrong_backend_is_rejected() {
         service
             .submit_proof(mismatched, worker_id(), locked.lock_id)
             .await,
-        Err(ProofJobQueueError::BackendMismatch { .. })
+        Err(ProofJobQueueError::BackendMismatch(_))
     ));
     assert_eq!(
         service.proof_status(id).await.unwrap(),

--- a/proofs/sp1-worker/src/lib.rs
+++ b/proofs/sp1-worker/src/lib.rs
@@ -18,4 +18,6 @@ pub use backend::{Sp1Backend, Sp1BackendConfig};
 
 // Re-exported so binaries and tests can build a worker without depending on
 // `world-chain-proof-worker` directly.
-pub use world_chain_proof_worker::{ClaimedProofJobHandler, ProofWorker, ProofWorkerConfig};
+pub use world_chain_proof_worker::{
+    ClaimedProofJobHandler, ProofWorker, ProofWorkerConfig, RetryConfig,
+};

--- a/proofs/sp1-worker/src/main.rs
+++ b/proofs/sp1-worker/src/main.rs
@@ -14,7 +14,7 @@ use world_chain_sp1_worker::{
     ProofWorker, ProofWorkerConfig, RetryConfig, Sp1Backend, Sp1BackendConfig,
 };
 
-const DEFAULT_SUBMIT_PROOF_RETRY_MAX_RETRIES: u32 = 5;
+const DEFAULT_SUBMIT_PROOF_RETRY_MAX_RETRIES: u32 = 10;
 const DEFAULT_SUBMIT_PROOF_RETRY_INITIAL_DELAY_MS: u64 = 100;
 const DEFAULT_SUBMIT_PROOF_RETRY_MAX_DELAY_MS: u64 = 10_000;
 

--- a/proofs/sp1-worker/src/main.rs
+++ b/proofs/sp1-worker/src/main.rs
@@ -14,7 +14,7 @@ use world_chain_sp1_worker::{
     ProofWorker, ProofWorkerConfig, RetryConfig, Sp1Backend, Sp1BackendConfig,
 };
 
-const DEFAULT_SUBMIT_PROOF_RETRY_MAX_RETRIES: u32 = 10;
+const DEFAULT_SUBMIT_PROOF_RETRY_MAX_RETRIES: usize = 10;
 const DEFAULT_SUBMIT_PROOF_RETRY_INITIAL_DELAY_MS: u64 = 100;
 const DEFAULT_SUBMIT_PROOF_RETRY_MAX_DELAY_MS: u64 = 10_000;
 
@@ -120,11 +120,7 @@ struct Cli {
         env = "SUBMIT_PROOF_RETRY_MAX_RETRIES",
         default_value_t = DEFAULT_SUBMIT_PROOF_RETRY_MAX_RETRIES
     )]
-    submit_proof_retry_max_retries: u32,
-
-    /// Retry submitProof without an attempt limit while errors remain retryable.
-    #[arg(long, env = "SUBMIT_PROOF_RETRY_UNBOUNDED", default_value_t = false)]
-    submit_proof_retry_unbounded: bool,
+    submit_proof_retry_max_retries: usize,
 
     /// Initial delay in milliseconds before retrying submitProof.
     #[arg(
@@ -189,15 +185,11 @@ fn main() -> Result<()> {
     let worker_id = format!("{}-sp1-worker", cli.worker_id);
     let retry_initial_delay = Duration::from_millis(cli.submit_proof_retry_initial_delay_ms);
     let retry_max_delay = Duration::from_millis(cli.submit_proof_retry_max_delay_ms);
-    let retry_config = if cli.submit_proof_retry_unbounded {
-        RetryConfig::unbounded(retry_initial_delay, retry_max_delay)
-    } else {
-        RetryConfig::new(
-            cli.submit_proof_retry_max_retries,
-            retry_initial_delay,
-            retry_max_delay,
-        )
-    };
+    let retry_config = RetryConfig::new(
+        cli.submit_proof_retry_max_retries,
+        retry_initial_delay,
+        retry_max_delay,
+    );
     let worker = ProofWorker::new(
         queue,
         backend,
@@ -215,7 +207,6 @@ fn main() -> Result<()> {
         ranges = cli.ranges.max(1),
         prover = ?cli.prover,
         submit_proof_retry_max_retries = cli.submit_proof_retry_max_retries,
-        submit_proof_retry_unbounded = cli.submit_proof_retry_unbounded,
         submit_proof_retry_initial_delay_ms = cli.submit_proof_retry_initial_delay_ms,
         submit_proof_retry_max_delay_ms = cli.submit_proof_retry_max_delay_ms,
         "sp1-worker starting"

--- a/proofs/sp1-worker/src/main.rs
+++ b/proofs/sp1-worker/src/main.rs
@@ -10,7 +10,13 @@ use world_chain_proof_kona_host_utils::online::build_online_config;
 use world_chain_proof_protocol::WorldHardforkConfig as ProtocolHardforkConfig;
 use world_chain_proof_succinct_host_utils::prover::{SP1ProofMode, Sp1ProverKind, SuccinctProver};
 use world_chain_prover_service::RpcProverServiceClient;
-use world_chain_sp1_worker::{ProofWorker, ProofWorkerConfig, Sp1Backend, Sp1BackendConfig};
+use world_chain_sp1_worker::{
+    ProofWorker, ProofWorkerConfig, RetryConfig, Sp1Backend, Sp1BackendConfig,
+};
+
+const DEFAULT_SUBMIT_PROOF_RETRY_MAX_RETRIES: u32 = 5;
+const DEFAULT_SUBMIT_PROOF_RETRY_INITIAL_DELAY_MS: u64 = 100;
+const DEFAULT_SUBMIT_PROOF_RETRY_MAX_DELAY_MS: u64 = 10_000;
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
 enum Network {
@@ -108,6 +114,34 @@ struct Cli {
     #[arg(long, default_value_t = 1)]
     max_concurrent_jobs: usize,
 
+    /// Maximum retries after a retryable submitProof failure.
+    #[arg(
+        long,
+        env = "SUBMIT_PROOF_RETRY_MAX_RETRIES",
+        default_value_t = DEFAULT_SUBMIT_PROOF_RETRY_MAX_RETRIES
+    )]
+    submit_proof_retry_max_retries: u32,
+
+    /// Retry submitProof without an attempt limit while errors remain retryable.
+    #[arg(long, env = "SUBMIT_PROOF_RETRY_UNBOUNDED", default_value_t = false)]
+    submit_proof_retry_unbounded: bool,
+
+    /// Initial delay in milliseconds before retrying submitProof.
+    #[arg(
+        long,
+        env = "SUBMIT_PROOF_RETRY_INITIAL_DELAY_MS",
+        default_value_t = DEFAULT_SUBMIT_PROOF_RETRY_INITIAL_DELAY_MS
+    )]
+    submit_proof_retry_initial_delay_ms: u64,
+
+    /// Maximum delay in milliseconds between submitProof retries.
+    #[arg(
+        long,
+        env = "SUBMIT_PROOF_RETRY_MAX_DELAY_MS",
+        default_value_t = DEFAULT_SUBMIT_PROOF_RETRY_MAX_DELAY_MS
+    )]
+    submit_proof_retry_max_delay_ms: u64,
+
     /// The unique worker id.
     #[arg(long)]
     worker_id: String,
@@ -153,6 +187,17 @@ fn main() -> Result<()> {
     let queue = RpcProverServiceClient::new(&cli.prover_service_url)
         .with_context(|| format!("failed to connect to {}", cli.prover_service_url))?;
     let worker_id = format!("{}-sp1-worker", cli.worker_id);
+    let retry_initial_delay = Duration::from_millis(cli.submit_proof_retry_initial_delay_ms);
+    let retry_max_delay = Duration::from_millis(cli.submit_proof_retry_max_delay_ms);
+    let retry_config = if cli.submit_proof_retry_unbounded {
+        RetryConfig::unbounded(retry_initial_delay, retry_max_delay)
+    } else {
+        RetryConfig::new(
+            cli.submit_proof_retry_max_retries,
+            retry_initial_delay,
+            retry_max_delay,
+        )
+    };
     let worker = ProofWorker::new(
         queue,
         backend,
@@ -160,6 +205,7 @@ fn main() -> Result<()> {
             worker_id,
             poll_interval: Duration::from_secs(cli.poll_interval_seconds),
             max_concurrent_jobs: cli.max_concurrent_jobs,
+            retry_config,
         },
     );
 
@@ -168,6 +214,10 @@ fn main() -> Result<()> {
         block_interval = cli.block_interval,
         ranges = cli.ranges.max(1),
         prover = ?cli.prover,
+        submit_proof_retry_max_retries = cli.submit_proof_retry_max_retries,
+        submit_proof_retry_unbounded = cli.submit_proof_retry_unbounded,
+        submit_proof_retry_initial_delay_ms = cli.submit_proof_retry_initial_delay_ms,
+        submit_proof_retry_max_delay_ms = cli.submit_proof_retry_max_delay_ms,
         "sp1-worker starting"
     );
 

--- a/proofs/sp1-worker/tests/e2e_proving.rs
+++ b/proofs/sp1-worker/tests/e2e_proving.rs
@@ -39,7 +39,9 @@ use world_chain_prover_service::{
     ProofBackend, ProofData, ProofRequest, ProofRequester, ProofStatus, ProverService,
     ProverServiceConfig, RpcProverServiceClient, start_rpc_server,
 };
-use world_chain_sp1_worker::{ProofWorker, ProofWorkerConfig, Sp1Backend, Sp1BackendConfig};
+use world_chain_sp1_worker::{
+    ProofWorker, ProofWorkerConfig, RetryConfig, Sp1Backend, Sp1BackendConfig,
+};
 
 /// Reads a required env var, or returns `None` (with a skip message) when absent.
 fn required(name: &str) -> Option<String> {
@@ -190,6 +192,7 @@ async fn worker_proves_real_range_end_to_end() {
             worker_id: "test-worker".to_string(),
             poll_interval: Duration::from_millis(500),
             max_concurrent_jobs: 1,
+            retry_config: RetryConfig::default(),
         },
     );
     let token = worker.cancellation_token();

--- a/proofs/sp1-worker/tests/rpc_roundtrip.rs
+++ b/proofs/sp1-worker/tests/rpc_roundtrip.rs
@@ -10,7 +10,7 @@ use world_chain_prover_service::{
     ProofBackend, ProofData, ProofRequest, ProofRequester, ProofStatus, ProverService,
     ProverServiceConfig, RpcProverServiceClient, start_rpc_server,
 };
-use world_chain_sp1_worker::{ClaimedProofJobHandler, ProofWorker, ProofWorkerConfig};
+use world_chain_sp1_worker::{ClaimedProofJobHandler, ProofWorker, ProofWorkerConfig, RetryConfig};
 
 /// Backend returning a canned SP1 proof for any request, without RPC or a prover.
 struct MockBackend;
@@ -86,6 +86,7 @@ async fn worker_completes_requested_proof_over_rpc() {
             worker_id: "test-worker".to_string(),
             poll_interval: Duration::from_millis(10),
             max_concurrent_jobs: 1,
+            retry_config: RetryConfig::default(),
         },
     );
     let worker_handle = tokio::spawn(worker);

--- a/proofs/worker/Cargo.toml
+++ b/proofs/worker/Cargo.toml
@@ -20,6 +20,7 @@ async-trait.workspace = true
 tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }
 tokio-util.workspace = true
 tracing.workspace = true
+backon.workspace = true
 
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = ["serde"] }

--- a/proofs/worker/src/lib.rs
+++ b/proofs/worker/src/lib.rs
@@ -16,6 +16,7 @@
 //! rather than re-run completed phases.
 
 mod backend;
+mod retry;
 mod worker;
 
 pub use backend::{ClaimedProofJobHandler, JobSessions, ProofJob};

--- a/proofs/worker/src/lib.rs
+++ b/proofs/worker/src/lib.rs
@@ -20,6 +20,10 @@ mod retry;
 mod worker;
 
 pub use backend::{ClaimedProofJobHandler, JobSessions, ProofJob};
+pub use retry::{
+    DEFAULT_BOUNDED_INITIAL_DELAY, DEFAULT_BOUNDED_MAX_ATTEMPTS, DEFAULT_BOUNDED_MAX_DELAY,
+    MIN_RETRY_DELAY, RetryConfig,
+};
 pub use worker::{
     DEFAULT_MAX_CONCURRENT_JOBS, DEFAULT_POLL_INTERVAL, ProofWorker, ProofWorkerConfig,
 };

--- a/proofs/worker/src/retry.rs
+++ b/proofs/worker/src/retry.rs
@@ -1,0 +1,80 @@
+use std::time::Duration;
+
+use backon::ExponentialBuilder;
+
+/// Minimum retry delay used to avoid tight retry loops.
+pub const MIN_RETRY_DELAY: Duration = Duration::from_millis(1);
+/// Default maximum bounded retry attempts.
+pub const DEFAULT_BOUNDED_MAX_ATTEMPTS: u32 = 5;
+/// Default initial bounded retry delay.
+pub const DEFAULT_BOUNDED_INITIAL_DELAY: Duration = Duration::from_millis(100);
+/// Default maximum bounded retry delay.
+pub const DEFAULT_BOUNDED_MAX_DELAY: Duration = Duration::from_secs(10);
+
+#[derive(Debug, Clone, Copy)]
+pub struct RetryConfig {
+    /// Maximum number of retries performed after the initial call.
+    ///
+    /// `None` retries without an attempt limit.
+    pub max_attempts: Option<u32>,
+    /// First delay after a retryable failure.
+    pub initial_delay: Duration,
+    /// Maximum delay between retry attempts.
+    pub max_delay: Duration,
+}
+
+impl RetryConfig {
+    /// Creates a bounded retry config.
+    pub const fn new(max_attempts: u32, initial_delay: Duration, max_delay: Duration) -> Self {
+        Self {
+            max_attempts: Some(max_attempts),
+            initial_delay,
+            max_delay,
+        }
+    }
+
+    /// Creates an unbounded retry config.
+    pub const fn unbounded(initial_delay: Duration, max_delay: Duration) -> Self {
+        Self {
+            max_attempts: None,
+            initial_delay,
+            max_delay,
+        }
+    }
+
+    /// Returns the configured max delay, clamped to the minimum allowed delay.
+    pub fn normalized_max_delay(&self) -> Duration {
+        self.max_delay.max(MIN_RETRY_DELAY)
+    }
+
+    /// Returns the configured initial delay, clamped to the configured max delay.
+    pub fn normalized_initial_delay(&self) -> Duration {
+        self.initial_delay
+            .max(MIN_RETRY_DELAY)
+            .min(self.normalized_max_delay())
+    }
+
+    /// Creates a `backon` [`ExponentialBuilder`] from this configuration.
+    pub fn to_backoff_builder(&self) -> ExponentialBuilder {
+        let builder = ExponentialBuilder::default()
+            .with_min_delay(self.normalized_initial_delay())
+            .with_max_delay(self.normalized_max_delay())
+            .with_jitter();
+
+        let Some(max_attempts) = self.max_attempts else {
+            return builder.without_max_times();
+        };
+
+        builder.with_max_times(max_attempts as usize)
+    }
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self::new(
+            DEFAULT_BOUNDED_MAX_ATTEMPTS,
+            DEFAULT_BOUNDED_INITIAL_DELAY,
+            DEFAULT_BOUNDED_MAX_DELAY,
+        )
+    }
+}

--- a/proofs/worker/src/retry.rs
+++ b/proofs/worker/src/retry.rs
@@ -5,7 +5,7 @@ use backon::ExponentialBuilder;
 /// Minimum retry delay used to avoid tight retry loops.
 pub const MIN_RETRY_DELAY: Duration = Duration::from_millis(1);
 /// Default maximum bounded retry attempts.
-pub const DEFAULT_BOUNDED_MAX_ATTEMPTS: u32 = 5;
+pub const DEFAULT_BOUNDED_MAX_ATTEMPTS: u32 = 10;
 /// Default initial bounded retry delay.
 pub const DEFAULT_BOUNDED_INITIAL_DELAY: Duration = Duration::from_millis(100);
 /// Default maximum bounded retry delay.

--- a/proofs/worker/src/retry.rs
+++ b/proofs/worker/src/retry.rs
@@ -5,7 +5,7 @@ use backon::ExponentialBuilder;
 /// Minimum retry delay used to avoid tight retry loops.
 pub const MIN_RETRY_DELAY: Duration = Duration::from_millis(1);
 /// Default maximum bounded retry attempts.
-pub const DEFAULT_BOUNDED_MAX_ATTEMPTS: u32 = 10;
+pub const DEFAULT_BOUNDED_MAX_ATTEMPTS: usize = 10;
 /// Default initial bounded retry delay.
 pub const DEFAULT_BOUNDED_INITIAL_DELAY: Duration = Duration::from_millis(100);
 /// Default maximum bounded retry delay.
@@ -14,9 +14,7 @@ pub const DEFAULT_BOUNDED_MAX_DELAY: Duration = Duration::from_secs(10);
 #[derive(Debug, Clone, Copy)]
 pub struct RetryConfig {
     /// Maximum number of retries performed after the initial call.
-    ///
-    /// `None` retries without an attempt limit.
-    pub max_attempts: Option<u32>,
+    pub max_attempts: usize,
     /// First delay after a retryable failure.
     pub initial_delay: Duration,
     /// Maximum delay between retry attempts.
@@ -25,18 +23,9 @@ pub struct RetryConfig {
 
 impl RetryConfig {
     /// Creates a bounded retry config.
-    pub const fn new(max_attempts: u32, initial_delay: Duration, max_delay: Duration) -> Self {
+    pub const fn new(max_attempts: usize, initial_delay: Duration, max_delay: Duration) -> Self {
         Self {
-            max_attempts: Some(max_attempts),
-            initial_delay,
-            max_delay,
-        }
-    }
-
-    /// Creates an unbounded retry config.
-    pub const fn unbounded(initial_delay: Duration, max_delay: Duration) -> Self {
-        Self {
-            max_attempts: None,
+            max_attempts,
             initial_delay,
             max_delay,
         }
@@ -56,16 +45,11 @@ impl RetryConfig {
 
     /// Creates a `backon` [`ExponentialBuilder`] from this configuration.
     pub fn to_backoff_builder(&self) -> ExponentialBuilder {
-        let builder = ExponentialBuilder::default()
+        ExponentialBuilder::default()
             .with_min_delay(self.normalized_initial_delay())
             .with_max_delay(self.normalized_max_delay())
-            .with_jitter();
-
-        let Some(max_attempts) = self.max_attempts else {
-            return builder.without_max_times();
-        };
-
-        builder.with_max_times(max_attempts as usize)
+            .with_max_times(self.max_attempts)
+            .with_jitter()
     }
 }
 

--- a/proofs/worker/src/worker.rs
+++ b/proofs/worker/src/worker.rs
@@ -1,5 +1,6 @@
 //! Service polling the `prover-service` for claimed proof jobs and submitting results.
 
+use backon::Retryable;
 use std::{
     future::Future,
     pin::Pin,
@@ -7,7 +8,6 @@ use std::{
     task::{Context, Poll},
     time::Duration,
 };
-
 use tokio::{
     sync::{OwnedSemaphorePermit, Semaphore},
     task::JoinSet,
@@ -16,7 +16,10 @@ use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, info, info_span, warn};
 use world_chain_prover_service::{LockedProofRequest, ProofJobQueue, ProofResponse};
 
-use crate::backend::{ClaimedProofJobHandler, JobSessions, ProofJob};
+use crate::{
+    backend::{ClaimedProofJobHandler, JobSessions, ProofJob},
+    retry::RetryConfig,
+};
 
 /// Default number of jobs proving concurrently. One is right for a local CPU prover, which a
 /// single job already saturates; raise it for backends that parallelize externally (the
@@ -36,17 +39,25 @@ pub struct ProofWorkerConfig {
     /// Maximum number of jobs this worker proves concurrently. Per-worker, not global, so an
     /// SP1 worker and a TEE worker in the same process throttle independently.
     pub max_concurrent_jobs: usize,
+    /// Configurations for retry.
+    pub retry_config: RetryConfig,
 }
 
 impl ProofWorkerConfig {
     /// Create a new `ProofWorkerConfig` with the provided `worker_id`,
-    /// `poll_interval` and `max_concurrent_jobs`.
+    /// `poll_interval`, `max_concurrent_jobs` and `retry_config`.
     #[must_use]
-    pub fn new(worker_id: String, poll_interval: Duration, max_concurrent_jobs: usize) -> Self {
+    pub fn new(
+        worker_id: String,
+        poll_interval: Duration,
+        max_concurrent_jobs: usize,
+        retry_config: RetryConfig,
+    ) -> Self {
         Self {
             worker_id,
             poll_interval,
             max_concurrent_jobs,
+            retry_config,
         }
     }
 }
@@ -167,6 +178,7 @@ async fn run_worker<Q, B>(
                     &config.worker_id,
                     locked,
                     permit,
+                    config.retry_config,
                 );
             }
             Ok(None) => {
@@ -206,6 +218,7 @@ fn spawn_job<Q, B>(
     worker_id: &str,
     locked: LockedProofRequest,
     permit: OwnedSemaphorePermit,
+    retry_config: RetryConfig,
 ) where
     Q: ProofJobQueue + Send + Sync + 'static,
     B: ClaimedProofJobHandler,
@@ -244,15 +257,29 @@ fn spawn_job<Q, B>(
                         id: proof_id,
                         proof,
                     };
-                    match queue.submit_proof(response, worker_id, lock_id).await {
+                    let submit_result = (|| async {
+                        queue
+                            .submit_proof(response.clone(), worker_id.clone(), lock_id)
+                            .await
+                    })
+                    .retry(retry_config.to_backoff_builder())
+                    .when(|err| err.is_retryable())
+                    .notify(|error, delay| {
+                        warn!(%error, ?delay, "failed to submit proof, retrying");
+                    })
+                    .await;
+                    match submit_result {
                         Ok(()) => info!("proof submitted"),
-                        Err(error) => warn!(%error, "failed to submit proof"),
+                        Err(error) => warn!(
+                            %error,
+                            "failed to submit proof after retries, lease will expire and re-queue"
+                        ),
                     }
                 }
                 // `{:#}` renders the full anyhow context chain into the failure reason.
                 Err(error) => warn!(
                     reason = %format!("{error:#}"),
-                    "proving failed; lease will expire and re-queue"
+                    "proving failed, lease will expire and re-queue"
                 ),
             }
         }


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4860/add-retry-functionality-to-the-submit-proof-method-that-the-proof

### Problem

Currently proof worker calls `submit_proof` to submit the computed proof back to the `prover-service`. If this fails, then we print a warning and drop it. The request is gonna be claimed by a new prover once it becomes stale, but we're losing precious computation time. In fact, we may do the proof generation again just due to a rpc disconnection or timeout or a temporary postgres failure.

### Solution

Add a retry feature to the proof worker for retryable errors.

### Notes

To achieve this, I had to refactor the error variants. Now they better represent what they truly are and the retry feature can be built on top of them.

### Next Steps

- I'm going to do a similar refactor for `ProofRequestError` as well

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches proof job submission, locking, and RPC error mapping in the prover-service; misclassified retryable vs terminal errors could delay or duplicate handling, though idempotent replay mitigates duplicate submits.
> 
> **Overview**
> Proof workers now **retry `submitProof`** to the prover-service when errors look transient (RPC timeouts/disconnects, transport issues, SQL/storage blips), using exponential backoff via `backon` and a new **`RetryConfig`** on `ProofWorkerConfig` (defaults: 10 attempts, 100ms–10s delays). SP1 and Nitro worker binaries expose matching CLI/env knobs; devnet and integration tests wire `RetryConfig::default()`.
> 
> **Prover-service** job-queue errors were reshaped: granular variants (`StaleLock`, `LockExpired`, `BackendMismatch`, `ProofMismatch`, etc.) with structured RPC error data and codes; **`ProofJobQueueError::is_retryable()`** drives worker retries. **`submit_proof`** in the store re-reads the row on failed updates for clearer errors and **idempotent success** when the same proof was already stored.
> 
> The RPC client maps JSON-RPC failures into these typed errors instead of generic internal/RPC strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89da98dcd74be04ec463247be1af35e2b376af0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->