### PR TITLE
chore: refactor proof request errors

### DIFF
--- a/proofs/defender/src/defender.rs
+++ b/proofs/defender/src/defender.rs
@@ -13,7 +13,7 @@ use std::{
 use tracing::{error, info, warn};
 use world_chain_proofs::{ConsensusProvider, GameCreated, ProofLane, RootState};
 use world_chain_prover_service::{
-    ProofBackend, ProofData, ProofRequest, ProofRequester, ProofStatus,
+    ProofBackend, ProofData, ProofRequest, ProofRequester, ProofResponse, ProofStatus,
 };
 
 /// The number of L1 blocks published in 24h.
@@ -208,7 +208,27 @@ where
                     ProofStatus::Created | ProofStatus::Running => state,
                     ProofStatus::Succeeded => {
                         let response = match self.proof_requester.get_proof(id).await {
-                            Ok(response) => response,
+                            Ok(ProofResponse::Succeeded(response)) => response,
+                            Ok(ProofResponse::Pending(response)) => {
+                                warn!(
+                                    %game,
+                                    ?lane,
+                                    %id,
+                                    status = %response.status,
+                                    "proof status was succeeded but proof response is pending; retrying next tick"
+                                );
+                                return state;
+                            }
+                            Ok(ProofResponse::Failed(response)) => {
+                                warn!(
+                                    %game,
+                                    ?lane,
+                                    %id,
+                                    reason = %response.reason,
+                                    "proof status was succeeded but proof response is failed; retrying next tick"
+                                );
+                                return state;
+                            }
                             Err(error) => {
                                 warn!(%game, ?lane, %id, %error, "proof retrieval failed; retrying next tick");
                                 return state;

--- a/proofs/defender/src/tests.rs
+++ b/proofs/defender/src/tests.rs
@@ -15,7 +15,7 @@ use std::{
 use world_chain_proofs::{ConsensusError, ConsensusProvider, GameCreated, ProofLane, RootState};
 use world_chain_prover_service::{
     ProofBackend, ProofData, ProofRequest, ProofRequestError, ProofRequestId, ProofRequester,
-    ProofResponse, ProofStatus,
+    ProofResponse, ProofStatus, SucceededProofResponse,
 };
 
 const GAME_1: Address = address!("0000000000000000000000000000000000000001");
@@ -221,7 +221,7 @@ impl ProofRequester for MockProver {
             .expect("not poisoned")
             .get(&proof_id)
             .cloned()
-            .ok_or(ProofRequestError::NotFound(proof_id))?;
+            .ok_or(ProofRequestError::ProofIdNotFound(proof_id))?;
         let proof = match request.backend {
             ProofBackend::Sp1 => ProofData::Sp1 {
                 proof: Bytes::from_static(b"proof"),
@@ -232,10 +232,10 @@ impl ProofRequester for MockProver {
                 signature: Bytes::from_static(b"signature"),
             },
         };
-        Ok(ProofResponse {
+        Ok(ProofResponse::Succeeded(SucceededProofResponse {
             id: proof_id,
             proof,
-        })
+        }))
     }
 }
 

--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -25,6 +25,7 @@ use world_chain_prover_service::{
     BackendSession, BackendSessionStatus, LockId, LockedProofRequest, ProofBackend, ProofData,
     ProofJobQueue, ProofJobQueueError, ProofRequest, ProofRequestError, ProofRequestId,
     ProofRequester, ProofResponse, ProofStatus, ProverService, ProverServiceConfig, SessionType,
+    SucceededProofResponse,
 };
 
 pub const BLOCK_INTERVAL: u64 = 10;
@@ -598,7 +599,7 @@ impl ProofJobQueue for SharedProverService {
 
     async fn submit_proof(
         &self,
-        proof: ProofResponse,
+        proof: SucceededProofResponse,
         worker_id: String,
         lock: LockId,
     ) -> Result<(), ProofJobQueueError> {

--- a/proofs/prover-service/src/error.rs
+++ b/proofs/prover-service/src/error.rs
@@ -33,19 +33,47 @@ pub enum ProofRequestError {
     RowMissingAfterConflict(ProofRequestId),
     #[error("{0}")]
     UnknownProofStatus(String),
-    #[error(
-        "This proof request {proof_id} has been retried more than max_retries = {max_retries}."
-    )]
-    TooManyRetries {
-        proof_id: ProofRequestId,
-        max_retries: u32,
-    },
+    #[error("{0}")]
+    TooManyRetries(TooManyRetriesErrorData),
     #[error("Proof request {0} not found.")]
     ProofIdNotFound(ProofRequestId),
     #[error(transparent)]
     ProofEncoding(#[from] serde_json::Error),
     #[error("The block number {0} exceeds i64 max value.")]
     BlockNumberExceedsI64(BlockNumber),
+    #[error("remote prover-service internal error.")]
+    RemoteInternal,
+    #[error("remote prover-service storage error.")]
+    RemoteSqlx,
+    #[error("RPC request timed out.")]
+    RpcRequestTimeout,
+    #[error("RPC transport error: {0}.")]
+    RpcTransport(#[from] jsonrpsee::core::BoxError),
+    #[error("RPC client restart needed: {0}.")]
+    RpcRestartNeeded(#[source] Arc<JsonRpseeError>),
+    #[error("RPC service disconnected.")]
+    RpcServiceDisconnected,
+    #[error("RPC client error: {0}.")]
+    RpcClient(#[source] JsonRpseeError),
+}
+
+/// Data describing a proof request that exceeded retry limits.
+#[derive(Debug, Clone, Copy, serde::Deserialize, serde::Serialize)]
+pub struct TooManyRetriesErrorData {
+    /// The proof request id.
+    pub proof_id: ProofRequestId,
+    /// The maximum number of retries configured by the prover-service.
+    pub max_retries: u32,
+}
+
+impl std::fmt::Display for TooManyRetriesErrorData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "This proof request {} has been retried more than max_retries = {}.",
+            self.proof_id, self.max_retries
+        )
+    }
 }
 
 /// Data describing a proof job status mismatch.

--- a/proofs/prover-service/src/error.rs
+++ b/proofs/prover-service/src/error.rs
@@ -1,7 +1,5 @@
-use crate::{
-    ProofBackend, ProofData, ProofJobStatus,
-    types::{ProofRequestId, ProofStatus},
-};
+use crate::{ProofBackend, ProofData, ProofJobStatus, ProofStatus, types::ProofRequestId};
+use alloy_primitives::BlockNumber;
 use jsonrpsee::core::client::Error as JsonRpseeError;
 use sqlx::migrate::MigrateError;
 use std::sync::Arc;
@@ -29,39 +27,25 @@ pub enum ProverServiceInitError {
 /// Error returned to a defender by the `prover-service`.
 #[derive(Error, Debug)]
 pub enum ProofRequestError {
-    /// No proof request with the given id is known.
-    #[error("proof request {0} not found")]
-    NotFound(ProofRequestId),
-    /// Conflicting row disappeared after insert conflict. Safe to retry.
-    #[error("proof_id {id}: proof request row missing after insert conflict; retry request_proof")]
-    RowMissingAfterConflict {
-        /// Proof request id that was expected to exist.
-        id: ProofRequestId,
+    #[error(transparent)]
+    Sqlx(#[from] sqlx::Error),
+    #[error("proof id {0}: proof request row missing after insert conflict. Retry request_proof.")]
+    RowMissingAfterConflict(ProofRequestId),
+    #[error("{0}")]
+    UnknownProofStatus(String),
+    #[error(
+        "This proof request {proof_id} has been retried more than max_retries = {max_retries}."
+    )]
+    TooManyRetries {
+        proof_id: ProofRequestId,
+        max_retries: u32,
     },
-    #[error("The proof request {0} has been retried too many times")]
-    TooManyRetries(ProofRequestId),
-    /// The proof is not ready yet.
-    #[error("proof request {id} is not ready yet (status: {status})")]
-    Pending {
-        /// The proof request id.
-        id: ProofRequestId,
-        /// The current status of the request.
-        status: ProofStatus,
-    },
-    /// The proof request permanently failed.
-    #[error("proof request {id} failed: {reason}")]
-    Failed {
-        /// The proof request id.
-        id: ProofRequestId,
-        /// The reason reported on the last attempt.
-        reason: String,
-    },
-    /// Internal service or storage error.
-    #[error("prover-service error: {0}")]
-    Internal(String),
-    /// RPC transport error.
-    #[error("RPC error: {0}")]
-    Rpc(String),
+    #[error("Proof request {0} not found.")]
+    ProofIdNotFound(ProofRequestId),
+    #[error(transparent)]
+    ProofEncoding(#[from] serde_json::Error),
+    #[error("The block number {0} exceeds i64 max value.")]
+    BlockNumberExceedsI64(BlockNumber),
 }
 
 /// Data describing a proof job status mismatch.

--- a/proofs/prover-service/src/error.rs
+++ b/proofs/prover-service/src/error.rs
@@ -1,4 +1,4 @@
-use crate::{ProofBackend, ProofData, ProofJobStatus, ProofStatus, types::ProofRequestId};
+use crate::{ProofBackend, ProofData, ProofJobStatus, types::ProofRequestId};
 use alloy_primitives::BlockNumber;
 use jsonrpsee::core::client::Error as JsonRpseeError;
 use sqlx::migrate::MigrateError;

--- a/proofs/prover-service/src/lib.rs
+++ b/proofs/prover-service/src/lib.rs
@@ -82,7 +82,7 @@ pub use config::{
 };
 pub use error::{
     BackendMismatchErrorData, InvalidConfigError, ProofJobQueueError, ProofJobStatusErrorData,
-    ProofMismatchErrorData, ProofRequestError, ProverServiceInitError,
+    ProofMismatchErrorData, ProofRequestError, ProverServiceInitError, TooManyRetriesErrorData,
 };
 pub use rpc::{
     ProverServiceApiClient, ProverServiceApiServer, ProverServiceRpc, RpcProverServiceClient,
@@ -91,9 +91,9 @@ pub use rpc::{
 pub use service::ProverService;
 pub use traits::{ProofJobQueue, ProofRequester};
 pub use types::{
-    BackendProofId, BackendSession, BackendSessionStatus, LockId, LockedProofRequest, ProofBackend,
-    ProofData, ProofJobStatus, ProofRequest, ProofRequestId, ProofResponse, ProofStatus,
-    SessionType,
+    BackendProofId, BackendSession, BackendSessionStatus, FailedProofResponse, LockId,
+    LockedProofRequest, PendingProofResponse, ProofBackend, ProofData, ProofJobStatus,
+    ProofRequest, ProofRequestId, ProofResponse, ProofStatus, SessionType, SucceededProofResponse,
 };
 
 #[cfg(test)]

--- a/proofs/prover-service/src/rpc.rs
+++ b/proofs/prover-service/src/rpc.rs
@@ -8,6 +8,7 @@ use crate::{
     types::{
         BackendSession, BackendSessionStatus, LockId, LockedProofRequest, ProofBackend,
         ProofRequest, ProofRequestId, ProofResponse, ProofStatus, SessionType,
+        SucceededProofResponse,
     },
 };
 use jsonrpsee::{
@@ -78,7 +79,7 @@ pub trait ProverServiceApi {
     #[method(name = "submitProof")]
     async fn submit_proof(
         &self,
-        proof: ProofResponse,
+        proof: SucceededProofResponse,
         worker_id: String,
         lock: LockId,
     ) -> RpcResult<()>;
@@ -221,7 +222,7 @@ impl ProverServiceApiServer for ProverServiceRpc {
 
     async fn submit_proof(
         &self,
-        proof: ProofResponse,
+        proof: SucceededProofResponse,
         worker_id: String,
         lock: LockId,
     ) -> RpcResult<()> {
@@ -423,7 +424,7 @@ impl ProofJobQueue for RpcProverServiceClient {
 
     async fn submit_proof(
         &self,
-        proof: ProofResponse,
+        proof: SucceededProofResponse,
         worker_id: String,
         lock: LockId,
     ) -> Result<(), ProofJobQueueError> {

--- a/proofs/prover-service/src/rpc.rs
+++ b/proofs/prover-service/src/rpc.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::{
         BackendMismatchErrorData, ProofJobQueueError, ProofJobStatusErrorData,
-        ProofMismatchErrorData, ProofRequestError,
+        ProofMismatchErrorData, ProofRequestError, TooManyRetriesErrorData,
     },
     service::ProverService,
     traits::{ProofJobQueue, ProofRequester},
@@ -25,10 +25,6 @@ use tracing::info;
 pub mod error_code {
     /// No proof request with the given id is known.
     pub const NOT_FOUND: i32 = -32002;
-    /// The proof is not ready yet; the error data holds the [`crate::ProofStatus`].
-    pub const PENDING: i32 = -32003;
-    /// The proof request permanently failed; the error data holds the reason.
-    pub const FAILED: i32 = -32004;
     /// The proof request has been retried more than the configured maximum.
     pub const TOO_MANY_RETRIES: i32 = -32005;
     /// A conflicting row vanished after an insert conflict; the request is safe to retry.
@@ -109,25 +105,26 @@ impl From<ProofRequestError> for ErrorObjectOwned {
     fn from(err: ProofRequestError) -> Self {
         let message = err.to_string();
         match err {
-            ProofRequestError::NotFound(_) => {
-                ErrorObject::owned(error_code::NOT_FOUND, message, None::<()>)
+            ProofRequestError::ProofIdNotFound(proof_id) => {
+                ErrorObject::owned(error_code::NOT_FOUND, message, Some(proof_id))
             }
-            ProofRequestError::RowMissingAfterConflict { .. } => {
-                ErrorObject::owned(error_code::RETRYABLE_CONFLICT, message, None::<()>)
+            ProofRequestError::RowMissingAfterConflict(proof_id) => {
+                ErrorObject::owned(error_code::RETRYABLE_CONFLICT, message, Some(proof_id))
             }
-            ProofRequestError::TooManyRetries(_) => {
-                ErrorObject::owned(error_code::TOO_MANY_RETRIES, message, None::<()>)
+            ProofRequestError::TooManyRetries(data) => {
+                ErrorObject::owned(error_code::TOO_MANY_RETRIES, message, Some(data))
             }
-            ProofRequestError::Pending { status, .. } => {
-                ErrorObject::owned(error_code::PENDING, message, Some(status))
-            }
-            ProofRequestError::Failed { reason, .. } => {
-                ErrorObject::owned(error_code::FAILED, message, Some(reason))
-            }
-            ProofRequestError::Internal(_) => {
-                ErrorObject::owned(INTERNAL_ERROR_CODE, message, None::<()>)
-            }
-            ProofRequestError::Rpc(_) => {
+            ProofRequestError::Sqlx(_) => ErrorObject::owned(error_code::SQLX, message, None::<()>),
+            ProofRequestError::UnknownProofStatus(_)
+            | ProofRequestError::ProofEncoding(_)
+            | ProofRequestError::BlockNumberExceedsI64(_)
+            | ProofRequestError::RemoteInternal
+            | ProofRequestError::RemoteSqlx
+            | ProofRequestError::RpcRequestTimeout
+            | ProofRequestError::RpcTransport(_)
+            | ProofRequestError::RpcRestartNeeded(_)
+            | ProofRequestError::RpcServiceDisconnected
+            | ProofRequestError::RpcClient(_) => {
                 ErrorObject::owned(INTERNAL_ERROR_CODE, message, None::<()>)
             }
         }
@@ -302,27 +299,35 @@ fn error_data<T: serde::de::DeserializeOwned>(err: &ErrorObjectOwned) -> Option<
         .and_then(|raw| serde_json::from_str(raw.get()).ok())
 }
 
-fn map_request_error(
-    err: ClientError,
-    id: ProofRequestId,
-    backend: Option<ProofBackend>,
-) -> ProofRequestError {
-    let ClientError::Call(err) = err else {
-        return ProofRequestError::Rpc(err.to_string());
-    };
-    match (err.code(), backend) {
-        (error_code::NOT_FOUND, _) => ProofRequestError::NotFound(id),
-        (error_code::TOO_MANY_RETRIES, _) => ProofRequestError::TooManyRetries(id),
-        (error_code::RETRYABLE_CONFLICT, _) => ProofRequestError::RowMissingAfterConflict { id },
-        (error_code::PENDING, _) => ProofRequestError::Pending {
-            id,
-            status: error_data(&err).unwrap_or(ProofStatus::Created),
-        },
-        (error_code::FAILED, _) => ProofRequestError::Failed {
-            id,
-            reason: error_data(&err).unwrap_or_else(|| err.message().to_string()),
-        },
-        _ => ProofRequestError::Rpc(format!("{} (code {})", err.message(), err.code())),
+fn map_request_error(err: ClientError, id: ProofRequestId) -> ProofRequestError {
+    match err {
+        ClientError::RequestTimeout => ProofRequestError::RpcRequestTimeout,
+        ClientError::Transport(err) => ProofRequestError::RpcTransport(err),
+        ClientError::RestartNeeded(err) => ProofRequestError::RpcRestartNeeded(err),
+        ClientError::ServiceDisconnect => ProofRequestError::RpcServiceDisconnected,
+        ClientError::Call(err) => map_request_call_error(err, id),
+        err => ProofRequestError::RpcClient(err),
+    }
+}
+
+fn map_request_call_error(err: ErrorObjectOwned, fallback_id: ProofRequestId) -> ProofRequestError {
+    match err.code() {
+        error_code::NOT_FOUND => {
+            ProofRequestError::ProofIdNotFound(error_data(&err).unwrap_or(fallback_id))
+        }
+        error_code::TOO_MANY_RETRIES => {
+            if let Some(data) = error_data::<TooManyRetriesErrorData>(&err) {
+                ProofRequestError::TooManyRetries(data)
+            } else {
+                ProofRequestError::RemoteInternal
+            }
+        }
+        error_code::RETRYABLE_CONFLICT => {
+            ProofRequestError::RowMissingAfterConflict(error_data(&err).unwrap_or(fallback_id))
+        }
+        error_code::SQLX => ProofRequestError::RemoteSqlx,
+        INTERNAL_ERROR_CODE => ProofRequestError::RemoteInternal,
+        _ => ProofRequestError::RpcClient(ClientError::Call(err)),
     }
 }
 
@@ -385,10 +390,9 @@ impl ProofRequester for RpcProverServiceClient {
         proof_request: ProofRequest,
     ) -> Result<ProofRequestId, ProofRequestError> {
         let id = proof_request.id();
-        let backend = proof_request.backend;
         ProverServiceApiClient::request_proof(&self.client, proof_request)
             .await
-            .map_err(|err| map_request_error(err, id, Some(backend)))
+            .map_err(|err| map_request_error(err, id))
     }
 
     async fn proof_status(
@@ -397,7 +401,7 @@ impl ProofRequester for RpcProverServiceClient {
     ) -> Result<ProofStatus, ProofRequestError> {
         ProverServiceApiClient::proof_status(&self.client, proof_id)
             .await
-            .map_err(|err| map_request_error(err, proof_id, None))
+            .map_err(|err| map_request_error(err, proof_id))
     }
 
     async fn get_proof(
@@ -406,7 +410,7 @@ impl ProofRequester for RpcProverServiceClient {
     ) -> Result<ProofResponse, ProofRequestError> {
         ProverServiceApiClient::get_proof(&self.client, proof_id)
             .await
-            .map_err(|err| map_request_error(err, proof_id, None))
+            .map_err(|err| map_request_error(err, proof_id))
     }
 }
 

--- a/proofs/prover-service/src/service.rs
+++ b/proofs/prover-service/src/service.rs
@@ -6,6 +6,7 @@ use crate::{
     types::{
         BackendSession, BackendSessionStatus, LockId, LockedProofRequest, ProofBackend,
         ProofRequest, ProofRequestId, ProofResponse, ProofStatus, SessionType,
+        SucceededProofResponse,
     },
 };
 use async_trait::async_trait;
@@ -87,7 +88,7 @@ impl ProofJobQueue for ProverService {
 
     async fn submit_proof(
         &self,
-        proof: ProofResponse,
+        proof: SucceededProofResponse,
         worker_id: String,
         lock: LockId,
     ) -> Result<(), ProofJobQueueError> {

--- a/proofs/prover-service/src/store.rs
+++ b/proofs/prover-service/src/store.rs
@@ -103,12 +103,11 @@ impl ProverServiceStore {
         .bind(now)
         .bind(now)
         .execute(&mut *tx)
-        .await
-        .map_err(request_db)?;
+        .await?;
 
         if insert_result.rows_affected() > 0 {
             // no conflict
-            tx.commit().await.map_err(request_db)?;
+            tx.commit().await?;
             return Ok(id);
         }
 
@@ -123,25 +122,26 @@ impl ProverServiceStore {
         )
         .bind(&proof_id)
         .fetch_optional(&mut *tx)
-        .await
-        .map_err(request_db)?;
+        .await?;
 
         let Some(row) = row else {
-            tx.rollback().await.map_err(request_db)?;
-            return Err(ProofRequestError::RowMissingAfterConflict { id });
+            tx.rollback().await?;
+            return Err(ProofRequestError::RowMissingAfterConflict(id));
         };
 
         let proof_status_str: &str = row.get("proof_status");
-        let proof_status = ProofStatus::try_from(proof_status_str).map_err(|e| {
-            ProofRequestError::Internal(format!("Invalid proof status in db: {}", e))
-        })?;
+        let proof_status = ProofStatus::try_from(proof_status_str)
+            .map_err(ProofRequestError::UnknownProofStatus)?;
 
         if proof_status == ProofStatus::Failed {
             // retry the entire proof job if retry_count is less than the max_retry
             let retry_count: i32 = row.get("retry_count");
             if retry_count > self.config.max_retries as i32 {
-                tx.rollback().await.map_err(request_db)?;
-                return Err(ProofRequestError::TooManyRetries(id));
+                tx.rollback().await?;
+                return Err(ProofRequestError::TooManyRetries {
+                    proof_id: id,
+                    max_retries: self.config.max_retries,
+                });
             }
 
             sqlx::query(
@@ -164,15 +164,14 @@ impl ProverServiceStore {
             .bind(ProofJobStatus::Pending.as_str())
             .bind(&proof_id)
             .execute(&mut *tx)
-            .await
-            .map_err(request_db)?;
+            .await?;
 
-            tx.commit().await.map_err(request_db)?;
+            tx.commit().await?;
             Ok(id)
         } else {
             // this proof request already exists in the db with a non-failing status.
             // Rollback the db transaction and return the proof id.
-            tx.rollback().await.map_err(request_db)?;
+            tx.rollback().await?;
             Ok(id)
         }
     }
@@ -184,10 +183,9 @@ impl ProverServiceStore {
         let row = sqlx::query("SELECT proof_status FROM proof_requests WHERE proof_id = $1")
             .bind(proof_id_bytes(proof_id))
             .fetch_optional(&self.pool)
-            .await
-            .map_err(request_db)?
-            .ok_or(ProofRequestError::NotFound(proof_id))?;
-        parse_status(row.try_get("proof_status").map_err(request_db)?)
+            .await?
+            .ok_or(ProofRequestError::ProofIdNotFound(proof_id))?;
+        parse_status(row.get("proof_status"))
     }
 
     pub(crate) async fn get_proof(
@@ -199,28 +197,24 @@ impl ProverServiceStore {
         )
         .bind(proof_id_bytes(proof_id))
         .fetch_optional(&self.pool)
-        .await
-        .map_err(request_db)?
-        .ok_or(ProofRequestError::NotFound(proof_id))?;
+        .await?
+        .ok_or(ProofRequestError::ProofIdNotFound(proof_id))?;
 
-        let status = parse_status(row.try_get("proof_status").map_err(request_db)?)?;
+        let status = parse_status(row.get("proof_status"))?;
         match status {
             ProofStatus::Succeeded => {
-                let data: Vec<u8> = row
-                    .try_get("proof_data")
-                    .map_err(|err| ProofRequestError::Internal(err.to_string()))?;
-                let proof = serde_json::from_slice(&data)
-                    .map_err(|err| ProofRequestError::Internal(err.to_string()))?;
-                Ok(ProofResponse {
+                let data: Vec<u8> = row.get("proof_data");
+                let proof =
+                    serde_json::from_slice(&data).map_err(ProofRequestError::ProofEncoding)?;
+                Ok(ProofResponse::Succeeded {
                     id: proof_id,
                     proof,
                 })
             }
-            ProofStatus::Failed => Err(ProofRequestError::Failed {
+            ProofStatus::Failed => Ok(ProofResponse::Failed {
                 id: proof_id,
                 reason: row
-                    .try_get::<Option<String>, _>("failure_reason")
-                    .map_err(request_db)?
+                    .get::<Option<String>, _>("failure_reason")
                     .unwrap_or_else(|| "proof job failed".to_string()),
             }),
             status => Err(ProofRequestError::Pending {
@@ -652,7 +646,7 @@ impl ProverServiceStore {
     async fn begin_request_tx(&self) -> Result<Transaction<'_, Postgres>, ProofRequestError> {
         self.begin_tx(PostgresIsolationLevel::ReadCommitted)
             .await
-            .map_err(request_db)
+            .map_err(ProofRequestError::Sqlx)
     }
 
     async fn begin_queue_tx(&self) -> Result<Transaction<'_, Postgres>, ProofJobQueueError> {
@@ -697,14 +691,9 @@ fn request_from_row(row: &PgRow) -> Result<ProofRequest, ProofJobQueueError> {
 }
 
 fn parse_status(status: String) -> Result<ProofStatus, ProofRequestError> {
-    ProofStatus::try_from(status.as_str()).map_err(ProofRequestError::Internal)
+    ProofStatus::try_from(status.as_str()).map_err(ProofRequestError::UnknownProofStatus)
 }
 
 fn l2_to_i64(value: u64) -> Result<i64, ProofRequestError> {
-    i64::try_from(value)
-        .map_err(|_| ProofRequestError::Internal(format!("l2 block number {value} exceeds i64")))
-}
-
-fn request_db(err: sqlx::Error) -> ProofRequestError {
-    ProofRequestError::Internal(err.to_string())
+    i64::try_from(value).map_err(|_| ProofRequestError::BlockNumberExceedsI64(value))
 }

--- a/proofs/prover-service/src/store.rs
+++ b/proofs/prover-service/src/store.rs
@@ -3,7 +3,7 @@ use crate::{
     config::ProverServiceConfig,
     error::{
         BackendMismatchErrorData, InvalidConfigError, ProofJobQueueError, ProofJobStatusErrorData,
-        ProofMismatchErrorData, ProofRequestError, ProverServiceInitError,
+        ProofMismatchErrorData, ProofRequestError, ProverServiceInitError, TooManyRetriesErrorData,
     },
     types::{
         BackendSession, BackendSessionStatus, FailedProofResponse, LockId, LockedProofRequest,
@@ -139,10 +139,10 @@ impl ProverServiceStore {
             let retry_count: i32 = row.get("retry_count");
             if retry_count > self.config.max_retries as i32 {
                 tx.rollback().await?;
-                return Err(ProofRequestError::TooManyRetries {
+                return Err(ProofRequestError::TooManyRetries(TooManyRetriesErrorData {
                     proof_id: id,
                     max_retries: self.config.max_retries,
-                });
+                }));
             }
 
             sqlx::query(

--- a/proofs/prover-service/src/store.rs
+++ b/proofs/prover-service/src/store.rs
@@ -6,8 +6,9 @@ use crate::{
         ProofMismatchErrorData, ProofRequestError, ProverServiceInitError,
     },
     types::{
-        BackendSession, BackendSessionStatus, LockId, LockedProofRequest, ProofBackend,
-        ProofJobStatus, ProofRequest, ProofRequestId, ProofResponse, ProofStatus, SessionType,
+        BackendSession, BackendSessionStatus, FailedProofResponse, LockId, LockedProofRequest,
+        PendingProofResponse, ProofBackend, ProofJobStatus, ProofRequest, ProofRequestId,
+        ProofResponse, ProofStatus, SessionType, SucceededProofResponse,
     },
 };
 use alloy_primitives::{Address, B256};
@@ -206,21 +207,21 @@ impl ProverServiceStore {
                 let data: Vec<u8> = row.get("proof_data");
                 let proof =
                     serde_json::from_slice(&data).map_err(ProofRequestError::ProofEncoding)?;
-                Ok(ProofResponse::Succeeded {
+                Ok(ProofResponse::Succeeded(SucceededProofResponse {
                     id: proof_id,
                     proof,
-                })
+                }))
             }
-            ProofStatus::Failed => Ok(ProofResponse::Failed {
+            ProofStatus::Failed => Ok(ProofResponse::Failed(FailedProofResponse {
                 id: proof_id,
                 reason: row
                     .get::<Option<String>, _>("failure_reason")
                     .unwrap_or_else(|| "proof job failed".to_string()),
-            }),
-            status => Err(ProofRequestError::Pending {
+            })),
+            status => Ok(ProofResponse::Pending(PendingProofResponse {
                 id: proof_id,
                 status,
-            }),
+            })),
         }
     }
 
@@ -478,7 +479,7 @@ impl ProverServiceStore {
 
     pub(crate) async fn submit_proof(
         &self,
-        proof: ProofResponse,
+        proof: SucceededProofResponse,
         worker_id: String,
         lock_id: LockId,
     ) -> Result<(), ProofJobQueueError> {

--- a/proofs/prover-service/src/tests.rs
+++ b/proofs/prover-service/src/tests.rs
@@ -1,7 +1,7 @@
 use crate::{
-    ProofBackend, ProofData, ProofJobQueue, ProofJobQueueError, ProofRequest, ProofRequestError,
-    ProofRequester, ProofResponse, ProofStatus, ProverService, ProverServiceConfig,
-    RpcProverServiceClient, start_rpc_server,
+    ProofBackend, ProofData, ProofJobQueue, ProofJobQueueError, ProofRequest, ProofRequester,
+    ProofResponse, ProofStatus, ProverService, ProverServiceConfig, RpcProverServiceClient,
+    SucceededProofResponse, start_rpc_server,
     types::{BackendSessionStatus, SessionType},
 };
 use alloy_primitives::{Address, B256, Bytes};
@@ -58,7 +58,7 @@ fn request(backend: ProofBackend, seed: u8) -> ProofRequest {
     }
 }
 
-fn proof_for(req: &ProofRequest) -> ProofResponse {
+fn proof_for(req: &ProofRequest) -> SucceededProofResponse {
     let proof = match req.backend {
         ProofBackend::Sp1 => ProofData::Sp1 {
             proof: Bytes::from(vec![0xaa]),
@@ -69,7 +69,7 @@ fn proof_for(req: &ProofRequest) -> ProofResponse {
             signature: Bytes::from(vec![0xdd]),
         },
     };
-    ProofResponse {
+    SucceededProofResponse {
         id: req.id(),
         proof,
     }
@@ -105,11 +105,9 @@ async fn full_lifecycle_succeeds() {
         ProofStatus::Created
     );
     assert!(matches!(
-        service.get_proof(id).await,
-        Err(ProofRequestError::Pending {
-            status: ProofStatus::Created,
-            ..
-        })
+        service.get_proof(id).await.unwrap(),
+        ProofResponse::Pending(response)
+            if response.id == id && response.status == ProofStatus::Created
     ));
 
     let locked = service
@@ -123,11 +121,9 @@ async fn full_lifecycle_succeeds() {
         ProofStatus::Running
     );
     assert!(matches!(
-        service.get_proof(id).await,
-        Err(ProofRequestError::Pending {
-            status: ProofStatus::Running,
-            ..
-        })
+        service.get_proof(id).await.unwrap(),
+        ProofResponse::Pending(response)
+            if response.id == id && response.status == ProofStatus::Running
     ));
 
     let response = proof_for(&req);
@@ -139,7 +135,10 @@ async fn full_lifecycle_succeeds() {
         service.proof_status(id).await.unwrap(),
         ProofStatus::Succeeded
     );
-    assert_eq!(service.get_proof(id).await.unwrap(), response);
+    assert_eq!(
+        service.get_proof(id).await.unwrap(),
+        ProofResponse::Succeeded(response)
+    );
 }
 
 #[tokio::test]
@@ -237,7 +236,7 @@ async fn submit_proof_with_wrong_backend_is_rejected() {
         .unwrap()
         .expect("lock");
 
-    let mismatched = ProofResponse {
+    let mismatched = SucceededProofResponse {
         id,
         proof: ProofData::Nitro {
             attestation: Bytes::from(vec![0xcc]),
@@ -326,7 +325,10 @@ async fn rpc_end_to_end() {
         .submit_proof(response.clone(), worker_id(), locked.lock_id)
         .await
         .unwrap();
-    assert_eq!(client.get_proof(id).await.unwrap(), response);
+    assert_eq!(
+        client.get_proof(id).await.unwrap(),
+        ProofResponse::Succeeded(response)
+    );
 
     handle.stop().unwrap();
     handle.stopped().await;

--- a/proofs/prover-service/src/traits.rs
+++ b/proofs/prover-service/src/traits.rs
@@ -3,6 +3,7 @@ use crate::{
     types::{
         BackendSession, BackendSessionStatus, LockId, LockedProofRequest, ProofBackend,
         ProofRequest, ProofRequestId, ProofResponse, ProofStatus, SessionType,
+        SucceededProofResponse,
     },
 };
 use async_trait::async_trait;
@@ -50,7 +51,7 @@ pub trait ProofJobQueue {
     /// Submit a final proof response to the `prover-service`.
     async fn submit_proof(
         &self,
-        proof: ProofResponse,
+        proof: SucceededProofResponse,
         worker_id: String,
         lock: LockId,
     ) -> Result<(), ProofJobQueueError>;

--- a/proofs/prover-service/src/types.rs
+++ b/proofs/prover-service/src/types.rs
@@ -217,24 +217,36 @@ impl ProofData {
 /// a defender that requests the proof back.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ProofResponse {
-    Succeeded {
-        /// The identifier of the proof request this proof answers.
-        id: ProofRequestId,
-        /// The actual proof.
-        proof: ProofData,
-    },
-    Failed {
-        /// The identifier of the proof request.
-        id: ProofRequestId,
-        /// Failure reason.
-        reason: String,
-    },
-    Pending {
-        /// The identifier of the proof request.
-        id: ProofRequestId,
-        /// Current proof status.
-        status: ProofStatus,
-    },
+    Succeeded(SucceededProofResponse),
+    Failed(FailedProofResponse),
+    Pending(PendingProofResponse),
+}
+
+/// The succeeded proof response.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SucceededProofResponse {
+    /// The identifier of the proof request this proof answers.
+    pub id: ProofRequestId,
+    /// The actual proof.
+    pub proof: ProofData,
+}
+
+/// The failed proof response.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FailedProofResponse {
+    /// The identifier of the proof request.
+    id: ProofRequestId,
+    /// Failure reason.
+    reason: String,
+}
+
+/// The pending proof response.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingProofResponse {
+    /// The identifier of the proof request.
+    id: ProofRequestId,
+    /// Current proof status.
+    status: ProofStatus,
 }
 
 /// External backend request identifier.

--- a/proofs/prover-service/src/types.rs
+++ b/proofs/prover-service/src/types.rs
@@ -216,11 +216,25 @@ impl ProofData {
 /// The response sent by the `prover-service` to
 /// a defender that requests the proof back.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ProofResponse {
-    /// The identifier of the proof request this proof answers.
-    pub id: ProofRequestId,
-    /// The generated proof.
-    pub proof: ProofData,
+pub enum ProofResponse {
+    Succeeded {
+        /// The identifier of the proof request this proof answers.
+        id: ProofRequestId,
+        /// The actual proof.
+        proof: ProofData,
+    },
+    Failed {
+        /// The identifier of the proof request.
+        id: ProofRequestId,
+        /// Failure reason.
+        reason: String,
+    },
+    Pending {
+        /// The identifier of the proof request.
+        id: ProofRequestId,
+        /// Current proof status.
+        status: ProofStatus,
+    },
 }
 
 /// External backend request identifier.

--- a/proofs/prover-service/src/types.rs
+++ b/proofs/prover-service/src/types.rs
@@ -235,18 +235,18 @@ pub struct SucceededProofResponse {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FailedProofResponse {
     /// The identifier of the proof request.
-    id: ProofRequestId,
+    pub id: ProofRequestId,
     /// Failure reason.
-    reason: String,
+    pub reason: String,
 }
 
 /// The pending proof response.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PendingProofResponse {
     /// The identifier of the proof request.
-    id: ProofRequestId,
+    pub id: ProofRequestId,
     /// Current proof status.
-    status: ProofStatus,
+    pub status: ProofStatus,
 }
 
 /// External backend request identifier.

--- a/proofs/sp1-worker/tests/e2e_proving.rs
+++ b/proofs/sp1-worker/tests/e2e_proving.rs
@@ -36,8 +36,8 @@ use world_chain_proof_kona_host_utils::online::{OnlineHostConfig, resolve_l1_hea
 use world_chain_proof_succinct_host_utils::prover::{SP1ProofMode, Sp1ProverKind, SuccinctProver};
 use world_chain_proofs::{ConsensusProvider, OptimismConsensusClient};
 use world_chain_prover_service::{
-    ProofBackend, ProofData, ProofRequest, ProofRequester, ProofStatus, ProverService,
-    ProverServiceConfig, RpcProverServiceClient, start_rpc_server,
+    ProofBackend, ProofData, ProofRequest, ProofRequester, ProofResponse, ProofStatus,
+    ProverService, ProverServiceConfig, RpcProverServiceClient, start_rpc_server,
 };
 use world_chain_sp1_worker::{
     ProofWorker, ProofWorkerConfig, RetryConfig, Sp1Backend, Sp1BackendConfig,
@@ -230,6 +230,9 @@ async fn worker_proves_real_range_end_to_end() {
     assert_eq!(status, ProofStatus::Succeeded);
 
     let response = client.get_proof(id).await.expect("fetch proof");
+    let ProofResponse::Succeeded(response) = response else {
+        panic!("expected succeeded proof response");
+    };
     assert_eq!(response.id, id);
     let ProofData::Sp1 {
         proof,

--- a/proofs/sp1-worker/tests/rpc_roundtrip.rs
+++ b/proofs/sp1-worker/tests/rpc_roundtrip.rs
@@ -7,8 +7,8 @@ use testcontainers::{ContainerAsync, runners::AsyncRunner};
 use testcontainers_modules::postgres;
 use world_chain_proof_worker::ProofJob;
 use world_chain_prover_service::{
-    ProofBackend, ProofData, ProofRequest, ProofRequester, ProofStatus, ProverService,
-    ProverServiceConfig, RpcProverServiceClient, start_rpc_server,
+    ProofBackend, ProofData, ProofRequest, ProofRequester, ProofResponse, ProofStatus,
+    ProverService, ProverServiceConfig, RpcProverServiceClient, start_rpc_server,
 };
 use world_chain_sp1_worker::{ClaimedProofJobHandler, ProofWorker, ProofWorkerConfig, RetryConfig};
 
@@ -102,6 +102,9 @@ async fn worker_completes_requested_proof_over_rpc() {
     assert_eq!(status, ProofStatus::Succeeded);
 
     let response = requester.get_proof(id).await.expect("proof available");
+    let ProofResponse::Succeeded(response) = response else {
+        panic!("expected succeeded proof response");
+    };
     assert_eq!(response.id, id);
     let ProofData::Sp1 {
         proof,

--- a/proofs/worker/src/worker.rs
+++ b/proofs/worker/src/worker.rs
@@ -14,7 +14,7 @@ use tokio::{
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, info, info_span, warn};
-use world_chain_prover_service::{LockedProofRequest, ProofJobQueue, ProofResponse};
+use world_chain_prover_service::{LockedProofRequest, ProofJobQueue, SucceededProofResponse};
 
 use crate::{
     backend::{ClaimedProofJobHandler, JobSessions, ProofJob},
@@ -253,7 +253,7 @@ fn spawn_job<Q, B>(
 
             match backend.handle_claimed_job(job).await {
                 Ok(proof) => {
-                    let response = ProofResponse {
+                    let response = SucceededProofResponse {
                         id: proof_id,
                         proof,
                     };


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4865/refactor-proofrequesterror-similarly-to-what-i-did-to

This is a similar refactor to what I did to `ProofJobQueueError`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes defender proof-fetch behavior and the prover-service RPC contract for getProof/submitProof; incorrect enum handling could delay or skip on-chain proof submission.
> 
> **Overview**
> Refactors **defender-facing proof APIs** so `getProof` returns a **`ProofResponse` enum** (`Succeeded` / `Failed` / `Pending`) instead of using RPC errors for in-progress or failed proofs. **`submitProof`** and worker paths now take **`SucceededProofResponse`** only.
> 
> **`ProofRequestError`** is aligned with **`ProofJobQueueError`**: typed variants for SQL, encoding, not-found, retry limits (`TooManyRetriesErrorData`), and granular RPC client errors; generic `Internal` / `Pending` / `Failed` / string `Rpc` variants are removed. The JSON-RPC layer drops **PENDING/FAILED** codes for `getProof` and maps server errors with structured payloads where applicable.
> 
> **Defender** logic after `proof_status == Succeeded` matches on `get_proof` and **retries next tick** if the response is still pending or failed (status/response race). Tests and mocks are updated across prover-service, defender, integration, SP1 worker, and generic worker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dedcc0cdd9a0fec61262a03fe8e79b7ce99071b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->