### PR TITLE
fix(builder): increment `cumulative_uncompressed_bytes` only for committed txs

### DIFF
--- a/crates/builder/src/execution_context.rs
+++ b/crates/builder/src/execution_context.rs
@@ -271,10 +271,16 @@ where
             let tx_uncompressed_size = tx.encode_2718_len() as u64;
             attempt_metrics.record_transaction_size_bytes(tx_uncompressed_size);
             attempt_metrics.record_transaction_da_size_bytes(tx_da_size);
-            cumulative_uncompressed_bytes += tx_uncompressed_size;
+            // Note: `cumulative_uncompressed_bytes` is only advanced once a transaction is actually
+            // committed to the block (see after `commit_changes` below). It must not be mutated for
+            // transactions that are merely considered, otherwise rejected / skipped transactions
+            // (e.g. a just-mined tx that the pool has not yet dropped and that fails with
+            // nonce-too-low) would permanently inflate the running total and cause otherwise-fitting
+            // transactions to be spuriously rejected against the limit.
             let is_uncompressed_block_full =
                 if let Some(block_uncompressed_size_limit) = self.block_uncompressed_size_limit {
-                    let result = cumulative_uncompressed_bytes > block_uncompressed_size_limit;
+                    let result = cumulative_uncompressed_bytes + tx_uncompressed_size
+                        > block_uncompressed_size_limit;
                     if result {
                         tracing::warn!(
                             "we've reached block uncompressed size limit - rejecting tx: {:?}",
@@ -398,6 +404,9 @@ where
             attempt_metrics.record_transaction_gas_used(gas_used);
             transactions_executed += 1;
             self.commit_changes(info, base_fee, gas_used, evm_gas_used, tx_da_size, tx);
+            // Only count bytes for transactions that made it into the block, mirroring how gas and
+            // DA usage are accumulated in `commit_changes`.
+            cumulative_uncompressed_bytes += tx_uncompressed_size;
         }
 
         if !spent_nullifier_hashes.is_empty() {


### PR DESCRIPTION
### Problem

The t`est_enforces_block_uncompressed_size_limit` e2e test was intermittently failing in CI (`tx3 should be included in block 3`), while passing locally.

Root cause is an accounting bug in `WorldChainPayloadBuilderCtx::execute_best_transactions`. The running total `cumulative_uncompressed_bytes` was incremented for every considered transaction, before any inclusion check, and was never rolled back when a transaction was subsequently skipped or rejected (over-limits, blob/deposit, nonce-too-low, invalid, etc.). This is inconsistent with how `cumulative_gas_used` and `cumulative_da_bytes_used` are tracked, which only accumulate in `commit_changes` for transactions actually included in the block.

This surfaces as flakiness because of a transaction-pool timing race: after a block is committed, the pool drops the just-mined transaction asynchronously via canonical-state maintenance. Under CI load, the next block's build occasionally snapshots `best_transactions()` before that maintenance runs, so the already-mined transaction (e.g. tx2) is re-considered. It fails execution with nonce-too-low and is skipped but its size had already inflated `cumulative_uncompressed_bytes`, pushing the next legitimate transaction (tx3) over the limit and causing it to be spuriously rejected. On fast machines the pool wins the race, so the test passes.

### Solution

Make the uncompressed-size counter reflect only committed bytes, mirroring the gas / DA accounting: the limit gate now checks `cumulative_uncompressed_bytes + tx_uncompressed_size > limit` without mutating the running total.

`cumulative_uncompressed_bytes` is advanced by `tx_uncompressed_size` only after a successful `commit_changes`, i.e. only for transactions that actually make it into the block. Considered-but-not-included transactions no longer inflate the counter, so a transaction is admitted whenever it genuinely fits, removing the CI flakiness and correcting the limit semantics (bytes are now counted against block contents rather than against everything considered).