### PR TITLE
feat: add heartbeat to proof worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19301,6 +19301,7 @@ dependencies = [
  "alloy-primitives",
  "anyhow",
  "async-trait",
+ "auto_impl",
  "chrono",
  "clap",
  "dotenvy",

--- a/proofs/prover-service/Cargo.toml
+++ b/proofs/prover-service/Cargo.toml
@@ -35,6 +35,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "
 tracing.workspace = true
 tracing-subscriber.workspace = true
 uuid.workspace = true
+auto_impl.workspace = true
 
 [dev-dependencies]
 testcontainers.workspace = true

--- a/proofs/prover-service/src/traits.rs
+++ b/proofs/prover-service/src/traits.rs
@@ -7,10 +7,12 @@ use crate::{
     },
 };
 use async_trait::async_trait;
+use auto_impl::auto_impl;
 
 /// It contains all methods needed for a defender to request a proof
 /// to the `prover-service`.
 #[async_trait]
+#[auto_impl(Arc)]
 pub trait ProofRequester {
     /// Send a proof request to the `prover-service`.
     ///
@@ -36,6 +38,7 @@ pub trait ProofRequester {
 /// It contains all methods needed for a prover worker to get
 /// new proof requests and submits proof responses.
 #[async_trait]
+#[auto_impl(Arc)]
 pub trait ProofJobQueue {
     /// Look for a new proof request to start on the given backend.
     ///

--- a/proofs/worker/src/heartbeat.rs
+++ b/proofs/worker/src/heartbeat.rs
@@ -1,0 +1,129 @@
+use std::time::Duration;
+use tokio::time::sleep;
+use tracing::warn;
+use world_chain_prover_service::{LockId, ProofJobQueue, ProofJobQueueError, ProofRequestId};
+
+/// Minimum proof-generation heartbeat interval.
+pub const MIN_WORKER_HEARTBEAT_INTERVAL: Duration = Duration::from_millis(1);
+
+/// Default interval between worker API heartbeats while a proof is being generated.
+pub const DEFAULT_WORKER_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Default maximum consecutive retryable heartbeat failures before aborting generation.
+pub const DEFAULT_WORKER_MAX_CONSECUTIVE_HEARTBEAT_FAILURES: u32 = 5;
+
+/// Heartbeat settings used while a worker is generating a proof.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WorkerHeartbeatConfig {
+    /// Delay between heartbeat attempts.
+    pub interval: Duration,
+    /// Maximum consecutive retryable heartbeat failures before aborting proof generation.
+    pub max_consecutive_failures: u32,
+}
+
+impl WorkerHeartbeatConfig {
+    /// Creates a heartbeat config.
+    pub const fn new(interval: Duration) -> Self {
+        Self::with_max_consecutive_failures(
+            interval,
+            DEFAULT_WORKER_MAX_CONSECUTIVE_HEARTBEAT_FAILURES,
+        )
+    }
+
+    /// Creates a heartbeat config with an explicit retryable failure limit.
+    pub const fn with_max_consecutive_failures(
+        interval: Duration,
+        max_consecutive_failures: u32,
+    ) -> Self {
+        Self {
+            interval,
+            max_consecutive_failures,
+        }
+    }
+
+    /// Returns the configured interval clamped to the minimum allowed delay.
+    pub fn normalized_interval(&self) -> Duration {
+        self.interval.max(MIN_WORKER_HEARTBEAT_INTERVAL)
+    }
+
+    /// Returns the configured retryable failure limit clamped to at least one.
+    pub const fn normalized_max_consecutive_failures(&self) -> u32 {
+        if self.max_consecutive_failures == 0 {
+            1
+        } else {
+            self.max_consecutive_failures
+        }
+    }
+}
+
+impl Default for WorkerHeartbeatConfig {
+    fn default() -> Self {
+        Self::new(DEFAULT_WORKER_HEARTBEAT_INTERVAL)
+    }
+}
+
+/// Worker heartbeat delivery.
+#[derive(Debug)]
+pub struct WorkerHeartbeat<Q> {
+    proof_id: ProofRequestId,
+    worker_id: String,
+    lock_id: LockId,
+    config: WorkerHeartbeatConfig,
+    queue: Q,
+}
+
+impl<Q: ProofJobQueue> WorkerHeartbeat<Q> {
+    /// Create a new [WorkerHeartbeat] with the provided proof_id,
+    ///  worker_id, lock_id, config and queue.
+    pub fn new(
+        proof_id: ProofRequestId,
+        worker_id: String,
+        lock_id: LockId,
+        config: WorkerHeartbeatConfig,
+        queue: Q,
+    ) -> Self {
+        Self {
+            proof_id,
+            worker_id,
+            lock_id,
+            config,
+            queue,
+        }
+    }
+
+    /// Sends heartbeats until a non-recoverable heartbeat failure occurs.
+    pub async fn run_until_failure(&self) -> ProofJobQueueError {
+        let max_consecutive_failures = self.config.normalized_max_consecutive_failures();
+        let mut consecutive_failures = 0;
+
+        loop {
+            sleep(self.config.normalized_interval()).await;
+
+            match self
+                .queue
+                .heartbeat(self.proof_id, self.worker_id.clone(), self.lock_id)
+                .await
+            {
+                Ok(_) => {
+                    consecutive_failures = 0;
+                }
+                Err(error) if error.is_retryable() => {
+                    consecutive_failures += 1;
+
+                    if consecutive_failures >= max_consecutive_failures {
+                        warn!(
+                            lock_id = %self.lock_id,
+                            worker_id = %self.worker_id,
+                            consecutive_failures,
+                            max_consecutive_failures,
+                            error = %error,
+                            "proof job heartbeat retryable failures exceeded limit"
+                        );
+                        return error;
+                    }
+                }
+                Err(error) => return error,
+            }
+        }
+    }
+}

--- a/proofs/worker/src/lib.rs
+++ b/proofs/worker/src/lib.rs
@@ -16,6 +16,7 @@
 //! rather than re-run completed phases.
 
 mod backend;
+mod heartbeat;
 mod retry;
 mod worker;
 

--- a/proofs/worker/src/worker.rs
+++ b/proofs/worker/src/worker.rs
@@ -294,6 +294,7 @@ fn spawn_job<Q, B>(
             };
 
             tokio::select! {
+                biased;
                 _ = proof_and_submit_task => {},
                 lease_lost = &mut heartbeat => {
                     warn!(%lease_lost, "heartbeat failed, cancelling proof job");

--- a/proofs/worker/src/worker.rs
+++ b/proofs/worker/src/worker.rs
@@ -18,6 +18,7 @@ use world_chain_prover_service::{LockedProofRequest, ProofJobQueue, SucceededPro
 
 use crate::{
     backend::{ClaimedProofJobHandler, JobSessions, ProofJob},
+    heartbeat::{WorkerHeartbeat, WorkerHeartbeatConfig},
     retry::RetryConfig,
 };
 
@@ -251,37 +252,54 @@ fn spawn_job<Q, B>(
                 sessions,
             };
 
-            match backend.handle_claimed_job(job).await {
-                Ok(proof) => {
-                    let response = SucceededProofResponse {
-                        id: proof_id,
-                        proof,
-                    };
-                    let submit_result = (|| async {
-                        queue
-                            .submit_proof(response.clone(), worker_id.clone(), lock_id)
-                            .await
-                    })
-                    .retry(retry_config.to_backoff_builder())
-                    .when(|err| err.is_retryable())
-                    .notify(|error, delay| {
-                        warn!(%error, ?delay, "failed to submit proof, retrying");
-                    })
-                    .await;
-                    match submit_result {
-                        Ok(()) => info!("proof submitted"),
-                        Err(error) => warn!(
-                            %error,
-                            "failed to submit proof after retries, lease will expire and re-queue"
-                        ),
+            let worker_heartbeat_config = WorkerHeartbeatConfig::default();
+            let worker_heartbeat =
+                WorkerHeartbeat::new(proof_id, worker_id.clone(), lock_id, worker_heartbeat_config, queue.clone());
+            let heartbeat = worker_heartbeat.run_until_failure();
+            tokio::pin!(heartbeat);
+
+            let proof_and_submit_task = async move {
+                let queue = queue.clone();
+                match backend.handle_claimed_job(job).await {
+                    Ok(proof) => {
+                        let response = SucceededProofResponse {
+                            id: proof_id,
+                            proof,
+                        };
+                        let submit_result = (|| async {
+                            queue
+                                .submit_proof(response.clone(), worker_id.clone(), lock_id)
+                                .await
+                        })
+                        .retry(retry_config.to_backoff_builder())
+                        .when(|err| err.is_retryable())
+                        .notify(|error, delay| {
+                            warn!(%error, ?delay, "failed to submit proof, retrying");
+                        })
+                        .await;
+                        match submit_result {
+                            Ok(()) => info!("proof submitted"),
+                            Err(error) => warn!(
+                                %error,
+                                "failed to submit proof after retries, lease will expire and re-queue"
+                            ),
+                        }
                     }
+                    // `{:#}` renders the full anyhow context chain into the failure reason.
+                    Err(error) => warn!(
+                        reason = %format!("{error:#}"),
+                        "proving failed, lease will expire and re-queue"
+                    ),
                 }
-                // `{:#}` renders the full anyhow context chain into the failure reason.
-                Err(error) => warn!(
-                    reason = %format!("{error:#}"),
-                    "proving failed, lease will expire and re-queue"
-                ),
-            }
+            };
+
+            tokio::select! {
+                _ = proof_and_submit_task => {},
+                lease_lost = &mut heartbeat => {
+                    warn!(%lease_lost, "heartbeat failed, cancelling proof job");
+                    return;
+                }
+            };
         }
         .instrument(span),
     );

--- a/proofs/worker/src/worker.rs
+++ b/proofs/worker/src/worker.rs
@@ -14,7 +14,9 @@ use tokio::{
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, info, info_span, warn};
-use world_chain_prover_service::{LockedProofRequest, ProofJobQueue, SucceededProofResponse};
+use world_chain_prover_service::{
+    LockedProofRequest, ProofJobQueue, ProofJobQueueError, SucceededProofResponse,
+};
 
 use crate::{
     backend::{ClaimedProofJobHandler, JobSessions, ProofJob},
@@ -253,20 +255,67 @@ fn spawn_job<Q, B>(
             };
 
             let worker_heartbeat_config = WorkerHeartbeatConfig::default();
-            let worker_heartbeat =
-                WorkerHeartbeat::new(proof_id, worker_id.clone(), lock_id, worker_heartbeat_config, queue.clone());
+            let worker_heartbeat = WorkerHeartbeat::new(
+                proof_id,
+                worker_id.clone(),
+                lock_id,
+                worker_heartbeat_config,
+                queue.clone(),
+            );
             let heartbeat = worker_heartbeat.run_until_failure();
             tokio::pin!(heartbeat);
 
-            let proof_and_submit_task = async move {
-                let queue = queue.clone();
-                match backend.handle_claimed_job(job).await {
-                    Ok(proof) => {
-                        let response = SucceededProofResponse {
-                            id: proof_id,
-                            proof,
-                        };
-                        let submit_result = (|| async {
+            let proof_result = tokio::select! {
+                biased;
+                result = backend.handle_claimed_job(job) => result,
+                lease_lost = &mut heartbeat => {
+                    warn!(%lease_lost, "heartbeat failed, cancelling proof job");
+                    return;
+                }
+            };
+
+            let proof = match proof_result {
+                Ok(proof) => proof,
+                // `{:#}` renders the full anyhow context chain into the failure reason.
+                Err(error) => {
+                    warn!(
+                        reason = %format!("{error:#}"),
+                        "proving failed, lease will expire and re-queue"
+                    );
+                    return;
+                }
+            };
+
+            let response = SucceededProofResponse {
+                id: proof_id,
+                proof,
+            };
+
+            let submit_proof = async {
+                (|| async {
+                    queue
+                        .submit_proof(response.clone(), worker_id.clone(), lock_id)
+                        .await
+                })
+                .retry(retry_config.to_backoff_builder())
+                .when(|err| err.is_retryable())
+                .notify(|error, delay| {
+                    warn!(%error, ?delay, "failed to submit proof, retrying");
+                })
+                .await
+            };
+
+            let submit_result = tokio::select! {
+                biased;
+                submit_result = submit_proof => submit_result,
+                lease_lost = &mut heartbeat => {
+                    if matches!(lease_lost, ProofJobQueueError::AlreadyTerminal(_)) {
+                        // When the submit_proof work submits the proof, it changes the job status to succeeded.
+                        // If shortly after that, the heartbeat tries to extend the lock, the heartbeat will fail
+                        // becasue the job status is not claimed anymore, therefore returns `AlreadyTerminal`.
+                        // In this case, try the `submit_proof` idempotent operation again. This should return
+                        // Ok(()) if everything is fine.
+                        (|| async {
                             queue
                                 .submit_proof(response.clone(), worker_id.clone(), lock_id)
                                 .await
@@ -276,31 +325,21 @@ fn spawn_job<Q, B>(
                         .notify(|error, delay| {
                             warn!(%error, ?delay, "failed to submit proof, retrying");
                         })
-                        .await;
-                        match submit_result {
-                            Ok(()) => info!("proof submitted"),
-                            Err(error) => warn!(
-                                %error,
-                                "failed to submit proof after retries, lease will expire and re-queue"
-                            ),
-                        }
+                        .await
+                    } else {
+                        warn!(%lease_lost, "heartbeat failed, cancelling proof job");
+                        return;
                     }
-                    // `{:#}` renders the full anyhow context chain into the failure reason.
-                    Err(error) => warn!(
-                        reason = %format!("{error:#}"),
-                        "proving failed, lease will expire and re-queue"
-                    ),
                 }
             };
 
-            tokio::select! {
-                biased;
-                _ = proof_and_submit_task => {},
-                lease_lost = &mut heartbeat => {
-                    warn!(%lease_lost, "heartbeat failed, cancelling proof job");
-                    return;
-                }
-            };
+            match submit_result {
+                Ok(()) => info!("proof submitted"),
+                Err(error) => warn!(
+                    %error,
+                    "failed to submit proof after retries, lease will expire and re-queue"
+                ),
+            }
         }
         .instrument(span),
     );


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4748/add-the-heartbeat-worker-side

### Important Notes

- this PR adds the `heartbeat` to the proof worker such that concurrently to the proof backend work, the proof worker periodically pings the `prover-service` to extend the `lock_expires_at` field of the proof request it's working on, to signal that it's still working on it.
- Currently, both nitro and sp1 are not super async friendly because they have `block_in_place` in some parts of their underlying code. This is not a good solution long term because it makes the heartbeat system way weaker. For example for sp1, the heartbeat is never called if the sp1 task is inside the `block_in_place` part of its code (which is the entire sp1 proof generation path). Therefore in follow up PRs, I'll refactor both nitro and sp1 proof backend to make them async friendly, which is the ultimate goal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core proof-worker job lifecycle and lock semantics; incorrect heartbeat/submit racing could drop or duplicate work, though mitigated by lease expiry and idempotent submit.
> 
> **Overview**
> While a worker runs **`handle_claimed_job`**, it now runs a background **`WorkerHeartbeat`** that calls **`ProofJobQueue::heartbeat`** on a default **30s** interval (with retry limits on transient failures) so the prover-service can extend **`lock_expires_at`** and avoid premature re-queueing.
> 
> Job completion is coordinated with **`tokio::select!`**: heartbeat loss aborts proving/submit except when the heartbeat returns **`AlreadyTerminal`** after a successful submit, in which case submit is retried idempotently. **`#[auto_impl(Arc)]`** was added on **`ProofRequester`** and **`ProofJobQueue`** so the worker can **`clone()`** the queue for the heartbeat task.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cad3455dfcc560a059f0fbe846eed7ea23df1e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->