### PR TITLE
feat: bump v2.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "2.3.0"
+version = "2.4.0"
 edition = "2024"
 rust-version = "1.95.0"
 license = "MIT"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single metadata version bump with no runtime, protocol, or dependency changes in this diff.
> 
> **Overview**
> Bumps the shared **`[workspace.package]` version** in `Cargo.toml` from **2.3.0** to **2.4.0**, aligning crate releases across the World Chain Rust workspace with the v2.4.0 release line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f07280f222b7dd1cf9f3e9db402be88526913bf6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->