### PR TITLE
fix: gate workflow runs to relevant files

### DIFF
--- a/.github/workflows/docker-proof.yml
+++ b/.github/workflows/docker-proof.yml
@@ -19,6 +19,17 @@ on:
         default: nightly
   push:
     branches: [main]
+    paths:
+      - "proofs/**"
+      - "crates/chainspec/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".cargo/config.toml"
+      - "Dockerfile.prover"
+      - "scripts/build-eif.sh"
+      - ".github/workflows/docker-proof.yml"
+      - ".github/actions/docker-build-push-digest/**"
+      - ".github/actions/docker-merge-manifest/**"
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,6 +18,17 @@ on:
           - tag
   push:
     branches: [main]
+    paths:
+      - "bin/world-chain/**"
+      - "crates/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".cargo/config.toml"
+      - "Dockerfile"
+      - "scripts/**"
+      - ".github/workflows/docker.yml"
+      - ".github/actions/docker-build-push-digest/**"
+      - ".github/actions/docker-merge-manifest/**"
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only change with no runtime impact; the main caveat is an incomplete path list could skip needed image rebuilds until a matching file changes or someone dispatches the workflow manually.
> 
> **Overview**
> **`push` to `main` no longer always runs the chain and prover Docker publish workflows.** Each workflow now uses a `paths` filter so automatic builds only trigger when files that affect that image pipeline change.
> 
> For **`docker.yml`**, pushes must touch `bin/world-chain/**`, `crates/**`, root `Cargo.toml` / `Cargo.lock`, `.cargo/config.toml`, `Dockerfile`, `scripts/**`, or the workflow / shared `docker-build-push-digest` and `docker-merge-manifest` actions.
> 
> For **`docker-proof.yml`**, pushes must touch `proofs/**`, `crates/chainspec/**`, the same Cargo / cargo config inputs, `Dockerfile.prover`, `scripts/build-eif.sh`, or those same workflow / Docker actions.
> 
> **`workflow_dispatch` is unchanged** — manual runs still build without path restrictions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75a31efee9bad88ca0c0d85664134bf77da1a5a5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->