### PR TITLE
fix: lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18493,7 +18493,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "clap",
  "color-eyre",
@@ -18513,7 +18513,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-builder"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -18564,7 +18564,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-chainspec"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -18586,7 +18586,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-challenger"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-network 2.0.5",
  "alloy-primitives",
@@ -18611,7 +18611,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-cli"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-chains",
  "alloy-genesis",
@@ -18646,7 +18646,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-defender"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-network 2.0.5",
  "alloy-primitives",
@@ -18669,7 +18669,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-devnet"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-genesis",
@@ -18721,7 +18721,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-evm"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eip7928 0.4.3",
@@ -18755,7 +18755,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-nitro-worker"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -18776,7 +18776,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-node"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -18835,7 +18835,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-p2p"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -18873,7 +18873,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-payload"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -18902,7 +18902,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-pbh"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -18919,7 +18919,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-pool"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -18956,7 +18956,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-primitives"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eip7928 0.4.3",
@@ -18990,7 +18990,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-core"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -19013,7 +19013,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-integration-tests"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -19032,7 +19032,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-kona-client-utils"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -19062,7 +19062,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-kona-host-utils"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -19089,7 +19089,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-nitro"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -19123,7 +19123,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-protocol"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-primitives",
  "op-revm",
@@ -19139,7 +19139,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-succinct-client-utils"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -19156,7 +19156,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-succinct-elfs"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "sp1-build",
  "sp1-sdk",
@@ -19164,7 +19164,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-succinct-ethereum-client-utils"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -19180,7 +19180,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-succinct-host-utils"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -19203,7 +19203,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-succinct-utils"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-primitives",
  "rkyv",
@@ -19213,7 +19213,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-worker"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -19227,7 +19227,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proofs"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -19242,7 +19242,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proposer"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-network 2.0.5",
  "alloy-primitives",
@@ -19265,7 +19265,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-prover"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -19282,7 +19282,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-prover-nitro"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -19296,7 +19296,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-prover-service"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -19319,7 +19319,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-prover-sp1"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -19338,7 +19338,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-rpc"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy",
  "alloy-consensus 2.0.5",
@@ -19396,7 +19396,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-sp1-worker"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -19426,7 +19426,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-test-utils"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-contract",
@@ -19510,7 +19510,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-tests"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -19573,7 +19573,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-validator"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eip7928 0.4.3",
@@ -19689,7 +19689,7 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xtask"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-contract",

--- a/proofs/succinct/programs/Cargo.lock
+++ b/proofs/succinct/programs/Cargo.lock
@@ -4698,7 +4698,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-core"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4721,7 +4721,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-kona-client-utils"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4767,7 +4767,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-succinct-client-utils"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Lockfile-only version metadata updates with no runtime or logic changes.
> 
> **Overview**
> Updates **`Cargo.lock`** and **`proofs/succinct/programs/Cargo.lock`** so every `world-chain-*` workspace crate is recorded at **2.4.0** instead of **2.3.0**. There are no application or library source changes in this diff—only lockfile entries aligned with the current crate versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94676dd8f45c957c73577ab31fd73abb9cd080ce. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->