### PR TITLE
Fix docker images tags reported

### DIFF
--- a/.github/workflows/docker-proof.yml
+++ b/.github/workflows/docker-proof.yml
@@ -320,7 +320,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Get short SHA
         id: short-sha
-        run: echo "value=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+        run: echo "value=${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
       - name: Build and push EIF carrier image
         uses: docker/build-push-action@v6
         with:
@@ -332,7 +332,7 @@ jobs:
             ${{ env.REGISTRY }}/${{ github.repository }}-nitro-worker-enclave-eif:${{ inputs.image_tag || 'nightly' }}
             ${{ env.REGISTRY }}/${{ github.repository }}-nitro-worker-enclave-eif:sha-${{ steps.short-sha.outputs.value }}
 
-  summary:
+summary:
     name: Image tags summary
     if: always()
     needs:
@@ -346,32 +346,31 @@ jobs:
     steps:
       - name: Write summary
         env:
-          TAG: ${{ inputs.image_tag || 'nightly' }}
-          SHA: ${{ github.sha }}
-          SP1_PROVER_RESULT:    ${{ needs.merge-sp1-prover-image.result }}
-          NITRO_PROVER_RESULT:  ${{ needs.merge-nitro-prover-image.result }}
-          NITRO_WORKER_RESULT:  ${{ needs.merge-nitro-worker-image.result }}
-          ENCLAVE_RESULT:       ${{ needs.merge-nitro-worker-enclave-image.result }}
-          EIF_RESULT:           ${{ needs.build-nitro-worker-enclave-eif-image.result }}
-          SERVICES_RESULT:      ${{ needs.merge-service-images.result }}
-          SP1_PROVER_DIGEST:    ${{ needs.merge-sp1-prover-image.outputs.digest }}
-          NITRO_PROVER_DIGEST:  ${{ needs.merge-nitro-prover-image.outputs.digest }}
-          NITRO_WORKER_DIGEST:  ${{ needs.merge-nitro-worker-image.outputs.digest }}
-          ENCLAVE_DIGEST:       ${{ needs.merge-nitro-worker-enclave-image.outputs.digest }}
-          EIF_DIGEST:           ${{ needs.build-nitro-worker-enclave-eif-image.outputs.digest }}
+          TAG:                 ${{ inputs.image_tag || 'nightly' }}
+          SP1_PROVER_RESULT:   ${{ needs.merge-sp1-prover-image.result }}
+          NITRO_PROVER_RESULT: ${{ needs.merge-nitro-prover-image.result }}
+          NITRO_WORKER_RESULT: ${{ needs.merge-nitro-worker-image.result }}
+          ENCLAVE_RESULT:      ${{ needs.merge-nitro-worker-enclave-image.result }}
+          EIF_RESULT:          ${{ needs.build-nitro-worker-enclave-eif-image.result }}
+          SERVICES_RESULT:     ${{ needs.merge-service-images.result }}
         run: |
-          SHORT="${SHA:0:7}"
+          SHORT="${{ github.sha }}"
+          SHORT="${SHORT:0:7}"
           REPO="ghcr.io/${{ github.repository }}"
-          status() { [ "$1" = "success" ] && echo "✅" || echo "❌ $1"; }
+          status() { [ "$1" = "success" ] && echo "✅" || echo "❌ ($1)"; }
           {
             echo "## 🐳 Image build results"
             echo ""
-            echo "| Image | Tag | Status |"
-            echo "|-------|-----|--------|"
-            echo "| \`$REPO-proof-sp1\` | \`sha-$SHORT\` | $(status $SP1_PROVER_RESULT) |"
-            echo "| \`$REPO-proof-nitro\` | \`sha-$SHORT\` | $(status $NITRO_PROVER_RESULT) |"
-            echo "| \`$REPO-nitro-worker\` | \`sha-$SHORT\` | $(status $NITRO_WORKER_RESULT) |"
-            echo "| \`$REPO-nitro-worker-enclave\` | \`sha-$SHORT\` | $(status $ENCLAVE_RESULT) |"
-            echo "| \`$REPO-nitro-worker-enclave-eif\` | \`sha-$SHORT\` | $(status $EIF_RESULT) |"
-            echo "| service images (sp1-worker, proposer, ...) | \`sha-$SHORT\` | $(status $SERVICES_RESULT) |"
+            echo "| Image | Tags | Status |"
+            echo "|-------|------|--------|"
+            echo "| \`$REPO-proof-sp1\` | \`$TAG\` \`sha-$SHORT\` | $(status $SP1_PROVER_RESULT) |"
+            echo "| \`$REPO-proof-nitro\` | \`$TAG\` \`sha-$SHORT\` | $(status $NITRO_PROVER_RESULT) |"
+            echo "| \`$REPO-nitro-worker\` | \`$TAG\` \`sha-$SHORT\` | $(status $NITRO_WORKER_RESULT) |"
+            echo "| \`$REPO-nitro-worker-enclave\` | \`$TAG\` \`sha-$SHORT\` | $(status $ENCLAVE_RESULT) |"
+            echo "| \`$REPO-nitro-worker-enclave-eif\` | \`$TAG\` \`sha-$SHORT\` | $(status $EIF_RESULT) |"
+            echo "| \`$REPO-sp1-worker\` | \`$TAG\` \`sha-$SHORT\` | $(status $SERVICES_RESULT) |"
+            echo "| \`$REPO-proposer\` | \`$TAG\` \`sha-$SHORT\` | $(status $SERVICES_RESULT) |"
+            echo "| \`$REPO-challenger\` | \`$TAG\` \`sha-$SHORT\` | $(status $SERVICES_RESULT) |"
+            echo "| \`$REPO-defender\` | \`$TAG\` \`sha-$SHORT\` | $(status $SERVICES_RESULT) |"
+            echo "| \`$REPO-prover-service\` | \`$TAG\` \`sha-$SHORT\` | $(status $SERVICES_RESULT) |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docker-proof.yml
+++ b/.github/workflows/docker-proof.yml
@@ -332,7 +332,7 @@ jobs:
             ${{ env.REGISTRY }}/${{ github.repository }}-nitro-worker-enclave-eif:${{ inputs.image_tag || 'nightly' }}
             ${{ env.REGISTRY }}/${{ github.repository }}-nitro-worker-enclave-eif:sha-${{ steps.short-sha.outputs.value }}
 
-summary:
+  summary:
     name: Image tags summary
     if: always()
     needs:

--- a/.github/workflows/docker-proof.yml
+++ b/.github/workflows/docker-proof.yml
@@ -331,6 +331,7 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ github.repository }}-nitro-worker-enclave-eif:${{ inputs.image_tag || 'nightly' }}
             ${{ env.REGISTRY }}/${{ github.repository }}-nitro-worker-enclave-eif:sha-${{ steps.short-sha.outputs.value }}
+
   summary:
     name: Image tags summary
     if: always()
@@ -344,23 +345,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Write summary
+        env:
+          TAG: ${{ inputs.image_tag || 'nightly' }}
+          SHA: ${{ github.sha }}
+          SP1_PROVER_RESULT:    ${{ needs.merge-sp1-prover-image.result }}
+          NITRO_PROVER_RESULT:  ${{ needs.merge-nitro-prover-image.result }}
+          NITRO_WORKER_RESULT:  ${{ needs.merge-nitro-worker-image.result }}
+          ENCLAVE_RESULT:       ${{ needs.merge-nitro-worker-enclave-image.result }}
+          EIF_RESULT:           ${{ needs.build-nitro-worker-enclave-eif-image.result }}
+          SERVICES_RESULT:      ${{ needs.merge-service-images.result }}
+          SP1_PROVER_DIGEST:    ${{ needs.merge-sp1-prover-image.outputs.digest }}
+          NITRO_PROVER_DIGEST:  ${{ needs.merge-nitro-prover-image.outputs.digest }}
+          NITRO_WORKER_DIGEST:  ${{ needs.merge-nitro-worker-image.outputs.digest }}
+          ENCLAVE_DIGEST:       ${{ needs.merge-nitro-worker-enclave-image.outputs.digest }}
+          EIF_DIGEST:           ${{ needs.build-nitro-worker-enclave-eif-image.outputs.digest }}
         run: |
-          TAG="${{ inputs.image_tag || 'nightly' }}"
-          SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          SHORT="${SHA:0:7}"
           REPO="ghcr.io/${{ github.repository }}"
+          status() { [ "$1" = "success" ] && echo "✅" || echo "❌ $1"; }
           {
-            echo "## 🐳 Images built"
+            echo "## 🐳 Image build results"
             echo ""
-            echo "| Image | Tags |"
-            echo "|-------|------|"
-            echo "| \`$REPO-proof-sp1\` | \`${TAG}\`, \`sha-${SHA}\` |"
-            echo "| \`$REPO-proof-nitro\` | \`${TAG}\`, \`sha-${SHA}\` |"
-            echo "| \`$REPO-nitro-worker\` | \`${TAG}\`, \`sha-${SHA}\` |"
-            echo "| \`$REPO-nitro-worker-enclave\` | \`${TAG}\`, \`sha-${SHA}\` |"
-            echo "| \`$REPO-nitro-worker-enclave-eif\` | \`${TAG}\`, \`sha-${SHA}\` |"
-            echo "| \`$REPO-sp1-worker\` | \`${TAG}\`, \`sha-${SHA}\` |"
-            echo "| \`$REPO-proposer\` | \`${TAG}\`, \`sha-${SHA}\` |"
-            echo "| \`$REPO-challenger\` | \`${TAG}\`, \`sha-${SHA}\` |"
-            echo "| \`$REPO-defender\` | \`${TAG}\`, \`sha-${SHA}\` |"
-            echo "| \`$REPO-prover-service\` | \`${TAG}\`, \`sha-${SHA}\` |"
+            echo "| Image | Tag | Status |"
+            echo "|-------|-----|--------|"
+            echo "| \`$REPO-proof-sp1\` | \`sha-$SHORT\` | $(status $SP1_PROVER_RESULT) |"
+            echo "| \`$REPO-proof-nitro\` | \`sha-$SHORT\` | $(status $NITRO_PROVER_RESULT) |"
+            echo "| \`$REPO-nitro-worker\` | \`sha-$SHORT\` | $(status $NITRO_WORKER_RESULT) |"
+            echo "| \`$REPO-nitro-worker-enclave\` | \`sha-$SHORT\` | $(status $ENCLAVE_RESULT) |"
+            echo "| \`$REPO-nitro-worker-enclave-eif\` | \`sha-$SHORT\` | $(status $EIF_RESULT) |"
+            echo "| service images (sp1-worker, proposer, ...) | \`sha-$SHORT\` | $(status $SERVICES_RESULT) |"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI workflow and GitHub step summary only; no application or image build logic changes beyond tag derivation for the EIF push step.
> 
> **Overview**
> Updates **`docker-proof`** so reported image tags and the workflow summary match what CI actually built.
> 
> The EIF carrier image **short SHA** step now uses **`${GITHUB_SHA:0:7}`** instead of **`git rev-parse --short HEAD`**, so `sha-*` tags follow the workflow commit even when checkout uses a different **`inputs.ref`**.
> 
> The **summary** job now passes each merge/build job’s **`needs.*.result`** into the step, adds a **Status** column (✅ / ❌ with failure reason), derives the displayed short SHA via bash substring on **`github.sha`**, and retitles the section to **Image build results**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af5decaa999dfc9844f990554931688c71bcfd25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->