### PR TITLE
feat: add sp1-prover execute bin to get PGUs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19274,6 +19274,7 @@ dependencies = [
  "world-chain-proof-core",
  "world-chain-proof-succinct-elfs",
  "world-chain-proof-succinct-host-utils",
+ "world-chain-proof-succinct-utils",
  "world-chain-prover",
 ]
 

--- a/docs/proof/elf-management.md
+++ b/docs/proof/elf-management.md
@@ -8,9 +8,9 @@ The World Chain fault-proof system runs two SP1 guest programs:
 | `world-chain-proof-succinct-aggregation`     | Aggregates many range proofs into one     | `proofs/succinct/programs/aggregation`     |
 
 Both are compiled to RISC-V ELFs by `cargo prove build` (the SP1 toolchain) and are consumed by
-the `proof` CLI, the SP1 worker, and the devnet's full-stack tests. They are also referenced on
-chain indirectly via the SP1 vkeys — the vkeys are deterministic over the ELF bytes, so the ELF
-bytes **are** the governance anchor for the proof lane.
+the `world-chain-prover-sp1` CLI, the SP1 worker, and the devnet's full-stack tests. They are also
+referenced on chain indirectly via the SP1 vkeys — the vkeys are deterministic over the ELF bytes,
+so the ELF bytes **are** the governance anchor for the proof lane.
 
 ## How the ELFs reach the host binaries
 
@@ -29,20 +29,20 @@ We use the OP Succinct upstream pattern (see [succinctlabs/op-succinct/utils/bui
 
 Net effect: the ELFs are never on disk for the host crate to find — they're statically baked
 into every binary that links `world-chain-proof-succinct-elfs` (e.g. `world-chain-sp1-worker`).
-There is committed ELF blob and manifest of SHA-256s. The on-chain governance anchor is the
-SP1 vkey computed from the embedded bytes (`just proof-vkeys`), which is exactly what we
-register on `OPSuccinctFaultDisputeGame` (name subject to change once World Chain ships its own
-proof system).
+There is no committed ELF blob. The derived vkeys and ELF SHA-256s are recorded in
+`proofs/succinct/elf/vkeys.json`. The on-chain governance anchor is the SP1 vkey computed from the
+embedded bytes (`just proof-vkeys`), which is exactly what we register on
+`OPSuccinctFaultDisputeGame` (name subject to change once World Chain ships its own proof system).
 
 ## Reproducibility
 
 `sp1_build::build_program_with_args` is called with `docker: true` and `tag: "v6.1.0"` by
-default, so a `cargo build -p proof --features sp1` from a clean checkout produces bit-for-bit
+default, so a `cargo build -p world-chain-prover-sp1` from a clean checkout produces bit-for-bit
 identical ELFs (and therefore identical vkeys) regardless of host toolchain — `cargo-prove`
 runs inside the pinned `succinctlabs/sp1:v6.1.0` image.
 
 Set `SP1_BUILD_DOCKER=false` to switch to a locally-installed `cargo-prove` instead. This is the
-mode `Dockerfile.proof` uses internally, because the Docker daemon is not reachable from inside
+mode `Dockerfile.prover` uses internally, because the Docker daemon is not reachable from inside
 a `docker build`; the Dockerfile installs the same pinned `sp1up --version v6.1.0` so the
 resulting ELFs are still reproducible across hosts.
 
@@ -51,7 +51,7 @@ resulting ELFs are still reproducible across hosts.
 Nothing extra is required:
 
 ```bash
-cargo build -p proof --features sp1     # builds guest ELFs (first time only) and the host CLI
+cargo build -p world-chain-prover-sp1   # builds guest ELFs (first time only) and the host CLI
 cargo build -p world-chain-sp1-worker   # likewise
 just proof-vkeys                         # prints the on-chain vkey commitments
 ```
@@ -88,7 +88,7 @@ need a matching update before the new prover can be deployed.
 The workflow is just normal source-control:
 
 1. Edit the guest source or bump the SP1 toolchain `tag` in `proofs/succinct/elfs/build.rs`.
-2. `cargo build -p proof --features sp1` to confirm the new ELFs build.
+2. `cargo build -p world-chain-prover-sp1` to confirm the new ELFs build.
 3. `just proof-vkeys` to print the new vkey commitments.
 4. Mention the rotated vkeys in the PR description and link the matching on-chain registry
    update.
@@ -96,7 +96,7 @@ The workflow is just normal source-control:
 ## CI
 
 There is no separate `elf.yml` workflow: the SP1 ELFs are compiled as part of every host
-`cargo build` that touches the `sp1` feature. Reproducibility is enforced implicitly — the
+`cargo build` that includes the ELF crate. Reproducibility is enforced implicitly — the
 `release-proof.yml` workflow rebuilds from source on every release tag and stamps the resulting
 vkeys into `manifest.json`. Any drift in the guest source or the toolchain tag shows up as a
 vkey diff in the release-notes "measurements" section.
@@ -110,9 +110,9 @@ cannot write to `.github/workflows/**`.
 [succinctlabs/op-succinct](https://github.com/succinctlabs/op-succinct) is the upstream SP1
 proof system that World Chain's proof system is based on. It uses exactly the same pattern:
 `sp1_build::build_program_with_args` in `build.rs` compiles the guest ELF at host `cargo build`
-time, and `sp1_sdk::include_elf!()` embeds it into the host binary. No ELF binaries or SHA-256
-hash manifests are committed to source control — the build is fully automatic and reproducible
-via the pinned `cargo-prove` toolchain.
+time, and `sp1_sdk::include_elf!()` embeds it into the host binary. No ELF binaries are committed
+to source control; the derived vkeys and hashes in `vkeys.json` can be reproduced with the pinned
+`cargo-prove` toolchain.
 
 World Chain follows this pattern directly:
 
@@ -122,7 +122,7 @@ World Chain follows this pattern directly:
 | Build reproducibility    | `build_program_with_args` + pinned SP1 toolchain tag | `build_program_with_args` + pinned `tag` in `build.rs` (`docker: true`) |
 | On-chain anchor          | SP1 vkey on `OPSuccinctL2OutputOracle` | SP1 vkey on `OPSuccinctFaultDisputeGame` |
 | Where the artifact lives | **Embedded into the host binary via `include_elf!()`** | **Embedded into the host binary via `include_elf!()`** |
-| Committed ELF / hash file | None | None |
+| Committed ELF blob       | None | None |
 
 For World Chain's Nitro lane (`proofs/nitro/`), a separate PCR-commit pattern is used for the
 TEE enclave image; the SP1 lane follows the op-succinct embed-at-compile-time pattern, which
@@ -134,9 +134,10 @@ avoids carrying any ELF artifacts (committed bytes or committed SHA-256s) in sou
 |:---|:---|
 | `proofs/succinct/elfs/build.rs` | Invokes `sp1_build::build_program_with_args` for each guest crate |
 | `proofs/succinct/elfs/src/lib.rs` | `range_elf()` / `aggregation_elf()` via `include_elf!()` |
-| `proofs/succinct/utils/host/src/env_prover.rs` | `range_elf()` / `aggregation_elf()` via runtime `RANGE_ELF_PATH` / `AGG_ELF_PATH` env vars |
+| `proofs/succinct/elf/vkeys.json` | Derived SP1 vkeys and ELF SHA-256s |
+| `proofs/succinct/utils/host/src/*_prover.rs` | CPU, mock, and network provers over the embedded ELFs |
 | `proofs/succinct/programs/range-ethereum/` | Range guest source |
 | `proofs/succinct/programs/aggregation/`    | Aggregation guest source |
-| `Dockerfile.proof` | Builder image installs the SP1 toolchain and sets `SP1_BUILD_DOCKER=false` |
+| `Dockerfile.prover` | Builder image installs the SP1 toolchain and sets `SP1_BUILD_DOCKER=false` |
 | `Justfile` | `just proof-vkeys` prints the current vkey commitments |
 | `.github/workflows/release-proof.yml` | Release gate: rebuilds, snapshots vkeys into `manifest.json` |

--- a/docs/proof/proof-cli.md
+++ b/docs/proof/proof-cli.md
@@ -1,32 +1,39 @@
-# `proof` CLI reference
+# World Chain prover CLI reference
 
-The `proof` binary is the entry point for World Chain fault proof operations: witness generation,
-SP1 zkVM proving, and AWS Nitro TEE attested proving.
+The host-side prover entry points are split by backend. Both binaries share witness generation and
+rollup-config hashing, while backend-specific commands live at the top level of each binary.
 
 ```
-proof <COMMAND>
+world-chain-prover-sp1 <COMMAND>
 
 Commands:
   hash-rollup-config   Print the rollup config hash used in proofs
   witness              Build and serialize a witness to a file
-  sp1                  SP1 zkVM proving  [requires --features sp1]
-  nitro                AWS Nitro TEE proving  [requires --features nitro]
+  execute              Estimate SP1 range PGUs without generating a proof
+  prove                Generate range + aggregation proofs
+  vkeys                Compute the SP1 verification keys
+```
+
+```
+world-chain-prover-nitro <COMMAND>
+
+Commands:
+  hash-rollup-config   Print the rollup config hash used in proofs
+  witness              Build and serialize a witness to a file
+  prove                Generate witness and send it to a Nitro enclave
 ```
 
 ## Building
 
 ```bash
-# Witness generation only (no external prover deps)
-cargo build -p proof
+# SP1 prover
+cargo build -p world-chain-prover-sp1
 
-# With SP1 proving support
-cargo build -p proof --features sp1
+# Nitro enclave prover (Linux only, requires AF_VSOCK)
+cargo build -p world-chain-prover-nitro
 
-# With Nitro enclave support (Linux only — requires AF_VSOCK)
-cargo build -p proof --features nitro
-
-# Both
-cargo build -p proof --features sp1,nitro
+# Shared library only
+cargo build -p world-chain-prover --lib
 ```
 
 ## Common environment variables
@@ -43,7 +50,7 @@ All RPC flags accept an environment variable fallback. The full set used across 
 | `L1_HEAD` | `--l1-head` | L1 head hash override |
 | `NETWORK` | `--network` | `worldchain` (default) or `worldchain-sepolia` |
 | `SP1_PROVER` | `--prover` | SP1 backend: `cpu`, `network`, or `mock` |
-| `SP1_PRIVATE_KEY` | — | Required for `--prover network` (sp1-sdk) |
+| `SP1_PRIVATE_KEY` | `--sp1-private-key` | Required for `--prover network` (sp1-sdk) |
 | `ENCLAVE_CID` | `--cid` | vsock CID of the running Nitro enclave |
 | `PCR0` / `PCR1` / `PCR2` | `--pcr0/1/2` | Expected Nitro PCR measurements |
 
@@ -56,7 +63,8 @@ A `.env` file in the working directory is loaded automatically.
 Prints the 32-byte rollup config hash that the contracts and proof programs must agree on.
 
 ```
-proof hash-rollup-config [--rollup-config <FILE> | --l2-rpc <URL>]
+world-chain-prover-sp1 hash-rollup-config [--rollup-config <FILE> | --l2-rpc <URL>]
+world-chain-prover-nitro hash-rollup-config [--rollup-config <FILE> | --l2-rpc <URL>]
 ```
 
 **Flags**
@@ -71,10 +79,10 @@ One of the two is required; they are mutually exclusive.
 **Example**
 
 ```bash
-proof hash-rollup-config --rollup-config ./rollup.json
+world-chain-prover-sp1 hash-rollup-config --rollup-config ./rollup.json
 # 0x00821da4d0ba868e5eaa4fd2d6c486161b7bfc0ce3d0644ce79d3317f4f94c50
 
-proof hash-rollup-config --l2-rpc https://rpc.world.org
+world-chain-prover-sp1 hash-rollup-config --l2-rpc https://rpc.world.org
 ```
 
 ---
@@ -85,7 +93,8 @@ Builds the Kona preimage witness for a block range and writes it to disk. Useful
 witness data or decoupling witness generation from proving.
 
 ```
-proof witness [RPC flags] --output <FILE>
+world-chain-prover-sp1 witness [RPC flags] --output <FILE>
+world-chain-prover-nitro witness [RPC flags] --output <FILE>
 ```
 
 **Flags**
@@ -110,7 +119,7 @@ A `<stem>.metadata.json` file is written alongside the output with block metadat
 **Example**
 
 ```bash
-proof witness \
+world-chain-prover-sp1 witness \
   --start-block 10000000 \
   --end-block   10000100 \
   --l2-rpc      $L2_RPC_URL \
@@ -122,44 +131,66 @@ proof witness \
 
 ---
 
-## `sp1`
+## `world-chain-prover-sp1`
 
 ```
-proof sp1 <COMMAND>
+world-chain-prover-sp1 <COMMAND>
 
 Commands:
-  execute   Execute the SP1 range program locally (no ZK proof)
-  prove     End-to-end range + aggregation proof from RPC
+  hash-rollup-config   Print the rollup config hash used in proofs
+  witness              Build and serialize a witness to a file
+  execute              Estimate SP1 range PGUs without generating a proof
+  prove                End-to-end range + aggregation proof from RPC
+  vkeys                Compute the on-chain verification keys
 ```
 
-### `sp1 execute`
+### `execute`
 
-Runs the SP1 range program in non-proving execution mode against a pre-built witness file. Fast —
-useful for checking the program terminates and inspecting cycle counts before committing to a full
-proof.
+Builds a witness for the requested block range in memory, then executes the embedded production
+range ELF locally with SP1 gas calculation enabled. It does not generate or submit a proof and does
+not require an SP1 private key.
 
 ```
-proof sp1 execute --witness <FILE>
+world-chain-prover-sp1 execute [RPC flags]
 ```
 
-| Flag | Env | Description |
-|---|---|---|
-| `--witness <FILE>` | `WITNESS_PATH` | rkyv witness produced by `proof witness` |
-| `--elf <FILE>` | `RANGE_ELF_PATH` | SP1 range ELF binary to execute |
+| Flag | Env | Default | Description |
+|---|---|---|---|
+| `--start-block <N>` | — | required | Exclusive lower bound of the executed range |
+| `--end-block <N>` | — | required | Inclusive upper bound |
+| `--l2-rpc <URL>` | `L2_RPC_URL` | required | World Chain L2 execution RPC |
+| `--l1-rpc <URL>` | `L1_RPC_URL` | required | Ethereum L1 execution RPC |
+| `--l1-beacon-rpc <URL>` | `L1_BEACON_RPC_URL` | required | Ethereum L1 beacon API |
+| `--rollup-config <FILE>` | `ROLLUP_CONFIG` | — | Rollup config JSON |
+| `--rollup-config-hash <HASH>` | `ROLLUP_CONFIG_HASH` | — | Required when `--rollup-config` is omitted |
+| `--l1-head <HASH>` | `L1_HEAD` | auto-resolved | Override the L1 checkpoint head |
+| `--allow-unfinalized` | — | false | Allow executing blocks newer than the finalized L2 head |
+| `--witness-timeout-seconds <N>` | — | 900 | Maximum seconds for witness collection |
+| `--network <NAME>` | `NETWORK` | `worldchain` | `worldchain` or `worldchain-sepolia` |
 
 **Example**
 
 ```bash
-proof sp1 execute --witness ./witness.bin --elf ./range-elf
+world-chain-prover-sp1 execute \
+  --start-block 10000000 \
+  --end-block   10000010 \
+  --l2-rpc      $L2_RPC_URL \
+  --l1-rpc      $L1_RPC_URL \
+  --l1-beacon-rpc $L1_BEACON_RPC_URL \
+  --rollup-config-hash $ROLLUP_CONFIG_HASH
 ```
 
-### `sp1 prove`
+The output includes the normalized PGU estimate used by SP1 Network as the range request's gas
+limit, plus total cycles, syscalls, and public values. This covers only the range request. The
+aggregation request, network base fee, and dynamic price per PGU are separate costs.
 
-Generates range proofs for N equal sub-ranges and then aggregates them into a single proof,
-entirely from RPC — no separate witness step needed.
+### `prove`
+
+Generates a compressed range proof and then aggregates it into a final proof, entirely from RPC.
+No separate witness step is needed.
 
 ```
-proof sp1 prove [RPC flags] [options]
+world-chain-prover-sp1 prove [RPC flags] [options]
 ```
 
 **Flags**
@@ -173,13 +204,13 @@ proof sp1 prove [RPC flags] [options]
 | `--l1-beacon-rpc <URL>` | `L1_BEACON_RPC_URL` | required | |
 | `--rollup-config <FILE>` | `ROLLUP_CONFIG` | — | |
 | `--rollup-config-hash <HASH>` | `ROLLUP_CONFIG_HASH` | — | |
-| `--ranges <N>` | — | `1` | Number of equal sub-ranges to prove in parallel |
+| `--ranges <N>` | — | `1` | Number of sub-ranges; currently must be `1` |
 | `--prover <NAME>` | `SP1_PROVER` | `cpu` | `cpu`, `network`, or `mock` |
 | `--mode <NAME>` | — | `groth16` | Aggregation proof mode: `core`, `compressed`, `plonk`, `groth16` |
 | `--prover-address <ADDR>` | — | zero address | On-chain attribution address |
 | `--output <FILE>` | — | — | Write aggregation proof JSON to file |
 
-The range and aggregation ELFs are embedded into the `proof` binary at compile time —
+The range and aggregation ELFs are embedded into the SP1 prover binary at compile time —
 there are no `--range-elf` / `--agg-elf` flags. See [`elf-management.md`](./elf-management.md).
 
 **Prover backends**
@@ -202,7 +233,7 @@ recursively verify them with `sp1_lib::verify::verify_sp1_proof`.
 **Example — mock proof (integration test)**
 
 ```bash
-proof sp1 prove \
+world-chain-prover-sp1 prove \
   --start-block 10000000 \
   --end-block   10000010 \
   --l2-rpc      $L2_RPC_URL \
@@ -218,10 +249,9 @@ proof sp1 prove \
 ```bash
 export SP1_PRIVATE_KEY=<your key>
 
-proof sp1 prove \
+world-chain-prover-sp1 prove \
   --start-block 10000000 \
   --end-block   10001000 \
-  --ranges      4 \
   --l2-rpc      $L2_RPC_URL \
   --l1-rpc      $L1_RPC_URL \
   --l1-beacon-rpc $L1_BEACON_RPC_URL \
@@ -230,7 +260,7 @@ proof sp1 prove \
   --output    ./proof.json
 ```
 
-### `sp1 vkeys`
+### `vkeys`
 
 Computes the on-chain verification keys for the (embedded) range and aggregation ELFs: the
 range vkey commitment (`multiBlockVKey` committed by the aggregation guest) and the
@@ -238,7 +268,7 @@ aggregation vkey registered with the SP1 verifier. Runs SP1 setup locally — no
 no arguments.
 
 ```
-proof sp1 vkeys [--output <FILE>]
+world-chain-prover-sp1 vkeys [--output <FILE>]
 ```
 
 | Flag | Env | Default | Description |
@@ -256,8 +286,8 @@ just proof-vkeys
   "range_vkey_commitment": "0x…",
   "aggregation_vkey": "0x…",
   "elfs": {
-    "world-chain-proof-succinct-range-ethereum": { "sha256": "…" },
-    "world-chain-proof-succinct-aggregation":    { "sha256": "…" }
+    "world-chain-range-ethereum": { "sha256": "…" },
+    "world-chain-aggregation":    { "sha256": "…" }
   }
 }
 ```
@@ -268,8 +298,8 @@ just proof-vkeys
 
 **Requirements:** an EC2 instance type with Nitro Enclave support (e.g. `m5.xlarge`) and the
 [AWS Nitro CLI](https://docs.aws.amazon.com/enclaves/latest/user/nitro-enclave-cli-install.html)
-installed. The enclave binary and the `proof nitro prove` command must both run on the same
-instance; vsock (AF_VSOCK) is Linux-only and does not cross machine boundaries.
+installed. The enclave binary and the `world-chain-prover-nitro prove` command must both run on
+the same instance; vsock (AF_VSOCK) is Linux-only and does not cross machine boundaries.
 
 ### 1. Build the Docker image
 
@@ -297,7 +327,7 @@ PCR1: <48-byte hex>   # kernel + bootstrap
 PCR2: <48-byte hex>   # application
 ```
 
-Save these — they are passed to `proof nitro prove` as `--pcr0/1/2`.
+Save these — they are passed to `world-chain-prover-nitro prove` as `--pcr0/1/2`.
 
 ### 3. Run the enclave
 
@@ -320,7 +350,7 @@ nitro-cli describe-enclaves
 ### 4. Prove from the host
 
 ```bash
-cargo run -p proof --features nitro -- nitro prove \
+cargo run -p world-chain-prover-nitro -- prove \
   --start-block 29875200 \
   --end-block   29875800 \
   --l2-rpc      $L2_RPC_URL \
@@ -343,25 +373,27 @@ nitro-cli terminate-enclave --enclave-id $(nitro-cli describe-enclaves | jq -r '
 
 ---
 
-## `nitro`
+## `world-chain-prover-nitro`
 
 ```
-proof nitro <COMMAND>
+world-chain-prover-nitro <COMMAND>
 
 Commands:
-  prove   Generate witness and send to a Nitro enclave for attested proving
+  hash-rollup-config   Print the rollup config hash used in proofs
+  witness              Build and serialize a witness to a file
+  prove                Generate witness and send to a Nitro enclave for attested proving
 ```
 
-### `nitro prove`
+### `prove`
 
 Builds the witness locally and sends it to a running AWS Nitro enclave over vsock. The enclave
 signs the result with an NSM attestation document; the host verifies the attestation and optionally
 writes the artifact to disk.
 
-**Requires:** Linux host with AF_VSOCK support; binary built with `--features nitro`.
+**Requires:** Linux host with AF_VSOCK support.
 
 ```
-proof nitro prove [RPC flags] [--cid <N>] [--pcr0/1/2 <HEX>] [--output <FILE>]
+world-chain-prover-nitro prove [RPC flags] [--cid <N>] [--pcr0/1/2 <HEX>] [--output <FILE>]
 ```
 
 | Flag | Env | Default | Description |
@@ -386,7 +418,7 @@ exact EIF image running in the Nitro enclave.
 **Example**
 
 ```bash
-proof nitro prove \
+world-chain-prover-nitro prove \
   --start-block 10000000 \
   --end-block   10000100 \
   --l2-rpc      $L2_RPC_URL \

--- a/proofs/prover-sp1/Cargo.toml
+++ b/proofs/prover-sp1/Cargo.toml
@@ -25,3 +25,4 @@ world-chain-prover.workspace = true
 world-chain-proof-core.workspace = true
 world-chain-proof-succinct-host-utils = { workspace = true, features = ["sp1"] }
 world-chain-proof-succinct-elfs.workspace = true
+world-chain-proof-succinct-utils.workspace = true

--- a/proofs/prover-sp1/src/main.rs
+++ b/proofs/prover-sp1/src/main.rs
@@ -6,9 +6,10 @@ use anyhow::{Context, Result};
 use clap::{Args, Parser, Subcommand};
 use serde_json::json;
 use world_chain_proof_succinct_host_utils::Sp1ProverKind;
+use world_chain_proof_succinct_utils::RangeProofRequest;
 use world_chain_prover::{
-    HashRollupConfigArgs, RpcArgs, WitnessArgs, ensure_parent_dir, online_host_config,
-    print_rollup_config_hash, write_json, write_witness,
+    HashRollupConfigArgs, RpcArgs, WitnessArgs, build_range_input_from_args, ensure_parent_dir,
+    online_host_config, print_rollup_config_hash, write_json, write_witness,
 };
 
 #[derive(Debug, Parser)]
@@ -24,8 +25,8 @@ enum Command {
     HashRollupConfig(HashRollupConfigArgs),
     /// Build and write the witness to a file without proving.
     Witness(WitnessArgs),
-    /// Execute the SP1 range program against a witness file (no ZK proof, fast).
-    Execute(Sp1ExecuteArgs),
+    /// Build a witness and estimate SP1 range PGUs without generating a proof.
+    Execute(Box<Sp1ExecuteArgs>),
     /// Generate range + aggregation proofs end-to-end from RPC.
     Prove(Box<Sp1ProveArgs>),
     /// Compute the on-chain verification keys for the range and aggregation ELFs.
@@ -34,13 +35,8 @@ enum Command {
 
 #[derive(Debug, Args)]
 struct Sp1ExecuteArgs {
-    /// rkyv-serialized witness file produced by the `witness` subcommand.
-    #[arg(long, env = "WITNESS_PATH")]
-    witness: PathBuf,
-
-    /// Path to the SP1 range ELF binary.
-    #[arg(long, env = "RANGE_ELF_PATH")]
-    elf: PathBuf,
+    #[command(flatten)]
+    rpc: RpcArgs,
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
@@ -107,7 +103,7 @@ async fn main() -> Result<()> {
     match Cli::parse().command {
         Command::HashRollupConfig(args) => print_rollup_config_hash(args).await?,
         Command::Witness(args) => write_witness(args).await?,
-        Command::Execute(args) => sp1_execute(args).await?,
+        Command::Execute(args) => sp1_execute(*args).await?,
         Command::Prove(args) => sp1_prove(*args).await?,
         Command::Vkeys(args) => sp1_vkeys(args).await?,
     }
@@ -118,23 +114,38 @@ async fn main() -> Result<()> {
 async fn sp1_execute(args: Sp1ExecuteArgs) -> Result<()> {
     use sp1_sdk::{Prover, ProverClient, SP1Stdin};
 
-    let witness_bytes = fs::read(&args.witness)
-        .with_context(|| format!("failed to read {}", args.witness.display()))?;
-    let elf = fs::read(&args.elf)
-        .with_context(|| format!("failed to read ELF {}", args.elf.display()))?;
+    let input = build_range_input_from_args(&args.rpc)
+        .await
+        .context("failed to build SP1 range witness")?;
+    let request = RangeProofRequest::from_witness_data(&input.witness)
+        .context("failed to serialize SP1 range witness")?;
 
     let mut stdin = SP1Stdin::new();
-    stdin.write_vec(witness_bytes);
+    stdin.write_vec(request.witness_rkyv);
 
     let client = ProverClient::builder().cpu().build().await;
     let (public_values, report) = client
-        .execute(elf.into(), stdin)
+        .execute(world_chain_proof_succinct_elfs::range_elf(), stdin)
+        .calculate_gas(true)
         .await
         .context("SP1 execution failed")?;
+    let pgus = report
+        .gas()
+        .context("SP1 execution report did not include a PGU estimate")?;
 
     println!("execution succeeded");
-    println!("total cycles:  {}", report.total_instruction_count());
-    println!("public values: 0x{}", hex::encode(public_values.as_slice()));
+    println!(
+        "range:          {}..={}",
+        input.metadata.start_block + 1,
+        input.metadata.end_block
+    );
+    println!("estimated PGUs: {pgus}");
+    println!("total cycles:   {}", report.total_instruction_count());
+    println!("total syscalls: {}", report.total_syscall_count());
+    println!(
+        "public values:  0x{}",
+        hex::encode(public_values.as_slice())
+    );
     Ok(())
 }
 
@@ -255,4 +266,119 @@ async fn sp1_vkeys(args: Sp1VkeysArgs) -> Result<()> {
         None => println!("{out}"),
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::error::ErrorKind;
+
+    use super::*;
+
+    fn execute_args() -> Vec<&'static str> {
+        vec![
+            "world-chain-prover-sp1",
+            "execute",
+            "--start-block",
+            "100",
+            "--end-block",
+            "110",
+            "--l2-rpc",
+            "http://localhost:9545",
+            "--l1-rpc",
+            "http://localhost:8545",
+            "--l1-beacon-rpc",
+            "http://localhost:5052",
+            "--rollup-config-hash",
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+        ]
+    }
+
+    fn rpc_args() -> RpcArgs {
+        RpcArgs {
+            start_block: 100,
+            end_block: 110,
+            l2_rpc: "http://localhost:9545".to_string(),
+            l1_rpc: "http://localhost:8545".to_string(),
+            l1_beacon_rpc: "http://localhost:5052".to_string(),
+            rollup_config: None,
+            rollup_config_hash: Some(B256::ZERO),
+            l1_head: None,
+            allow_unfinalized: false,
+            witness_timeout_seconds: 900,
+            network: world_chain_prover::Network::WorldChain,
+        }
+    }
+
+    #[test]
+    fn execute_parses_rpc_backed_range() {
+        let cli =
+            Cli::try_parse_from(execute_args()).expect("RPC-backed execute arguments should parse");
+
+        let Command::Execute(args) = cli.command else {
+            panic!("expected execute command");
+        };
+        assert_eq!(args.rpc.start_block, 100);
+        assert_eq!(args.rpc.end_block, 110);
+        assert_eq!(args.rpc.network.chain_id(), 480);
+    }
+
+    #[test]
+    fn execute_requires_an_explicit_block_range() {
+        let error = Cli::try_parse_from([
+            "world-chain-prover-sp1",
+            "execute",
+            "--l2-rpc",
+            "http://localhost:9545",
+            "--l1-rpc",
+            "http://localhost:8545",
+            "--l1-beacon-rpc",
+            "http://localhost:5052",
+        ])
+        .expect_err("execute should require start and end blocks");
+
+        assert_eq!(error.kind(), ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn execute_rejects_legacy_file_arguments() {
+        for (flag, value) in [("--witness", "witness.bin"), ("--elf", "range-elf")] {
+            let mut args = execute_args();
+            args.extend([flag, value]);
+            let error = Cli::try_parse_from(args)
+                .expect_err("execute should no longer accept witness or ELF paths");
+
+            assert_eq!(error.kind(), ErrorKind::UnknownArgument, "flag: {flag}");
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_requires_rollup_config_identity() {
+        let mut rpc = rpc_args();
+        rpc.rollup_config_hash = None;
+
+        let error = sp1_execute(Sp1ExecuteArgs { rpc })
+            .await
+            .expect_err("execute should require a rollup config or hash");
+
+        assert!(
+            format!("{error:#}").contains("provide --rollup-config"),
+            "unexpected error: {error:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_rejects_an_invalid_block_range() {
+        let mut rpc = rpc_args();
+        rpc.start_block = 110;
+        rpc.end_block = 100;
+
+        let error = sp1_execute(Sp1ExecuteArgs { rpc })
+            .await
+            .expect_err("execute should reject an inverted block range");
+
+        assert!(
+            format!("{error:#}").contains("end_block (100) must be greater than start_block (110)"),
+            "unexpected error: {error:#}"
+        );
+    }
 }

--- a/proofs/prover/src/lib.rs
+++ b/proofs/prover/src/lib.rs
@@ -48,7 +48,7 @@ pub struct HashRollupConfigArgs {
     #[arg(long, env = "ROLLUP_CONFIG", conflicts_with = "l2_rpc")]
     pub rollup_config: Option<PathBuf>,
 
-    /// L2 RPC URL to fetch the rollup config from. Mutually exclusive with --rollup-config.
+    /// L2 consensus RPC URL to fetch the rollup config from. Mutually exclusive with --rollup-config.
     #[arg(long, env = "L2_RPC_URL", conflicts_with = "rollup_config")]
     pub l2_rpc: Option<String>,
 }
@@ -75,7 +75,8 @@ pub struct RpcArgs {
     #[arg(long, env = "L1_BEACON_RPC_URL")]
     pub l1_beacon_rpc: String,
 
-    /// Rollup config JSON file. If omitted, uses the built-in World Chain mainnet config.
+    /// Rollup config JSON file. If omitted, uses the selected network's built-in fork schedule
+    /// and requires --rollup-config-hash.
     #[arg(long, env = "ROLLUP_CONFIG")]
     pub rollup_config: Option<PathBuf>,
 


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4883/estimate-pgu-for-sp1

### How to run

Here is how to run this command:

```rust
SP1_SKIP_PROGRAM_BUILD=true cargo run -p world-chain-prover-sp1 --release -- execute \
    --start-block 32151829 \
    --end-block 32151839 \
    --l2-rpc $WORLDCHAIN_PROVIDER \
    --l1-rpc $ETHEREUM_PROVIDER \
    --l1-beacon-rpc $ETHEREUM_BEACON_PROVIDER \
    --rollup-config ./rollup-config.json \
    --network worldchain
```

- it's important to use the `--release` flag, the dev binary is too slow and will fail the default 900s timeout
- you need to provide the rollup config, you can easily find it on alchemy [here](https://raas-backend.alchemy.com/rollups/worldchain-mainnet/rollup.json)
- you need to provide all rpcs, start and end block, remember that the start block is excluded, the end block is included

### How does it work

This command generates the witness by fetching all the data it needs from rpc, `SP1_SKIP_PROGRAM_BUILD=true` uses the already cached ELFs, remove it if the SP1 guest programs have not been built yet. Then it executes the sp1 proof work without actually generating the proof and prints a report like this:

```
execution succeeded
range:          32151830..=32151839
estimated PGUs: 11862381806
total cycles:   11840565729
total syscalls: 2372111
public values:  0x20000000000000008c189c96b1e9613416df0c38a2d09401d905ccbb85e29d7ecdd9e313857077762000000000000000ba6ff907ceec325361d9a9346370d7c527c05445bdd5e296ec2a53b9af4a6c0c2000000000000000fb7daa1506535c3b4cc3c2cdbd1b3cfba7175fc24ff74f98162675f59cbb54881f99ea01000000002000000000000000af3c3aec57f209e4e8df4364e0cf0232074171c16498a98f52b9866121ba0d9a
```

### PGUs

For the block range I used (32151830..=32151839), the estimated required PGUs are 11862381806 or 11.86 billion units. Note that these blocks are pretty light - average 8M-9M gas used. This result is in line with some past results shared by succinct.