### PR TITLE
chore: remove intermediate roots from contracts

### DIFF
--- a/pkg/contracts/scripts/devnet/DeployProofSystem.s.sol
+++ b/pkg/contracts/scripts/devnet/DeployProofSystem.s.sol
@@ -25,7 +25,6 @@ contract DeployProofSystem is Script {
         uint256 l2ChainId;
         bytes32 rollupConfigHash;
         uint256 blockInterval;
-        uint256 intermediateBlockInterval;
         uint8 proofThreshold;
     }
 
@@ -59,7 +58,6 @@ contract DeployProofSystem is Script {
         config.l2ChainId = vm.envUint("WORLD_CHAIN_L2_CHAIN_ID");
         config.rollupConfigHash = vm.envBytes32("ROLLUP_CONFIG_HASH");
         config.blockInterval = vm.envOr("PROOF_SYSTEM_BLOCK_INTERVAL", uint256(10));
-        config.intermediateBlockInterval = vm.envOr("PROOF_SYSTEM_INTERMEDIATE_BLOCK_INTERVAL", uint256(5));
         config.proofThreshold = uint8(vm.envOr("PROOF_THRESHOLD", uint256(WorldChainProofLib.PROOF_THRESHOLD)));
     }
 
@@ -72,8 +70,7 @@ contract DeployProofSystem is Script {
                 chainId: config.l2ChainId,
                 proofSystemVersion: 1,
                 rollupConfigHash: config.rollupConfigHash,
-                blockInterval: config.blockInterval,
-                intermediateBlockInterval: config.intermediateBlockInterval
+                blockInterval: config.blockInterval
             }),
             CHALLENGE_PERIOD,
             PROOF_PERIOD,
@@ -102,8 +99,7 @@ contract DeployProofSystem is Script {
         vm.serializeUint(root, "l2ChainId", config.l2ChainId);
         vm.serializeUint(root, "proofSystemVersion", 1);
         vm.serializeUint(root, "blockInterval", config.blockInterval);
-        vm.serializeUint(root, "proofThreshold", config.proofThreshold);
-        string memory json = vm.serializeUint(root, "intermediateBlockInterval", config.intermediateBlockInterval);
+        string memory json = vm.serializeUint(root, "proofThreshold", config.proofThreshold);
         vm.writeJson(json, out);
     }
 }

--- a/pkg/contracts/src/proofs/WorldChainProofLib.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofLib.sol
@@ -27,19 +27,13 @@ library WorldChainProofLib {
         uint256 proofSystemVersion;
         bytes32 rollupConfigHash;
         uint256 blockInterval;
-        uint256 intermediateBlockInterval;
     }
 
     function domainHash(Domain memory domain) internal pure returns (bytes32) {
-        return keccak256(
-            abi.encode(
-                domain.chainId,
-                domain.proofSystemVersion,
-                domain.rollupConfigHash,
-                domain.blockInterval,
-                domain.intermediateBlockInterval
-            )
-        );
+        return
+            keccak256(
+                abi.encode(domain.chainId, domain.proofSystemVersion, domain.rollupConfigHash, domain.blockInterval)
+            );
     }
 
     function rootId(
@@ -47,25 +41,18 @@ library WorldChainProofLib {
         address parentRef,
         bytes32 rootClaim,
         uint256 l2BlockNumber,
-        bytes32 intermediateRootsHash,
         bytes32 l1OriginHash,
         uint256 l1OriginNumber
     ) internal pure returns (bytes32) {
-        return keccak256(
-            abi.encode(
-                domainHash_, parentRef, rootClaim, l2BlockNumber, intermediateRootsHash, l1OriginHash, l1OriginNumber
-            )
-        );
+        return keccak256(abi.encode(domainHash_, parentRef, rootClaim, l2BlockNumber, l1OriginHash, l1OriginNumber));
     }
 
-    function proposalKey(
-        bytes32 domainHash_,
-        address parentRef,
-        bytes32 rootClaim,
-        uint256 l2BlockNumber,
-        bytes32 intermediateRootsHash
-    ) internal pure returns (bytes32) {
-        return keccak256(abi.encode(domainHash_, parentRef, rootClaim, l2BlockNumber, intermediateRootsHash));
+    function proposalKey(bytes32 domainHash_, address parentRef, bytes32 rootClaim, uint256 l2BlockNumber)
+        internal
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encode(domainHash_, parentRef, rootClaim, l2BlockNumber));
     }
 
     function laneMask(ProofLane lane) internal pure returns (uint8) {

--- a/pkg/contracts/src/proofs/WorldChainProofSystemFactory.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofSystemFactory.sol
@@ -64,8 +64,7 @@ contract WorldChainProofSystemFactory {
     ) {
         if (
             challengePeriod_ == 0 || proofPeriod_ == 0 || domain_.chainId == 0 || domain_.proofSystemVersion == 0
-                || domain_.blockInterval == 0 || domain_.intermediateBlockInterval == 0
-                || domain_.blockInterval % domain_.intermediateBlockInterval != 0 || proofThreshold_ == 0
+                || domain_.blockInterval == 0 || proofThreshold_ == 0
                 || proofThreshold_ > WorldChainProofLib.PROOF_LANE_COUNT
         ) {
             revert InvalidActivationParameters();
@@ -84,7 +83,7 @@ contract WorldChainProofSystemFactory {
         stakingRegistry = stakingRegistry_;
     }
 
-    function propose(address parentRef, bytes32 rootClaim, uint256 l2BlockNumber, bytes32 intermediateRootsHash)
+    function propose(address parentRef, bytes32 rootClaim, uint256 l2BlockNumber)
         external
         payable
         returns (address game, bytes32 id)
@@ -92,14 +91,11 @@ contract WorldChainProofSystemFactory {
         uint256 l1OriginNumber = block.number == 0 ? 0 : block.number - 1;
         bytes32 l1OriginHash = block.number == 0 ? bytes32(0) : blockhash(l1OriginNumber);
 
-        bytes32 key =
-            WorldChainProofLib.proposalKey(domainHash, parentRef, rootClaim, l2BlockNumber, intermediateRootsHash);
+        bytes32 key = WorldChainProofLib.proposalKey(domainHash, parentRef, rootClaim, l2BlockNumber);
         address existing = games[key];
         if (existing != address(0)) revert GameAlreadyExists(key, existing);
 
-        id = WorldChainProofLib.rootId(
-            domainHash, parentRef, rootClaim, l2BlockNumber, intermediateRootsHash, l1OriginHash, l1OriginNumber
-        );
+        id = WorldChainProofLib.rootId(domainHash, parentRef, rootClaim, l2BlockNumber, l1OriginHash, l1OriginNumber);
 
         game = address(
             new WorldChainProofSystemGame{value: msg.value}(
@@ -108,7 +104,6 @@ contract WorldChainProofSystemFactory {
                     parentRef: parentRef,
                     rootClaim: rootClaim,
                     l2BlockNumber: l2BlockNumber,
-                    intermediateRootsHash: intermediateRootsHash,
                     l1OriginHash: l1OriginHash,
                     l1OriginNumber: l1OriginNumber
                 }),
@@ -143,26 +138,22 @@ contract WorldChainProofSystemFactory {
         );
     }
 
-    function computeProposalKey(
-        address parentRef,
-        bytes32 rootClaim,
-        uint256 l2BlockNumber,
-        bytes32 intermediateRootsHash
-    ) external view returns (bytes32) {
-        return WorldChainProofLib.proposalKey(domainHash, parentRef, rootClaim, l2BlockNumber, intermediateRootsHash);
+    function computeProposalKey(address parentRef, bytes32 rootClaim, uint256 l2BlockNumber)
+        external
+        view
+        returns (bytes32)
+    {
+        return WorldChainProofLib.proposalKey(domainHash, parentRef, rootClaim, l2BlockNumber);
     }
 
     function computeRootId(
         address parentRef,
         bytes32 rootClaim,
         uint256 l2BlockNumber,
-        bytes32 intermediateRootsHash,
         bytes32 l1OriginHash,
         uint256 l1OriginNumber
     ) external view returns (bytes32) {
-        return WorldChainProofLib.rootId(
-            domainHash, parentRef, rootClaim, l2BlockNumber, intermediateRootsHash, l1OriginHash, l1OriginNumber
-        );
+        return WorldChainProofLib.rootId(domainHash, parentRef, rootClaim, l2BlockNumber, l1OriginHash, l1OriginNumber);
     }
 
     function _emitGameCreated(GameCreatedLog memory log) private {

--- a/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
@@ -13,7 +13,6 @@ contract WorldChainProofSystemGame {
         address parentRef;
         bytes32 rootClaim;
         uint256 l2BlockNumber;
-        bytes32 intermediateRootsHash;
         bytes32 l1OriginHash;
         uint256 l1OriginNumber;
     }
@@ -58,7 +57,6 @@ contract WorldChainProofSystemGame {
     address public immutable parentRef;
     bytes32 public immutable rootClaim;
     uint256 public immutable l2BlockNumber;
-    bytes32 public immutable intermediateRootsHash;
     bytes32 public immutable l1OriginHash;
     uint256 public immutable l1OriginNumber;
     bytes32 public immutable domainHash;
@@ -93,7 +91,6 @@ contract WorldChainProofSystemGame {
         parentRef = proposal.parentRef;
         rootClaim = proposal.rootClaim;
         l2BlockNumber = proposal.l2BlockNumber;
-        intermediateRootsHash = proposal.intermediateRootsHash;
         l1OriginHash = proposal.l1OriginHash;
         l1OriginNumber = proposal.l1OriginNumber;
         domainHash = config.domainHash;
@@ -102,7 +99,6 @@ contract WorldChainProofSystemGame {
             proposal.parentRef,
             proposal.rootClaim,
             proposal.l2BlockNumber,
-            proposal.intermediateRootsHash,
             proposal.l1OriginHash,
             proposal.l1OriginNumber
         );

--- a/pkg/contracts/src/proofs/nitro/NitroProofVerifier.sol
+++ b/pkg/contracts/src/proofs/nitro/NitroProofVerifier.sol
@@ -69,7 +69,6 @@ contract NitroProofVerifier is IWorldChainProofVerifier {
     ///        (
     ///            bytes32 domainHash,
     ///            address parentRef,
-    ///            bytes32 intermediateRootsHash,
     ///            bytes32 l1OriginHash,
     ///            uint256 l1OriginNumber,
     ///            bytes32 rollupConfigHash,
@@ -99,7 +98,6 @@ contract NitroProofVerifier is IWorldChainProofVerifier {
         (
             bytes32 domainHash,
             address parentRef,
-            bytes32 intermediateRootsHash,
             bytes32 l1OriginHash,
             uint256 l1OriginNumber,
             bytes32 rollupConfigHash,
@@ -107,19 +105,13 @@ contract NitroProofVerifier is IWorldChainProofVerifier {
             uint64 l2BlockNumber,
             bytes memory signature,
             bytes memory expectedPublicKey
-        ) = abi.decode(proof, (bytes32, address, bytes32, bytes32, uint256, bytes32, bytes32, uint64, bytes, bytes));
+        ) = abi.decode(proof, (bytes32, address, bytes32, uint256, bytes32, bytes32, uint64, bytes, bytes));
 
         // 1. Bind the proof to the supplied rootId. The boot_info's
         //    `l2PostRoot` plays the role of `rootClaim` (the proposal's
         //    claimed L2 output root) in WorldChainProofLib.rootId.
         bytes32 expectedRootId = WorldChainProofLib.rootId(
-            domainHash,
-            parentRef,
-            l2PostRoot,
-            uint256(l2BlockNumber),
-            intermediateRootsHash,
-            l1OriginHash,
-            l1OriginNumber
+            domainHash, parentRef, l2PostRoot, uint256(l2BlockNumber), l1OriginHash, l1OriginNumber
         );
         if (expectedRootId != rootId) return false;
 

--- a/pkg/contracts/src/proofs/sp1/SP1ValidityVerifier.sol
+++ b/pkg/contracts/src/proofs/sp1/SP1ValidityVerifier.sol
@@ -101,7 +101,6 @@ contract SP1ValidityVerifier is IWorldChainProofVerifier {
     ///        (
     ///            bytes32 domainHash,
     ///            address parentRef,
-    ///            bytes32 intermediateRootsHash,
     ///            uint256 l1OriginNumber,
     ///            bytes   publicValues,
     ///            bytes   proofBytes
@@ -132,11 +131,10 @@ contract SP1ValidityVerifier is IWorldChainProofVerifier {
         (
             bytes32 domainHash,
             address parentRef,
-            bytes32 intermediateRootsHash,
             uint256 l1OriginNumber,
             bytes memory publicValues,
             bytes memory proofBytes
-        ) = abi.decode(proof, (bytes32, address, bytes32, uint256, bytes, bytes));
+        ) = abi.decode(proof, (bytes32, address, uint256, bytes, bytes));
 
         AggregationOutputs memory outputs = abi.decode(publicValues, (AggregationOutputs));
 
@@ -144,13 +142,7 @@ contract SP1ValidityVerifier is IWorldChainProofVerifier {
         if (outputs.multiBlockVKey != rangeVKeyCommitment) return false;
 
         bytes32 expectedRootId = WorldChainProofLib.rootId(
-            domainHash,
-            parentRef,
-            outputs.l2PostRoot,
-            uint256(outputs.l2BlockNumber),
-            intermediateRootsHash,
-            outputs.l1Head,
-            l1OriginNumber
+            domainHash, parentRef, outputs.l2PostRoot, uint256(outputs.l2BlockNumber), outputs.l1Head, l1OriginNumber
         );
         if (expectedRootId != rootId) return false;
 

--- a/pkg/contracts/test/WorldChainProofSystem.t.sol
+++ b/pkg/contracts/test/WorldChainProofSystem.t.sol
@@ -47,8 +47,7 @@ contract WorldChainProofSystemTest is Test {
                 chainId: 4801,
                 proofSystemVersion: 1,
                 rollupConfigHash: keccak256("world-chain-devnet-rollup-config"),
-                blockInterval: 10,
-                intermediateBlockInterval: 5
+                blockInterval: 10
             }),
             CHALLENGE_PERIOD,
             PROOF_PERIOD,
@@ -121,9 +120,8 @@ contract WorldChainProofSystemTest is Test {
         WorldChainProofSystemFactory thresholdOne = _thresholdFactory(1);
 
         vm.prank(proposer);
-        (address gameAddress, bytes32 rootId) = thresholdOne.propose{value: PROPOSER_BOND}(
-            address(anchor), keccak256("threshold-one-root"), 10, keccak256("threshold-one-intermediate")
-        );
+        (address gameAddress, bytes32 rootId) =
+            thresholdOne.propose{value: PROPOSER_BOND}(address(anchor), keccak256("threshold-one-root"), 10);
         WorldChainProofSystemGame game = WorldChainProofSystemGame(payable(gameAddress));
         assertEq(game.PROOF_THRESHOLD(), 1);
 
@@ -148,8 +146,7 @@ contract WorldChainProofSystemTest is Test {
                 chainId: 4801,
                 proofSystemVersion: 1,
                 rollupConfigHash: keccak256("world-chain-devnet-rollup-config"),
-                blockInterval: 10,
-                intermediateBlockInterval: 5
+                blockInterval: 10
             }),
             CHALLENGE_PERIOD,
             PROOF_PERIOD,
@@ -210,12 +207,10 @@ contract WorldChainProofSystemTest is Test {
 
     function testFactoryIndexesGamesByProposalKeyWithoutL1Origin() public {
         bytes32 rootClaim = keccak256("root");
-        bytes32 intermediateRootsHash = keccak256("intermediate");
-        bytes32 proposalKey = factory.computeProposalKey(address(anchor), rootClaim, 10, intermediateRootsHash);
+        bytes32 proposalKey = factory.computeProposalKey(address(anchor), rootClaim, 10);
 
         vm.prank(proposer);
-        (address game, bytes32 rootId) =
-            factory.propose{value: PROPOSER_BOND}(address(anchor), rootClaim, 10, intermediateRootsHash);
+        (address game, bytes32 rootId) = factory.propose{value: PROPOSER_BOND}(address(anchor), rootClaim, 10);
 
         assertEq(factory.games(proposalKey), game);
         assertEq(WorldChainProofSystemGame(payable(game)).rootId(), rootId);
@@ -225,7 +220,7 @@ contract WorldChainProofSystemTest is Test {
         vm.expectRevert(
             abi.encodeWithSelector(WorldChainProofSystemFactory.GameAlreadyExists.selector, proposalKey, game)
         );
-        factory.propose{value: PROPOSER_BOND}(address(anchor), rootClaim, 10, intermediateRootsHash);
+        factory.propose{value: PROPOSER_BOND}(address(anchor), rootClaim, 10);
     }
 
     function testAnchorUpdatesOnlyAcceptFinalizedMonotonicRoots() public {
@@ -265,10 +260,7 @@ contract WorldChainProofSystemTest is Test {
         proposalSalt++;
         vm.prank(proposer);
         (address gameAddress, bytes32 id) = factory.propose{value: PROPOSER_BOND}(
-            address(anchor),
-            keccak256(abi.encode("root", l2BlockNumber, proposalSalt)),
-            l2BlockNumber,
-            keccak256(abi.encode("intermediate", l2BlockNumber, proposalSalt))
+            address(anchor), keccak256(abi.encode("root", l2BlockNumber, proposalSalt)), l2BlockNumber
         );
         return (WorldChainProofSystemGame(payable(gameAddress)), id);
     }

--- a/pkg/contracts/test/nitro/NitroEndToEnd.t.sol
+++ b/pkg/contracts/test/nitro/NitroEndToEnd.t.sol
@@ -38,7 +38,6 @@ contract NitroEndToEndTest is Test {
 
     bytes32 constant DOMAIN = keccak256("worldchain-integration");
     address constant PARENT = address(0x1234);
-    bytes32 constant INTER = keccak256("intermediate-roots");
     bytes32 constant L1H = keccak256("l1-origin");
     uint256 constant L1N = 7_777;
     bytes32 constant CFG = keccak256("rollup-cfg");
@@ -84,11 +83,11 @@ contract NitroEndToEndTest is Test {
         pure
         returns (bytes memory)
     {
-        return abi.encode(DOMAIN, PARENT, INTER, L1H, L1N, cfg, postRoot, blk, sig, pub);
+        return abi.encode(DOMAIN, PARENT, L1H, L1N, cfg, postRoot, blk, sig, pub);
     }
 
     function _rootId(bytes32 postRoot, uint64 blk) internal pure returns (bytes32) {
-        return WorldChainProofLib.rootId(DOMAIN, PARENT, postRoot, uint256(blk), INTER, L1H, L1N);
+        return WorldChainProofLib.rootId(DOMAIN, PARENT, postRoot, uint256(blk), L1H, L1N);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/pkg/contracts/test/nitro/NitroProofVerifier.t.sol
+++ b/pkg/contracts/test/nitro/NitroProofVerifier.t.sol
@@ -29,7 +29,6 @@ contract NitroProofVerifierTest is Test {
     // Context fields needed to rebuild rootId.
     bytes32 constant DOMAIN_HASH = keccak256("domain");
     address constant PARENT_REF = address(0xBEEF);
-    bytes32 constant INTERMEDIATE_ROOTS = keccak256("intermediate-roots");
     bytes32 constant L1_ORIGIN_HASH = keccak256("l1-origin");
     uint256 constant L1_ORIGIN_NUMBER = 9_001;
 
@@ -76,28 +75,13 @@ contract NitroProofVerifierTest is Test {
 
     function _expectedRootId() internal pure returns (bytes32) {
         return WorldChainProofLib.rootId(
-            DOMAIN_HASH,
-            PARENT_REF,
-            L2_POST_ROOT,
-            uint256(L2_BLOCK),
-            INTERMEDIATE_ROOTS,
-            L1_ORIGIN_HASH,
-            L1_ORIGIN_NUMBER
+            DOMAIN_HASH, PARENT_REF, L2_POST_ROOT, uint256(L2_BLOCK), L1_ORIGIN_HASH, L1_ORIGIN_NUMBER
         );
     }
 
     function _proofBytes(bytes memory sig, bytes memory pub) internal pure returns (bytes memory) {
         return abi.encode(
-            DOMAIN_HASH,
-            PARENT_REF,
-            INTERMEDIATE_ROOTS,
-            L1_ORIGIN_HASH,
-            L1_ORIGIN_NUMBER,
-            ROLLUP_CFG,
-            L2_POST_ROOT,
-            L2_BLOCK,
-            sig,
-            pub
+            DOMAIN_HASH, PARENT_REF, L1_ORIGIN_HASH, L1_ORIGIN_NUMBER, ROLLUP_CFG, L2_POST_ROOT, L2_BLOCK, sig, pub
         );
     }
 
@@ -130,18 +114,11 @@ contract NitroProofVerifierTest is Test {
         bytes memory sig = _sign(_commitment());
         // Build a proof with a mismatched block number and a matching rootId.
         bytes32 wrongRootId = WorldChainProofLib.rootId(
-            DOMAIN_HASH,
-            PARENT_REF,
-            L2_POST_ROOT,
-            uint256(L2_BLOCK + 1),
-            INTERMEDIATE_ROOTS,
-            L1_ORIGIN_HASH,
-            L1_ORIGIN_NUMBER
+            DOMAIN_HASH, PARENT_REF, L2_POST_ROOT, uint256(L2_BLOCK + 1), L1_ORIGIN_HASH, L1_ORIGIN_NUMBER
         );
         bytes memory proof = abi.encode(
             DOMAIN_HASH,
             PARENT_REF,
-            INTERMEDIATE_ROOTS,
             L1_ORIGIN_HASH,
             L1_ORIGIN_NUMBER,
             ROLLUP_CFG,
@@ -310,15 +287,13 @@ contract NitroProofVerifierTest is Test {
         // Boundary: l2BlockNumber = 0 must work, since the rootId is
         // recomputed deterministically and the commitment is signed over
         // exactly that value.
-        bytes32 rootId = WorldChainProofLib.rootId(
-            DOMAIN_HASH, PARENT_REF, L2_POST_ROOT, 0, INTERMEDIATE_ROOTS, L1_ORIGIN_HASH, L1_ORIGIN_NUMBER
-        );
+        bytes32 rootId =
+            WorldChainProofLib.rootId(DOMAIN_HASH, PARENT_REF, L2_POST_ROOT, 0, L1_ORIGIN_HASH, L1_ORIGIN_NUMBER);
         bytes32 commitment = keccak256(abi.encodePacked(L2_POST_ROOT, uint64(0), ROLLUP_CFG));
         bytes memory sig = _sign(commitment);
         bytes memory proof = abi.encode(
             DOMAIN_HASH,
             PARENT_REF,
-            INTERMEDIATE_ROOTS,
             L1_ORIGIN_HASH,
             L1_ORIGIN_NUMBER,
             ROLLUP_CFG,
@@ -346,7 +321,6 @@ contract NitroProofVerifierTest is Test {
         bytes memory proof = abi.encode(
             DOMAIN_HASH,
             PARENT_REF,
-            INTERMEDIATE_ROOTS,
             L1_ORIGIN_HASH,
             L1_ORIGIN_NUMBER,
             ROLLUP_CFG,

--- a/pkg/contracts/test/sp1/SP1ValidityVerifier.t.sol
+++ b/pkg/contracts/test/sp1/SP1ValidityVerifier.t.sol
@@ -66,7 +66,6 @@ contract SP1ValidityVerifierTest is Test {
     bytes32 internal constant RANGE_VKEY_COMMITMENT = keccak256("range-vkey");
 
     bytes32 internal constant DOMAIN_HASH = keccak256("domain");
-    bytes32 internal constant INTERMEDIATE_ROOTS_HASH = keccak256("intermediate-roots");
     bytes32 internal constant L1_ORIGIN_HASH = keccak256("l1-origin");
     uint256 internal constant L1_ORIGIN_NUMBER = 9_001;
 
@@ -107,20 +106,17 @@ contract SP1ValidityVerifierTest is Test {
     }
 
     function _proof(AggregationOutputs memory outputs) internal view returns (bytes memory) {
-        return _proof(DOMAIN_HASH, address(parent), INTERMEDIATE_ROOTS_HASH, L1_ORIGIN_NUMBER, outputs, SP1_PROOF_BYTES);
+        return _proof(DOMAIN_HASH, address(parent), L1_ORIGIN_NUMBER, outputs, SP1_PROOF_BYTES);
     }
 
     function _proof(
         bytes32 domainHash,
         address parentRef,
-        bytes32 intermediateRootsHash,
         uint256 l1OriginNumber,
         AggregationOutputs memory outputs,
         bytes memory proofBytes
     ) internal pure returns (bytes memory) {
-        return abi.encode(
-            domainHash, parentRef, intermediateRootsHash, l1OriginNumber, _publicValues(outputs), proofBytes
-        );
+        return abi.encode(domainHash, parentRef, l1OriginNumber, _publicValues(outputs), proofBytes);
     }
 
     function _rootId() internal view returns (bytes32) {
@@ -129,13 +125,7 @@ contract SP1ValidityVerifierTest is Test {
 
     function _rootId(address parentRef) internal pure returns (bytes32) {
         return WorldChainProofLib.rootId(
-            DOMAIN_HASH,
-            parentRef,
-            L2_POST_ROOT,
-            uint256(L2_BLOCK_NUMBER),
-            INTERMEDIATE_ROOTS_HASH,
-            L1_ORIGIN_HASH,
-            L1_ORIGIN_NUMBER
+            DOMAIN_HASH, parentRef, L2_POST_ROOT, uint256(L2_BLOCK_NUMBER), L1_ORIGIN_HASH, L1_ORIGIN_NUMBER
         );
     }
 
@@ -197,8 +187,7 @@ contract SP1ValidityVerifierTest is Test {
         AggregationOutputs memory outputs = _outputs();
         _expectSp1Call(outputs);
 
-        bytes memory proof =
-            _proof(DOMAIN_HASH, address(anchor), INTERMEDIATE_ROOTS_HASH, L1_ORIGIN_NUMBER, outputs, SP1_PROOF_BYTES);
+        bytes memory proof = _proof(DOMAIN_HASH, address(anchor), L1_ORIGIN_NUMBER, outputs, SP1_PROOF_BYTES);
 
         assertTrue(verifier.verify(_rootId(address(anchor)), proof));
     }
@@ -212,9 +201,7 @@ contract SP1ValidityVerifierTest is Test {
     }
 
     function test_Verify_FalseForMalformedPublicValues() public view {
-        bytes memory proof = abi.encode(
-            DOMAIN_HASH, address(parent), INTERMEDIATE_ROOTS_HASH, L1_ORIGIN_NUMBER, hex"deadbeef", SP1_PROOF_BYTES
-        );
+        bytes memory proof = abi.encode(DOMAIN_HASH, address(parent), L1_ORIGIN_NUMBER, hex"deadbeef", SP1_PROOF_BYTES);
 
         assertFalse(verifier.verify(_rootId(), proof));
     }
@@ -266,8 +253,7 @@ contract SP1ValidityVerifierTest is Test {
     function test_Verify_FalseForAnchorRegistryPreRootMismatch() public view {
         AggregationOutputs memory outputs = _outputs();
         outputs.l2PreRoot = keccak256("wrong-pre-root");
-        bytes memory proof =
-            _proof(DOMAIN_HASH, address(anchor), INTERMEDIATE_ROOTS_HASH, L1_ORIGIN_NUMBER, outputs, SP1_PROOF_BYTES);
+        bytes memory proof = _proof(DOMAIN_HASH, address(anchor), L1_ORIGIN_NUMBER, outputs, SP1_PROOF_BYTES);
 
         assertFalse(verifier.verify(_rootId(address(anchor)), proof));
     }
@@ -275,9 +261,7 @@ contract SP1ValidityVerifierTest is Test {
     function test_Verify_FalseForUnreadableParentRef() public view {
         AggregationOutputs memory outputs = _outputs();
         address unreadableParentRef = address(0xBEEF);
-        bytes memory proof = _proof(
-            DOMAIN_HASH, unreadableParentRef, INTERMEDIATE_ROOTS_HASH, L1_ORIGIN_NUMBER, outputs, SP1_PROOF_BYTES
-        );
+        bytes memory proof = _proof(DOMAIN_HASH, unreadableParentRef, L1_ORIGIN_NUMBER, outputs, SP1_PROOF_BYTES);
 
         assertFalse(verifier.verify(_rootId(unreadableParentRef), proof));
     }
@@ -295,22 +279,15 @@ contract SP1ValidityVerifierTest is Test {
 
     function test_Verify_FalseForDomainHashMismatch() public view {
         AggregationOutputs memory outputs = _outputs();
-        bytes memory proof = _proof(
-            keccak256("wrong-domain"),
-            address(parent),
-            INTERMEDIATE_ROOTS_HASH,
-            L1_ORIGIN_NUMBER,
-            outputs,
-            SP1_PROOF_BYTES
-        );
+        bytes memory proof =
+            _proof(keccak256("wrong-domain"), address(parent), L1_ORIGIN_NUMBER, outputs, SP1_PROOF_BYTES);
 
         assertFalse(verifier.verify(_rootId(), proof));
     }
 
     function test_Verify_FalseForParentRefMismatch() public view {
         AggregationOutputs memory outputs = _outputs();
-        bytes memory proof =
-            _proof(DOMAIN_HASH, address(0xBAD), INTERMEDIATE_ROOTS_HASH, L1_ORIGIN_NUMBER, outputs, SP1_PROOF_BYTES);
+        bytes memory proof = _proof(DOMAIN_HASH, address(0xBAD), L1_ORIGIN_NUMBER, outputs, SP1_PROOF_BYTES);
 
         assertFalse(verifier.verify(_rootId(), proof));
     }
@@ -329,15 +306,6 @@ contract SP1ValidityVerifierTest is Test {
         assertFalse(verifier.verify(_rootId(), _proof(outputs)));
     }
 
-    function test_Verify_FalseForIntermediateRootsHashMismatch() public view {
-        AggregationOutputs memory outputs = _outputs();
-        bytes memory proof = _proof(
-            DOMAIN_HASH, address(parent), keccak256("wrong-intermediate"), L1_ORIGIN_NUMBER, outputs, SP1_PROOF_BYTES
-        );
-
-        assertFalse(verifier.verify(_rootId(), proof));
-    }
-
     function test_Verify_FalseForL1HeadMismatch() public view {
         AggregationOutputs memory outputs = _outputs();
         outputs.l1Head = keccak256("wrong-l1-head");
@@ -347,9 +315,7 @@ contract SP1ValidityVerifierTest is Test {
 
     function test_Verify_FalseForL1OriginNumberMismatch() public view {
         AggregationOutputs memory outputs = _outputs();
-        bytes memory proof = _proof(
-            DOMAIN_HASH, address(parent), INTERMEDIATE_ROOTS_HASH, L1_ORIGIN_NUMBER + 1, outputs, SP1_PROOF_BYTES
-        );
+        bytes memory proof = _proof(DOMAIN_HASH, address(parent), L1_ORIGIN_NUMBER + 1, outputs, SP1_PROOF_BYTES);
 
         assertFalse(verifier.verify(_rootId(), proof));
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> 
> **Overview**
> **Removes intermediate roots** from the World Chain proof contracts so proposals and identity hashes depend only on parent, root claim, L2 block, and L1 origin—not a separate intermediate-roots commitment.
> 
> `WorldChainProofLib` drops `intermediateBlockInterval` from `Domain` and from `domainHash`, `rootId`, and `proposalKey`. `WorldChainProofSystemFactory.propose` and related helpers lose the extra argument; factory activation no longer requires `blockInterval % intermediateBlockInterval`. Games no longer store `intermediateRootsHash`.
> 
> **Nitro and SP1 verifiers** use shorter ABI-encoded proof tuples (no `intermediateRootsHash` field). Devnet deploy drops `PROOF_SYSTEM_INTERMEDIATE_BLOCK_INTERVAL` and related deployment JSON. Tests and the SP1 intermediate-hash mismatch case are updated accordingly.
> 
> **Breaking change** for off-chain proposers and proof builders: `rootId` / `proposalKey` values and proof encodings change vs. the previous schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53711e76e01cb3ff1be5615348da3d38bc9f46d1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->