### PR TITLE
feat: add heartbeat api

### DIFF
--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -634,4 +634,13 @@ impl ProofJobQueue for SharedProverService {
             )
             .await
     }
+
+    async fn heartbeat(
+        &self,
+        proof_id: ProofRequestId,
+        worker_id: String,
+        lock: LockId,
+    ) -> Result<(), ProofJobQueueError> {
+        self.service.heartbeat(proof_id, worker_id, lock).await
+    }
 }

--- a/proofs/prover-service/src/rpc.rs
+++ b/proofs/prover-service/src/rpc.rs
@@ -103,6 +103,15 @@ pub trait ProverServiceApi {
         backend_session_id: String,
         state: BackendSessionStatus,
     ) -> RpcResult<()>;
+
+    /// Heartbeat call.
+    #[method(name = "heartbeat")]
+    async fn heartbeat(
+        &self,
+        proof_id: ProofRequestId,
+        worker_id: String,
+        lock: LockId,
+    ) -> RpcResult<()>;
 }
 
 impl From<ProofRequestError> for ErrorObjectOwned {
@@ -266,6 +275,15 @@ impl ProverServiceApiServer for ProverServiceRpc {
                 state,
             )
             .await?)
+    }
+
+    async fn heartbeat(
+        &self,
+        proof_id: ProofRequestId,
+        worker_id: String,
+        lock: LockId,
+    ) -> RpcResult<()> {
+        Ok(self.service.heartbeat(proof_id, worker_id, lock).await?)
     }
 }
 
@@ -484,5 +502,16 @@ impl ProofJobQueue for RpcProverServiceClient {
         )
         .await
         .map_err(|err| map_job_error(err, proof_id))
+    }
+
+    async fn heartbeat(
+        &self,
+        proof_id: ProofRequestId,
+        worker_id: String,
+        lock: LockId,
+    ) -> Result<(), ProofJobQueueError> {
+        ProverServiceApiClient::heartbeat(&self.client, proof_id, worker_id, lock)
+            .await
+            .map_err(|err| map_job_error(err, proof_id))
     }
 }

--- a/proofs/prover-service/src/service.rs
+++ b/proofs/prover-service/src/service.rs
@@ -123,4 +123,13 @@ impl ProofJobQueue for ProverService {
             )
             .await
     }
+
+    async fn heartbeat(
+        &self,
+        proof_id: ProofRequestId,
+        worker_id: String,
+        lock: LockId,
+    ) -> Result<(), ProofJobQueueError> {
+        self.store.hearbeat(proof_id, worker_id, lock).await
+    }
 }

--- a/proofs/prover-service/src/service.rs
+++ b/proofs/prover-service/src/service.rs
@@ -130,6 +130,6 @@ impl ProofJobQueue for ProverService {
         worker_id: String,
         lock: LockId,
     ) -> Result<(), ProofJobQueueError> {
-        self.store.hearbeat(proof_id, worker_id, lock).await
+        self.store.heartbeat(proof_id, worker_id, lock).await
     }
 }

--- a/proofs/prover-service/src/store.rs
+++ b/proofs/prover-service/src/store.rs
@@ -648,6 +648,92 @@ impl ProverServiceStore {
         }
     }
 
+    pub(crate) async fn heartbeat(
+        &self,
+        proof_id: ProofRequestId,
+        worker_id: String,
+        lock_id: LockId,
+    ) -> Result<(), ProofJobQueueError> {
+        let now = Utc::now();
+        let next_lock_expiration = now + self.config.lock_timeout;
+        let maybe_row = sqlx::query(
+            r#"
+            UPDATE proof_requests
+            SET lock_expires_at = $1,
+                updated_at = $2
+            WHERE proof_id = $3
+                AND job_status = $3
+                AND worker_id = $4
+                AND lock_id = $5
+                AND lock_expires_at > $6
+                RETURNING proof_id
+            "#,
+        )
+        .bind(next_lock_expiration)
+        .bind(now)
+        .bind(proof_id_bytes(proof_id))
+        .bind(ProofJobStatus::Claimed.as_str())
+        .bind(worker_id.clone())
+        .bind(lock_id.0)
+        .bind(now)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        if maybe_row.is_some() {
+            // row updated, return successfully
+            Ok(())
+        } else {
+            // read the row to return a better error
+            let row = sqlx::query(
+                r#"
+                SELECT backend, game, root_claim, l2_block_number, l1_head, proof_status,
+                    lock_id, worker_id, lock_expires_at, job_status
+                FROM proof_requests
+                WHERE proof_id = $1
+                "#,
+            )
+            .bind(proof_id_bytes(proof_id))
+            .fetch_optional(&self.pool)
+            .await?;
+            let Some(existing) = row else {
+                return Err(ProofJobQueueError::ProofIdNotFound(proof_id));
+            };
+            // validation to return a proper error
+            let stored_job_status_str: &str = existing.get("job_status");
+            let stored_lock_id: Option<Uuid> = existing.try_get("lock_id").ok();
+            let stored_worker_id: Option<String> = existing.get("worker_id");
+            let stored_lock_expires_at: Option<chrono::DateTime<Utc>> =
+                existing.get("lock_expires_at");
+            let stored_parsed_status = ProofJobStatus::try_from(stored_job_status_str)
+                .map_err(ProofJobQueueError::UnknownProofJobStatus)?;
+            if matches!(
+                stored_parsed_status,
+                ProofJobStatus::Succeeded | ProofJobStatus::Failed
+            ) {
+                return Err(ProofJobQueueError::AlreadyTerminal(proof_id));
+            }
+            if stored_parsed_status != ProofJobStatus::Claimed {
+                return Err(ProofJobQueueError::ProofJobStatusNotClaimed(
+                    ProofJobStatusErrorData {
+                        proof_id,
+                        expected: ProofJobStatus::Claimed,
+                        actual: stored_parsed_status,
+                    },
+                ));
+            }
+            if stored_lock_id != Some(lock_id.0) || stored_worker_id != Some(worker_id) {
+                return Err(ProofJobQueueError::StaleLock(proof_id));
+            }
+            if stored_lock_expires_at.is_none()
+                || stored_lock_expires_at.map_or(true, |expires_at| expires_at <= now)
+            {
+                return Err(ProofJobQueueError::StaleLock(proof_id));
+            }
+
+            Err(ProofJobQueueError::Unknown(proof_id))
+        }
+    }
+
     async fn begin_tx(
         &self,
         isolation_level: PostgresIsolationLevel,

--- a/proofs/prover-service/src/store.rs
+++ b/proofs/prover-service/src/store.rs
@@ -725,7 +725,7 @@ impl ProverServiceStore {
                 return Err(ProofJobQueueError::StaleLock(proof_id));
             }
             if stored_lock_expires_at.is_none()
-                || stored_lock_expires_at.map_or(true, |expires_at| expires_at <= now)
+                || stored_lock_expires_at.is_none_or(|expires_at| expires_at <= now)
             {
                 return Err(ProofJobQueueError::StaleLock(proof_id));
             }

--- a/proofs/prover-service/src/store.rs
+++ b/proofs/prover-service/src/store.rs
@@ -727,7 +727,7 @@ impl ProverServiceStore {
             if stored_lock_expires_at.is_none()
                 || stored_lock_expires_at.is_none_or(|expires_at| expires_at <= now)
             {
-                return Err(ProofJobQueueError::StaleLock(proof_id));
+                return Err(ProofJobQueueError::LockExpired(proof_id));
             }
 
             Err(ProofJobQueueError::Unknown(proof_id))

--- a/proofs/prover-service/src/store.rs
+++ b/proofs/prover-service/src/store.rs
@@ -662,10 +662,10 @@ impl ProverServiceStore {
             SET lock_expires_at = $1,
                 updated_at = $2
             WHERE proof_id = $3
-                AND job_status = $3
-                AND worker_id = $4
-                AND lock_id = $5
-                AND lock_expires_at > $6
+                AND job_status = $4
+                AND worker_id = $5
+                AND lock_id = $6
+                AND lock_expires_at > $7
                 RETURNING proof_id
             "#,
         )

--- a/proofs/prover-service/src/traits.rs
+++ b/proofs/prover-service/src/traits.rs
@@ -56,12 +56,16 @@ pub trait ProofJobQueue {
         lock: LockId,
     ) -> Result<(), ProofJobQueueError>;
 
+    /// Get a backend session that matches the provided proof_id and
+    /// session_type if it exists.
     async fn get_proof_session(
         &self,
         proof_id: ProofRequestId,
         session_type: SessionType,
     ) -> Result<Option<BackendSession>, ProofJobQueueError>;
 
+    /// Record a backend session tied to the provided proof_id
+    /// and session_type.
     async fn record_proof_session(
         &self,
         proof_id: ProofRequestId,

--- a/proofs/prover-service/src/traits.rs
+++ b/proofs/prover-service/src/traits.rs
@@ -75,4 +75,14 @@ pub trait ProofJobQueue {
         backend_session_id: String,
         state: BackendSessionStatus,
     ) -> Result<(), ProofJobQueueError>;
+
+    /// Ping the `prover-service` to signal that a proof worker tied
+    /// to the provided `worker_id` and `lock` is still working on
+    /// the provided `proof_id` job.
+    async fn heartbeat(
+        &self,
+        proof_id: ProofRequestId,
+        worker_id: String,
+        lock: LockId,
+    ) -> Result<(), ProofJobQueueError>;
 }


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4747/add-the-heartbeat-server-side

This PR adds the `heartbeat` api and its server side implementation.

### Next Step

- make the worker use the `heartbeat` api to periodically extend the `lock_expires_at` field

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes proof job locking behavior on a critical queue path, but reuses existing lock checks and does not yet change workers.
> 
> **Overview**
> Adds a **`heartbeat`** endpoint on the proof job queue so workers can keep a claimed job alive by refreshing **`lock_expires_at`** (and **`updated_at`**) while they still hold a valid lock.
> 
> The method is wired through **`ProofJobQueue`**, **`ProverService`**, JSON-RPC **`prover.heartbeat`**, and the integration-test **`SharedProverService`** wrapper. The store applies a conditional **`UPDATE`** only when the job is **`Claimed`**, **`worker_id`** / **`lock_id`** match, and the current lock has not expired; on success it sets expiration to **now + `lock_timeout`**. Failed updates fall through to a read path that returns the same structured errors as other worker mutations (**not found**, **terminal**, **not claimed**, **stale lock**, **expired**).
> 
> Worker-side periodic heartbeats are explicitly out of scope for this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fafe212a6b4815dae030efa3c1e2cf06ea21848b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->