### PR TITLE
chore: acceptance small refactor

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -12,8 +12,8 @@ on:
           - all
           - prod
           - stage
-          - dev-us-east-1
-          - dev-eu-central-2
+          - betanet
+          - alphanet
       bundler_rpc_url:
         description: Optional Rundler RPC URL for ERC-4337 sponsored user operation checks
         required: false
@@ -72,7 +72,7 @@ jobs:
             karst_deposit_enabled: "false"
             optimism_portal: ""
             allow_failure: false
-          - network: dev-us-east-1
+          - network: betanet
             environment: dev
             include_in_all: true
             rpc_url: https://wc-node-devnet.worldcoin.dev
@@ -87,7 +87,7 @@ jobs:
             karst_deposit_enabled: "true"
             optimism_portal: "0x081a60097c9e1fbe7f55a950eaf77c81dbe3c7af"
             allow_failure: true
-          - network: dev-eu-central-2
+          - network: alphanet
             environment: dev-eu-central-2
             include_in_all: true
             rpc_url: https://tx-proxy-devnet-eu-central-2.worldcoin.dev
@@ -151,7 +151,7 @@ jobs:
           ACCEPTANCE_NETWORK: ${{ matrix.network }}
           ACCEPTANCE_RPC_URL: ${{ matrix.rpc_url }}
           ACCEPTANCE_L1_RPC_URL: ${{ secrets.SEPOLIA_RPC_URL }}
-          ACCEPTANCE_BUNDLER_RPC_URL: ${{ matrix.network == 'dev-eu-central-2' && inputs.bundler_rpc_url != '' && inputs.bundler_rpc_url || matrix.bundler_rpc_url }}
+          ACCEPTANCE_BUNDLER_RPC_URL: ${{ matrix.network == 'alphanet' && inputs.bundler_rpc_url != '' && inputs.bundler_rpc_url || matrix.bundler_rpc_url }}
           ACCEPTANCE_CHAIN_ID: ${{ matrix.expected_chain_id }}
           ACCEPTANCE_4337_RPC_URL: ${{ matrix.erc4337_rpc_url }}
           ACCEPTANCE_4337_ENTRY_POINT: ${{ matrix.entry_point }}

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -48,6 +48,7 @@ jobs:
             rpc_url: https://worldchain-mainnet.g.alchemy.com/public
             acceptance_profile: smoke
             bundler_rpc_url: https://rundler-mainnet.worldcoin.dev
+            erc4337_rpc_url: ""
             entry_point: "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
             safe_4337_module: "0x70673A08a5B1086585d39979Fb2d84FDC0bB6Aaf"
             safe_4337_wallet_deployer: "0xd1f0B51940DbD6e73891D2a41Ef14483fDC5Cb6e"
@@ -62,6 +63,7 @@ jobs:
             rpc_url: https://wc-node-sepolia.worldcoin.dev
             acceptance_profile: smoke
             bundler_rpc_url: https://rundler-stage.worldcoin.dev
+            erc4337_rpc_url: https://worldchain-mainnet.g.alchemy.com/public
             entry_point: "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
             safe_4337_module: "0x70673A08a5B1086585d39979Fb2d84FDC0bB6Aaf"
             safe_4337_wallet_deployer: "0xd1f0B51940DbD6e73891D2a41Ef14483fDC5Cb6e"
@@ -76,6 +78,7 @@ jobs:
             rpc_url: https://wc-node-devnet.worldcoin.dev
             acceptance_profile: ""
             bundler_rpc_url: ""
+            erc4337_rpc_url: ""
             entry_point: ""
             safe_4337_module: ""
             safe_4337_wallet_deployer: ""
@@ -90,6 +93,7 @@ jobs:
             rpc_url: https://tx-proxy-devnet-eu-central-2.worldcoin.dev
             acceptance_profile: smoke
             bundler_rpc_url: https://rundler-devnet-eu-central-2.worldcoin.dev
+            erc4337_rpc_url: ""
             expected_chain_id: "69420"
             entry_point: ""
             safe_4337_module: ""
@@ -149,6 +153,7 @@ jobs:
           ACCEPTANCE_L1_RPC_URL: ${{ secrets.SEPOLIA_RPC_URL }}
           ACCEPTANCE_BUNDLER_RPC_URL: ${{ matrix.network == 'dev-eu-central-2' && inputs.bundler_rpc_url != '' && inputs.bundler_rpc_url || matrix.bundler_rpc_url }}
           ACCEPTANCE_CHAIN_ID: ${{ matrix.expected_chain_id }}
+          ACCEPTANCE_4337_RPC_URL: ${{ matrix.erc4337_rpc_url }}
           ACCEPTANCE_4337_ENTRY_POINT: ${{ matrix.entry_point }}
           ACCEPTANCE_4337_MODULE: ${{ matrix.safe_4337_module }}
           ACCEPTANCE_4337_WALLET_DEPLOYER: ${{ matrix.safe_4337_wallet_deployer }}

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -59,13 +59,13 @@ jobs:
           - network: stage
             environment: stage
             include_in_all: true
-            rpc_url: https://worldchain-mainnet.g.alchemy.com/public
+            rpc_url: https://wc-node-sepolia.worldcoin.dev
             acceptance_profile: smoke
             bundler_rpc_url: https://rundler-stage.worldcoin.dev
             entry_point: "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
             safe_4337_module: "0x70673A08a5B1086585d39979Fb2d84FDC0bB6Aaf"
             safe_4337_wallet_deployer: "0xd1f0B51940DbD6e73891D2a41Ef14483fDC5Cb6e"
-            expected_chain_id: "480"
+            expected_chain_id: "4801"
             karst_enabled: "false"
             karst_deposit_enabled: "false"
             optimism_portal: ""

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -59,13 +59,13 @@ jobs:
           - network: stage
             environment: stage
             include_in_all: true
-            rpc_url: https://wc-node-sepolia.worldcoin.dev
+            rpc_url: https://worldchain-mainnet.g.alchemy.com/public
             acceptance_profile: smoke
             bundler_rpc_url: https://rundler-stage.worldcoin.dev
             entry_point: "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
-            safe_4337_module: "0x829Efdda958f06eA49f1F416e10b35C140bf45EF"
-            safe_4337_wallet_deployer: "0x6966cAE939Cbbb2DE66E1e7c67Ddb9143fDbA36c"
-            expected_chain_id: "4801"
+            safe_4337_module: "0x70673A08a5B1086585d39979Fb2d84FDC0bB6Aaf"
+            safe_4337_wallet_deployer: "0xd1f0B51940DbD6e73891D2a41Ef14483fDC5Cb6e"
+            expected_chain_id: "480"
             karst_enabled: "false"
             karst_deposit_enabled: "false"
             optimism_portal: ""

--- a/e2e-tests/src/it/acceptance_tests/README.md
+++ b/e2e-tests/src/it/acceptance_tests/README.md
@@ -55,7 +55,10 @@ The MVP checks:
 The ERC-4337 wallet owners are deterministic test mnemonic accounts and are only
 used to sign Safe user operations. They do not need ETH. The tests send standard
 two-parameter `eth_sendUserOperation` requests; sponsorship is expected to be
-injected by the configured Rundler endpoint.
+injected by the configured Rundler endpoint. The ERC-4337 signing chain ID is
+read from Rundler. Contract reads use the regular acceptance RPC when it matches
+that chain ID, and otherwise use the public World Chain mainnet RPC for the known
+stage-Rundler-on-mainnet case.
 
 The GitHub Actions acceptance workflow sets `ACCEPTANCE_4337_PROFILE=smoke` for
 bundler-enabled runs. That profile means 20 ephemeral Safe wallets, 2 post-deploy

--- a/e2e-tests/src/it/acceptance_tests/README.md
+++ b/e2e-tests/src/it/acceptance_tests/README.md
@@ -12,7 +12,7 @@ The MVP checks:
 - when `ACCEPTANCE_KARST_DEPOSIT_ENABLED=true`, the Karst checks also submit an
   L1 portal deposit whose derived L2 deposit gas limit is above the Karst
   transaction gas cap, then require the L2 deposit receipt to land
-- when `ACCEPTANCE_BUNDLER_RPC_URL` is set, Rundler accepts sponsored ERC-4337 v0.7 user operations for ephemeral Safe smart account wallets
+- when `ACCEPTANCE_BUNDLER_RPC_URL` is set, the configured sponsored Rundler endpoint accepts ERC-4337 v0.7 user operations for ephemeral Safe smart account wallets
 - the sponsored ERC-4337 checks cover concurrent wallet deployment, parallel post-deploy user operations across every wallet, multi-lane 2D nonce bursts, replay/gap rejection, and sponsorship constraint rejection
 
 ## Environment
@@ -51,12 +51,11 @@ The MVP checks:
 | `ACCEPTANCE_USEROP_TIMEOUT_SECS` | no | `30` | Max time to wait for a sent user operation receipt. |
 | `ACCEPTANCE_USEROP_REJECT_TIMEOUT_SECS` | no | `3` | Max time to wait for a sad-path user operation to be rejected. |
 | `ACCEPTANCE_USEROP_POLL_INTERVAL_MS` | no | `250` | Poll interval while waiting for a user operation receipt. |
-| `ACCEPTANCE_4337_SPONSORSHIP_MAX_COST_WEI` | no | `1000000000000000000` | `bundlerSponsorship.maxCost` sent as Rundler's permissioned third parameter. |
-| `ACCEPTANCE_4337_SPONSORSHIP_VALIDITY_SECS` | no | `60` | Seconds from now used to compute `bundlerSponsorship.validUntil`. |
 
 The ERC-4337 wallet owners are deterministic test mnemonic accounts and are only
-used to sign Safe user operations. They do not need ETH. Sponsored operations are
-paid by the configured Rundler instance.
+used to sign Safe user operations. They do not need ETH. The tests send standard
+two-parameter `eth_sendUserOperation` requests; sponsorship is expected to be
+injected by the configured Rundler endpoint.
 
 The GitHub Actions acceptance workflow sets `ACCEPTANCE_4337_PROFILE=smoke` for
 bundler-enabled runs. That profile means 20 ephemeral Safe wallets, 2 post-deploy

--- a/e2e-tests/src/it/acceptance_tests/README.md
+++ b/e2e-tests/src/it/acceptance_tests/README.md
@@ -38,6 +38,7 @@ The MVP checks:
 | `ACCEPTANCE_L1_KEY` | yes when Karst deposit checks are enabled | unset | Funded L1 EOA key used to pay L1 gas for the OptimismPortal deposit transaction. |
 | `ACCEPTANCE_OPTIMISM_PORTAL` | yes when Karst deposit checks are enabled | unset | L1 OptimismPortal proxy address. |
 | `ACCEPTANCE_BUNDLER_RPC_URL` | no | unset | Rundler RPC endpoint. If unset, ERC-4337 checks are skipped. |
+| `ACCEPTANCE_4337_RPC_URL` | no | `ACCEPTANCE_RPC_URL` | Execution RPC used for ERC-4337 contract reads when the configured Rundler targets a different chain than the rest of the acceptance suite. |
 | `ACCEPTANCE_4337_ENTRY_POINT` | no on chain `69420`; yes otherwise | `0x0000000071727De22E5E9d8BAf0edAc6f37da032` on chain `69420` | ERC-4337 v0.7 EntryPoint address. |
 | `ACCEPTANCE_4337_MODULE` | no on chain `69420`; yes otherwise | `0x70673A08a5B1086585d39979Fb2d84FDC0bB6Aaf` on chain `69420` | Safe4337 module used to sign Safe user operations. |
 | `ACCEPTANCE_4337_WALLET_DEPLOYER` | no on chain `69420`; yes otherwise | `0xd1f0B51940DbD6e73891D2a41Ef14483fDC5Cb6e` on chain `69420` | Safe4337 wallet deployer used as the v0.7 factory. |
@@ -56,9 +57,9 @@ The ERC-4337 wallet owners are deterministic test mnemonic accounts and are only
 used to sign Safe user operations. They do not need ETH. The tests send standard
 two-parameter `eth_sendUserOperation` requests; sponsorship is expected to be
 injected by the configured Rundler endpoint. The ERC-4337 signing chain ID is
-read from Rundler. Contract reads use the regular acceptance RPC when it matches
-that chain ID, and otherwise use the public World Chain mainnet RPC for the known
-stage-Rundler-on-mainnet case.
+read from Rundler. Contract reads use `ACCEPTANCE_RPC_URL` unless
+`ACCEPTANCE_4337_RPC_URL` is set; when set, the override RPC chain ID must match
+Rundler's chain ID.
 
 The GitHub Actions acceptance workflow sets `ACCEPTANCE_4337_PROFILE=smoke` for
 bundler-enabled runs. That profile means 20 ephemeral Safe wallets, 2 post-deploy

--- a/e2e-tests/src/it/acceptance_tests/config.rs
+++ b/e2e-tests/src/it/acceptance_tests/config.rs
@@ -17,8 +17,6 @@ const DEFAULT_USER_OPERATION_OPS_PER_WALLET: u64 = 3;
 const DEFAULT_USER_OPERATION_OP_CONCURRENCY: usize = 60;
 const DEFAULT_USER_OPERATION_NONCE_CONCURRENCY: usize = 2;
 const DEFAULT_USER_OPERATION_OWNER_START_INDEX: u32 = 1000;
-const DEFAULT_USER_OPERATION_SPONSORSHIP_VALIDITY_SECS: u64 = 60;
-const DEFAULT_USER_OPERATION_SPONSORSHIP_MAX_COST_WEI: &str = "1000000000000000000";
 const DEFAULT_TX_TIMEOUT_SECS: u64 = 60;
 const DEFAULT_TX_POLL_INTERVAL_MS: u64 = 500;
 const DEFAULT_DEPOSIT_TIMEOUT_SECS: u64 = 300;
@@ -87,8 +85,6 @@ pub(super) struct BundlerConfig {
     pub(super) user_operation_timeout: Duration,
     pub(super) user_operation_reject_timeout: Duration,
     pub(super) user_operation_poll_interval: Duration,
-    pub(super) sponsorship_max_cost: U256,
-    pub(super) sponsorship_validity: Duration,
 }
 
 #[derive(Clone)]
@@ -307,14 +303,6 @@ fn bundler_config_from_env(
         user_operation_poll_interval: Duration::from_millis(parse_optional_value(
             "ACCEPTANCE_USEROP_POLL_INTERVAL_MS",
             DEFAULT_USER_OPERATION_POLL_INTERVAL_MS,
-        )?),
-        sponsorship_max_cost: parse_optional_value_from_str(
-            "ACCEPTANCE_4337_SPONSORSHIP_MAX_COST_WEI",
-            DEFAULT_USER_OPERATION_SPONSORSHIP_MAX_COST_WEI,
-        )?,
-        sponsorship_validity: Duration::from_secs(parse_optional_value(
-            "ACCEPTANCE_4337_SPONSORSHIP_VALIDITY_SECS",
-            DEFAULT_USER_OPERATION_SPONSORSHIP_VALIDITY_SECS,
         )?),
     }))
 }

--- a/e2e-tests/src/it/acceptance_tests/config.rs
+++ b/e2e-tests/src/it/acceptance_tests/config.rs
@@ -72,6 +72,7 @@ pub(super) struct CloudflareAccess {
 #[derive(Clone)]
 pub(super) struct BundlerConfig {
     pub(super) rpc_url: Url,
+    pub(super) chain_rpc_url: Option<Url>,
     pub(super) cloudflare_access: Option<CloudflareAccess>,
     pub(super) entry_point: Address,
     pub(super) module: Address,
@@ -158,6 +159,10 @@ impl BundlerConfig {
     pub(super) fn rpc_target(&self) -> String {
         rpc_target(&self.rpc_url)
     }
+
+    pub(super) fn chain_rpc_target(&self) -> Option<String> {
+        self.chain_rpc_url.as_ref().map(rpc_target)
+    }
 }
 
 impl KarstDepositConfig {
@@ -240,6 +245,9 @@ fn bundler_config_from_env(
         rpc_url: rpc_url
             .parse()
             .wrap_err("failed to parse ERC-4337 bundler RPC URL")?,
+        chain_rpc_url: optional_env("ACCEPTANCE_4337_RPC_URL")
+            .map(|value| value.parse().wrap_err("failed to parse ERC-4337 RPC URL"))
+            .transpose()?,
         cloudflare_access: bundler_cloudflare_access_from_env(chain_cloudflare_access)?,
         entry_point: parse_optional_address(
             "ACCEPTANCE_4337_ENTRY_POINT",

--- a/e2e-tests/src/it/acceptance_tests/erc4337.rs
+++ b/e2e-tests/src/it/acceptance_tests/erc4337.rs
@@ -27,8 +27,6 @@ use super::{
     rpc::{self, RpcEnv},
 };
 
-const WORLD_CHAIN_MAINNET_CHAIN_ID: u64 = 480;
-const WORLD_CHAIN_MAINNET_RPC_URL: &str = "https://worldchain-mainnet.g.alchemy.com/public";
 const SAFE_OP_TYPE_HASH: FixedBytes<32> =
     fixed_bytes!("c03dfc11d8b10bf9cf703d558958c8c42777f785d998c62060d85a4f0ef6ea7f");
 const SAFE_DOMAIN_TYPE_HASH: FixedBytes<32> =
@@ -82,7 +80,7 @@ pub(super) async fn sponsored_user_operations(env: &RpcEnv) -> eyre::Result<()> 
         .get_chain_id()
         .await
         .context("failed to read ERC-4337 bundler chain ID")?;
-    let (chain, chain_rpc) = erc4337_chain_provider(env, bundler_chain_id)?;
+    let (chain, chain_rpc) = erc4337_chain_provider(env, config, bundler_chain_id).await?;
 
     let harness = UserOperationHarness::new(chain, bundler.clone(), config, bundler_chain_id)?;
 
@@ -103,26 +101,37 @@ pub(super) async fn sponsored_user_operations(env: &RpcEnv) -> eyre::Result<()> 
     harness.run().await
 }
 
-fn erc4337_chain_provider(
+async fn erc4337_chain_provider(
     env: &RpcEnv,
+    config: &BundlerConfig,
     bundler_chain_id: u64,
 ) -> eyre::Result<(RootProvider, String)> {
-    if bundler_chain_id == env.config().expected_chain_id {
-        return Ok((env.chain_provider().clone(), env.config().rpc_target()));
+    if let Some(rpc_url) = &config.chain_rpc_url {
+        let provider = rpc::provider_for_url::<Ethereum>(rpc_url, None)?;
+        let chain_id = provider
+            .get_chain_id()
+            .await
+            .context("failed to read ERC-4337 RPC chain ID")?;
+        ensure!(
+            chain_id == bundler_chain_id,
+            "ACCEPTANCE_4337_RPC_URL chain ID {chain_id} does not match ERC-4337 bundler chain ID {bundler_chain_id}"
+        );
+
+        return Ok((
+            provider,
+            config
+                .chain_rpc_target()
+                .unwrap_or_else(|| "<configured ERC-4337 RPC>".to_string()),
+        ));
     }
 
-    if bundler_chain_id == WORLD_CHAIN_MAINNET_CHAIN_ID {
-        let rpc_url = WORLD_CHAIN_MAINNET_RPC_URL
-            .parse()
-            .wrap_err("failed to parse World Chain mainnet RPC URL")?;
-        let provider = rpc::provider_for_url::<Ethereum>(&rpc_url, None)?;
-        return Ok((provider, WORLD_CHAIN_MAINNET_RPC_URL.to_string()));
-    }
-
-    bail!(
-        "ERC-4337 bundler chain ID {bundler_chain_id} does not match ACCEPTANCE_CHAIN_ID {} and no fallback RPC is configured for it",
+    ensure!(
+        bundler_chain_id == env.config().expected_chain_id,
+        "ERC-4337 bundler chain ID {bundler_chain_id} does not match ACCEPTANCE_CHAIN_ID {}; set ACCEPTANCE_4337_RPC_URL for the chain backing the bundler",
         env.config().expected_chain_id
-    )
+    );
+
+    Ok((env.chain_provider().clone(), env.config().rpc_target()))
 }
 
 struct UserOperationHarness<'a> {

--- a/e2e-tests/src/it/acceptance_tests/erc4337.rs
+++ b/e2e-tests/src/it/acceptance_tests/erc4337.rs
@@ -17,7 +17,6 @@ use alloy_signer::SignerSync;
 use alloy_sol_types::{SolCall, SolValue, sol};
 use eyre::eyre::{Context, OptionExt, bail, ensure};
 use futures::{StreamExt, TryStreamExt, stream};
-use serde::Serialize;
 use tokio::time::{Instant, sleep, timeout};
 use tracing::{info, warn};
 use world_chain_test_utils::utils::signer;
@@ -31,7 +30,7 @@ const SAFE_DOMAIN_TYPE_HASH: FixedBytes<32> =
 const PARALLEL_NOOP_NONCE_KEY: u64 = 10;
 const MULTI_LANE_NONCE_KEYS: [u64; 3] = [20, 21, 22];
 const SINGLE_WALLET_NONCE_OPS: u64 = 4;
-const SAD_PATH_REJECTION_CHECKS: u64 = 7;
+const SAD_PATH_REJECTION_CHECKS: u64 = 6;
 
 sol! {
     struct EncodedSafeOpStruct {
@@ -119,19 +118,6 @@ struct UserOperationOverrides {
     max_priority_fee_per_gas: U256,
     paymaster: Option<Address>,
     invalidate_signature: bool,
-}
-
-#[derive(Clone, Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct UserOperationPermissions {
-    bundler_sponsorship: BundlerSponsorship,
-}
-
-#[derive(Clone, Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct BundlerSponsorship {
-    max_cost: String,
-    valid_until: u64,
 }
 
 impl<'a> UserOperationHarness<'a> {
@@ -332,7 +318,7 @@ impl<'a> UserOperationHarness<'a> {
                 UserOperationOverrides::default(),
             )
             .await?;
-        self.expect_send_rejected("replayed 2D nonce", replay, true)
+        self.expect_send_rejected("replayed 2D nonce", replay)
             .await?;
 
         let gap = self
@@ -344,27 +330,10 @@ impl<'a> UserOperationHarness<'a> {
                 UserOperationOverrides::default(),
             )
             .await?;
-        self.expect_send_rejected("2D nonce sequence gap", gap, true)
+        self.expect_send_rejected("2D nonce sequence gap", gap)
             .await?;
 
-        let without_permissions = self.fresh_wallet(self.config.wallet_count).await?;
-        let zero_fee_op = self
-            .signed_noop_user_operation(
-                &without_permissions,
-                0,
-                0,
-                true,
-                UserOperationOverrides::default(),
-            )
-            .await?;
-        self.expect_send_rejected(
-            "zero fee operation without sponsorship permissions",
-            zero_fee_op,
-            false,
-        )
-        .await?;
-
-        let nonzero_fee_wallet = self.fresh_wallet(self.config.wallet_count + 1).await?;
+        let nonzero_fee_wallet = self.fresh_wallet(self.config.wallet_count).await?;
         let nonzero_fee_op = self
             .signed_noop_user_operation(
                 &nonzero_fee_wallet,
@@ -381,11 +350,10 @@ impl<'a> UserOperationHarness<'a> {
         self.expect_send_rejected(
             "sponsored operation with non-zero fee fields",
             nonzero_fee_op,
-            true,
         )
         .await?;
 
-        let nonzero_pvg_wallet = self.fresh_wallet(self.config.wallet_count + 2).await?;
+        let nonzero_pvg_wallet = self.fresh_wallet(self.config.wallet_count + 1).await?;
         let nonzero_pvg_op = self
             .signed_noop_user_operation(
                 &nonzero_pvg_wallet,
@@ -401,11 +369,10 @@ impl<'a> UserOperationHarness<'a> {
         self.expect_send_rejected(
             "sponsored operation with non-zero preVerificationGas",
             nonzero_pvg_op,
-            true,
         )
         .await?;
 
-        let paymaster_wallet = self.fresh_wallet(self.config.wallet_count + 3).await?;
+        let paymaster_wallet = self.fresh_wallet(self.config.wallet_count + 2).await?;
         let paymaster_op = self
             .signed_noop_user_operation(
                 &paymaster_wallet,
@@ -418,10 +385,10 @@ impl<'a> UserOperationHarness<'a> {
                 },
             )
             .await?;
-        self.expect_send_rejected("sponsored operation with paymaster", paymaster_op, true)
+        self.expect_send_rejected("sponsored operation with paymaster", paymaster_op)
             .await?;
 
-        let bad_sig_wallet = self.fresh_wallet(self.config.wallet_count + 4).await?;
+        let bad_sig_wallet = self.fresh_wallet(self.config.wallet_count + 3).await?;
         let bad_sig_op = self
             .signed_noop_user_operation(
                 &bad_sig_wallet,
@@ -434,7 +401,7 @@ impl<'a> UserOperationHarness<'a> {
                 },
             )
             .await?;
-        self.expect_send_rejected("invalid Safe signature", bad_sig_op, true)
+        self.expect_send_rejected("invalid Safe signature", bad_sig_op)
             .await
     }
 
@@ -580,26 +547,10 @@ impl<'a> UserOperationHarness<'a> {
             .bundler
             .raw_request(
                 Cow::Borrowed("eth_sendUserOperation"),
-                (user_op, self.config.entry_point, self.permissions()?),
-            )
-            .await
-            .context("failed to send sponsored user operation")?;
-
-        Ok(hash)
-    }
-
-    async fn send_user_operation_without_permissions(
-        &self,
-        user_op: PackedUserOperation,
-    ) -> eyre::Result<B256> {
-        let hash = self
-            .bundler
-            .raw_request(
-                Cow::Borrowed("eth_sendUserOperation"),
                 (user_op, self.config.entry_point),
             )
             .await
-            .context("failed to send user operation without permissions")?;
+            .context("failed to send proxy-sponsored user operation")?;
 
         Ok(hash)
     }
@@ -608,15 +559,8 @@ impl<'a> UserOperationHarness<'a> {
         &self,
         label: &'static str,
         user_op: PackedUserOperation,
-        with_permissions: bool,
     ) -> eyre::Result<()> {
-        let send = async {
-            if with_permissions {
-                self.send_sponsored_user_operation(user_op).await
-            } else {
-                self.send_user_operation_without_permissions(user_op).await
-            }
-        };
+        let send = self.send_sponsored_user_operation(user_op);
 
         match timeout(self.config.user_operation_reject_timeout, send).await {
             Ok(Ok(hash)) => bail!("{label} was accepted by bundler as {hash:?}"),
@@ -760,22 +704,6 @@ impl<'a> UserOperationHarness<'a> {
             .raw_request(Cow::Borrowed("eth_call"), (request, "latest"))
             .await
             .context("eth_call failed")
-    }
-
-    fn permissions(&self) -> eyre::Result<UserOperationPermissions> {
-        let valid_until = SystemTime::now()
-            .checked_add(self.config.sponsorship_validity)
-            .ok_or_eyre("sponsorship validUntil overflowed SystemTime")?
-            .duration_since(UNIX_EPOCH)
-            .wrap_err("system clock is before UNIX_EPOCH")?
-            .as_secs();
-
-        Ok(UserOperationPermissions {
-            bundler_sponsorship: BundlerSponsorship {
-                max_cost: format!("{:#x}", self.config.sponsorship_max_cost),
-                valid_until,
-            },
-        })
     }
 
     fn log_completion_summary(&self, wallet_count: usize) {

--- a/e2e-tests/src/it/acceptance_tests/erc4337.rs
+++ b/e2e-tests/src/it/acceptance_tests/erc4337.rs
@@ -3,6 +3,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
+use alloy_network::Ethereum;
 use alloy_primitives::{
     Address, B256, Bytes, FixedBytes, U256, address,
     aliases::{U48, U192},
@@ -21,8 +22,13 @@ use tokio::time::{Instant, sleep, timeout};
 use tracing::{info, warn};
 use world_chain_test_utils::utils::signer;
 
-use super::{config::BundlerConfig, rpc::RpcEnv};
+use super::{
+    config::BundlerConfig,
+    rpc::{self, RpcEnv},
+};
 
+const WORLD_CHAIN_MAINNET_CHAIN_ID: u64 = 480;
+const WORLD_CHAIN_MAINNET_RPC_URL: &str = "https://worldchain-mainnet.g.alchemy.com/public";
 const SAFE_OP_TYPE_HASH: FixedBytes<32> =
     fixed_bytes!("c03dfc11d8b10bf9cf703d558958c8c42777f785d998c62060d85a4f0ef6ea7f");
 const SAFE_DOMAIN_TYPE_HASH: FixedBytes<32> =
@@ -72,18 +78,20 @@ pub(super) async fn sponsored_user_operations(env: &RpcEnv) -> eyre::Result<()> 
     let bundler = env
         .bundler_provider()
         .ok_or_eyre("ERC-4337 bundler provider missing")?;
+    let bundler_chain_id = bundler
+        .get_chain_id()
+        .await
+        .context("failed to read ERC-4337 bundler chain ID")?;
+    let (chain, chain_rpc) = erc4337_chain_provider(env, bundler_chain_id)?;
 
-    let harness = UserOperationHarness::new(
-        env.chain_provider(),
-        bundler,
-        config,
-        env.config().expected_chain_id,
-    )?;
+    let harness = UserOperationHarness::new(chain, bundler.clone(), config, bundler_chain_id)?;
 
     info!(
         network = env.config().network,
-        chain_rpc = env.config().rpc_target(),
+        acceptance_rpc = env.config().rpc_target(),
+        chain_rpc,
         bundler_rpc = config.rpc_target(),
+        bundler_chain_id,
         entry_point = ?config.entry_point,
         wallets = config.wallet_count,
         deploy_concurrency = config.deploy_concurrency,
@@ -95,9 +103,31 @@ pub(super) async fn sponsored_user_operations(env: &RpcEnv) -> eyre::Result<()> 
     harness.run().await
 }
 
+fn erc4337_chain_provider(
+    env: &RpcEnv,
+    bundler_chain_id: u64,
+) -> eyre::Result<(RootProvider, String)> {
+    if bundler_chain_id == env.config().expected_chain_id {
+        return Ok((env.chain_provider().clone(), env.config().rpc_target()));
+    }
+
+    if bundler_chain_id == WORLD_CHAIN_MAINNET_CHAIN_ID {
+        let rpc_url = WORLD_CHAIN_MAINNET_RPC_URL
+            .parse()
+            .wrap_err("failed to parse World Chain mainnet RPC URL")?;
+        let provider = rpc::provider_for_url::<Ethereum>(&rpc_url, None)?;
+        return Ok((provider, WORLD_CHAIN_MAINNET_RPC_URL.to_string()));
+    }
+
+    bail!(
+        "ERC-4337 bundler chain ID {bundler_chain_id} does not match ACCEPTANCE_CHAIN_ID {} and no fallback RPC is configured for it",
+        env.config().expected_chain_id
+    )
+}
+
 struct UserOperationHarness<'a> {
-    chain: &'a RootProvider,
-    bundler: &'a RootProvider,
+    chain: RootProvider,
+    bundler: RootProvider,
     config: &'a BundlerConfig,
     chain_id: u64,
     salt_base: U256,
@@ -122,8 +152,8 @@ struct UserOperationOverrides {
 
 impl<'a> UserOperationHarness<'a> {
     fn new(
-        chain: &'a RootProvider,
-        bundler: &'a RootProvider,
+        chain: RootProvider,
+        bundler: RootProvider,
         config: &'a BundlerConfig,
         chain_id: u64,
     ) -> eyre::Result<Self> {

--- a/e2e-tests/src/it/acceptance_tests/rpc.rs
+++ b/e2e-tests/src/it/acceptance_tests/rpc.rs
@@ -88,7 +88,7 @@ impl RpcEnv {
     }
 }
 
-fn provider_for_url<N: Network>(
+pub(super) fn provider_for_url<N: Network>(
     url: &url::Url,
     cloudflare_access: Option<&CloudflareAccess>,
 ) -> eyre::Result<RootProvider<N>> {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes live acceptance workflow matrix (stage Safe addresses, cross-chain stage ERC-4337 RPC) and alter how sponsored user ops are sent—CI coverage of bundler behavior shifts materially though scope is test/CI only.
> 
> **Overview**
> Refactors acceptance ERC-4337 checks to match **proxy-sponsored Rundler** behavior and supports **bundler vs execution RPC on different chains**.
> 
> **Workflow:** Renames matrix networks `dev-us-east-1` → `betanet` and `dev-eu-central-2` → `alphanet`. Adds per-matrix `erc4337_rpc_url` and passes `ACCEPTANCE_4337_RPC_URL`. **Stage** now uses the same Safe4337 module/deployer addresses as prod and sets `erc4337_rpc_url` to mainnet public RPC so bundler checks can target a different chain than the acceptance RPC.
> 
> **ERC-4337 tests:** Drops client-side `bundlerSponsorship` (third `eth_sendUserOperation` arg) and related env (`ACCEPTANCE_4337_SPONSORSHIP_*`). Sends standard two-parameter requests; sponsorship is expected from the bundler endpoint. **Chain ID** for signing comes from the bundler; contract reads use `ACCEPTANCE_RPC_URL` or optional `ACCEPTANCE_4337_RPC_URL` when the bundler’s chain differs from `ACCEPTANCE_CHAIN_ID` (with chain-ID validation). Removes the “zero fee without sponsorship permissions” rejection case (sad paths 7 → 6).
> 
> Docs updated accordingly; `provider_for_url` is exported for the ERC-4337 module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea09853fca4bf9a5047fa59f6b037c84e4815bea. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->