### PR TITLE
feat: add failure_reason to record_proof_session

### DIFF
--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -622,6 +622,7 @@ impl ProofJobQueue for SharedProverService {
         lock_id: LockId,
         backend_session_id: String,
         state: BackendSessionStatus,
+        failure_reason: String,
     ) -> Result<(), ProofJobQueueError> {
         self.service
             .record_proof_session(
@@ -631,6 +632,7 @@ impl ProofJobQueue for SharedProverService {
                 lock_id,
                 backend_session_id,
                 state,
+                failure_reason,
             )
             .await
     }

--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -622,7 +622,7 @@ impl ProofJobQueue for SharedProverService {
         lock_id: LockId,
         backend_session_id: String,
         state: BackendSessionStatus,
-        failure_reason: String,
+        failure_reason: Option<String>,
     ) -> Result<(), ProofJobQueueError> {
         self.service
             .record_proof_session(

--- a/proofs/prover-service/src/rpc.rs
+++ b/proofs/prover-service/src/rpc.rs
@@ -102,6 +102,7 @@ pub trait ProverServiceApi {
         lock_id: LockId,
         backend_session_id: String,
         state: BackendSessionStatus,
+        failure_reason: String,
     ) -> RpcResult<()>;
 
     /// Heartbeat call.
@@ -263,6 +264,7 @@ impl ProverServiceApiServer for ProverServiceRpc {
         lock_id: LockId,
         backend_session_id: String,
         state: BackendSessionStatus,
+        failure_reason: String,
     ) -> RpcResult<()> {
         Ok(self
             .service
@@ -273,6 +275,7 @@ impl ProverServiceApiServer for ProverServiceRpc {
                 lock_id,
                 backend_session_id,
                 state,
+                failure_reason,
             )
             .await?)
     }
@@ -490,6 +493,7 @@ impl ProofJobQueue for RpcProverServiceClient {
         lock_id: LockId,
         backend_session_id: String,
         state: BackendSessionStatus,
+        failure_reason: String,
     ) -> Result<(), ProofJobQueueError> {
         ProverServiceApiClient::record_proof_session(
             &self.client,
@@ -499,6 +503,7 @@ impl ProofJobQueue for RpcProverServiceClient {
             lock_id,
             backend_session_id,
             state,
+            failure_reason,
         )
         .await
         .map_err(|err| map_job_error(err, proof_id))

--- a/proofs/prover-service/src/rpc.rs
+++ b/proofs/prover-service/src/rpc.rs
@@ -102,7 +102,7 @@ pub trait ProverServiceApi {
         lock_id: LockId,
         backend_session_id: String,
         state: BackendSessionStatus,
-        failure_reason: String,
+        failure_reason: Option<String>,
     ) -> RpcResult<()>;
 
     /// Heartbeat call.
@@ -264,7 +264,7 @@ impl ProverServiceApiServer for ProverServiceRpc {
         lock_id: LockId,
         backend_session_id: String,
         state: BackendSessionStatus,
-        failure_reason: String,
+        failure_reason: Option<String>,
     ) -> RpcResult<()> {
         Ok(self
             .service
@@ -493,7 +493,7 @@ impl ProofJobQueue for RpcProverServiceClient {
         lock_id: LockId,
         backend_session_id: String,
         state: BackendSessionStatus,
-        failure_reason: String,
+        failure_reason: Option<String>,
     ) -> Result<(), ProofJobQueueError> {
         ProverServiceApiClient::record_proof_session(
             &self.client,

--- a/proofs/prover-service/src/service.rs
+++ b/proofs/prover-service/src/service.rs
@@ -111,7 +111,7 @@ impl ProofJobQueue for ProverService {
         lock_id: LockId,
         backend_session_id: String,
         state: BackendSessionStatus,
-        failure_reason: String,
+        failure_reason: Option<String>,
     ) -> Result<(), ProofJobQueueError> {
         self.store
             .record_proof_session(

--- a/proofs/prover-service/src/service.rs
+++ b/proofs/prover-service/src/service.rs
@@ -111,6 +111,7 @@ impl ProofJobQueue for ProverService {
         lock_id: LockId,
         backend_session_id: String,
         state: BackendSessionStatus,
+        failure_reason: String,
     ) -> Result<(), ProofJobQueueError> {
         self.store
             .record_proof_session(
@@ -120,6 +121,7 @@ impl ProofJobQueue for ProverService {
                 lock_id,
                 backend_session_id,
                 state,
+                failure_reason,
             )
             .await
     }

--- a/proofs/prover-service/src/store.rs
+++ b/proofs/prover-service/src/store.rs
@@ -336,7 +336,7 @@ impl ProverServiceStore {
         lock_id: LockId,
         backend_session_id: String,
         status: BackendSessionStatus,
-        failure_reason: String,
+        failure_reason: Option<String>,
     ) -> Result<(), ProofJobQueueError> {
         let now = Utc::now();
         let mut tx = self.begin_queue_tx().await?;

--- a/proofs/prover-service/src/store.rs
+++ b/proofs/prover-service/src/store.rs
@@ -336,6 +336,7 @@ impl ProverServiceStore {
         lock_id: LockId,
         backend_session_id: String,
         status: BackendSessionStatus,
+        failure_reason: String,
     ) -> Result<(), ProofJobQueueError> {
         let now = Utc::now();
         let mut tx = self.begin_queue_tx().await?;
@@ -462,7 +463,7 @@ impl ProverServiceStore {
             )
             .bind(backend_session_id)
             .bind(status.as_str())
-            .bind("failure reason".to_string()) // TODO: replace this with an input value
+            .bind(failure_reason)
             .bind(active_id)
             .bind(BackendSessionStatus::Submitting.as_str())
             .bind(BackendSessionStatus::Running.as_str())

--- a/proofs/prover-service/src/tests.rs
+++ b/proofs/prover-service/src/tests.rs
@@ -285,6 +285,7 @@ async fn record_and_get_proof_session_round_trips() {
             locked.lock_id,
             backend_session_id(1),
             BackendSessionStatus::Running,
+            String::new(),
         )
         .await
         .unwrap();

--- a/proofs/prover-service/src/tests.rs
+++ b/proofs/prover-service/src/tests.rs
@@ -285,7 +285,7 @@ async fn record_and_get_proof_session_round_trips() {
             locked.lock_id,
             backend_session_id(1),
             BackendSessionStatus::Running,
-            String::new(),
+            None,
         )
         .await
         .unwrap();

--- a/proofs/prover-service/src/traits.rs
+++ b/proofs/prover-service/src/traits.rs
@@ -77,6 +77,7 @@ pub trait ProofJobQueue {
         lock_id: LockId,
         backend_session_id: String,
         state: BackendSessionStatus,
+        failure_reason: String,
     ) -> Result<(), ProofJobQueueError>;
 
     /// Ping the `prover-service` to signal that a proof worker tied

--- a/proofs/prover-service/src/traits.rs
+++ b/proofs/prover-service/src/traits.rs
@@ -77,7 +77,7 @@ pub trait ProofJobQueue {
         lock_id: LockId,
         backend_session_id: String,
         state: BackendSessionStatus,
-        failure_reason: String,
+        failure_reason: Option<String>,
     ) -> Result<(), ProofJobQueueError>;
 
     /// Ping the `prover-service` to signal that a proof worker tied

--- a/proofs/sp1-worker/src/backend.rs
+++ b/proofs/sp1-worker/src/backend.rs
@@ -162,7 +162,7 @@ impl<P: WorldSuccinctProver> Sp1Backend<P> {
         session_type: SessionType,
         session_id: &str,
         status: BackendSessionStatus,
-        failure_reason: String,
+        failure_reason: Option<String>,
     ) -> anyhow::Result<()> {
         if !self.prover.supports_persistent_sessions() {
             return Ok(());
@@ -182,7 +182,7 @@ impl<P: WorldSuccinctProver> Sp1Backend<P> {
         request: Sp1ProofRequest,
     ) -> anyhow::Result<String> {
         let session_id = self.prover.submit(request).await?;
-        let empty_failure_reason = String::new();
+        let empty_failure_reason = None;
 
         self.record_session(
             job,
@@ -211,7 +211,7 @@ impl<P: WorldSuccinctProver> Sp1Backend<P> {
                 Sp1SessionStatus::Completed => {
                     let proof = self.prover.download(&session_id).await?;
                     let artifact = range_artifact_from_sp1_proof(&proof)?;
-                    let empty_failure_reason = String::new();
+                    let empty_failure_reason = None;
 
                     self.record_session(
                         job,
@@ -230,7 +230,7 @@ impl<P: WorldSuccinctProver> Sp1Backend<P> {
                         session_type.clone(),
                         &session_id,
                         BackendSessionStatus::Failed,
-                        reason.clone(),
+                        Some(reason.clone()),
                     )
                     .await?;
 
@@ -258,7 +258,7 @@ impl<P: WorldSuccinctProver> Sp1Backend<P> {
                 Sp1SessionStatus::Completed => {
                     let proof = self.prover.download(&session_id).await?;
                     let artifact = aggregation_artifact_from_sp1_proof(&proof)?;
-                    let empty_failure_reason = String::new();
+                    let empty_failure_reason = None;
 
                     self.record_session(
                         job,
@@ -277,7 +277,7 @@ impl<P: WorldSuccinctProver> Sp1Backend<P> {
                         session_type.clone(),
                         &session_id,
                         BackendSessionStatus::Failed,
-                        reason.clone(),
+                        Some(reason.clone()),
                     )
                     .await?;
 

--- a/proofs/sp1-worker/src/backend.rs
+++ b/proofs/sp1-worker/src/backend.rs
@@ -162,13 +162,14 @@ impl<P: WorldSuccinctProver> Sp1Backend<P> {
         session_type: SessionType,
         session_id: &str,
         status: BackendSessionStatus,
+        failure_reason: String,
     ) -> anyhow::Result<()> {
         if !self.prover.supports_persistent_sessions() {
             return Ok(());
         }
 
         job.sessions
-            .record(session_type, session_id.to_string(), status)
+            .record(session_type, session_id.to_string(), status, failure_reason)
             .await?;
 
         Ok(())
@@ -181,12 +182,14 @@ impl<P: WorldSuccinctProver> Sp1Backend<P> {
         request: Sp1ProofRequest,
     ) -> anyhow::Result<String> {
         let session_id = self.prover.submit(request).await?;
+        let empty_failure_reason = String::new();
 
         self.record_session(
             job,
             session_type,
             &session_id,
             BackendSessionStatus::Running,
+            empty_failure_reason,
         )
         .await?;
 
@@ -208,12 +211,14 @@ impl<P: WorldSuccinctProver> Sp1Backend<P> {
                 Sp1SessionStatus::Completed => {
                     let proof = self.prover.download(&session_id).await?;
                     let artifact = range_artifact_from_sp1_proof(&proof)?;
+                    let empty_failure_reason = String::new();
 
                     self.record_session(
                         job,
                         session_type.clone(),
                         &session_id,
                         BackendSessionStatus::Completed,
+                        empty_failure_reason,
                     )
                     .await?;
 
@@ -225,6 +230,7 @@ impl<P: WorldSuccinctProver> Sp1Backend<P> {
                         session_type.clone(),
                         &session_id,
                         BackendSessionStatus::Failed,
+                        reason.clone(),
                     )
                     .await?;
 
@@ -252,12 +258,14 @@ impl<P: WorldSuccinctProver> Sp1Backend<P> {
                 Sp1SessionStatus::Completed => {
                     let proof = self.prover.download(&session_id).await?;
                     let artifact = aggregation_artifact_from_sp1_proof(&proof)?;
+                    let empty_failure_reason = String::new();
 
                     self.record_session(
                         job,
                         session_type.clone(),
                         &session_id,
                         BackendSessionStatus::Completed,
+                        empty_failure_reason,
                     )
                     .await?;
 
@@ -269,6 +277,7 @@ impl<P: WorldSuccinctProver> Sp1Backend<P> {
                         session_type.clone(),
                         &session_id,
                         BackendSessionStatus::Failed,
+                        reason.clone(),
                     )
                     .await?;
 

--- a/proofs/worker/src/backend.rs
+++ b/proofs/worker/src/backend.rs
@@ -55,7 +55,7 @@ impl JobSessions {
         session_type: SessionType,
         backend_session_id: String,
         status: BackendSessionStatus,
-        failure_reason: String,
+        failure_reason: Option<String>,
     ) -> Result<(), ProofJobQueueError> {
         self.queue
             .record_proof_session(

--- a/proofs/worker/src/backend.rs
+++ b/proofs/worker/src/backend.rs
@@ -55,6 +55,7 @@ impl JobSessions {
         session_type: SessionType,
         backend_session_id: String,
         status: BackendSessionStatus,
+        failure_reason: String,
     ) -> Result<(), ProofJobQueueError> {
         self.queue
             .record_proof_session(
@@ -64,6 +65,7 @@ impl JobSessions {
                 self.lock_id,
                 backend_session_id,
                 status,
+                failure_reason,
             )
             .await
     }


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4876/the-record-session-method-should-add-failure-reson-as-an-input-empty

### Problem

We were hardcoding a failure reason to `failure reason` which is not representative of the real failure reason (obviously). There was a `TODO` to fix this.

### Solution

Pass the `failure_reason` as an input to the function:

- when none: null failure reason
- when some: failure reason to store

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends the worker-facing JSON-RPC contract and must be deployed in lockstep with callers; behavior change is limited to persisting real session failure text instead of a stub.
> 
> **Overview**
> **`record_proof_session`** now takes an optional **`failure_reason`** and threads it through the worker queue trait, prover service, JSON-RPC **`recordProofSession`**, and Postgres updates on **`proof_sessions`**.
> 
> The store no longer hardcodes a placeholder failure string when updating an active session; it persists **`None`** for non-failure updates and the caller-supplied text when a session is marked failed. The SP1 worker passes **`Some(reason)`** when the prover reports **`Sp1SessionStatus::Failed`**, and **`None`** for running/completed session checkpoints.
> 
> Call sites (integration harness, unit tests, **`JobSessions::record`**) were updated for the new parameter. This is a **breaking RPC/API change** for any worker or client that has not been redeployed with the new signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fade18fb2b1d2af969de4189e50e937263f63fce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->