### PR TITLE
refactor(proof-system): make `WorldSuccinctProver` trait better

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19146,12 +19146,9 @@ name = "world-chain-proof-succinct-utils"
 version = "2.4.0"
 dependencies = [
  "alloy-primitives",
- "anyhow",
- "async-trait",
  "rkyv",
  "serde",
  "world-chain-proof-core",
- "world-chain-prover-service",
 ]
 
 [[package]]

--- a/proofs/nitro/src/lib.rs
+++ b/proofs/nitro/src/lib.rs
@@ -7,7 +7,7 @@
 //! `BootInfoStruct` is attested by the enclave's NSM device. Verifiers check the attestation
 //! document instead of a ZK proof.
 //!
-//! The boundary mirrors [`world_chain_proof_succinct_proof_utils::WorldSuccinctProver`]:
+//! The boundary mirrors [`world_chain_proof_succinct_host_utils::WorldSuccinctProver`]:
 //!
 //! - [`NitroRangeProofRequest`] carries the full rkyv-serialized [`WorldRangeWitnessData`]
 //!   that the enclave needs to drive the derivation pipeline.
@@ -207,7 +207,7 @@ pub struct NitroAggregationProofArtifact {
 
 /// Backend trait for TEE-attested World prover implementations.
 ///
-/// Modeled after [`world_chain_proof_succinct_proof_utils::WorldSuccinctProver`], but the
+/// Modeled after [`world_chain_proof_succinct_host_utils::WorldSuccinctProver`], but the
 /// request and artifact types carry attestation material instead of ZK proofs.
 #[async_trait]
 pub trait WorldNitroProver {

--- a/proofs/sp1-worker/src/backend.rs
+++ b/proofs/sp1-worker/src/backend.rs
@@ -196,23 +196,6 @@ impl<P: WorldSuccinctProver> Sp1Backend<P> {
         job: &ProofJob,
         session_id: String,
     ) -> anyhow::Result<RangeProofArtifact> {
-        self.wait_and_download_range_artifact(job, session_id).await
-    }
-
-    async fn wait_and_download_aggregation(
-        &self,
-        job: &ProofJob,
-        session_id: String,
-    ) -> anyhow::Result<AggregationProofArtifact> {
-        self.wait_and_download_aggregation_artifact(job, session_id)
-            .await
-    }
-
-    async fn wait_and_download_range_artifact(
-        &self,
-        job: &ProofJob,
-        session_id: String,
-    ) -> anyhow::Result<RangeProofArtifact> {
         let session_type = SessionType::Stark;
         let session_label = session_type.as_str();
         loop {
@@ -254,7 +237,7 @@ impl<P: WorldSuccinctProver> Sp1Backend<P> {
         }
     }
 
-    async fn wait_and_download_aggregation_artifact(
+    async fn wait_and_download_aggregation(
         &self,
         job: &ProofJob,
         session_id: String,

--- a/proofs/sp1-worker/src/backend.rs
+++ b/proofs/sp1-worker/src/backend.rs
@@ -5,18 +5,19 @@ use std::time::Duration;
 use alloy_primitives::{Address, B256};
 use alloy_sol_types::SolValue;
 use anyhow::Context;
-use world_chain_proof_core::artifacts::{AggregationProofArtifact, ProofArtifact};
+use world_chain_proof_core::artifacts::{AggregationProofArtifact, RangeProofArtifact};
 use world_chain_proof_kona_host_utils::online::{
     OnlineHostConfig, RangeWitnessRequest, build_range_input, fetch_l1_header_by_hash,
 };
+use world_chain_proof_succinct_host_utils::{
+    WorldSuccinctProver, aggregation_artifact_from_sp1_proof, range_artifact_from_sp1_proof,
+};
 use world_chain_proof_succinct_utils::{
-    AggregationSessionRequest, ProofRequest as SuccinctProofRequest, RangeProofArtifact,
-    RangeProofRequest, Sp1SessionStatus, WorldSuccinctProver,
+    AggregationSessionRequest, RangeProofRequest, Sp1ProofRequest, Sp1SessionStatus,
 };
 use world_chain_proof_worker::{ClaimedProofJobHandler, ProofJob};
 use world_chain_prover_service::{
-    BackendSession, BackendSessionStatus, ProofBackend, ProofData, ProofRequest, ProofRequestId,
-    SessionType,
+    BackendSession, BackendSessionStatus, ProofBackend, ProofData, ProofRequest, SessionType,
 };
 
 /// Configuration for [`Sp1Backend`].
@@ -64,7 +65,6 @@ where
 
     async fn handle_claimed_job(&self, job: ProofJob) -> anyhow::Result<ProofData> {
         let request = &job.request;
-        let proof_id = request.id();
         let start_block = self.start_block(request)?;
 
         if let Some(snark_session) = self.get_session(&job, SessionType::Snark).await? {
@@ -91,9 +91,8 @@ where
             let session_id = self
                 .submit_session(
                     &job,
-                    proof_id,
                     SessionType::Stark,
-                    SuccinctProofRequest::Range(range_request),
+                    Sp1ProofRequest::Range(range_request),
                 )
                 .await
                 .context("failed to submit range proof")?;
@@ -113,9 +112,8 @@ where
         let snark_session_id = self
             .submit_session(
                 &job,
-                proof_id,
                 SessionType::Snark,
-                SuccinctProofRequest::Aggregation(aggregation_request),
+                Sp1ProofRequest::Aggregation(aggregation_request),
             )
             .await
             .context("failed to submit aggregation proof")?;
@@ -177,14 +175,10 @@ impl<P: WorldSuccinctProver> Sp1Backend<P> {
     async fn submit_session(
         &self,
         job: &ProofJob,
-        proof_id: ProofRequestId,
         session_type: SessionType,
-        request: SuccinctProofRequest,
+        request: Sp1ProofRequest,
     ) -> anyhow::Result<String> {
-        let session_id = self
-            .prover
-            .submit(proof_id, session_type.clone(), request)
-            .await?;
+        let session_id = self.prover.submit(request).await?;
 
         self.record_session(
             job,
@@ -202,15 +196,7 @@ impl<P: WorldSuccinctProver> Sp1Backend<P> {
         job: &ProofJob,
         session_id: String,
     ) -> anyhow::Result<RangeProofArtifact> {
-        let artifact = self
-            .wait_and_download_artifact(job, SessionType::Stark, session_id.clone())
-            .await?;
-
-        let ProofArtifact::Range(range) = artifact else {
-            anyhow::bail!("expected range proof artifact for STARK session {session_id}");
-        };
-
-        Ok(range)
+        self.wait_and_download_range_artifact(job, session_id).await
     }
 
     async fn wait_and_download_aggregation(
@@ -218,40 +204,73 @@ impl<P: WorldSuccinctProver> Sp1Backend<P> {
         job: &ProofJob,
         session_id: String,
     ) -> anyhow::Result<AggregationProofArtifact> {
-        let artifact = self
-            .wait_and_download_artifact(job, SessionType::Snark, session_id.clone())
-            .await?;
-
-        let ProofArtifact::Aggregation(agg) = artifact else {
-            anyhow::bail!("expected aggregation proof artifact for SNARK session {session_id}");
-        };
-
-        Ok(agg)
+        self.wait_and_download_aggregation_artifact(job, session_id)
+            .await
     }
 
-    async fn wait_and_download_artifact(
+    async fn wait_and_download_range_artifact(
         &self,
         job: &ProofJob,
-        session_type: SessionType,
         session_id: String,
-    ) -> anyhow::Result<ProofArtifact> {
+    ) -> anyhow::Result<RangeProofArtifact> {
+        let session_type = SessionType::Stark;
         let session_label = session_type.as_str();
         loop {
-            match self
-                .prover
-                .poll(session_id.clone(), session_type.clone())
-                .await?
-            {
+            match self.prover.poll(&session_id).await? {
                 Sp1SessionStatus::Running => {
                     // TODO: replace this hardcoded duration with a cli flag
                     let duration = Duration::from_secs(10);
                     tokio::time::sleep(duration).await;
                 }
                 Sp1SessionStatus::Completed => {
-                    let artifact = self
-                        .prover
-                        .download(session_id.clone(), session_type.clone())
-                        .await?;
+                    let proof = self.prover.download(&session_id).await?;
+                    let artifact = range_artifact_from_sp1_proof(&proof)?;
+
+                    self.record_session(
+                        job,
+                        session_type.clone(),
+                        &session_id,
+                        BackendSessionStatus::Completed,
+                    )
+                    .await?;
+
+                    return Ok(artifact);
+                }
+                Sp1SessionStatus::Failed(reason) => {
+                    self.record_session(
+                        job,
+                        session_type.clone(),
+                        &session_id,
+                        BackendSessionStatus::Failed,
+                    )
+                    .await?;
+
+                    anyhow::bail!("{session_label} proof session {session_id} failed: {reason}");
+                }
+                Sp1SessionStatus::NotFound => {
+                    anyhow::bail!("{session_label} proof session {session_id} not found by prover");
+                }
+            }
+        }
+    }
+
+    async fn wait_and_download_aggregation_artifact(
+        &self,
+        job: &ProofJob,
+        session_id: String,
+    ) -> anyhow::Result<AggregationProofArtifact> {
+        let session_type = SessionType::Snark;
+        let session_label = session_type.as_str();
+        loop {
+            match self.prover.poll(&session_id).await? {
+                Sp1SessionStatus::Running => {
+                    // TODO: replace this hardcoded duration with a cli flag
+                    let duration = Duration::from_secs(10);
+                    tokio::time::sleep(duration).await;
+                }
+                Sp1SessionStatus::Completed => {
+                    let proof = self.prover.download(&session_id).await?;
+                    let artifact = aggregation_artifact_from_sp1_proof(&proof)?;
 
                     self.record_session(
                         job,
@@ -318,7 +337,7 @@ impl<P: WorldSuccinctProver> Sp1Backend<P> {
         .await
         .context("failed to build SP1 range witness")?;
 
-        let range_request = RangeProofRequest::from_witness_data(&input.witness, None)
+        let range_request = RangeProofRequest::from_witness_data(&input.witness)
             .context("failed to serialize SP1 range witness")?;
 
         Ok(range_request)

--- a/proofs/succinct/utils/host/src/cpu_prover.rs
+++ b/proofs/succinct/utils/host/src/cpu_prover.rs
@@ -1,23 +1,25 @@
 //! Range proofs are produced in `Compressed` mode so the aggregation guest can recursively
 //! verify them; the aggregation proof mode is configurable (Groth16 for on-chain verification).
 
-use crate::SuccinctProverError;
-use anyhow::{Context, bail};
+use crate::{SuccinctProverError, WorldSuccinctProver};
+use anyhow::Context;
 use async_trait::async_trait;
 pub use sp1_sdk::SP1ProofMode;
 use sp1_sdk::{
-    CpuProver, HashableKey, ProveRequest, Prover, ProvingKey, SP1Proof, SP1ProvingKey, SP1Stdin,
+    CpuProver, HashableKey, ProveRequest, Prover, ProvingKey, SP1Proof, SP1ProofWithPublicValues,
+    SP1ProvingKey, SP1Stdin,
 };
-use std::{collections::HashMap, sync::Mutex};
-use world_chain_proof_core::{
-    artifacts::{AggregationProofArtifact, ProofArtifact, RangeProofArtifact},
-    boot::BootInfoStruct,
-    types::{AggregationInputs, AggregationOutputs},
+use std::{
+    collections::HashMap,
+    sync::{
+        Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
 };
+use world_chain_proof_core::types::AggregationInputs;
 use world_chain_proof_succinct_utils::{
-    AggregationProofRequest, ProofRequest, RangeProofRequest, Sp1SessionStatus, WorldSuccinctProver,
+    AggregationProofRequest, RangeProofRequest, Sp1ProofRequest, Sp1SessionStatus,
 };
-use world_chain_prover_service::{ProofRequestId, SessionType};
 
 /// [`WorldSuccinctProver`] CPU-local implementation over the sp1-sdk local prover.
 pub struct CpuSuccinctProver {
@@ -27,8 +29,8 @@ pub struct CpuSuccinctProver {
     multi_block_vkey: [u32; 8],
     agg_mode: SP1ProofMode,
 
-    range_proofs: Mutex<HashMap<String, RangeProofArtifact>>,
-    agg_proofs: Mutex<HashMap<String, AggregationProofArtifact>>,
+    next_session_id: AtomicU64,
+    proofs: Mutex<HashMap<String, SP1ProofWithPublicValues>>,
 }
 
 impl CpuSuccinctProver {
@@ -54,12 +56,20 @@ impl CpuSuccinctProver {
             agg_pk,
             multi_block_vkey,
             agg_mode,
-            range_proofs: Mutex::new(HashMap::default()),
-            agg_proofs: Mutex::new(HashMap::default()),
+            next_session_id: AtomicU64::new(0),
+            proofs: Mutex::new(HashMap::default()),
         })
     }
 
-    async fn prove_range(&self, request: RangeProofRequest) -> anyhow::Result<RangeProofArtifact> {
+    fn next_session_id(&self, prefix: &str) -> String {
+        let id = self.next_session_id.fetch_add(1, Ordering::Relaxed);
+        format!("{prefix}-{id}")
+    }
+
+    async fn prove_range(
+        &self,
+        request: RangeProofRequest,
+    ) -> anyhow::Result<SP1ProofWithPublicValues> {
         let mut stdin = SP1Stdin::new();
         stdin.write_vec(request.witness_rkyv);
 
@@ -70,32 +80,13 @@ impl CpuSuccinctProver {
             .await
             .context("range proving failed")?;
 
-        let boot_info: BootInfoStruct = bincode::deserialize(proof.public_values.as_slice())
-            .context("range proof public values deserialization failed")?;
-
-        if let Some(expected) = request.expected_public_values {
-            let expected_boot = BootInfoStruct::from(expected.boot_info);
-            if expected_boot != boot_info {
-                return Err(SuccinctProverError::BootInfoMismatch {
-                    expected: Box::new(expected_boot),
-                    actual: Box::new(boot_info),
-                }
-                .into());
-            }
-        }
-
-        let proof_bytes = bincode::serialize(&proof).context("range proof serialization failed")?;
-
-        Ok(RangeProofArtifact {
-            boot_info,
-            proof: proof_bytes,
-        })
+        Ok(proof)
     }
 
     async fn prove_aggregation(
         &self,
         request: AggregationProofRequest,
-    ) -> anyhow::Result<AggregationProofArtifact> {
+    ) -> anyhow::Result<SP1ProofWithPublicValues> {
         let mut stdin = SP1Stdin::new();
         let range_vk = self.range_pk.verifying_key().vk.clone();
         for proof_bytes in &request.range_proofs {
@@ -120,22 +111,7 @@ impl CpuSuccinctProver {
             .verify(&proof, self.agg_pk.verifying_key(), None)
             .context("aggregation proof verification failed")?;
 
-        let outputs = <AggregationOutputs as alloy_sol_types::SolValue>::abi_decode(
-            proof.public_values.as_slice(),
-        )
-        .context("aggregation outputs abi decoding failed")?;
-
-        // Groth16/Plonk proofs serialize to their on-chain calldata representation; other
-        // modes (mock runs, compressed) keep the full sdk proof for offline use.
-        let proof_bytes = match &proof.proof {
-            SP1Proof::Groth16(_) | SP1Proof::Plonk(_) => proof.bytes(),
-            _ => bincode::serialize(&proof).context("aggregation proof serialization failed")?,
-        };
-
-        Ok(AggregationProofArtifact {
-            outputs,
-            proof: proof_bytes,
-        })
+        Ok(proof)
     }
 }
 
@@ -145,29 +121,12 @@ impl WorldSuccinctProver for CpuSuccinctProver {
         false
     }
 
-    async fn submit(
-        &self,
-        proof_id: ProofRequestId,
-        session_type: SessionType,
-        request: ProofRequest,
-    ) -> anyhow::Result<String> {
-        match session_type {
-            SessionType::Stark => {
-                let ProofRequest::Range(range_request) = request else {
-                    bail!("proof request and session type mistmach")
-                };
-                let range_proof = self.prove_range(range_request).await?;
-                let mut range_proofs = self
-                    .range_proofs
-                    .lock()
-                    .map_err(|_| anyhow::anyhow!("mutex lock poisoned"))?;
-                range_proofs.insert(proof_id.to_string(), range_proof);
-                Ok(proof_id.to_string())
+    async fn submit(&self, request: Sp1ProofRequest) -> anyhow::Result<String> {
+        let (prefix, proof) = match request {
+            Sp1ProofRequest::Range(range_request) => {
+                ("range", self.prove_range(range_request).await?)
             }
-            SessionType::Snark => {
-                let ProofRequest::Aggregation(session_request) = request else {
-                    bail!("proof request and session type mistmach")
-                };
+            Sp1ProofRequest::Aggregation(session_request) => {
                 let agg_request = AggregationProofRequest {
                     inputs: AggregationInputs {
                         boot_infos: session_request.boot_infos,
@@ -178,76 +137,40 @@ impl WorldSuccinctProver for CpuSuccinctProver {
                     l1_headers_cbor: session_request.l1_headers_cbor,
                     range_proofs: session_request.range_proofs,
                 };
-                let agg_proof = self.prove_aggregation(agg_request).await?;
-                let mut agg_proofs = self
-                    .agg_proofs
-                    .lock()
-                    .map_err(|_| anyhow::anyhow!("mutex lock poisoned"))?;
-                agg_proofs.insert(proof_id.to_string(), agg_proof);
-                Ok(proof_id.to_string())
+                ("aggregation", self.prove_aggregation(agg_request).await?)
             }
+        };
+
+        let session_id = self.next_session_id(prefix);
+        let mut proofs = self
+            .proofs
+            .lock()
+            .map_err(|_| anyhow::anyhow!("mutex lock poisoned"))?;
+        proofs.insert(session_id.clone(), proof);
+        Ok(session_id)
+    }
+
+    async fn poll(&self, session_id: &str) -> anyhow::Result<Sp1SessionStatus> {
+        let proofs = self
+            .proofs
+            .lock()
+            .map_err(|_| anyhow::anyhow!("mutex lock poisoned"))?;
+        if proofs.contains_key(session_id) {
+            // CPU prover immediately returns completed status if the entry exists in the hashmap.
+            Ok(Sp1SessionStatus::Completed)
+        } else {
+            Ok(Sp1SessionStatus::NotFound)
         }
     }
 
-    async fn poll(
-        &self,
-        session_id: String,
-        session_type: SessionType,
-    ) -> anyhow::Result<Sp1SessionStatus> {
-        match session_type {
-            SessionType::Stark => {
-                let range_proofs = self
-                    .range_proofs
-                    .lock()
-                    .map_err(|_| anyhow::anyhow!("mutex lock poisoned"))?;
-                if range_proofs.contains_key(&session_id) {
-                    // CPU prover immediately returns completed status if the entry exists in the hashmap
-                    Ok(Sp1SessionStatus::Completed)
-                } else {
-                    Ok(Sp1SessionStatus::NotFound)
-                }
-            }
-            SessionType::Snark => {
-                let agg_proofs = self
-                    .agg_proofs
-                    .lock()
-                    .map_err(|_| anyhow::anyhow!("mutex lock poisoned"))?;
-                if agg_proofs.contains_key(&session_id) {
-                    // CPU prover immediately returns completed status if the entry exists in the hashmap
-                    Ok(Sp1SessionStatus::Completed)
-                } else {
-                    Ok(Sp1SessionStatus::NotFound)
-                }
-            }
-        }
-    }
-
-    async fn download(
-        &self,
-        session_id: String,
-        session_type: SessionType,
-    ) -> anyhow::Result<ProofArtifact> {
-        match session_type {
-            SessionType::Stark => {
-                let range_proofs = self
-                    .range_proofs
-                    .lock()
-                    .map_err(|_| anyhow::anyhow!("mutex lock poisoned"))?;
-                let range_proof = range_proofs.get(&session_id).ok_or_else(|| {
-                    anyhow::anyhow!("no range proof found for session_id: {}", session_id)
-                })?;
-                Ok(ProofArtifact::Range(range_proof.clone()))
-            }
-            SessionType::Snark => {
-                let agg_proofs = self
-                    .agg_proofs
-                    .lock()
-                    .map_err(|_| anyhow::anyhow!("mutex lock poisoned"))?;
-                let agg_proof = agg_proofs.get(&session_id).ok_or_else(|| {
-                    anyhow::anyhow!("no agg proof found for session_id: {}", session_id)
-                })?;
-                Ok(ProofArtifact::Aggregation(agg_proof.clone()))
-            }
-        }
+    async fn download(&self, session_id: &str) -> anyhow::Result<SP1ProofWithPublicValues> {
+        let proofs = self
+            .proofs
+            .lock()
+            .map_err(|_| anyhow::anyhow!("mutex lock poisoned"))?;
+        let proof = proofs
+            .get(session_id)
+            .ok_or_else(|| anyhow::anyhow!("no proof found for session_id: {session_id}"))?;
+        Ok(proof.clone())
     }
 }

--- a/proofs/succinct/utils/host/src/lib.rs
+++ b/proofs/succinct/utils/host/src/lib.rs
@@ -3,17 +3,26 @@
 use std::fmt;
 
 use alloy_primitives::{Address, B256, U256};
+#[cfg(feature = "sp1")]
+use anyhow::Context;
+#[cfg(feature = "sp1")]
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "sp1")]
+use sp1_sdk::{SP1Proof, SP1ProofWithPublicValues};
 use strum::EnumString;
+#[cfg(feature = "sp1")]
+use world_chain_proof_core::artifacts::{AggregationProofArtifact, RangeProofArtifact};
+#[cfg(feature = "sp1")]
+use world_chain_proof_core::types::AggregationOutputs;
 use world_chain_proof_core::{
     RollupConfigHashError,
     boot::{BootInfoStruct, hash_world_rollup_config_generic},
     hash_rollup_config,
-    range::{WorldRangeHardforkConfig, WorldRangeProofPublicValues},
+    range::WorldRangeHardforkConfig,
     types::AggregationInputs,
     witness::WorldRangeWitnessData,
 };
-pub use world_chain_proof_succinct_utils::WorldSuccinctProver;
 use world_chain_proof_succinct_utils::{AggregationProofRequest, RangeProofRequest};
 
 #[cfg(feature = "sp1")]
@@ -22,21 +31,78 @@ pub mod cpu_prover;
 pub mod mock_prover;
 #[cfg(feature = "sp1")]
 pub mod network_prover;
+#[cfg(feature = "sp1")]
 pub mod validity;
 
 /// Structured failures specific to all succinct provers; surfaced wrapped in
 /// [`anyhow::Error`] so callers can downcast when they need to match on them.
 #[derive(Debug, thiserror::Error)]
 pub enum SuccinctProverError {
-    /// The guest committed boot info that differs from the host-computed expectation.
-    #[error("range proof boot info mismatch: expected {expected:?}, got {actual:?}")]
-    BootInfoMismatch {
-        expected: Box<BootInfoStruct>,
-        actual: Box<BootInfoStruct>,
-    },
     /// Aggregation requires compressed range proofs for recursive verification.
     #[error("range proof was not in compressed mode")]
     NotCompressed,
+}
+
+/// Interface expected from a concrete SP1 prover backend.
+#[cfg(feature = "sp1")]
+#[async_trait]
+pub trait WorldSuccinctProver {
+    fn supports_persistent_sessions(&self) -> bool;
+
+    async fn submit(
+        &self,
+        request: world_chain_proof_succinct_utils::Sp1ProofRequest,
+    ) -> anyhow::Result<String>;
+
+    async fn poll(
+        &self,
+        session_id: &str,
+    ) -> anyhow::Result<world_chain_proof_succinct_utils::Sp1SessionStatus>;
+
+    async fn download(&self, session_id: &str) -> anyhow::Result<SP1ProofWithPublicValues>;
+}
+
+/// Converts a raw compressed SP1 range proof into the artifact consumed by aggregation.
+#[cfg(feature = "sp1")]
+pub fn range_artifact_from_sp1_proof(
+    proof: &SP1ProofWithPublicValues,
+) -> anyhow::Result<RangeProofArtifact> {
+    let boot_info: BootInfoStruct = bincode::deserialize(proof.public_values.as_slice())
+        .context("range proof public values deserialization failed")?;
+
+    let SP1Proof::Compressed(_) = &proof.proof else {
+        return Err(SuccinctProverError::NotCompressed.into());
+    };
+
+    let proof_bytes = bincode::serialize(proof).context("range proof serialization failed")?;
+
+    Ok(RangeProofArtifact {
+        boot_info,
+        proof: proof_bytes,
+    })
+}
+
+/// Converts a raw SP1 aggregation proof into the artifact submitted on-chain.
+#[cfg(feature = "sp1")]
+pub fn aggregation_artifact_from_sp1_proof(
+    proof: &SP1ProofWithPublicValues,
+) -> anyhow::Result<AggregationProofArtifact> {
+    let outputs = <AggregationOutputs as alloy_sol_types::SolValue>::abi_decode(
+        proof.public_values.as_slice(),
+    )
+    .context("aggregation outputs abi decoding failed")?;
+
+    // Groth16/Plonk proofs serialize to their on-chain calldata representation; other
+    // modes (mock runs, compressed) keep the full sdk proof for offline use.
+    let proof_bytes = match &proof.proof {
+        SP1Proof::Groth16(_) | SP1Proof::Plonk(_) => proof.bytes(),
+        _ => bincode::serialize(proof).context("aggregation proof serialization failed")?,
+    };
+
+    Ok(AggregationProofArtifact {
+        outputs,
+        proof: proof_bytes,
+    })
 }
 
 /// SP1 proving backend selected by binaries and dev tooling.
@@ -303,22 +369,8 @@ impl WorldSuccinctHost {
     pub fn range_request(
         &self,
         witness: &WorldRangeWitnessData,
-        expected_public_values: Option<WorldRangeProofPublicValues>,
     ) -> Result<RangeProofRequest, WorldSuccinctHostError> {
-        if let Some(expected) = &expected_public_values {
-            let expected_hash = self.config.identity().rollup_config_hash;
-            if expected.boot_info.rollup_config_hash != expected_hash {
-                return Err(WorldSuccinctHostError::RollupConfigHashMismatch {
-                    expected: expected_hash,
-                    actual: expected.boot_info.rollup_config_hash,
-                });
-            }
-        }
-
-        Ok(RangeProofRequest::from_witness_data(
-            witness,
-            expected_public_values,
-        )?)
+        Ok(RangeProofRequest::from_witness_data(witness)?)
     }
 
     pub fn aggregation_request(

--- a/proofs/succinct/utils/host/src/mock_prover.rs
+++ b/proofs/succinct/utils/host/src/mock_prover.rs
@@ -1,24 +1,24 @@
 //! Range proofs are produced in `Compressed` mode so the aggregation guest can recursively
 //! verify them; the aggregation proof mode is configurable (Groth16 for on-chain verification).
 
-use crate::SuccinctProverError;
-use anyhow::{Context, bail};
+use crate::{SuccinctProverError, WorldSuccinctProver};
+use anyhow::Context;
 use async_trait::async_trait;
 use sp1_sdk::{
     HashableKey, MockProver, ProveRequest, Prover, ProvingKey, SP1Proof, SP1ProofMode,
-    SP1ProvingKey, SP1Stdin,
+    SP1ProofWithPublicValues, SP1ProvingKey, SP1Stdin,
 };
-use std::{collections::HashMap, sync::Mutex};
-use world_chain_proof_core::{
-    artifacts::ProofArtifact,
-    boot::BootInfoStruct,
-    types::{AggregationInputs, AggregationOutputs},
+use std::{
+    collections::HashMap,
+    sync::{
+        Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
 };
+use world_chain_proof_core::types::AggregationInputs;
 use world_chain_proof_succinct_utils::{
-    AggregationProofArtifact, AggregationProofRequest, ProofRequest, RangeProofArtifact,
-    RangeProofRequest, Sp1SessionStatus, WorldSuccinctProver,
+    AggregationProofRequest, RangeProofRequest, Sp1ProofRequest, Sp1SessionStatus,
 };
-use world_chain_prover_service::{ProofRequestId, SessionType};
 
 /// [`WorldSuccinctProver`] mock implementation over the sp1-sdk mock prover.
 pub struct MockSuccinctProver {
@@ -28,8 +28,8 @@ pub struct MockSuccinctProver {
     multi_block_vkey: [u32; 8],
     agg_mode: SP1ProofMode,
 
-    range_proofs: Mutex<HashMap<String, RangeProofArtifact>>,
-    agg_proofs: Mutex<HashMap<String, AggregationProofArtifact>>,
+    next_session_id: AtomicU64,
+    proofs: Mutex<HashMap<String, SP1ProofWithPublicValues>>,
 }
 
 impl MockSuccinctProver {
@@ -55,12 +55,20 @@ impl MockSuccinctProver {
             agg_pk,
             multi_block_vkey,
             agg_mode,
-            range_proofs: Mutex::new(HashMap::default()),
-            agg_proofs: Mutex::new(HashMap::default()),
+            next_session_id: AtomicU64::new(0),
+            proofs: Mutex::new(HashMap::default()),
         })
     }
 
-    async fn prove_range(&self, request: RangeProofRequest) -> anyhow::Result<RangeProofArtifact> {
+    fn next_session_id(&self, prefix: &str) -> String {
+        let id = self.next_session_id.fetch_add(1, Ordering::Relaxed);
+        format!("{prefix}-{id}")
+    }
+
+    async fn prove_range(
+        &self,
+        request: RangeProofRequest,
+    ) -> anyhow::Result<SP1ProofWithPublicValues> {
         let mut stdin = SP1Stdin::new();
         stdin.write_vec(request.witness_rkyv);
 
@@ -72,32 +80,13 @@ impl MockSuccinctProver {
             .await
             .context("range proving failed")?;
 
-        let boot_info: BootInfoStruct = bincode::deserialize(proof.public_values.as_slice())
-            .context("range proof public values deserialization failed")?;
-
-        if let Some(expected) = request.expected_public_values {
-            let expected_boot = BootInfoStruct::from(expected.boot_info);
-            if expected_boot != boot_info {
-                return Err(SuccinctProverError::BootInfoMismatch {
-                    expected: Box::new(expected_boot),
-                    actual: Box::new(boot_info),
-                }
-                .into());
-            }
-        }
-
-        let proof_bytes = bincode::serialize(&proof).context("range proof serialization failed")?;
-
-        Ok(RangeProofArtifact {
-            boot_info,
-            proof: proof_bytes,
-        })
+        Ok(proof)
     }
 
     async fn prove_aggregation(
         &self,
         request: AggregationProofRequest,
-    ) -> anyhow::Result<AggregationProofArtifact> {
+    ) -> anyhow::Result<SP1ProofWithPublicValues> {
         let mut stdin = SP1Stdin::new();
         let range_vk = self.range_pk.verifying_key().vk.clone();
         for proof_bytes in &request.range_proofs {
@@ -123,22 +112,7 @@ impl MockSuccinctProver {
             .verify(&proof, self.agg_pk.verifying_key(), None)
             .context("aggregation proof verification failed")?;
 
-        let outputs = <AggregationOutputs as alloy_sol_types::SolValue>::abi_decode(
-            proof.public_values.as_slice(),
-        )
-        .context("aggregation outputs abi decoding failed")?;
-
-        // Groth16/Plonk proofs serialize to their on-chain calldata representation; other
-        // modes (mock runs, compressed) keep the full sdk proof for offline use.
-        let proof_bytes = match &proof.proof {
-            SP1Proof::Groth16(_) | SP1Proof::Plonk(_) => proof.bytes(),
-            _ => bincode::serialize(&proof).context("aggregation proof serialization failed")?,
-        };
-
-        Ok(AggregationProofArtifact {
-            outputs,
-            proof: proof_bytes,
-        })
+        Ok(proof)
     }
 }
 
@@ -148,29 +122,12 @@ impl WorldSuccinctProver for MockSuccinctProver {
         false
     }
 
-    async fn submit(
-        &self,
-        proof_id: ProofRequestId,
-        session_type: SessionType,
-        request: ProofRequest,
-    ) -> anyhow::Result<String> {
-        match session_type {
-            SessionType::Stark => {
-                let ProofRequest::Range(range_request) = request else {
-                    bail!("proof request and session type mistmach")
-                };
-                let range_proof = self.prove_range(range_request).await?;
-                let mut range_proofs = self
-                    .range_proofs
-                    .lock()
-                    .map_err(|_| anyhow::anyhow!("mutex lock poisoned"))?;
-                range_proofs.insert(proof_id.to_string(), range_proof);
-                Ok(proof_id.to_string())
+    async fn submit(&self, request: Sp1ProofRequest) -> anyhow::Result<String> {
+        let (prefix, proof) = match request {
+            Sp1ProofRequest::Range(range_request) => {
+                ("range", self.prove_range(range_request).await?)
             }
-            SessionType::Snark => {
-                let ProofRequest::Aggregation(session_request) = request else {
-                    bail!("proof request and session type mistmach")
-                };
+            Sp1ProofRequest::Aggregation(session_request) => {
                 let agg_request = AggregationProofRequest {
                     inputs: AggregationInputs {
                         boot_infos: session_request.boot_infos,
@@ -181,76 +138,40 @@ impl WorldSuccinctProver for MockSuccinctProver {
                     l1_headers_cbor: session_request.l1_headers_cbor,
                     range_proofs: session_request.range_proofs,
                 };
-                let agg_proof = self.prove_aggregation(agg_request).await?;
-                let mut agg_proofs = self
-                    .agg_proofs
-                    .lock()
-                    .map_err(|_| anyhow::anyhow!("mutex lock poisoned"))?;
-                agg_proofs.insert(proof_id.to_string(), agg_proof);
-                Ok(proof_id.to_string())
+                ("aggregation", self.prove_aggregation(agg_request).await?)
             }
+        };
+
+        let session_id = self.next_session_id(prefix);
+        let mut proofs = self
+            .proofs
+            .lock()
+            .map_err(|_| anyhow::anyhow!("mutex lock poisoned"))?;
+        proofs.insert(session_id.clone(), proof);
+        Ok(session_id)
+    }
+
+    async fn poll(&self, session_id: &str) -> anyhow::Result<Sp1SessionStatus> {
+        let proofs = self
+            .proofs
+            .lock()
+            .map_err(|_| anyhow::anyhow!("mutex lock poisoned"))?;
+        if proofs.contains_key(session_id) {
+            // Mock prover immediately returns completed status if the entry exists in the hashmap.
+            Ok(Sp1SessionStatus::Completed)
+        } else {
+            Ok(Sp1SessionStatus::NotFound)
         }
     }
 
-    async fn poll(
-        &self,
-        session_id: String,
-        session_type: SessionType,
-    ) -> anyhow::Result<Sp1SessionStatus> {
-        match session_type {
-            SessionType::Stark => {
-                let range_proofs = self
-                    .range_proofs
-                    .lock()
-                    .map_err(|_| anyhow::anyhow!("mutex lock poisoned"))?;
-                if range_proofs.contains_key(&session_id) {
-                    // CPU prover immediately returns completed status if the entry exists in the hashmap
-                    Ok(Sp1SessionStatus::Completed)
-                } else {
-                    Ok(Sp1SessionStatus::NotFound)
-                }
-            }
-            SessionType::Snark => {
-                let agg_proofs = self
-                    .agg_proofs
-                    .lock()
-                    .map_err(|_| anyhow::anyhow!("mutex lock poisoned"))?;
-                if agg_proofs.contains_key(&session_id) {
-                    // CPU prover immediately returns completed status if the entry exists in the hashmap
-                    Ok(Sp1SessionStatus::Completed)
-                } else {
-                    Ok(Sp1SessionStatus::NotFound)
-                }
-            }
-        }
-    }
-
-    async fn download(
-        &self,
-        session_id: String,
-        session_type: SessionType,
-    ) -> anyhow::Result<ProofArtifact> {
-        match session_type {
-            SessionType::Stark => {
-                let range_proofs = self
-                    .range_proofs
-                    .lock()
-                    .map_err(|_| anyhow::anyhow!("mutex lock poisoned"))?;
-                let range_proof = range_proofs.get(&session_id).ok_or_else(|| {
-                    anyhow::anyhow!("no range proof found for session_id: {}", session_id)
-                })?;
-                Ok(ProofArtifact::Range(range_proof.clone()))
-            }
-            SessionType::Snark => {
-                let agg_proofs = self
-                    .agg_proofs
-                    .lock()
-                    .map_err(|_| anyhow::anyhow!("mutex lock poisoned"))?;
-                let agg_proof = agg_proofs.get(&session_id).ok_or_else(|| {
-                    anyhow::anyhow!("no agg proof found for session_id: {}", session_id)
-                })?;
-                Ok(ProofArtifact::Aggregation(agg_proof.clone()))
-            }
-        }
+    async fn download(&self, session_id: &str) -> anyhow::Result<SP1ProofWithPublicValues> {
+        let proofs = self
+            .proofs
+            .lock()
+            .map_err(|_| anyhow::anyhow!("mutex lock poisoned"))?;
+        let proof = proofs
+            .get(session_id)
+            .ok_or_else(|| anyhow::anyhow!("no proof found for session_id: {session_id}"))?;
+        Ok(proof.clone())
     }
 }

--- a/proofs/succinct/utils/host/src/network_prover.rs
+++ b/proofs/succinct/utils/host/src/network_prover.rs
@@ -1,7 +1,7 @@
 //! Range proofs are produced in `Compressed` mode so the aggregation guest can recursively
 //! verify them; the aggregation proof mode is configurable (Groth16 for on-chain verification).
 
-use crate::SuccinctProverError;
+use crate::{SuccinctProverError, WorldSuccinctProver};
 use alloy_primitives::B256;
 use anyhow::{Context, bail};
 use async_trait::async_trait;
@@ -11,15 +11,10 @@ use sp1_sdk::{
     SP1ProofWithPublicValues, SP1ProvingKey, SP1Stdin,
     network::proto::{GetProofRequestStatusResponse, types::FulfillmentStatus},
 };
-use world_chain_proof_core::{
-    artifacts::{AggregationProofArtifact, ProofArtifact, RangeProofArtifact},
-    boot::BootInfoStruct,
-    types::{AggregationInputs, AggregationOutputs},
-};
+use world_chain_proof_core::types::AggregationInputs;
 use world_chain_proof_succinct_utils::{
-    AggregationProofRequest, ProofRequest, RangeProofRequest, Sp1SessionStatus, WorldSuccinctProver,
+    AggregationProofRequest, RangeProofRequest, Sp1ProofRequest, Sp1SessionStatus,
 };
-use world_chain_prover_service::{ProofRequestId, SessionType};
 
 /// [`WorldSuccinctProver`] network implementation over the sp1-sdk network prover.
 pub struct NetworkSuccinctProver {
@@ -125,24 +120,10 @@ impl WorldSuccinctProver for NetworkSuccinctProver {
         true
     }
 
-    async fn submit(
-        &self,
-        _proof_id: ProofRequestId,
-        session_type: SessionType,
-        request: ProofRequest,
-    ) -> anyhow::Result<String> {
-        match session_type {
-            SessionType::Stark => {
-                let ProofRequest::Range(range_request) = request else {
-                    bail!("proof request and session type mistmach")
-                };
-                let backend_session_id = self.request_range_proof(range_request).await?;
-                Ok(backend_session_id)
-            }
-            SessionType::Snark => {
-                let ProofRequest::Aggregation(session_request) = request else {
-                    bail!("proof request and session type mistmach")
-                };
+    async fn submit(&self, request: Sp1ProofRequest) -> anyhow::Result<String> {
+        match request {
+            Sp1ProofRequest::Range(range_request) => self.request_range_proof(range_request).await,
+            Sp1ProofRequest::Aggregation(session_request) => {
                 let agg_request = AggregationProofRequest {
                     inputs: AggregationInputs {
                         boot_infos: session_request.boot_infos,
@@ -153,69 +134,22 @@ impl WorldSuccinctProver for NetworkSuccinctProver {
                     l1_headers_cbor: session_request.l1_headers_cbor,
                     range_proofs: session_request.range_proofs,
                 };
-                let backend_session_id = self.request_aggregation_proof(agg_request).await?;
-                Ok(backend_session_id.to_string())
+                self.request_aggregation_proof(agg_request).await
             }
         }
     }
 
-    async fn poll(
-        &self,
-        session_id: String,
-        _session_type: SessionType,
-    ) -> anyhow::Result<Sp1SessionStatus> {
-        let (sp1_status, _maybe_proof) = self.get_network_proof_status(&session_id).await?;
+    async fn poll(&self, session_id: &str) -> anyhow::Result<Sp1SessionStatus> {
+        let (sp1_status, _maybe_proof) = self.get_network_proof_status(session_id).await?;
         Ok(sp1_status)
     }
 
-    async fn download(
-        &self,
-        session_id: String,
-        session_type: SessionType,
-    ) -> anyhow::Result<ProofArtifact> {
-        let (sp1_status, maybe_proof) = self.get_network_proof_status(&session_id).await?;
+    async fn download(&self, session_id: &str) -> anyhow::Result<SP1ProofWithPublicValues> {
+        let (sp1_status, maybe_proof) = self.get_network_proof_status(session_id).await?;
         match sp1_status {
-            Sp1SessionStatus::Completed => {
-                let proof = maybe_proof.ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "network proof {session_id} is fulfilled but no proof was returned"
-                    )
-                })?;
-                match session_type {
-                    SessionType::Stark => {
-                        let boot_info: BootInfoStruct =
-                            bincode::deserialize(proof.public_values.as_slice())
-                                .context("range proof public values deserialization failed")?;
-
-                        let proof_bytes = bincode::serialize(&proof)
-                            .context("range proof serialization failed")?;
-
-                        Ok(ProofArtifact::Range(RangeProofArtifact {
-                            boot_info,
-                            proof: proof_bytes,
-                        }))
-                    }
-                    SessionType::Snark => {
-                        let outputs =
-                            <AggregationOutputs as alloy_sol_types::SolValue>::abi_decode(
-                                proof.public_values.as_slice(),
-                            )
-                            .context("aggregation outputs abi decoding failed")?;
-
-                        // Groth16/Plonk proofs serialize to their on-chain calldata representation; other
-                        // modes (mock runs, compressed) keep the full sdk proof for offline use.
-                        let proof_bytes = match &proof.proof {
-                            SP1Proof::Groth16(_) | SP1Proof::Plonk(_) => proof.bytes(),
-                            _ => bincode::serialize(&proof)
-                                .context("aggregation proof serialization failed")?,
-                        };
-                        Ok(ProofArtifact::Aggregation(AggregationProofArtifact {
-                            outputs,
-                            proof: proof_bytes,
-                        }))
-                    }
-                }
-            }
+            Sp1SessionStatus::Completed => maybe_proof.ok_or_else(|| {
+                anyhow::anyhow!("network proof {session_id} is fulfilled but no proof was returned")
+            }),
             Sp1SessionStatus::Running => {
                 bail!("network proof {session_id} is not fulfilled yet");
             }

--- a/proofs/succinct/utils/host/src/validity.rs
+++ b/proofs/succinct/utils/host/src/validity.rs
@@ -2,20 +2,20 @@
 
 use std::time::Duration;
 
-use alloy_primitives::{Address, B256, keccak256};
-use anyhow::{Context, bail};
-use world_chain_proof_core::artifacts::{
-    AggregationProofArtifact, ProofArtifact, RangeProofArtifact,
+use crate::{
+    WorldSuccinctProver, aggregation_artifact_from_sp1_proof, range_artifact_from_sp1_proof,
 };
+use alloy_primitives::{Address, B256};
+use anyhow::{Context, bail};
+use sp1_sdk::SP1ProofWithPublicValues;
+use world_chain_proof_core::artifacts::{AggregationProofArtifact, RangeProofArtifact};
 use world_chain_proof_kona_host_utils::online::{
     OnlineHostConfig, RangeMetadata, RangeWitnessRequest, build_range_input,
     fetch_l1_header_by_hash,
 };
 use world_chain_proof_succinct_utils::{
-    AggregationSessionRequest, ProofRequest as SuccinctProofRequest, RangeProofRequest,
-    Sp1SessionStatus, WorldSuccinctProver,
+    AggregationSessionRequest, RangeProofRequest, Sp1ProofRequest, Sp1SessionStatus,
 };
-use world_chain_prover_service::{ProofRequestId, SessionType};
 
 /// Request for proving one contiguous L2 validity range and aggregating it into a final proof.
 #[derive(Clone, Debug)]
@@ -63,16 +63,11 @@ where
         );
     }
 
-    let proof_id = validity_proof_id(&request);
     let range_input = build_range_request(host, &request)
         .await
         .context("failed to build range proof request")?;
     let range_session_id = prover
-        .submit(
-            proof_id,
-            SessionType::Stark,
-            SuccinctProofRequest::Range(range_input.request),
-        )
+        .submit(Sp1ProofRequest::Range(range_input.request))
         .await
         .context("failed to submit range proof")?;
     let range = wait_and_download_range(prover, range_session_id)
@@ -85,11 +80,7 @@ where
         .await
         .context("failed to build aggregation proof request")?;
     let aggregation_session_id = prover
-        .submit(
-            proof_id,
-            SessionType::Snark,
-            SuccinctProofRequest::Aggregation(aggregation_request),
-        )
+        .submit(Sp1ProofRequest::Aggregation(aggregation_request))
         .await
         .context("failed to submit aggregation proof")?;
     let aggregation = wait_and_download_aggregation(prover, aggregation_session_id)
@@ -99,16 +90,6 @@ where
     validate_aggregation_artifact(&range_input.metadata, &aggregation)?;
 
     Ok(aggregation)
-}
-
-fn validity_proof_id(request: &ValidityProofRequest) -> ProofRequestId {
-    let mut bytes = Vec::with_capacity(16 + 8 + 8 + 32 + 20);
-    bytes.extend_from_slice(b"sp1-validity-v1");
-    bytes.extend_from_slice(&request.start_block.to_be_bytes());
-    bytes.extend_from_slice(&request.end_block.to_be_bytes());
-    bytes.extend_from_slice(request.l1_head.unwrap_or_default().as_slice());
-    bytes.extend_from_slice(request.prover_address.as_slice());
-    ProofRequestId(keccak256(bytes))
 }
 
 async fn build_range_request(
@@ -127,7 +108,7 @@ async fn build_range_request(
     .await
     .context("failed to build SP1 range witness")?;
 
-    let request = RangeProofRequest::from_witness_data(&input.witness, None)
+    let request = RangeProofRequest::from_witness_data(&input.witness)
         .context("failed to serialize SP1 range witness")?;
 
     Ok(BuiltRangeRequest {
@@ -164,12 +145,8 @@ async fn wait_and_download_range<P>(
 where
     P: WorldSuccinctProver + Sync,
 {
-    let artifact =
-        wait_and_download_artifact(prover, SessionType::Stark, session_id.clone()).await?;
-    let ProofArtifact::Range(range) = artifact else {
-        bail!("expected range proof artifact for STARK session {session_id}");
-    };
-    Ok(range)
+    let proof = wait_and_download_proof(prover, session_id, "STARK").await?;
+    range_artifact_from_sp1_proof(&proof)
 }
 
 async fn wait_and_download_aggregation<P>(
@@ -179,32 +156,24 @@ async fn wait_and_download_aggregation<P>(
 where
     P: WorldSuccinctProver + Sync,
 {
-    let artifact =
-        wait_and_download_artifact(prover, SessionType::Snark, session_id.clone()).await?;
-    let ProofArtifact::Aggregation(aggregation) = artifact else {
-        bail!("expected aggregation proof artifact for SNARK session {session_id}");
-    };
-    Ok(aggregation)
+    let proof = wait_and_download_proof(prover, session_id, "SNARK").await?;
+    aggregation_artifact_from_sp1_proof(&proof)
 }
 
-async fn wait_and_download_artifact<P>(
+async fn wait_and_download_proof<P>(
     prover: &P,
-    session_type: SessionType,
     session_id: String,
-) -> anyhow::Result<ProofArtifact>
+    session_label: &'static str,
+) -> anyhow::Result<SP1ProofWithPublicValues>
 where
     P: WorldSuccinctProver + Sync,
 {
-    let session_label = session_type.as_str();
     loop {
-        match prover
-            .poll(session_id.clone(), session_type.clone())
-            .await?
-        {
+        match prover.poll(&session_id).await? {
             Sp1SessionStatus::Running => tokio::time::sleep(Duration::from_secs(10)).await,
             Sp1SessionStatus::Completed => {
                 return prover
-                    .download(session_id, session_type)
+                    .download(&session_id)
                     .await
                     .with_context(|| format!("failed to download {session_label} proof"));
             }

--- a/proofs/succinct/utils/proof/Cargo.toml
+++ b/proofs/succinct/utils/proof/Cargo.toml
@@ -12,6 +12,3 @@ alloy-primitives.workspace = true
 rkyv.workspace = true
 serde.workspace = true
 world-chain-proof-core.workspace = true
-async-trait.workspace = true
-world-chain-prover-service.workspace = true
-anyhow.workspace = true

--- a/proofs/succinct/utils/proof/src/lib.rs
+++ b/proofs/succinct/utils/proof/src/lib.rs
@@ -1,23 +1,21 @@
 use alloy_primitives::{Address, B256};
-use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use world_chain_proof_core::{
-    artifacts::ProofArtifact, boot::BootInfoStruct, range::WorldRangeProofPublicValues,
-    types::AggregationInputs, witness::WorldRangeWitnessData,
+    boot::BootInfoStruct, types::AggregationInputs, witness::WorldRangeWitnessData,
 };
 
 pub use world_chain_proof_core::artifacts::{AggregationProofArtifact, RangeProofArtifact};
-use world_chain_prover_service::{ProofRequestId, SessionType};
 
 // ---------------------------------------------------------------------------
-// Proof request types and prover trait
+// Proof request types
 // ---------------------------------------------------------------------------
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum ProofRequest {
+pub enum Sp1ProofRequest {
     Range(RangeProofRequest),
     Aggregation(AggregationSessionRequest),
 }
+
 /// Host request for a single SP1 range proof.
 ///
 /// Carries the full rkyv-serialized [`WorldRangeWitnessData`] that the range guest reads from
@@ -26,20 +24,14 @@ pub enum ProofRequest {
 pub struct RangeProofRequest {
     /// rkyv-serialized [`WorldRangeWitnessData`] consumed by the range guest.
     pub witness_rkyv: Vec<u8>,
-    /// Optional host-computed public values checked against the guest commitment.
-    pub expected_public_values: Option<WorldRangeProofPublicValues>,
 }
 
 impl RangeProofRequest {
     /// Builds a request by rkyv-serializing the supplied witness data.
-    pub fn from_witness_data(
-        witness: &WorldRangeWitnessData,
-        expected_public_values: Option<WorldRangeProofPublicValues>,
-    ) -> Result<Self, rkyv::rancor::Error> {
+    pub fn from_witness_data(witness: &WorldRangeWitnessData) -> Result<Self, rkyv::rancor::Error> {
         let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(witness)?;
         Ok(Self {
             witness_rkyv: bytes.to_vec(),
-            expected_public_values,
         })
     }
 }
@@ -87,29 +79,4 @@ pub enum Sp1SessionStatus {
     Failed(String),
     /// The backend has no record of the session id.
     NotFound,
-}
-
-/// Interface expected from a concrete SP1 prover backend.
-#[async_trait]
-pub trait WorldSuccinctProver {
-    fn supports_persistent_sessions(&self) -> bool;
-
-    async fn submit(
-        &self,
-        proof_id: ProofRequestId,
-        session_type: SessionType,
-        request: ProofRequest,
-    ) -> anyhow::Result<String>;
-
-    async fn poll(
-        &self,
-        session_id: String,
-        session_type: SessionType,
-    ) -> anyhow::Result<Sp1SessionStatus>;
-
-    async fn download(
-        &self,
-        session_id: String,
-        session_type: SessionType,
-    ) -> anyhow::Result<ProofArtifact>;
 }


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4879/refactor-simplify-worldsuccinctprover-trait

### Problem

`WorldSuccinctProver` mixed backend session management with World specific proof artifact conversion. It also required `proof_id` and `SessionType` even though the network prover does not need them, and CPU / mock only used them as local development conveniences.

### Solution

Simplify the SP1 prover trait so concrete provers submit, poll, and download raw SP1 proofs. Move range and aggregation artifact conversion into the generic SP1 host / worker layer, and update CPU / mock / network provers to use the simplified trait.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core SP1 fault-proof worker path and shifts where boot-info checks run (away from prover submit), so regressions could affect proof job completion or artifact shape without being obvious in unit tests.
> 
> **Overview**
> Refactors the SP1 proving boundary so **`WorldSuccinctProver` lives in `world-chain-proof-succinct-host-utils`** and only manages backend sessions: **`submit(Sp1ProofRequest)`**, **`poll` / `download` by session id**, returning raw **`SP1ProofWithPublicValues`** instead of `ProofArtifact`. **`ProofRequestId` and `SessionType` are no longer part of the trait** (CPU/mock assign local session ids; the network prover uses the network proof id).
> 
> **`world-chain-proof-succinct-utils`** keeps wire/request types only: **`ProofRequest` → `Sp1ProofRequest`**, and **`RangeProofRequest` drops `expected_public_values`**. Shared conversion helpers **`range_artifact_from_sp1_proof`** and **`aggregation_artifact_from_sp1_proof`** (plus removal of **`BootInfoMismatch`** at the prover layer) sit on the host crate.
> 
> **CPU, mock, and network provers** were updated to prove into a single in-memory proof map (or network status) rather than building range/aggregation artifacts internally. **`Sp1Backend`**, **`validity`**, and **`WorldSuccinctHost::range_request`** now build artifacts after download and still validate boot info against job/metadata where applicable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c60d8d1a72a157117ddeb376a10c94e2a9b96ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->