### PR TITLE
fix: gate nitro behind linux os

### DIFF
--- a/proofs/nitro/worker/src/main.rs
+++ b/proofs/nitro/worker/src/main.rs
@@ -1,8 +1,12 @@
+#[cfg(target_os = "linux")]
 mod cmd;
 
+#[cfg(target_os = "linux")]
 use clap::{Parser, Subcommand};
+#[cfg(target_os = "linux")]
 use cmd::{get_attestation::GetAttestationArgs, run::WorkerArgs};
 
+#[cfg(target_os = "linux")]
 #[derive(Parser)]
 #[command(name = "nitro-worker", about = "World Chain Nitro TEE proving worker")]
 struct Cli {
@@ -10,6 +14,7 @@ struct Cli {
     command: Command,
 }
 
+#[cfg(target_os = "linux")]
 #[derive(Subcommand)]
 enum Command {
     /// Start the proving worker.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Compile-time cfg only; Linux runtime path is unchanged and non-Linux already used a stub main.
> 
> **Overview**
> **nitro-worker** now only compiles the `cmd` module, **clap** imports, and the `Cli` / `Command` types on **Linux**, aligning with the existing non-Linux stub `main` that exits with an AF_VSOCK message.
> 
> This prevents **macOS** (and other non-Linux) workspace builds from failing when Linux-only Nitro dependencies are not linked, while keeping the same runtime behavior on Linux.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21ded3b2ef28cc187960d7bded526ada1eb745a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->