### PR TITLE
feat: separate proof acceptance from settlement

### DIFF
--- a/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
@@ -186,6 +186,7 @@ contract WorldChainProofSystemGame {
         proofBitmap |= mask;
         emit ProofLaneSupported(lane, rootId, proofBitmap);
 
+        // Emit only on the transition to settlement-ready so offchain consumers receive a single signal.
         if (!thresholdAlreadyReached && WorldChainProofLib.hasThreshold(proofBitmap, PROOF_THRESHOLD)) {
             emit ProofThresholdReached(rootId, proofBitmap);
         }

--- a/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
@@ -49,6 +49,7 @@ contract WorldChainProofSystemGame {
 
     event Challenged(address indexed challenger, uint64 proofDeadline);
     event ProofLaneSupported(WorldChainProofLib.ProofLane indexed lane, bytes32 indexed rootId, uint8 proofBitmap);
+    event ProofThresholdReached(bytes32 indexed rootId, uint8 proofBitmap);
     event DuplicateProofLane(WorldChainProofLib.ProofLane indexed lane, bytes32 indexed rootId, uint8 proofBitmap);
     event Finalized(bytes32 indexed rootId);
     event Invalidated(bytes32 indexed rootId);
@@ -181,11 +182,12 @@ contract WorldChainProofSystemGame {
             revert InvalidProof(lane, rootId);
         }
 
+        bool thresholdAlreadyReached = WorldChainProofLib.hasThreshold(proofBitmap, PROOF_THRESHOLD);
         proofBitmap |= mask;
         emit ProofLaneSupported(lane, rootId, proofBitmap);
 
-        if (WorldChainProofLib.hasThreshold(proofBitmap, PROOF_THRESHOLD)) {
-            _finalize();
+        if (!thresholdAlreadyReached && WorldChainProofLib.hasThreshold(proofBitmap, PROOF_THRESHOLD)) {
+            emit ProofThresholdReached(rootId, proofBitmap);
         }
     }
 

--- a/pkg/contracts/test/WorldChainProofSystem.t.sol
+++ b/pkg/contracts/test/WorldChainProofSystem.t.sol
@@ -98,6 +98,7 @@ contract WorldChainProofSystemTest is Test {
 
         game.submitProofLane(uint8(WorldChainProofLib.ProofLane.VALIDITY_PROOF), abi.encode(rootId));
 
+        // VALIDITY_PROOF (bit 0) and TEE_ATTESTATION (bit 1) produce the bitmap 0b011.
         vm.expectEmit(true, false, false, true);
         emit WorldChainProofSystemGame.ProofThresholdReached(rootId, 3);
         game.submitProofLane(uint8(WorldChainProofLib.ProofLane.TEE_ATTESTATION), abi.encode(rootId));

--- a/pkg/contracts/test/WorldChainProofSystem.t.sol
+++ b/pkg/contracts/test/WorldChainProofSystem.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.28;
 
 import {Test} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
 
 import {WorldChainAnchorStateRegistry} from "../src/proofs/WorldChainAnchorStateRegistry.sol";
 import {WorldChainProofLib} from "../src/proofs/WorldChainProofLib.sol";
@@ -92,17 +93,29 @@ contract WorldChainProofSystemTest is Test {
         assertEq(uint8(game.state()), uint8(WorldChainProofLib.RootState.CHALLENGED));
     }
 
-    function testProposerDefendsWithTwoDistinctLanes() public {
+    function testProofThresholdDoesNotFinalizeUntilSettlement() public {
         (WorldChainProofSystemGame game, bytes32 rootId) = _proposeAndChallenge(10);
 
         game.submitProofLane(uint8(WorldChainProofLib.ProofLane.VALIDITY_PROOF), abi.encode(rootId));
+
+        vm.expectEmit(true, false, false, true);
+        emit WorldChainProofSystemGame.ProofThresholdReached(rootId, 3);
         game.submitProofLane(uint8(WorldChainProofLib.ProofLane.TEE_ATTESTATION), abi.encode(rootId));
 
         assertEq(game.proofCount(), 2);
+        assertEq(uint8(game.state()), uint8(WorldChainProofLib.RootState.CHALLENGED));
+
+        vm.recordLogs();
+        game.submitProofLane(uint8(WorldChainProofLib.ProofLane.SECURITY_COUNCIL), abi.encode(rootId));
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 1, "threshold event must only be emitted once");
+
+        game.finalize();
+
         assertEq(uint8(game.state()), uint8(WorldChainProofLib.RootState.FINALIZED));
     }
 
-    function testThresholdOneFinalizesWithSingleLane() public {
+    function testThresholdOneRequiresExplicitSettlementAfterSingleLane() public {
         WorldChainAnchorStateRegistry thresholdAnchor = new WorldChainAnchorStateRegistry(bytes32(uint256(1)), 0);
         WorldChainProofSystemFactory thresholdOne = _newFactory(thresholdAnchor, 1);
         thresholdAnchor.initializeFactory(address(thresholdOne));
@@ -117,6 +130,10 @@ contract WorldChainProofSystemTest is Test {
         game.submitProofLane(uint8(WorldChainProofLib.ProofLane.VALIDITY_PROOF), abi.encode(rootId));
 
         assertEq(game.proofCount(), 1);
+        assertEq(uint8(game.state()), uint8(WorldChainProofLib.RootState.CHALLENGED));
+
+        game.finalize();
+
         assertEq(uint8(game.state()), uint8(WorldChainProofLib.RootState.FINALIZED));
     }
 
@@ -357,6 +374,7 @@ contract WorldChainProofSystemTest is Test {
         _challenge(game, challenger);
         game.submitProofLane(uint8(WorldChainProofLib.ProofLane.VALIDITY_PROOF), abi.encode(rootId));
         game.submitProofLane(uint8(WorldChainProofLib.ProofLane.TEE_ATTESTATION), abi.encode(rootId));
+        game.finalize();
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -387,6 +405,7 @@ contract WorldChainProofSystemTest is Test {
         (game, rootId) = _proposeAndChallenge(l2BlockNumber);
         game.submitProofLane(uint8(WorldChainProofLib.ProofLane.VALIDITY_PROOF), abi.encode(rootId));
         game.submitProofLane(uint8(WorldChainProofLib.ProofLane.TEE_ATTESTATION), abi.encode(rootId));
+        game.finalize();
     }
 
     function _challenge(WorldChainProofSystemGame game, address account) internal {


### PR DESCRIPTION
Separate proof acceptance from settlement, in a follow up we will implement a general resolve function

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core dispute-game lifecycle timing and bond payout, so off-chain or on-chain integrations that assumed auto-finalize on the last proof lane must now call `finalize()` explicitly.
> 
> **Overview**
> **Challenged roots no longer auto-finalize when enough proof lanes are accepted.** `submitProofLane` still updates the bitmap and verifies lanes, but crossing `PROOF_THRESHOLD` only emits a new **`ProofThresholdReached`** event (once per game, when the threshold is first met). **Settlement stays on `finalize()`**, which unchanged still requires the threshold in the `CHALLENGED` path before calling `_finalize()`.
> 
> Tests are updated to assert games remain **`CHALLENGED`** after sufficient proofs until an explicit **`finalize()`**, including threshold-one deployments and helper flows used for anchor tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5d17c8a68d2549addf20b83de85eb10d25cad28. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->