### PR TITLE
feat: make sp1 backend async friendly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19186,6 +19186,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "anyhow",
+ "async-trait",
  "bincode 1.3.3",
  "reqwest 0.12.28",
  "rkyv",
@@ -19207,6 +19208,7 @@ name = "world-chain-proof-succinct-utils"
 version = "2.4.0"
 dependencies = [
  "alloy-primitives",
+ "async-trait",
  "rkyv",
  "serde",
  "world-chain-proof-core",

--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -2678,11 +2678,9 @@ async fn start_sp1_worker(
     .map_err(|error| eyre!("failed to build SP1 worker host config: {error}"))?;
 
     // `SuccinctProver` owns its own runtime, so build it off the async runtime.
-    let prover =
-        tokio::task::spawn_blocking(move || SuccinctProver::new(kind, SP1ProofMode::Groth16))
-            .await
-            .wrap_err("SP1 prover setup task panicked")?
-            .map_err(|error| eyre!("failed to build SP1 prover: {error}"))?;
+    let prover = SuccinctProver::new(kind, SP1ProofMode::Groth16)
+        .await
+        .map_err(|error| eyre!("failed to build SP1 prover: {error}"))?;
 
     let backend = Sp1Backend::new(
         host,

--- a/proofs/nitro/worker/src/main.rs
+++ b/proofs/nitro/worker/src/main.rs
@@ -1,11 +1,12 @@
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("nitro-worker requires Linux (AF_VSOCK)");
+    std::process::exit(1);
+}
+
+#[cfg(target_os = "linux")]
 #[tokio::main]
 async fn main() {
-    #[cfg(not(target_os = "linux"))]
-    {
-        eprintln!("nitro-worker requires Linux (AF_VSOCK)");
-        std::process::exit(1);
-    }
-    #[cfg(target_os = "linux")]
     if let Err(e) = world_chain_nitro_worker::run().await {
         eprintln!("error: {e:#}");
         std::process::exit(1);

--- a/proofs/prover-sp1/src/main.rs
+++ b/proofs/prover-sp1/src/main.rs
@@ -154,7 +154,7 @@ async fn sp1_prove(args: Sp1ProveArgs) -> Result<()> {
         prover = args.prover,
     );
 
-    let prover = SuccinctProver::new(args.prover, mode)?;
+    let prover = SuccinctProver::new(args.prover, mode).await?;
     let artifact = prove_validity(
         &host,
         &prover,

--- a/proofs/sp1-worker/src/main.rs
+++ b/proofs/sp1-worker/src/main.rs
@@ -143,7 +143,8 @@ struct Cli {
     worker_id: String,
 }
 
-fn main() -> Result<()> {
+#[tokio::main(flavor = "multi_thread", worker_threads = 2)]
+async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
@@ -167,7 +168,7 @@ fn main() -> Result<()> {
     // ELFs are embedded at compile time via `sp1_sdk::include_elf!()`
     // (see `proofs/succinct/elfs/build.rs`). Challenged roots are
     // defended on-chain; Groth16 keeps verification ~100k gas.
-    let prover = SuccinctProver::new(cli.prover, SP1ProofMode::Groth16)?;
+    let prover = SuccinctProver::new(cli.prover, SP1ProofMode::Groth16).await?;
 
     let backend = Sp1Backend::new(
         host,
@@ -212,26 +213,16 @@ fn main() -> Result<()> {
         "sp1-worker starting"
     );
 
-    // The async side is light (job-queue RPC and timers); proving runs on the blocking
-    // pool, and range proofs parallelize on their own scoped threads.
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .thread_name("sp1-worker")
-        .worker_threads(2)
-        .max_blocking_threads(4)
-        .build()
-        .context("failed to build tokio runtime")?;
-
     // Ctrl-C triggers a graceful shutdown: the worker stops leasing, flushes pending
     // reports, and resolves.
     let token = worker.cancellation_token();
-    runtime.spawn(async move {
+    tokio::spawn(async move {
         if tokio::signal::ctrl_c().await.is_ok() {
             tracing::info!("received ctrl-c, shutting down");
             token.cancel();
         }
     });
 
-    runtime.block_on(worker);
+    worker.await;
     Ok(())
 }

--- a/proofs/sp1-worker/tests/e2e_proving.rs
+++ b/proofs/sp1-worker/tests/e2e_proving.rs
@@ -130,11 +130,9 @@ async fn worker_proves_real_range_end_to_end() {
 
     let kind = prover_kind();
     // Build the prover off the async runtime: it owns its own runtime internally.
-    let prover =
-        tokio::task::spawn_blocking(move || SuccinctProver::new(kind, SP1ProofMode::Groth16))
-            .await
-            .expect("prover setup task")
-            .expect("build prover");
+    let prover = SuccinctProver::new(kind, SP1ProofMode::Groth16)
+        .await
+        .expect("build prover");
 
     let backend = Sp1Backend::new(
         host,

--- a/proofs/succinct/utils/host/Cargo.toml
+++ b/proofs/succinct/utils/host/Cargo.toml
@@ -29,3 +29,4 @@ world-chain-proof-succinct-utils.workspace = true
 alloy-sol-types = { workspace = true, optional = true }
 bincode = { version = "1", optional = true }
 sp1-sdk = { version = "=6.1.0", features = ["network"], optional = true }
+async-trait.workspace = true

--- a/proofs/succinct/utils/host/src/prover.rs
+++ b/proofs/succinct/utils/host/src/prover.rs
@@ -6,6 +6,7 @@
 
 use alloy_primitives::B256;
 use anyhow::Context;
+use async_trait::async_trait;
 use sp1_sdk::{
     CpuProver, HashableKey, MockProver, ProveRequest, Prover, ProverClient, ProvingKey, SP1Proof,
     SP1ProofWithPublicValues, SP1ProvingKey, SP1Stdin,
@@ -64,10 +65,6 @@ pub enum SuccinctProverError {
 }
 
 /// [`WorldSuccinctProver`] implementation over the sp1-sdk environment provers.
-///
-/// Synchronous like the trait it implements: holds its own Tokio runtime and blocks on the
-/// async sp1-sdk calls, mirroring `NitroProver`. Construct and call it from blocking-capable
-/// threads only.
 pub struct SuccinctProver {
     kind: Sp1ProverKind,
     client: EnvProver,
@@ -78,69 +75,66 @@ pub struct SuccinctProver {
     agg_network_pk: Option<SP1ProvingKey>,
     multi_block_vkey: [u32; 8],
     agg_mode: SP1ProofMode,
-    runtime: tokio::runtime::Runtime,
 }
 
 impl SuccinctProver {
     /// Creates the prover using caller-supplied ELFs. Use this in production binaries with
     /// ELFs embedded at compile time via `world_chain_proof_succinct_elfs`.
-    pub fn new(kind: Sp1ProverKind, agg_mode: SP1ProofMode) -> anyhow::Result<Self> {
+    pub async fn new(kind: Sp1ProverKind, agg_mode: SP1ProofMode) -> anyhow::Result<Self> {
         let range_elf = world_chain_proof_succinct_elfs::range_elf();
         let agg_elf = world_chain_proof_succinct_elfs::aggregation_elf();
-        let runtime = tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
-        let (client, range_pk, agg_pk, network_client, range_network_pk, agg_network_pk) = runtime
-            .block_on(async {
-                let client = match kind {
-                    Sp1ProverKind::Cpu => EnvProver::Cpu(CpuProver::new().await),
-                    Sp1ProverKind::Mock => EnvProver::Mock(MockProver::new().await),
-                    Sp1ProverKind::Network => {
-                        let private_key = std::env::var("SP1_PRIVATE_KEY").context(
+        let (client, range_pk, agg_pk, network_client, range_network_pk, agg_network_pk) = {
+            let client = match kind {
+                Sp1ProverKind::Cpu => EnvProver::Cpu(CpuProver::new().await),
+                Sp1ProverKind::Mock => EnvProver::Mock(MockProver::new().await),
+                Sp1ProverKind::Network => {
+                    let private_key = std::env::var("SP1_PRIVATE_KEY").context(
                             "SP1_PRIVATE_KEY environment variable must be set to use the network prover",
                         )?;
-                        EnvProver::Network(
-                            ProverClient::builder()
-                                .network()
-                                .private_key(&private_key)
-                                .build()
-                                .await,
-                        )
-                    }
-                };
-                let range_pk = client
-                    .setup(range_elf.clone())
-                    .await
-                    .context("range program setup failed")?;
-                let agg_pk = client
-                    .setup(agg_elf.clone())
-                    .await
-                    .context("aggregation program setup failed")?;
-                let (network_client, range_network_pk, agg_network_pk) = match &client {
-                    EnvProver::Network(network) => {
-                        let range_network_pk = network
-                            .setup(range_elf)
-                            .await
-                            .context("network range program setup failed")?;
-                        let agg_network_pk = network
-                            .setup(agg_elf)
-                            .await
-                            .context("network aggregation program setup failed")?;
-                        (
-                            Some(network.clone()),
-                            Some(range_network_pk),
-                            Some(agg_network_pk),
-                        )
-                    }
-                    _ => (None, None, None),
-                };
-                anyhow::Ok((
-                    client,
-                    range_pk,
-                    agg_pk,
-                    network_client,
-                    range_network_pk,
-                    agg_network_pk,
-                ))
-            })?;
+                    EnvProver::Network(
+                        ProverClient::builder()
+                            .network()
+                            .private_key(&private_key)
+                            .build()
+                            .await,
+                    )
+                }
+            };
+            let range_pk = client
+                .setup(range_elf.clone())
+                .await
+                .context("range program setup failed")?;
+            let agg_pk = client
+                .setup(agg_elf.clone())
+                .await
+                .context("aggregation program setup failed")?;
+            let (network_client, range_network_pk, agg_network_pk) = match &client {
+                EnvProver::Network(network) => {
+                    let range_network_pk = network
+                        .setup(range_elf)
+                        .await
+                        .context("network range program setup failed")?;
+                    let agg_network_pk = network
+                        .setup(agg_elf)
+                        .await
+                        .context("network aggregation program setup failed")?;
+                    (
+                        Some(network.clone()),
+                        Some(range_network_pk),
+                        Some(agg_network_pk),
+                    )
+                }
+                _ => (None, None, None),
+            };
+            anyhow::Ok((
+                client,
+                range_pk,
+                agg_pk,
+                network_client,
+                range_network_pk,
+                agg_network_pk,
+            ))
+        }?;
         let multi_block_vkey = range_pk.verifying_key().hash_u32();
 
         Ok(Self {
@@ -153,7 +147,6 @@ impl SuccinctProver {
             agg_network_pk,
             multi_block_vkey,
             agg_mode,
-            runtime,
         })
     }
 
@@ -176,6 +169,7 @@ impl SuccinctProver {
     }
 }
 
+#[async_trait]
 impl WorldSuccinctProver for SuccinctProver {
     type Error = anyhow::Error;
 
@@ -183,13 +177,18 @@ impl WorldSuccinctProver for SuccinctProver {
         self.multi_block_vkey
     }
 
-    fn prove_range(&self, request: RangeProofRequest) -> Result<RangeProofArtifact, Self::Error> {
+    async fn prove_range(
+        &self,
+        request: RangeProofRequest,
+    ) -> Result<RangeProofArtifact, Self::Error> {
         let mut stdin = SP1Stdin::new();
         stdin.write_vec(request.witness_rkyv);
 
         let proof = self
-            .runtime
-            .block_on(async { self.client.prove(&self.range_pk, stdin).compressed().await })
+            .client
+            .prove(&self.range_pk, stdin)
+            .compressed()
+            .await
             .context("range proving failed")?;
 
         let boot_info: BootInfoStruct = bincode::deserialize(proof.public_values.as_slice())
@@ -214,7 +213,7 @@ impl WorldSuccinctProver for SuccinctProver {
         })
     }
 
-    fn prove_aggregation(
+    async fn prove_aggregation(
         &self,
         request: AggregationProofRequest,
     ) -> Result<AggregationProofArtifact, Self::Error> {
@@ -231,17 +230,15 @@ impl WorldSuccinctProver for SuccinctProver {
         stdin.write(&request.inputs);
         stdin.write_vec(request.l1_headers_cbor);
 
-        let proof = self
-            .runtime
-            .block_on(async {
-                let mut prove = self.client.prove(&self.agg_pk, stdin).mode(self.agg_mode);
-                if self.kind == Sp1ProverKind::Mock {
-                    // Mock range proofs are dummies; skip recursive verification in the guest.
-                    prove = prove.deferred_proof_verification(false);
-                }
-                prove.await
-            })
-            .context("aggregation proving failed")?;
+        let proof = {
+            let mut prove = self.client.prove(&self.agg_pk, stdin).mode(self.agg_mode);
+            if self.kind == Sp1ProverKind::Mock {
+                // Mock range proofs are dummies; skip recursive verification in the guest.
+                prove = prove.deferred_proof_verification(false);
+            }
+            prove.await
+        }
+        .context("aggregation proving failed")?;
 
         if self.kind != Sp1ProverKind::Mock {
             self.client
@@ -271,20 +268,23 @@ impl WorldSuccinctProver for SuccinctProver {
         self.kind == Sp1ProverKind::Network
     }
 
-    fn request_range(&self, request: RangeProofRequest) -> Result<B256, Self::Error> {
+    async fn request_range(&self, request: RangeProofRequest) -> Result<B256, Self::Error> {
         let (network, range_pk, _) = self.network_parts()?;
         let mut stdin = SP1Stdin::new();
         stdin.write_vec(request.witness_rkyv);
-        self.runtime
-            .block_on(async { network.prove(range_pk, stdin).compressed().request().await })
+        network
+            .prove(range_pk, stdin)
+            .compressed()
+            .request()
+            .await
             .context("range proof network request failed")
     }
 
-    fn poll_range(&self, id: B256) -> Result<Option<RangeProofArtifact>, Self::Error> {
+    async fn poll_range(&self, id: B256) -> Result<Option<RangeProofArtifact>, Self::Error> {
         let (network, _, _) = self.network_parts()?;
-        let maybe_proof = self
-            .runtime
-            .block_on(async { network.get_proof_status(id).await })
+        let maybe_proof = network
+            .get_proof_status(id)
+            .await
             .context("range proof network status failed")?
             .1;
 
@@ -294,7 +294,10 @@ impl WorldSuccinctProver for SuccinctProver {
             .context("range proof conversion failed")
     }
 
-    fn request_aggregation(&self, request: AggregationProofRequest) -> Result<B256, Self::Error> {
+    async fn request_aggregation(
+        &self,
+        request: AggregationProofRequest,
+    ) -> Result<B256, Self::Error> {
         let (network, range_pk, agg_pk) = self.network_parts()?;
         let mut stdin = SP1Stdin::new();
         let range_vk = range_pk.verifying_key().vk.clone();
@@ -309,22 +312,22 @@ impl WorldSuccinctProver for SuccinctProver {
         stdin.write(&request.inputs);
         stdin.write_vec(request.l1_headers_cbor);
 
-        self.runtime
-            .block_on(async {
-                network
-                    .prove(agg_pk, stdin)
-                    .mode(self.agg_mode)
-                    .request()
-                    .await
-            })
+        network
+            .prove(agg_pk, stdin)
+            .mode(self.agg_mode)
+            .request()
+            .await
             .context("aggregation proof network request failed")
     }
 
-    fn poll_aggregation(&self, id: B256) -> Result<Option<AggregationProofArtifact>, Self::Error> {
+    async fn poll_aggregation(
+        &self,
+        id: B256,
+    ) -> Result<Option<AggregationProofArtifact>, Self::Error> {
         let (network, _, agg_pk) = self.network_parts()?;
-        let maybe_proof = self
-            .runtime
-            .block_on(async { network.get_proof_status(id).await })
+        let maybe_proof = network
+            .get_proof_status(id)
+            .await
             .context("aggregation proof network status failed")?
             .1;
 

--- a/proofs/succinct/utils/host/src/validity.rs
+++ b/proofs/succinct/utils/host/src/validity.rs
@@ -114,7 +114,10 @@ where
         );
         let range_request = RangeProofRequest::from_witness_data(&input.witness, None)
             .context("failed to serialize range witness")?;
-        let artifact = prover.prove_range(range_request).map_err(Into::into)?;
+        let artifact = prover
+            .prove_range(range_request)
+            .await
+            .map_err(Into::into)?;
 
         if artifact.boot_info.l2PostRoot != input.metadata.l2_post_root {
             bail!(
@@ -145,5 +148,6 @@ where
             l1_headers_cbor,
             range_proofs,
         })
+        .await
         .map_err(Into::into)
 }

--- a/proofs/succinct/utils/proof/Cargo.toml
+++ b/proofs/succinct/utils/proof/Cargo.toml
@@ -12,3 +12,4 @@ alloy-primitives.workspace = true
 rkyv.workspace = true
 serde.workspace = true
 world-chain-proof-core.workspace = true
+async-trait.workspace = true

--- a/proofs/succinct/utils/proof/src/lib.rs
+++ b/proofs/succinct/utils/proof/src/lib.rs
@@ -1,4 +1,5 @@
 use alloy_primitives::B256;
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use world_chain_proof_core::{
     range::WorldRangeProofPublicValues, types::AggregationInputs, witness::WorldRangeWitnessData,
@@ -51,6 +52,7 @@ pub struct AggregationProofRequest {
 }
 
 /// Interface expected from a concrete SP1 prover backend.
+#[async_trait]
 pub trait WorldSuccinctProver {
     /// Backend-specific error type.
     type Error;
@@ -59,10 +61,13 @@ pub trait WorldSuccinctProver {
     fn multi_block_vkey(&self) -> [u32; 8];
 
     /// Proves one range witness.
-    fn prove_range(&self, request: RangeProofRequest) -> Result<RangeProofArtifact, Self::Error>;
+    async fn prove_range(
+        &self,
+        request: RangeProofRequest,
+    ) -> Result<RangeProofArtifact, Self::Error>;
 
     /// Aggregates already-generated range proofs.
-    fn prove_aggregation(
+    async fn prove_aggregation(
         &self,
         request: AggregationProofRequest,
     ) -> Result<AggregationProofArtifact, Self::Error>;
@@ -73,14 +78,20 @@ pub trait WorldSuccinctProver {
     }
 
     /// Request a range proof from an external backend without waiting for completion.
-    fn request_range(&self, request: RangeProofRequest) -> Result<B256, Self::Error>;
+    async fn request_range(&self, request: RangeProofRequest) -> Result<B256, Self::Error>;
 
     /// Poll a previously requested range proof.
-    fn poll_range(&self, id: B256) -> Result<Option<RangeProofArtifact>, Self::Error>;
+    async fn poll_range(&self, id: B256) -> Result<Option<RangeProofArtifact>, Self::Error>;
 
     /// Request an aggregation proof from an external backend without waiting for completion.
-    fn request_aggregation(&self, request: AggregationProofRequest) -> Result<B256, Self::Error>;
+    async fn request_aggregation(
+        &self,
+        request: AggregationProofRequest,
+    ) -> Result<B256, Self::Error>;
 
     /// Poll a previously requested aggregation proof.
-    fn poll_aggregation(&self, id: B256) -> Result<Option<AggregationProofArtifact>, Self::Error>;
+    async fn poll_aggregation(
+        &self,
+        id: B256,
+    ) -> Result<Option<AggregationProofArtifact>, Self::Error>;
 }


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4870/sp1-backend-make-it-async-friendly

This PR refactors the `WorldSuccinctProver` trait and make is fully async. This way I was able to completely remove the tokio runtime.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core validity proving and worker entrypoints; behavior should be equivalent but nested async runtimes and long-running prove paths need regression on CPU/mock/network backends.
> 
> **Overview**
> Makes the SP1 proving stack **async end-to-end** so callers can `.await` setup and proving instead of blocking on an internal Tokio runtime.
> 
> **`WorldSuccinctProver`** (in `world-chain-proof-succinct-utils`) is now an `async_trait`: `prove_range`, `prove_aggregation`, and network request/poll helpers are `async`. **`SuccinctProver`** drops its owned `Runtime` and `block_on`; `new` is `async` and SP1 SDK calls are awaited directly. **`prove_validity`** awaits those trait methods as it walks witnesses and aggregation.
> 
> **Binaries and tests** are updated to match: `sp1-worker` uses `#[tokio::main]` and no longer builds a separate runtime for the worker loop; devnet, `world-chain-prover-sp1`, and e2e tests call `SuccinctProver::new(...).await` instead of `spawn_blocking`. **`async-trait`** is added to the succinct host/utils crates. **`nitro-worker`** only moves the non-Linux early exit above the async `main` (behavior unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbae8cc4871f6518dd1f454b617ebcf104ad4574. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->