### PR TITLE
fix: make record-proof-session idempotent

### DIFF
--- a/proofs/prover-service/src/error.rs
+++ b/proofs/prover-service/src/error.rs
@@ -1,4 +1,7 @@
-use crate::{ProofBackend, ProofData, ProofJobStatus, types::ProofRequestId};
+use crate::{
+    ProofBackend, ProofData, ProofJobStatus,
+    types::{BackendSessionStatus, ProofRequestId, SessionType},
+};
 use alloy_primitives::BlockNumber;
 use jsonrpsee::core::client::Error as JsonRpseeError;
 use sqlx::migrate::MigrateError;
@@ -118,6 +121,36 @@ impl std::fmt::Display for BackendMismatchErrorData {
     }
 }
 
+/// Data describing an attempt to record a backend session that has already
+/// reached a terminal status with a conflicting status.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct BackendSessionAlreadyTerminalErrorData {
+    /// The proof request id.
+    pub proof_id: ProofRequestId,
+    /// The session type of the conflicting backend session.
+    pub session_type: SessionType,
+    /// The backend-issued session identifier.
+    pub backend_session_id: String,
+    /// The terminal status already stored for this backend session.
+    pub stored: BackendSessionStatus,
+    /// The status the worker attempted to record.
+    pub attempted: BackendSessionStatus,
+}
+
+impl std::fmt::Display for BackendSessionAlreadyTerminalErrorData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "backend session {} for proof {} ({}) already reached terminal status {}; cannot record status {}.",
+            self.backend_session_id,
+            self.proof_id,
+            self.session_type.as_str(),
+            self.stored.as_str(),
+            self.attempted.as_str(),
+        )
+    }
+}
+
 /// Data describing a repeated proof submission with different proof data.
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct ProofMismatchErrorData {
@@ -168,6 +201,8 @@ pub enum ProofJobQueueError {
     BackendMismatch(BackendMismatchErrorData),
     #[error("The proof {0} has already reached a terminal job status.")]
     AlreadyTerminal(ProofRequestId),
+    #[error("{0}")]
+    BackendSessionAlreadyTerminal(BackendSessionAlreadyTerminalErrorData),
     #[error(transparent)]
     ProofEncoding(#[from] serde_json::Error),
     #[error("{0}")]

--- a/proofs/prover-service/src/rpc.rs
+++ b/proofs/prover-service/src/rpc.rs
@@ -1,7 +1,8 @@
 use crate::{
     error::{
-        BackendMismatchErrorData, ProofJobQueueError, ProofJobStatusErrorData,
-        ProofMismatchErrorData, ProofRequestError, TooManyRetriesErrorData,
+        BackendMismatchErrorData, BackendSessionAlreadyTerminalErrorData, ProofJobQueueError,
+        ProofJobStatusErrorData, ProofMismatchErrorData, ProofRequestError,
+        TooManyRetriesErrorData,
     },
     service::ProverService,
     traits::{ProofJobQueue, ProofRequester},
@@ -45,6 +46,9 @@ pub mod error_code {
     pub const PROOF_MISMATCH: i32 = -32018;
     /// Temporary prover-service storage failure.
     pub const SQLX: i32 = -32019;
+    /// A worker tried to record a backend session that already reached a
+    /// conflicting terminal status.
+    pub const BACKEND_SESSION_ALREADY_TERMINAL: i32 = -32020;
 }
 
 /// The `prover-service` JSON-RPC API, covering both the defender-facing
@@ -155,6 +159,11 @@ impl From<ProofJobQueueError> for ErrorObjectOwned {
             ProofJobQueueError::AlreadyTerminal(proof_id) => {
                 ErrorObject::owned(error_code::ALREADY_TERMINAL, message, Some(proof_id))
             }
+            ProofJobQueueError::BackendSessionAlreadyTerminal(data) => ErrorObject::owned(
+                error_code::BACKEND_SESSION_ALREADY_TERMINAL,
+                message,
+                Some(data),
+            ),
             ProofJobQueueError::ProofMismatch(data) => {
                 ErrorObject::owned(error_code::PROOF_MISMATCH, message, Some(data))
             }
@@ -369,6 +378,13 @@ fn map_job_call_error(err: ErrorObjectOwned, fallback_id: ProofRequestId) -> Pro
         }
         error_code::ALREADY_TERMINAL => {
             ProofJobQueueError::AlreadyTerminal(error_data(&err).unwrap_or(fallback_id))
+        }
+        error_code::BACKEND_SESSION_ALREADY_TERMINAL => {
+            if let Some(data) = error_data::<BackendSessionAlreadyTerminalErrorData>(&err) {
+                ProofJobQueueError::BackendSessionAlreadyTerminal(data)
+            } else {
+                ProofJobQueueError::RemoteInternal
+            }
         }
         error_code::PROOF_MISMATCH => {
             if let Some(data) = error_data::<Box<ProofMismatchErrorData>>(&err) {

--- a/proofs/prover-service/src/store.rs
+++ b/proofs/prover-service/src/store.rs
@@ -2,8 +2,9 @@ use crate::{
     ProofData,
     config::ProverServiceConfig,
     error::{
-        BackendMismatchErrorData, InvalidConfigError, ProofJobQueueError, ProofJobStatusErrorData,
-        ProofMismatchErrorData, ProofRequestError, ProverServiceInitError, TooManyRetriesErrorData,
+        BackendMismatchErrorData, BackendSessionAlreadyTerminalErrorData, InvalidConfigError,
+        ProofJobQueueError, ProofJobStatusErrorData, ProofMismatchErrorData, ProofRequestError,
+        ProverServiceInitError, TooManyRetriesErrorData,
     },
     types::{
         BackendSession, BackendSessionStatus, FailedProofResponse, LockId, LockedProofRequest,
@@ -384,6 +385,7 @@ impl ProverServiceStore {
                 WHERE proof_id = $1
                   AND session_type = $2
                   AND backend_session_id = $3
+                ORDER BY id
                 FOR UPDATE
             "#,
         )
@@ -393,13 +395,26 @@ impl ProverServiceStore {
         .fetch_all(&mut *tx)
         .await?;
 
-        for row in existing_backend_sessions {
+        // A terminal backend session is immutable, so short-circuit before the
+        // active-session update below. Re-recording the same status is an idempotent
+        // retry, any other status is a conflict.
+        for row in &existing_backend_sessions {
             let status_str: &str = row.get("status");
-            let status = BackendSessionStatus::try_from(status_str)
+            let stored = BackendSessionStatus::try_from(status_str)
                 .map_err(ProofJobQueueError::UnknownBackendSessionStatus)?;
-            if status.is_terminal() {
-                // return this proof session
-                // TODO: do it
+            if stored.is_terminal() {
+                if stored == status {
+                    return Ok(());
+                }
+                return Err(ProofJobQueueError::BackendSessionAlreadyTerminal(
+                    BackendSessionAlreadyTerminalErrorData {
+                        proof_id,
+                        session_type,
+                        backend_session_id,
+                        stored,
+                        attempted: status,
+                    },
+                ));
             }
         }
 


### PR DESCRIPTION
Part of https://linear.app/worldcoin/issue/PROTO-4858/in-the-storers-file-there-are-some-todos-that-must-be-completed

This PR makes the `record_proof_session` fn idempotent, such that if the backend session status is already in a terminal state (completed or failed), if you try to record the same status, then it becomes a no-op. If the status is different than the finalized one, then return an error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes worker write semantics and concurrency around proof session rows; incorrect early-return transaction handling could matter, but behavior is narrowly scoped to terminal session conflicts.
> 
> **Overview**
> **`record_proof_session`** now treats terminal backend session rows as immutable before the usual active-session update/insert path.
> 
> When a matching `proof_sessions` row (same proof, session type, and backend session id) is already terminal, re-recording the **same** status returns success as a no-op for worker retries. Recording a **different** status returns a new **`BackendSessionAlreadyTerminal`** error with structured details (stored vs attempted status).
> 
> That error is wired through **`ProofJobQueueError`**, JSON-RPC code **`-32020`**, and the HTTP client’s error mapping. The session lookup query also adds **`ORDER BY id`** for deterministic row locking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6305ed09906a2ca935135539c12e39ba9d38610. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->