### PR TITLE
feat: add sp1 mock prover

### DIFF
--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -44,8 +44,9 @@ use world_chain_challenger::{AlloyChallengerClient, ChallengerConfig, WorldChain
 use world_chain_defender::{AlloyDefenderClient, DefenderConfig, WorldChainDefender};
 use world_chain_proof_kona_host_utils::online::OnlineHostConfig;
 use world_chain_proof_succinct_host_utils::{
-    Sp1ProverKind,
+    Sp1ProverKind, WorldSuccinctProver,
     cpu_prover::{CpuSuccinctProver, SP1ProofMode},
+    mock_prover::MockSuccinctProver,
 };
 use world_chain_proof_worker::{
     ProofWorker, ProofWorkerConfig, RetryConfig, WorkerHeartbeatConfig,
@@ -2683,16 +2684,36 @@ async fn start_sp1_worker(
     )
     .map_err(|error| eyre!("failed to build SP1 worker host config: {error}"))?;
 
-    let prover = match kind {
-        Sp1ProverKind::Cpu => CpuSuccinctProver::new(SP1ProofMode::Groth16)
-            .await
-            .map_err(|error| eyre!("failed to build SP1 prover: {error}"))?,
-        Sp1ProverKind::Mock | Sp1ProverKind::Network => bail!(
-            "unsupported SP1 prover '{}'; only 'cpu' is currently available",
+    match kind {
+        Sp1ProverKind::Cpu => {
+            let prover = CpuSuccinctProver::new(SP1ProofMode::Groth16)
+                .await
+                .map_err(|error| eyre!("failed to build SP1 prover: {error}"))?;
+            start_sp1_worker_with_prover(prover_service_url, deployment, kind, host, prover)
+        }
+        Sp1ProverKind::Mock => {
+            let prover = MockSuccinctProver::new(SP1ProofMode::Groth16)
+                .await
+                .map_err(|error| eyre!("failed to build SP1 prover: {error}"))?;
+            start_sp1_worker_with_prover(prover_service_url, deployment, kind, host, prover)
+        }
+        Sp1ProverKind::Network => bail!(
+            "unsupported SP1 prover '{}'; only 'cpu' and 'mock' are currently available",
             kind
         ),
-    };
+    }
+}
 
+fn start_sp1_worker_with_prover<P>(
+    prover_service_url: &str,
+    deployment: &WorldProofSystemDeployment,
+    kind: Sp1ProverKind,
+    host: OnlineHostConfig,
+    prover: P,
+) -> Result<Sp1WorkerTask>
+where
+    P: WorldSuccinctProver + Send + Sync + 'static,
+{
     let backend = Sp1Backend::new(
         host,
         prover,

--- a/proofs/prover-sp1/src/main.rs
+++ b/proofs/prover-sp1/src/main.rs
@@ -68,7 +68,7 @@ struct Sp1ProveArgs {
     #[arg(long, default_value_t = 1)]
     ranges: u64,
 
-    /// Prover backend. Mock and network are reserved for follow-up implementations.
+    /// Prover backend. Network is reserved for a follow-up implementation.
     #[arg(
         long,
         env = "SP1_PROVER",
@@ -138,6 +138,7 @@ async fn sp1_prove(args: Sp1ProveArgs) -> Result<()> {
     use sp1_sdk::SP1ProofMode;
     use world_chain_proof_succinct_host_utils::{
         cpu_prover::CpuSuccinctProver,
+        mock_prover::MockSuccinctProver,
         validity::{ValidityProofRequest, prove_validity},
     };
 
@@ -159,28 +160,31 @@ async fn sp1_prove(args: Sp1ProveArgs) -> Result<()> {
         prover = args.prover,
     );
 
-    let prover = match args.prover {
-        Sp1ProverKind::Cpu => CpuSuccinctProver::new(mode).await?,
-        Sp1ProverKind::Mock | Sp1ProverKind::Network => {
+    let proof_request = ValidityProofRequest {
+        start_block: args.rpc.start_block,
+        end_block: args.rpc.end_block,
+        l1_head: args.rpc.l1_head,
+        allow_unfinalized: args.rpc.allow_unfinalized,
+        split_count: args.ranges.max(1),
+        prover_address: args.prover_address,
+    };
+
+    let artifact = match args.prover {
+        Sp1ProverKind::Cpu => {
+            let prover = CpuSuccinctProver::new(mode).await?;
+            prove_validity(&host, &prover, proof_request.clone()).await?
+        }
+        Sp1ProverKind::Mock => {
+            let prover = MockSuccinctProver::new(mode).await?;
+            prove_validity(&host, &prover, proof_request).await?
+        }
+        Sp1ProverKind::Network => {
             anyhow::bail!(
-                "unsupported SP1 prover '{}'; only 'cpu' is currently available",
+                "unsupported SP1 prover '{}'; only 'cpu' and 'mock' are currently available",
                 args.prover
             );
         }
     };
-    let artifact = prove_validity(
-        &host,
-        &prover,
-        ValidityProofRequest {
-            start_block: args.rpc.start_block,
-            end_block: args.rpc.end_block,
-            l1_head: args.rpc.l1_head,
-            allow_unfinalized: args.rpc.allow_unfinalized,
-            split_count: args.ranges.max(1),
-            prover_address: args.prover_address,
-        },
-    )
-    .await?;
 
     println!(
         "aggregation proof complete: block {block} pre={pre:?} post={post:?}",

--- a/proofs/sp1-worker/src/main.rs
+++ b/proofs/sp1-worker/src/main.rs
@@ -6,11 +6,12 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use std::{path::PathBuf, sync::Arc, time::Duration};
 use world_chain_chainspec::WorldChainSpec;
-use world_chain_proof_kona_host_utils::online::build_online_config;
+use world_chain_proof_kona_host_utils::online::{OnlineHostConfig, build_online_config};
 use world_chain_proof_protocol::WorldHardforkConfig as ProtocolHardforkConfig;
 use world_chain_proof_succinct_host_utils::{
-    Sp1ProverKind,
+    Sp1ProverKind, WorldSuccinctProver,
     cpu_prover::{CpuSuccinctProver, SP1ProofMode},
+    mock_prover::MockSuccinctProver,
 };
 use world_chain_proof_worker::WorkerHeartbeatConfig;
 use world_chain_prover_service::RpcProverServiceClient;
@@ -99,7 +100,7 @@ struct Cli {
     #[arg(long, default_value_t = 900)]
     witness_timeout_seconds: u64,
 
-    /// Prover backend. Mock and network are reserved for follow-up implementations.
+    /// Prover backend. Network is reserved for a follow-up implementation.
     #[arg(
         long,
         env = "SP1_PROVER",
@@ -186,16 +187,37 @@ async fn main() -> Result<()> {
     // ELFs are embedded at compile time via `sp1_sdk::include_elf!()`
     // (see `proofs/succinct/elfs/build.rs`). Challenged roots are
     // defended on-chain; Groth16 keeps verification ~100k gas.
-    let prover = match cli.prover {
-        Sp1ProverKind::Cpu => CpuSuccinctProver::new(SP1ProofMode::Groth16).await?,
-        Sp1ProverKind::Mock | Sp1ProverKind::Network => {
+    let prover_kind = cli.prover;
+    match prover_kind {
+        Sp1ProverKind::Cpu => {
+            run_worker(
+                cli,
+                host,
+                CpuSuccinctProver::new(SP1ProofMode::Groth16).await?,
+            )
+            .await
+        }
+        Sp1ProverKind::Mock => {
+            run_worker(
+                cli,
+                host,
+                MockSuccinctProver::new(SP1ProofMode::Groth16).await?,
+            )
+            .await
+        }
+        Sp1ProverKind::Network => {
             anyhow::bail!(
-                "unsupported SP1 prover '{}'; only 'cpu' is currently available",
-                cli.prover
+                "unsupported SP1 prover '{}'; only 'cpu' and 'mock' are currently available",
+                prover_kind
             );
         }
-    };
+    }
+}
 
+async fn run_worker<P>(cli: Cli, host: OnlineHostConfig, prover: P) -> Result<()>
+where
+    P: WorldSuccinctProver + Send + Sync + 'static,
+{
     let backend = Sp1Backend::new(
         host,
         prover,

--- a/proofs/sp1-worker/tests/e2e_proving.rs
+++ b/proofs/sp1-worker/tests/e2e_proving.rs
@@ -17,7 +17,7 @@
 //! export L1_BEACON_RPC_URL=$L1_RPC_URL          # devnet uses calldata DA; L1 RPC doubles as beacon
 //! export ROLLUP_RPC_URL=http://127.0.0.1:7545   # op-node, for output roots
 //! export ROLLUP_CONFIG=/path/to/rollup.json
-//! export SP1_PROVER=cpu                          # cpu | mock | network (mock/network not wired yet)
+//! export SP1_PROVER=cpu                          # cpu | mock | network (network not wired yet)
 //! cargo test -p world-chain-sp1-worker --test e2e_proving -- --ignored --nocapture
 //! ```
 //!
@@ -27,13 +27,14 @@
 
 use std::{path::PathBuf, sync::Arc, time::Duration};
 
-use alloy_primitives::Address;
+use alloy_primitives::{Address, B256};
 use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::postgres;
 use world_chain_proof_kona_host_utils::online::{OnlineHostConfig, resolve_l1_head};
 use world_chain_proof_succinct_host_utils::{
-    Sp1ProverKind,
+    Sp1ProverKind, WorldSuccinctProver,
     cpu_prover::{CpuSuccinctProver, SP1ProofMode},
+    mock_prover::MockSuccinctProver,
 };
 use world_chain_proof_worker::WorkerHeartbeatConfig;
 use world_chain_proofs::{ConsensusProvider, OptimismConsensusClient};
@@ -131,15 +132,62 @@ async fn worker_proves_real_range_end_to_end() {
     .expect("build host config");
 
     let kind = prover_kind();
-    let prover = match kind {
-        Sp1ProverKind::Cpu => CpuSuccinctProver::new(SP1ProofMode::Groth16)
-            .await
-            .expect("build prover"),
-        Sp1ProverKind::Mock | Sp1ProverKind::Network => {
-            panic!("unsupported SP1 prover '{kind}'; only 'cpu' is currently available");
+    match kind {
+        Sp1ProverKind::Cpu => {
+            let prover = CpuSuccinctProver::new(SP1ProofMode::Groth16)
+                .await
+                .expect("build prover");
+            run_worker_proves_real_range_end_to_end_with_prover(
+                host,
+                prover,
+                kind,
+                block_interval,
+                split_count,
+                root_claim,
+                l1_head,
+                claimed_block,
+                timeout,
+            )
+            .await;
         }
-    };
+        Sp1ProverKind::Mock => {
+            let prover = MockSuccinctProver::new(SP1ProofMode::Groth16)
+                .await
+                .expect("build prover");
+            run_worker_proves_real_range_end_to_end_with_prover(
+                host,
+                prover,
+                kind,
+                block_interval,
+                split_count,
+                root_claim,
+                l1_head,
+                claimed_block,
+                timeout,
+            )
+            .await;
+        }
+        Sp1ProverKind::Network => {
+            panic!(
+                "unsupported SP1 prover '{kind}'; only 'cpu' and 'mock' are currently available"
+            );
+        }
+    }
+}
 
+async fn run_worker_proves_real_range_end_to_end_with_prover<P>(
+    host: OnlineHostConfig,
+    prover: P,
+    kind: Sp1ProverKind,
+    block_interval: u64,
+    split_count: u64,
+    root_claim: B256,
+    l1_head: B256,
+    claimed_block: u64,
+    timeout: Duration,
+) where
+    P: WorldSuccinctProver + Send + Sync + 'static,
+{
     let backend = Sp1Backend::new(
         host,
         prover,
@@ -235,7 +283,9 @@ async fn worker_proves_real_range_end_to_end() {
         panic!("expected SP1 proof data");
     };
     assert!(!public_values.is_empty(), "public values must be populated");
-    assert!(!proof.is_empty(), "cpu proof must be non-empty");
+    if !matches!(kind, Sp1ProverKind::Mock) {
+        assert!(!proof.is_empty(), "non-mock proof must be non-empty");
+    }
 
     token.cancel();
     let _ = tokio::time::timeout(Duration::from_secs(5), worker_handle).await;

--- a/proofs/succinct/utils/host/src/lib.rs
+++ b/proofs/succinct/utils/host/src/lib.rs
@@ -13,6 +13,7 @@ use world_chain_proof_core::{
     types::AggregationInputs,
     witness::WorldRangeWitnessData,
 };
+pub use world_chain_proof_succinct_utils::WorldSuccinctProver;
 use world_chain_proof_succinct_utils::{AggregationProofRequest, RangeProofRequest};
 
 #[cfg(feature = "sp1")]

--- a/proofs/succinct/utils/host/src/mock_prover.rs
+++ b/proofs/succinct/utils/host/src/mock_prover.rs
@@ -1,1 +1,254 @@
+//! Range proofs are produced in `Compressed` mode so the aggregation guest can recursively
+//! verify them; the aggregation proof mode is configurable (Groth16 for on-chain verification).
 
+use crate::cpu_prover::SuccinctProverError;
+use anyhow::{Context, bail};
+use async_trait::async_trait;
+use sp1_sdk::{
+    HashableKey, MockProver, ProveRequest, Prover, ProvingKey, SP1Proof, SP1ProofMode,
+    SP1ProvingKey, SP1Stdin,
+};
+use std::{collections::HashMap, sync::Mutex};
+use world_chain_proof_core::{
+    artifacts::ProofArtifact,
+    boot::BootInfoStruct,
+    types::{AggregationInputs, AggregationOutputs},
+};
+use world_chain_proof_succinct_utils::{
+    AggregationProofArtifact, AggregationProofRequest, ProofRequest, RangeProofArtifact,
+    RangeProofRequest, Sp1SessionStatus, WorldSuccinctProver,
+};
+use world_chain_prover_service::{ProofRequestId, SessionType};
+
+pub struct MockSuccinctProver {
+    client: MockProver,
+    range_pk: SP1ProvingKey,
+    agg_pk: SP1ProvingKey,
+    multi_block_vkey: [u32; 8],
+    agg_mode: SP1ProofMode,
+    range_proofs: Mutex<HashMap<String, RangeProofArtifact>>,
+    agg_proofs: Mutex<HashMap<String, AggregationProofArtifact>>,
+}
+
+impl MockSuccinctProver {
+    /// Creates the prover using caller-supplied ELFs. Use this in production binaries with
+    /// ELFs embedded at compile time via `world_chain_proof_succinct_elfs`.
+    pub async fn new(agg_mode: SP1ProofMode) -> anyhow::Result<Self> {
+        let range_elf = world_chain_proof_succinct_elfs::range_elf();
+        let agg_elf = world_chain_proof_succinct_elfs::aggregation_elf();
+        let client = MockProver::new().await;
+        let range_pk = client
+            .setup(range_elf.clone())
+            .await
+            .context("range program setup failed")?;
+        let agg_pk = client
+            .setup(agg_elf.clone())
+            .await
+            .context("aggregation program setup failed")?;
+        let multi_block_vkey = range_pk.verifying_key().hash_u32();
+
+        Ok(Self {
+            client,
+            range_pk,
+            agg_pk,
+            multi_block_vkey,
+            agg_mode,
+            range_proofs: Mutex::new(HashMap::default()),
+            agg_proofs: Mutex::new(HashMap::default()),
+        })
+    }
+
+    async fn prove_range(&self, request: RangeProofRequest) -> anyhow::Result<RangeProofArtifact> {
+        let mut stdin = SP1Stdin::new();
+        stdin.write_vec(request.witness_rkyv);
+
+        let proof = self
+            .client
+            .prove(&self.range_pk, stdin)
+            .compressed()
+            .deferred_proof_verification(false)
+            .await
+            .context("range proving failed")?;
+
+        let boot_info: BootInfoStruct = bincode::deserialize(proof.public_values.as_slice())
+            .context("range proof public values deserialization failed")?;
+
+        if let Some(expected) = request.expected_public_values {
+            let expected_boot = BootInfoStruct::from(expected.boot_info);
+            if expected_boot != boot_info {
+                return Err(SuccinctProverError::BootInfoMismatch {
+                    expected: Box::new(expected_boot),
+                    actual: Box::new(boot_info),
+                }
+                .into());
+            }
+        }
+
+        let proof_bytes = bincode::serialize(&proof).context("range proof serialization failed")?;
+
+        Ok(RangeProofArtifact {
+            boot_info,
+            proof: proof_bytes,
+        })
+    }
+
+    async fn prove_aggregation(
+        &self,
+        request: AggregationProofRequest,
+    ) -> anyhow::Result<AggregationProofArtifact> {
+        let mut stdin = SP1Stdin::new();
+        let range_vk = self.range_pk.verifying_key().vk.clone();
+        for proof_bytes in &request.range_proofs {
+            let proof: sp1_sdk::SP1ProofWithPublicValues =
+                bincode::deserialize(proof_bytes).context("range proof deserialization failed")?;
+            let SP1Proof::Compressed(inner) = proof.proof else {
+                return Err(SuccinctProverError::NotCompressed.into());
+            };
+            stdin.write_proof(*inner, range_vk.clone());
+        }
+        stdin.write(&request.inputs);
+        stdin.write_vec(request.l1_headers_cbor);
+
+        let proof = self
+            .client
+            .prove(&self.agg_pk, stdin)
+            .mode(self.agg_mode)
+            .deferred_proof_verification(false)
+            .await
+            .context("aggregation proving failed")?;
+
+        self.client
+            .verify(&proof, self.agg_pk.verifying_key(), None)
+            .context("aggregation proof verification failed")?;
+
+        let outputs = <AggregationOutputs as alloy_sol_types::SolValue>::abi_decode(
+            proof.public_values.as_slice(),
+        )
+        .context("aggregation outputs abi decoding failed")?;
+
+        // Groth16/Plonk proofs serialize to their on-chain calldata representation; other
+        // modes (mock runs, compressed) keep the full sdk proof for offline use.
+        let proof_bytes = match &proof.proof {
+            SP1Proof::Groth16(_) | SP1Proof::Plonk(_) => proof.bytes(),
+            _ => bincode::serialize(&proof).context("aggregation proof serialization failed")?,
+        };
+
+        Ok(AggregationProofArtifact {
+            outputs,
+            proof: proof_bytes,
+        })
+    }
+}
+
+#[async_trait]
+impl WorldSuccinctProver for MockSuccinctProver {
+    fn supports_persistent_sessions(&self) -> bool {
+        false
+    }
+
+    async fn submit(
+        &self,
+        proof_id: ProofRequestId,
+        session_type: SessionType,
+        request: ProofRequest,
+    ) -> anyhow::Result<String> {
+        match session_type {
+            SessionType::Stark => {
+                let ProofRequest::Range(range_request) = request else {
+                    bail!("proof request and session type mistmach")
+                };
+                let range_proof = self.prove_range(range_request).await?;
+                let mut range_proofs = self
+                    .range_proofs
+                    .lock()
+                    .map_err(|_| anyhow::anyhow!("mutex lock poisoned"))?;
+                range_proofs.insert(proof_id.to_string(), range_proof);
+                Ok(proof_id.to_string())
+            }
+            SessionType::Snark => {
+                let ProofRequest::Aggregation(session_request) = request else {
+                    bail!("proof request and session type mistmach")
+                };
+                let agg_request = AggregationProofRequest {
+                    inputs: AggregationInputs {
+                        boot_infos: session_request.boot_infos,
+                        latest_l1_checkpoint_head: session_request.latest_l1_checkpoint_head,
+                        multi_block_vkey: self.multi_block_vkey,
+                        prover_address: session_request.prover_address,
+                    },
+                    l1_headers_cbor: session_request.l1_headers_cbor,
+                    range_proofs: session_request.range_proofs,
+                };
+                let agg_proof = self.prove_aggregation(agg_request).await?;
+                let mut agg_proofs = self
+                    .agg_proofs
+                    .lock()
+                    .map_err(|_| anyhow::anyhow!("mutex lock poisoned"))?;
+                agg_proofs.insert(proof_id.to_string(), agg_proof);
+                Ok(proof_id.to_string())
+            }
+        }
+    }
+
+    async fn poll(
+        &self,
+        session_id: String,
+        session_type: SessionType,
+    ) -> anyhow::Result<Sp1SessionStatus> {
+        match session_type {
+            SessionType::Stark => {
+                let range_proofs = self
+                    .range_proofs
+                    .lock()
+                    .map_err(|_| anyhow::anyhow!("mutex lock poisoned"))?;
+                if range_proofs.contains_key(&session_id) {
+                    // CPU prover immediately returns completed status if the entry exists in the hashmap
+                    Ok(Sp1SessionStatus::Completed)
+                } else {
+                    Ok(Sp1SessionStatus::NotFound)
+                }
+            }
+            SessionType::Snark => {
+                let agg_proofs = self
+                    .agg_proofs
+                    .lock()
+                    .map_err(|_| anyhow::anyhow!("mutex lock poisoned"))?;
+                if agg_proofs.contains_key(&session_id) {
+                    // CPU prover immediately returns completed status if the entry exists in the hashmap
+                    Ok(Sp1SessionStatus::Completed)
+                } else {
+                    Ok(Sp1SessionStatus::NotFound)
+                }
+            }
+        }
+    }
+
+    async fn download(
+        &self,
+        session_id: String,
+        session_type: SessionType,
+    ) -> anyhow::Result<ProofArtifact> {
+        match session_type {
+            SessionType::Stark => {
+                let range_proofs = self
+                    .range_proofs
+                    .lock()
+                    .map_err(|_| anyhow::anyhow!("mutex lock poisoned"))?;
+                let range_proof = range_proofs.get(&session_id).ok_or_else(|| {
+                    anyhow::anyhow!("no range proof found for session_id: {}", session_id)
+                })?;
+                Ok(ProofArtifact::Range(range_proof.clone()))
+            }
+            SessionType::Snark => {
+                let agg_proofs = self
+                    .agg_proofs
+                    .lock()
+                    .map_err(|_| anyhow::anyhow!("mutex lock poisoned"))?;
+                let agg_proof = agg_proofs.get(&session_id).ok_or_else(|| {
+                    anyhow::anyhow!("no agg proof found for session_id: {}", session_id)
+                })?;
+                Ok(ProofArtifact::Aggregation(agg_proof.clone()))
+            }
+        }
+    }
+}

--- a/proofs/succinct/utils/host/src/mock_prover.rs
+++ b/proofs/succinct/utils/host/src/mock_prover.rs
@@ -26,6 +26,7 @@ pub struct MockSuccinctProver {
     agg_pk: SP1ProvingKey,
     multi_block_vkey: [u32; 8],
     agg_mode: SP1ProofMode,
+
     range_proofs: Mutex<HashMap<String, RangeProofArtifact>>,
     agg_proofs: Mutex<HashMap<String, AggregationProofArtifact>>,
 }


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4874/add-mock-sp1-prover

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes add an alternate local proving backend for dev and tests; core CPU proving and on-chain paths are unchanged, with network prover still disabled.
> 
> **Overview**
> Adds a **`MockSuccinctProver`** that implements `WorldSuccinctProver` using SP1’s `MockProver`, running the same range (compressed) and aggregation flow as the CPU backend and storing artifacts in memory for submit/poll/download.
> 
> **`SP1_PROVER=mock`** is now supported in the **sp1-worker**, **world-chain-prover-sp1** `prove` command, and the devnet in-process SP1 worker (`DEVNET_SP1_WORKER_PROVER`). Entry points were refactored with generic helpers (`run_worker`, `start_sp1_worker_with_prover`, shared e2e helper) so CPU and mock share one code path; **network** remains explicitly unsupported.
> 
> The host crate **re-exports** `WorldSuccinctProver` and documents the mock module. E2E proving tests accept mock and relax the “non-empty proof bytes” assertion for mock runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e4bc897b87247cbd57901f5b1d6f027c7c57139. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->