### PR TITLE
chore: reset nitro protocol version to 1

### DIFF
--- a/proofs/nitro/src/protocol.rs
+++ b/proofs/nitro/src/protocol.rs
@@ -15,7 +15,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use world_chain_proof_core::boot::TransitionPublicValues;
 
 /// Current protocol version. Bumped whenever the wire format changes incompatibly.
-pub const PROTOCOL_VERSION: u32 = 5;
+pub const PROTOCOL_VERSION: u32 = 1;
 
 /// Default vsock port the enclave binary listens on.
 pub const DEFAULT_VSOCK_PORT: u32 = 5005;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single constant change with no auth or proof logic edits; risk is operational mismatch if host and enclave binaries are not upgraded together.
> 
> **Overview**
> Resets the Nitro host–enclave **`PROTOCOL_VERSION`** constant from **5** to **1** in `protocol.rs`, establishing a fresh baseline for the CBOR wire format.
> 
> Host and enclave already negotiate this value on **`EnclaveRequest::Range`** (host sends `version`, enclave rejects mismatches via `check_version`). **Deploy host and enclave images together** after this change—mixed versions will fail range proofs with an unsupported-protocol error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5c20bcad04874a7680778a86c1449a95865cfc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->