### PR TITLE
feat: make nitro backend async friendly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19094,6 +19094,7 @@ dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
  "anyhow",
+ "async-trait",
  "aws-nitro-enclaves-nsm-api",
  "base64 0.22.1",
  "ciborium",

--- a/proofs/kona-host/src/online.rs
+++ b/proofs/kona-host/src/online.rs
@@ -19,7 +19,7 @@ use anyhow::{Context, anyhow, bail};
 use kona_host::{DataFormat, single::SingleChainHost};
 use kona_preimage::{BidirectionalChannel, HintWriter, NativeChannel, OracleReader};
 use kona_proof::{CachingOracle, l1::OracleBlobProvider};
-use reqwest::blocking::Client;
+use reqwest::Client;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::{Value, json};
 use world_chain_proof_core::{
@@ -242,7 +242,7 @@ struct RpcError {
 ///
 /// Synchronous: creates its own Tokio runtime for the Kona host, so it must run on a
 /// blocking-capable thread (not inside an async task).
-pub fn build_range_input(
+pub async fn build_range_input(
     config: &OnlineHostConfig,
     request: RangeWitnessRequest,
 ) -> anyhow::Result<RangeProofInput> {
@@ -255,7 +255,7 @@ pub fn build_range_input(
     }
 
     let client = Client::new();
-    let finalized_l2_head = finalized_l2_head(&client, &config.l2_rpc)?;
+    let finalized_l2_head = finalized_l2_head(&client, &config.l2_rpc).await?;
     if !request.allow_unfinalized && finalized_l2_head.is_some_and(|head| request.end_block > head)
     {
         bail!(
@@ -269,16 +269,20 @@ pub fn build_range_input(
         &client,
         &config.l2_rpc,
         BlockTag::Number(request.start_block),
-    )?;
-    let post_block = get_block(&client, &config.l2_rpc, BlockTag::Number(request.end_block))?;
-    let pre_state = output_root_witness(&client, &config.l2_rpc, request.start_block, &pre_block)?;
-    let post_state = output_root_witness(&client, &config.l2_rpc, request.end_block, &post_block)?;
+    )
+    .await?;
+    let post_block =
+        get_block(&client, &config.l2_rpc, BlockTag::Number(request.end_block)).await?;
+    let pre_state =
+        output_root_witness(&client, &config.l2_rpc, request.start_block, &pre_block).await?;
+    let post_state =
+        output_root_witness(&client, &config.l2_rpc, request.end_block, &post_block).await?;
     let pre_root = pre_state.output_root();
     let post_root = post_state.output_root();
 
     let l1_head = match request.l1_head {
         Some(hash) => hash,
-        None => resolve_l1_head(&client, &config.l2_rpc, &config.l1_rpc, request.end_block)?,
+        None => resolve_l1_head(&client, &config.l2_rpc, &config.l1_rpc, request.end_block).await?,
     };
 
     let active_fork = config
@@ -308,11 +312,8 @@ pub fn build_range_input(
         l1_config_path: None,
     };
 
-    let witness = tokio::runtime::Runtime::new()?.block_on(collect_world_range_witness(
-        host,
-        config.schedule.clone(),
-        config.witness_timeout,
-    ))?;
+    let witness =
+        collect_world_range_witness(host, config.schedule.clone(), config.witness_timeout).await?;
 
     Ok(RangeProofInput {
         metadata: RangeMetadata {
@@ -437,27 +438,29 @@ async fn collect_witness_from_channels(
 }
 
 /// Fetches the finalized L2 head block number, when the RPC exposes one.
-pub fn finalized_l2_head(client: &Client, rpc_url: &str) -> anyhow::Result<Option<u64>> {
+pub async fn finalized_l2_head(client: &Client, rpc_url: &str) -> anyhow::Result<Option<u64>> {
     Ok(rpc::<RpcBlock>(
         client,
         rpc_url,
         "eth_getBlockByNumber",
         json!(["finalized", false]),
-    )?
+    )
+    .await?
     .map(|b| b.number.0))
 }
 
-fn get_block(client: &Client, rpc_url: &str, tag: BlockTag) -> anyhow::Result<RpcBlock> {
+async fn get_block(client: &Client, rpc_url: &str, tag: BlockTag) -> anyhow::Result<RpcBlock> {
     rpc(
         client,
         rpc_url,
         "eth_getBlockByNumber",
         json!([tag.to_rpc_value(), false]),
-    )?
+    )
+    .await?
     .with_context(|| format!("eth_getBlockByNumber returned null for {}", tag.display()))
 }
 
-fn output_root_witness(
+async fn output_root_witness(
     client: &Client,
     rpc_url: &str,
     block_number: u64,
@@ -472,11 +475,14 @@ fn output_root_witness(
             Vec::<String>::new(),
             BlockTag::Number(block_number).to_rpc_value(),
         ]),
-    ) {
+    )
+    .await
+    {
         Ok(Some(proof)) => proof,
         Ok(None) => bail!("eth_getProof returned null"),
         Err(proof_err) => {
             return output_root_witness_from_op_node(client, rpc_url, block_number, block)
+                .await
                 .with_context(|| format!("eth_getProof failed first: {proof_err}"));
         }
     };
@@ -488,7 +494,7 @@ fn output_root_witness(
     })
 }
 
-fn output_root_witness_from_op_node(
+async fn output_root_witness_from_op_node(
     client: &Client,
     rpc_url: &str,
     block_number: u64,
@@ -499,7 +505,8 @@ fn output_root_witness_from_op_node(
         rpc_url,
         "optimism_outputAtBlock",
         json!([BlockTag::Number(block_number).to_rpc_value()]),
-    )?
+    )
+    .await?
     .context("optimism_outputAtBlock returned null")?;
 
     let witness = OutputRootWitness {
@@ -518,21 +525,27 @@ fn output_root_witness_from_op_node(
 }
 
 /// Resolves a finalized L1 head past the range's L1 origin, mirroring the proposer's choice.
-pub fn resolve_l1_head(
+pub async fn resolve_l1_head(
     client: &Client,
     l2_rpc: &str,
     l1_rpc: &str,
     end_block: u64,
 ) -> anyhow::Result<B256> {
-    let l1_origin_number = l1_origin_number(client, l2_rpc, end_block)?;
-    let finalized_l1 = get_block(client, l1_rpc, BlockTag::Finalized)?;
+    let l1_origin_number = l1_origin_number(client, l2_rpc, end_block).await?;
+    let finalized_l1 = get_block(client, l1_rpc, BlockTag::Finalized).await?;
     let target = l1_origin_number
         .saturating_add(20)
         .min(finalized_l1.number.0);
-    Ok(get_block(client, l1_rpc, BlockTag::Number(target))?.hash)
+    Ok(get_block(client, l1_rpc, BlockTag::Number(target))
+        .await?
+        .hash)
 }
 
-fn l1_origin_number(client: &Client, rpc_url: &str, block_number: u64) -> anyhow::Result<u64> {
+async fn l1_origin_number(
+    client: &Client,
+    rpc_url: &str,
+    block_number: u64,
+) -> anyhow::Result<u64> {
     let selector = &keccak256("number()")[..4];
     let result: String = rpc(
         client,
@@ -545,7 +558,8 @@ fn l1_origin_number(client: &Client, rpc_url: &str, block_number: u64) -> anyhow
             },
             BlockTag::Number(block_number).to_rpc_value(),
         ]),
-    )?
+    )
+    .await?
     .context("eth_call to L1Block.number() returned null")?;
 
     parse_hex_u64_word(&result)
@@ -564,18 +578,19 @@ fn parse_hex_u64_word(value: &str) -> anyhow::Result<u64> {
 }
 
 /// Fetches an L1 header by hash, e.g. the checkpoint head consumed by the aggregation guest.
-pub fn fetch_l1_header_by_hash(
+pub async fn fetch_l1_header_by_hash(
     client: &Client,
     rpc_url: &str,
     hash: B256,
 ) -> anyhow::Result<alloy_consensus::Header> {
-    let block_json: Value = rpc(client, rpc_url, "eth_getBlockByHash", json!([hash, false]))?
+    let block_json: Value = rpc(client, rpc_url, "eth_getBlockByHash", json!([hash, false]))
+        .await?
         .with_context(|| format!("eth_getBlockByHash returned null for {hash:?}"))?;
     serde_json::from_value(block_json).context("failed to deserialize L1 block header")
 }
 
 /// Minimal blocking JSON-RPC call helper.
-pub fn rpc<T: DeserializeOwned>(
+pub async fn rpc<T: DeserializeOwned>(
     client: &Client,
     rpc_url: &str,
     method: &str,
@@ -590,10 +605,12 @@ pub fn rpc<T: DeserializeOwned>(
             "params": params,
         }))
         .send()
+        .await
         .with_context(|| format!("failed to call {method}"))?
         .error_for_status()
         .with_context(|| format!("{method} returned HTTP error"))?
         .json()
+        .await
         .with_context(|| format!("failed to decode {method} response"))?;
 
     if let Some(error) = response.error {

--- a/proofs/nitro/Cargo.toml
+++ b/proofs/nitro/Cargo.toml
@@ -61,6 +61,7 @@ thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
 world-chain-proof-core.workspace = true
+async-trait.workspace = true
 
 # Host-side attestation verification deps (non-optional: used by parse_check_and_verify) --
 # These are compiled on all platforms; the p384 / x509-parser crates are pure Rust and

--- a/proofs/nitro/src/host.rs
+++ b/proofs/nitro/src/host.rs
@@ -1,5 +1,6 @@
 //! Host-side `NitroProver` that talks to a running Nitro enclave over vsock.
 
+use async_trait::async_trait;
 use k256::ecdsa::{RecoveryId, Signature as K256Signature, VerifyingKey};
 use tokio_vsock::{VsockAddr, VsockStream};
 use tracing::{debug, instrument, warn};
@@ -276,6 +277,7 @@ fn aggregation_outputs(
     }
 }
 
+#[async_trait]
 impl WorldNitroProver for NitroProver {
     type Error = NitroProverError;
 
@@ -283,14 +285,14 @@ impl WorldNitroProver for NitroProver {
         &self,
         request: NitroRangeProofRequest,
     ) -> Result<NitroRangeProofArtifact, Self::Error> {
-        self.prove_range_async(request)
+        self.prove_range_async(request).await
     }
 
     async fn prove_aggregation(
         &self,
         request: NitroAggregationProofRequest,
     ) -> Result<NitroAggregationProofArtifact, Self::Error> {
-        self.prove_aggregation_async(request)
+        self.prove_aggregation_async(request).await
     }
 }
 

--- a/proofs/nitro/src/host.rs
+++ b/proofs/nitro/src/host.rs
@@ -45,31 +45,15 @@ impl EnclaveEndpoint {
 pub struct NitroProver {
     endpoint: EnclaveEndpoint,
     expected_pcrs: ExpectedPcrs,
-    runtime: tokio::runtime::Handle,
 }
 
 impl NitroProver {
-    /// Creates a new prover bound to the current tokio runtime.
-    ///
-    /// # Panics
-    /// Panics if no tokio runtime is currently active. Use [`NitroProver::with_runtime`]
-    /// when calling from a non-async context.
+    /// Creates a new prover.
     #[must_use]
     pub fn new(endpoint: EnclaveEndpoint, expected_pcrs: ExpectedPcrs) -> Self {
-        Self::with_runtime(endpoint, expected_pcrs, tokio::runtime::Handle::current())
-    }
-
-    /// Creates a new prover with an explicit tokio runtime handle.
-    #[must_use]
-    pub fn with_runtime(
-        endpoint: EnclaveEndpoint,
-        expected_pcrs: ExpectedPcrs,
-        runtime: tokio::runtime::Handle,
-    ) -> Self {
         Self {
             endpoint,
             expected_pcrs,
-            runtime,
         }
     }
 
@@ -295,22 +279,18 @@ fn aggregation_outputs(
 impl WorldNitroProver for NitroProver {
     type Error = NitroProverError;
 
-    fn prove_range(
+    async fn prove_range(
         &self,
         request: NitroRangeProofRequest,
     ) -> Result<NitroRangeProofArtifact, Self::Error> {
-        let runtime = self.runtime.clone();
-        let prover = self.clone();
-        runtime.block_on(prover.prove_range_async(request))
+        self.prove_range_async(request)
     }
 
-    fn prove_aggregation(
+    async fn prove_aggregation(
         &self,
         request: NitroAggregationProofRequest,
     ) -> Result<NitroAggregationProofArtifact, Self::Error> {
-        let runtime = self.runtime.clone();
-        let prover = self.clone();
-        runtime.block_on(prover.prove_aggregation_async(request))
+        self.prove_aggregation_async(request)
     }
 }
 

--- a/proofs/nitro/src/lib.rs
+++ b/proofs/nitro/src/lib.rs
@@ -26,6 +26,7 @@
 //!
 //! The enclave-side guest is the `world-chain-nitro-enclave` binary (`src/enclave.rs`).
 
+use async_trait::async_trait;
 // clap is used by the p384-hints binary; reference it here so the
 // `unused_crate_dependencies` lint does not fire on the lib target.
 use clap as _;
@@ -208,18 +209,19 @@ pub struct NitroAggregationProofArtifact {
 ///
 /// Modeled after [`world_chain_proof_succinct_proof_utils::WorldSuccinctProver`], but the
 /// request and artifact types carry attestation material instead of ZK proofs.
+#[async_trait]
 pub trait WorldNitroProver {
     /// Backend-specific error type.
     type Error;
 
     /// Proves one range witness inside an attested execution environment.
-    fn prove_range(
+    async fn prove_range(
         &self,
         request: NitroRangeProofRequest,
     ) -> Result<NitroRangeProofArtifact, Self::Error>;
 
     /// Aggregates already-attested range proofs.
-    fn prove_aggregation(
+    async fn prove_aggregation(
         &self,
         request: NitroAggregationProofRequest,
     ) -> Result<NitroAggregationProofArtifact, Self::Error>;

--- a/proofs/nitro/worker/src/lib.rs
+++ b/proofs/nitro/worker/src/lib.rs
@@ -96,7 +96,6 @@ impl ClaimedProofJobHandler for NitroBackend {
         let prover =
             NitroProver::with_runtime(endpoint, self.config.expected_pcrs, self.rt_handle.clone());
 
-        // Witness generation is synchronous and heavy; keep it off the async scheduler.
         let input = build_range_input(
             &self.config.online,
             RangeWitnessRequest {

--- a/proofs/nitro/worker/src/lib.rs
+++ b/proofs/nitro/worker/src/lib.rs
@@ -61,13 +61,11 @@ struct NitroBackendConfig {
 
 struct NitroBackend {
     config: NitroBackendConfig,
-    /// Handle to the async runtime so we can call async enclave methods from `prove`.
-    rt_handle: tokio::runtime::Handle,
 }
 
 impl NitroBackend {
-    fn new(config: NitroBackendConfig, rt_handle: tokio::runtime::Handle) -> Self {
-        Self { config, rt_handle }
+    fn new(config: NitroBackendConfig) -> Self {
+        Self { config }
     }
 }
 
@@ -93,8 +91,7 @@ impl ClaimedProofJobHandler for NitroBackend {
 
         let endpoint =
             EnclaveEndpoint::with_port(self.config.enclave_cid, self.config.enclave_port);
-        let prover =
-            NitroProver::with_runtime(endpoint, self.config.expected_pcrs, self.rt_handle.clone());
+        let prover = NitroProver::new(endpoint, self.config.expected_pcrs);
 
         let input = build_range_input(
             &self.config.online,
@@ -294,7 +291,7 @@ struct Cli {
 // Entry point
 // ──────────────────────────────────────────────────────────────────────────────────────
 
-pub fn run() -> Result<()> {
+pub async fn run() -> Result<()> {
     dotenvy::dotenv().ok();
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
@@ -330,14 +327,6 @@ pub fn run() -> Result<()> {
         "nitro-worker starting"
     );
 
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .thread_name("nitro-worker")
-        .worker_threads(2)
-        .max_blocking_threads(4)
-        .build()
-        .context("failed to build tokio runtime")?;
-
     let backend_config = NitroBackendConfig {
         block_interval: cli.block_interval,
         online,
@@ -346,7 +335,7 @@ pub fn run() -> Result<()> {
         expected_pcrs,
     };
 
-    let backend = NitroBackend::new(backend_config, runtime.handle().clone());
+    let backend = NitroBackend::new(backend_config);
 
     let queue = RpcProverServiceClient::new(&cli.prover_service_url)
         .with_context(|| format!("failed to connect to {}", cli.prover_service_url))?;
@@ -370,15 +359,7 @@ pub fn run() -> Result<()> {
         },
     );
 
-    let token = worker.cancellation_token();
-    runtime.spawn(async move {
-        if tokio::signal::ctrl_c().await.is_ok() {
-            info!("received ctrl-c, shutting down");
-            token.cancel();
-        }
-    });
-
-    runtime.block_on(worker);
+    worker.await;
     Ok(())
 }
 

--- a/proofs/nitro/worker/src/lib.rs
+++ b/proofs/nitro/worker/src/lib.rs
@@ -359,6 +359,16 @@ pub async fn run() -> Result<()> {
         },
     );
 
+    // Ctrl-C triggers a graceful shutdown: the worker stops leasing, signals the backend to
+    // shut down, and resolves.
+    let token = worker.cancellation_token();
+    tokio::spawn(async move {
+        if tokio::signal::ctrl_c().await.is_ok() {
+            info!("received ctrl-c, shutting down");
+            token.cancel();
+        }
+    });
+
     worker.await;
     Ok(())
 }

--- a/proofs/nitro/worker/src/lib.rs
+++ b/proofs/nitro/worker/src/lib.rs
@@ -97,17 +97,16 @@ impl ClaimedProofJobHandler for NitroBackend {
             NitroProver::with_runtime(endpoint, self.config.expected_pcrs, self.rt_handle.clone());
 
         // Witness generation is synchronous and heavy; keep it off the async scheduler.
-        let input = tokio::task::block_in_place(|| {
-            build_range_input(
-                &self.config.online,
-                RangeWitnessRequest {
-                    start_block,
-                    end_block: request.l2_block_number,
-                    l1_head: Some(request.l1_head),
-                    allow_unfinalized: false,
-                },
-            )
-        })
+        let input = build_range_input(
+            &self.config.online,
+            RangeWitnessRequest {
+                start_block,
+                end_block: request.l2_block_number,
+                l1_head: Some(request.l1_head),
+                allow_unfinalized: false,
+            },
+        )
+        .await
         .context("witness generation failed")?;
 
         let nitro_request = NitroRangeProofRequest::from_witness_data(&input.witness, None)

--- a/proofs/nitro/worker/src/main.rs
+++ b/proofs/nitro/worker/src/main.rs
@@ -1,11 +1,12 @@
-fn main() {
+#[tokio::main]
+async fn main() {
     #[cfg(not(target_os = "linux"))]
     {
         eprintln!("nitro-worker requires Linux (AF_VSOCK)");
         std::process::exit(1);
     }
     #[cfg(target_os = "linux")]
-    if let Err(e) = world_chain_nitro_worker::run() {
+    if let Err(e) = world_chain_nitro_worker::run().await {
         eprintln!("error: {e:#}");
         std::process::exit(1);
     }

--- a/proofs/prover-nitro/src/main.rs
+++ b/proofs/prover-nitro/src/main.rs
@@ -97,12 +97,7 @@ async fn nitro_prove(args: NitroArgs) -> Result<()> {
     let request = NitroRangeProofRequest::from_witness_data(&input.witness, None)
         .map_err(|e| anyhow!("failed to serialize witness: {e}"))?;
 
-    let rt = tokio::runtime::Runtime::new()?;
-    let prover = NitroProver::with_runtime(
-        EnclaveEndpoint::new(args.cid),
-        expected_pcrs,
-        rt.handle().clone(),
-    );
+    let prover = NitroProver::new(EnclaveEndpoint::new(args.cid), expected_pcrs);
 
     println!(
         "sending range {start}..={end} to enclave (cid {cid})",
@@ -111,8 +106,9 @@ async fn nitro_prove(args: NitroArgs) -> Result<()> {
         cid = args.cid,
     );
 
-    let artifact = rt
-        .block_on(prover.prove_range_async(request))
+    let artifact = prover
+        .prove_range_async(request)
+        .await
         .map_err(|e| anyhow!("enclave proving failed: {e}"))?;
 
     println!(

--- a/proofs/prover-nitro/src/main.rs
+++ b/proofs/prover-nitro/src/main.rs
@@ -54,20 +54,21 @@ struct NitroArgs {
     output: Option<PathBuf>,
 }
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     match Cli::parse().command {
-        Command::HashRollupConfig(args) => print_rollup_config_hash(args)?,
-        Command::Witness(args) => write_witness(args)?,
-        Command::Prove(args) => nitro_prove(args)?,
+        Command::HashRollupConfig(args) => print_rollup_config_hash(args).await?,
+        Command::Witness(args) => write_witness(args).await?,
+        Command::Prove(args) => nitro_prove(args).await?,
     }
 
     Ok(())
 }
 
 #[cfg(target_os = "linux")]
-fn nitro_prove(args: NitroArgs) -> Result<()> {
+async fn nitro_prove(args: NitroArgs) -> Result<()> {
     use anyhow::anyhow;
     use world_chain_proof_nitro::{
         ExpectedPcrs, NitroRangeProofRequest,
@@ -77,7 +78,7 @@ fn nitro_prove(args: NitroArgs) -> Result<()> {
     };
     use world_chain_prover::{build_range_input_from_args, write_json};
 
-    let input = build_range_input_from_args(&args.rpc)?;
+    let input = build_range_input_from_args(&args.rpc).await?;
 
     let expected_pcrs = match (args.pcr0, args.pcr1, args.pcr2) {
         (Some(p0), Some(p1), Some(p2)) => ExpectedPcrs {
@@ -147,7 +148,7 @@ fn nitro_prove(args: NitroArgs) -> Result<()> {
 }
 
 #[cfg(not(target_os = "linux"))]
-fn nitro_prove(_args: NitroArgs) -> Result<()> {
+async fn nitro_prove(_args: NitroArgs) -> Result<()> {
     bail!("world-chain-prover-nitro requires Linux with AF_VSOCK support")
 }
 

--- a/proofs/prover-sp1/src/main.rs
+++ b/proofs/prover-sp1/src/main.rs
@@ -91,21 +91,22 @@ struct Sp1VkeysArgs {
     output: Option<PathBuf>,
 }
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     match Cli::parse().command {
-        Command::HashRollupConfig(args) => print_rollup_config_hash(args)?,
-        Command::Witness(args) => write_witness(args)?,
-        Command::Execute(args) => sp1_execute(args)?,
-        Command::Prove(args) => sp1_prove(*args)?,
-        Command::Vkeys(args) => sp1_vkeys(args)?,
+        Command::HashRollupConfig(args) => print_rollup_config_hash(args).await?,
+        Command::Witness(args) => write_witness(args).await?,
+        Command::Execute(args) => sp1_execute(args).await?,
+        Command::Prove(args) => sp1_prove(*args).await?,
+        Command::Vkeys(args) => sp1_vkeys(args).await?,
     }
 
     Ok(())
 }
 
-fn sp1_execute(args: Sp1ExecuteArgs) -> Result<()> {
+async fn sp1_execute(args: Sp1ExecuteArgs) -> Result<()> {
     use sp1_sdk::{Prover, ProverClient, SP1Stdin};
 
     let witness_bytes = fs::read(&args.witness)
@@ -116,21 +117,19 @@ fn sp1_execute(args: Sp1ExecuteArgs) -> Result<()> {
     let mut stdin = SP1Stdin::new();
     stdin.write_vec(witness_bytes);
 
-    tokio::runtime::Runtime::new()?.block_on(async {
-        let client = ProverClient::builder().cpu().build().await;
-        let (public_values, report) = client
-            .execute(elf.into(), stdin)
-            .await
-            .context("SP1 execution failed")?;
+    let client = ProverClient::builder().cpu().build().await;
+    let (public_values, report) = client
+        .execute(elf.into(), stdin)
+        .await
+        .context("SP1 execution failed")?;
 
-        println!("execution succeeded");
-        println!("total cycles:  {}", report.total_instruction_count());
-        println!("public values: 0x{}", hex::encode(public_values.as_slice()));
-        Ok(())
-    })
+    println!("execution succeeded");
+    println!("total cycles:  {}", report.total_instruction_count());
+    println!("public values: 0x{}", hex::encode(public_values.as_slice()));
+    Ok(())
 }
 
-fn sp1_prove(args: Sp1ProveArgs) -> Result<()> {
+async fn sp1_prove(args: Sp1ProveArgs) -> Result<()> {
     use sp1_sdk::SP1ProofMode;
     use world_chain_proof_succinct_host_utils::{
         prover::SuccinctProver,
@@ -167,7 +166,8 @@ fn sp1_prove(args: Sp1ProveArgs) -> Result<()> {
             split_count: args.ranges.max(1),
             prover_address: args.prover_address,
         },
-    )?;
+    )
+    .await?;
 
     println!(
         "aggregation proof complete: block {block} pre={pre:?} post={post:?}",
@@ -184,7 +184,7 @@ fn sp1_prove(args: Sp1ProveArgs) -> Result<()> {
     Ok(())
 }
 
-fn sp1_vkeys(args: Sp1VkeysArgs) -> Result<()> {
+async fn sp1_vkeys(args: Sp1VkeysArgs) -> Result<()> {
     use anyhow::anyhow;
     use sp1_sdk::{CpuProver, HashableKey, Prover, ProvingKey, env::EnvProver};
     use world_chain_proof_core::types::u32_to_u8;
@@ -194,21 +194,20 @@ fn sp1_vkeys(args: Sp1VkeysArgs) -> Result<()> {
     let range_elf_sha256 = hex::encode(Sha256::digest(&*range_elf_bytes));
     let agg_elf_sha256 = hex::encode(Sha256::digest(&*agg_elf_bytes));
 
-    let (range_vkey_commitment, aggregation_vkey) =
-        tokio::runtime::Runtime::new()?.block_on(async {
-            let client = EnvProver::Cpu(CpuProver::new().await);
-            let range_pk = client
-                .setup(range_elf_bytes)
-                .await
-                .map_err(|e| anyhow!("range setup failed: {e}"))?;
-            let agg_pk = client
-                .setup(agg_elf_bytes)
-                .await
-                .map_err(|e| anyhow!("aggregation setup failed: {e}"))?;
-            let range_vkey_commitment = B256::from(u32_to_u8(range_pk.verifying_key().hash_u32()));
-            let aggregation_vkey = agg_pk.verifying_key().bytes32();
-            anyhow::Ok((range_vkey_commitment, aggregation_vkey))
-        })?;
+    let (range_vkey_commitment, aggregation_vkey) = {
+        let client = EnvProver::Cpu(CpuProver::new().await);
+        let range_pk = client
+            .setup(range_elf_bytes)
+            .await
+            .map_err(|e| anyhow!("range setup failed: {e}"))?;
+        let agg_pk = client
+            .setup(agg_elf_bytes)
+            .await
+            .map_err(|e| anyhow!("aggregation setup failed: {e}"))?;
+        let range_vkey_commitment = B256::from(u32_to_u8(range_pk.verifying_key().hash_u32()));
+        let aggregation_vkey = agg_pk.verifying_key().bytes32();
+        anyhow::Ok((range_vkey_commitment, aggregation_vkey))
+    }?;
 
     let out = serde_json::to_string_pretty(&json!({
         "range_vkey_commitment": range_vkey_commitment,

--- a/proofs/prover/src/lib.rs
+++ b/proofs/prover/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
 use alloy_primitives::B256;
 use anyhow::{Context, Result, bail};
 use clap::Args;
-use reqwest::blocking::Client;
+use reqwest::Client;
 use serde::Serialize;
 use serde_json::{Value, json};
 use world_chain_chainspec::WorldChainSpec;
@@ -110,18 +110,19 @@ pub struct WitnessArgs {
     pub output: PathBuf,
 }
 
-pub fn print_rollup_config_hash(args: HashRollupConfigArgs) -> Result<()> {
-    let hash = rollup_config_hash_from_args(args)?;
+pub async fn print_rollup_config_hash(args: HashRollupConfigArgs) -> Result<()> {
+    let hash = rollup_config_hash_from_args(args).await?;
     println!("{hash:?}");
     Ok(())
 }
 
-pub fn rollup_config_hash_from_args(args: HashRollupConfigArgs) -> Result<B256> {
+pub async fn rollup_config_hash_from_args(args: HashRollupConfigArgs) -> Result<B256> {
     match (args.rollup_config, args.l2_rpc) {
         (Some(path), _) => Ok(proof_config_from_file(&path)?.1),
         (None, Some(url)) => {
             let client = Client::new();
-            let value: Value = rpc(&client, &url, "optimism_rollupConfig", json!([]))?
+            let value: Value = rpc(&client, &url, "optimism_rollupConfig", json!([]))
+                .await?
                 .context("optimism_rollupConfig returned null")?;
             Ok(world_chain_proof_protocol::hash_rollup_config(&value)?)
         }
@@ -129,8 +130,8 @@ pub fn rollup_config_hash_from_args(args: HashRollupConfigArgs) -> Result<B256> 
     }
 }
 
-pub fn write_witness(args: WitnessArgs) -> Result<()> {
-    let input = build_range_input_from_args(&args.rpc)?;
+pub async fn write_witness(args: WitnessArgs) -> Result<()> {
+    let input = build_range_input_from_args(&args.rpc).await?;
     let bytes = witness_bytes(&input.witness)?;
     write_bytes(&args.output, &bytes)?;
     let metadata_path = sibling_path(&args.output, "metadata.json");
@@ -163,7 +164,7 @@ pub fn online_host_config(args: &RpcArgs) -> Result<OnlineHostConfig> {
     })
 }
 
-pub fn build_range_input_from_args(args: &RpcArgs) -> Result<RangeProofInput> {
+pub async fn build_range_input_from_args(args: &RpcArgs) -> Result<RangeProofInput> {
     let config = online_host_config(args)?;
     build_range_input(
         &config,
@@ -174,6 +175,7 @@ pub fn build_range_input_from_args(args: &RpcArgs) -> Result<RangeProofInput> {
             allow_unfinalized: args.allow_unfinalized,
         },
     )
+    .await
 }
 
 pub fn proof_config(

--- a/proofs/sp1-worker/src/backend.rs
+++ b/proofs/sp1-worker/src/backend.rs
@@ -66,20 +66,19 @@ where
         // aggregation (SNARK) sessions through `job.sessions` so a worker restart resumes
         // in-flight network proofs instead of re-running them.
         let _ = &job.sessions;
-        let artifact = tokio::task::block_in_place(|| {
-            prove_validity(
-                &self.host,
-                &self.prover,
-                ValidityProofRequest::new(
-                    start_block,
-                    request.l2_block_number,
-                    Some(request.l1_head),
-                    self.config.allow_unfinalized,
-                    self.config.split_count,
-                    self.config.prover_address,
-                ),
-            )
-        })
+        let artifact = prove_validity(
+            &self.host,
+            &self.prover,
+            ValidityProofRequest::new(
+                start_block,
+                request.l2_block_number,
+                Some(request.l1_head),
+                self.config.allow_unfinalized,
+                self.config.split_count,
+                self.config.prover_address,
+            ),
+        )
+        .await
         .context("SP1 validity proving failed")?;
 
         check_artifact(request, &artifact)?;

--- a/proofs/sp1-worker/src/backend.rs
+++ b/proofs/sp1-worker/src/backend.rs
@@ -58,10 +58,6 @@ where
         let request = &job.request;
         let start_block = self.start_block(request)?;
 
-        // Witness generation and proving are CPU/IO heavy and fully synchronous; run them on
-        // the blocking pool so the worker's async scheduler is not starved. Range proofs
-        // parallelize on their own scoped threads inside `prove_validity`.
-        //
         // TODO: drive the SP1 proving network asynchronously, checkpointing range (STARK) and
         // aggregation (SNARK) sessions through `job.sessions` so a worker restart resumes
         // in-flight network proofs instead of re-running them.

--- a/proofs/sp1-worker/tests/e2e_proving.rs
+++ b/proofs/sp1-worker/tests/e2e_proving.rs
@@ -111,21 +111,9 @@ async fn worker_proves_real_range_end_to_end() {
         .await
         .expect("query claimed output root");
 
-    // `resolve_l1_head` uses a blocking HTTP client, so run it off the async runtime.
-    let l1_head = {
-        let (l1_rpc, l2_rpc) = (l1_rpc.clone(), l2_rpc.clone());
-        tokio::task::spawn_blocking(move || {
-            resolve_l1_head(
-                &reqwest::blocking::Client::new(),
-                &l2_rpc,
-                &l1_rpc,
-                claimed_block,
-            )
-        })
+    let l1_head = resolve_l1_head(&reqwest::Client::new(), &l2_rpc, &l1_rpc, claimed_block)
         .await
-        .expect("resolve_l1_head task")
-        .expect("resolve l1 head")
-    };
+        .expect("resolve l1 head");
 
     let rollup_config_value =
         serde_json::from_slice(&std::fs::read(&rollup_config).expect("read rollup config"))

--- a/proofs/succinct/utils/host/src/validity.rs
+++ b/proofs/succinct/utils/host/src/validity.rs
@@ -6,7 +6,7 @@
 
 use alloy_primitives::{Address, B256};
 use anyhow::{Context, bail};
-use reqwest::blocking::Client;
+use reqwest::Client;
 use world_chain_proof_core::{artifacts::AggregationProofArtifact, types::AggregationInputs};
 use world_chain_proof_succinct_utils::{
     AggregationProofRequest, RangeProofRequest, WorldSuccinctProver,
@@ -68,7 +68,7 @@ impl ValidityProofRequest {
 /// level up by the worker's concurrency permits. Sequential proving also keeps only one
 /// witness alive at a time, bounding memory, and avoids sharing the prover's runtime across
 /// threads.
-pub fn prove_validity<P>(
+pub async fn prove_validity<P>(
     host: &OnlineHostConfig,
     prover: &P,
     request: ValidityProofRequest,
@@ -85,7 +85,7 @@ where
     let client = Client::new();
     let l1_head = match request.l1_head {
         Some(hash) => hash,
-        None => resolve_l1_head(&client, &host.l2_rpc, &host.l1_rpc, request.end_block)?,
+        None => resolve_l1_head(&client, &host.l2_rpc, &host.l1_rpc, request.end_block).await?,
     };
 
     let mut boot_infos = Vec::with_capacity(ranges.len());
@@ -104,7 +104,8 @@ where
                 l1_head: Some(l1_head),
                 allow_unfinalized: request.allow_unfinalized,
             },
-        )?;
+        )
+        .await?;
 
         tracing::info!(
             start = sub_range.start + 1,
@@ -128,7 +129,7 @@ where
         range_proofs.push(artifact.proof);
     }
 
-    let l1_header = fetch_l1_header_by_hash(&client, &host.l1_rpc, l1_head)?;
+    let l1_header = fetch_l1_header_by_hash(&client, &host.l1_rpc, l1_head).await?;
     let l1_headers_cbor =
         serde_cbor::to_vec(&vec![l1_header]).context("CBOR-encoding L1 header failed")?;
 


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4871/nitro-backend-make-it-async-friendly

This PR makes the nitro prover async friendly. Nitro underlying library was already async friendly but we were wrapping it in a synchronous runtime and injecting a tokio runtime in the code. That's bad and it also makes the heartbeat system not working properly.

### Next Step

- make sp1 prover `SuccinctProver` completely async friendly by refactoring the `WorldSuccinctProver` trait and make it an async trait.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes around runtime threading and long-running witness/prove work on the async executor can affect worker heartbeats and concurrency; logic is largely mechanical but touches critical proving paths for Nitro and SP1 workers.
> 
> **Overview**
> **Makes the Nitro proving path and shared online witness stack async-friendly** so workers can await RPC, Kona witness collection, and enclave vsock I/O on one Tokio runtime instead of nesting `Runtime::new().block_on` or `block_in_place`.
> 
> `WorldNitroProver` is now an **`async_trait`** with `async fn prove_range` / `prove_aggregation`; `NitroProver` drops the stored `Handle` and `with_runtime`, and trait methods delegate directly to the existing async implementations. The **nitro-worker** no longer builds its own multi-thread runtime or runs witness generation on the blocking pool—it uses `#[tokio::main]` and `run().await`.
> 
> **Online host helpers** switch from `reqwest::blocking` to async `reqwest::Client`: `build_range_input`, `rpc`, `resolve_l1_head`, and related RPC paths are `async` and no longer spin a nested runtime inside `build_range_input`. Shared **prover** CLIs (`world-chain-prover`, nitro, sp1) and **`prove_validity`** await those calls; **sp1-worker** awaits `prove_validity` without `spawn_blocking`. E2E tests call `resolve_l1_head` directly on the async client.
> 
> **`async-trait`** is added as a dependency for `world-chain-proof-nitro`. `WorldSuccinctProver` remains synchronous in this PR (noted as follow-up in the PR description).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a760b14ae6172e53c39fb71946834d1372c3e5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->