### PR TITLE
chore: Refactor proof job queue trait envelopes

### DIFF
--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -22,10 +22,11 @@ use world_chain_proposer::{
     ParentRef, Proposal, ProposalSubmission, ProposerClient, ProposerError,
 };
 use world_chain_prover_service::{
-    BackendSession, BackendSessionStatus, LockId, LockedProofRequest, ProofBackend, ProofData,
-    ProofJobQueue, ProofJobQueueError, ProofRequest, ProofRequestError, ProofRequestId,
-    ProofRequester, ProofResponse, ProofStatus, ProverService, ProverServiceConfig, SessionType,
-    SucceededProofResponse,
+    GetNextProofRequest, GetNextProofResponse, GetProofSessionRequest, GetProofSessionResponse,
+    HeartbeatRequest, HeartbeatResponse, ProofBackend, ProofData, ProofJobQueue,
+    ProofJobQueueError, ProofRequest, ProofRequestError, ProofRequestId, ProofRequester,
+    ProofResponse, ProofStatus, ProverService, ProverServiceConfig, RecordProofSessionRequest,
+    RecordProofSessionResponse, SubmitProofRequest, SubmitProofResponse,
 };
 
 pub const BLOCK_INTERVAL: u64 = 10;
@@ -591,58 +592,36 @@ impl ProofRequester for SharedProverService {
 impl ProofJobQueue for SharedProverService {
     async fn get_next_proof(
         &self,
-        backend: ProofBackend,
-        worker_id: String,
-    ) -> Result<Option<LockedProofRequest>, ProofJobQueueError> {
-        self.service.get_next_proof(backend, worker_id).await
+        request: GetNextProofRequest,
+    ) -> Result<GetNextProofResponse, ProofJobQueueError> {
+        self.service.get_next_proof(request).await
     }
 
     async fn submit_proof(
         &self,
-        proof: SucceededProofResponse,
-        worker_id: String,
-        lock: LockId,
-    ) -> Result<(), ProofJobQueueError> {
-        self.service.submit_proof(proof, worker_id, lock).await
+        request: SubmitProofRequest,
+    ) -> Result<SubmitProofResponse, ProofJobQueueError> {
+        self.service.submit_proof(request).await
     }
 
     async fn get_proof_session(
         &self,
-        proof_id: ProofRequestId,
-        session_type: SessionType,
-    ) -> Result<Option<BackendSession>, ProofJobQueueError> {
-        self.service.get_proof_session(proof_id, session_type).await
+        request: GetProofSessionRequest,
+    ) -> Result<GetProofSessionResponse, ProofJobQueueError> {
+        self.service.get_proof_session(request).await
     }
 
     async fn record_proof_session(
         &self,
-        proof_id: ProofRequestId,
-        session_type: SessionType,
-        worker_id: String,
-        lock_id: LockId,
-        backend_session_id: String,
-        state: BackendSessionStatus,
-        failure_reason: Option<String>,
-    ) -> Result<(), ProofJobQueueError> {
-        self.service
-            .record_proof_session(
-                proof_id,
-                session_type,
-                worker_id,
-                lock_id,
-                backend_session_id,
-                state,
-                failure_reason,
-            )
-            .await
+        request: RecordProofSessionRequest,
+    ) -> Result<RecordProofSessionResponse, ProofJobQueueError> {
+        self.service.record_proof_session(request).await
     }
 
     async fn heartbeat(
         &self,
-        proof_id: ProofRequestId,
-        worker_id: String,
-        lock: LockId,
-    ) -> Result<(), ProofJobQueueError> {
-        self.service.heartbeat(proof_id, worker_id, lock).await
+        request: HeartbeatRequest,
+    ) -> Result<HeartbeatResponse, ProofJobQueueError> {
+        self.service.heartbeat(request).await
     }
 }

--- a/proofs/prover-service/src/lib.rs
+++ b/proofs/prover-service/src/lib.rs
@@ -94,9 +94,12 @@ pub use service::ProverService;
 pub use status_poller::run_status_poller;
 pub use traits::{ProofJobQueue, ProofRequester};
 pub use types::{
-    BackendProofId, BackendSession, BackendSessionStatus, FailedProofResponse, LockId,
-    LockedProofRequest, PendingProofResponse, ProofBackend, ProofData, ProofJobStatus,
-    ProofRequest, ProofRequestId, ProofResponse, ProofStatus, SessionType, SucceededProofResponse,
+    BackendProofId, BackendSession, BackendSessionStatus, FailedProofResponse, GetNextProofRequest,
+    GetNextProofResponse, GetProofSessionRequest, GetProofSessionResponse, HeartbeatRequest,
+    HeartbeatResponse, LockId, LockedProofRequest, PendingProofResponse, ProofBackend, ProofData,
+    ProofJobStatus, ProofRequest, ProofRequestId, ProofResponse, ProofStatus,
+    RecordProofSessionRequest, RecordProofSessionResponse, SessionType, SubmitProofRequest,
+    SubmitProofResponse, SucceededProofResponse,
 };
 
 #[cfg(test)]

--- a/proofs/prover-service/src/rpc.rs
+++ b/proofs/prover-service/src/rpc.rs
@@ -7,9 +7,10 @@ use crate::{
     service::ProverService,
     traits::{ProofJobQueue, ProofRequester},
     types::{
-        BackendSession, BackendSessionStatus, LockId, LockedProofRequest, ProofBackend,
-        ProofRequest, ProofRequestId, ProofResponse, ProofStatus, SessionType,
-        SucceededProofResponse,
+        GetNextProofRequest, GetNextProofResponse, GetProofSessionRequest, GetProofSessionResponse,
+        HeartbeatRequest, HeartbeatResponse, ProofRequest, ProofRequestId, ProofResponse,
+        ProofStatus, RecordProofSessionRequest, RecordProofSessionResponse, SubmitProofRequest,
+        SubmitProofResponse,
     },
 };
 use jsonrpsee::{
@@ -69,50 +70,30 @@ pub trait ProverServiceApi {
 
     /// Lock the next queued proof request for the given backend.
     #[method(name = "getNextProof")]
-    async fn get_next_proof(
-        &self,
-        backend: ProofBackend,
-        worker_id: String,
-    ) -> RpcResult<Option<LockedProofRequest>>;
+    async fn get_next_proof(&self, request: GetNextProofRequest)
+    -> RpcResult<GetNextProofResponse>;
 
     /// Submit a generated proof.
     #[method(name = "submitProof")]
-    async fn submit_proof(
-        &self,
-        proof: SucceededProofResponse,
-        worker_id: String,
-        lock: LockId,
-    ) -> RpcResult<()>;
+    async fn submit_proof(&self, request: SubmitProofRequest) -> RpcResult<SubmitProofResponse>;
 
     /// Get a proof session if any.
     #[method(name = "getProofSession")]
     async fn get_proof_session(
         &self,
-        proof_id: ProofRequestId,
-        session_type: SessionType,
-    ) -> RpcResult<Option<BackendSession>>;
+        request: GetProofSessionRequest,
+    ) -> RpcResult<GetProofSessionResponse>;
 
     /// Record a new proof session.
     #[method(name = "recordProofSession")]
     async fn record_proof_session(
         &self,
-        proof_id: ProofRequestId,
-        session_type: SessionType,
-        worker_id: String,
-        lock_id: LockId,
-        backend_session_id: String,
-        state: BackendSessionStatus,
-        failure_reason: Option<String>,
-    ) -> RpcResult<()>;
+        request: RecordProofSessionRequest,
+    ) -> RpcResult<RecordProofSessionResponse>;
 
     /// Heartbeat call.
     #[method(name = "heartbeat")]
-    async fn heartbeat(
-        &self,
-        proof_id: ProofRequestId,
-        worker_id: String,
-        lock: LockId,
-    ) -> RpcResult<()>;
+    async fn heartbeat(&self, request: HeartbeatRequest) -> RpcResult<HeartbeatResponse>;
 }
 
 impl From<ProofRequestError> for ErrorObjectOwned {
@@ -230,63 +211,31 @@ impl ProverServiceApiServer for ProverServiceRpc {
 
     async fn get_next_proof(
         &self,
-        backend: ProofBackend,
-        worker_id: String,
-    ) -> RpcResult<Option<LockedProofRequest>> {
-        Ok(self.service.get_next_proof(backend, worker_id).await?)
+        request: GetNextProofRequest,
+    ) -> RpcResult<GetNextProofResponse> {
+        Ok(self.service.get_next_proof(request).await?)
     }
 
-    async fn submit_proof(
-        &self,
-        proof: SucceededProofResponse,
-        worker_id: String,
-        lock: LockId,
-    ) -> RpcResult<()> {
-        Ok(self.service.submit_proof(proof, worker_id, lock).await?)
+    async fn submit_proof(&self, request: SubmitProofRequest) -> RpcResult<SubmitProofResponse> {
+        Ok(self.service.submit_proof(request).await?)
     }
 
     async fn get_proof_session(
         &self,
-        proof_id: ProofRequestId,
-        session_type: SessionType,
-    ) -> RpcResult<Option<BackendSession>> {
-        Ok(self
-            .service
-            .get_proof_session(proof_id, session_type)
-            .await?)
+        request: GetProofSessionRequest,
+    ) -> RpcResult<GetProofSessionResponse> {
+        Ok(self.service.get_proof_session(request).await?)
     }
 
     async fn record_proof_session(
         &self,
-        proof_id: ProofRequestId,
-        session_type: SessionType,
-        worker_id: String,
-        lock_id: LockId,
-        backend_session_id: String,
-        state: BackendSessionStatus,
-        failure_reason: Option<String>,
-    ) -> RpcResult<()> {
-        Ok(self
-            .service
-            .record_proof_session(
-                proof_id,
-                session_type,
-                worker_id,
-                lock_id,
-                backend_session_id,
-                state,
-                failure_reason,
-            )
-            .await?)
+        request: RecordProofSessionRequest,
+    ) -> RpcResult<RecordProofSessionResponse> {
+        Ok(self.service.record_proof_session(request).await?)
     }
 
-    async fn heartbeat(
-        &self,
-        proof_id: ProofRequestId,
-        worker_id: String,
-        lock: LockId,
-    ) -> RpcResult<()> {
-        Ok(self.service.heartbeat(proof_id, worker_id, lock).await?)
+    async fn heartbeat(&self, request: HeartbeatRequest) -> RpcResult<HeartbeatResponse> {
+        Ok(self.service.heartbeat(request).await?)
     }
 }
 
@@ -455,67 +404,49 @@ impl ProofRequester for RpcProverServiceClient {
 impl ProofJobQueue for RpcProverServiceClient {
     async fn get_next_proof(
         &self,
-        backend: ProofBackend,
-        worker_id: String,
-    ) -> Result<Option<LockedProofRequest>, ProofJobQueueError> {
-        ProverServiceApiClient::get_next_proof(&self.client, backend, worker_id)
+        request: GetNextProofRequest,
+    ) -> Result<GetNextProofResponse, ProofJobQueueError> {
+        ProverServiceApiClient::get_next_proof(&self.client, request)
             .await
             .map_err(|err| map_job_error(err, ProofRequestId(Default::default())))
     }
 
     async fn submit_proof(
         &self,
-        proof: SucceededProofResponse,
-        worker_id: String,
-        lock: LockId,
-    ) -> Result<(), ProofJobQueueError> {
-        let id = proof.id;
-        ProverServiceApiClient::submit_proof(&self.client, proof, worker_id, lock)
+        request: SubmitProofRequest,
+    ) -> Result<SubmitProofResponse, ProofJobQueueError> {
+        let id = request.proof.id;
+        ProverServiceApiClient::submit_proof(&self.client, request)
             .await
             .map_err(|err| map_job_error(err, id))
     }
 
     async fn get_proof_session(
         &self,
-        proof_id: ProofRequestId,
-        session_type: SessionType,
-    ) -> Result<Option<BackendSession>, ProofJobQueueError> {
-        ProverServiceApiClient::get_proof_session(&self.client, proof_id, session_type)
+        request: GetProofSessionRequest,
+    ) -> Result<GetProofSessionResponse, ProofJobQueueError> {
+        let proof_id = request.proof_id;
+        ProverServiceApiClient::get_proof_session(&self.client, request)
             .await
             .map_err(|err| map_job_error(err, proof_id))
     }
 
     async fn record_proof_session(
         &self,
-        proof_id: ProofRequestId,
-        session_type: SessionType,
-        worker_id: String,
-        lock_id: LockId,
-        backend_session_id: String,
-        state: BackendSessionStatus,
-        failure_reason: Option<String>,
-    ) -> Result<(), ProofJobQueueError> {
-        ProverServiceApiClient::record_proof_session(
-            &self.client,
-            proof_id,
-            session_type,
-            worker_id,
-            lock_id,
-            backend_session_id,
-            state,
-            failure_reason,
-        )
-        .await
-        .map_err(|err| map_job_error(err, proof_id))
+        request: RecordProofSessionRequest,
+    ) -> Result<RecordProofSessionResponse, ProofJobQueueError> {
+        let proof_id = request.proof_id;
+        ProverServiceApiClient::record_proof_session(&self.client, request)
+            .await
+            .map_err(|err| map_job_error(err, proof_id))
     }
 
     async fn heartbeat(
         &self,
-        proof_id: ProofRequestId,
-        worker_id: String,
-        lock: LockId,
-    ) -> Result<(), ProofJobQueueError> {
-        ProverServiceApiClient::heartbeat(&self.client, proof_id, worker_id, lock)
+        request: HeartbeatRequest,
+    ) -> Result<HeartbeatResponse, ProofJobQueueError> {
+        let proof_id = request.proof_id;
+        ProverServiceApiClient::heartbeat(&self.client, request)
             .await
             .map_err(|err| map_job_error(err, proof_id))
     }

--- a/proofs/prover-service/src/service.rs
+++ b/proofs/prover-service/src/service.rs
@@ -4,9 +4,10 @@ use crate::{
     store::ProverServiceStore,
     traits::{ProofJobQueue, ProofRequester},
     types::{
-        BackendSession, BackendSessionStatus, LockId, LockedProofRequest, ProofBackend,
-        ProofRequest, ProofRequestId, ProofResponse, ProofStatus, SessionType,
-        SucceededProofResponse,
+        GetNextProofRequest, GetNextProofResponse, GetProofSessionRequest, GetProofSessionResponse,
+        HeartbeatRequest, HeartbeatResponse, ProofRequest, ProofRequestId, ProofResponse,
+        ProofStatus, RecordProofSessionRequest, RecordProofSessionResponse, SubmitProofRequest,
+        SubmitProofResponse,
     },
 };
 use async_trait::async_trait;
@@ -85,58 +86,36 @@ impl ProofRequester for ProverService {
 impl ProofJobQueue for ProverService {
     async fn get_next_proof(
         &self,
-        backend: ProofBackend,
-        worker_id: String,
-    ) -> Result<Option<LockedProofRequest>, ProofJobQueueError> {
-        self.store.get_next_proof(backend, worker_id).await
+        request: GetNextProofRequest,
+    ) -> Result<GetNextProofResponse, ProofJobQueueError> {
+        self.store.get_next_proof(request).await
     }
 
     async fn submit_proof(
         &self,
-        proof: SucceededProofResponse,
-        worker_id: String,
-        lock: LockId,
-    ) -> Result<(), ProofJobQueueError> {
-        self.store.submit_proof(proof, worker_id, lock).await
+        request: SubmitProofRequest,
+    ) -> Result<SubmitProofResponse, ProofJobQueueError> {
+        self.store.submit_proof(request).await
     }
 
     async fn get_proof_session(
         &self,
-        proof_id: ProofRequestId,
-        session_type: SessionType,
-    ) -> Result<Option<BackendSession>, ProofJobQueueError> {
-        self.store.get_proof_session(proof_id, session_type).await
+        request: GetProofSessionRequest,
+    ) -> Result<GetProofSessionResponse, ProofJobQueueError> {
+        self.store.get_proof_session(request).await
     }
 
     async fn record_proof_session(
         &self,
-        proof_id: ProofRequestId,
-        session_type: SessionType,
-        worker_id: String,
-        lock_id: LockId,
-        backend_session_id: String,
-        state: BackendSessionStatus,
-        failure_reason: Option<String>,
-    ) -> Result<(), ProofJobQueueError> {
-        self.store
-            .record_proof_session(
-                proof_id,
-                session_type,
-                worker_id,
-                lock_id,
-                backend_session_id,
-                state,
-                failure_reason,
-            )
-            .await
+        request: RecordProofSessionRequest,
+    ) -> Result<RecordProofSessionResponse, ProofJobQueueError> {
+        self.store.record_proof_session(request).await
     }
 
     async fn heartbeat(
         &self,
-        proof_id: ProofRequestId,
-        worker_id: String,
-        lock: LockId,
-    ) -> Result<(), ProofJobQueueError> {
-        self.store.heartbeat(proof_id, worker_id, lock).await
+        request: HeartbeatRequest,
+    ) -> Result<HeartbeatResponse, ProofJobQueueError> {
+        self.store.heartbeat(request).await
     }
 }

--- a/proofs/prover-service/src/store.rs
+++ b/proofs/prover-service/src/store.rs
@@ -7,9 +7,12 @@ use crate::{
         ProverServiceInitError, TooManyRetriesErrorData,
     },
     types::{
-        BackendSession, BackendSessionStatus, FailedProofResponse, LockId, LockedProofRequest,
-        PendingProofResponse, ProofBackend, ProofJobStatus, ProofRequest, ProofRequestId,
-        ProofResponse, ProofStatus, SessionType, SucceededProofResponse,
+        BackendSession, BackendSessionStatus, FailedProofResponse, GetNextProofRequest,
+        GetNextProofResponse, GetProofSessionRequest, GetProofSessionResponse, HeartbeatRequest,
+        HeartbeatResponse, LockId, LockedProofRequest, PendingProofResponse, ProofBackend,
+        ProofJobStatus, ProofRequest, ProofRequestId, ProofResponse, ProofStatus,
+        RecordProofSessionRequest, RecordProofSessionResponse, SubmitProofRequest,
+        SubmitProofResponse, SucceededProofResponse,
     },
 };
 use alloy_primitives::{Address, B256};
@@ -294,9 +297,9 @@ impl ProverServiceStore {
 
     pub(crate) async fn get_next_proof(
         &self,
-        backend: ProofBackend,
-        worker_id: String,
-    ) -> Result<Option<LockedProofRequest>, ProofJobQueueError> {
+        request: GetNextProofRequest,
+    ) -> Result<GetNextProofResponse, ProofJobQueueError> {
+        let GetNextProofRequest { backend, worker_id } = request;
         let lock_id = LockId::new();
         let now = Utc::now();
         let lock_expires_at = now + self.config.lock_timeout;
@@ -341,17 +344,24 @@ impl ProverServiceStore {
 
         if let Some(row) = query {
             let request = request_from_row(&row)?;
-            Ok(Some(LockedProofRequest { request, lock_id }))
+            Ok(GetNextProofResponse {
+                locked_request: Some(LockedProofRequest { request, lock_id }),
+            })
         } else {
-            Ok(None)
+            Ok(GetNextProofResponse {
+                locked_request: None,
+            })
         }
     }
 
     pub(crate) async fn get_proof_session(
         &self,
-        proof_id: ProofRequestId,
-        session_type: SessionType,
-    ) -> Result<Option<BackendSession>, ProofJobQueueError> {
+        request: GetProofSessionRequest,
+    ) -> Result<GetProofSessionResponse, ProofJobQueueError> {
+        let GetProofSessionRequest {
+            proof_id,
+            session_type,
+        } = request;
         let row = sqlx::query(
             r#"
             SELECT ps.backend_session_id, ps.status
@@ -392,19 +402,22 @@ impl ProverServiceStore {
             None
         };
 
-        Ok(session)
+        Ok(GetProofSessionResponse { session })
     }
 
     pub(crate) async fn record_proof_session(
         &self,
-        proof_id: ProofRequestId,
-        session_type: SessionType,
-        worker_id: String,
-        lock_id: LockId,
-        backend_session_id: String,
-        status: BackendSessionStatus,
-        failure_reason: Option<String>,
-    ) -> Result<(), ProofJobQueueError> {
+        request: RecordProofSessionRequest,
+    ) -> Result<RecordProofSessionResponse, ProofJobQueueError> {
+        let RecordProofSessionRequest {
+            proof_id,
+            session_type,
+            worker_id,
+            lock_id,
+            backend_session_id,
+            status,
+            failure_reason,
+        } = request;
         let now = Utc::now();
         let mut tx = self.begin_queue_tx().await?;
         let claim = sqlx::query(
@@ -481,7 +494,7 @@ impl ProverServiceStore {
                 .map_err(ProofJobQueueError::UnknownBackendSessionStatus)?;
             if stored.is_terminal() {
                 if stored == status {
-                    return Ok(());
+                    return Ok(RecordProofSessionResponse {});
                 }
                 return Err(ProofJobQueueError::BackendSessionAlreadyTerminal(
                     BackendSessionAlreadyTerminalErrorData {
@@ -566,15 +579,18 @@ impl ProverServiceStore {
 
         tx.commit().await?;
 
-        Ok(())
+        Ok(RecordProofSessionResponse {})
     }
 
     pub(crate) async fn submit_proof(
         &self,
-        proof: SucceededProofResponse,
-        worker_id: String,
-        lock_id: LockId,
-    ) -> Result<(), ProofJobQueueError> {
+        request: SubmitProofRequest,
+    ) -> Result<SubmitProofResponse, ProofJobQueueError> {
+        let SubmitProofRequest {
+            proof,
+            worker_id,
+            lock_id,
+        } = request;
         let now = Utc::now();
         let row = sqlx::query(
             r#"
@@ -655,9 +671,9 @@ impl ProverServiceStore {
 
         if let Some(_row) = row {
             // db is updated, return successfully
-            Ok(())
+            Ok(SubmitProofResponse {})
         } else {
-            // re-read the row to anaylize the error or return Ok(()) if the proof
+            // re-read the row to anaylize the error or return success if the proof
             // has already been submitted (idempotency).
             let row = sqlx::query(
                 r#"
@@ -689,7 +705,7 @@ impl ProverServiceStore {
                 let stored_proof_data: ProofData = serde_json::from_slice(&stored_proof_data_vec)?;
                 if stored_proof_data == proof.proof {
                     // proof has already been submitted - no op
-                    return Ok(());
+                    return Ok(SubmitProofResponse {});
                 } else {
                     return Err(ProofJobQueueError::ProofMismatch(Box::new(
                         ProofMismatchErrorData {
@@ -727,10 +743,13 @@ impl ProverServiceStore {
 
     pub(crate) async fn heartbeat(
         &self,
-        proof_id: ProofRequestId,
-        worker_id: String,
-        lock_id: LockId,
-    ) -> Result<(), ProofJobQueueError> {
+        request: HeartbeatRequest,
+    ) -> Result<HeartbeatResponse, ProofJobQueueError> {
+        let HeartbeatRequest {
+            proof_id,
+            worker_id,
+            lock_id,
+        } = request;
         let now = Utc::now();
         let next_lock_expiration = now + self.config.lock_timeout;
         let maybe_row = sqlx::query(
@@ -758,7 +777,7 @@ impl ProverServiceStore {
 
         if maybe_row.is_some() {
             // row updated, return successfully
-            Ok(())
+            Ok(HeartbeatResponse {})
         } else {
             // read the row to return a better error
             let row = sqlx::query(

--- a/proofs/prover-service/src/tests.rs
+++ b/proofs/prover-service/src/tests.rs
@@ -1,7 +1,8 @@
 use crate::{
-    ProofBackend, ProofData, ProofJobQueue, ProofJobQueueError, ProofRequest, ProofRequester,
-    ProofResponse, ProofStatus, ProverService, ProverServiceConfig, RpcProverServiceClient,
-    SucceededProofResponse, start_rpc_server,
+    GetNextProofRequest, GetProofSessionRequest, LockId, ProofBackend, ProofData, ProofJobQueue,
+    ProofJobQueueError, ProofRequest, ProofRequestId, ProofRequester, ProofResponse, ProofStatus,
+    ProverService, ProverServiceConfig, RecordProofSessionRequest, RpcProverServiceClient,
+    SubmitProofRequest, SucceededProofResponse, start_rpc_server,
     types::{BackendSessionStatus, SessionType},
 };
 use alloy_primitives::{Address, B256, Bytes};
@@ -84,6 +85,50 @@ fn worker_id() -> String {
     "test-worker".to_string()
 }
 
+fn get_next_proof_request(backend: ProofBackend) -> GetNextProofRequest {
+    GetNextProofRequest {
+        backend,
+        worker_id: worker_id(),
+    }
+}
+
+fn submit_proof_request(proof: SucceededProofResponse, lock_id: LockId) -> SubmitProofRequest {
+    SubmitProofRequest {
+        proof,
+        worker_id: worker_id(),
+        lock_id,
+    }
+}
+
+fn get_proof_session_request(
+    proof_id: ProofRequestId,
+    session_type: SessionType,
+) -> GetProofSessionRequest {
+    GetProofSessionRequest {
+        proof_id,
+        session_type,
+    }
+}
+
+fn record_proof_session_request(
+    proof_id: ProofRequestId,
+    session_type: SessionType,
+    lock_id: LockId,
+    backend_session_id: String,
+    status: BackendSessionStatus,
+    failure_reason: Option<String>,
+) -> RecordProofSessionRequest {
+    RecordProofSessionRequest {
+        proof_id,
+        session_type,
+        worker_id: worker_id(),
+        lock_id,
+        backend_session_id,
+        status,
+        failure_reason,
+    }
+}
+
 #[test]
 fn request_id_is_deterministic() {
     let sp1 = request(ProofBackend::Sp1, 1);
@@ -112,9 +157,10 @@ async fn full_lifecycle_succeeds() {
     ));
 
     let locked = service
-        .get_next_proof(ProofBackend::Nitro, worker_id())
+        .get_next_proof(get_next_proof_request(ProofBackend::Nitro))
         .await
         .unwrap()
+        .locked_request
         .expect("job available");
     assert_eq!(locked.request, req);
     assert_eq!(
@@ -129,7 +175,7 @@ async fn full_lifecycle_succeeds() {
 
     let response = proof_for(&req);
     service
-        .submit_proof(response.clone(), worker_id(), locked.lock_id)
+        .submit_proof(submit_proof_request(response.clone(), locked.lock_id))
         .await
         .unwrap();
     assert_eq!(
@@ -168,9 +214,10 @@ async fn get_next_proof_on_empty_queue_returns_none() {
     let service = ctx.service;
     assert!(
         service
-            .get_next_proof(ProofBackend::Sp1, worker_id())
+            .get_next_proof(get_next_proof_request(ProofBackend::Sp1))
             .await
             .unwrap()
+            .locked_request
             .is_none()
     );
 }
@@ -190,31 +237,33 @@ async fn stale_lock_is_rejected_and_reclaim_succeeds() {
     let id = service.request_proof(req.clone()).await.unwrap();
 
     let first = service
-        .get_next_proof(ProofBackend::Sp1, worker_id())
+        .get_next_proof(get_next_proof_request(ProofBackend::Sp1))
         .await
         .unwrap()
+        .locked_request
         .expect("first lock");
 
     // Let the first lock expire so the job can be reclaimed.
     tokio::time::sleep(Duration::from_millis(80)).await;
     let second = service
-        .get_next_proof(ProofBackend::Sp1, worker_id())
+        .get_next_proof(get_next_proof_request(ProofBackend::Sp1))
         .await
         .unwrap()
+        .locked_request
         .expect("second lock");
     assert_ne!(first.lock_id, second.lock_id);
 
     // The first (now superseded) lock can no longer submit.
     assert!(matches!(
         service
-            .submit_proof(proof_for(&req), worker_id(), first.lock_id)
+            .submit_proof(submit_proof_request(proof_for(&req), first.lock_id))
             .await,
         Err(ProofJobQueueError::StaleLock(_))
     ));
 
     // The current lock owner can submit successfully.
     service
-        .submit_proof(proof_for(&req), worker_id(), second.lock_id)
+        .submit_proof(submit_proof_request(proof_for(&req), second.lock_id))
         .await
         .unwrap();
     assert_eq!(
@@ -232,9 +281,10 @@ async fn submit_proof_with_wrong_backend_is_rejected() {
     let req = request(ProofBackend::Sp1, 4);
     let id = service.request_proof(req.clone()).await.unwrap();
     let locked = service
-        .get_next_proof(ProofBackend::Sp1, worker_id())
+        .get_next_proof(get_next_proof_request(ProofBackend::Sp1))
         .await
         .unwrap()
+        .locked_request
         .expect("lock");
 
     let mismatched = SucceededProofResponse {
@@ -246,7 +296,7 @@ async fn submit_proof_with_wrong_backend_is_rejected() {
     };
     assert!(matches!(
         service
-            .submit_proof(mismatched, worker_id(), locked.lock_id)
+            .submit_proof(submit_proof_request(mismatched, locked.lock_id))
             .await,
         Err(ProofJobQueueError::BackendMismatch(_))
     ));
@@ -272,29 +322,30 @@ async fn status_poller_marks_expired_exhausted_jobs_failed() {
     let id = service.request_proof(req).await.unwrap();
 
     let first = service
-        .get_next_proof(ProofBackend::Sp1, worker_id())
+        .get_next_proof(get_next_proof_request(ProofBackend::Sp1))
         .await
         .unwrap()
+        .locked_request
         .expect("first lock");
     tokio::time::sleep(Duration::from_millis(80)).await;
 
     let second = service
-        .get_next_proof(ProofBackend::Sp1, worker_id())
+        .get_next_proof(get_next_proof_request(ProofBackend::Sp1))
         .await
         .unwrap()
+        .locked_request
         .expect("second lock");
     assert_ne!(first.lock_id, second.lock_id);
 
     service
-        .record_proof_session(
+        .record_proof_session(record_proof_session_request(
             id,
             SessionType::Stark,
-            worker_id(),
             second.lock_id,
             backend_session_id(5),
             BackendSessionStatus::Running,
             None,
-        )
+        ))
         .await
         .unwrap();
 
@@ -316,9 +367,10 @@ async fn status_poller_marks_expired_exhausted_jobs_failed() {
     // without status poller, this job is not claimable
     assert!(
         service
-            .get_next_proof(ProofBackend::Sp1, worker_id())
+            .get_next_proof(get_next_proof_request(ProofBackend::Sp1))
             .await
             .unwrap()
+            .locked_request
             .is_none()
     );
 
@@ -341,9 +393,10 @@ async fn status_poller_marks_expired_exhausted_jobs_failed() {
     // sp1 proof session is cleaned up too
     assert!(
         service
-            .get_proof_session(id, SessionType::Stark)
+            .get_proof_session(get_proof_session_request(id, SessionType::Stark))
             .await
             .unwrap()
+            .session
             .is_none()
     );
     assert_eq!(
@@ -364,36 +417,38 @@ async fn record_and_get_proof_session_round_trips() {
     let req = request(ProofBackend::Sp1, 5);
     let id = service.request_proof(req.clone()).await.unwrap();
     let locked = service
-        .get_next_proof(ProofBackend::Sp1, worker_id())
+        .get_next_proof(get_next_proof_request(ProofBackend::Sp1))
         .await
         .unwrap()
+        .locked_request
         .expect("lock");
 
     assert!(
         service
-            .get_proof_session(id, SessionType::Stark)
+            .get_proof_session(get_proof_session_request(id, SessionType::Stark))
             .await
             .unwrap()
+            .session
             .is_none()
     );
 
     service
-        .record_proof_session(
+        .record_proof_session(record_proof_session_request(
             id,
             SessionType::Stark,
-            worker_id(),
             locked.lock_id,
             backend_session_id(1),
             BackendSessionStatus::Running,
             None,
-        )
+        ))
         .await
         .unwrap();
 
     let session = service
-        .get_proof_session(id, SessionType::Stark)
+        .get_proof_session(get_proof_session_request(id, SessionType::Stark))
         .await
         .unwrap()
+        .session
         .expect("session recorded");
     assert_eq!(session.backend_session_id, backend_session_id(1));
     assert_eq!(session.status, BackendSessionStatus::Running);
@@ -415,15 +470,16 @@ async fn rpc_end_to_end() {
     assert_eq!(client.proof_status(id).await.unwrap(), ProofStatus::Created);
 
     let locked = client
-        .get_next_proof(ProofBackend::Sp1, worker_id())
+        .get_next_proof(get_next_proof_request(ProofBackend::Sp1))
         .await
         .unwrap()
+        .locked_request
         .expect("job available");
     assert_eq!(locked.request, req);
 
     let response = proof_for(&req);
     client
-        .submit_proof(response.clone(), worker_id(), locked.lock_id)
+        .submit_proof(submit_proof_request(response.clone(), locked.lock_id))
         .await
         .unwrap();
     assert_eq!(

--- a/proofs/prover-service/src/traits.rs
+++ b/proofs/prover-service/src/traits.rs
@@ -1,9 +1,10 @@
 use crate::{
     error::{ProofJobQueueError, ProofRequestError},
     types::{
-        BackendSession, BackendSessionStatus, LockId, LockedProofRequest, ProofBackend,
-        ProofRequest, ProofRequestId, ProofResponse, ProofStatus, SessionType,
-        SucceededProofResponse,
+        GetNextProofRequest, GetNextProofResponse, GetProofSessionRequest, GetProofSessionResponse,
+        HeartbeatRequest, HeartbeatResponse, ProofRequest, ProofRequestId, ProofResponse,
+        ProofStatus, RecordProofSessionRequest, RecordProofSessionResponse, SubmitProofRequest,
+        SubmitProofResponse,
     },
 };
 use async_trait::async_trait;
@@ -47,46 +48,34 @@ pub trait ProofJobQueue {
     /// is re-queued.
     async fn get_next_proof(
         &self,
-        backend: ProofBackend,
-        worker_id: String,
-    ) -> Result<Option<LockedProofRequest>, ProofJobQueueError>;
+        request: GetNextProofRequest,
+    ) -> Result<GetNextProofResponse, ProofJobQueueError>;
 
     /// Submit a final proof response to the `prover-service`.
     async fn submit_proof(
         &self,
-        proof: SucceededProofResponse,
-        worker_id: String,
-        lock: LockId,
-    ) -> Result<(), ProofJobQueueError>;
+        request: SubmitProofRequest,
+    ) -> Result<SubmitProofResponse, ProofJobQueueError>;
 
     /// Get a backend session that matches the provided proof_id and
     /// session_type if it exists.
     async fn get_proof_session(
         &self,
-        proof_id: ProofRequestId,
-        session_type: SessionType,
-    ) -> Result<Option<BackendSession>, ProofJobQueueError>;
+        request: GetProofSessionRequest,
+    ) -> Result<GetProofSessionResponse, ProofJobQueueError>;
 
     /// Record a backend session tied to the provided proof_id
     /// and session_type.
     async fn record_proof_session(
         &self,
-        proof_id: ProofRequestId,
-        session_type: SessionType,
-        worker_id: String,
-        lock_id: LockId,
-        backend_session_id: String,
-        state: BackendSessionStatus,
-        failure_reason: Option<String>,
-    ) -> Result<(), ProofJobQueueError>;
+        request: RecordProofSessionRequest,
+    ) -> Result<RecordProofSessionResponse, ProofJobQueueError>;
 
     /// Ping the `prover-service` to signal that a proof worker tied
-    /// to the provided `worker_id` and `lock` is still working on
+    /// to the provided `worker_id` and `lock_id` is still working on
     /// the provided `proof_id` job.
     async fn heartbeat(
         &self,
-        proof_id: ProofRequestId,
-        worker_id: String,
-        lock: LockId,
-    ) -> Result<(), ProofJobQueueError>;
+        request: HeartbeatRequest,
+    ) -> Result<HeartbeatResponse, ProofJobQueueError>;
 }

--- a/proofs/prover-service/src/types.rs
+++ b/proofs/prover-service/src/types.rs
@@ -380,3 +380,88 @@ impl TryFrom<&str> for BackendSessionStatus {
         }
     }
 }
+
+/// Request to claim the next queued proof job for a worker.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GetNextProofRequest {
+    /// The backend lane this worker is able to prove.
+    pub backend: ProofBackend,
+    /// Stable id of the worker claiming the job.
+    pub worker_id: String,
+}
+
+/// Response returned after attempting to claim the next proof job.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GetNextProofResponse {
+    /// The locked job, or `None` when no matching work is available.
+    pub locked_request: Option<LockedProofRequest>,
+}
+
+/// Request to submit a completed proof for a claimed job.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SubmitProofRequest {
+    /// The generated proof payload.
+    pub proof: SucceededProofResponse,
+    /// Stable id of the worker that owns the lock.
+    pub worker_id: String,
+    /// Token authorizing updates to the locked proof job.
+    pub lock_id: LockId,
+}
+
+/// Response returned after submitting a completed proof.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct SubmitProofResponse {}
+
+/// Request to read the tracked backend session for a proof job.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GetProofSessionRequest {
+    /// The proof request whose backend session should be read.
+    pub proof_id: ProofRequestId,
+    /// The backend session phase to read.
+    pub session_type: SessionType,
+}
+
+/// Response returned after reading a tracked backend session.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GetProofSessionResponse {
+    /// The active or completed backend session, if one exists.
+    pub session: Option<BackendSession>,
+}
+
+/// Request to record backend-session progress for a claimed proof job.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecordProofSessionRequest {
+    /// The proof request whose backend session should be recorded.
+    pub proof_id: ProofRequestId,
+    /// The backend session phase being recorded.
+    pub session_type: SessionType,
+    /// Stable id of the worker that owns the lock.
+    pub worker_id: String,
+    /// Token authorizing updates to the locked proof job.
+    pub lock_id: LockId,
+    /// Backend-specific session identifier used to resume polling.
+    pub backend_session_id: String,
+    /// Current backend session lifecycle status.
+    pub status: BackendSessionStatus,
+    /// Backend failure details when the session failed.
+    pub failure_reason: Option<String>,
+}
+
+/// Response returned after recording backend-session progress.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct RecordProofSessionResponse {}
+
+/// Request to extend a claimed proof job's lock.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HeartbeatRequest {
+    /// The proof request whose lock should be extended.
+    pub proof_id: ProofRequestId,
+    /// Stable id of the worker that owns the lock.
+    pub worker_id: String,
+    /// Token authorizing updates to the locked proof job.
+    pub lock_id: LockId,
+}
+
+/// Response returned after extending a claimed proof job's lock.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct HeartbeatResponse {}

--- a/proofs/worker/src/backend.rs
+++ b/proofs/worker/src/backend.rs
@@ -4,8 +4,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use world_chain_prover_service::{
-    BackendSession, BackendSessionStatus, LockId, ProofBackend, ProofData, ProofJobQueue,
-    ProofJobQueueError, ProofRequest, ProofRequestId, SessionType,
+    BackendSession, BackendSessionStatus, GetProofSessionRequest, LockId, ProofBackend, ProofData,
+    ProofJobQueue, ProofJobQueueError, ProofRequest, ProofRequestId, RecordProofSessionRequest,
+    SessionType,
 };
 
 /// Session bookkeeping handle pre-bound to one claimed job's identifiers.
@@ -45,8 +46,12 @@ impl JobSessions {
         session_type: SessionType,
     ) -> Result<Option<BackendSession>, ProofJobQueueError> {
         self.queue
-            .get_proof_session(self.proof_id, session_type)
+            .get_proof_session(GetProofSessionRequest {
+                proof_id: self.proof_id,
+                session_type,
+            })
             .await
+            .map(|response| response.session)
     }
 
     /// Record (insert or update) a backend session for this job.
@@ -58,16 +63,17 @@ impl JobSessions {
         failure_reason: Option<String>,
     ) -> Result<(), ProofJobQueueError> {
         self.queue
-            .record_proof_session(
-                self.proof_id,
+            .record_proof_session(RecordProofSessionRequest {
+                proof_id: self.proof_id,
                 session_type,
-                self.worker_id.clone(),
-                self.lock_id,
+                worker_id: self.worker_id.clone(),
+                lock_id: self.lock_id,
                 backend_session_id,
                 status,
                 failure_reason,
-            )
+            })
             .await
+            .map(|_| ())
     }
 }
 

--- a/proofs/worker/src/heartbeat.rs
+++ b/proofs/worker/src/heartbeat.rs
@@ -1,7 +1,9 @@
 use std::time::Duration;
 use tokio::time::sleep;
 use tracing::warn;
-use world_chain_prover_service::{LockId, ProofJobQueue, ProofJobQueueError, ProofRequestId};
+use world_chain_prover_service::{
+    HeartbeatRequest, LockId, ProofJobQueue, ProofJobQueueError, ProofRequestId,
+};
 
 /// Minimum proof-generation heartbeat interval.
 pub const MIN_WORKER_HEARTBEAT_INTERVAL: Duration = Duration::from_millis(1);
@@ -101,7 +103,11 @@ impl<Q: ProofJobQueue> WorkerHeartbeat<Q> {
 
             match self
                 .queue
-                .heartbeat(self.proof_id, self.worker_id.clone(), self.lock_id)
+                .heartbeat(HeartbeatRequest {
+                    proof_id: self.proof_id,
+                    worker_id: self.worker_id.clone(),
+                    lock_id: self.lock_id,
+                })
                 .await
             {
                 Ok(_) => {

--- a/proofs/worker/src/worker.rs
+++ b/proofs/worker/src/worker.rs
@@ -15,7 +15,8 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, info, info_span, warn};
 use world_chain_prover_service::{
-    LockedProofRequest, ProofJobQueue, ProofJobQueueError, SucceededProofResponse,
+    GetNextProofRequest, LockedProofRequest, ProofJobQueue, ProofJobQueueError, SubmitProofRequest,
+    SucceededProofResponse,
 };
 
 use crate::{
@@ -173,26 +174,30 @@ async fn run_worker<Q, B>(
         let claimed = tokio::select! {
             biased;
             () = cancel.cancelled() => break,
-            claimed = queue.get_next_proof(lane, config.worker_id.clone()) => claimed,
+            claimed = queue.get_next_proof(GetNextProofRequest {
+                backend: lane,
+                worker_id: config.worker_id.clone(),
+            }) => claimed,
         };
 
         match claimed {
-            Ok(Some(locked)) => {
-                spawn_job(
-                    &mut jobs,
-                    &queue,
-                    &backend,
-                    &config.worker_id,
-                    locked,
-                    permit,
-                    config.retry_config,
-                    config.heartbeat_config,
-                );
-            }
-            Ok(None) => {
-                drop(permit);
-                if sleep_or_cancel(&cancel, config.poll_interval).await {
-                    break;
+            Ok(response) => {
+                if let Some(locked) = response.locked_request {
+                    spawn_job(
+                        &mut jobs,
+                        &queue,
+                        &backend,
+                        &config.worker_id,
+                        locked,
+                        permit,
+                        config.retry_config,
+                        config.heartbeat_config,
+                    );
+                } else {
+                    drop(permit);
+                    if sleep_or_cancel(&cancel, config.poll_interval).await {
+                        break;
+                    }
                 }
             }
             Err(error) => {
@@ -299,7 +304,11 @@ fn spawn_job<Q, B>(
             let submit_proof = async {
                 (|| async {
                     queue
-                        .submit_proof(response.clone(), worker_id.clone(), lock_id)
+                        .submit_proof(SubmitProofRequest {
+                            proof: response.clone(),
+                            worker_id: worker_id.clone(),
+                            lock_id,
+                        })
                         .await
                 })
                 .retry(retry_config.to_backoff_builder())
@@ -322,7 +331,11 @@ fn spawn_job<Q, B>(
                         // Ok(()) if everything is fine.
                         (|| async {
                             queue
-                                .submit_proof(response.clone(), worker_id.clone(), lock_id)
+                                .submit_proof(SubmitProofRequest {
+                                    proof: response.clone(),
+                                    worker_id: worker_id.clone(),
+                                    lock_id,
+                                })
                                 .await
                         })
                         .retry(retry_config.to_backoff_builder())
@@ -339,7 +352,7 @@ fn spawn_job<Q, B>(
             };
 
             match submit_result {
-                Ok(()) => info!("proof submitted"),
+                Ok(_) => info!("proof submitted"),
                 Err(error) => warn!(
                     %error,
                     "failed to submit proof after retries, lease will expire and re-queue"


### PR DESCRIPTION
closes https://linear.app/worldcoin/issue/PROTO-4882/clean-up-proofjobqueue-trait

for easier review: we changed ProofJobQueue function signatures by extracting params into req/response types and then cascaded that change through.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking JSON-RPC and trait contract for all proof workers and RPC clients; proving/lock semantics are refactored in place without intentional behavior changes.
> 
> **Overview**
> Refactors the worker-facing **`ProofJobQueue`** surface (trait, in-process service/store, JSON-RPC, RPC client, proof worker, and integration harness) so each operation takes a single serialized **request** struct and returns a typed **response** instead of long positional argument lists and bare `()` / `Option` returns.
> 
> New envelopes cover **`getNextProof`**, **`submitProof`**, **`getProofSession`**, **`recordProofSession`**, and **`heartbeat`** (e.g. `GetNextProofResponse.locked_request` replaces `Option<LockedProofRequest>`). Call sites build the structs and unwrap fields where needed; Postgres locking and validation paths are unchanged aside from destructuring.
> 
> **Breaking change:** JSON-RPC method signatures now pass one object per call; any out-of-tree `ProofJobQueue` implementations must be updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dac1ef18f73f6a68918ba090edde83199c8fd292. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->