### PR TITLE
Fix docker image tags. Add summary.

### DIFF
--- a/.github/workflows/docker-proof.yml
+++ b/.github/workflows/docker-proof.yml
@@ -331,3 +331,36 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ github.repository }}-nitro-worker-enclave-eif:${{ inputs.image_tag || 'nightly' }}
             ${{ env.REGISTRY }}/${{ github.repository }}-nitro-worker-enclave-eif:sha-${{ steps.short-sha.outputs.value }}
+  summary:
+    name: Image tags summary
+    if: always()
+    needs:
+      - merge-sp1-prover-image
+      - merge-nitro-prover-image
+      - merge-nitro-worker-image
+      - merge-nitro-worker-enclave-image
+      - merge-nitro-worker-enclave-eif-image
+      - merge-service-images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write summary
+        run: |
+          TAG="${{ inputs.image_tag || 'nightly' }}"
+          SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          REPO="ghcr.io/${{ github.repository }}"
+          {
+            echo "## 🐳 Images built"
+            echo ""
+            echo "| Image | Tags |"
+            echo "|-------|------|"
+            echo "| \`$REPO-proof-sp1\` | \`${TAG}\`, \`sha-${SHA}\` |"
+            echo "| \`$REPO-proof-nitro\` | \`${TAG}\`, \`sha-${SHA}\` |"
+            echo "| \`$REPO-nitro-worker\` | \`${TAG}\`, \`sha-${SHA}\` |"
+            echo "| \`$REPO-nitro-worker-enclave\` | \`${TAG}\`, \`sha-${SHA}\` |"
+            echo "| \`$REPO-nitro-worker-enclave-eif\` | \`${TAG}\`, \`sha-${SHA}\` |"
+            echo "| \`$REPO-sp1-worker\` | \`${TAG}\`, \`sha-${SHA}\` |"
+            echo "| \`$REPO-proposer\` | \`${TAG}\`, \`sha-${SHA}\` |"
+            echo "| \`$REPO-challenger\` | \`${TAG}\`, \`sha-${SHA}\` |"
+            echo "| \`$REPO-defender\` | \`${TAG}\`, \`sha-${SHA}\` |"
+            echo "| \`$REPO-prover-service\` | \`${TAG}\`, \`sha-${SHA}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docker-proof.yml
+++ b/.github/workflows/docker-proof.yml
@@ -339,7 +339,7 @@ jobs:
       - merge-nitro-prover-image
       - merge-nitro-worker-image
       - merge-nitro-worker-enclave-image
-      - merge-nitro-worker-enclave-eif-image
+      - build-nitro-worker-enclave-eif-image
       - merge-service-images
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docker-proof.yml
+++ b/.github/workflows/docker-proof.yml
@@ -318,6 +318,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Get short SHA
+        id: short-sha
+        run: echo "value=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
       - name: Build and push EIF carrier image
         uses: docker/build-push-action@v6
         with:
@@ -327,4 +330,4 @@ jobs:
           platforms: linux/amd64
           tags: |
             ${{ env.REGISTRY }}/${{ github.repository }}-nitro-worker-enclave-eif:${{ inputs.image_tag || 'nightly' }}
-            ${{ env.REGISTRY }}/${{ github.repository }}-nitro-worker-enclave-eif:sha-${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ github.repository }}-nitro-worker-enclave-eif:sha-${{ steps.short-sha.outputs.value }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only workflow changes for Docker tagging and run visibility; no application or runtime behavior changes.
> 
> **Overview**
> Aligns **nitro-worker-enclave-eif** GHCR tagging with the rest of the workflow and surfaces built image names in the Actions run summary.
> 
> The EIF carrier push no longer tags with the full **`github.sha`**; it adds a **Get short SHA** step and publishes **`sha-<short>`** via `git rev-parse --short HEAD`, consistent with merge jobs that use **`type=sha`**.
> 
> A new **`summary`** job runs **`if: always()`** after the merge/EIF jobs and writes a markdown table to **`GITHUB_STEP_SUMMARY`** listing each **`ghcr.io/<repo>-…`** image with **`nightly`** (or the dispatch **`image_tag`**) and **`sha-<7-char>`** tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07d6277f6b8d14f2c10a10614891dfdd0f56b5a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->