### PR TITLE
fix: remove intermediate roots from proof system services

### DIFF
--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -86,7 +86,6 @@ const SERVICE_RPC_PORT: u16 = 8545;
 const SERVICE_METRICS_PORT: u16 = 7300;
 const PROVER_SERVICE_POSTGRES_PORT: u16 = 5432;
 const PROOF_SYSTEM_BLOCK_INTERVAL: u64 = 10;
-const PROOF_SYSTEM_INTERMEDIATE_BLOCK_INTERVAL: u64 = 5;
 /// Poll interval for the in-process SP1 worker leasing jobs from the prover-service.
 const SP1_WORKER_POLL_INTERVAL: Duration = Duration::from_secs(5);
 /// Env var enabling the in-process defender, prover-service, and SP1 worker. Off by default:
@@ -265,7 +264,6 @@ struct WorldProofSystemDeployment {
     l2_chain_id: u64,
     proof_system_version: u64,
     block_interval: u64,
-    intermediate_block_interval: u64,
 }
 
 /// In-process World Chain proof-system proposer task. Aborted on devnet drop.
@@ -955,10 +953,6 @@ async fn deploy_world_proof_system(
         .env(
             "PROOF_SYSTEM_BLOCK_INTERVAL",
             PROOF_SYSTEM_BLOCK_INTERVAL.to_string(),
-        )
-        .env(
-            "PROOF_SYSTEM_INTERMEDIATE_BLOCK_INTERVAL",
-            PROOF_SYSTEM_INTERMEDIATE_BLOCK_INTERVAL.to_string(),
         )
         .env("PROOF_SYSTEM_DEPLOYMENT_OUT", &deployment_rel_path);
 
@@ -3135,10 +3129,8 @@ fn build_components(
                 deployment.proof_system_version
             ))
             .with_note(format!(
-                "l2_chain_id={}, block_interval={}, intermediate_block_interval={}",
-                deployment.l2_chain_id,
-                deployment.block_interval,
-                deployment.intermediate_block_interval
+                "l2_chain_id={}, block_interval={}",
+                deployment.l2_chain_id, deployment.block_interval
             ))
             .with_note(format!(
                 "rollup_config_hash={}",

--- a/docs/proof/nitro-worker.md
+++ b/docs/proof/nitro-worker.md
@@ -488,8 +488,8 @@ verify(rootId, proof)
 NitroProofVerifier
         │
         ├─ 1. ABI-decode proof:
-        │      (domainHash, parentRef, intermediateRootsHash,
-        │       l1OriginHash, l1OriginNumber, rollupConfigHash,
+        │      (domainHash, parentRef, l1OriginHash, l1OriginNumber,
+        │       rollupConfigHash,
         │       l2PostRoot, l2BlockNumber, signature, expectedPublicKey)
         │
         ├─ 2. Reconstruct rootId from proof fields

--- a/proofs/defender/src/defender.rs
+++ b/proofs/defender/src/defender.rs
@@ -432,7 +432,7 @@ fn proof_request(game_created: &GameCreated, backend: ProofBackend) -> ProofRequ
 ///
 /// TODO: encode proofs for their concrete on-chain verifiers. SP1 proofs must
 /// match `SP1ValidityVerifier`'s ABI tuple:
-/// `(domainHash, parentRef, intermediateRootsHash, l1OriginNumber, publicValues, proofBytes)`.
+/// `(domainHash, parentRef, l1OriginNumber, publicValues, proofBytes)`.
 /// That requires proposal context in addition to `ProofData`, so this helper
 /// should move closer to the game/lane submission path before real SP1 lanes
 /// are enabled.

--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -30,7 +30,6 @@ use world_chain_prover_service::{
 };
 
 pub const BLOCK_INTERVAL: u64 = 10;
-pub const INTERMEDIATE_BLOCK_INTERVAL: u64 = 5;
 pub const CHAIN_ID: u64 = 4801;
 pub const ANCHOR: Address = address!("0000000000000000000000000000000000001006");
 
@@ -47,7 +46,6 @@ pub fn test_domain() -> ProofDomain {
         proof_system_version: PROOF_SYSTEM_VERSION,
         rollup_config_hash: B256::repeat_byte(0x99),
         block_interval: BLOCK_INTERVAL,
-        intermediate_block_interval: INTERMEDIATE_BLOCK_INTERVAL,
     }
 }
 

--- a/proofs/primitives/src/bindings.rs
+++ b/proofs/primitives/src/bindings.rs
@@ -20,20 +20,17 @@ sol! {
         function propose(
             address parentRef,
             bytes32 rootClaim,
-            uint256 l2BlockNumber,
-            bytes32 intermediateRootsHash
+            uint256 l2BlockNumber
         ) external payable returns (address game, bytes32 rootId);
         function computeProposalKey(
             address parentRef,
             bytes32 rootClaim,
-            uint256 l2BlockNumber,
-            bytes32 intermediateRootsHash
+            uint256 l2BlockNumber
         ) external view returns (bytes32);
         function computeRootId(
             address parentRef,
             bytes32 rootClaim,
             uint256 l2BlockNumber,
-            bytes32 intermediateRootsHash,
             bytes32 l1OriginHash,
             uint256 l1OriginNumber
         ) external view returns (bytes32);

--- a/proofs/primitives/src/types.rs
+++ b/proofs/primitives/src/types.rs
@@ -68,8 +68,6 @@ pub struct ProofDomain {
     pub rollup_config_hash: B256,
     /// Distance in L2 blocks between parent and proposed roots.
     pub block_interval: u64,
-    /// Distance in L2 blocks between intermediate roots.
-    pub intermediate_block_interval: u64,
 }
 
 impl ProofDomain {
@@ -81,7 +79,6 @@ impl ProofDomain {
             U256::from(self.proof_system_version),
             self.rollup_config_hash,
             U256::from(self.block_interval),
-            U256::from(self.intermediate_block_interval),
         )
             .abi_encode();
         keccak256(encoded)
@@ -97,8 +94,6 @@ pub struct ProposalCommitment {
     pub root_claim: B256,
     /// L2 block number for `root_claim`.
     pub l2_block_number: u64,
-    /// Commitment to ordered intermediate roots, or zero if unused.
-    pub intermediate_roots_hash: B256,
 }
 
 impl ProposalCommitment {
@@ -110,7 +105,6 @@ impl ProposalCommitment {
             self.parent_ref,
             self.root_claim,
             U256::from(self.l2_block_number),
-            self.intermediate_roots_hash,
         )
             .abi_encode();
         keccak256(encoded)
@@ -143,7 +137,6 @@ impl RootCommitment {
             self.proposal.parent_ref,
             self.proposal.root_claim,
             U256::from(self.proposal.l2_block_number),
-            self.proposal.intermediate_roots_hash,
             self.l1_origin_hash,
             U256::from(self.l1_origin_number),
         )
@@ -215,13 +208,11 @@ mod tests {
                 "1111111111111111111111111111111111111111111111111111111111111111"
             ),
             block_interval: 10,
-            intermediate_block_interval: 5,
         };
         let proposal = ProposalCommitment {
             parent_ref: address!("0000000000000000000000000000000000001006"),
             root_claim: b256!("2222222222222222222222222222222222222222222222222222222222222222"),
             l2_block_number: 10,
-            intermediate_roots_hash: B256::ZERO,
         };
         let commitment = RootCommitment {
             proposal,

--- a/proofs/proposer/README.md
+++ b/proofs/proposer/README.md
@@ -15,7 +15,6 @@ Propose a new L2 output root by creating a new `WorldChainProofSystemGame` contr
 - `parent_ref`: address of the parent game, or the `WorldChainAnchorStateRegistry` contract address if there is no parent game.
 - `root_claim`: OP stack output root.
 - `l2_block_number`: L2 block number for the root claim.
-- `intermediate_root_hash`: commitment to ordered intermediate roots, or zero if unused. To be honest, I think this field is useless for us according to wip1006. I'm down to remove it entirely in the near term future.
 
 ## How to get these items
 
@@ -23,7 +22,7 @@ Propose a new L2 output root by creating a new `WorldChainProofSystemGame` contr
 
 - start with `parent_ref` equal to `WorldChainAnchorStateRegistry`
 - compute L2 output root for block equal to `parent_ref`'s `l2_block_number` + `BLOCK_INTERVAL` (a protocol constant that we don't currently have, therefore we need to add it)
-- compute the proposal key from `domain_hash`, `parent_ref`, `root_claim`, `l2_block_number`, and `intermediate_root_hash`
+- compute the proposal key from `domain_hash`, `parent_ref`, `root_claim`, and `l2_block_number`
 - check whether the game already exists
 - if so, this game becomes the `parent_ref` and we continue this loop
 - if it doesn't exist - i.e. the address is `0x00..00`, then the current `parent_ref` is returned
@@ -35,7 +34,3 @@ Propose a new L2 output root by creating a new `WorldChainProofSystemGame` contr
 ### `l2_block_number`
 
 - `parent_ref`'s `l2_block_number` field + `BLOCK_INTERVAL`
-
-### `intermediate_root_hash`
-
-- defaults to zero. I want to remove this in the near term future, so let's assume this always defaults to zero.

--- a/proofs/proposer/src/alloy.rs
+++ b/proofs/proposer/src/alloy.rs
@@ -70,7 +70,6 @@ where
                 commitment.parent_ref,
                 commitment.root_claim,
                 U256::from(commitment.l2_block_number),
-                commitment.intermediate_roots_hash,
             )
             .call()
             .await
@@ -102,7 +101,6 @@ where
                 proposal.parent_ref,
                 proposal.root_claim,
                 U256::from(proposal.l2_block_number),
-                proposal.intermediate_roots_hash,
             )
             .value(proposer_bond)
             .send()

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -68,7 +68,6 @@ where
                 parent_ref: parent.address,
                 root_claim,
                 l2_block_number,
-                intermediate_roots_hash: B256::ZERO,
                 proposal_key: B256::ZERO,
             };
             proposal.proposal_key = self

--- a/proofs/proposer/src/tests.rs
+++ b/proofs/proposer/src/tests.rs
@@ -89,7 +89,6 @@ fn proposal_key(parent_ref: Address, root_claim: B256, l2_block_number: u64) -> 
         parent_ref,
         root_claim,
         l2_block_number,
-        intermediate_roots_hash: B256::ZERO,
     }
     .proposal_key(DOMAIN_HASH)
 }
@@ -120,7 +119,6 @@ async fn prepare_next_proposal_walks_existing_games_until_gap() {
     assert_eq!(proposal.parent_ref, GAME_1);
     assert_eq!(proposal.root_claim, root_20);
     assert_eq!(proposal.l2_block_number, 20);
-    assert_eq!(proposal.intermediate_roots_hash, B256::ZERO);
     assert_eq!(proposal.proposal_key, proposal_key(GAME_1, root_20, 20));
 }
 

--- a/proofs/proposer/src/types.rs
+++ b/proofs/proposer/src/types.rs
@@ -19,8 +19,6 @@ pub struct Proposal {
     pub root_claim: B256,
     /// L2 block number for `root_claim`.
     pub l2_block_number: u64,
-    /// Commitment to ordered intermediate roots. Currently always zero.
-    pub intermediate_roots_hash: B256,
     /// Deterministic factory lookup key, excluding L1 origin.
     pub proposal_key: B256,
 }
@@ -33,7 +31,6 @@ impl Proposal {
             parent_ref: self.parent_ref,
             root_claim: self.root_claim,
             l2_block_number: self.l2_block_number,
-            intermediate_roots_hash: self.intermediate_roots_hash,
         }
     }
 }

--- a/wips/wip-1006.md
+++ b/wips/wip-1006.md
@@ -62,7 +62,7 @@ Multiple proofs from the same lane MUST NOT increase the threshold count.
 
 ### Root Commitments
 
-The data bound by every proof and attestation is split into two layers so that the proposer's submission surface is the same as the OP Stack and Base Azul proposer surfaces. Per-proposal data is supplied by the proposer or captured by the factory at proposal creation. Domain constants are fixed on the verifier implementation and are not part of the proposer's calldata.
+The data bound by every proof and attestation is split into two layers so that the proposer's submission surface stays aligned with the OP Stack. Per-proposal data is supplied by the proposer or captured by the factory at proposal creation. Domain constants are fixed on the verifier implementation and are not part of the proposer's calldata.
 
 #### Proposal (per-proposal)
 
@@ -71,11 +71,10 @@ The data bound by every proof and attestation is split into two layers so that t
 | `rootClaim` | Proposer | Claimed L2 output root, computed as in the [OP Stack output-root V1 encoding][op-output-root]. |
 | `l2BlockNumber` | Proposer | L2 block number for `rootClaim`, matching the [`l2BlockNumber` field of an OP Stack L2 output proposal][op-proposals]. |
 | `parentRef` | Proposer | Address of the parent — the `AnchorStateRegistry` for the first proposal, otherwise the parent proposal. Same convention as the OP Stack [Fault Dispute Game `extraData` parent reference][op-dgi] and the parent reference encoded in Base Azul's `AggregateVerifier` extra-data layout (see [Base Azul proof system][base-azul]). The parent's `rootClaim` and `l2BlockNumber` are read from this reference rather than re-supplied. |
-| `intermediateRootsHash` | Proposer | Commitment to ordered intermediate output roots, compatible with Base Azul's intermediate-root commitment. Implementations that do not use intermediate roots MUST set this field to `bytes32(0)`. |
 | `l1OriginHash` | Factory | L1 origin hash captured at proposal creation. The proposer does not pass it as calldata; it is read via `blockhash()` or [EIP-2935][eip-2935] history and pinned by the factory, mirroring the OP Stack [`l1Head` snapshot at clone creation][op-dgi] that Base Azul inherits. |
 | `l1OriginNumber` | Factory | L1 block number paired with `l1OriginHash`. |
 
-This matches the OP Stack and Base proposer surface field-for-field. Any OP Stack proposer that already submits `(rootClaim, l2BlockNumber)` against a parent reference can be reused without protocol-level change. See [Backwards Compatibility](#backwards-compatibility) for the full compatibility statement.
+Any OP Stack proposer that already submits `(rootClaim, l2BlockNumber)` against a parent reference can be reused without protocol-level change. See [Backwards Compatibility](#backwards-compatibility) for the full compatibility statement.
 
 [op-output-root]: https://specs.optimism.io/protocol/proposals.html#l2-output-commitment-construction
 [op-proposals]: https://specs.optimism.io/protocol/proposals.html
@@ -92,9 +91,8 @@ This matches the OP Stack and Base proposer surface field-for-field. Any OP Stac
 | `proofSystemVersion` | Version of this proof system's proof-domain encoding. |
 | `rollupConfigHash` | Hash of the rollup configuration and World Chain hardfork schedule. |
 | `blockInterval` | Distance in L2 blocks between a parent root and a proposed root. |
-| `intermediateBlockInterval` | Distance in L2 blocks between intermediate roots inside one proposal. |
 
-These values are set once on the verifier implementation (analogous to Base's `CONFIG_HASH`, `L2_CHAIN_ID`, `BLOCK_INTERVAL`, and `INTERMEDIATE_BLOCK_INTERVAL` immutables) and are not supplied per proposal. Lane-specific verifier constants — such as the active TEE image hash, the validity proof program key, and the fault proof game type — live in the lane verifiers' own configuration and are committed to in those lanes' proof journals.
+These values are set once on the verifier implementation (analogous to Base's `CONFIG_HASH`, `L2_CHAIN_ID`, and `BLOCK_INTERVAL` immutables) and are not supplied per proposal. Lane-specific verifier constants — such as the active TEE image hash, the validity proof program key, and the fault proof game type — live in the lane verifiers' own configuration and are committed to in those lanes' proof journals.
 
 #### Canonical identifiers
 
@@ -110,16 +108,14 @@ domainHash = keccak256(abi.encode(
     chainId,
     proofSystemVersion,
     rollupConfigHash,
-    blockInterval,
-    intermediateBlockInterval
+    blockInterval
 ))
 
 proposalKey = keccak256(abi.encode(
     domainHash,
     parentRef,
     rootClaim,
-    l2BlockNumber,
-    intermediateRootsHash
+    l2BlockNumber
 ))
 
 rootId = keccak256(abi.encode(
@@ -127,7 +123,6 @@ rootId = keccak256(abi.encode(
     parentRef,
     rootClaim,
     l2BlockNumber,
-    intermediateRootsHash,
     l1OriginHash,
     l1OriginNumber
 ))
@@ -282,7 +277,7 @@ The proposer interface is preserved field-for-field with the OP Stack. Specifica
 - `l1OriginHash` is factory-captured at proposal creation, matching the L1 head snapshot taken by `DisputeGameFactory` at clone creation.
 - The factory lookup key intentionally excludes `l1OriginHash` and `l1OriginNumber`, matching the OP Stack/Base pattern where game existence is keyed by deterministic proposal data and the L1 origin is stored on the created game.
 
-An existing OP Stack proposer that already produces `(rootClaim, l2BlockNumber)` against a parent reference can be reused. Domain constants (`chainId`, `proofSystemVersion`, `rollupConfigHash`, `blockInterval`, `intermediateBlockInterval`) and lane-specific verifier constants live on the verifier implementation, not in the proposer's calldata, so changes to those values do not require a proposer change.
+An existing OP Stack proposer that already produces `(rootClaim, l2BlockNumber)` against a parent reference can be reused. Domain constants (`chainId`, `proofSystemVersion`, `rollupConfigHash`, `blockInterval`) and lane-specific verifier constants live on the verifier implementation, not in the proposer's calldata, so changes to those values do not require a proposer change.
 
 ## Test Cases
 


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4905/remove-intermediate-root-hash

This PR removes intermediate roots field from everywhere in the code except for the contracts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes canonical `domainHash`, `proposalKey`, and `rootId` derivations and factory calldata in Rust services—must stay aligned with deployed contracts and any in-flight games; misalignment would break proposals, lookups, and proof binding.
> 
> **Overview**
> Strips **intermediate roots** from the Rust proof stack, devnet, and WIP-1006 docs so proposals and identifiers match a simpler OP-style surface (`parentRef`, `rootClaim`, `l2BlockNumber` only). On-chain contracts are **unchanged** per the PR description.
> 
> **Domain and commitments:** `ProofDomain` no longer carries `intermediate_block_interval`; `domainHash` encoding drops that field. `ProposalCommitment` and `RootCommitment` / `proposalKey` / `rootId` hashing no longer include `intermediate_roots_hash`.
> 
> **Factory bindings and proposer:** Alloy `propose`, `computeProposalKey`, and `computeRootId` call sites lose the intermediate-root argument; the proposer always builds proposals without `intermediate_roots_hash`.
> 
> **Devnet:** Removes `PROOF_SYSTEM_INTERMEDIATE_BLOCK_INTERVAL`, deployment env wiring, and deployment JSON field; component notes only show `block_interval`.
> 
> **Docs:** WIP-1006 and proposer README drop intermediate-root fields and intervals; Nitro verifier doc updates the ABI-decoded proof tuple to match.
> 
> **Defender:** SP1 encoding TODO comment updated to the slimmer tuple (no `intermediateRootsHash`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d122e12a2562e8edd5a129308ae550d8dce0a20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->