### PR TITLE
fix: ensure split_count is exactly 1

### DIFF
--- a/proofs/sp1-worker/src/main.rs
+++ b/proofs/sp1-worker/src/main.rs
@@ -2,7 +2,7 @@
 //! submits the proofs back.
 
 use alloy_primitives::{Address, B256};
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use clap::Parser;
 use std::{path::PathBuf, sync::Arc, time::Duration};
 use world_chain_chainspec::WorldChainSpec;
@@ -198,6 +198,13 @@ async fn main() -> Result<()> {
         &protocol_cfg,
         Duration::from_secs(cli.witness_timeout_seconds),
     )?;
+
+    // currently we don't support split_range != 1, therefore we ensure it's exactly 1
+    if cli.ranges != 1 {
+        bail!(
+            "Currently we don't support splitting the range proof into multiple ranges. Set `ranges` to 1."
+        )
+    }
 
     // ELFs are embedded at compile time via `sp1_sdk::include_elf!()`
     // (see `proofs/succinct/elfs/build.rs`). Challenged roots are

--- a/proofs/sp1-worker/tests/e2e_proving.rs
+++ b/proofs/sp1-worker/tests/e2e_proving.rs
@@ -87,6 +87,12 @@ async fn worker_proves_real_range_end_to_end() {
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(1);
+    // currently we don't support split_range != 1, therefore we ensure it's exactly 1
+    if split_count != 1 {
+        panic!(
+            "Currently we don't support splitting the range proof into multiple ranges. Set `ranges` to 1."
+        )
+    }
     let timeout = Duration::from_secs(
         std::env::var("E2E_TIMEOUT_SECS")
             .ok()


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4878/fix-hard-code-split-count-to-1

### Problem

The `Sp1BackendConfig` has a `split_count` field that tells the sp1 backend how many range proofs to generate (by dividing the entire block range to proof into multiple smaller ranges). The idea of this split is to make the proof generation faster because it's done in parallel.

But we currently don't support `split_count != 1`, the concrete `handle_claimed_job` completely ignores the `split_count` field and always generate a single range proof of the entire block range.

### Solution

Validate the `split_range` flag to be always exactly 1, otherwise return error.

### Future Possibilities

If in the future we want to add the possibility to have `split_count` to a value different than `1`, we definitely can. But we need to slightly refactor the `proof_sessions` table so that it can accept multiple block range proofs (stark) that are tied to the same proof id.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Startup-time validation only; no change to proving logic or data paths when `ranges`/`split_count` is 1.
> 
> **Overview**
> **Fails fast** when operators configure more than one proof sub-range: the SP1 worker CLI `--ranges` flag and the e2e `E2E_SPLIT_COUNT` env var must be **exactly 1**, or startup / the test panics with a clear message.
> 
> This matches current behavior where `split_count` is passed into `Sp1BackendConfig` but job handling still proves a **single** range for the full block interval—so values other than 1 would be misleading rather than parallelizing work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9ed792c25d35fbd5c262e726bf9f384512188f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->