### PR TITLE
feat: authenticate proof games through factory registry

### DIFF
--- a/pkg/contracts/scripts/devnet/DeployProofSystem.s.sol
+++ b/pkg/contracts/scripts/devnet/DeployProofSystem.s.sol
@@ -6,6 +6,7 @@ import {Script} from "forge-std/Script.sol";
 import {WorldChainAnchorStateRegistry} from "../../src/proofs/WorldChainAnchorStateRegistry.sol";
 import {WorldChainProofLib} from "../../src/proofs/WorldChainProofLib.sol";
 import {WorldChainProofSystemFactory} from "../../src/proofs/WorldChainProofSystemFactory.sol";
+import {IWorldChainAnchorStateRegistry} from "../../src/proofs/interfaces/IWorldChainAnchorStateRegistry.sol";
 import {MockRootIdVerifier} from "../../src/proofs/mocks/MockRootIdVerifier.sol";
 import {MockStakingRegistry} from "../../src/proofs/mocks/MockStakingRegistry.sol";
 
@@ -47,6 +48,7 @@ contract DeployProofSystem is Script {
             deployment.staking.setStaked(config.challenger, true);
         }
         deployment.factory = _deployFactory(deployment, config);
+        deployment.anchor.initializeFactory(address(deployment.factory));
         vm.stopBroadcast();
 
         _writeDeployment(deployment, config);
@@ -72,6 +74,7 @@ contract DeployProofSystem is Script {
                 rollupConfigHash: config.rollupConfigHash,
                 blockInterval: config.blockInterval
             }),
+            IWorldChainAnchorStateRegistry(address(deployment.anchor)),
             CHALLENGE_PERIOD,
             PROOF_PERIOD,
             PROPOSER_BOND,

--- a/pkg/contracts/src/proofs/WorldChainAnchorStateRegistry.sol
+++ b/pkg/contracts/src/proofs/WorldChainAnchorStateRegistry.sol
@@ -81,7 +81,7 @@ contract WorldChainAnchorStateRegistry {
         if (proofGame.anchorStateRegistry() != address(this)) {
             revert InvalidGameRegistry(address(this), proofGame.anchorStateRegistry());
         }
-        if (!IWorldChainProofSystemFactory(factory).isGame(game)) revert UnregisteredGame(game);
+        if (!IWorldChainProofSystemFactory(factory).isFactoryGame(game)) revert UnregisteredGame(game);
 
         if (proofGame.state() != IWorldChainProofSystemGame.RootState.FINALIZED) {
             revert GameNotFinalized(game);

--- a/pkg/contracts/src/proofs/WorldChainAnchorStateRegistry.sol
+++ b/pkg/contracts/src/proofs/WorldChainAnchorStateRegistry.sol
@@ -2,20 +2,29 @@
 pragma solidity 0.8.28;
 
 import {IWorldChainProofSystemGame} from "./interfaces/IWorldChainProofSystemGame.sol";
+import {IWorldChainProofSystemFactory} from "./interfaces/IWorldChainProofSystemFactory.sol";
 
 contract WorldChainAnchorStateRegistry {
     error NotOwner();
+    error InvalidFactory(address factory);
+    error FactoryAlreadyInitialized(address factory);
+    error FactoryNotInitialized();
     error RegistryPaused();
     error GameBlacklisted(address game);
+    error InvalidGameFactory(address expectedFactory, address actualFactory);
+    error InvalidGameRegistry(address expectedRegistry, address actualRegistry);
+    error UnregisteredGame(address game);
     error GameNotFinalized(address game);
     error NonMonotonicRoot(uint256 currentL2BlockNumber, uint256 nextL2BlockNumber);
     error InvalidParent(address parentRef);
 
     event AnchorUpdated(address indexed game, bytes32 indexed rootId, bytes32 rootClaim, uint256 l2BlockNumber);
+    event FactoryInitialized(address indexed factory);
     event PausedSet(bool paused);
     event GameBlacklistedSet(address indexed game, bool blacklisted);
 
     address public owner;
+    address public proofSystemFactory;
     bool public paused;
 
     bytes32 public currentRootId;
@@ -42,6 +51,14 @@ contract WorldChainAnchorStateRegistry {
         owner = nextOwner;
     }
 
+    function initializeFactory(address factory) external onlyOwner {
+        if (factory == address(0)) revert InvalidFactory(factory);
+        if (proofSystemFactory != address(0)) revert FactoryAlreadyInitialized(proofSystemFactory);
+
+        proofSystemFactory = factory;
+        emit FactoryInitialized(factory);
+    }
+
     function setPaused(bool nextPaused) external onlyOwner {
         paused = nextPaused;
         emit PausedSet(nextPaused);
@@ -56,7 +73,16 @@ contract WorldChainAnchorStateRegistry {
         if (paused) revert RegistryPaused();
         if (blacklistedGames[game]) revert GameBlacklisted(game);
 
+        address factory = proofSystemFactory;
+        if (factory == address(0)) revert FactoryNotInitialized();
+
         IWorldChainProofSystemGame proofGame = IWorldChainProofSystemGame(game);
+        if (proofGame.factory() != factory) revert InvalidGameFactory(factory, proofGame.factory());
+        if (proofGame.anchorStateRegistry() != address(this)) {
+            revert InvalidGameRegistry(address(this), proofGame.anchorStateRegistry());
+        }
+        if (!IWorldChainProofSystemFactory(factory).isGame(game)) revert UnregisteredGame(game);
+
         if (proofGame.state() != IWorldChainProofSystemGame.RootState.FINALIZED) {
             revert GameNotFinalized(game);
         }

--- a/pkg/contracts/src/proofs/WorldChainProofSystemFactory.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofSystemFactory.sol
@@ -59,7 +59,7 @@ contract WorldChainProofSystemFactory {
     IWorldChainStakingRegistry public immutable stakingRegistry;
 
     mapping(bytes32 proposalKey => address game) public games;
-    mapping(address game => bool created) public isGame;
+    mapping(address game => bool created) public isFactoryGame;
     address[] private allGames;
 
     constructor(
@@ -151,7 +151,7 @@ contract WorldChainProofSystemFactory {
             )
         );
         games[key] = game;
-        isGame[game] = true;
+        isFactoryGame[game] = true;
         allGames.push(game);
 
         _emitGameCreated(
@@ -203,7 +203,7 @@ contract WorldChainProofSystemFactory {
             startingRootClaim = anchorStateRegistry.currentRootClaim();
             startingL2BlockNumber = anchorStateRegistry.currentL2BlockNumber();
         } else {
-            if (!isGame[parentRef]) revert InvalidParent(parentRef);
+            if (!isFactoryGame[parentRef]) revert InvalidParent(parentRef);
             if (anchorStateRegistry.blacklistedGames(parentRef)) revert ParentGameBlacklisted(parentRef);
 
             IWorldChainProofSystemGame parentGame = IWorldChainProofSystemGame(parentRef);

--- a/pkg/contracts/src/proofs/WorldChainProofSystemFactory.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofSystemFactory.sol
@@ -116,7 +116,14 @@ contract WorldChainProofSystemFactory {
 
         bytes32 key = WorldChainProofLib.proposalKey(domainHash, parentRef, rootClaim, l2BlockNumber);
         address existing = games[key];
-        if (existing != address(0)) revert GameAlreadyExists(key, existing);
+        uint256 attempt;
+        if (existing != address(0)) {
+            IWorldChainProofSystemGame existingGame = IWorldChainProofSystemGame(existing);
+            if (existingGame.state() != IWorldChainProofSystemGame.RootState.INVALIDATED) {
+                revert GameAlreadyExists(key, existing);
+            }
+            attempt = existingGame.attempt() + 1;
+        }
 
         (bytes32 startingRootClaim, uint256 startingL2BlockNumber) = _validateParent(parentRef, l2BlockNumber);
 
@@ -127,7 +134,7 @@ contract WorldChainProofSystemFactory {
                 WorldChainProofSystemGame.ProposalInit({
                     factory: address(this),
                     anchorStateRegistry: address(anchorStateRegistry),
-                    attempt: 0,
+                    attempt: attempt,
                     proposer: msg.sender,
                     parentRef: parentRef,
                     startingRootClaim: startingRootClaim,

--- a/pkg/contracts/src/proofs/WorldChainProofSystemFactory.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofSystemFactory.sol
@@ -200,6 +200,7 @@ contract WorldChainProofSystemFactory {
             revert RegistryFactoryMismatch(address(this), configuredFactory);
         }
 
+        // The registry is the parent sentinel for transitions starting from the current accepted anchor.
         if (parentRef == address(anchorStateRegistry)) {
             startingRootClaim = anchorStateRegistry.currentRootClaim();
             startingL2BlockNumber = anchorStateRegistry.currentL2BlockNumber();

--- a/pkg/contracts/src/proofs/WorldChainProofSystemFactory.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofSystemFactory.sol
@@ -3,12 +3,21 @@ pragma solidity 0.8.28;
 
 import {WorldChainProofLib} from "./WorldChainProofLib.sol";
 import {WorldChainProofSystemGame} from "./WorldChainProofSystemGame.sol";
+import {IWorldChainAnchorStateRegistry} from "./interfaces/IWorldChainAnchorStateRegistry.sol";
 import {IWorldChainProofVerifier} from "./interfaces/IWorldChainProofVerifier.sol";
+import {IWorldChainProofSystemGame} from "./interfaces/IWorldChainProofSystemGame.sol";
 import {IWorldChainStakingRegistry} from "./interfaces/IWorldChainStakingRegistry.sol";
 
 contract WorldChainProofSystemFactory {
     error GameAlreadyExists(bytes32 proposalKey, address game);
     error InvalidActivationParameters();
+    error RegistryPaused();
+    error RegistryFactoryMismatch(address expectedFactory, address actualFactory);
+    error InvalidParent(address parentRef);
+    error InvalidParentState(address parentRef, WorldChainProofLib.RootState state);
+    error ParentGameBlacklisted(address parentRef);
+    error InvalidL2BlockNumber(uint256 expectedL2BlockNumber, uint256 actualL2BlockNumber);
+    error TargetBlockNotNewer(uint256 currentL2BlockNumber, uint256 targetL2BlockNumber);
 
     event GameCreated(
         bytes32 indexed proposalKey,
@@ -36,6 +45,7 @@ contract WorldChainProofSystemFactory {
 
     WorldChainProofLib.Domain public domain;
     bytes32 public immutable domainHash;
+    IWorldChainAnchorStateRegistry public immutable anchorStateRegistry;
 
     uint64 public immutable challengePeriod;
     uint64 public immutable proofPeriod;
@@ -49,9 +59,12 @@ contract WorldChainProofSystemFactory {
     IWorldChainStakingRegistry public immutable stakingRegistry;
 
     mapping(bytes32 proposalKey => address game) public games;
+    mapping(address game => bool created) public isGame;
+    address[] private allGames;
 
     constructor(
         WorldChainProofLib.Domain memory domain_,
+        IWorldChainAnchorStateRegistry anchorStateRegistry_,
         uint64 challengePeriod_,
         uint64 proofPeriod_,
         uint256 proposerBond_,
@@ -64,7 +77,7 @@ contract WorldChainProofSystemFactory {
     ) {
         if (
             challengePeriod_ == 0 || proofPeriod_ == 0 || domain_.chainId == 0 || domain_.proofSystemVersion == 0
-                || domain_.blockInterval == 0 || proofThreshold_ == 0
+                || domain_.blockInterval == 0 || address(anchorStateRegistry_) == address(0) || proofThreshold_ == 0
                 || proofThreshold_ > WorldChainProofLib.PROOF_LANE_COUNT
         ) {
             revert InvalidActivationParameters();
@@ -72,6 +85,7 @@ contract WorldChainProofSystemFactory {
 
         domain = domain_;
         domainHash = WorldChainProofLib.domainHash(domain_);
+        anchorStateRegistry = anchorStateRegistry_;
         challengePeriod = challengePeriod_;
         proofPeriod = proofPeriod_;
         proposerBond = proposerBond_;
@@ -81,6 +95,14 @@ contract WorldChainProofSystemFactory {
         teeVerifier = teeVerifier_;
         securityCouncil = securityCouncil_;
         stakingRegistry = stakingRegistry_;
+    }
+
+    function gameCount() external view returns (uint256) {
+        return allGames.length;
+    }
+
+    function gameAt(uint256 index) external view returns (address) {
+        return allGames[index];
     }
 
     function propose(address parentRef, bytes32 rootClaim, uint256 l2BlockNumber)
@@ -95,13 +117,20 @@ contract WorldChainProofSystemFactory {
         address existing = games[key];
         if (existing != address(0)) revert GameAlreadyExists(key, existing);
 
+        (bytes32 startingRootClaim, uint256 startingL2BlockNumber) = _validateParent(parentRef, l2BlockNumber);
+
         id = WorldChainProofLib.rootId(domainHash, parentRef, rootClaim, l2BlockNumber, l1OriginHash, l1OriginNumber);
 
         game = address(
             new WorldChainProofSystemGame{value: msg.value}(
                 WorldChainProofSystemGame.ProposalInit({
+                    factory: address(this),
+                    anchorStateRegistry: address(anchorStateRegistry),
+                    attempt: 0,
                     proposer: msg.sender,
                     parentRef: parentRef,
+                    startingRootClaim: startingRootClaim,
+                    startingL2BlockNumber: startingL2BlockNumber,
                     rootClaim: rootClaim,
                     l2BlockNumber: l2BlockNumber,
                     l1OriginHash: l1OriginHash,
@@ -122,6 +151,8 @@ contract WorldChainProofSystemFactory {
             )
         );
         games[key] = game;
+        isGame[game] = true;
+        allGames.push(game);
 
         _emitGameCreated(
             GameCreatedLog({
@@ -154,6 +185,54 @@ contract WorldChainProofSystemFactory {
         uint256 l1OriginNumber
     ) external view returns (bytes32) {
         return WorldChainProofLib.rootId(domainHash, parentRef, rootClaim, l2BlockNumber, l1OriginHash, l1OriginNumber);
+    }
+
+    function _validateParent(address parentRef, uint256 l2BlockNumber)
+        private
+        view
+        returns (bytes32 startingRootClaim, uint256 startingL2BlockNumber)
+    {
+        if (anchorStateRegistry.paused()) revert RegistryPaused();
+
+        address configuredFactory = anchorStateRegistry.proofSystemFactory();
+        if (configuredFactory != address(this)) {
+            revert RegistryFactoryMismatch(address(this), configuredFactory);
+        }
+
+        if (parentRef == address(anchorStateRegistry)) {
+            startingRootClaim = anchorStateRegistry.currentRootClaim();
+            startingL2BlockNumber = anchorStateRegistry.currentL2BlockNumber();
+        } else {
+            if (!isGame[parentRef]) revert InvalidParent(parentRef);
+            if (anchorStateRegistry.blacklistedGames(parentRef)) revert ParentGameBlacklisted(parentRef);
+
+            IWorldChainProofSystemGame parentGame = IWorldChainProofSystemGame(parentRef);
+            if (
+                parentGame.factory() != address(this)
+                    || parentGame.anchorStateRegistry() != address(anchorStateRegistry)
+                    || parentGame.domainHash() != domainHash
+            ) {
+                revert InvalidParent(parentRef);
+            }
+
+            IWorldChainProofSystemGame.RootState parentState = parentGame.state();
+            if (parentState == IWorldChainProofSystemGame.RootState.INVALIDATED) {
+                revert InvalidParentState(parentRef, WorldChainProofLib.RootState.INVALIDATED);
+            }
+
+            startingRootClaim = parentGame.rootClaim();
+            startingL2BlockNumber = parentGame.l2BlockNumber();
+        }
+
+        uint256 expectedL2BlockNumber = startingL2BlockNumber + domain.blockInterval;
+        if (l2BlockNumber != expectedL2BlockNumber) {
+            revert InvalidL2BlockNumber(expectedL2BlockNumber, l2BlockNumber);
+        }
+
+        uint256 currentAnchorBlock = anchorStateRegistry.currentL2BlockNumber();
+        if (l2BlockNumber <= currentAnchorBlock) {
+            revert TargetBlockNotNewer(currentAnchorBlock, l2BlockNumber);
+        }
     }
 
     function _emitGameCreated(GameCreatedLog memory log) private {

--- a/pkg/contracts/src/proofs/WorldChainProofSystemFactory.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofSystemFactory.sol
@@ -226,6 +226,7 @@ contract WorldChainProofSystemFactory {
             startingL2BlockNumber = parentGame.l2BlockNumber();
         }
 
+        // TODO(PROTO-4907): Confirm whether proposals require an exact block interval or only a bounded range.
         uint256 expectedL2BlockNumber = startingL2BlockNumber + domain.blockInterval;
         if (l2BlockNumber != expectedL2BlockNumber) {
             revert InvalidL2BlockNumber(expectedL2BlockNumber, l2BlockNumber);

--- a/pkg/contracts/src/proofs/WorldChainProofSystemFactory.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofSystemFactory.sol
@@ -60,6 +60,7 @@ contract WorldChainProofSystemFactory {
 
     mapping(bytes32 proposalKey => address game) public games;
     mapping(address game => bool created) public isFactoryGame;
+    // Lets stateless services reconstruct all games after restart without relying on historical logs.
     address[] private allGames;
 
     constructor(

--- a/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
@@ -9,8 +9,13 @@ contract WorldChainProofSystemGame {
     using WorldChainProofLib for uint8;
 
     struct ProposalInit {
+        address factory;
+        address anchorStateRegistry;
+        uint256 attempt;
         address proposer;
         address parentRef;
+        bytes32 startingRootClaim;
+        uint256 startingL2BlockNumber;
         bytes32 rootClaim;
         uint256 l2BlockNumber;
         bytes32 l1OriginHash;
@@ -53,8 +58,13 @@ contract WorldChainProofSystemGame {
     uint8 public immutable PROOF_THRESHOLD;
     uint8 public constant PROOF_LANE_COUNT = WorldChainProofLib.PROOF_LANE_COUNT;
 
+    address public immutable factory;
+    address public immutable anchorStateRegistry;
+    uint256 public immutable attempt;
     address payable public immutable proposer;
     address public immutable parentRef;
+    bytes32 public immutable startingRootClaim;
+    uint256 public immutable startingL2BlockNumber;
     bytes32 public immutable rootClaim;
     uint256 public immutable l2BlockNumber;
     bytes32 public immutable l1OriginHash;
@@ -87,8 +97,13 @@ contract WorldChainProofSystemGame {
     constructor(ProposalInit memory proposal, ActivationConfig memory config) payable {
         if (msg.value != config.proposerBond) revert InvalidBond(config.proposerBond, msg.value);
 
+        factory = proposal.factory;
+        anchorStateRegistry = proposal.anchorStateRegistry;
+        attempt = proposal.attempt;
         proposer = payable(proposal.proposer);
         parentRef = proposal.parentRef;
+        startingRootClaim = proposal.startingRootClaim;
+        startingL2BlockNumber = proposal.startingL2BlockNumber;
         rootClaim = proposal.rootClaim;
         l2BlockNumber = proposal.l2BlockNumber;
         l1OriginHash = proposal.l1OriginHash;

--- a/pkg/contracts/src/proofs/interfaces/IWorldChainAnchorStateRegistry.sol
+++ b/pkg/contracts/src/proofs/interfaces/IWorldChainAnchorStateRegistry.sol
@@ -2,5 +2,10 @@
 pragma solidity 0.8.28;
 
 interface IWorldChainAnchorStateRegistry {
+    function proofSystemFactory() external view returns (address);
+    function paused() external view returns (bool);
     function currentRootClaim() external view returns (bytes32);
+    function currentL2BlockNumber() external view returns (uint256);
+    function anchorGame() external view returns (address);
+    function blacklistedGames(address game) external view returns (bool);
 }

--- a/pkg/contracts/src/proofs/interfaces/IWorldChainProofSystemFactory.sol
+++ b/pkg/contracts/src/proofs/interfaces/IWorldChainProofSystemFactory.sol
@@ -2,5 +2,5 @@
 pragma solidity 0.8.28;
 
 interface IWorldChainProofSystemFactory {
-    function isGame(address game) external view returns (bool);
+    function isFactoryGame(address game) external view returns (bool);
 }

--- a/pkg/contracts/src/proofs/interfaces/IWorldChainProofSystemFactory.sol
+++ b/pkg/contracts/src/proofs/interfaces/IWorldChainProofSystemFactory.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+interface IWorldChainProofSystemFactory {
+    function isGame(address game) external view returns (bool);
+}

--- a/pkg/contracts/src/proofs/interfaces/IWorldChainProofSystemGame.sol
+++ b/pkg/contracts/src/proofs/interfaces/IWorldChainProofSystemGame.sol
@@ -11,7 +11,13 @@ interface IWorldChainProofSystemGame {
     }
 
     function rootId() external view returns (bytes32);
+    function factory() external view returns (address);
+    function anchorStateRegistry() external view returns (address);
+    function domainHash() external view returns (bytes32);
+    function attempt() external view returns (uint256);
     function parentRef() external view returns (address);
+    function startingRootClaim() external view returns (bytes32);
+    function startingL2BlockNumber() external view returns (uint256);
     function rootClaim() external view returns (bytes32);
     function l2BlockNumber() external view returns (uint256);
     function state() external view returns (RootState);

--- a/pkg/contracts/test/WorldChainProofSystem.t.sol
+++ b/pkg/contracts/test/WorldChainProofSystem.t.sol
@@ -217,6 +217,36 @@ contract WorldChainProofSystemTest is Test {
         factory.propose{value: PROPOSER_BOND}(address(anchor), rootClaim, 10);
     }
 
+    function testFactoryAllowsReplacementAttemptAfterInvalidation() public {
+        bytes32 rootClaim = keccak256("retry-root");
+        bytes32 proposalKey = factory.computeProposalKey(address(anchor), rootClaim, 10);
+
+        vm.prank(proposer);
+        (address firstAddress, bytes32 firstRootId) =
+            factory.propose{value: PROPOSER_BOND}(address(anchor), rootClaim, 10);
+        WorldChainProofSystemGame first = WorldChainProofSystemGame(payable(firstAddress));
+
+        _challenge(first, challenger);
+        vm.warp(block.timestamp + PROOF_PERIOD);
+        first.invalidate();
+        vm.roll(block.number + 1);
+
+        vm.prank(proposer);
+        (address replacementAddress, bytes32 replacementRootId) =
+            factory.propose{value: PROPOSER_BOND}(address(anchor), rootClaim, 10);
+        WorldChainProofSystemGame replacement = WorldChainProofSystemGame(payable(replacementAddress));
+
+        assertNotEq(replacementAddress, firstAddress);
+        assertNotEq(replacementRootId, firstRootId);
+        assertEq(replacement.attempt(), 1);
+        assertEq(factory.games(proposalKey), replacementAddress);
+        assertTrue(factory.isFactoryGame(firstAddress));
+        assertTrue(factory.isFactoryGame(replacementAddress));
+        assertEq(factory.gameCount(), 2);
+        assertEq(factory.gameAt(0), firstAddress);
+        assertEq(factory.gameAt(1), replacementAddress);
+    }
+
     function testFactoryRequiresRegistryInitializationBeforePropose() public {
         WorldChainAnchorStateRegistry uninitializedAnchor = new WorldChainAnchorStateRegistry(bytes32(uint256(1)), 0);
         WorldChainProofSystemFactory uninitializedFactory =

--- a/pkg/contracts/test/WorldChainProofSystem.t.sol
+++ b/pkg/contracts/test/WorldChainProofSystem.t.sol
@@ -7,6 +7,7 @@ import {WorldChainAnchorStateRegistry} from "../src/proofs/WorldChainAnchorState
 import {WorldChainProofLib} from "../src/proofs/WorldChainProofLib.sol";
 import {WorldChainProofSystemFactory} from "../src/proofs/WorldChainProofSystemFactory.sol";
 import {WorldChainProofSystemGame} from "../src/proofs/WorldChainProofSystemGame.sol";
+import {IWorldChainAnchorStateRegistry} from "../src/proofs/interfaces/IWorldChainAnchorStateRegistry.sol";
 import {MockRootIdVerifier} from "../src/proofs/mocks/MockRootIdVerifier.sol";
 import {MockStakingRegistry} from "../src/proofs/mocks/MockStakingRegistry.sol";
 
@@ -42,23 +43,8 @@ contract WorldChainProofSystemTest is Test {
         teeVerifier = new MockRootIdVerifier(false);
         councilVerifier = new MockRootIdVerifier(false);
 
-        factory = new WorldChainProofSystemFactory(
-            WorldChainProofLib.Domain({
-                chainId: 4801,
-                proofSystemVersion: 1,
-                rollupConfigHash: keccak256("world-chain-devnet-rollup-config"),
-                blockInterval: 10
-            }),
-            CHALLENGE_PERIOD,
-            PROOF_PERIOD,
-            PROPOSER_BOND,
-            CHALLENGER_BOND,
-            WorldChainProofLib.PROOF_THRESHOLD,
-            validityVerifier,
-            teeVerifier,
-            councilVerifier,
-            staking
-        );
+        factory = _newFactory(anchor, WorldChainProofLib.PROOF_THRESHOLD);
+        anchor.initializeFactory(address(factory));
     }
 
     function testUnchallengedRootFinalizesAfterChallengePeriod() public {
@@ -117,11 +103,13 @@ contract WorldChainProofSystemTest is Test {
     }
 
     function testThresholdOneFinalizesWithSingleLane() public {
-        WorldChainProofSystemFactory thresholdOne = _thresholdFactory(1);
+        WorldChainAnchorStateRegistry thresholdAnchor = new WorldChainAnchorStateRegistry(bytes32(uint256(1)), 0);
+        WorldChainProofSystemFactory thresholdOne = _newFactory(thresholdAnchor, 1);
+        thresholdAnchor.initializeFactory(address(thresholdOne));
 
         vm.prank(proposer);
         (address gameAddress, bytes32 rootId) =
-            thresholdOne.propose{value: PROPOSER_BOND}(address(anchor), keccak256("threshold-one-root"), 10);
+            thresholdOne.propose{value: PROPOSER_BOND}(address(thresholdAnchor), keccak256("threshold-one-root"), 10);
         WorldChainProofSystemGame game = WorldChainProofSystemGame(payable(gameAddress));
         assertEq(game.PROOF_THRESHOLD(), 1);
 
@@ -133,14 +121,19 @@ contract WorldChainProofSystemTest is Test {
     }
 
     function testFactoryRejectsOutOfRangeThreshold() public {
-        vm.expectRevert(WorldChainProofSystemFactory.InvalidActivationParameters.selector);
-        _thresholdFactory(0);
+        WorldChainAnchorStateRegistry thresholdAnchor = new WorldChainAnchorStateRegistry(bytes32(uint256(1)), 0);
 
         vm.expectRevert(WorldChainProofSystemFactory.InvalidActivationParameters.selector);
-        _thresholdFactory(WorldChainProofLib.PROOF_LANE_COUNT + 1);
+        _newFactory(thresholdAnchor, 0);
+
+        vm.expectRevert(WorldChainProofSystemFactory.InvalidActivationParameters.selector);
+        _newFactory(thresholdAnchor, WorldChainProofLib.PROOF_LANE_COUNT + 1);
     }
 
-    function _thresholdFactory(uint8 threshold) internal returns (WorldChainProofSystemFactory) {
+    function _newFactory(WorldChainAnchorStateRegistry registry, uint8 threshold)
+        internal
+        returns (WorldChainProofSystemFactory)
+    {
         return new WorldChainProofSystemFactory(
             WorldChainProofLib.Domain({
                 chainId: 4801,
@@ -148,6 +141,7 @@ contract WorldChainProofSystemTest is Test {
                 rollupConfigHash: keccak256("world-chain-devnet-rollup-config"),
                 blockInterval: 10
             }),
+            IWorldChainAnchorStateRegistry(address(registry)),
             CHALLENGE_PERIOD,
             PROOF_PERIOD,
             PROPOSER_BOND,
@@ -223,6 +217,72 @@ contract WorldChainProofSystemTest is Test {
         factory.propose{value: PROPOSER_BOND}(address(anchor), rootClaim, 10);
     }
 
+    function testFactoryRequiresRegistryInitializationBeforePropose() public {
+        WorldChainAnchorStateRegistry uninitializedAnchor = new WorldChainAnchorStateRegistry(bytes32(uint256(1)), 0);
+        WorldChainProofSystemFactory uninitializedFactory =
+            _newFactory(uninitializedAnchor, WorldChainProofLib.PROOF_THRESHOLD);
+
+        vm.prank(proposer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                WorldChainProofSystemFactory.RegistryFactoryMismatch.selector, address(uninitializedFactory), address(0)
+            )
+        );
+        uninitializedFactory.propose{value: PROPOSER_BOND}(
+            address(uninitializedAnchor), keccak256("uninitialized-root"), 10
+        );
+    }
+
+    function testRegistryFactoryCanOnlyBeInitializedOnce() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(WorldChainAnchorStateRegistry.FactoryAlreadyInitialized.selector, address(factory))
+        );
+        anchor.initializeFactory(address(0xFACADE));
+    }
+
+    function testFactoryTracksCreatedGamesByIndexAndMembership() public {
+        assertEq(factory.gameCount(), 0);
+
+        (WorldChainProofSystemGame game,) = _propose(10);
+
+        assertEq(factory.gameCount(), 1);
+        assertEq(factory.gameAt(0), address(game));
+        assertTrue(factory.isGame(address(game)));
+        assertEq(game.factory(), address(factory));
+        assertEq(game.anchorStateRegistry(), address(anchor));
+        assertEq(game.attempt(), 0);
+        assertEq(game.startingRootClaim(), anchor.currentRootClaim());
+        assertEq(game.startingL2BlockNumber(), 0);
+    }
+
+    function testFactoryAllowsRegisteredGameParentAtNextInterval() public {
+        (WorldChainProofSystemGame parent,) = _propose(10);
+
+        vm.prank(proposer);
+        (address childAddress,) = factory.propose{value: PROPOSER_BOND}(address(parent), keccak256("child-root"), 20);
+        WorldChainProofSystemGame child = WorldChainProofSystemGame(payable(childAddress));
+
+        assertEq(child.parentRef(), address(parent));
+        assertEq(child.startingRootClaim(), parent.rootClaim());
+        assertEq(child.startingL2BlockNumber(), parent.l2BlockNumber());
+    }
+
+    function testFactoryRejectsUnexpectedBlockInterval() public {
+        vm.prank(proposer);
+        vm.expectRevert(
+            abi.encodeWithSelector(WorldChainProofSystemFactory.InvalidL2BlockNumber.selector, uint256(10), uint256(20))
+        );
+        factory.propose{value: PROPOSER_BOND}(address(anchor), keccak256("wrong-block"), 20);
+    }
+
+    function testFactoryRejectsUnregisteredParent() public {
+        address unknownParent = address(0xFACE);
+
+        vm.prank(proposer);
+        vm.expectRevert(abi.encodeWithSelector(WorldChainProofSystemFactory.InvalidParent.selector, unknownParent));
+        factory.propose{value: PROPOSER_BOND}(unknownParent, keccak256("unknown-parent"), 10);
+    }
+
     function testAnchorUpdatesOnlyAcceptFinalizedMonotonicRoots() public {
         (WorldChainProofSystemGame game,) = _finalizedGame(10);
 
@@ -251,9 +311,29 @@ contract WorldChainProofSystemTest is Test {
         anchor.setPaused(false);
 
         anchor.setAnchorState(address(finalized));
-        (WorldChainProofSystemGame lower,) = _finalizedGame(5);
         vm.expectRevert();
-        anchor.setAnchorState(address(lower));
+        anchor.setAnchorState(address(finalized));
+    }
+
+    function testAnchorRejectsFinalizedGameFromDifferentFactory() public {
+        WorldChainAnchorStateRegistry otherAnchor = new WorldChainAnchorStateRegistry(bytes32(uint256(1)), 0);
+        WorldChainProofSystemFactory otherFactory = _newFactory(otherAnchor, WorldChainProofLib.PROOF_THRESHOLD);
+        otherAnchor.initializeFactory(address(otherFactory));
+
+        vm.prank(proposer);
+        (address gameAddress, bytes32 rootId) =
+            otherFactory.propose{value: PROPOSER_BOND}(address(otherAnchor), keccak256("other-root"), 10);
+        WorldChainProofSystemGame game = WorldChainProofSystemGame(payable(gameAddress));
+        _challenge(game, challenger);
+        game.submitProofLane(uint8(WorldChainProofLib.ProofLane.VALIDITY_PROOF), abi.encode(rootId));
+        game.submitProofLane(uint8(WorldChainProofLib.ProofLane.TEE_ATTESTATION), abi.encode(rootId));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                WorldChainAnchorStateRegistry.InvalidGameFactory.selector, address(factory), address(otherFactory)
+            )
+        );
+        anchor.setAnchorState(address(game));
     }
 
     function _propose(uint256 l2BlockNumber) internal returns (WorldChainProofSystemGame game, bytes32 rootId) {

--- a/pkg/contracts/test/WorldChainProofSystem.t.sol
+++ b/pkg/contracts/test/WorldChainProofSystem.t.sol
@@ -247,7 +247,7 @@ contract WorldChainProofSystemTest is Test {
 
         assertEq(factory.gameCount(), 1);
         assertEq(factory.gameAt(0), address(game));
-        assertTrue(factory.isGame(address(game)));
+        assertTrue(factory.isFactoryGame(address(game)));
         assertEq(game.factory(), address(factory));
         assertEq(game.anchorStateRegistry(), address(anchor));
         assertEq(game.attempt(), 0);


### PR DESCRIPTION
This PR adds:
- One-time factory registration on the anchor registry.
- Authentication of factory-created games through isFactoryGame.
- Parent validation during proposals, including factory, registry, domain, blacklist, state, and block-range checks.
- Immutable transition context on every game, including starting root/block and L1 origin
- Factory enumeration through gameCount() and gameAt() so stateless services can recover after restart.
- Stronger registry checks before accepting finalized games.


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes L1 anchor acceptance and proposal gating for the proof system; misconfiguration or logic bugs could block valid roots or weaken game authentication.
> 
> **Overview**
> **Binds the anchor registry to a single proof factory** and only accepts anchor updates from games that factory created and registered.
> 
> The registry gains one-time owner `initializeFactory`, stores `proofSystemFactory`, and `setAnchorState` now checks the game’s factory/registry match, `factory.isGame(game)`, and existing finalize/parent rules. The factory constructor takes an immutable `IWorldChainAnchorStateRegistry`, tracks `isGame` / `gameCount` / `gameAt`, and runs `_validateParent` on `propose` (registry not paused, factory initialized on registry, valid parent chain, exact `blockInterval` step, target L2 block ahead of current anchor).
> 
> Each game is stamped at deploy with `factory`, `anchorStateRegistry`, `attempt`, and starting anchor/parent root metadata. Devnet deploy calls `initializeFactory` after factory deploy; tests cover init-once, propose without init, parent/interval rules, and cross-factory anchor rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f3387c2548611c136a1f3adc398d79804360d27. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->