### PR TITLE
feat(sp1-worker): add session poll interval flag

### DIFF
--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -2730,6 +2730,7 @@ where
             split_count: 1,
             prover_address: Address::ZERO,
             allow_unfinalized: false,
+            session_poll_interval: Duration::from_secs(10),
         },
     );
 

--- a/proofs/sp1-worker/src/backend.rs
+++ b/proofs/sp1-worker/src/backend.rs
@@ -33,6 +33,8 @@ pub struct Sp1BackendConfig {
     pub prover_address: Address,
     /// Allow proving blocks newer than the finalized L2 head.
     pub allow_unfinalized: bool,
+    /// Sleep between SP1 prover session status polls while a proof is still running.
+    pub session_poll_interval: Duration,
 }
 
 /// [`ClaimedProofJobHandler`] for the [`ProofBackend::Sp1`] lane: builds witnesses over RPC
@@ -201,9 +203,7 @@ impl<P: WorldSuccinctProver> Sp1Backend<P> {
         loop {
             match self.prover.poll(&session_id).await? {
                 Sp1SessionStatus::Running => {
-                    // TODO: replace this hardcoded duration with a cli flag
-                    let duration = Duration::from_secs(10);
-                    tokio::time::sleep(duration).await;
+                    tokio::time::sleep(self.config.session_poll_interval).await;
                 }
                 Sp1SessionStatus::Completed => {
                     let proof = self.prover.download(&session_id).await?;
@@ -247,9 +247,7 @@ impl<P: WorldSuccinctProver> Sp1Backend<P> {
         loop {
             match self.prover.poll(&session_id).await? {
                 Sp1SessionStatus::Running => {
-                    // TODO: replace this hardcoded duration with a cli flag
-                    let duration = Duration::from_secs(10);
-                    tokio::time::sleep(duration).await;
+                    tokio::time::sleep(self.config.session_poll_interval).await;
                 }
                 Sp1SessionStatus::Completed => {
                     let proof = self.prover.download(&session_id).await?;

--- a/proofs/sp1-worker/src/main.rs
+++ b/proofs/sp1-worker/src/main.rs
@@ -25,6 +25,7 @@ const DEFAULT_SUBMIT_PROOF_RETRY_INITIAL_DELAY_MS: u64 = 100;
 const DEFAULT_SUBMIT_PROOF_RETRY_MAX_DELAY_MS: u64 = 10_000;
 const DEFAULT_WORKER_HEARTBEAT_INTERVAL_SEC: u64 = 30;
 const DEFAULT_WORKER_MAX_CONSECUTIVE_HEARTBEAT_FAILURES: u32 = 5;
+const DEFAULT_SP1_SESSION_POLL_INTERVAL: Duration = Duration::from_secs(10);
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
 enum Network {
@@ -124,6 +125,15 @@ struct Cli {
     /// Seconds to sleep between job-queue polls when no work is available.
     #[arg(long, default_value_t = 10)]
     poll_interval_seconds: u64,
+
+    /// Seconds to sleep between SP1 prover session status polls while a proof is running.
+    #[arg(
+        long,
+        env = "SP1_SESSION_POLL_INTERVAL_SECONDS",
+        default_value_t = DEFAULT_SP1_SESSION_POLL_INTERVAL.as_secs(),
+        value_parser = clap::value_parser!(u64).range(1..)
+    )]
+    sp1_session_poll_interval_seconds: u64,
 
     /// Maximum number of jobs proved concurrently. One suits a local CPU prover; raise it for
     /// the Succinct proving network.
@@ -237,6 +247,7 @@ where
             split_count: cli.ranges.max(1),
             prover_address: cli.prover_address,
             allow_unfinalized: cli.allow_unfinalized,
+            session_poll_interval: Duration::from_secs(cli.sp1_session_poll_interval_seconds),
         },
     );
 
@@ -271,6 +282,7 @@ where
         block_interval = cli.block_interval,
         ranges = cli.ranges.max(1),
         prover = %cli.prover,
+        sp1_session_poll_interval_seconds = cli.sp1_session_poll_interval_seconds,
         submit_proof_retry_max_retries = cli.submit_proof_retry_max_retries,
         submit_proof_retry_initial_delay_ms = cli.submit_proof_retry_initial_delay_ms,
         submit_proof_retry_max_delay_ms = cli.submit_proof_retry_max_delay_ms,
@@ -289,4 +301,47 @@ where
 
     worker.await;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_args() -> Vec<&'static str> {
+        vec![
+            "sp1-worker",
+            "--prover-service-url",
+            "http://127.0.0.1:8545",
+            "--l2-rpc",
+            "http://127.0.0.1:9545",
+            "--l1-rpc",
+            "http://127.0.0.1:8545",
+            "--l1-beacon-rpc",
+            "http://127.0.0.1:5052",
+            "--block-interval",
+            "10",
+            "--worker-id",
+            "test",
+        ]
+    }
+
+    #[test]
+    fn parses_sp1_session_poll_interval_seconds() {
+        let mut args = base_args();
+        args.extend(["--sp1-session-poll-interval-seconds", "3"]);
+
+        let cli = Cli::parse_from(args);
+
+        assert_eq!(cli.sp1_session_poll_interval_seconds, 3);
+    }
+
+    #[test]
+    fn rejects_zero_sp1_session_poll_interval_seconds() {
+        let mut args = base_args();
+        args.extend(["--sp1-session-poll-interval-seconds", "0"]);
+
+        let error = Cli::try_parse_from(args).expect_err("zero poll interval should be rejected");
+
+        assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
+    }
 }

--- a/proofs/sp1-worker/tests/e2e_proving.rs
+++ b/proofs/sp1-worker/tests/e2e_proving.rs
@@ -213,6 +213,7 @@ async fn run_worker_proves_real_range_end_to_end_with_prover<P>(
             split_count,
             prover_address: Address::ZERO,
             allow_unfinalized: false,
+            session_poll_interval: Duration::from_secs(10),
         },
     );
 


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4880/add-proof-worker-poll-duration-in-sp1-proof-worker-cli-flag

### Problem

The SP1 worker used a hardcoded 10 second sleep when polling range and aggregation proof sessions, making the interval impossible to tune at runtime.

### Solution

Add a configurable `--sp1-session-poll-interval-seconds` cli flag with `SP1_SESSION_POLL_INTERVAL_SECONDS` env support, defaulting to the previous 10 second behavior. The value lives in `Sp1BackendConfig` and is used it in both session  (range and aggregation) polling loops.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Operational tuning only; default remains 10 seconds and proof logic is unchanged.
> 
> **Overview**
> Replaces the **hardcoded 10s sleep** while SP1 range and aggregation sessions are still `Running` with a **`session_poll_interval`** on `Sp1BackendConfig`, wired from the worker CLI.
> 
> The **`sp1-worker`** binary adds **`--sp1-session-poll-interval-seconds`** (env **`SP1_SESSION_POLL_INTERVAL_SECONDS`**, default **10**, minimum **1**). Startup logging includes the chosen value. **CLI tests** cover parsing and rejecting zero.
> 
> **Devnet** and **e2e** `Sp1Backend` construction sets **`session_poll_interval: Duration::from_secs(10)`** so behavior stays unchanged when the flag is not used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59bb1c31a79a4e0a47a7039eea6648ff64646753. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->