### PR TITLE
feat: add sp1 network prover

### DIFF
--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -47,6 +47,7 @@ use world_chain_proof_succinct_host_utils::{
     Sp1ProverKind, WorldSuccinctProver,
     cpu_prover::{CpuSuccinctProver, SP1ProofMode},
     mock_prover::MockSuccinctProver,
+    network_prover::NetworkSuccinctProver,
 };
 use world_chain_proof_worker::{
     ProofWorker, ProofWorkerConfig, RetryConfig, WorkerHeartbeatConfig,
@@ -91,6 +92,8 @@ const SP1_WORKER_POLL_INTERVAL: Duration = Duration::from_secs(5);
 /// Env var enabling the in-process defender, prover-service, and SP1 worker. Off by default:
 /// real proving needs the SP1 ELFs. Set a prover backend to turn it on.
 const SP1_WORKER_PROVER_ENV: &str = "DEVNET_SP1_WORKER_PROVER";
+/// SP1 network private key. Required when `DEVNET_SP1_WORKER_PROVER=network`.
+const SP1_PRIVATE_KEY_ENV: &str = "SP1_PRIVATE_KEY";
 /// Bond, in wei, sent with every `WorldChainProofSystemFactory.propose`.
 /// Matches `PROPOSER_BOND` (1 ether) in `scripts/devnet/DeployProofSystem.s.sol`.
 const WORLD_PROPOSER_BOND_WEI: u128 = 1_000_000_000_000_000_000;
@@ -2697,10 +2700,15 @@ async fn start_sp1_worker(
                 .map_err(|error| eyre!("failed to build SP1 prover: {error}"))?;
             start_sp1_worker_with_prover(prover_service_url, deployment, kind, host, prover)
         }
-        Sp1ProverKind::Network => bail!(
-            "unsupported SP1 prover '{}'; only 'cpu' and 'mock' are currently available",
-            kind
-        ),
+        Sp1ProverKind::Network => {
+            let private_key = std::env::var(SP1_PRIVATE_KEY_ENV).wrap_err_with(|| {
+                format!("{SP1_PRIVATE_KEY_ENV} is required when {SP1_WORKER_PROVER_ENV}=network")
+            })?;
+            let prover = NetworkSuccinctProver::new(SP1ProofMode::Groth16, &private_key)
+                .await
+                .map_err(|error| eyre!("failed to build SP1 prover: {error}"))?;
+            start_sp1_worker_with_prover(prover_service_url, deployment, kind, host, prover)
+        }
     }
 }
 

--- a/proofs/prover-sp1/src/main.rs
+++ b/proofs/prover-sp1/src/main.rs
@@ -68,13 +68,17 @@ struct Sp1ProveArgs {
     #[arg(long, default_value_t = 1)]
     ranges: u64,
 
-    /// Prover backend. Network is reserved for a follow-up implementation.
+    /// Prover backend.
     #[arg(
         long,
         env = "SP1_PROVER",
         default_value_t = Sp1ProverKind::Cpu
     )]
     prover: Sp1ProverKind,
+
+    /// SP1 network private key. Required when --prover network.
+    #[arg(long, env = "SP1_PRIVATE_KEY")]
+    sp1_private_key: Option<String>,
 
     /// Aggregation proof mode.
     #[arg(long, default_value = "groth16")]
@@ -139,6 +143,7 @@ async fn sp1_prove(args: Sp1ProveArgs) -> Result<()> {
     use world_chain_proof_succinct_host_utils::{
         cpu_prover::CpuSuccinctProver,
         mock_prover::MockSuccinctProver,
+        network_prover::NetworkSuccinctProver,
         validity::{ValidityProofRequest, prove_validity},
     };
 
@@ -179,10 +184,12 @@ async fn sp1_prove(args: Sp1ProveArgs) -> Result<()> {
             prove_validity(&host, &prover, proof_request).await?
         }
         Sp1ProverKind::Network => {
-            anyhow::bail!(
-                "unsupported SP1 prover '{}'; only 'cpu' and 'mock' are currently available",
-                args.prover
-            );
+            let private_key = args
+                .sp1_private_key
+                .clone()
+                .context("SP1_PRIVATE_KEY is required when --prover network")?;
+            let prover = NetworkSuccinctProver::new(mode, &private_key).await?;
+            prove_validity(&host, &prover, proof_request).await?
         }
     };
 

--- a/proofs/sp1-worker/src/main.rs
+++ b/proofs/sp1-worker/src/main.rs
@@ -12,6 +12,7 @@ use world_chain_proof_succinct_host_utils::{
     Sp1ProverKind, WorldSuccinctProver,
     cpu_prover::{CpuSuccinctProver, SP1ProofMode},
     mock_prover::MockSuccinctProver,
+    network_prover::NetworkSuccinctProver,
 };
 use world_chain_proof_worker::WorkerHeartbeatConfig;
 use world_chain_prover_service::RpcProverServiceClient;
@@ -100,13 +101,17 @@ struct Cli {
     #[arg(long, default_value_t = 900)]
     witness_timeout_seconds: u64,
 
-    /// Prover backend. Network is reserved for a follow-up implementation.
+    /// Prover backend.
     #[arg(
         long,
         env = "SP1_PROVER",
         default_value_t = Sp1ProverKind::Cpu
     )]
     prover: Sp1ProverKind,
+
+    /// SP1 network private key. Required when --prover network.
+    #[arg(long, env = "SP1_PRIVATE_KEY")]
+    sp1_private_key: Option<String>,
 
     /// Prover address for on-chain attribution (defaults to zero address).
     #[arg(
@@ -206,10 +211,16 @@ async fn main() -> Result<()> {
             .await
         }
         Sp1ProverKind::Network => {
-            anyhow::bail!(
-                "unsupported SP1 prover '{}'; only 'cpu' and 'mock' are currently available",
-                prover_kind
-            );
+            let private_key = cli
+                .sp1_private_key
+                .clone()
+                .context("SP1_PRIVATE_KEY is required when --prover network")?;
+            run_worker(
+                cli,
+                host,
+                NetworkSuccinctProver::new(SP1ProofMode::Groth16, &private_key).await?,
+            )
+            .await
         }
     }
 }

--- a/proofs/sp1-worker/tests/e2e_proving.rs
+++ b/proofs/sp1-worker/tests/e2e_proving.rs
@@ -17,7 +17,8 @@
 //! export L1_BEACON_RPC_URL=$L1_RPC_URL          # devnet uses calldata DA; L1 RPC doubles as beacon
 //! export ROLLUP_RPC_URL=http://127.0.0.1:7545   # op-node, for output roots
 //! export ROLLUP_CONFIG=/path/to/rollup.json
-//! export SP1_PROVER=cpu                          # cpu | mock | network (network not wired yet)
+//! export SP1_PROVER=cpu                          # cpu | mock | network
+//! export SP1_PRIVATE_KEY=<your key>              # required for SP1_PROVER=network
 //! cargo test -p world-chain-sp1-worker --test e2e_proving -- --ignored --nocapture
 //! ```
 //!
@@ -35,6 +36,7 @@ use world_chain_proof_succinct_host_utils::{
     Sp1ProverKind, WorldSuccinctProver,
     cpu_prover::{CpuSuccinctProver, SP1ProofMode},
     mock_prover::MockSuccinctProver,
+    network_prover::NetworkSuccinctProver,
 };
 use world_chain_proof_worker::WorkerHeartbeatConfig;
 use world_chain_proofs::{ConsensusProvider, OptimismConsensusClient};
@@ -168,9 +170,24 @@ async fn worker_proves_real_range_end_to_end() {
             .await;
         }
         Sp1ProverKind::Network => {
-            panic!(
-                "unsupported SP1 prover '{kind}'; only 'cpu' and 'mock' are currently available"
-            );
+            let Some(private_key) = required("SP1_PRIVATE_KEY") else {
+                return;
+            };
+            let prover = NetworkSuccinctProver::new(SP1ProofMode::Groth16, &private_key)
+                .await
+                .expect("build prover");
+            run_worker_proves_real_range_end_to_end_with_prover(
+                host,
+                prover,
+                kind,
+                block_interval,
+                split_count,
+                root_claim,
+                l1_head,
+                claimed_block,
+                timeout,
+            )
+            .await;
         }
     }
 }

--- a/proofs/succinct/utils/host/src/cpu_prover.rs
+++ b/proofs/succinct/utils/host/src/cpu_prover.rs
@@ -1,6 +1,7 @@
 //! Range proofs are produced in `Compressed` mode so the aggregation guest can recursively
 //! verify them; the aggregation proof mode is configurable (Groth16 for on-chain verification).
 
+use crate::SuccinctProverError;
 use anyhow::{Context, bail};
 use async_trait::async_trait;
 pub use sp1_sdk::SP1ProofMode;
@@ -17,21 +18,6 @@ use world_chain_proof_succinct_utils::{
     AggregationProofRequest, ProofRequest, RangeProofRequest, Sp1SessionStatus, WorldSuccinctProver,
 };
 use world_chain_prover_service::{ProofRequestId, SessionType};
-
-/// Structured failures specific to [`SuccinctProver`]; surfaced wrapped in
-/// [`anyhow::Error`] so callers can downcast when they need to match on them.
-#[derive(Debug, thiserror::Error)]
-pub enum SuccinctProverError {
-    /// The guest committed boot info that differs from the host-computed expectation.
-    #[error("range proof boot info mismatch: expected {expected:?}, got {actual:?}")]
-    BootInfoMismatch {
-        expected: Box<BootInfoStruct>,
-        actual: Box<BootInfoStruct>,
-    },
-    /// Aggregation requires compressed range proofs for recursive verification.
-    #[error("range proof was not in compressed mode")]
-    NotCompressed,
-}
 
 /// [`WorldSuccinctProver`] CPU-local implementation over the sp1-sdk local prover.
 pub struct CpuSuccinctProver {

--- a/proofs/succinct/utils/host/src/lib.rs
+++ b/proofs/succinct/utils/host/src/lib.rs
@@ -24,6 +24,21 @@ pub mod mock_prover;
 pub mod network_prover;
 pub mod validity;
 
+/// Structured failures specific to all succinct provers; surfaced wrapped in
+/// [`anyhow::Error`] so callers can downcast when they need to match on them.
+#[derive(Debug, thiserror::Error)]
+pub enum SuccinctProverError {
+    /// The guest committed boot info that differs from the host-computed expectation.
+    #[error("range proof boot info mismatch: expected {expected:?}, got {actual:?}")]
+    BootInfoMismatch {
+        expected: Box<BootInfoStruct>,
+        actual: Box<BootInfoStruct>,
+    },
+    /// Aggregation requires compressed range proofs for recursive verification.
+    #[error("range proof was not in compressed mode")]
+    NotCompressed,
+}
+
 /// SP1 proving backend selected by binaries and dev tooling.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, EnumString)]
 #[serde(rename_all = "kebab-case")]

--- a/proofs/succinct/utils/host/src/mock_prover.rs
+++ b/proofs/succinct/utils/host/src/mock_prover.rs
@@ -1,7 +1,7 @@
 //! Range proofs are produced in `Compressed` mode so the aggregation guest can recursively
 //! verify them; the aggregation proof mode is configurable (Groth16 for on-chain verification).
 
-use crate::cpu_prover::SuccinctProverError;
+use crate::SuccinctProverError;
 use anyhow::{Context, bail};
 use async_trait::async_trait;
 use sp1_sdk::{
@@ -20,6 +20,7 @@ use world_chain_proof_succinct_utils::{
 };
 use world_chain_prover_service::{ProofRequestId, SessionType};
 
+/// [`WorldSuccinctProver`] mock implementation over the sp1-sdk mock prover.
 pub struct MockSuccinctProver {
     client: MockProver,
     range_pk: SP1ProvingKey,

--- a/proofs/succinct/utils/host/src/network_prover.rs
+++ b/proofs/succinct/utils/host/src/network_prover.rs
@@ -242,7 +242,9 @@ fn sp1_status(status: &GetProofRequestStatusResponse) -> Sp1SessionStatus {
             "proof unfulfillable, execution_status={}",
             status.execution_status()
         )),
-        Ok(_) => Sp1SessionStatus::Running,
+        Ok(FulfillmentStatus::Assigned)
+        | Ok(FulfillmentStatus::Requested)
+        | Ok(FulfillmentStatus::UnspecifiedFulfillmentStatus) => Sp1SessionStatus::Running,
         Err(_) => Sp1SessionStatus::Failed(format!(
             "unknown network proof fulfillment status: {}",
             status.fulfillment_status()

--- a/proofs/succinct/utils/host/src/network_prover.rs
+++ b/proofs/succinct/utils/host/src/network_prover.rs
@@ -1,1 +1,251 @@
+//! Range proofs are produced in `Compressed` mode so the aggregation guest can recursively
+//! verify them; the aggregation proof mode is configurable (Groth16 for on-chain verification).
 
+use crate::SuccinctProverError;
+use alloy_primitives::B256;
+use anyhow::{Context, bail};
+use async_trait::async_trait;
+pub use sp1_sdk::SP1ProofMode;
+use sp1_sdk::{
+    HashableKey, NetworkProver, ProveRequest, Prover, ProverClient, ProvingKey, SP1Proof,
+    SP1ProofWithPublicValues, SP1ProvingKey, SP1Stdin,
+    network::proto::{GetProofRequestStatusResponse, types::FulfillmentStatus},
+};
+use world_chain_proof_core::{
+    artifacts::{AggregationProofArtifact, ProofArtifact, RangeProofArtifact},
+    boot::BootInfoStruct,
+    types::{AggregationInputs, AggregationOutputs},
+};
+use world_chain_proof_succinct_utils::{
+    AggregationProofRequest, ProofRequest, RangeProofRequest, Sp1SessionStatus, WorldSuccinctProver,
+};
+use world_chain_prover_service::{ProofRequestId, SessionType};
+
+/// [`WorldSuccinctProver`] network implementation over the sp1-sdk network prover.
+pub struct NetworkSuccinctProver {
+    client: NetworkProver,
+    range_pk: SP1ProvingKey,
+    agg_pk: SP1ProvingKey,
+    multi_block_vkey: [u32; 8],
+    agg_mode: SP1ProofMode,
+}
+
+impl NetworkSuccinctProver {
+    /// Creates the prover using caller-supplied ELFs. Use this in production binaries with
+    /// ELFs embedded at compile time via `world_chain_proof_succinct_elfs`.
+    pub async fn new(agg_mode: SP1ProofMode, private_key: &str) -> anyhow::Result<Self> {
+        let range_elf = world_chain_proof_succinct_elfs::range_elf();
+        let agg_elf = world_chain_proof_succinct_elfs::aggregation_elf();
+        let client = ProverClient::builder()
+            .network()
+            .private_key(private_key)
+            .build()
+            .await;
+        let range_pk = client
+            .setup(range_elf.clone())
+            .await
+            .context("range program setup failed")?;
+        let agg_pk = client
+            .setup(agg_elf.clone())
+            .await
+            .context("aggregation program setup failed")?;
+        let multi_block_vkey = range_pk.verifying_key().hash_u32();
+
+        Ok(Self {
+            client,
+            range_pk,
+            agg_pk,
+            multi_block_vkey,
+            agg_mode,
+        })
+    }
+
+    async fn request_range_proof(&self, request: RangeProofRequest) -> anyhow::Result<String> {
+        let mut stdin = SP1Stdin::new();
+        stdin.write_vec(request.witness_rkyv);
+
+        let backend_session_id = self
+            .client
+            .prove(&self.range_pk, stdin)
+            .compressed()
+            .request()
+            .await
+            .context("request range proving failed")?;
+
+        Ok(backend_session_id.to_string())
+    }
+
+    async fn request_aggregation_proof(
+        &self,
+        request: AggregationProofRequest,
+    ) -> anyhow::Result<String> {
+        let mut stdin = SP1Stdin::new();
+        let range_vk = self.range_pk.verifying_key().vk.clone();
+        for proof_bytes in &request.range_proofs {
+            let proof: sp1_sdk::SP1ProofWithPublicValues =
+                bincode::deserialize(proof_bytes).context("range proof deserialization failed")?;
+            let SP1Proof::Compressed(inner) = proof.proof else {
+                return Err(SuccinctProverError::NotCompressed.into());
+            };
+            stdin.write_proof(*inner, range_vk.clone());
+        }
+        stdin.write(&request.inputs);
+        stdin.write_vec(request.l1_headers_cbor);
+
+        let backend_session_id = self
+            .client
+            .prove(&self.agg_pk, stdin)
+            .mode(self.agg_mode)
+            .request()
+            .await
+            .context("aggregation proving failed")?;
+
+        Ok(backend_session_id.to_string())
+    }
+
+    /// Fetch the network session state and any proof returned by the SP1 Network.
+    pub async fn get_network_proof_status(
+        &self,
+        backend_session_id: &str,
+    ) -> anyhow::Result<(Sp1SessionStatus, Option<SP1ProofWithPublicValues>)> {
+        let proof_id = parse_proof_id(backend_session_id)?;
+        let (status, proof) = self
+            .client
+            .get_proof_status(proof_id)
+            .await
+            .context("failed to get network proof status")?;
+        let sp1_status = sp1_status(&status);
+        Ok((sp1_status, proof))
+    }
+}
+
+#[async_trait]
+impl WorldSuccinctProver for NetworkSuccinctProver {
+    fn supports_persistent_sessions(&self) -> bool {
+        true
+    }
+
+    async fn submit(
+        &self,
+        _proof_id: ProofRequestId,
+        session_type: SessionType,
+        request: ProofRequest,
+    ) -> anyhow::Result<String> {
+        match session_type {
+            SessionType::Stark => {
+                let ProofRequest::Range(range_request) = request else {
+                    bail!("proof request and session type mistmach")
+                };
+                let backend_session_id = self.request_range_proof(range_request).await?;
+                Ok(backend_session_id)
+            }
+            SessionType::Snark => {
+                let ProofRequest::Aggregation(session_request) = request else {
+                    bail!("proof request and session type mistmach")
+                };
+                let agg_request = AggregationProofRequest {
+                    inputs: AggregationInputs {
+                        boot_infos: session_request.boot_infos,
+                        latest_l1_checkpoint_head: session_request.latest_l1_checkpoint_head,
+                        multi_block_vkey: self.multi_block_vkey,
+                        prover_address: session_request.prover_address,
+                    },
+                    l1_headers_cbor: session_request.l1_headers_cbor,
+                    range_proofs: session_request.range_proofs,
+                };
+                let backend_session_id = self.request_aggregation_proof(agg_request).await?;
+                Ok(backend_session_id.to_string())
+            }
+        }
+    }
+
+    async fn poll(
+        &self,
+        session_id: String,
+        _session_type: SessionType,
+    ) -> anyhow::Result<Sp1SessionStatus> {
+        let (sp1_status, _maybe_proof) = self.get_network_proof_status(&session_id).await?;
+        Ok(sp1_status)
+    }
+
+    async fn download(
+        &self,
+        session_id: String,
+        session_type: SessionType,
+    ) -> anyhow::Result<ProofArtifact> {
+        let (sp1_status, maybe_proof) = self.get_network_proof_status(&session_id).await?;
+        match sp1_status {
+            Sp1SessionStatus::Completed => {
+                let proof = maybe_proof.ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "network proof {session_id} is fulfilled but no proof was returned"
+                    )
+                })?;
+                match session_type {
+                    SessionType::Stark => {
+                        let boot_info: BootInfoStruct =
+                            bincode::deserialize(proof.public_values.as_slice())
+                                .context("range proof public values deserialization failed")?;
+
+                        let proof_bytes = bincode::serialize(&proof)
+                            .context("range proof serialization failed")?;
+
+                        Ok(ProofArtifact::Range(RangeProofArtifact {
+                            boot_info,
+                            proof: proof_bytes,
+                        }))
+                    }
+                    SessionType::Snark => {
+                        let outputs =
+                            <AggregationOutputs as alloy_sol_types::SolValue>::abi_decode(
+                                proof.public_values.as_slice(),
+                            )
+                            .context("aggregation outputs abi decoding failed")?;
+
+                        // Groth16/Plonk proofs serialize to their on-chain calldata representation; other
+                        // modes (mock runs, compressed) keep the full sdk proof for offline use.
+                        let proof_bytes = match &proof.proof {
+                            SP1Proof::Groth16(_) | SP1Proof::Plonk(_) => proof.bytes(),
+                            _ => bincode::serialize(&proof)
+                                .context("aggregation proof serialization failed")?,
+                        };
+                        Ok(ProofArtifact::Aggregation(AggregationProofArtifact {
+                            outputs,
+                            proof: proof_bytes,
+                        }))
+                    }
+                }
+            }
+            Sp1SessionStatus::Running => {
+                bail!("network proof {session_id} is not fulfilled yet");
+            }
+            Sp1SessionStatus::Failed(reason) => bail!("{reason}"),
+            Sp1SessionStatus::NotFound => {
+                bail!("network proof {session_id} was not found");
+            }
+        }
+    }
+}
+
+/// Parse a network proof ID from its hex string representation.
+fn parse_proof_id(proof_id: &str) -> anyhow::Result<B256> {
+    proof_id
+        .parse::<B256>()
+        .map_err(|e| anyhow::anyhow!("invalid network proof ID: {e}"))
+}
+
+/// Map an SP1 Network proof status response to the sp1 session status.
+fn sp1_status(status: &GetProofRequestStatusResponse) -> Sp1SessionStatus {
+    match FulfillmentStatus::try_from(status.fulfillment_status()) {
+        Ok(FulfillmentStatus::Fulfilled) => Sp1SessionStatus::Completed,
+        Ok(FulfillmentStatus::Unfulfillable) => Sp1SessionStatus::Failed(format!(
+            "proof unfulfillable, execution_status={}",
+            status.execution_status()
+        )),
+        Ok(_) => Sp1SessionStatus::Running,
+        Err(_) => Sp1SessionStatus::Failed(format!(
+            "unknown network proof fulfillment status: {}",
+            status.fulfillment_status()
+        )),
+    }
+}


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4875/add-network-sp1-prover

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces external network proving and mandatory private-key auth for that path; misconfiguration or key handling could block or mis-attribute proofs, though local CPU/mock behavior is unchanged.
> 
> **Overview**
> Adds **`NetworkSuccinctProver`** as a third `Sp1ProverKind` option alongside CPU and mock, wiring Succinct’s remote proving network into the same `WorldSuccinctProver` flow used by the worker and CLI.
> 
> The new backend **submits** compressed range and aggregation jobs via `sp1-sdk`’s network client (returns network proof IDs), **polls** fulfillment status, and **downloads** artifacts when complete—`supports_persistent_sessions` is **true** so the SP1 worker can resume in-flight network sessions. **`SuccinctProverError`** is hoisted to `lib.rs` so CPU, mock, and network share boot-info / not-compressed errors.
> 
> **`SP1_PRIVATE_KEY`** (or `--sp1-private-key` / env) is required when `--prover network` or `DEVNET_SP1_WORKER_PROVER=network`; devnet, `world-chain-prover-sp1`, `sp1-worker`, and the ignored e2e test all replace the previous “unsupported” bail with this path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 541a604920f3bbf434680798db670928833eab4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->