### PR TITLE
chore: cleanup readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,20 +31,19 @@ World Chain is a blockchain designed for humans. It prioritizes scalability and 
 
 | Crate | Description |
 |-------|-------------|
-| [`world-chain-builder`](./crates/builder) | Custom block builder with priority blockspace for humans (PBH). |
-| [`world-chain-chainspec`](./crates/chainspec) | Chain specification and genesis configuration. |
-| [`world-chain-cli`](./crates/cli) | CLI tooling for operating World Chain nodes. |
+| [`world-chain-builder`](./crates/builder) | World Chain Payload Builder components |
+| [`world-chain-chainspec`](./crates/chainspec) | World Chain specification and genesis configuration. |
+| [`world-chain-cli`](./crates/cli) | World Chain CLI |
 | [`world-chain-devnet`](./crates/devnet) | Local devnet setup and tooling. |
 | [`world-chain-evm`](./crates/evm) | Custom EVM configuration and execution logic. |
-| [`world-chain-node`](./crates/node) | World Chain execution node built on reth. |
-| [`world-chain-p2p`](./crates/p2p) | Peer-to-peer networking layer. |
-| [`world-chain-payload`](./crates/payload) | Payload building and attributes. |
+| [`world-chain-node`](./crates/node) | World Chain node components builder |
+| [`world-chain-p2p`](./crates/p2p) | RLPX Satellite Protocol Components |
+| [`world-chain-payload`](./crates/payload) | Payload job lifecycle management, and continuous block building |
 | [`world-chain-pbh`](./crates/pbh) | Priority Blockspace for Humans — verified human transaction prioritization. |
-| [`world-chain-pool`](./crates/pool) | Transaction pool with PBH-aware ordering. |
-| [`world-chain-primitives`](./crates/primitives) | Shared types and primitives. |
-| [`world-chain-rpc`](./crates/rpc) | Custom RPC extensions for World Chain. |
-| [`world-chain-state`](./crates/state) | State management and storage. |
-| [`world-chain-validator`](./crates/validator) | Transaction validation with World ID proof verification. |
+| [`world-chain-pool`](./crates/pool) | Transaction pool with custom ordering. |
+| [`world-chain-primitives`](./crates/primitives) | Project wide primitives |
+| [`world-chain-rpc`](./crates/rpc) | World Chain RPC API Extensions |
+| [`world-chain-validator`](./crates/validator) | World Chain Flashblocks Execution Engine |
 
 ## Proofs
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> README text only; no runtime, config, or dependency changes.
> 
> **Overview**
> **Documentation-only change** to the **Crates** table in `README.md`.
> 
> Crate blurbs are rewritten to be shorter and more component-oriented (e.g. builder, node, p2p, payload, rpc, primitives). Wording shifts away from marketing-style lines (e.g. “custom block builder with priority blockspace for humans”) toward implementation labels (e.g. “Payload Builder components”, “RLPX Satellite Protocol Components”, “Payload job lifecycle management, and continuous block building”).
> 
> Notable description updates: **`world-chain-validator`** is now described as “World Chain Flashblocks Execution Engine” instead of transaction validation / World ID proof verification; **`world-chain-pool`** drops “PBH-aware” in favor of “custom ordering”. The **`world-chain-state`** row is no longer listed in the table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08989f7a3dbcabb2de1245890c76ecf0ee051cb0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->