### PR TITLE
feat: Add prover service status poller

### DIFF
--- a/proofs/defender/src/defender.rs
+++ b/proofs/defender/src/defender.rs
@@ -263,10 +263,21 @@ where
                             .request_proof(proof_request(game_created, backend))
                             .await
                         {
-                            Ok(id) => LaneState::Requested {
-                                id,
-                                attempts: attempts + 1,
-                            },
+                            Ok(id) => {
+                                let next_attempt = attempts + 1;
+                                warn!(
+                                    %game,
+                                    ?lane,
+                                    %id,
+                                    attempts = next_attempt,
+                                    max_attempts = self.config.max_proof_attempts,
+                                    "proof failed; re-requested proof"
+                                );
+                                LaneState::Requested {
+                                    id,
+                                    attempts: next_attempt,
+                                }
+                            }
                             Err(error) => {
                                 warn!(%game, ?lane, %error, "proof re-request failed; retrying next tick");
                                 state

--- a/proofs/integration-tests/tests/orchestration.rs
+++ b/proofs/integration-tests/tests/orchestration.rs
@@ -91,6 +91,7 @@ async fn start_proof_stack_with(
             max_attempts: 2,
             max_retries: 2,
             backend_poll_interval: Duration::from_millis(5),
+            status_poller_interval: Duration::from_millis(5),
         },
     )
     .await

--- a/proofs/prover-service/src/config.rs
+++ b/proofs/prover-service/src/config.rs
@@ -13,6 +13,9 @@ pub const DEFAULT_MAX_RETRIES: u32 = 3;
 /// Default delay before polling an unchanged backend job again.
 pub const DEFAULT_BACKEND_POLL_INTERVAL: Duration = Duration::from_secs(30);
 
+/// Default delay between status-poller scans.
+pub const DEFAULT_STATUS_POLLER_INTERVAL: Duration = Duration::from_secs(30);
+
 /// Configuration for the `prover-service`.
 #[derive(Debug, Clone)]
 pub struct ProverServiceConfig {
@@ -27,6 +30,8 @@ pub struct ProverServiceConfig {
     pub max_retries: u32,
     /// Delay before a backend job that returned `Noop` becomes pollable again.
     pub backend_poll_interval: Duration,
+    /// Delay between scans that terminalize unhealthy proof requests.
+    pub status_poller_interval: Duration,
 }
 
 impl ProverServiceConfig {
@@ -45,6 +50,11 @@ impl ProverServiceConfig {
                 "backend_poll_interval must be greater than zero",
             ));
         }
+        if self.status_poller_interval.is_zero() {
+            return Err(InvalidConfigError(
+                "status_poller_interval must be greater than zero",
+            ));
+        }
         Ok(())
     }
 }
@@ -56,6 +66,7 @@ impl Default for ProverServiceConfig {
             max_attempts: DEFAULT_MAX_ATTEMPTS,
             max_retries: DEFAULT_MAX_RETRIES,
             backend_poll_interval: DEFAULT_BACKEND_POLL_INTERVAL,
+            status_poller_interval: DEFAULT_STATUS_POLLER_INTERVAL,
         }
     }
 }

--- a/proofs/prover-service/src/lib.rs
+++ b/proofs/prover-service/src/lib.rs
@@ -72,13 +72,15 @@ mod config;
 mod error;
 mod rpc;
 mod service;
+mod status_poller;
 mod store;
 mod traits;
 mod types;
 
 // re-exports
 pub use config::{
-    DEFAULT_BACKEND_POLL_INTERVAL, DEFAULT_LOCK_TIMEOUT, DEFAULT_MAX_ATTEMPTS, ProverServiceConfig,
+    DEFAULT_BACKEND_POLL_INTERVAL, DEFAULT_LOCK_TIMEOUT, DEFAULT_MAX_ATTEMPTS,
+    DEFAULT_STATUS_POLLER_INTERVAL, ProverServiceConfig,
 };
 pub use error::{
     BackendMismatchErrorData, InvalidConfigError, ProofJobQueueError, ProofJobStatusErrorData,
@@ -89,6 +91,7 @@ pub use rpc::{
     start_rpc_server,
 };
 pub use service::ProverService;
+pub use status_poller::run_status_poller;
 pub use traits::{ProofJobQueue, ProofRequester};
 pub use types::{
     BackendProofId, BackendSession, BackendSessionStatus, FailedProofResponse, LockId,

--- a/proofs/prover-service/src/main.rs
+++ b/proofs/prover-service/src/main.rs
@@ -11,7 +11,9 @@ use std::{net::SocketAddr, sync::Arc, time::Duration};
 use anyhow::{Context, Result};
 use clap::Parser;
 use tracing::info;
-use world_chain_prover_service::{ProverService, ProverServiceConfig, start_rpc_server};
+use world_chain_prover_service::{
+    ProverService, ProverServiceConfig, run_status_poller, start_rpc_server,
+};
 
 #[derive(Debug, Parser)]
 #[command(
@@ -42,6 +44,10 @@ struct Cli {
     /// Seconds to wait before polling an unchanged backend job again.
     #[arg(long, env = "BACKEND_POLL_INTERVAL_SECONDS", default_value_t = 30)]
     backend_poll_interval_seconds: u64,
+
+    /// Seconds between scans that fail proof requests after exhausted attempts.
+    #[arg(long, env = "STATUS_POLLER_INTERVAL_SECS", default_value_t = 30)]
+    status_poller_interval_secs: u64,
 }
 
 #[tokio::main]
@@ -58,15 +64,19 @@ async fn main() -> Result<()> {
         max_attempts: cli.max_attempts,
         backend_poll_interval: Duration::from_secs(cli.backend_poll_interval_seconds),
         max_retries: cli.max_retries,
+        status_poller_interval: Duration::from_secs(cli.status_poller_interval_secs),
     };
+    let status_poller_interval = config.status_poller_interval;
     let service = Arc::new(
         ProverService::connect(&cli.database_url, config)
             .await
             .context("failed to initialize postgres-backed prover-service")?,
     );
-    let (addr, handle) = start_rpc_server(cli.listen_addr, service)
+    let (addr, handle) = start_rpc_server(cli.listen_addr, Arc::clone(&service))
         .await
         .context("failed to start prover-service RPC server")?;
+
+    let status_poller = tokio::spawn(run_status_poller(service, status_poller_interval));
 
     info!(listen_addr = %addr, "world-chain prover-service started");
 
@@ -77,5 +87,6 @@ async fn main() -> Result<()> {
             let _ = handle.stop();
         }
     }
+    status_poller.abort();
     Ok(())
 }

--- a/proofs/prover-service/src/service.rs
+++ b/proofs/prover-service/src/service.rs
@@ -50,6 +50,11 @@ impl ProverService {
     pub const fn pool(&self) -> &PgPool {
         self.store.pool()
     }
+
+    /// Mark proof requests that exhausted all worker attempts as failed.
+    pub(crate) async fn mark_exhausted_proof_requests_failed(&self) -> Result<u64, sqlx::Error> {
+        self.store.mark_exhausted_proof_requests_failed().await
+    }
 }
 
 #[async_trait]

--- a/proofs/prover-service/src/status_poller.rs
+++ b/proofs/prover-service/src/status_poller.rs
@@ -1,0 +1,29 @@
+use std::{sync::Arc, time::Duration};
+
+use tokio::time::MissedTickBehavior;
+use tracing::warn;
+
+use crate::ProverService;
+
+/// Runs the periodic maintenance loop that terminalizes proof requests which
+/// exhausted their worker attempts.
+pub async fn run_status_poller(service: Arc<ProverService>, poll_interval: Duration) {
+    let mut interval = tokio::time::interval(poll_interval);
+    interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+    loop {
+        interval.tick().await;
+        match service.mark_exhausted_proof_requests_failed().await {
+            Ok(0) => {}
+            Ok(failed) => {
+                warn!(
+                    failed,
+                    "status poller marked exhausted proof requests failed"
+                );
+            }
+            Err(error) => {
+                warn!(%error, "status poller scan failed");
+            }
+        }
+    }
+}

--- a/proofs/prover-service/src/store.rs
+++ b/proofs/prover-service/src/store.rs
@@ -19,6 +19,7 @@ use sqlx::{
     migrate::{MigrateError, Migrator},
     postgres::{PgPoolOptions, PgRow},
 };
+use tracing::info;
 use uuid::Uuid;
 
 static MIGRATOR: Migrator = sqlx::migrate!("./migrations");
@@ -168,6 +169,13 @@ impl ProverServiceStore {
             .execute(&mut *tx)
             .await?;
 
+            info!(
+                proof_id = %id,
+                retry_count = retry_count + 1,
+                max_retries = self.config.max_retries,
+                "re-queued failed proof request"
+            );
+
             tx.commit().await?;
             Ok(id)
         } else {
@@ -226,6 +234,64 @@ impl ProverServiceStore {
         }
     }
 
+    pub(crate) async fn mark_exhausted_proof_requests_failed(&self) -> Result<u64, sqlx::Error> {
+        let now = Utc::now();
+        let reason = format!(
+            "proof request exhausted max attempts ({})",
+            self.config.max_attempts
+        );
+        let row = sqlx::query(
+            r#"
+            WITH failed_requests AS (
+                UPDATE proof_requests
+                SET proof_status = $1,
+                    job_status = $2,
+                    failure_reason = $3,
+                    worker_id = NULL,
+                    lock_id = NULL,
+                    lock_expires_at = NULL,
+                    updated_at = $4,
+                    finished_at = $4
+                WHERE attempt >= $5
+                    AND (proof_status = $6 OR proof_status = $7)
+                    AND (
+                        job_status = $8
+                        OR (job_status = $9 AND lock_expires_at < $4)
+                    )
+                RETURNING proof_id
+            ),
+            failed_sessions AS (
+                UPDATE proof_sessions
+                SET status = $10,
+                    failure_reason = $3,
+                    completed_at = $4
+                WHERE proof_id IN (SELECT proof_id FROM failed_requests)
+                    AND (status = $11 OR status = $12)
+                RETURNING id
+            )
+            SELECT COUNT(*) AS failed_request_count
+            FROM failed_requests
+            "#,
+        )
+        .bind(ProofStatus::Failed.as_str())
+        .bind(ProofJobStatus::Failed.as_str())
+        .bind(reason)
+        .bind(now)
+        .bind(self.config.max_attempts as i32)
+        .bind(ProofStatus::Created.as_str())
+        .bind(ProofStatus::Running.as_str())
+        .bind(ProofJobStatus::Pending.as_str())
+        .bind(ProofJobStatus::Claimed.as_str())
+        .bind(BackendSessionStatus::Failed.as_str())
+        .bind(BackendSessionStatus::Submitting.as_str())
+        .bind(BackendSessionStatus::Running.as_str())
+        .fetch_one(&self.pool)
+        .await?;
+
+        let failed_request_count: i64 = row.get("failed_request_count");
+        Ok(failed_request_count as u64)
+    }
+
     pub(crate) async fn get_next_proof(
         &self,
         backend: ProofBackend,
@@ -247,9 +313,10 @@ impl ProverServiceStore {
             WHERE proof_id = (
                 SELECT proof_id FROM proof_requests
                 WHERE backend = $7
+                    AND attempt < $11
                     AND (
                         job_status = $8
-                        OR (job_status = $9 AND lock_expires_at < $10 AND attempt < $11)
+                        OR (job_status = $9 AND lock_expires_at < $10)
                     ) 
                 ORDER BY l2_block_number ASC, created_at ASC, proof_id ASC
                 FOR UPDATE SKIP LOCKED

--- a/proofs/prover-service/src/store.rs
+++ b/proofs/prover-service/src/store.rs
@@ -313,10 +313,10 @@ impl ProverServiceStore {
             WHERE proof_id = (
                 SELECT proof_id FROM proof_requests
                 WHERE backend = $7
-                    AND attempt < $11
+                    AND attempt < $8
                     AND (
-                        job_status = $8
-                        OR (job_status = $9 AND lock_expires_at < $10)
+                        job_status = $9
+                        OR (job_status = $10 AND lock_expires_at < $11)
                     ) 
                 ORDER BY l2_block_number ASC, created_at ASC, proof_id ASC
                 FOR UPDATE SKIP LOCKED
@@ -332,10 +332,10 @@ impl ProverServiceStore {
         .bind(lock_expires_at)
         .bind(now)
         .bind(backend.as_str())
+        .bind(self.config.max_attempts as i32)
         .bind(ProofJobStatus::Pending.as_str())
         .bind(ProofJobStatus::Claimed.as_str())
         .bind(now)
-        .bind(self.config.max_attempts as i32)
         .fetch_optional(&self.pool)
         .await?;
 

--- a/proofs/prover-service/src/tests.rs
+++ b/proofs/prover-service/src/tests.rs
@@ -15,6 +15,7 @@ fn test_config() -> ProverServiceConfig {
         max_attempts: 2,
         max_retries: 2,
         backend_poll_interval: Duration::from_millis(25),
+        status_poller_interval: Duration::from_millis(25),
     }
 }
 
@@ -252,6 +253,104 @@ async fn submit_proof_with_wrong_backend_is_rejected() {
     assert_eq!(
         service.proof_status(id).await.unwrap(),
         ProofStatus::Running
+    );
+}
+
+#[tokio::test]
+async fn status_poller_marks_expired_exhausted_jobs_failed() {
+    let config = ProverServiceConfig {
+        lock_timeout: Duration::from_millis(50),
+        ..test_config()
+    };
+    let max_attempts = config.max_attempts;
+    let expected_failure_reason = format!("proof request exhausted max attempts ({max_attempts})");
+    let Some(ctx) = service(config).await else {
+        return;
+    };
+    let service = ctx.service;
+    let req = request(ProofBackend::Sp1, 5);
+    let id = service.request_proof(req).await.unwrap();
+
+    let first = service
+        .get_next_proof(ProofBackend::Sp1, worker_id())
+        .await
+        .unwrap()
+        .expect("first lock");
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    let second = service
+        .get_next_proof(ProofBackend::Sp1, worker_id())
+        .await
+        .unwrap()
+        .expect("second lock");
+    assert_ne!(first.lock_id, second.lock_id);
+
+    service
+        .record_proof_session(
+            id,
+            SessionType::Stark,
+            worker_id(),
+            second.lock_id,
+            backend_session_id(5),
+            BackendSessionStatus::Running,
+        )
+        .await
+        .unwrap();
+
+    // we dont fail active work
+    assert_eq!(
+        service
+            .mark_exhausted_proof_requests_failed()
+            .await
+            .unwrap(),
+        0
+    );
+    assert_eq!(
+        service.proof_status(id).await.unwrap(),
+        ProofStatus::Running
+    );
+
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    // without status poller, this job is not claimable
+    assert!(
+        service
+            .get_next_proof(ProofBackend::Sp1, worker_id())
+            .await
+            .unwrap()
+            .is_none()
+    );
+
+    // clean up status poller status and expect to clean up 1 row
+    assert_eq!(
+        service
+            .mark_exhausted_proof_requests_failed()
+            .await
+            .unwrap(),
+        1
+    );
+    assert_eq!(service.proof_status(id).await.unwrap(), ProofStatus::Failed);
+
+    assert!(matches!(
+        service.get_proof(id).await.unwrap(),
+        ProofResponse::Failed(response)
+            if response.id == id && response.reason == expected_failure_reason
+    ));
+
+    // sp1 proof session is cleaned up too
+    assert!(
+        service
+            .get_proof_session(id, SessionType::Stark)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        service
+            .mark_exhausted_proof_requests_failed()
+            .await
+            .unwrap(),
+        0
     );
 }
 

--- a/proofs/prover-service/src/tests.rs
+++ b/proofs/prover-service/src/tests.rs
@@ -293,6 +293,7 @@ async fn status_poller_marks_expired_exhausted_jobs_failed() {
             second.lock_id,
             backend_session_id(5),
             BackendSessionStatus::Running,
+            None,
         )
         .await
         .unwrap();


### PR DESCRIPTION
closes https://linear.app/worldcoin/issue/PROTO-4749/add-the-status-poller


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when proof jobs become terminal and how the queue behaves at max attempts, which affects defenders and workers; logic is covered by new store tests but touches durable queue state.
> 
> **Overview**
> Adds a **background status poller** to the prover-service so proof requests that have used all worker attempts (`max_attempts`) are **marked failed** instead of staying stuck in `Created`/`Running` with an unclaimable expired lock.
> 
> The poller runs on a new **`status_poller_interval`** (config, default 30s; CLI/env `STATUS_POLLER_INTERVAL_SECS`) and is started from the **`world-chain-prover-service`** binary alongside the RPC server. Each tick calls **`mark_exhausted_proof_requests_failed`**, which updates matching `proof_requests` and related in-flight **`proof_sessions`**, clears locks, and sets a standardized failure reason.
> 
> **`get_next_proof`** now excludes jobs with `attempt >= max_attempts` up front, so exhausted work is no longer re-leased; terminal failure depends on the poller (or direct store calls in tests). **Defender** logs a **warn** when it re-requests a proof after a failed status.
> 
> Tests cover the exhausted-job path; orchestration config sets a short poller interval for faster retries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ca86a2d333de5881ed10cfee920435f53ebbdd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->