### PR TITLE
feat: wire heartbeat config into proof workers cli flags

### DIFF
--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -44,7 +44,9 @@ use world_chain_challenger::{AlloyChallengerClient, ChallengerConfig, WorldChain
 use world_chain_defender::{AlloyDefenderClient, DefenderConfig, WorldChainDefender};
 use world_chain_proof_kona_host_utils::online::OnlineHostConfig;
 use world_chain_proof_succinct_host_utils::prover::{SP1ProofMode, Sp1ProverKind, SuccinctProver};
-use world_chain_proof_worker::{ProofWorker, ProofWorkerConfig, RetryConfig};
+use world_chain_proof_worker::{
+    ProofWorker, ProofWorkerConfig, RetryConfig, WorkerHeartbeatConfig,
+};
 use world_chain_proofs::{OptimismConsensusClient, PROOF_SYSTEM_VERSION, PROOF_THRESHOLD};
 use world_chain_proposer::{AlloyProofSystemClient, ProposerConfig, WorldChainProposer};
 use world_chain_prover_service::{
@@ -2696,6 +2698,7 @@ async fn start_sp1_worker(
     let queue = RpcProverServiceClient::new(prover_service_url)
         .map_err(|error| eyre!("failed to connect SP1 worker to prover-service: {error}"))?;
     let retry_config = RetryConfig::default();
+    let heartbeat_config = WorkerHeartbeatConfig::default();
     let worker = ProofWorker::new(
         queue,
         backend,
@@ -2704,6 +2707,7 @@ async fn start_sp1_worker(
             poll_interval: SP1_WORKER_POLL_INTERVAL,
             max_concurrent_jobs: 1,
             retry_config,
+            heartbeat_config,
         },
     );
 

--- a/proofs/integration-tests/tests/orchestration.rs
+++ b/proofs/integration-tests/tests/orchestration.rs
@@ -10,7 +10,9 @@ use world_chain_defender::{DefenderConfig, WorldChainDefender};
 use world_chain_proof_integration_tests::{
     BLOCK_INTERVAL, FakeConsensus, FakeExecution, FakeProofBackend, SharedProverService,
 };
-use world_chain_proof_worker::{ProofWorker, ProofWorkerConfig, RetryConfig};
+use world_chain_proof_worker::{
+    ProofWorker, ProofWorkerConfig, RetryConfig, WorkerHeartbeatConfig,
+};
 use world_chain_proofs::{ProofLane, RootState};
 use world_chain_proposer::{ProposerConfig, WorldChainProposer};
 use world_chain_prover_service::{ProofBackend, ProverServiceConfig};
@@ -102,6 +104,7 @@ async fn start_proof_stack_with(
             poll_interval: Duration::from_millis(5),
             max_concurrent_jobs: 1,
             retry_config: RetryConfig::default(),
+            heartbeat_config: WorkerHeartbeatConfig::default(),
         },
     );
     let sp1_cancel = sp1_worker.cancellation_token();
@@ -115,6 +118,7 @@ async fn start_proof_stack_with(
             poll_interval: Duration::from_millis(5),
             max_concurrent_jobs: 1,
             retry_config: RetryConfig::default(),
+            heartbeat_config: WorkerHeartbeatConfig::default(),
         },
     );
     let nitro_cancel = nitro_worker.cancellation_token();

--- a/proofs/nitro/worker/src/lib.rs
+++ b/proofs/nitro/worker/src/lib.rs
@@ -39,12 +39,15 @@ use world_chain_proof_nitro::{
 use world_chain_proof_protocol::WorldHardforkConfig as ProtocolHardforkConfig;
 use world_chain_proof_worker::{
     ClaimedProofJobHandler, ProofJob, ProofWorker, ProofWorkerConfig, RetryConfig,
+    WorkerHeartbeatConfig,
 };
 use world_chain_prover_service::{ProofBackend, ProofData, RpcProverServiceClient};
 
 const DEFAULT_SUBMIT_PROOF_RETRY_MAX_RETRIES: usize = 10;
 const DEFAULT_SUBMIT_PROOF_RETRY_INITIAL_DELAY_MS: u64 = 100;
 const DEFAULT_SUBMIT_PROOF_RETRY_MAX_DELAY_MS: u64 = 10_000;
+const DEFAULT_WORKER_HEARTBEAT_INTERVAL_SEC: u64 = 30;
+const DEFAULT_WORKER_MAX_CONSECUTIVE_HEARTBEAT_FAILURES: u32 = 5;
 
 // ──────────────────────────────────────────────────────────────────────────────────────
 // NitroBackend — ClaimedProofJobHandler implementation for the Nitro TEE lane
@@ -285,6 +288,14 @@ struct Cli {
     /// The unique worker id.
     #[arg(long)]
     worker_id: String,
+
+    #[arg(long, default_value_t = DEFAULT_WORKER_HEARTBEAT_INTERVAL_SEC)]
+    /// The worker heartbeat interval in seconds.
+    heartbeat_interval_sec: u64,
+
+    #[arg(long, default_value_t = DEFAULT_WORKER_MAX_CONSECUTIVE_HEARTBEAT_FAILURES)]
+    /// Maximum consecutive retryable heartbeat failures before aborting proof generation.
+    heartbeat_max_consecutive_failures: u32,
 }
 
 // ──────────────────────────────────────────────────────────────────────────────────────
@@ -348,6 +359,10 @@ pub async fn run() -> Result<()> {
         retry_initial_delay,
         retry_max_delay,
     );
+    let heartbeat_config = WorkerHeartbeatConfig::with_max_consecutive_failures(
+        Duration::from_secs(cli.heartbeat_interval_sec),
+        cli.heartbeat_max_consecutive_failures,
+    );
     let worker = ProofWorker::new(
         queue,
         backend,
@@ -356,6 +371,7 @@ pub async fn run() -> Result<()> {
             poll_interval: Duration::from_secs(cli.poll_interval_seconds),
             max_concurrent_jobs: cli.max_concurrent_jobs,
             retry_config,
+            heartbeat_config,
         },
     );
 

--- a/proofs/sp1-worker/src/main.rs
+++ b/proofs/sp1-worker/src/main.rs
@@ -214,7 +214,7 @@ async fn main() -> Result<()> {
             poll_interval: Duration::from_secs(cli.poll_interval_seconds),
             max_concurrent_jobs: cli.max_concurrent_jobs,
             retry_config,
-            heartbeat_config
+            heartbeat_config,
         },
     );
 

--- a/proofs/sp1-worker/src/main.rs
+++ b/proofs/sp1-worker/src/main.rs
@@ -9,6 +9,7 @@ use world_chain_chainspec::WorldChainSpec;
 use world_chain_proof_kona_host_utils::online::build_online_config;
 use world_chain_proof_protocol::WorldHardforkConfig as ProtocolHardforkConfig;
 use world_chain_proof_succinct_host_utils::prover::{SP1ProofMode, Sp1ProverKind, SuccinctProver};
+use world_chain_proof_worker::WorkerHeartbeatConfig;
 use world_chain_prover_service::RpcProverServiceClient;
 use world_chain_sp1_worker::{
     ProofWorker, ProofWorkerConfig, RetryConfig, Sp1Backend, Sp1BackendConfig,
@@ -17,6 +18,8 @@ use world_chain_sp1_worker::{
 const DEFAULT_SUBMIT_PROOF_RETRY_MAX_RETRIES: usize = 10;
 const DEFAULT_SUBMIT_PROOF_RETRY_INITIAL_DELAY_MS: u64 = 100;
 const DEFAULT_SUBMIT_PROOF_RETRY_MAX_DELAY_MS: u64 = 10_000;
+const DEFAULT_WORKER_HEARTBEAT_INTERVAL_SEC: u64 = 30;
+const DEFAULT_WORKER_MAX_CONSECUTIVE_HEARTBEAT_FAILURES: u32 = 5;
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
 enum Network {
@@ -141,6 +144,14 @@ struct Cli {
     /// The unique worker id.
     #[arg(long)]
     worker_id: String,
+
+    #[arg(long, default_value_t = DEFAULT_WORKER_HEARTBEAT_INTERVAL_SEC)]
+    /// The worker heartbeat interval in seconds.
+    heartbeat_interval_sec: u64,
+
+    #[arg(long, default_value_t = DEFAULT_WORKER_MAX_CONSECUTIVE_HEARTBEAT_FAILURES)]
+    /// Maximum consecutive retryable heartbeat failures before aborting proof generation.
+    heartbeat_max_consecutive_failures: u32,
 }
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 2)]
@@ -191,6 +202,10 @@ async fn main() -> Result<()> {
         retry_initial_delay,
         retry_max_delay,
     );
+    let heartbeat_config = WorkerHeartbeatConfig::with_max_consecutive_failures(
+        Duration::from_secs(cli.heartbeat_interval_sec),
+        cli.heartbeat_max_consecutive_failures,
+    );
     let worker = ProofWorker::new(
         queue,
         backend,
@@ -199,6 +214,7 @@ async fn main() -> Result<()> {
             poll_interval: Duration::from_secs(cli.poll_interval_seconds),
             max_concurrent_jobs: cli.max_concurrent_jobs,
             retry_config,
+            heartbeat_config
         },
     );
 

--- a/proofs/sp1-worker/tests/e2e_proving.rs
+++ b/proofs/sp1-worker/tests/e2e_proving.rs
@@ -34,6 +34,7 @@ use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::postgres;
 use world_chain_proof_kona_host_utils::online::{OnlineHostConfig, resolve_l1_head};
 use world_chain_proof_succinct_host_utils::prover::{SP1ProofMode, Sp1ProverKind, SuccinctProver};
+use world_chain_proof_worker::WorkerHeartbeatConfig;
 use world_chain_proofs::{ConsensusProvider, OptimismConsensusClient};
 use world_chain_prover_service::{
     ProofBackend, ProofData, ProofRequest, ProofRequester, ProofResponse, ProofStatus,
@@ -179,6 +180,7 @@ async fn worker_proves_real_range_end_to_end() {
             poll_interval: Duration::from_millis(500),
             max_concurrent_jobs: 1,
             retry_config: RetryConfig::default(),
+            heartbeat_config: WorkerHeartbeatConfig::default(),
         },
     );
     let token = worker.cancellation_token();

--- a/proofs/sp1-worker/tests/rpc_roundtrip.rs
+++ b/proofs/sp1-worker/tests/rpc_roundtrip.rs
@@ -5,7 +5,7 @@ use std::{sync::Arc, time::Duration};
 use alloy_primitives::{Address, B256, Bytes};
 use testcontainers::{ContainerAsync, runners::AsyncRunner};
 use testcontainers_modules::postgres;
-use world_chain_proof_worker::ProofJob;
+use world_chain_proof_worker::{ProofJob, WorkerHeartbeatConfig};
 use world_chain_prover_service::{
     ProofBackend, ProofData, ProofRequest, ProofRequester, ProofResponse, ProofStatus,
     ProverService, ProverServiceConfig, RpcProverServiceClient, start_rpc_server,
@@ -87,6 +87,7 @@ async fn worker_completes_requested_proof_over_rpc() {
             poll_interval: Duration::from_millis(10),
             max_concurrent_jobs: 1,
             retry_config: RetryConfig::default(),
+            heartbeat_config: WorkerHeartbeatConfig::default(),
         },
     );
     let worker_handle = tokio::spawn(worker);

--- a/proofs/worker/src/lib.rs
+++ b/proofs/worker/src/lib.rs
@@ -21,6 +21,7 @@ mod retry;
 mod worker;
 
 pub use backend::{ClaimedProofJobHandler, JobSessions, ProofJob};
+pub use heartbeat::WorkerHeartbeatConfig;
 pub use retry::{
     DEFAULT_BOUNDED_INITIAL_DELAY, DEFAULT_BOUNDED_MAX_ATTEMPTS, DEFAULT_BOUNDED_MAX_DELAY,
     MIN_RETRY_DELAY, RetryConfig,

--- a/proofs/worker/src/worker.rs
+++ b/proofs/worker/src/worker.rs
@@ -44,23 +44,27 @@ pub struct ProofWorkerConfig {
     pub max_concurrent_jobs: usize,
     /// Configurations for retry.
     pub retry_config: RetryConfig,
+    /// Configurations for worker heartbeat.
+    pub heartbeat_config: WorkerHeartbeatConfig,
 }
 
 impl ProofWorkerConfig {
     /// Create a new `ProofWorkerConfig` with the provided `worker_id`,
-    /// `poll_interval`, `max_concurrent_jobs` and `retry_config`.
+    /// `poll_interval`, `max_concurrent_jobs`, `retry_config` and `heartbeat_config`.
     #[must_use]
     pub fn new(
         worker_id: String,
         poll_interval: Duration,
         max_concurrent_jobs: usize,
         retry_config: RetryConfig,
+        heartbeat_config: WorkerHeartbeatConfig,
     ) -> Self {
         Self {
             worker_id,
             poll_interval,
             max_concurrent_jobs,
             retry_config,
+            heartbeat_config,
         }
     }
 }
@@ -182,6 +186,7 @@ async fn run_worker<Q, B>(
                     locked,
                     permit,
                     config.retry_config,
+                    config.heartbeat_config,
                 );
             }
             Ok(None) => {
@@ -222,6 +227,7 @@ fn spawn_job<Q, B>(
     locked: LockedProofRequest,
     permit: OwnedSemaphorePermit,
     retry_config: RetryConfig,
+    worker_heartbeat_config: WorkerHeartbeatConfig,
 ) where
     Q: ProofJobQueue + Send + Sync + 'static,
     B: ClaimedProofJobHandler,
@@ -254,7 +260,6 @@ fn spawn_job<Q, B>(
                 sessions,
             };
 
-            let worker_heartbeat_config = WorkerHeartbeatConfig::default();
             let worker_heartbeat = WorkerHeartbeat::new(
                 proof_id,
                 worker_id.clone(),


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4869/heartbeat-wire-the-heartbeat-config-in-proof-worker-configs-so-that

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration and call-site wiring only; heartbeat abort-on-failure behavior was already present and is now tunable via CLI.
> 
> **Overview**
> Proof workers now take **heartbeat settings** as part of `ProofWorkerConfig` instead of always using `WorkerHeartbeatConfig::default()` inside each job task. The worker crate re-exports `WorkerHeartbeatConfig`, and `ProofWorkerConfig::new` requires the new field.
> 
> **SP1** and **Nitro** worker binaries gain CLI flags `--heartbeat-interval-sec` (default 30) and `--heartbeat-max-consecutive-failures` (default 5), wired into `WorkerHeartbeatConfig::with_max_consecutive_failures` at startup. Devnet, integration tests, and SP1 worker tests pass `WorkerHeartbeatConfig::default()` where no CLI exists.
> 
> This makes lease-extension behavior during long proofs **operator-configurable** without changing the underlying heartbeat implementation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ba718fbe5b0d0931f7ad56bc4675b3c940b8e97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->