### PR TITLE
feat: make nitro sign over TransitionPublicValues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18694,6 +18694,7 @@ name = "world-chain-nitro-worker"
 version = "2.4.0"
 dependencies = [
  "alloy-primitives",
+ "alloy-sol-types",
  "anyhow",
  "async-trait",
  "clap",
@@ -19027,6 +19028,7 @@ name = "world-chain-proof-nitro"
 version = "2.4.0"
 dependencies = [
  "alloy-primitives",
+ "alloy-sol-types",
  "anyhow",
  "aws-nitro-enclaves-nsm-api",
  "base64 0.22.1",

--- a/docs/proof/nitro-worker.md
+++ b/docs/proof/nitro-worker.md
@@ -275,7 +275,7 @@ Here is the full journey from "job available" to "proof accepted":
    checks that the computed `TransitionPublicValues` matches.
 
 9. **Signing commitment computed.** The enclave computes
-   `keccak256(l2_post_root || l2_block_number_be || rollup_config_hash)`.
+   `keccak256(abi.encode(TransitionPublicValues))`.
 
 10. **Signature produced.** The enclave signs the commitment with its ephemeral
     secp256k1 key, applying EIP-2 low-s normalization (required for `ecrecover`
@@ -283,7 +283,7 @@ Here is the full journey from "job available" to "proof accepted":
 
 11. **NSM attestation requested.** The enclave asks the NSM for an attestation
     document with:
-    - `user_data` = `SHA256(l1_head || l2_pre_root || l2_pre_block_number_be || l2_post_root || l2_post_block_number_be || rollup_config_hash)`
+    - `user_data` = `keccak256(abi.encode(TransitionPublicValues))`
     - `nonce` = the caller-supplied nonce
     - `public_key` = the ephemeral secp256k1 public key (33-byte compressed)
 
@@ -304,7 +304,8 @@ Here is the full journey from "job available" to "proof accepted":
 14. **Public values validated.** The worker checks that `TransitionPublicValues` fields match
     the job's expected `root_claim`, `l2_block_number`, `l1_head`, and `rollup_config_hash`.
 
-15. **Proof submitted.** The worker posts `ProofData::Nitro { attestation, signature }`
+15. **Proof submitted.** The worker posts
+    `ProofData::Nitro { attestation, public_values, signature }`
     back to the `prover-service`.
 
 ---
@@ -322,7 +323,7 @@ signature is backed by a certificate chain rooted at the AWS Nitro Root CA. It p
 - **Code identity:** PCR0/1/2 in the attestation identify _exactly which enclave
   image_ produced this document.
 - **Computation output:** The `user_data` field contains
-  `SHA256(l1_head || l2_pre_root || l2_pre_block_number_be || l2_post_root || l2_post_block_number_be || rollup_config_hash)`,
+  `keccak256(abi.encode(TransitionPublicValues))`,
   binding the attestation to the specific state transition.
 - **Key certification:** The `public_key` field contains the enclave's ephemeral
   secp256k1 public key, certifying that this key was generated inside this specific
@@ -332,7 +333,7 @@ signature is backed by a certificate chain rooted at the AWS Nitro Root CA. It p
 
 ### Layer 2: Secp256k1 Signature (ECDSA)
 
-The enclave signs `keccak256(l2_post_root || l2_block_number_be || rollup_config_hash)`
+The enclave signs `keccak256(abi.encode(TransitionPublicValues))`
 with the ephemeral secp256k1 key. This signature is:
 
 - **EVM-native:** Verifiable via `ecrecover` (3,000 gas) — orders of magnitude cheaper
@@ -364,46 +365,17 @@ cert chain validation, done once at key registration) from the **cheap operation
 
 ---
 
-## Commitments: `user_data` vs `signing_commitment`
-
-There are two hash functions because they serve different purposes and face different
-constraints:
-
-### `range_user_data` — SHA-256
+## Transition commitment
 
 ```
-SHA256(l1_head || l2_pre_root || l2_pre_block_number_be || l2_post_root || l2_post_block_number_be || rollup_config_hash)
+keccak256(abi.encode(TransitionPublicValues))
 ```
 
-- **Used in:** The `user_data` field of the NSM attestation document.
-- **Hash algorithm:** SHA-256, because the NSM device accepts arbitrary bytes in
-  `user_data` and SHA-256 is standard for non-EVM contexts.
-- **Includes all transition public values:** Yes — the full attestation commits to the L1
-  derivation context and the complete L2 state transition.
-- **Verified:** Host-side only (during `parse_check_and_verify`). Not used on-chain
-  for per-proof verification.
-
-### `signing_commitment` — keccak256
-
-```
-keccak256(l2_post_root || l2_block_number_be || rollup_config_hash)
-```
-
-- **Used in:** The message signed by the ephemeral secp256k1 key.
-- **Hash algorithm:** keccak256, because `ecrecover` operates on keccak256 hashes
-  natively, and the EVM precompile for keccak256 costs only 30 gas + 6 gas/word.
-- **Omits `l2_pre_root`:** Yes — this makes the commitment reconstructable from
-  minimal post-state fields. The on-chain verifier only needs the claimed output state,
-  not the input state, to verify the signature. The pre-root is implicitly committed
-  via the fault proof's `parentRef`.
-- **Verified:** On-chain in `NitroProofVerifier.verify()` via `ecrecover`.
-
-### Why Two?
-
-The NSM attestation provides a complete audit trail (pre-root + post-root), verified
-host-side with full cert chain validation. The secp256k1 signature provides a minimal,
-EVM-efficient proof artifact. They commit to overlapping but different data because
-their verification contexts have different requirements.
+The canonical commitment includes `l1Head`, both L2 roots and block numbers, and
+`rollupConfigHash`. It is used both as the NSM attestation document's `user_data` and
+as the prehash signed by the enclave's ephemeral secp256k1 key. The host verifies the
+attestation binding, while `NitroProofVerifier` reconstructs the same ABI hash and
+verifies the recoverable signature with `ecrecover`.
 
 ---
 
@@ -489,26 +461,27 @@ verify(rootId, proof)
 NitroProofVerifier
         │
         ├─ 1. ABI-decode proof:
-        │      (domainHash, parentRef, l1OriginHash, l1OriginNumber,
-        │       rollupConfigHash,
-        │       l2PostRoot, l2BlockNumber, signature, expectedPublicKey)
+        │      (domainHash, parentRef, l1OriginNumber,
+        │       transitionPublicValues, signature, expectedPublicKey)
         │
         ├─ 2. Reconstruct rootId from proof fields
         │      └─ Assert reconstructed == supplied rootId
         │
-        ├─ 3. Check expectedPublicKey is registered in NitroEnclaveKeyRegistry
+        ├─ 3. Check l2PreRoot matches parentRef's root claim
+        │
+        ├─ 4. Check expectedPublicKey is registered in NitroEnclaveKeyRegistry
         │      └─ isKeyRegistered(expectedPublicKey) must return true
         │
-        ├─ 4. Compute signing commitment:
-        │      keccak256(l2PostRoot || l2BlockNumber || rollupConfigHash)
+        ├─ 5. Compute signing commitment:
+        │      keccak256(abi.encode(transitionPublicValues))
         │
-        ├─ 5. ecrecover(commitment, signature) → recovered address
+        ├─ 6. ecrecover(commitment, signature) → recovered address
         │      └─ EIP-2 low-s check: reject if s > secp256k1n/2
         │
-        ├─ 6. Compare recovered address with keccak256(expectedPublicKey[1:65])[12:]
+        ├─ 7. Compare recovered address with keccak256(expectedPublicKey[1:65])[12:]
         │      └─ Must match
         │
-        └─ 7. Return true (or false on any failure — never reverts)
+        └─ 8. Return true (or false on any failure — never reverts)
 ```
 
 > **Base comparison:** Base's `SystemConfigGlobal.registerSigner()` performs the same
@@ -888,7 +861,7 @@ When production PCRs are configured, the host performs five verification checks 
 every attestation:
 
 1. **PCR + user_data invariants:** PCR0/1/2 match expected values; `user_data` matches
-   `SHA256(l1_head || l2_pre_root || l2_pre_block_number_be || l2_post_root || l2_post_block_number_be || rollup_config_hash)`.
+   `keccak256(abi.encode(TransitionPublicValues))`.
 2. **COSE_Sign1 signature:** P-384 ECDSA signature verified against the leaf
    certificate's public key.
 3. **Root certificate:** The root of the certificate chain matches the hardcoded

--- a/pkg/contracts/scripts/devnet/DeployNitro.s.sol
+++ b/pkg/contracts/scripts/devnet/DeployNitro.s.sol
@@ -20,6 +20,7 @@ import {NitroProofVerifier} from "../../src/proofs/nitro/NitroProofVerifier.sol"
 ///        - `OWNER` — address that becomes the owner of both
 ///          `NitroAttestationVerifier` (manages the PCR allowlist) and
 ///          `NitroEnclaveKeyRegistry` (revokes keys).
+///        - `ANCHOR_STATE_REGISTRY` — World Chain anchor-state registry.
 ///
 ///      ## Hinted P-384 verification (gas optimisation)
 ///      Signature verification uses off-chain-computed modular-inverse hints
@@ -66,6 +67,7 @@ import {NitroProofVerifier} from "../../src/proofs/nitro/NitroProofVerifier.sol"
 contract DeployNitro is Script {
     function run() external {
         address owner = vm.envAddress("OWNER");
+        address anchorStateRegistry = vm.envAddress("ANCHOR_STATE_REGISTRY");
 
         vm.startBroadcast();
 
@@ -83,7 +85,7 @@ contract DeployNitro is Script {
         NitroEnclaveKeyRegistry registry = new NitroEnclaveKeyRegistry(verifier, owner);
         console.log("NitroEnclaveKeyRegistry:", address(registry));
 
-        NitroProofVerifier proofVerifier = new NitroProofVerifier(registry);
+        NitroProofVerifier proofVerifier = new NitroProofVerifier(registry, anchorStateRegistry);
         console.log("NitroProofVerifier:", address(proofVerifier));
 
         vm.stopBroadcast();

--- a/pkg/contracts/src/proofs/nitro/NitroProofVerifier.sol
+++ b/pkg/contracts/src/proofs/nitro/NitroProofVerifier.sol
@@ -1,29 +1,42 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
+import {IWorldChainAnchorStateRegistry} from "../interfaces/IWorldChainAnchorStateRegistry.sol";
+import {IWorldChainProofSystemGame} from "../interfaces/IWorldChainProofSystemGame.sol";
 import {IWorldChainProofVerifier} from "../interfaces/IWorldChainProofVerifier.sol";
 import {WorldChainProofLib} from "../WorldChainProofLib.sol";
 import {NitroEnclaveKeyRegistry} from "./NitroEnclaveKeyRegistry.sol";
+
+/// ABI-encoded public values signed by the World Chain Nitro enclave.
+/// Must match `world_chain_proof_core::boot::TransitionPublicValues`.
+struct TransitionPublicValues {
+    bytes32 l1Head;
+    bytes32 l2PreRoot;
+    uint64 l2PreBlockNumber;
+    bytes32 l2PostRoot;
+    uint64 l2PostBlockNumber;
+    bytes32 rollupConfigHash;
+}
 
 /// @title NitroProofVerifier
 /// @author Worldcoin
 /// @notice TEE-attestation proof lane verifier compatible with WIP-1006's
 ///         multi-proof system (`IWorldChainProofVerifier`).
 /// @dev The enclave produces an ECDSA (secp256k1) signature over the
-///      `signing_commitment` computed in `proofs/nitro/src/protocol.rs`:
+///      `transition_commitment` computed in `proofs/nitro/src/protocol.rs`:
 ///
-///         signingCommitment =
-///             keccak256( l2PostRoot || uint64BE(l2BlockNumber) || rollupConfigHash )
+///         signingCommitment = keccak256(abi.encode(transitionPublicValues))
 ///
 ///      The `verify` hook — the only public entry point on this contract —:
-///        1. Reconstructs the proposal's `rootId` from the boot-info plus the
+///        1. Reconstructs the proposal's `rootId` from the transition public values plus the
 ///           remaining context fields supplied in the proof and asserts it
 ///           equals the `rootId` the game is asking about. This binds the
 ///           Nitro signature to the *specific* proposal under dispute.
-///        2. Checks that `expectedPublicKey` is currently registered in
+///        2. Binds the transition's pre-root to the parent proposal.
+///        3. Checks that `expectedPublicKey` is currently registered in
 ///           `NitroEnclaveKeyRegistry`.
-///        3. Recomputes the signing commitment from the boot-info fields.
-///        4. Recovers the signer via `ecrecover` and matches it against the
+///        4. Recomputes the signing commitment from all transition public values.
+///        5. Recovers the signer via `ecrecover` and matches it against the
 ///           Ethereum address derived from `expectedPublicKey`.
 ///
 ///      Any decode or verification failure is surfaced as `false` (never
@@ -50,13 +63,18 @@ contract NitroProofVerifier is IWorldChainProofVerifier {
     /// @notice Registry of attested enclave keys.
     NitroEnclaveKeyRegistry public immutable registry;
 
+    /// @notice Anchor-state registry used when the proposal parent is the current anchor.
+    address public immutable anchorStateRegistry;
+
     /*//////////////////////////////////////////////////////////////
                               CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
 
     /// @param registry_ The Nitro enclave key registry to consult.
-    constructor(NitroEnclaveKeyRegistry registry_) {
+    /// @param anchorStateRegistry_ Anchor-state registry used to resolve anchor parent roots.
+    constructor(NitroEnclaveKeyRegistry registry_, address anchorStateRegistry_) {
         registry = registry_;
+        anchorStateRegistry = anchorStateRegistry_;
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -69,11 +87,8 @@ contract NitroProofVerifier is IWorldChainProofVerifier {
     ///        (
     ///            bytes32 domainHash,
     ///            address parentRef,
-    ///            bytes32 l1OriginHash,
     ///            uint256 l1OriginNumber,
-    ///            bytes32 rollupConfigHash,
-    ///            bytes32 l2PostRoot,
-    ///            uint64  l2BlockNumber,
+    ///            TransitionPublicValues transitionPublicValues,
     ///            bytes   signature,
     ///            bytes   expectedPublicKey
     ///        )
@@ -98,30 +113,30 @@ contract NitroProofVerifier is IWorldChainProofVerifier {
         (
             bytes32 domainHash,
             address parentRef,
-            bytes32 l1OriginHash,
             uint256 l1OriginNumber,
-            bytes32 rollupConfigHash,
-            bytes32 l2PostRoot,
-            uint64 l2BlockNumber,
+            TransitionPublicValues memory transition,
             bytes memory signature,
             bytes memory expectedPublicKey
-        ) = abi.decode(proof, (bytes32, address, bytes32, uint256, bytes32, bytes32, uint64, bytes, bytes));
+        ) = abi.decode(proof, (bytes32, address, uint256, TransitionPublicValues, bytes, bytes));
 
         // 1. Bind the proof to the supplied rootId. The transition public values'
         //    `l2PostRoot` plays the role of `rootClaim` (the proposal's
         //    claimed L2 output root) in WorldChainProofLib.rootId.
         bytes32 expectedRootId = WorldChainProofLib.rootId(
-            domainHash, parentRef, l2PostRoot, uint256(l2BlockNumber), l1OriginHash, l1OriginNumber
+            domainHash,
+            parentRef,
+            transition.l2PostRoot,
+            uint256(transition.l2PostBlockNumber),
+            transition.l1Head,
+            l1OriginNumber
         );
         if (expectedRootId != rootId) return false;
 
-        // TODO: if Nitro becomes a production validity lane, extend this proof
-        // payload and the enclave-signed commitment with `l2PreRoot`, then
-        // compare it against the root claim behind `parentRef` as in the SP1 lane.
+        // 2. Bind the signed pre-root to the proposal's parent.
+        if (transition.l2PreRoot != _parentRootClaim(parentRef)) return false;
 
-        // 2. Verify the enclave signature over the signing commitment
-        //    derived from the same transition public value fields.
-        bytes32 commitment = _signingCommitment(l2PostRoot, l2BlockNumber, rollupConfigHash);
+        // 3. Verify the enclave signature over all transition public values.
+        bytes32 commitment = _signingCommitment(transition);
         return _verifyEnclaveSignature(commitment, signature, expectedPublicKey);
     }
 
@@ -130,16 +145,18 @@ contract NitroProofVerifier is IWorldChainProofVerifier {
     //////////////////////////////////////////////////////////////*/
 
     /// @dev Reconstructs the 32-byte commitment the enclave actually signed,
-    ///      matching `signing_commitment(transition_public_values)` in
+    ///      matching `transition_commitment(transition_public_values)` in
     ///      `proofs/nitro/src/protocol.rs`.
-    ///      Layout: `l2PostRoot (32) || uint64BE(l2BlockNumber) (8) ||
-    ///      rollupConfigHash (32)`, hashed with keccak256.
-    function _signingCommitment(bytes32 l2PostRoot, uint64 l2BlockNumber, bytes32 rollupConfigHash)
-        internal
-        pure
-        returns (bytes32)
-    {
-        return keccak256(abi.encodePacked(l2PostRoot, l2BlockNumber, rollupConfigHash));
+    ///      The entire struct is ABI-encoded before hashing.
+    function _signingCommitment(TransitionPublicValues memory transition) internal pure returns (bytes32) {
+        return keccak256(abi.encode(transition));
+    }
+
+    function _parentRootClaim(address parentRef) internal view returns (bytes32) {
+        if (parentRef == anchorStateRegistry) {
+            return IWorldChainAnchorStateRegistry(parentRef).currentRootClaim();
+        }
+        return IWorldChainProofSystemGame(parentRef).rootClaim();
     }
 
     /// @dev Checks that `signature` over `commitment` recovers to the address

--- a/pkg/contracts/src/proofs/nitro/NitroProofVerifier.sol
+++ b/pkg/contracts/src/proofs/nitro/NitroProofVerifier.sol
@@ -56,6 +56,9 @@ contract NitroProofVerifier is IWorldChainProofVerifier {
     ///      Nitro enclave always emits this form.
     error InvalidPublicKey();
 
+    /// @dev Thrown when the anchor-state registry address is zero.
+    error ZeroAnchorStateRegistry();
+
     /*//////////////////////////////////////////////////////////////
                                 STORAGE
     //////////////////////////////////////////////////////////////*/
@@ -73,6 +76,8 @@ contract NitroProofVerifier is IWorldChainProofVerifier {
     /// @param registry_ The Nitro enclave key registry to consult.
     /// @param anchorStateRegistry_ Anchor-state registry used to resolve anchor parent roots.
     constructor(NitroEnclaveKeyRegistry registry_, address anchorStateRegistry_) {
+        if (anchorStateRegistry_ == address(0)) revert ZeroAnchorStateRegistry();
+
         registry = registry_;
         anchorStateRegistry = anchorStateRegistry_;
     }

--- a/pkg/contracts/test/nitro/NitroEndToEnd.t.sol
+++ b/pkg/contracts/test/nitro/NitroEndToEnd.t.sol
@@ -52,6 +52,7 @@ contract NitroEndToEndTest is Test {
     uint64 constant PRE_BLK = 41_999;
     bytes32 constant POST = keccak256("post-root");
     uint64 constant BLK = 42_000;
+    address constant ANCHOR_STATE_REGISTRY = address(0xA11CE);
 
     bytes constant TBS = hex"abcdabcd";
     bytes constant SIG = hex"feedfeed";
@@ -64,7 +65,7 @@ contract NitroEndToEndTest is Test {
         attestationVerifier = new MockNitroAttestationVerifier();
         registry = new NitroEnclaveKeyRegistry(attestationVerifier, owner);
         parent = new EndToEndParentGame(PRE);
-        proofVerifier = new NitroProofVerifier(registry, address(0));
+        proofVerifier = new NitroProofVerifier(registry, ANCHOR_STATE_REGISTRY);
 
         enclaveWallet = vm.createWallet("enclave-integration");
         enclavePubKey = _uncompressedKey(enclaveWallet.publicKeyX, enclaveWallet.publicKeyY);

--- a/pkg/contracts/test/nitro/NitroEndToEnd.t.sol
+++ b/pkg/contracts/test/nitro/NitroEndToEnd.t.sol
@@ -4,10 +4,18 @@ pragma solidity ^0.8.28;
 import {Test, Vm} from "forge-std/Test.sol";
 import {NitroAttestationVerifier} from "../../src/proofs/nitro/NitroAttestationVerifier.sol";
 import {NitroEnclaveKeyRegistry} from "../../src/proofs/nitro/NitroEnclaveKeyRegistry.sol";
-import {NitroProofVerifier} from "../../src/proofs/nitro/NitroProofVerifier.sol";
+import {NitroProofVerifier, TransitionPublicValues} from "../../src/proofs/nitro/NitroProofVerifier.sol";
 import {INitroAttestationVerifier} from "../../src/proofs/nitro/INitroAttestationVerifier.sol";
 import {WorldChainProofLib} from "../../src/proofs/WorldChainProofLib.sol";
 import {MockNitroAttestationVerifier} from "./mocks/MockNitroAttestationVerifier.sol";
+
+contract EndToEndParentGame {
+    bytes32 public rootClaim;
+
+    constructor(bytes32 rootClaim_) {
+        rootClaim = rootClaim_;
+    }
+}
 
 /// @title NitroEndToEndTest
 /// @notice Full pipeline integration test wiring:
@@ -18,7 +26,7 @@ import {MockNitroAttestationVerifier} from "./mocks/MockNitroAttestationVerifier
 /// @dev A truly end-to-end test that goes through a real AWS-signed Nitro
 ///      attestation AND a real `NitroProofVerifier` verification would
 ///      require knowing the enclave's private key (so we could sign a fresh
-///      `signing_commitment`). Since we obviously don't have AWS NSM's
+///      `transition_commitment`). Since we obviously don't have AWS NSM's
 ///      private key, the integration test mocks the attestation step but
 ///      otherwise exercises the registry + proof-verifier code paths exactly
 ///      as they run in production. The PCR-allowlist piece of the
@@ -37,10 +45,11 @@ contract NitroEndToEndTest is Test {
     bytes32 constant PCR2 = bytes32(uint256(0xCAFE));
 
     bytes32 constant DOMAIN = keccak256("worldchain-integration");
-    address constant PARENT = address(0x1234);
     bytes32 constant L1H = keccak256("l1-origin");
     uint256 constant L1N = 7_777;
     bytes32 constant CFG = keccak256("rollup-cfg");
+    bytes32 constant PRE = keccak256("pre-root");
+    uint64 constant PRE_BLK = 41_999;
     bytes32 constant POST = keccak256("post-root");
     uint64 constant BLK = 42_000;
 
@@ -49,11 +58,13 @@ contract NitroEndToEndTest is Test {
 
     Vm.Wallet enclaveWallet;
     bytes enclavePubKey;
+    EndToEndParentGame parent;
 
     function setUp() public {
         attestationVerifier = new MockNitroAttestationVerifier();
         registry = new NitroEnclaveKeyRegistry(attestationVerifier, owner);
-        proofVerifier = new NitroProofVerifier(registry);
+        parent = new EndToEndParentGame(PRE);
+        proofVerifier = new NitroProofVerifier(registry, address(0));
 
         enclaveWallet = vm.createWallet("enclave-integration");
         enclavePubKey = _uncompressedKey(enclaveWallet.publicKeyX, enclaveWallet.publicKeyY);
@@ -69,25 +80,55 @@ contract NitroEndToEndTest is Test {
         }
     }
 
-    function _signCommitment(Vm.Wallet memory w, bytes32 postRoot, uint64 blk, bytes32 cfg)
+    function _transition(bytes32 postRoot, uint64 blk, bytes32 cfg)
+        internal
+        pure
+        returns (TransitionPublicValues memory)
+    {
+        return TransitionPublicValues({
+            l1Head: L1H,
+            l2PreRoot: PRE,
+            l2PreBlockNumber: PRE_BLK,
+            l2PostRoot: postRoot,
+            l2PostBlockNumber: blk,
+            rollupConfigHash: cfg
+        });
+    }
+
+    function _signCommitment(Vm.Wallet memory w, TransitionPublicValues memory transition)
         internal
         returns (bytes memory)
     {
-        bytes32 commitment = keccak256(abi.encodePacked(postRoot, blk, cfg));
+        bytes32 commitment = keccak256(abi.encode(transition));
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(w, commitment);
         return abi.encodePacked(r, s, v);
     }
 
-    function _proof(bytes memory sig, bytes memory pub, bytes32 postRoot, uint64 blk, bytes32 cfg)
+    function _signCommitment(Vm.Wallet memory w, bytes32 postRoot, uint64 blk, bytes32 cfg)
         internal
-        pure
         returns (bytes memory)
     {
-        return abi.encode(DOMAIN, PARENT, L1H, L1N, cfg, postRoot, blk, sig, pub);
+        return _signCommitment(w, _transition(postRoot, blk, cfg));
     }
 
-    function _rootId(bytes32 postRoot, uint64 blk) internal pure returns (bytes32) {
-        return WorldChainProofLib.rootId(DOMAIN, PARENT, postRoot, uint256(blk), L1H, L1N);
+    function _proof(bytes memory sig, bytes memory pub, TransitionPublicValues memory transition)
+        internal
+        view
+        returns (bytes memory)
+    {
+        return abi.encode(DOMAIN, address(parent), L1N, transition, sig, pub);
+    }
+
+    function _proof(bytes memory sig, bytes memory pub, bytes32 postRoot, uint64 blk, bytes32 cfg)
+        internal
+        view
+        returns (bytes memory)
+    {
+        return _proof(sig, pub, _transition(postRoot, blk, cfg));
+    }
+
+    function _rootId(bytes32 postRoot, uint64 blk) internal view returns (bytes32) {
+        return WorldChainProofLib.rootId(DOMAIN, address(parent), postRoot, uint256(blk), L1H, L1N);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/pkg/contracts/test/nitro/NitroProofVerifier.t.sol
+++ b/pkg/contracts/test/nitro/NitroProofVerifier.t.sol
@@ -40,6 +40,7 @@ contract NitroProofVerifierTest is Test {
     bytes32 constant DOMAIN_HASH = keccak256("domain");
     bytes32 constant L1_ORIGIN_HASH = keccak256("l1-origin");
     uint256 constant L1_ORIGIN_NUMBER = 9_001;
+    address constant ANCHOR_STATE_REGISTRY = address(0xA11CE);
 
     Vm.Wallet enclaveWallet;
     bytes enclavePubKey;
@@ -49,7 +50,7 @@ contract NitroProofVerifierTest is Test {
         attestationVerifier = new MockNitroAttestationVerifier();
         registry = new NitroEnclaveKeyRegistry(attestationVerifier, owner);
         parent = new MockParentGame(L2_PRE_ROOT);
-        proofVerifier = new NitroProofVerifier(registry, address(0));
+        proofVerifier = new NitroProofVerifier(registry, ANCHOR_STATE_REGISTRY);
 
         enclaveWallet = vm.createWallet("enclave");
         enclavePubKey = _uncompressedKey(enclaveWallet.publicKeyX, enclaveWallet.publicKeyY);
@@ -112,6 +113,11 @@ contract NitroProofVerifierTest is Test {
     function test_Verify_HappyPath() public {
         bytes memory sig = _sign(_commitment());
         assertTrue(proofVerifier.verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
+    }
+
+    function test_Constructor_RevertsForZeroAnchorStateRegistry() public {
+        vm.expectRevert(NitroProofVerifier.ZeroAnchorStateRegistry.selector);
+        new NitroProofVerifier(registry, address(0));
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/pkg/contracts/test/nitro/NitroProofVerifier.t.sol
+++ b/pkg/contracts/test/nitro/NitroProofVerifier.t.sol
@@ -3,9 +3,17 @@ pragma solidity ^0.8.28;
 
 import {Test, Vm} from "forge-std/Test.sol";
 import {NitroEnclaveKeyRegistry} from "../../src/proofs/nitro/NitroEnclaveKeyRegistry.sol";
-import {NitroProofVerifier} from "../../src/proofs/nitro/NitroProofVerifier.sol";
+import {NitroProofVerifier, TransitionPublicValues} from "../../src/proofs/nitro/NitroProofVerifier.sol";
 import {WorldChainProofLib} from "../../src/proofs/WorldChainProofLib.sol";
 import {MockNitroAttestationVerifier} from "./mocks/MockNitroAttestationVerifier.sol";
+
+contract MockParentGame {
+    bytes32 public rootClaim;
+
+    constructor(bytes32 rootClaim_) {
+        rootClaim = rootClaim_;
+    }
+}
 
 contract NitroProofVerifierTest is Test {
     MockNitroAttestationVerifier attestationVerifier;
@@ -21,24 +29,27 @@ contract NitroProofVerifierTest is Test {
     bytes constant TBS = hex"deadbeef";
     bytes constant SIG = hex"cafebabe";
 
-    // Boot-info fields used to build a signing commitment.
+    // Transition public values used to build a signing commitment.
+    bytes32 constant L2_PRE_ROOT = keccak256("l2-pre-root");
+    uint64 constant L2_PRE_BLOCK = 123_455;
     bytes32 constant L2_POST_ROOT = keccak256("l2-post-root");
     uint64 constant L2_BLOCK = 123_456;
     bytes32 constant ROLLUP_CFG = keccak256("rollup-cfg");
 
     // Context fields needed to rebuild rootId.
     bytes32 constant DOMAIN_HASH = keccak256("domain");
-    address constant PARENT_REF = address(0xBEEF);
     bytes32 constant L1_ORIGIN_HASH = keccak256("l1-origin");
     uint256 constant L1_ORIGIN_NUMBER = 9_001;
 
     Vm.Wallet enclaveWallet;
     bytes enclavePubKey;
+    MockParentGame parent;
 
     function setUp() public {
         attestationVerifier = new MockNitroAttestationVerifier();
         registry = new NitroEnclaveKeyRegistry(attestationVerifier, owner);
-        proofVerifier = new NitroProofVerifier(registry);
+        parent = new MockParentGame(L2_PRE_ROOT);
+        proofVerifier = new NitroProofVerifier(registry, address(0));
 
         enclaveWallet = vm.createWallet("enclave");
         enclavePubKey = _uncompressedKey(enclaveWallet.publicKeyX, enclaveWallet.publicKeyY);
@@ -69,20 +80,29 @@ contract NitroProofVerifierTest is Test {
         return _sign(enclaveWallet, digest);
     }
 
+    function _transition() internal pure returns (TransitionPublicValues memory) {
+        return TransitionPublicValues({
+            l1Head: L1_ORIGIN_HASH,
+            l2PreRoot: L2_PRE_ROOT,
+            l2PreBlockNumber: L2_PRE_BLOCK,
+            l2PostRoot: L2_POST_ROOT,
+            l2PostBlockNumber: L2_BLOCK,
+            rollupConfigHash: ROLLUP_CFG
+        });
+    }
+
     function _commitment() internal pure returns (bytes32) {
-        return keccak256(abi.encodePacked(L2_POST_ROOT, L2_BLOCK, ROLLUP_CFG));
+        return keccak256(abi.encode(_transition()));
     }
 
-    function _expectedRootId() internal pure returns (bytes32) {
+    function _expectedRootId() internal view returns (bytes32) {
         return WorldChainProofLib.rootId(
-            DOMAIN_HASH, PARENT_REF, L2_POST_ROOT, uint256(L2_BLOCK), L1_ORIGIN_HASH, L1_ORIGIN_NUMBER
+            DOMAIN_HASH, address(parent), L2_POST_ROOT, uint256(L2_BLOCK), L1_ORIGIN_HASH, L1_ORIGIN_NUMBER
         );
     }
 
-    function _proofBytes(bytes memory sig, bytes memory pub) internal pure returns (bytes memory) {
-        return abi.encode(
-            DOMAIN_HASH, PARENT_REF, L1_ORIGIN_HASH, L1_ORIGIN_NUMBER, ROLLUP_CFG, L2_POST_ROOT, L2_BLOCK, sig, pub
-        );
+    function _proofBytes(bytes memory sig, bytes memory pub) internal view returns (bytes memory) {
+        return abi.encode(DOMAIN_HASH, address(parent), L1_ORIGIN_NUMBER, _transition(), sig, pub);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -99,7 +119,7 @@ contract NitroProofVerifierTest is Test {
     //////////////////////////////////////////////////////////////*/
 
     function test_Verify_FalseForWrongRootId() public {
-        // Honest signature + boot_info, but the game asks about a different
+        // Honest signature + transition public values, but the game asks about a different
         // rootId — the verifier must NOT validate.
         bytes memory sig = _sign(_commitment());
         assertFalse(proofVerifier.verify(bytes32(uint256(0xdead)), _proofBytes(sig, enclavePubKey)));
@@ -109,25 +129,32 @@ contract NitroProofVerifierTest is Test {
         // The proof claims (L2_POST_ROOT, L2_BLOCK + 1, ROLLUP_CFG) but the
         // signature is over the L2_BLOCK commitment — rootId check still
         // passes for the modified block number? It must not: the signing
-        // commitment is recomputed from the proof's boot_info, so a wrong
+        // commitment is recomputed from the proof's transition public values, so a wrong
         // commitment surfaces as a signature mismatch.
         bytes memory sig = _sign(_commitment());
         // Build a proof with a mismatched block number and a matching rootId.
+        TransitionPublicValues memory wrongTransition = _transition();
+        wrongTransition.l2PostBlockNumber += 1;
         bytes32 wrongRootId = WorldChainProofLib.rootId(
-            DOMAIN_HASH, PARENT_REF, L2_POST_ROOT, uint256(L2_BLOCK + 1), L1_ORIGIN_HASH, L1_ORIGIN_NUMBER
-        );
-        bytes memory proof = abi.encode(
             DOMAIN_HASH,
-            PARENT_REF,
-            L1_ORIGIN_HASH,
-            L1_ORIGIN_NUMBER,
-            ROLLUP_CFG,
+            address(parent),
             L2_POST_ROOT,
-            L2_BLOCK + 1,
-            sig,
-            enclavePubKey
+            uint256(wrongTransition.l2PostBlockNumber),
+            L1_ORIGIN_HASH,
+            L1_ORIGIN_NUMBER
         );
+        bytes memory proof =
+            abi.encode(DOMAIN_HASH, address(parent), L1_ORIGIN_NUMBER, wrongTransition, sig, enclavePubKey);
         assertFalse(proofVerifier.verify(wrongRootId, proof));
+    }
+
+    function test_Verify_FalseForWrongPreRoot() public {
+        bytes memory sig = _sign(_commitment());
+        TransitionPublicValues memory wrongTransition = _transition();
+        wrongTransition.l2PreRoot = keccak256("wrong-pre-root");
+        bytes memory proof =
+            abi.encode(DOMAIN_HASH, address(parent), L1_ORIGIN_NUMBER, wrongTransition, sig, enclavePubKey);
+        assertFalse(proofVerifier.verify(_expectedRootId(), proof));
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -287,21 +314,13 @@ contract NitroProofVerifierTest is Test {
         // Boundary: l2BlockNumber = 0 must work, since the rootId is
         // recomputed deterministically and the commitment is signed over
         // exactly that value.
+        TransitionPublicValues memory transition = _transition();
+        transition.l2PostBlockNumber = 0;
         bytes32 rootId =
-            WorldChainProofLib.rootId(DOMAIN_HASH, PARENT_REF, L2_POST_ROOT, 0, L1_ORIGIN_HASH, L1_ORIGIN_NUMBER);
-        bytes32 commitment = keccak256(abi.encodePacked(L2_POST_ROOT, uint64(0), ROLLUP_CFG));
+            WorldChainProofLib.rootId(DOMAIN_HASH, address(parent), L2_POST_ROOT, 0, L1_ORIGIN_HASH, L1_ORIGIN_NUMBER);
+        bytes32 commitment = keccak256(abi.encode(transition));
         bytes memory sig = _sign(commitment);
-        bytes memory proof = abi.encode(
-            DOMAIN_HASH,
-            PARENT_REF,
-            L1_ORIGIN_HASH,
-            L1_ORIGIN_NUMBER,
-            ROLLUP_CFG,
-            L2_POST_ROOT,
-            uint64(0),
-            sig,
-            enclavePubKey
-        );
+        bytes memory proof = abi.encode(DOMAIN_HASH, address(parent), L1_ORIGIN_NUMBER, transition, sig, enclavePubKey);
         assertTrue(proofVerifier.verify(rootId, proof));
     }
 
@@ -313,22 +332,15 @@ contract NitroProofVerifierTest is Test {
         // recovery to mismatch the expected key and surface as `false`,
         // even though `rootId` still reconstructs correctly.
         bytes32 wrongCfg = keccak256("wrong-cfg");
-        bytes32 commitment = keccak256(abi.encodePacked(L2_POST_ROOT, L2_BLOCK, wrongCfg));
+        TransitionPublicValues memory wrongTransition = _transition();
+        wrongTransition.rollupConfigHash = wrongCfg;
+        bytes32 commitment = keccak256(abi.encode(wrongTransition));
         bytes memory sig = _sign(commitment);
         // Build the proof claiming the ORIGINAL rollupConfigHash (so rootId
         // reconstructs to the expected one), but with a signature over the
         // wrong-cfg commitment.
-        bytes memory proof = abi.encode(
-            DOMAIN_HASH,
-            PARENT_REF,
-            L1_ORIGIN_HASH,
-            L1_ORIGIN_NUMBER,
-            ROLLUP_CFG,
-            L2_POST_ROOT,
-            L2_BLOCK,
-            sig,
-            enclavePubKey
-        );
+        bytes memory proof =
+            abi.encode(DOMAIN_HASH, address(parent), L1_ORIGIN_NUMBER, _transition(), sig, enclavePubKey);
         assertFalse(proofVerifier.verify(_expectedRootId(), proof));
     }
 

--- a/proofs/core/src/boot.rs
+++ b/proofs/core/src/boot.rs
@@ -88,9 +88,8 @@ struct WorldRollupConfigHashInput<'a, T: Serialize + ?Sized> {
 /// blob hashed here. The resulting `rollupConfigHash` is therefore an implicit
 /// domain separator: a Nitro signature whose payload commits to this hash
 /// cannot be replayed on a different chain id. The on-chain
-/// `NitroProofVerifier.signingCommitment(l2PostRoot, l2PostBlockNumber,
-/// rollupConfigHash)` inherits the same property without needing an explicit
-/// `chainId` field in the commitment.
+/// `NitroProofVerifier` commitment over `TransitionPublicValues` inherits the
+/// same property without needing an explicit `chainId` field.
 pub fn hash_world_rollup_config(
     rollup_config: &RollupConfig,
     world_schedule: &WorldRangeHardforkConfig,

--- a/proofs/defender/src/defender.rs
+++ b/proofs/defender/src/defender.rs
@@ -444,8 +444,15 @@ fn encode_proof(proof: &ProofData) -> Bytes {
         } => [public_values.as_ref(), proof.as_ref()].concat().into(),
         ProofData::Nitro {
             attestation,
+            public_values,
             signature,
-        } => [attestation.as_ref(), signature.as_ref()].concat().into(),
+        } => [
+            public_values.as_ref(),
+            attestation.as_ref(),
+            signature.as_ref(),
+        ]
+        .concat()
+        .into(),
     }
 }
 

--- a/proofs/defender/src/tests.rs
+++ b/proofs/defender/src/tests.rs
@@ -229,6 +229,7 @@ impl ProofRequester for MockProver {
             },
             ProofBackend::Nitro => ProofData::Nitro {
                 attestation: Bytes::from_static(b"attestation"),
+                public_values: Bytes::from_static(b"public values"),
                 signature: Bytes::from_static(b"signature"),
             },
         };

--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -540,6 +540,7 @@ impl ClaimedProofJobHandler for FakeProofBackend {
             },
             ProofBackend::Nitro => ProofData::Nitro {
                 attestation: request.l1_head.as_slice().to_vec().into(),
+                public_values: request.root_claim.as_slice().to_vec().into(),
                 signature: vec![0x7e, request.l2_block_number as u8].into(), // mock signature
             },
         })

--- a/proofs/nitro/Cargo.toml
+++ b/proofs/nitro/Cargo.toml
@@ -45,6 +45,7 @@ enclave = [
 [dependencies]
 # Shared (host + enclave) ----------------------------------------------------
 alloy-primitives = { workspace = true, features = ["serde"] }
+alloy-sol-types.workspace = true
 anyhow.workspace = true
 base64 = { workspace = true }
 ciborium = "0.2"

--- a/proofs/nitro/src/bin/test_attestation.rs
+++ b/proofs/nitro/src/bin/test_attestation.rs
@@ -10,7 +10,7 @@ use world_chain_proof_nitro::{
     ExpectedPcrs, NitroRangeProofRequest,
     attestation::parse_and_check_pcrs,
     host::{EnclaveEndpoint, NitroProver},
-    protocol::range_user_data,
+    protocol::transition_commitment,
 };
 
 #[cfg(target_os = "linux")]
@@ -63,7 +63,7 @@ async fn main() -> anyhow::Result<()> {
         "received artifact"
     );
 
-    let expected_user_data = range_user_data(&artifact.transition_public_values);
+    let expected_user_data = transition_commitment(&artifact.transition_public_values);
     parse_and_check_pcrs(
         &artifact.attestation_doc,
         &expected_pcrs,

--- a/proofs/nitro/src/enclave.rs
+++ b/proofs/nitro/src/enclave.rs
@@ -17,7 +17,7 @@
 //!   [`EnclaveRequest::PublicKey`], binding it to the enclave's PCR measurements.
 //!
 //! Every [`EnclaveResponse::Range`] includes a 65-byte recoverable secp256k1 signature over
-//! `keccak256(l2_post_root ‖ l2_post_block_number_be ‖ rollup_config_hash)`.
+//! `keccak256(abi.encode(TransitionPublicValues))`.
 
 use std::sync::{Arc, OnceLock};
 
@@ -146,11 +146,11 @@ fn signing_key() -> &'static SigningKey {
 
 /// Computes the signing commitment and produces a 65-byte recoverable secp256k1 signature.
 ///
-/// Commitment: `keccak256(l2_post_root ‖ l2_post_block_number_be ‖ rollup_config_hash)`
+/// Commitment: `keccak256(abi.encode(TransitionPublicValues))`
 fn sign_transition_public_values(
     transition_public_values: &TransitionPublicValues,
 ) -> Result<Vec<u8>> {
-    let commitment = protocol::signing_commitment(transition_public_values);
+    let commitment = protocol::transition_commitment(transition_public_values);
 
     let (sig, rec_id) = signing_key()
         .sign_prehash_recoverable(&commitment)
@@ -291,7 +291,7 @@ async fn handle_range(
 
     let signature = sign_transition_public_values(&transition_public_values)?;
 
-    let user_data = protocol::range_user_data(&transition_public_values);
+    let user_data = protocol::transition_commitment(&transition_public_values);
     let attestation_doc = request_attestation_doc(Some(&user_data), &nonce)?;
 
     Ok(EnclaveResponse::Range {

--- a/proofs/nitro/src/host.rs
+++ b/proofs/nitro/src/host.rs
@@ -156,7 +156,7 @@ impl NitroProver {
         // the enclave's ephemeral public key, so a single AWS-signed document certifies both.
         // Skipped in placeholder / dev mode.
         if !self.expected_pcrs.is_placeholder() {
-            let expected_user_data = protocol::range_user_data(&transition_public_values);
+            let expected_user_data = protocol::transition_commitment(&transition_public_values);
             attestation::parse_check_and_verify(
                 &attestation_doc,
                 &self.expected_pcrs,
@@ -181,7 +181,7 @@ impl NitroProver {
 }
 
 /// Verifies the enclave's 65-byte recoverable secp256k1 signature over
-/// `signing_commitment(transition_public_values)` and checks that the recovered key matches
+/// `transition_commitment(transition_public_values)` and checks that the recovered key matches
 /// `expected_pub_key` (the uncompressed SEC1-encoded public key, `0x04 || X || Y`,
 /// from the key-attestation document).
 ///
@@ -200,7 +200,7 @@ fn verify_proof_signature(
             signature.len()
         )));
     }
-    let commitment = protocol::signing_commitment(transition_public_values);
+    let commitment = protocol::transition_commitment(transition_public_values);
     let sig = K256Signature::from_slice(&signature[..64])
         .map_err(|e| NitroProverError::InvalidSignature(e.to_string()))?;
     // Enclave encodes v as EVM-style (27 or 28); convert back to 0/1 for k256.

--- a/proofs/nitro/src/lib.rs
+++ b/proofs/nitro/src/lib.rs
@@ -150,39 +150,29 @@ pub struct NitroRangeProofArtifact {
     pub transition_public_values: TransitionPublicValues,
     /// `COSE_Sign1` attestation document bytes returned by the Nitro NSM device.
     ///
-    /// The document's `user_data` field commits to [`protocol::range_user_data`] of the
+    /// The document's `user_data` field commits to [`protocol::transition_commitment`] of the
     /// transition public values, binding the attestation to this specific transition.
     pub attestation_doc: Vec<u8>,
     /// 65-byte recoverable secp256k1 signature over
-    /// `keccak256(l2_post_root || l2_post_block_number_be || rollup_config_hash)`.
+    /// `keccak256(abi.encode(TransitionPublicValues))`.
     ///
     /// Produced by the enclave's ephemeral signing key, which is certified by the NSM
     /// attestation document. Enables EVM-native on-chain signature recovery.
     pub signature: Vec<u8>,
 }
 
-/// Convenience hash used to bind transition public values into the attestation `user_data` field.
+/// Canonical transition commitment used for attestation and signing.
 ///
-/// `SHA256(l1_head || l2_pre_root || l2_pre_block_number_be || l2_post_root ||
-/// l2_post_block_number_be || rollup_config_hash)`
+/// `keccak256(abi.encode(TransitionPublicValues))`
 #[must_use]
-pub fn range_user_data(transition_public_values: &TransitionPublicValues) -> [u8; 32] {
-    protocol::range_user_data(transition_public_values)
-}
-
-/// Convenience re-export of the enclave signing commitment.
-///
-/// `keccak256(l2_post_root || l2_post_block_number_be || rollup_config_hash)`
-#[must_use]
-pub fn signing_commitment(transition_public_values: &TransitionPublicValues) -> [u8; 32] {
-    protocol::signing_commitment(transition_public_values)
+pub fn transition_commitment(transition_public_values: &TransitionPublicValues) -> [u8; 32] {
+    protocol::transition_commitment(transition_public_values)
 }
 
 /// Re-exports of common host-facing types so callers can do `use world_chain_proof_nitro::*`.
 pub mod prelude {
     pub use crate::{
-        ExpectedPcrs, NitroRangeProofArtifact, NitroRangeProofRequest, range_user_data,
-        signing_commitment,
+        ExpectedPcrs, NitroRangeProofArtifact, NitroRangeProofRequest, transition_commitment,
     };
     #[cfg(all(feature = "enclave", target_os = "linux"))]
     pub use crate::{NitroProver, NitroProverError};
@@ -196,7 +186,7 @@ mod tests {
     use crate::{
         ExpectedPcrs, NitroRangeProofArtifact, PCR_LEN,
         attestation::{AttestationError, parse_and_check_pcrs},
-        protocol::range_user_data,
+        protocol::transition_commitment,
     };
 
     /// Builds a minimal synthetic COSE_Sign1 attestation document suitable for unit tests.
@@ -276,7 +266,7 @@ mod tests {
     #[test]
     fn range_artifact_user_data_binds_transition_public_values() {
         let transition_public_values = transition_public_values();
-        let user_data = range_user_data(&transition_public_values);
+        let user_data = transition_commitment(&transition_public_values);
         let attestation_doc = make_attestation_doc(&test_pcrs(), &user_data);
 
         let artifact = NitroRangeProofArtifact {
@@ -285,7 +275,7 @@ mod tests {
             signature: vec![],
         };
 
-        let expected_user_data = range_user_data(&artifact.transition_public_values);
+        let expected_user_data = transition_commitment(&artifact.transition_public_values);
         parse_and_check_pcrs(
             &artifact.attestation_doc,
             &test_expected_pcrs(),
@@ -297,13 +287,13 @@ mod tests {
     #[test]
     fn tampered_transition_public_values_fail_user_data_check() {
         let transition_public_values = transition_public_values();
-        let user_data = range_user_data(&transition_public_values);
+        let user_data = transition_commitment(&transition_public_values);
         let attestation_doc = make_attestation_doc(&test_pcrs(), &user_data);
 
         let mut tampered = transition_public_values;
         tampered.l2PostRoot = B256::from([9; 32]);
 
-        let expected_user_data = range_user_data(&tampered);
+        let expected_user_data = transition_commitment(&tampered);
         let err =
             parse_and_check_pcrs(&attestation_doc, &test_expected_pcrs(), &expected_user_data)
                 .unwrap_err();
@@ -314,7 +304,7 @@ mod tests {
     #[test]
     fn wrong_pcrs_fail_verification() {
         let transition_public_values = transition_public_values();
-        let user_data = range_user_data(&transition_public_values);
+        let user_data = transition_commitment(&transition_public_values);
         // Document carries PCR0 = 0x03; we verify against a different non-zero value.
         let attestation_doc = make_attestation_doc(&test_pcrs(), &user_data);
 
@@ -334,7 +324,7 @@ mod tests {
     #[test]
     fn placeholder_pcrs_are_rejected() {
         let transition_public_values = transition_public_values();
-        let user_data = range_user_data(&transition_public_values);
+        let user_data = transition_commitment(&transition_public_values);
         let attestation_doc = make_attestation_doc(&[[0u8; PCR_LEN]; 3], &user_data);
 
         let err = parse_and_check_pcrs(&attestation_doc, &ExpectedPcrs::PLACEHOLDER, &user_data)

--- a/proofs/nitro/src/protocol.rs
+++ b/proofs/nitro/src/protocol.rs
@@ -8,13 +8,14 @@
 //! program already consumes.
 
 use alloy_primitives::B256;
+use alloy_sol_types::SolValue;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use world_chain_proof_core::boot::TransitionPublicValues;
 
 /// Current protocol version. Bumped whenever the wire format changes incompatibly.
-pub const PROTOCOL_VERSION: u32 = 4;
+pub const PROTOCOL_VERSION: u32 = 5;
 
 /// Default vsock port the enclave binary listens on.
 pub const DEFAULT_VSOCK_PORT: u32 = 5005;
@@ -64,8 +65,7 @@ pub enum EnclaveResponse {
         transition_public_values: TransitionPublicValues,
         /// `COSE_Sign1` attestation document bytes from the NSM device.
         attestation_doc: Vec<u8>,
-        /// 65-byte recoverable secp256k1 signature over
-        /// `keccak256(l2_post_root || l2_post_block_number_be || rollup_config_hash)`.
+        /// 65-byte recoverable secp256k1 signature over the ABI-encoded transition public values.
         ///
         /// The signing key is the enclave's ephemeral keypair, whose public key is
         /// certified by the NSM attestation document via [`EnclaveRequest::PublicKey`].
@@ -96,26 +96,6 @@ pub enum EnclaveResponse {
         /// Human-readable error message produced inside the enclave.
         message: String,
     },
-}
-
-/// Computes the 32-byte `user_data` that the enclave embeds in the attestation request when
-/// signing a range proof. Binding this commits the attestation to the exact transition.
-///
-/// `SHA256(l1_head || l2_pre_root || l2_pre_block_number_be || l2_post_root ||
-/// l2_post_block_number_be || rollup_config_hash)`
-#[must_use]
-pub fn range_user_data(transition_public_values: &TransitionPublicValues) -> [u8; 32] {
-    let mut hasher = Sha256::new();
-    hasher.update(transition_public_values.l1Head.as_slice());
-    hasher.update(transition_public_values.l2PreRoot.as_slice());
-    hasher.update(transition_public_values.l2PreBlockNumber.to_be_bytes());
-    hasher.update(transition_public_values.l2PostRoot.as_slice());
-    hasher.update(transition_public_values.l2PostBlockNumber.to_be_bytes());
-    hasher.update(transition_public_values.rollupConfigHash.as_slice());
-    let out = hasher.finalize();
-    let mut user_data = [0u8; 32];
-    user_data.copy_from_slice(out.as_slice());
-    user_data
 }
 
 /// Writes a length-prefixed CBOR frame.
@@ -175,20 +155,12 @@ pub enum FrameError {
     FrameTooLarge(usize),
 }
 
-/// Computes the 32-byte commitment the enclave signs with its ephemeral secp256k1 key.
+/// Computes the canonical commitment used for attestation and signing.
 ///
-/// `keccak256(l2_post_root || l2_post_block_number_be || rollup_config_hash)`
-///
-/// Unlike [`range_user_data`] (which uses SHA-256 and includes `l2_pre_root`), this
-/// commitment uses keccak256 for EVM-native verifiability and omits `l2_pre_root` so it
-/// can be reconstructed from only the minimal post-state fields.
+/// `keccak256(abi.encode(TransitionPublicValues))`
 #[must_use]
-pub fn signing_commitment(transition_public_values: &TransitionPublicValues) -> [u8; 32] {
-    let mut buf = Vec::with_capacity(32 + 8 + 32);
-    buf.extend_from_slice(transition_public_values.l2PostRoot.as_slice());
-    buf.extend_from_slice(&transition_public_values.l2PostBlockNumber.to_be_bytes());
-    buf.extend_from_slice(transition_public_values.rollupConfigHash.as_slice());
-    *alloy_primitives::keccak256(&buf)
+pub fn transition_commitment(transition_public_values: &TransitionPublicValues) -> [u8; 32] {
+    *alloy_primitives::keccak256(transition_public_values.abi_encode())
 }
 
 /// Hashes an arbitrary byte slice and returns it as a 32-byte `B256`.
@@ -216,35 +188,44 @@ mod tests {
     }
 
     #[test]
-    fn range_user_data_is_deterministic() {
-        let a = range_user_data(&transition_public_values());
-        let b = range_user_data(&transition_public_values());
+    fn transition_commitment_is_deterministic() {
+        let a = transition_commitment(&transition_public_values());
+        let b = transition_commitment(&transition_public_values());
         assert_eq!(a, b);
     }
 
     #[test]
-    fn range_user_data_depends_on_post_root() {
+    fn transition_commitment_depends_on_post_root() {
         let mut transition_public_values = transition_public_values();
-        let original = range_user_data(&transition_public_values);
+        let original = transition_commitment(&transition_public_values);
         transition_public_values.l2PostRoot = B256::from([9; 32]);
-        let mutated = range_user_data(&transition_public_values);
+        let mutated = transition_commitment(&transition_public_values);
         assert_ne!(original, mutated);
     }
 
     #[test]
-    fn range_user_data_depends_on_l1_head_and_block_numbers() {
-        let original = range_user_data(&transition_public_values());
+    fn transition_commitment_depends_on_l1_head_and_block_numbers() {
+        let original = transition_commitment(&transition_public_values());
 
         let mut changed_l1_head = transition_public_values();
         changed_l1_head.l1Head = B256::from([9; 32]);
-        assert_ne!(original, range_user_data(&changed_l1_head));
+        assert_ne!(original, transition_commitment(&changed_l1_head));
 
         let mut changed_pre_block = transition_public_values();
         changed_pre_block.l2PreBlockNumber += 1;
-        assert_ne!(original, range_user_data(&changed_pre_block));
+        assert_ne!(original, transition_commitment(&changed_pre_block));
 
         let mut changed_post_block = transition_public_values();
         changed_post_block.l2PostBlockNumber += 1;
-        assert_ne!(original, range_user_data(&changed_post_block));
+        assert_ne!(original, transition_commitment(&changed_post_block));
+    }
+
+    #[test]
+    fn transition_commitment_hashes_abi_encoded_public_values() {
+        let values = transition_public_values();
+        assert_eq!(
+            transition_commitment(&values),
+            *alloy_primitives::keccak256(values.abi_encode())
+        );
     }
 }

--- a/proofs/nitro/worker/Cargo.toml
+++ b/proofs/nitro/worker/Cargo.toml
@@ -31,6 +31,7 @@ world-chain-chainspec.workspace = true
 
 # Alloy types
 alloy-primitives = { workspace = true, features = ["serde"] }
+alloy-sol-types.workspace = true
 
 # Async / runtime
 tokio = { workspace = true, features = ["full", "signal"] }

--- a/proofs/nitro/worker/src/lib.rs
+++ b/proofs/nitro/worker/src/lib.rs
@@ -16,13 +16,14 @@
 //!  │  NitroProver::prove_range  ────────────► Nitro Enclave                              │
 //!  │       │                                  (vsock / PCR-pinned)                       │
 //!  │       ▼                                                                              │
-//!  │  prover_submitProof(Nitro { attestation, signature })                               │
+//!  │  prover_submitProof(Nitro { attestation, public_values, signature })                │
 //!  └──────────────────────────────────────────────────────────────────────────────────────┘
 //! ```
 
 #![cfg(target_os = "linux")]
 
 use alloy_primitives::Bytes;
+use alloy_sol_types::SolValue;
 use anyhow::{Context, Result, anyhow, bail};
 use tracing::info;
 use world_chain_proof_kona_host_utils::online::{
@@ -143,6 +144,7 @@ impl ClaimedProofJobHandler for NitroBackend {
 
         Ok(ProofData::Nitro {
             attestation: Bytes::from(artifact.attestation_doc),
+            public_values: artifact.transition_public_values.abi_encode().into(),
             signature: Bytes::from(artifact.signature),
         })
     }

--- a/proofs/prover-nitro/src/main.rs
+++ b/proofs/prover-nitro/src/main.rs
@@ -114,7 +114,7 @@ async fn nitro_prove(args: NitroArgs) -> Result<()> {
         ExpectedPcrs, NitroRangeProofRequest,
         attestation::parse_and_check_pcrs,
         host::{EnclaveEndpoint, NitroProver},
-        protocol::range_user_data,
+        protocol::transition_commitment,
     };
     use world_chain_prover::{build_range_input_from_args, write_json};
 
@@ -161,7 +161,7 @@ async fn nitro_prove(args: NitroArgs) -> Result<()> {
         block = artifact.transition_public_values.l2PostBlockNumber,
     );
 
-    let expected_user_data = range_user_data(&artifact.transition_public_values);
+    let expected_user_data = transition_commitment(&artifact.transition_public_values);
     parse_and_check_pcrs(
         &artifact.attestation_doc,
         &expected_pcrs,

--- a/proofs/prover-service/src/tests.rs
+++ b/proofs/prover-service/src/tests.rs
@@ -68,6 +68,7 @@ fn proof_for(req: &ProofRequest) -> SucceededProofResponse {
         },
         ProofBackend::Nitro => ProofData::Nitro {
             attestation: Bytes::from(vec![0xcc]),
+            public_values: Bytes::from(vec![0xee]),
             signature: Bytes::from(vec![0xdd]),
         },
     };
@@ -291,6 +292,7 @@ async fn submit_proof_with_wrong_backend_is_rejected() {
         id,
         proof: ProofData::Nitro {
             attestation: Bytes::from(vec![0xcc]),
+            public_values: Bytes::from(vec![0xee]),
             signature: Bytes::from(vec![0xdd]),
         },
     };

--- a/proofs/prover-service/src/types.rs
+++ b/proofs/prover-service/src/types.rs
@@ -197,6 +197,8 @@ pub enum ProofData {
     Nitro {
         /// Attestation document produced by the enclave.
         attestation: Bytes,
+        /// ABI-encoded transition public values signed by the enclave.
+        public_values: Bytes,
         /// Enclave signature over the proven outputs.
         signature: Bytes,
     },


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4906/create-transitionpublicvalues-and-sp1aggregationpublicvalues and https://linear.app/worldcoin/issue/PROTO-4887/multi-proof-system-investigate-and-potentially-extend

This PR makes Nitro prover sign over the same `TransitionPublicValues` struct that sp1 range proof is using.

There were some inaccuracies in the previous separation between `signing_commitment` and `range_user_data`:

- `ecrecover` doesn't work only for keccak, it just performs a ecdsa public key recovery function
- claiming the pre-root was “implicitly committed via parentRef” was incomplete because the verifier did not actually compare the signed pre-root against the parent.

Further, I think it's in general better to use a single source of trust. `TransitionPublicValues` is the best struct to represent a state transition between old and new state.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes cryptographic commitments, Nitro dispute-game proof ABI, and on-chain verification logic including parent-root binding—security-critical fault-proof infrastructure with a breaking protocol bump.
> 
> **Overview**
> Nitro proving now uses one **`TransitionPublicValues`** commitment—`keccak256(abi.encode(...))`—for NSM `user_data`, enclave secp256k1 signing, host checks, and on-chain `ecrecover`, replacing the old split between SHA-256 `range_user_data` and a narrower post-state `signing_commitment`. The enclave wire protocol bumps to **v5**, and workers submit **`ProofData::Nitro`** with ABI-encoded `public_values` alongside attestation and signature.
> 
> **`NitroProofVerifier`** decodes a full `TransitionPublicValues` tuple, recomputes `rootId` from it, and **requires `l2PreRoot` to match the parent proposal’s root claim** (parent game or anchor-state registry). Deploy takes **`ANCHOR_STATE_REGISTRY`**. Docs and contract/integration tests follow the new proof layout and parent binding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6638ec833376d4eb06097c8540344ebfc7f32b85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->