### PR TITLE
feat: bind transition public values to proof games

### DIFF
--- a/pkg/contracts/scripts/devnet/DeployNitro.s.sol
+++ b/pkg/contracts/scripts/devnet/DeployNitro.s.sol
@@ -20,7 +20,6 @@ import {NitroProofVerifier} from "../../src/proofs/nitro/NitroProofVerifier.sol"
 ///        - `OWNER` — address that becomes the owner of both
 ///          `NitroAttestationVerifier` (manages the PCR allowlist) and
 ///          `NitroEnclaveKeyRegistry` (revokes keys).
-///        - `ANCHOR_STATE_REGISTRY` — World Chain anchor-state registry.
 ///
 ///      ## Hinted P-384 verification (gas optimisation)
 ///      Signature verification uses off-chain-computed modular-inverse hints
@@ -67,7 +66,6 @@ import {NitroProofVerifier} from "../../src/proofs/nitro/NitroProofVerifier.sol"
 contract DeployNitro is Script {
     function run() external {
         address owner = vm.envAddress("OWNER");
-        address anchorStateRegistry = vm.envAddress("ANCHOR_STATE_REGISTRY");
 
         vm.startBroadcast();
 
@@ -78,14 +76,15 @@ contract DeployNitro is Script {
         CertManager certManager = new CertManager(IP384Verifier(address(p384Verifier)));
         console.log("CertManager:", address(certManager));
 
-        NitroAttestationVerifier verifier =
-            new NitroAttestationVerifier(ICertManager(address(certManager)), IP384Verifier(address(p384Verifier)), owner);
+        NitroAttestationVerifier verifier = new NitroAttestationVerifier(
+            ICertManager(address(certManager)), IP384Verifier(address(p384Verifier)), owner
+        );
         console.log("NitroAttestationVerifier:", address(verifier));
 
         NitroEnclaveKeyRegistry registry = new NitroEnclaveKeyRegistry(verifier, owner);
         console.log("NitroEnclaveKeyRegistry:", address(registry));
 
-        NitroProofVerifier proofVerifier = new NitroProofVerifier(registry, anchorStateRegistry);
+        NitroProofVerifier proofVerifier = new NitroProofVerifier(registry);
         console.log("NitroProofVerifier:", address(proofVerifier));
 
         vm.stopBroadcast();

--- a/pkg/contracts/src/proofs/WorldChainProofLib.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofLib.sol
@@ -36,6 +36,17 @@ library WorldChainProofLib {
         uint256 blockInterval;
     }
 
+    /// ABI-encoded public values shared by all transition proof lanes.
+    /// Must match `world_chain_proof_core::boot::TransitionPublicValues`.
+    struct TransitionPublicValues {
+        bytes32 l1Head;
+        bytes32 l2PreRoot;
+        uint64 l2PreBlockNumber;
+        bytes32 l2PostRoot;
+        uint64 l2PostBlockNumber;
+        bytes32 rollupConfigHash;
+    }
+
     function domainHash(Domain memory domain) internal pure returns (bytes32) {
         return
             keccak256(

--- a/pkg/contracts/src/proofs/WorldChainProofVerificationLib.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofVerificationLib.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.28;
 
 import {IWorldChainProofSystemGame} from "./interfaces/IWorldChainProofSystemGame.sol";
+import {IWorldChainProofSystemFactory} from "./interfaces/IWorldChainProofSystemFactory.sol";
 import {WorldChainProofLib} from "./WorldChainProofLib.sol";
 
 library WorldChainProofVerificationLib {
@@ -25,8 +26,19 @@ library WorldChainProofVerificationLib {
         if (expectedRootId != rootId) return false;
 
         IWorldChainProofSystemGame game = IWorldChainProofSystemGame(gameAddress);
-        return game.rootId() == rootId && game.domainHash() == domainHash && game.parentRef() == parentRef
-            && game.startingRootClaim() == transition.l2PreRoot
+        if (game.rootId() != rootId || game.domainHash() != domainHash || game.parentRef() != parentRef) return false;
+
+        (uint256 chainId, uint256 proofSystemVersion, bytes32 rollupConfigHash, uint256 blockInterval) =
+            IWorldChainProofSystemFactory(game.factory()).domain();
+        WorldChainProofLib.Domain memory expectedDomain = WorldChainProofLib.Domain({
+            chainId: chainId,
+            proofSystemVersion: proofSystemVersion,
+            rollupConfigHash: rollupConfigHash,
+            blockInterval: blockInterval
+        });
+        if (WorldChainProofLib.domainHash(expectedDomain) != domainHash) return false;
+
+        return transition.rollupConfigHash == rollupConfigHash && game.startingRootClaim() == transition.l2PreRoot
             && game.startingL2BlockNumber() == uint256(transition.l2PreBlockNumber)
             && game.rootClaim() == transition.l2PostRoot
             && game.l2BlockNumber() == uint256(transition.l2PostBlockNumber) && game.l1OriginHash() == transition.l1Head

--- a/pkg/contracts/src/proofs/WorldChainProofVerificationLib.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofVerificationLib.sol
@@ -8,7 +8,6 @@ library WorldChainProofVerificationLib {
     /// @dev Validates the proof's identity commitment before comparing it with the game's creation-time snapshot.
     function matchesGame(
         address gameAddress,
-        address expectedAnchorStateRegistry,
         bytes32 rootId,
         bytes32 domainHash,
         address parentRef,
@@ -26,8 +25,7 @@ library WorldChainProofVerificationLib {
         if (expectedRootId != rootId) return false;
 
         IWorldChainProofSystemGame game = IWorldChainProofSystemGame(gameAddress);
-        return game.rootId() == rootId && game.anchorStateRegistry() == expectedAnchorStateRegistry
-            && game.domainHash() == domainHash && game.parentRef() == parentRef
+        return game.rootId() == rootId && game.domainHash() == domainHash && game.parentRef() == parentRef
             && game.startingRootClaim() == transition.l2PreRoot
             && game.startingL2BlockNumber() == uint256(transition.l2PreBlockNumber)
             && game.rootClaim() == transition.l2PostRoot

--- a/pkg/contracts/src/proofs/WorldChainProofVerificationLib.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofVerificationLib.sol
@@ -5,7 +5,7 @@ import {IWorldChainProofSystemGame} from "./interfaces/IWorldChainProofSystemGam
 import {WorldChainProofLib} from "./WorldChainProofLib.sol";
 
 library WorldChainProofVerificationLib {
-    /// @dev Existing games remain bound to their creation-time snapshot when their parent or anchor later advances.
+    /// @dev Validates the proof's identity commitment before comparing it with the game's creation-time snapshot.
     function matchesGame(
         address gameAddress,
         address expectedAnchorStateRegistry,
@@ -15,6 +15,16 @@ library WorldChainProofVerificationLib {
         uint256 l1OriginNumber,
         WorldChainProofLib.TransitionPublicValues memory transition
     ) internal view returns (bool) {
+        bytes32 expectedRootId = WorldChainProofLib.rootId(
+            domainHash,
+            parentRef,
+            transition.l2PostRoot,
+            uint256(transition.l2PostBlockNumber),
+            transition.l1Head,
+            l1OriginNumber
+        );
+        if (expectedRootId != rootId) return false;
+
         IWorldChainProofSystemGame game = IWorldChainProofSystemGame(gameAddress);
         return game.rootId() == rootId && game.anchorStateRegistry() == expectedAnchorStateRegistry
             && game.domainHash() == domainHash && game.parentRef() == parentRef

--- a/pkg/contracts/src/proofs/WorldChainProofVerificationLib.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofVerificationLib.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {IWorldChainProofSystemGame} from "./interfaces/IWorldChainProofSystemGame.sol";
+import {WorldChainProofLib} from "./WorldChainProofLib.sol";
+
+library WorldChainProofVerificationLib {
+    /// @dev Existing games remain bound to their creation-time snapshot when their parent or anchor later advances.
+    function matchesGame(
+        address gameAddress,
+        address expectedAnchorStateRegistry,
+        bytes32 rootId,
+        bytes32 domainHash,
+        address parentRef,
+        uint256 l1OriginNumber,
+        WorldChainProofLib.TransitionPublicValues memory transition
+    ) internal view returns (bool) {
+        IWorldChainProofSystemGame game = IWorldChainProofSystemGame(gameAddress);
+        return game.rootId() == rootId && game.anchorStateRegistry() == expectedAnchorStateRegistry
+            && game.domainHash() == domainHash && game.parentRef() == parentRef
+            && game.startingRootClaim() == transition.l2PreRoot
+            && game.startingL2BlockNumber() == uint256(transition.l2PreBlockNumber)
+            && game.rootClaim() == transition.l2PostRoot
+            && game.l2BlockNumber() == uint256(transition.l2PostBlockNumber) && game.l1OriginHash() == transition.l1Head
+            && game.l1OriginNumber() == l1OriginNumber;
+    }
+}

--- a/pkg/contracts/src/proofs/WorldChainProofVerificationLib.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofVerificationLib.sol
@@ -6,42 +6,77 @@ import {IWorldChainProofSystemFactory} from "./interfaces/IWorldChainProofSystem
 import {WorldChainProofLib} from "./WorldChainProofLib.sol";
 
 library WorldChainProofVerificationLib {
-    /// @dev Validates the proof's identity commitment before comparing it with the game's creation-time snapshot.
+    /// @dev Validates the proof against the game's root, factory domain, and creation-time transition snapshot.
     function matchesGame(
         address gameAddress,
         bytes32 rootId,
-        bytes32 domainHash,
-        address parentRef,
-        uint256 l1OriginNumber,
+        bytes32 proofDomainHash,
+        address proofParentRef,
+        uint256 proofL1OriginNumber,
         WorldChainProofLib.TransitionPublicValues memory transition
     ) internal view returns (bool) {
-        bytes32 expectedRootId = WorldChainProofLib.rootId(
-            domainHash,
-            parentRef,
-            transition.l2PostRoot,
-            uint256(transition.l2PostBlockNumber),
-            transition.l1Head,
-            l1OriginNumber
-        );
-        if (expectedRootId != rootId) return false;
-
         IWorldChainProofSystemGame game = IWorldChainProofSystemGame(gameAddress);
-        if (game.rootId() != rootId || game.domainHash() != domainHash || game.parentRef() != parentRef) return false;
+        if (!_matchesRoot(game, rootId, proofDomainHash, proofParentRef, proofL1OriginNumber, transition)) {
+            return false;
+        }
 
+        WorldChainProofLib.Domain memory factoryDomain = _readFactoryDomain(game.factory());
+        if (!_matchesDomain(game, proofDomainHash, transition.rollupConfigHash, factoryDomain)) return false;
+
+        return _matchesTransition(game, proofL1OriginNumber, transition);
+    }
+
+    function _readFactoryDomain(address factory) private view returns (WorldChainProofLib.Domain memory domain) {
         (uint256 chainId, uint256 proofSystemVersion, bytes32 rollupConfigHash, uint256 blockInterval) =
-            IWorldChainProofSystemFactory(game.factory()).domain();
-        WorldChainProofLib.Domain memory expectedDomain = WorldChainProofLib.Domain({
+            IWorldChainProofSystemFactory(factory).domain();
+        domain = WorldChainProofLib.Domain({
             chainId: chainId,
             proofSystemVersion: proofSystemVersion,
             rollupConfigHash: rollupConfigHash,
             blockInterval: blockInterval
         });
-        if (WorldChainProofLib.domainHash(expectedDomain) != domainHash) return false;
+    }
 
-        return transition.rollupConfigHash == rollupConfigHash && game.startingRootClaim() == transition.l2PreRoot
+    function _matchesRoot(
+        IWorldChainProofSystemGame game,
+        bytes32 rootId,
+        bytes32 proofDomainHash,
+        address proofParentRef,
+        uint256 proofL1OriginNumber,
+        WorldChainProofLib.TransitionPublicValues memory transition
+    ) private view returns (bool) {
+        bytes32 reconstructedRootId =
+            WorldChainProofLib.rootId(
+                proofDomainHash,
+                proofParentRef,
+                transition.l2PostRoot,
+                uint256(transition.l2PostBlockNumber),
+                transition.l1Head,
+                proofL1OriginNumber
+            );
+
+        return reconstructedRootId == rootId && game.rootId() == rootId && game.parentRef() == proofParentRef;
+    }
+
+    function _matchesDomain(
+        IWorldChainProofSystemGame game,
+        bytes32 proofDomainHash,
+        bytes32 transitionRollupConfigHash,
+        WorldChainProofLib.Domain memory factoryDomain
+    ) private view returns (bool) {
+        return game.domainHash() == proofDomainHash && WorldChainProofLib.domainHash(factoryDomain) == proofDomainHash
+            && transitionRollupConfigHash == factoryDomain.rollupConfigHash;
+    }
+
+    function _matchesTransition(
+        IWorldChainProofSystemGame game,
+        uint256 proofL1OriginNumber,
+        WorldChainProofLib.TransitionPublicValues memory transition
+    ) private view returns (bool) {
+        return game.startingRootClaim() == transition.l2PreRoot
             && game.startingL2BlockNumber() == uint256(transition.l2PreBlockNumber)
             && game.rootClaim() == transition.l2PostRoot
             && game.l2BlockNumber() == uint256(transition.l2PostBlockNumber) && game.l1OriginHash() == transition.l1Head
-            && game.l1OriginNumber() == l1OriginNumber;
+            && game.l1OriginNumber() == proofL1OriginNumber;
     }
 }

--- a/pkg/contracts/src/proofs/interfaces/IWorldChainProofSystemFactory.sol
+++ b/pkg/contracts/src/proofs/interfaces/IWorldChainProofSystemFactory.sol
@@ -2,5 +2,11 @@
 pragma solidity 0.8.28;
 
 interface IWorldChainProofSystemFactory {
+    /// @notice Returns the canonical domain configuration shared by every game created by this factory.
+    function domain()
+        external
+        view
+        returns (uint256 chainId, uint256 proofSystemVersion, bytes32 rollupConfigHash, uint256 blockInterval);
+
     function isFactoryGame(address game) external view returns (bool);
 }

--- a/pkg/contracts/src/proofs/interfaces/IWorldChainProofSystemGame.sol
+++ b/pkg/contracts/src/proofs/interfaces/IWorldChainProofSystemGame.sol
@@ -14,6 +14,8 @@ interface IWorldChainProofSystemGame {
     function startingL2BlockNumber() external view returns (uint256);
     function rootClaim() external view returns (bytes32);
     function l2BlockNumber() external view returns (uint256);
+    function l1OriginHash() external view returns (bytes32);
+    function l1OriginNumber() external view returns (uint256);
     function state() external view returns (WorldChainProofLib.RootState);
     function invalidationReason() external view returns (WorldChainProofLib.InvalidationReason);
     function proofBitmap() external view returns (uint8);

--- a/pkg/contracts/src/proofs/interfaces/IWorldChainProofVerifier.sol
+++ b/pkg/contracts/src/proofs/interfaces/IWorldChainProofVerifier.sol
@@ -2,5 +2,6 @@
 pragma solidity 0.8.28;
 
 interface IWorldChainProofVerifier {
+    /// @dev The calling game is the source of truth for the expected proposal transition.
     function verify(bytes32 rootId, bytes calldata proof) external view returns (bool);
 }

--- a/pkg/contracts/src/proofs/nitro/NitroProofVerifier.sol
+++ b/pkg/contracts/src/proofs/nitro/NitroProofVerifier.sol
@@ -44,9 +44,6 @@ contract NitroProofVerifier is IWorldChainProofVerifier {
     ///      Nitro enclave always emits this form.
     error InvalidPublicKey();
 
-    /// @dev Thrown when the anchor-state registry address is zero.
-    error ZeroAnchorStateRegistry();
-
     /*//////////////////////////////////////////////////////////////
                                 STORAGE
     //////////////////////////////////////////////////////////////*/
@@ -54,20 +51,13 @@ contract NitroProofVerifier is IWorldChainProofVerifier {
     /// @notice Registry of attested enclave keys.
     NitroEnclaveKeyRegistry public immutable registry;
 
-    /// @notice Anchor-state registry that calling games must belong to.
-    address public immutable anchorStateRegistry;
-
     /*//////////////////////////////////////////////////////////////
                               CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
 
     /// @param registry_ The Nitro enclave key registry to consult.
-    /// @param anchorStateRegistry_ Anchor-state registry that calling games must belong to.
-    constructor(NitroEnclaveKeyRegistry registry_, address anchorStateRegistry_) {
-        if (anchorStateRegistry_ == address(0)) revert ZeroAnchorStateRegistry();
-
+    constructor(NitroEnclaveKeyRegistry registry_) {
         registry = registry_;
-        anchorStateRegistry = anchorStateRegistry_;
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -114,7 +104,7 @@ contract NitroProofVerifier is IWorldChainProofVerifier {
 
         // 1. Bind the proof identity and transition fields to the calling game's immutable snapshot.
         bool matchesGame = WorldChainProofVerificationLib.matchesGame(
-            gameAddress, anchorStateRegistry, rootId, domainHash, parentRef, l1OriginNumber, transition
+            gameAddress, rootId, domainHash, parentRef, l1OriginNumber, transition
         );
         if (!matchesGame) return false;
 

--- a/pkg/contracts/src/proofs/nitro/NitroProofVerifier.sol
+++ b/pkg/contracts/src/proofs/nitro/NitroProofVerifier.sol
@@ -1,21 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {IWorldChainProofSystemGame} from "../interfaces/IWorldChainProofSystemGame.sol";
 import {IWorldChainProofVerifier} from "../interfaces/IWorldChainProofVerifier.sol";
 import {WorldChainProofLib} from "../WorldChainProofLib.sol";
+import {WorldChainProofVerificationLib} from "../WorldChainProofVerificationLib.sol";
 import {NitroEnclaveKeyRegistry} from "./NitroEnclaveKeyRegistry.sol";
-
-/// ABI-encoded public values signed by the World Chain Nitro enclave.
-/// Must match `world_chain_proof_core::boot::TransitionPublicValues`.
-struct TransitionPublicValues {
-    bytes32 l1Head;
-    bytes32 l2PreRoot;
-    uint64 l2PreBlockNumber;
-    bytes32 l2PostRoot;
-    uint64 l2PostBlockNumber;
-    bytes32 rollupConfigHash;
-}
 
 /// @title NitroProofVerifier
 /// @author Worldcoin
@@ -118,10 +107,10 @@ contract NitroProofVerifier is IWorldChainProofVerifier {
             bytes32 domainHash,
             address parentRef,
             uint256 l1OriginNumber,
-            TransitionPublicValues memory transition,
+            WorldChainProofLib.TransitionPublicValues memory transition,
             bytes memory signature,
             bytes memory expectedPublicKey
-        ) = abi.decode(proof, (bytes32, address, uint256, TransitionPublicValues, bytes, bytes));
+        ) = abi.decode(proof, (bytes32, address, uint256, WorldChainProofLib.TransitionPublicValues, bytes, bytes));
 
         // 1. Bind the proof to the supplied rootId. The transition public values'
         //    `l2PostRoot` plays the role of `rootClaim` (the proposal's
@@ -137,7 +126,10 @@ contract NitroProofVerifier is IWorldChainProofVerifier {
         if (expectedRootId != rootId) return false;
 
         // 2. Bind the proposal transition fields to the calling game's immutable snapshot.
-        if (!_matchesGame(gameAddress, rootId, domainHash, parentRef, l1OriginNumber, transition)) return false;
+        bool matchesGame = WorldChainProofVerificationLib.matchesGame(
+            gameAddress, anchorStateRegistry, rootId, domainHash, parentRef, l1OriginNumber, transition
+        );
+        if (!matchesGame) return false;
 
         // 3. Verify the enclave signature over all transition public values.
         bytes32 commitment = _signingCommitment(transition);
@@ -152,26 +144,12 @@ contract NitroProofVerifier is IWorldChainProofVerifier {
     ///      matching `transition_commitment(transition_public_values)` in
     ///      `proofs/nitro/src/protocol.rs`.
     ///      The entire struct is ABI-encoded before hashing.
-    function _signingCommitment(TransitionPublicValues memory transition) internal pure returns (bytes32) {
+    function _signingCommitment(WorldChainProofLib.TransitionPublicValues memory transition)
+        internal
+        pure
+        returns (bytes32)
+    {
         return keccak256(abi.encode(transition));
-    }
-
-    function _matchesGame(
-        address gameAddress,
-        bytes32 rootId,
-        bytes32 domainHash,
-        address parentRef,
-        uint256 l1OriginNumber,
-        TransitionPublicValues memory transition
-    ) internal view returns (bool) {
-        IWorldChainProofSystemGame game = IWorldChainProofSystemGame(gameAddress);
-        return game.rootId() == rootId && game.anchorStateRegistry() == anchorStateRegistry
-            && game.domainHash() == domainHash && game.parentRef() == parentRef
-            && game.startingRootClaim() == transition.l2PreRoot
-            && game.startingL2BlockNumber() == uint256(transition.l2PreBlockNumber)
-            && game.rootClaim() == transition.l2PostRoot
-            && game.l2BlockNumber() == uint256(transition.l2PostBlockNumber) && game.l1OriginHash() == transition.l1Head
-            && game.l1OriginNumber() == l1OriginNumber;
     }
 
     /// @dev Checks that `signature` over `commitment` recovers to the address

--- a/pkg/contracts/src/proofs/nitro/NitroProofVerifier.sol
+++ b/pkg/contracts/src/proofs/nitro/NitroProofVerifier.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {IWorldChainAnchorStateRegistry} from "../interfaces/IWorldChainAnchorStateRegistry.sol";
 import {IWorldChainProofSystemGame} from "../interfaces/IWorldChainProofSystemGame.sol";
 import {IWorldChainProofVerifier} from "../interfaces/IWorldChainProofVerifier.sol";
 import {WorldChainProofLib} from "../WorldChainProofLib.sol";
@@ -32,7 +31,7 @@ struct TransitionPublicValues {
 ///           remaining context fields supplied in the proof and asserts it
 ///           equals the `rootId` the game is asking about. This binds the
 ///           Nitro signature to the *specific* proposal under dispute.
-///        2. Binds the transition's pre-root to the parent proposal.
+///        2. Binds the proposal transition fields to the calling game's immutable snapshot.
 ///        3. Checks that `expectedPublicKey` is currently registered in
 ///           `NitroEnclaveKeyRegistry`.
 ///        4. Recomputes the signing commitment from all transition public values.
@@ -66,7 +65,7 @@ contract NitroProofVerifier is IWorldChainProofVerifier {
     /// @notice Registry of attested enclave keys.
     NitroEnclaveKeyRegistry public immutable registry;
 
-    /// @notice Anchor-state registry used when the proposal parent is the current anchor.
+    /// @notice Anchor-state registry that calling games must belong to.
     address public immutable anchorStateRegistry;
 
     /*//////////////////////////////////////////////////////////////
@@ -74,7 +73,7 @@ contract NitroProofVerifier is IWorldChainProofVerifier {
     //////////////////////////////////////////////////////////////*/
 
     /// @param registry_ The Nitro enclave key registry to consult.
-    /// @param anchorStateRegistry_ Anchor-state registry used to resolve anchor parent roots.
+    /// @param anchorStateRegistry_ Anchor-state registry that calling games must belong to.
     constructor(NitroEnclaveKeyRegistry registry_, address anchorStateRegistry_) {
         if (anchorStateRegistry_ == address(0)) revert ZeroAnchorStateRegistry();
 
@@ -102,7 +101,7 @@ contract NitroProofVerifier is IWorldChainProofVerifier {
     ///      call so the try/catch in `verify` traps every revert path —
     ///      including a malformed ABI payload — and surfaces it as `false`.
     function verify(bytes32 rootId, bytes calldata proof) external view returns (bool) {
-        try this._decodeAndVerify(rootId, proof) returns (bool ok) {
+        try this._decodeAndVerify(msg.sender, rootId, proof) returns (bool ok) {
             return ok;
         } catch {
             return false;
@@ -113,7 +112,7 @@ contract NitroProofVerifier is IWorldChainProofVerifier {
     ///         directly.
     /// @dev External so that `verify` can invoke it via `this.` and trap
     ///      reverts (including the ABI decode revert) in a try/catch.
-    function _decodeAndVerify(bytes32 rootId, bytes calldata proof) external view returns (bool) {
+    function _decodeAndVerify(address gameAddress, bytes32 rootId, bytes calldata proof) external view returns (bool) {
         require(msg.sender == address(this), "internal");
         (
             bytes32 domainHash,
@@ -137,8 +136,8 @@ contract NitroProofVerifier is IWorldChainProofVerifier {
         );
         if (expectedRootId != rootId) return false;
 
-        // 2. Bind the signed pre-root to the proposal's parent.
-        if (transition.l2PreRoot != _parentRootClaim(parentRef)) return false;
+        // 2. Bind the proposal transition fields to the calling game's immutable snapshot.
+        if (!_matchesGame(gameAddress, rootId, domainHash, parentRef, l1OriginNumber, transition)) return false;
 
         // 3. Verify the enclave signature over all transition public values.
         bytes32 commitment = _signingCommitment(transition);
@@ -157,11 +156,22 @@ contract NitroProofVerifier is IWorldChainProofVerifier {
         return keccak256(abi.encode(transition));
     }
 
-    function _parentRootClaim(address parentRef) internal view returns (bytes32) {
-        if (parentRef == anchorStateRegistry) {
-            return IWorldChainAnchorStateRegistry(parentRef).currentRootClaim();
-        }
-        return IWorldChainProofSystemGame(parentRef).rootClaim();
+    function _matchesGame(
+        address gameAddress,
+        bytes32 rootId,
+        bytes32 domainHash,
+        address parentRef,
+        uint256 l1OriginNumber,
+        TransitionPublicValues memory transition
+    ) internal view returns (bool) {
+        IWorldChainProofSystemGame game = IWorldChainProofSystemGame(gameAddress);
+        return game.rootId() == rootId && game.anchorStateRegistry() == anchorStateRegistry
+            && game.domainHash() == domainHash && game.parentRef() == parentRef
+            && game.startingRootClaim() == transition.l2PreRoot
+            && game.startingL2BlockNumber() == uint256(transition.l2PreBlockNumber)
+            && game.rootClaim() == transition.l2PostRoot
+            && game.l2BlockNumber() == uint256(transition.l2PostBlockNumber) && game.l1OriginHash() == transition.l1Head
+            && game.l1OriginNumber() == l1OriginNumber;
     }
 
     /// @dev Checks that `signature` over `commitment` recovers to the address

--- a/pkg/contracts/src/proofs/nitro/NitroProofVerifier.sol
+++ b/pkg/contracts/src/proofs/nitro/NitroProofVerifier.sol
@@ -112,26 +112,13 @@ contract NitroProofVerifier is IWorldChainProofVerifier {
             bytes memory expectedPublicKey
         ) = abi.decode(proof, (bytes32, address, uint256, WorldChainProofLib.TransitionPublicValues, bytes, bytes));
 
-        // 1. Bind the proof to the supplied rootId. The transition public values'
-        //    `l2PostRoot` plays the role of `rootClaim` (the proposal's
-        //    claimed L2 output root) in WorldChainProofLib.rootId.
-        bytes32 expectedRootId = WorldChainProofLib.rootId(
-            domainHash,
-            parentRef,
-            transition.l2PostRoot,
-            uint256(transition.l2PostBlockNumber),
-            transition.l1Head,
-            l1OriginNumber
-        );
-        if (expectedRootId != rootId) return false;
-
-        // 2. Bind the proposal transition fields to the calling game's immutable snapshot.
+        // 1. Bind the proof identity and transition fields to the calling game's immutable snapshot.
         bool matchesGame = WorldChainProofVerificationLib.matchesGame(
             gameAddress, anchorStateRegistry, rootId, domainHash, parentRef, l1OriginNumber, transition
         );
         if (!matchesGame) return false;
 
-        // 3. Verify the enclave signature over all transition public values.
+        // 2. Verify the enclave signature over all transition public values.
         bytes32 commitment = _signingCommitment(transition);
         return _verifyEnclaveSignature(commitment, signature, expectedPublicKey);
     }

--- a/pkg/contracts/src/proofs/sp1/SP1ValidityVerifier.sol
+++ b/pkg/contracts/src/proofs/sp1/SP1ValidityVerifier.sol
@@ -38,9 +38,6 @@ contract SP1ValidityVerifier is IWorldChainProofVerifier {
     /// @notice Thrown when the expected range program verification key is zero.
     error ZeroRangeVKeyCommitment();
 
-    /// @notice Thrown when the anchor-state registry address is zero.
-    error ZeroAnchorStateRegistry();
-
     /*//////////////////////////////////////////////////////////////
                                STORAGE
     //////////////////////////////////////////////////////////////*/
@@ -57,9 +54,6 @@ contract SP1ValidityVerifier is IWorldChainProofVerifier {
     /// @notice Range-program verification key committed by the aggregation proof.
     bytes32 public immutable rangeVKeyCommitment;
 
-    /// @notice Anchor-state registry that calling games must belong to.
-    address public immutable anchorStateRegistry;
-
     /*//////////////////////////////////////////////////////////////
                              CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
@@ -68,20 +62,17 @@ contract SP1ValidityVerifier is IWorldChainProofVerifier {
         ISP1Verifier sp1Verifier_,
         bytes32 aggregationVKey_,
         bytes32 rollupConfigHash_,
-        bytes32 rangeVKeyCommitment_,
-        address anchorStateRegistry_
+        bytes32 rangeVKeyCommitment_
     ) {
         if (address(sp1Verifier_) == address(0)) revert ZeroSP1Verifier();
         if (aggregationVKey_ == bytes32(0)) revert ZeroAggregationVKey();
         if (rollupConfigHash_ == bytes32(0)) revert ZeroRollupConfigHash();
         if (rangeVKeyCommitment_ == bytes32(0)) revert ZeroRangeVKeyCommitment();
-        if (anchorStateRegistry_ == address(0)) revert ZeroAnchorStateRegistry();
 
         sp1Verifier = sp1Verifier_;
         aggregationVKey = aggregationVKey_;
         rollupConfigHash = rollupConfigHash_;
         rangeVKeyCommitment = rangeVKeyCommitment_;
-        anchorStateRegistry = anchorStateRegistry_;
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -136,7 +127,7 @@ contract SP1ValidityVerifier is IWorldChainProofVerifier {
         if (outputs.multiBlockVKey != rangeVKeyCommitment) return false;
 
         bool matchesGame = WorldChainProofVerificationLib.matchesGame(
-            gameAddress, anchorStateRegistry, rootId, domainHash, parentRef, l1OriginNumber, transition
+            gameAddress, rootId, domainHash, parentRef, l1OriginNumber, transition
         );
         if (!matchesGame) return false;
 

--- a/pkg/contracts/src/proofs/sp1/SP1ValidityVerifier.sol
+++ b/pkg/contracts/src/proofs/sp1/SP1ValidityVerifier.sol
@@ -135,16 +135,6 @@ contract SP1ValidityVerifier is IWorldChainProofVerifier {
         if (transition.rollupConfigHash != rollupConfigHash) return false;
         if (outputs.multiBlockVKey != rangeVKeyCommitment) return false;
 
-        bytes32 expectedRootId = WorldChainProofLib.rootId(
-            domainHash,
-            parentRef,
-            transition.l2PostRoot,
-            uint256(transition.l2PostBlockNumber),
-            transition.l1Head,
-            l1OriginNumber
-        );
-        if (expectedRootId != rootId) return false;
-
         bool matchesGame = WorldChainProofVerificationLib.matchesGame(
             gameAddress, anchorStateRegistry, rootId, domainHash, parentRef, l1OriginNumber, transition
         );

--- a/pkg/contracts/src/proofs/sp1/SP1ValidityVerifier.sol
+++ b/pkg/contracts/src/proofs/sp1/SP1ValidityVerifier.sol
@@ -32,9 +32,6 @@ contract SP1ValidityVerifier is IWorldChainProofVerifier {
     /// @notice Thrown when the aggregation program verification key is zero.
     error ZeroAggregationVKey();
 
-    /// @notice Thrown when the expected rollup config hash is zero.
-    error ZeroRollupConfigHash();
-
     /// @notice Thrown when the expected range program verification key is zero.
     error ZeroRangeVKeyCommitment();
 
@@ -48,9 +45,6 @@ contract SP1ValidityVerifier is IWorldChainProofVerifier {
     /// @notice Verification key for the World Chain aggregation program.
     bytes32 public immutable aggregationVKey;
 
-    /// @notice Rollup config hash the aggregation public values must commit to.
-    bytes32 public immutable rollupConfigHash;
-
     /// @notice Range-program verification key committed by the aggregation proof.
     bytes32 public immutable rangeVKeyCommitment;
 
@@ -58,20 +52,13 @@ contract SP1ValidityVerifier is IWorldChainProofVerifier {
                              CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
 
-    constructor(
-        ISP1Verifier sp1Verifier_,
-        bytes32 aggregationVKey_,
-        bytes32 rollupConfigHash_,
-        bytes32 rangeVKeyCommitment_
-    ) {
+    constructor(ISP1Verifier sp1Verifier_, bytes32 aggregationVKey_, bytes32 rangeVKeyCommitment_) {
         if (address(sp1Verifier_) == address(0)) revert ZeroSP1Verifier();
         if (aggregationVKey_ == bytes32(0)) revert ZeroAggregationVKey();
-        if (rollupConfigHash_ == bytes32(0)) revert ZeroRollupConfigHash();
         if (rangeVKeyCommitment_ == bytes32(0)) revert ZeroRangeVKeyCommitment();
 
         sp1Verifier = sp1Verifier_;
         aggregationVKey = aggregationVKey_;
-        rollupConfigHash = rollupConfigHash_;
         rangeVKeyCommitment = rangeVKeyCommitment_;
     }
 
@@ -123,7 +110,6 @@ contract SP1ValidityVerifier is IWorldChainProofVerifier {
         AggregationPublicValues memory outputs = abi.decode(publicValues, (AggregationPublicValues));
         WorldChainProofLib.TransitionPublicValues memory transition = outputs.transitionPublicValues;
 
-        if (transition.rollupConfigHash != rollupConfigHash) return false;
         if (outputs.multiBlockVKey != rangeVKeyCommitment) return false;
 
         bool matchesGame = WorldChainProofVerificationLib.matchesGame(

--- a/pkg/contracts/src/proofs/sp1/SP1ValidityVerifier.sol
+++ b/pkg/contracts/src/proofs/sp1/SP1ValidityVerifier.sol
@@ -2,24 +2,13 @@
 pragma solidity 0.8.28;
 
 import {IWorldChainProofVerifier} from "../interfaces/IWorldChainProofVerifier.sol";
-import {IWorldChainProofSystemGame} from "../interfaces/IWorldChainProofSystemGame.sol";
 import {ISP1Verifier} from "@sp1-contracts/src/ISP1Verifier.sol";
 import {WorldChainProofLib} from "../WorldChainProofLib.sol";
-
-/// ABI-encoded public values committed by the World Chain SP1 aggregation proof.
-/// Must match `world_chain_proof_core::boot::TransitionPublicValues`.
-struct TransitionPublicValues {
-    bytes32 l1Head;
-    bytes32 l2PreRoot;
-    uint64 l2PreBlockNumber;
-    bytes32 l2PostRoot;
-    uint64 l2PostBlockNumber;
-    bytes32 rollupConfigHash;
-}
+import {WorldChainProofVerificationLib} from "../WorldChainProofVerificationLib.sol";
 
 /// Must match `world_chain_proof_core::types::AggregationPublicValues`.
 struct AggregationPublicValues {
-    TransitionPublicValues transitionPublicValues;
+    WorldChainProofLib.TransitionPublicValues transitionPublicValues;
     bytes32 multiBlockVKey;
 }
 
@@ -141,7 +130,7 @@ contract SP1ValidityVerifier is IWorldChainProofVerifier {
         ) = abi.decode(proof, (bytes32, address, uint256, bytes, bytes));
 
         AggregationPublicValues memory outputs = abi.decode(publicValues, (AggregationPublicValues));
-        TransitionPublicValues memory transition = outputs.transitionPublicValues;
+        WorldChainProofLib.TransitionPublicValues memory transition = outputs.transitionPublicValues;
 
         if (transition.rollupConfigHash != rollupConfigHash) return false;
         if (outputs.multiBlockVKey != rangeVKeyCommitment) return false;
@@ -156,27 +145,12 @@ contract SP1ValidityVerifier is IWorldChainProofVerifier {
         );
         if (expectedRootId != rootId) return false;
 
-        if (!_matchesGame(gameAddress, rootId, domainHash, parentRef, l1OriginNumber, transition)) return false;
+        bool matchesGame = WorldChainProofVerificationLib.matchesGame(
+            gameAddress, anchorStateRegistry, rootId, domainHash, parentRef, l1OriginNumber, transition
+        );
+        if (!matchesGame) return false;
 
         sp1Verifier.verifyProof(aggregationVKey, publicValues, proofBytes);
         return true;
-    }
-
-    function _matchesGame(
-        address gameAddress,
-        bytes32 rootId,
-        bytes32 domainHash,
-        address parentRef,
-        uint256 l1OriginNumber,
-        TransitionPublicValues memory transition
-    ) internal view returns (bool) {
-        IWorldChainProofSystemGame game = IWorldChainProofSystemGame(gameAddress);
-        return game.rootId() == rootId && game.anchorStateRegistry() == anchorStateRegistry
-            && game.domainHash() == domainHash && game.parentRef() == parentRef
-            && game.startingRootClaim() == transition.l2PreRoot
-            && game.startingL2BlockNumber() == uint256(transition.l2PreBlockNumber)
-            && game.rootClaim() == transition.l2PostRoot
-            && game.l2BlockNumber() == uint256(transition.l2PostBlockNumber) && game.l1OriginHash() == transition.l1Head
-            && game.l1OriginNumber() == l1OriginNumber;
     }
 }

--- a/pkg/contracts/src/proofs/sp1/SP1ValidityVerifier.sol
+++ b/pkg/contracts/src/proofs/sp1/SP1ValidityVerifier.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {IWorldChainAnchorStateRegistry} from "../interfaces/IWorldChainAnchorStateRegistry.sol";
 import {IWorldChainProofVerifier} from "../interfaces/IWorldChainProofVerifier.sol";
 import {IWorldChainProofSystemGame} from "../interfaces/IWorldChainProofSystemGame.sol";
 import {ISP1Verifier} from "@sp1-contracts/src/ISP1Verifier.sol";
@@ -69,7 +68,7 @@ contract SP1ValidityVerifier is IWorldChainProofVerifier {
     /// @notice Range-program verification key committed by the aggregation proof.
     bytes32 public immutable rangeVKeyCommitment;
 
-    /// @notice Anchor-state registry used when the proposal parent is the current anchor.
+    /// @notice Anchor-state registry that calling games must belong to.
     address public immutable anchorStateRegistry;
 
     /*//////////////////////////////////////////////////////////////
@@ -119,7 +118,7 @@ contract SP1ValidityVerifier is IWorldChainProofVerifier {
     ///      the try/catch in `verify` traps malformed ABI payloads, invalid
     ///      public values, and SP1 verifier reverts as `false`.
     function verify(bytes32 rootId, bytes calldata proof) external view returns (bool) {
-        try this._decodeAndVerify(rootId, proof) returns (bool ok) {
+        try this._decodeAndVerify(msg.sender, rootId, proof) returns (bool ok) {
             return ok;
         } catch {
             return false;
@@ -130,7 +129,7 @@ contract SP1ValidityVerifier is IWorldChainProofVerifier {
     ///         directly.
     /// @dev External so `verify` can catch every revert path, including ABI
     ///      decode failures and verifier-gateway reverts.
-    function _decodeAndVerify(bytes32 rootId, bytes calldata proof) external view returns (bool) {
+    function _decodeAndVerify(address gameAddress, bytes32 rootId, bytes calldata proof) external view returns (bool) {
         require(msg.sender == address(this), "internal");
 
         (
@@ -157,18 +156,27 @@ contract SP1ValidityVerifier is IWorldChainProofVerifier {
         );
         if (expectedRootId != rootId) return false;
 
-        // `rootId` commits to the parent reference address, so the SP1 public
-        // values must separately bind the proved pre-root to that parent's root.
-        if (transition.l2PreRoot != _parentRootClaim(parentRef)) return false;
+        if (!_matchesGame(gameAddress, rootId, domainHash, parentRef, l1OriginNumber, transition)) return false;
 
         sp1Verifier.verifyProof(aggregationVKey, publicValues, proofBytes);
         return true;
     }
 
-    function _parentRootClaim(address parentRef) internal view returns (bytes32) {
-        if (parentRef == anchorStateRegistry) {
-            return IWorldChainAnchorStateRegistry(parentRef).currentRootClaim();
-        }
-        return IWorldChainProofSystemGame(parentRef).rootClaim();
+    function _matchesGame(
+        address gameAddress,
+        bytes32 rootId,
+        bytes32 domainHash,
+        address parentRef,
+        uint256 l1OriginNumber,
+        TransitionPublicValues memory transition
+    ) internal view returns (bool) {
+        IWorldChainProofSystemGame game = IWorldChainProofSystemGame(gameAddress);
+        return game.rootId() == rootId && game.anchorStateRegistry() == anchorStateRegistry
+            && game.domainHash() == domainHash && game.parentRef() == parentRef
+            && game.startingRootClaim() == transition.l2PreRoot
+            && game.startingL2BlockNumber() == uint256(transition.l2PreBlockNumber)
+            && game.rootClaim() == transition.l2PostRoot
+            && game.l2BlockNumber() == uint256(transition.l2PostBlockNumber) && game.l1OriginHash() == transition.l1Head
+            && game.l1OriginNumber() == l1OriginNumber;
     }
 }

--- a/pkg/contracts/test/mocks/MockProofSystemGame.sol
+++ b/pkg/contracts/test/mocks/MockProofSystemGame.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {IWorldChainProofVerifier} from "../../src/proofs/interfaces/IWorldChainProofVerifier.sol";
+
+contract MockProofSystemGame {
+    struct Context {
+        bytes32 rootId;
+        address anchorStateRegistry;
+        bytes32 domainHash;
+        address parentRef;
+        bytes32 startingRootClaim;
+        uint256 startingL2BlockNumber;
+        bytes32 rootClaim;
+        uint256 l2BlockNumber;
+        bytes32 l1OriginHash;
+        uint256 l1OriginNumber;
+    }
+
+    bytes32 public rootId;
+    address public anchorStateRegistry;
+    bytes32 public domainHash;
+    address public parentRef;
+    bytes32 public startingRootClaim;
+    uint256 public startingL2BlockNumber;
+    bytes32 public rootClaim;
+    uint256 public l2BlockNumber;
+    bytes32 public l1OriginHash;
+    uint256 public l1OriginNumber;
+
+    function setContext(Context memory context) external {
+        rootId = context.rootId;
+        anchorStateRegistry = context.anchorStateRegistry;
+        domainHash = context.domainHash;
+        parentRef = context.parentRef;
+        startingRootClaim = context.startingRootClaim;
+        startingL2BlockNumber = context.startingL2BlockNumber;
+        rootClaim = context.rootClaim;
+        l2BlockNumber = context.l2BlockNumber;
+        l1OriginHash = context.l1OriginHash;
+        l1OriginNumber = context.l1OriginNumber;
+    }
+
+    function verify(address verifier, bytes32 rootId_, bytes calldata proof) external view returns (bool) {
+        return IWorldChainProofVerifier(verifier).verify(rootId_, proof);
+    }
+}

--- a/pkg/contracts/test/mocks/MockProofSystemGame.sol
+++ b/pkg/contracts/test/mocks/MockProofSystemGame.sol
@@ -2,9 +2,19 @@
 pragma solidity 0.8.28;
 
 import {IWorldChainProofVerifier} from "../../src/proofs/interfaces/IWorldChainProofVerifier.sol";
+import {WorldChainProofLib} from "../../src/proofs/WorldChainProofLib.sol";
+
+contract MockProofSystemFactory {
+    WorldChainProofLib.Domain public domain;
+
+    constructor(WorldChainProofLib.Domain memory domain_) {
+        domain = domain_;
+    }
+}
 
 contract MockProofSystemGame {
     struct Context {
+        address factory;
         bytes32 rootId;
         address anchorStateRegistry;
         bytes32 domainHash;
@@ -17,6 +27,7 @@ contract MockProofSystemGame {
         uint256 l1OriginNumber;
     }
 
+    address public factory;
     bytes32 public rootId;
     address public anchorStateRegistry;
     bytes32 public domainHash;
@@ -29,6 +40,7 @@ contract MockProofSystemGame {
     uint256 public l1OriginNumber;
 
     function setContext(Context memory context) external {
+        factory = context.factory;
         rootId = context.rootId;
         anchorStateRegistry = context.anchorStateRegistry;
         domainHash = context.domainHash;

--- a/pkg/contracts/test/nitro/NitroEndToEnd.t.sol
+++ b/pkg/contracts/test/nitro/NitroEndToEnd.t.sol
@@ -7,7 +7,7 @@ import {NitroEnclaveKeyRegistry} from "../../src/proofs/nitro/NitroEnclaveKeyReg
 import {NitroProofVerifier} from "../../src/proofs/nitro/NitroProofVerifier.sol";
 import {INitroAttestationVerifier} from "../../src/proofs/nitro/INitroAttestationVerifier.sol";
 import {WorldChainProofLib} from "../../src/proofs/WorldChainProofLib.sol";
-import {MockProofSystemGame} from "../mocks/MockProofSystemGame.sol";
+import {MockProofSystemFactory, MockProofSystemGame} from "../mocks/MockProofSystemGame.sol";
 import {MockNitroAttestationVerifier} from "./mocks/MockNitroAttestationVerifier.sol";
 
 contract EndToEndParentGame {
@@ -45,7 +45,6 @@ contract NitroEndToEndTest is Test {
     bytes32 constant PCR1 = bytes32(uint256(0xBEEF));
     bytes32 constant PCR2 = bytes32(uint256(0xCAFE));
 
-    bytes32 constant DOMAIN = keccak256("worldchain-integration");
     bytes32 constant L1H = keccak256("l1-origin");
     uint256 constant L1N = 7_777;
     bytes32 constant CFG = keccak256("rollup-cfg");
@@ -62,18 +61,26 @@ contract NitroEndToEndTest is Test {
     bytes enclavePubKey;
     EndToEndParentGame parent;
     MockProofSystemGame game;
+    MockProofSystemFactory proofSystemFactory;
+    bytes32 domainHash;
 
     function setUp() public {
         attestationVerifier = new MockNitroAttestationVerifier();
         registry = new NitroEnclaveKeyRegistry(attestationVerifier, owner);
         parent = new EndToEndParentGame(PRE);
         proofVerifier = new NitroProofVerifier(registry);
+        WorldChainProofLib.Domain memory domain = WorldChainProofLib.Domain({
+            chainId: 480, proofSystemVersion: 1, rollupConfigHash: CFG, blockInterval: BLK - PRE_BLK
+        });
+        proofSystemFactory = new MockProofSystemFactory(domain);
+        domainHash = WorldChainProofLib.domainHash(domain);
         game = new MockProofSystemGame();
         game.setContext(
             MockProofSystemGame.Context({
+                factory: address(proofSystemFactory),
                 rootId: _rootId(POST, BLK),
                 anchorStateRegistry: ANCHOR_STATE_REGISTRY,
-                domainHash: DOMAIN,
+                domainHash: domainHash,
                 parentRef: address(parent),
                 startingRootClaim: PRE,
                 startingL2BlockNumber: PRE_BLK,
@@ -134,7 +141,7 @@ contract NitroEndToEndTest is Test {
         view
         returns (bytes memory)
     {
-        return abi.encode(DOMAIN, address(parent), L1N, transition, sig, pub);
+        return abi.encode(domainHash, address(parent), L1N, transition, sig, pub);
     }
 
     function _proof(bytes memory sig, bytes memory pub, bytes32 postRoot, uint64 blk, bytes32 cfg)
@@ -146,7 +153,7 @@ contract NitroEndToEndTest is Test {
     }
 
     function _rootId(bytes32 postRoot, uint64 blk) internal view returns (bytes32) {
-        return WorldChainProofLib.rootId(DOMAIN, address(parent), postRoot, uint256(blk), L1H, L1N);
+        return WorldChainProofLib.rootId(domainHash, address(parent), postRoot, uint256(blk), L1H, L1N);
     }
 
     function _verify(bytes32 rootId, bytes memory proof) internal view returns (bool) {

--- a/pkg/contracts/test/nitro/NitroEndToEnd.t.sol
+++ b/pkg/contracts/test/nitro/NitroEndToEnd.t.sol
@@ -67,7 +67,7 @@ contract NitroEndToEndTest is Test {
         attestationVerifier = new MockNitroAttestationVerifier();
         registry = new NitroEnclaveKeyRegistry(attestationVerifier, owner);
         parent = new EndToEndParentGame(PRE);
-        proofVerifier = new NitroProofVerifier(registry, ANCHOR_STATE_REGISTRY);
+        proofVerifier = new NitroProofVerifier(registry);
         game = new MockProofSystemGame();
         game.setContext(
             MockProofSystemGame.Context({

--- a/pkg/contracts/test/nitro/NitroEndToEnd.t.sol
+++ b/pkg/contracts/test/nitro/NitroEndToEnd.t.sol
@@ -7,6 +7,7 @@ import {NitroEnclaveKeyRegistry} from "../../src/proofs/nitro/NitroEnclaveKeyReg
 import {NitroProofVerifier, TransitionPublicValues} from "../../src/proofs/nitro/NitroProofVerifier.sol";
 import {INitroAttestationVerifier} from "../../src/proofs/nitro/INitroAttestationVerifier.sol";
 import {WorldChainProofLib} from "../../src/proofs/WorldChainProofLib.sol";
+import {MockProofSystemGame} from "../mocks/MockProofSystemGame.sol";
 import {MockNitroAttestationVerifier} from "./mocks/MockNitroAttestationVerifier.sol";
 
 contract EndToEndParentGame {
@@ -60,12 +61,28 @@ contract NitroEndToEndTest is Test {
     Vm.Wallet enclaveWallet;
     bytes enclavePubKey;
     EndToEndParentGame parent;
+    MockProofSystemGame game;
 
     function setUp() public {
         attestationVerifier = new MockNitroAttestationVerifier();
         registry = new NitroEnclaveKeyRegistry(attestationVerifier, owner);
         parent = new EndToEndParentGame(PRE);
         proofVerifier = new NitroProofVerifier(registry, ANCHOR_STATE_REGISTRY);
+        game = new MockProofSystemGame();
+        game.setContext(
+            MockProofSystemGame.Context({
+                rootId: _rootId(POST, BLK),
+                anchorStateRegistry: ANCHOR_STATE_REGISTRY,
+                domainHash: DOMAIN,
+                parentRef: address(parent),
+                startingRootClaim: PRE,
+                startingL2BlockNumber: PRE_BLK,
+                rootClaim: POST,
+                l2BlockNumber: BLK,
+                l1OriginHash: L1H,
+                l1OriginNumber: L1N
+            })
+        );
 
         enclaveWallet = vm.createWallet("enclave-integration");
         enclavePubKey = _uncompressedKey(enclaveWallet.publicKeyX, enclaveWallet.publicKeyY);
@@ -132,6 +149,10 @@ contract NitroEndToEndTest is Test {
         return WorldChainProofLib.rootId(DOMAIN, address(parent), postRoot, uint256(blk), L1H, L1N);
     }
 
+    function _verify(bytes32 rootId, bytes memory proof) internal view returns (bool) {
+        return game.verify(address(proofVerifier), rootId, proof);
+    }
+
     /*//////////////////////////////////////////////////////////////
                               FULL PIPELINE
     //////////////////////////////////////////////////////////////*/
@@ -153,7 +174,7 @@ contract NitroEndToEndTest is Test {
         //    boot-info. The proposer wraps it up into a NitroProofVerifier
         //    proof tuple and submits it to dispute-game resolution.
         bytes memory sig = _signCommitment(enclaveWallet, POST, BLK, CFG);
-        assertTrue(proofVerifier.verify(_rootId(POST, BLK), _proof(sig, enclavePubKey, POST, BLK, CFG)));
+        assertTrue(_verify(_rootId(POST, BLK), _proof(sig, enclavePubKey, POST, BLK, CFG)));
     }
 
     function test_E2E_RevokeKeyInvalidatesFutureProofs() public {
@@ -161,7 +182,7 @@ contract NitroEndToEndTest is Test {
         bytes memory sig = _signCommitment(enclaveWallet, POST, BLK, CFG);
 
         // Pre-revoke: proof is valid.
-        assertTrue(proofVerifier.verify(_rootId(POST, BLK), _proof(sig, enclavePubKey, POST, BLK, CFG)));
+        assertTrue(_verify(_rootId(POST, BLK), _proof(sig, enclavePubKey, POST, BLK, CFG)));
 
         // Owner revokes the key (e.g. on compromise).
         vm.prank(owner);
@@ -170,7 +191,7 @@ contract NitroEndToEndTest is Test {
 
         // Same (previously valid) proof MUST now be rejected — the proof
         // verifier consults the registry on every call.
-        assertFalse(proofVerifier.verify(_rootId(POST, BLK), _proof(sig, enclavePubKey, POST, BLK, CFG)));
+        assertFalse(_verify(_rootId(POST, BLK), _proof(sig, enclavePubKey, POST, BLK, CFG)));
 
         // And the registry must permanently refuse to re-register the key,
         // even via a fresh attestation.
@@ -193,8 +214,8 @@ contract NitroEndToEndTest is Test {
         bytes memory sigA = _signCommitment(enclaveWallet, POST, BLK, CFG);
         bytes memory sigB = _signCommitment(secondWallet, POST, BLK, CFG);
 
-        assertTrue(proofVerifier.verify(_rootId(POST, BLK), _proof(sigA, enclavePubKey, POST, BLK, CFG)));
-        assertTrue(proofVerifier.verify(_rootId(POST, BLK), _proof(sigB, secondPubKey, POST, BLK, CFG)));
+        assertTrue(_verify(_rootId(POST, BLK), _proof(sigA, enclavePubKey, POST, BLK, CFG)));
+        assertTrue(_verify(_rootId(POST, BLK), _proof(sigB, secondPubKey, POST, BLK, CFG)));
     }
 
     function test_E2E_RevokeOneEnclaveDoesNotAffectPeer() public {
@@ -213,15 +234,15 @@ contract NitroEndToEndTest is Test {
 
         bytes memory sigA = _signCommitment(enclaveWallet, POST, BLK, CFG);
         bytes memory sigB = _signCommitment(secondWallet, POST, BLK, CFG);
-        assertFalse(proofVerifier.verify(_rootId(POST, BLK), _proof(sigA, enclavePubKey, POST, BLK, CFG)));
-        assertTrue(proofVerifier.verify(_rootId(POST, BLK), _proof(sigB, secondPubKey, POST, BLK, CFG)));
+        assertFalse(_verify(_rootId(POST, BLK), _proof(sigA, enclavePubKey, POST, BLK, CFG)));
+        assertTrue(_verify(_rootId(POST, BLK), _proof(sigB, secondPubKey, POST, BLK, CFG)));
     }
 
     function test_E2E_UnregisteredKeyFails() public {
         // Skip registration; the proof verifier MUST refuse even a
         // cryptographically-valid signature from an unknown key.
         bytes memory sig = _signCommitment(enclaveWallet, POST, BLK, CFG);
-        assertFalse(proofVerifier.verify(_rootId(POST, BLK), _proof(sig, enclavePubKey, POST, BLK, CFG)));
+        assertFalse(_verify(_rootId(POST, BLK), _proof(sig, enclavePubKey, POST, BLK, CFG)));
     }
 
     function test_E2E_ProofMustBindToRequestedRootId() public {
@@ -229,6 +250,6 @@ contract NitroEndToEndTest is Test {
         bytes memory sig = _signCommitment(enclaveWallet, POST, BLK, CFG);
 
         // Honest proof but the dispute game asks about a different rootId.
-        assertFalse(proofVerifier.verify(bytes32(uint256(0xdead)), _proof(sig, enclavePubKey, POST, BLK, CFG)));
+        assertFalse(_verify(bytes32(uint256(0xdead)), _proof(sig, enclavePubKey, POST, BLK, CFG)));
     }
 }

--- a/pkg/contracts/test/nitro/NitroEndToEnd.t.sol
+++ b/pkg/contracts/test/nitro/NitroEndToEnd.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.28;
 import {Test, Vm} from "forge-std/Test.sol";
 import {NitroAttestationVerifier} from "../../src/proofs/nitro/NitroAttestationVerifier.sol";
 import {NitroEnclaveKeyRegistry} from "../../src/proofs/nitro/NitroEnclaveKeyRegistry.sol";
-import {NitroProofVerifier, TransitionPublicValues} from "../../src/proofs/nitro/NitroProofVerifier.sol";
+import {NitroProofVerifier} from "../../src/proofs/nitro/NitroProofVerifier.sol";
 import {INitroAttestationVerifier} from "../../src/proofs/nitro/INitroAttestationVerifier.sol";
 import {WorldChainProofLib} from "../../src/proofs/WorldChainProofLib.sol";
 import {MockProofSystemGame} from "../mocks/MockProofSystemGame.sol";
@@ -101,9 +101,9 @@ contract NitroEndToEndTest is Test {
     function _transition(bytes32 postRoot, uint64 blk, bytes32 cfg)
         internal
         pure
-        returns (TransitionPublicValues memory)
+        returns (WorldChainProofLib.TransitionPublicValues memory)
     {
-        return TransitionPublicValues({
+        return WorldChainProofLib.TransitionPublicValues({
             l1Head: L1H,
             l2PreRoot: PRE,
             l2PreBlockNumber: PRE_BLK,
@@ -113,7 +113,7 @@ contract NitroEndToEndTest is Test {
         });
     }
 
-    function _signCommitment(Vm.Wallet memory w, TransitionPublicValues memory transition)
+    function _signCommitment(Vm.Wallet memory w, WorldChainProofLib.TransitionPublicValues memory transition)
         internal
         returns (bytes memory)
     {
@@ -129,7 +129,7 @@ contract NitroEndToEndTest is Test {
         return _signCommitment(w, _transition(postRoot, blk, cfg));
     }
 
-    function _proof(bytes memory sig, bytes memory pub, TransitionPublicValues memory transition)
+    function _proof(bytes memory sig, bytes memory pub, WorldChainProofLib.TransitionPublicValues memory transition)
         internal
         view
         returns (bytes memory)

--- a/pkg/contracts/test/nitro/NitroProofVerifier.t.sol
+++ b/pkg/contracts/test/nitro/NitroProofVerifier.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.28;
 
 import {Test, Vm} from "forge-std/Test.sol";
 import {NitroEnclaveKeyRegistry} from "../../src/proofs/nitro/NitroEnclaveKeyRegistry.sol";
-import {NitroProofVerifier, TransitionPublicValues} from "../../src/proofs/nitro/NitroProofVerifier.sol";
+import {NitroProofVerifier} from "../../src/proofs/nitro/NitroProofVerifier.sol";
 import {WorldChainProofLib} from "../../src/proofs/WorldChainProofLib.sol";
 import {MockProofSystemGame} from "../mocks/MockProofSystemGame.sol";
 import {MockNitroAttestationVerifier} from "./mocks/MockNitroAttestationVerifier.sol";
@@ -85,8 +85,8 @@ contract NitroProofVerifierTest is Test {
         return _sign(enclaveWallet, digest);
     }
 
-    function _transition() internal pure returns (TransitionPublicValues memory) {
-        return TransitionPublicValues({
+    function _transition() internal pure returns (WorldChainProofLib.TransitionPublicValues memory) {
+        return WorldChainProofLib.TransitionPublicValues({
             l1Head: L1_ORIGIN_HASH,
             l2PreRoot: L2_PRE_ROOT,
             l2PreBlockNumber: L2_PRE_BLOCK,
@@ -110,7 +110,7 @@ contract NitroProofVerifierTest is Test {
         return abi.encode(DOMAIN_HASH, address(parent), L1_ORIGIN_NUMBER, _transition(), sig, pub);
     }
 
-    function _setGameContext(TransitionPublicValues memory transition) internal {
+    function _setGameContext(WorldChainProofLib.TransitionPublicValues memory transition) internal {
         bytes32 rootId = WorldChainProofLib.rootId(
             DOMAIN_HASH,
             address(parent),
@@ -165,7 +165,7 @@ contract NitroProofVerifierTest is Test {
     }
 
     function test_Verify_FalseForWrongBootInfo() public {
-        TransitionPublicValues memory wrongTransition = _transition();
+        WorldChainProofLib.TransitionPublicValues memory wrongTransition = _transition();
         wrongTransition.l2PostBlockNumber += 1;
         bytes memory sig = _sign(keccak256(abi.encode(wrongTransition)));
         bytes32 wrongRootId = WorldChainProofLib.rootId(
@@ -182,7 +182,7 @@ contract NitroProofVerifierTest is Test {
     }
 
     function test_Verify_FalseForWrongPreRoot() public {
-        TransitionPublicValues memory wrongTransition = _transition();
+        WorldChainProofLib.TransitionPublicValues memory wrongTransition = _transition();
         wrongTransition.l2PreRoot = keccak256("wrong-pre-root");
         bytes memory sig = _sign(keccak256(abi.encode(wrongTransition)));
         bytes memory proof =
@@ -191,7 +191,7 @@ contract NitroProofVerifierTest is Test {
     }
 
     function test_Verify_FalseForWrongPreBlockNumber() public {
-        TransitionPublicValues memory wrongTransition = _transition();
+        WorldChainProofLib.TransitionPublicValues memory wrongTransition = _transition();
         wrongTransition.l2PreBlockNumber += 1;
         bytes memory sig = _sign(keccak256(abi.encode(wrongTransition)));
         bytes memory proof =
@@ -355,7 +355,7 @@ contract NitroProofVerifierTest is Test {
         // Boundary: l2BlockNumber = 0 must work, since the rootId is
         // recomputed deterministically and the commitment is signed over
         // exactly that value.
-        TransitionPublicValues memory transition = _transition();
+        WorldChainProofLib.TransitionPublicValues memory transition = _transition();
         transition.l2PostBlockNumber = 0;
         bytes32 rootId =
             WorldChainProofLib.rootId(DOMAIN_HASH, address(parent), L2_POST_ROOT, 0, L1_ORIGIN_HASH, L1_ORIGIN_NUMBER);
@@ -374,7 +374,7 @@ contract NitroProofVerifierTest is Test {
         // recovery to mismatch the expected key and surface as `false`,
         // even though `rootId` still reconstructs correctly.
         bytes32 wrongCfg = keccak256("wrong-cfg");
-        TransitionPublicValues memory wrongTransition = _transition();
+        WorldChainProofLib.TransitionPublicValues memory wrongTransition = _transition();
         wrongTransition.rollupConfigHash = wrongCfg;
         bytes32 commitment = keccak256(abi.encode(wrongTransition));
         bytes memory sig = _sign(commitment);

--- a/pkg/contracts/test/nitro/NitroProofVerifier.t.sol
+++ b/pkg/contracts/test/nitro/NitroProofVerifier.t.sol
@@ -52,7 +52,7 @@ contract NitroProofVerifierTest is Test {
         attestationVerifier = new MockNitroAttestationVerifier();
         registry = new NitroEnclaveKeyRegistry(attestationVerifier, owner);
         parent = new MockParentGame(L2_PRE_ROOT);
-        proofVerifier = new NitroProofVerifier(registry, ANCHOR_STATE_REGISTRY);
+        proofVerifier = new NitroProofVerifier(registry);
         game = new MockProofSystemGame();
         _setGameContext(_transition());
 
@@ -146,11 +146,6 @@ contract NitroProofVerifierTest is Test {
     function test_Verify_HappyPath() public {
         bytes memory sig = _sign(_commitment());
         assertTrue(_verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
-    }
-
-    function test_Constructor_RevertsForZeroAnchorStateRegistry() public {
-        vm.expectRevert(NitroProofVerifier.ZeroAnchorStateRegistry.selector);
-        new NitroProofVerifier(registry, address(0));
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/pkg/contracts/test/nitro/NitroProofVerifier.t.sol
+++ b/pkg/contracts/test/nitro/NitroProofVerifier.t.sol
@@ -5,6 +5,7 @@ import {Test, Vm} from "forge-std/Test.sol";
 import {NitroEnclaveKeyRegistry} from "../../src/proofs/nitro/NitroEnclaveKeyRegistry.sol";
 import {NitroProofVerifier, TransitionPublicValues} from "../../src/proofs/nitro/NitroProofVerifier.sol";
 import {WorldChainProofLib} from "../../src/proofs/WorldChainProofLib.sol";
+import {MockProofSystemGame} from "../mocks/MockProofSystemGame.sol";
 import {MockNitroAttestationVerifier} from "./mocks/MockNitroAttestationVerifier.sol";
 
 contract MockParentGame {
@@ -45,12 +46,15 @@ contract NitroProofVerifierTest is Test {
     Vm.Wallet enclaveWallet;
     bytes enclavePubKey;
     MockParentGame parent;
+    MockProofSystemGame game;
 
     function setUp() public {
         attestationVerifier = new MockNitroAttestationVerifier();
         registry = new NitroEnclaveKeyRegistry(attestationVerifier, owner);
         parent = new MockParentGame(L2_PRE_ROOT);
         proofVerifier = new NitroProofVerifier(registry, ANCHOR_STATE_REGISTRY);
+        game = new MockProofSystemGame();
+        _setGameContext(_transition());
 
         enclaveWallet = vm.createWallet("enclave");
         enclavePubKey = _uncompressedKey(enclaveWallet.publicKeyX, enclaveWallet.publicKeyY);
@@ -106,13 +110,42 @@ contract NitroProofVerifierTest is Test {
         return abi.encode(DOMAIN_HASH, address(parent), L1_ORIGIN_NUMBER, _transition(), sig, pub);
     }
 
+    function _setGameContext(TransitionPublicValues memory transition) internal {
+        bytes32 rootId = WorldChainProofLib.rootId(
+            DOMAIN_HASH,
+            address(parent),
+            transition.l2PostRoot,
+            uint256(transition.l2PostBlockNumber),
+            transition.l1Head,
+            L1_ORIGIN_NUMBER
+        );
+        game.setContext(
+            MockProofSystemGame.Context({
+                rootId: rootId,
+                anchorStateRegistry: ANCHOR_STATE_REGISTRY,
+                domainHash: DOMAIN_HASH,
+                parentRef: address(parent),
+                startingRootClaim: L2_PRE_ROOT,
+                startingL2BlockNumber: L2_PRE_BLOCK,
+                rootClaim: transition.l2PostRoot,
+                l2BlockNumber: transition.l2PostBlockNumber,
+                l1OriginHash: transition.l1Head,
+                l1OriginNumber: L1_ORIGIN_NUMBER
+            })
+        );
+    }
+
+    function _verify(bytes32 rootId, bytes memory proof) internal view returns (bool) {
+        return game.verify(address(proofVerifier), rootId, proof);
+    }
+
     /*//////////////////////////////////////////////////////////////
                               HAPPY PATH
     //////////////////////////////////////////////////////////////*/
 
     function test_Verify_HappyPath() public {
         bytes memory sig = _sign(_commitment());
-        assertTrue(proofVerifier.verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
+        assertTrue(_verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
     }
 
     function test_Constructor_RevertsForZeroAnchorStateRegistry() public {
@@ -128,19 +161,13 @@ contract NitroProofVerifierTest is Test {
         // Honest signature + transition public values, but the game asks about a different
         // rootId — the verifier must NOT validate.
         bytes memory sig = _sign(_commitment());
-        assertFalse(proofVerifier.verify(bytes32(uint256(0xdead)), _proofBytes(sig, enclavePubKey)));
+        assertFalse(_verify(bytes32(uint256(0xdead)), _proofBytes(sig, enclavePubKey)));
     }
 
     function test_Verify_FalseForWrongBootInfo() public {
-        // The proof claims (L2_POST_ROOT, L2_BLOCK + 1, ROLLUP_CFG) but the
-        // signature is over the L2_BLOCK commitment — rootId check still
-        // passes for the modified block number? It must not: the signing
-        // commitment is recomputed from the proof's transition public values, so a wrong
-        // commitment surfaces as a signature mismatch.
-        bytes memory sig = _sign(_commitment());
-        // Build a proof with a mismatched block number and a matching rootId.
         TransitionPublicValues memory wrongTransition = _transition();
         wrongTransition.l2PostBlockNumber += 1;
+        bytes memory sig = _sign(keccak256(abi.encode(wrongTransition)));
         bytes32 wrongRootId = WorldChainProofLib.rootId(
             DOMAIN_HASH,
             address(parent),
@@ -151,16 +178,26 @@ contract NitroProofVerifierTest is Test {
         );
         bytes memory proof =
             abi.encode(DOMAIN_HASH, address(parent), L1_ORIGIN_NUMBER, wrongTransition, sig, enclavePubKey);
-        assertFalse(proofVerifier.verify(wrongRootId, proof));
+        assertFalse(_verify(wrongRootId, proof));
     }
 
     function test_Verify_FalseForWrongPreRoot() public {
-        bytes memory sig = _sign(_commitment());
         TransitionPublicValues memory wrongTransition = _transition();
         wrongTransition.l2PreRoot = keccak256("wrong-pre-root");
+        bytes memory sig = _sign(keccak256(abi.encode(wrongTransition)));
         bytes memory proof =
             abi.encode(DOMAIN_HASH, address(parent), L1_ORIGIN_NUMBER, wrongTransition, sig, enclavePubKey);
-        assertFalse(proofVerifier.verify(_expectedRootId(), proof));
+        assertFalse(_verify(_expectedRootId(), proof));
+    }
+
+    function test_Verify_FalseForWrongPreBlockNumber() public {
+        TransitionPublicValues memory wrongTransition = _transition();
+        wrongTransition.l2PreBlockNumber += 1;
+        bytes memory sig = _sign(keccak256(abi.encode(wrongTransition)));
+        bytes memory proof =
+            abi.encode(DOMAIN_HASH, address(parent), L1_ORIGIN_NUMBER, wrongTransition, sig, enclavePubKey);
+
+        assertFalse(_verify(_expectedRootId(), proof));
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -171,7 +208,7 @@ contract NitroProofVerifierTest is Test {
         Vm.Wallet memory rogue = vm.createWallet("rogue");
         bytes memory roguePub = _uncompressedKey(rogue.publicKeyX, rogue.publicKeyY);
         bytes memory sig = _sign(rogue, _commitment());
-        assertFalse(proofVerifier.verify(_expectedRootId(), _proofBytes(sig, roguePub)));
+        assertFalse(_verify(_expectedRootId(), _proofBytes(sig, roguePub)));
     }
 
     function test_Verify_FalseForRevokedKey() public {
@@ -180,7 +217,7 @@ contract NitroProofVerifierTest is Test {
         vm.prank(owner);
         registry.revokeKey(enclavePubKey);
 
-        assertFalse(proofVerifier.verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
+        assertFalse(_verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -191,24 +228,24 @@ contract NitroProofVerifierTest is Test {
         // Sign with a different key while passing the registered enclave key.
         Vm.Wallet memory rogue = vm.createWallet("rogue");
         bytes memory sig = _sign(rogue, _commitment());
-        assertFalse(proofVerifier.verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
+        assertFalse(_verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
     }
 
     function test_Verify_FalseForBadSignatureLength() public {
         bytes memory sig = hex"1234";
-        assertFalse(proofVerifier.verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
+        assertFalse(_verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
     }
 
     function test_Verify_FalseForSignatureLength64() public {
         // EIP-2098 "compact" 64-byte signatures are NOT accepted; the
         // contract is strict about 65-byte (r || s || v) tuples.
         bytes memory sig = new bytes(64);
-        assertFalse(proofVerifier.verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
+        assertFalse(_verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
     }
 
     function test_Verify_FalseForEmptySignature() public {
         bytes memory sig = "";
-        assertFalse(proofVerifier.verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
+        assertFalse(_verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
     }
 
     function test_Verify_FalseForHighSSignature() public {
@@ -230,9 +267,9 @@ contract NitroProofVerifierTest is Test {
         uint8 vFlipped = v == 27 ? 28 : 27;
         bytes memory malleable = abi.encodePacked(r, sHigh, vFlipped);
         // Original signature still validates...
-        assertTrue(proofVerifier.verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
+        assertTrue(_verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
         // ...but the malleable high-s twin must NOT.
-        assertFalse(proofVerifier.verify(_expectedRootId(), _proofBytes(malleable, enclavePubKey)));
+        assertFalse(_verify(_expectedRootId(), _proofBytes(malleable, enclavePubKey)));
     }
 
     function test_Verify_FalseForInvalidV() public {
@@ -242,24 +279,24 @@ contract NitroProofVerifierTest is Test {
         assembly {
             mstore8(add(add(sig, 32), 64), 29)
         }
-        assertFalse(proofVerifier.verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
+        assertFalse(_verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
         // Also v = 0 (legacy unsigned).
         assembly {
             mstore8(add(add(sig, 32), 64), 0)
         }
-        assertFalse(proofVerifier.verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
+        assertFalse(_verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
         // Also v = 26.
         assembly {
             mstore8(add(add(sig, 32), 64), 26)
         }
-        assertFalse(proofVerifier.verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
+        assertFalse(_verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
     }
 
     function test_Verify_FalseForAllZeroSignature() public {
         // r = s = 0, v = 27. ecrecover returns address(0) → false.
         bytes memory sig = new bytes(65);
         sig[64] = bytes1(uint8(27));
-        assertFalse(proofVerifier.verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
+        assertFalse(_verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -270,19 +307,19 @@ contract NitroProofVerifierTest is Test {
         bytes memory compressed = new bytes(33);
         compressed[0] = 0x02;
         bytes memory sig = _sign(_commitment());
-        assertFalse(proofVerifier.verify(_expectedRootId(), _proofBytes(sig, compressed)));
+        assertFalse(_verify(_expectedRootId(), _proofBytes(sig, compressed)));
     }
 
     function test_Verify_FalseForBadKey() public view {
         // 7-byte key cannot be SEC1-decoded → _verifyEnclaveSignature
         // reverts with InvalidPublicKey → verify() catches and returns false.
         bytes memory badKey = hex"01020304050607";
-        assertFalse(proofVerifier.verify(_expectedRootId(), _proofBytes(hex"00", badKey)));
+        assertFalse(_verify(_expectedRootId(), _proofBytes(hex"00", badKey)));
     }
 
     function test_Verify_FalseForEmptyPublicKey() public view {
         bytes memory emptyKey = "";
-        assertFalse(proofVerifier.verify(_expectedRootId(), _proofBytes(hex"00", emptyKey)));
+        assertFalse(_verify(_expectedRootId(), _proofBytes(hex"00", emptyKey)));
     }
 
     function test_Verify_FalseForKeyWithLength65AndWrongPrefix() public {
@@ -292,7 +329,7 @@ contract NitroProofVerifierTest is Test {
         key[0] = 0x03;
         // Use a real signature so we fail on the prefix check, not earlier.
         bytes memory sig = _sign(_commitment());
-        assertFalse(proofVerifier.verify(_expectedRootId(), _proofBytes(sig, key)));
+        assertFalse(_verify(_expectedRootId(), _proofBytes(sig, key)));
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -302,18 +339,16 @@ contract NitroProofVerifierTest is Test {
     function test_Verify_FalseForGarbage() public view {
         // Garbage proof bytes that don't decode into the expected tuple must
         // be surfaced as `false` — the ABI decode lives inside the try/catch.
-        assertFalse(proofVerifier.verify(bytes32(0), hex"00"));
+        assertFalse(_verify(bytes32(0), hex"00"));
     }
 
     function test_Verify_FalseForEmptyProof() public view {
-        assertFalse(proofVerifier.verify(bytes32(0), ""));
+        assertFalse(_verify(bytes32(0), ""));
     }
 
     function test_Verify_FalseForTruncatedProof() public view {
         // 31 bytes is too short to even decode the first uint256.
-        assertFalse(
-            proofVerifier.verify(_expectedRootId(), hex"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
-        );
+        assertFalse(_verify(_expectedRootId(), hex"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"));
     }
 
     function test_Verify_AcceptsZeroL2BlockNumber() public {
@@ -327,7 +362,8 @@ contract NitroProofVerifierTest is Test {
         bytes32 commitment = keccak256(abi.encode(transition));
         bytes memory sig = _sign(commitment);
         bytes memory proof = abi.encode(DOMAIN_HASH, address(parent), L1_ORIGIN_NUMBER, transition, sig, enclavePubKey);
-        assertTrue(proofVerifier.verify(rootId, proof));
+        _setGameContext(transition);
+        assertTrue(_verify(rootId, proof));
     }
 
     function test_Verify_FalseForWrongRollupConfigHash() public {
@@ -347,7 +383,7 @@ contract NitroProofVerifierTest is Test {
         // wrong-cfg commitment.
         bytes memory proof =
             abi.encode(DOMAIN_HASH, address(parent), L1_ORIGIN_NUMBER, _transition(), sig, enclavePubKey);
-        assertFalse(proofVerifier.verify(_expectedRootId(), proof));
+        assertFalse(_verify(_expectedRootId(), proof));
     }
 
     function test_Verify_PerCallIdempotent() public {
@@ -356,8 +392,8 @@ contract NitroProofVerifierTest is Test {
         bytes memory sig = _sign(_commitment());
         bytes memory proof = _proofBytes(sig, enclavePubKey);
         bytes32 root = _expectedRootId();
-        assertTrue(proofVerifier.verify(root, proof));
-        assertTrue(proofVerifier.verify(root, proof));
+        assertTrue(_verify(root, proof));
+        assertTrue(_verify(root, proof));
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -366,6 +402,6 @@ contract NitroProofVerifierTest is Test {
 
     function test_DecodeAndVerify_NotCallableExternally() public {
         vm.expectRevert(bytes("internal"));
-        proofVerifier._decodeAndVerify(bytes32(0), hex"00");
+        proofVerifier._decodeAndVerify(address(game), bytes32(0), hex"00");
     }
 }

--- a/pkg/contracts/test/nitro/NitroProofVerifier.t.sol
+++ b/pkg/contracts/test/nitro/NitroProofVerifier.t.sol
@@ -5,7 +5,7 @@ import {Test, Vm} from "forge-std/Test.sol";
 import {NitroEnclaveKeyRegistry} from "../../src/proofs/nitro/NitroEnclaveKeyRegistry.sol";
 import {NitroProofVerifier} from "../../src/proofs/nitro/NitroProofVerifier.sol";
 import {WorldChainProofLib} from "../../src/proofs/WorldChainProofLib.sol";
-import {MockProofSystemGame} from "../mocks/MockProofSystemGame.sol";
+import {MockProofSystemFactory, MockProofSystemGame} from "../mocks/MockProofSystemGame.sol";
 import {MockNitroAttestationVerifier} from "./mocks/MockNitroAttestationVerifier.sol";
 
 contract MockParentGame {
@@ -38,7 +38,6 @@ contract NitroProofVerifierTest is Test {
     bytes32 constant ROLLUP_CFG = keccak256("rollup-cfg");
 
     // Context fields needed to rebuild rootId.
-    bytes32 constant DOMAIN_HASH = keccak256("domain");
     bytes32 constant L1_ORIGIN_HASH = keccak256("l1-origin");
     uint256 constant L1_ORIGIN_NUMBER = 9_001;
     address constant ANCHOR_STATE_REGISTRY = address(0xA11CE);
@@ -47,12 +46,19 @@ contract NitroProofVerifierTest is Test {
     bytes enclavePubKey;
     MockParentGame parent;
     MockProofSystemGame game;
+    MockProofSystemFactory proofSystemFactory;
+    bytes32 domainHash;
 
     function setUp() public {
         attestationVerifier = new MockNitroAttestationVerifier();
         registry = new NitroEnclaveKeyRegistry(attestationVerifier, owner);
         parent = new MockParentGame(L2_PRE_ROOT);
         proofVerifier = new NitroProofVerifier(registry);
+        WorldChainProofLib.Domain memory domain = WorldChainProofLib.Domain({
+            chainId: 480, proofSystemVersion: 1, rollupConfigHash: ROLLUP_CFG, blockInterval: L2_BLOCK - L2_PRE_BLOCK
+        });
+        proofSystemFactory = new MockProofSystemFactory(domain);
+        domainHash = WorldChainProofLib.domainHash(domain);
         game = new MockProofSystemGame();
         _setGameContext(_transition());
 
@@ -102,17 +108,17 @@ contract NitroProofVerifierTest is Test {
 
     function _expectedRootId() internal view returns (bytes32) {
         return WorldChainProofLib.rootId(
-            DOMAIN_HASH, address(parent), L2_POST_ROOT, uint256(L2_BLOCK), L1_ORIGIN_HASH, L1_ORIGIN_NUMBER
+            domainHash, address(parent), L2_POST_ROOT, uint256(L2_BLOCK), L1_ORIGIN_HASH, L1_ORIGIN_NUMBER
         );
     }
 
     function _proofBytes(bytes memory sig, bytes memory pub) internal view returns (bytes memory) {
-        return abi.encode(DOMAIN_HASH, address(parent), L1_ORIGIN_NUMBER, _transition(), sig, pub);
+        return abi.encode(domainHash, address(parent), L1_ORIGIN_NUMBER, _transition(), sig, pub);
     }
 
     function _setGameContext(WorldChainProofLib.TransitionPublicValues memory transition) internal {
         bytes32 rootId = WorldChainProofLib.rootId(
-            DOMAIN_HASH,
+            domainHash,
             address(parent),
             transition.l2PostRoot,
             uint256(transition.l2PostBlockNumber),
@@ -121,9 +127,10 @@ contract NitroProofVerifierTest is Test {
         );
         game.setContext(
             MockProofSystemGame.Context({
+                factory: address(proofSystemFactory),
                 rootId: rootId,
                 anchorStateRegistry: ANCHOR_STATE_REGISTRY,
-                domainHash: DOMAIN_HASH,
+                domainHash: domainHash,
                 parentRef: address(parent),
                 startingRootClaim: L2_PRE_ROOT,
                 startingL2BlockNumber: L2_PRE_BLOCK,
@@ -164,7 +171,7 @@ contract NitroProofVerifierTest is Test {
         wrongTransition.l2PostBlockNumber += 1;
         bytes memory sig = _sign(keccak256(abi.encode(wrongTransition)));
         bytes32 wrongRootId = WorldChainProofLib.rootId(
-            DOMAIN_HASH,
+            domainHash,
             address(parent),
             L2_POST_ROOT,
             uint256(wrongTransition.l2PostBlockNumber),
@@ -172,7 +179,7 @@ contract NitroProofVerifierTest is Test {
             L1_ORIGIN_NUMBER
         );
         bytes memory proof =
-            abi.encode(DOMAIN_HASH, address(parent), L1_ORIGIN_NUMBER, wrongTransition, sig, enclavePubKey);
+            abi.encode(domainHash, address(parent), L1_ORIGIN_NUMBER, wrongTransition, sig, enclavePubKey);
         assertFalse(_verify(wrongRootId, proof));
     }
 
@@ -181,7 +188,7 @@ contract NitroProofVerifierTest is Test {
         wrongTransition.l2PreRoot = keccak256("wrong-pre-root");
         bytes memory sig = _sign(keccak256(abi.encode(wrongTransition)));
         bytes memory proof =
-            abi.encode(DOMAIN_HASH, address(parent), L1_ORIGIN_NUMBER, wrongTransition, sig, enclavePubKey);
+            abi.encode(domainHash, address(parent), L1_ORIGIN_NUMBER, wrongTransition, sig, enclavePubKey);
         assertFalse(_verify(_expectedRootId(), proof));
     }
 
@@ -190,7 +197,7 @@ contract NitroProofVerifierTest is Test {
         wrongTransition.l2PreBlockNumber += 1;
         bytes memory sig = _sign(keccak256(abi.encode(wrongTransition)));
         bytes memory proof =
-            abi.encode(DOMAIN_HASH, address(parent), L1_ORIGIN_NUMBER, wrongTransition, sig, enclavePubKey);
+            abi.encode(domainHash, address(parent), L1_ORIGIN_NUMBER, wrongTransition, sig, enclavePubKey);
 
         assertFalse(_verify(_expectedRootId(), proof));
     }
@@ -353,31 +360,24 @@ contract NitroProofVerifierTest is Test {
         WorldChainProofLib.TransitionPublicValues memory transition = _transition();
         transition.l2PostBlockNumber = 0;
         bytes32 rootId =
-            WorldChainProofLib.rootId(DOMAIN_HASH, address(parent), L2_POST_ROOT, 0, L1_ORIGIN_HASH, L1_ORIGIN_NUMBER);
+            WorldChainProofLib.rootId(domainHash, address(parent), L2_POST_ROOT, 0, L1_ORIGIN_HASH, L1_ORIGIN_NUMBER);
         bytes32 commitment = keccak256(abi.encode(transition));
         bytes memory sig = _sign(commitment);
-        bytes memory proof = abi.encode(DOMAIN_HASH, address(parent), L1_ORIGIN_NUMBER, transition, sig, enclavePubKey);
+        bytes memory proof = abi.encode(domainHash, address(parent), L1_ORIGIN_NUMBER, transition, sig, enclavePubKey);
         _setGameContext(transition);
         assertTrue(_verify(rootId, proof));
     }
 
     function test_Verify_FalseForWrongRollupConfigHash() public {
-        // The proof's `rollupConfigHash` participates in the signing
-        // commitment but NOT in the rootId reconstruction (see
-        // `NitroProofVerifier._decodeAndVerify`). A mismatched
-        // rollupConfigHash in the proof must therefore cause the signature
-        // recovery to mismatch the expected key and surface as `false`,
-        // even though `rootId` still reconstructs correctly.
+        // A valid enclave signature is insufficient when the transition was
+        // produced against a different rollup configuration than the game's factory domain.
         bytes32 wrongCfg = keccak256("wrong-cfg");
         WorldChainProofLib.TransitionPublicValues memory wrongTransition = _transition();
         wrongTransition.rollupConfigHash = wrongCfg;
         bytes32 commitment = keccak256(abi.encode(wrongTransition));
         bytes memory sig = _sign(commitment);
-        // Build the proof claiming the ORIGINAL rollupConfigHash (so rootId
-        // reconstructs to the expected one), but with a signature over the
-        // wrong-cfg commitment.
         bytes memory proof =
-            abi.encode(DOMAIN_HASH, address(parent), L1_ORIGIN_NUMBER, _transition(), sig, enclavePubKey);
+            abi.encode(domainHash, address(parent), L1_ORIGIN_NUMBER, wrongTransition, sig, enclavePubKey);
         assertFalse(_verify(_expectedRootId(), proof));
     }
 

--- a/pkg/contracts/test/sp1/SP1ValidityVerifier.t.sol
+++ b/pkg/contracts/test/sp1/SP1ValidityVerifier.t.sol
@@ -10,6 +10,7 @@ import {
     TransitionPublicValues
 } from "../../src/proofs/sp1/SP1ValidityVerifier.sol";
 import {WorldChainProofLib} from "../../src/proofs/WorldChainProofLib.sol";
+import {MockProofSystemGame} from "../mocks/MockProofSystemGame.sol";
 
 contract StubSP1Verifier is ISP1Verifier {
     bool public reject;
@@ -64,6 +65,7 @@ contract SP1ValidityVerifierTest is Test {
     StubAnchorStateRegistry internal anchor;
     StubParentGame internal parent;
     SP1ValidityVerifier internal verifier;
+    MockProofSystemGame internal game;
 
     bytes32 internal constant AGGREGATION_VKEY = bytes32(uint256(0xA66));
     bytes32 internal constant ROLLUP_CONFIG_HASH = keccak256("world-chain-rollup-config");
@@ -87,6 +89,8 @@ contract SP1ValidityVerifierTest is Test {
         verifier = new SP1ValidityVerifier(
             ISP1Verifier(address(sp1)), AGGREGATION_VKEY, ROLLUP_CONFIG_HASH, RANGE_VKEY_COMMITMENT, address(anchor)
         );
+        game = new MockProofSystemGame();
+        _setGameContext(address(parent));
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -139,6 +143,27 @@ contract SP1ValidityVerifierTest is Test {
         sp1.setExpectation(AGGREGATION_VKEY, _publicValues(values), SP1_PROOF_BYTES);
     }
 
+    function _setGameContext(address parentRef) internal {
+        game.setContext(
+            MockProofSystemGame.Context({
+                rootId: _rootId(parentRef),
+                anchorStateRegistry: address(anchor),
+                domainHash: DOMAIN_HASH,
+                parentRef: parentRef,
+                startingRootClaim: L2_PRE_ROOT,
+                startingL2BlockNumber: L2_PRE_BLOCK_NUMBER,
+                rootClaim: L2_POST_ROOT,
+                l2BlockNumber: L2_BLOCK_NUMBER,
+                l1OriginHash: L1_ORIGIN_HASH,
+                l1OriginNumber: L1_ORIGIN_NUMBER
+            })
+        );
+    }
+
+    function _verify(bytes32 rootId, bytes memory proof) internal view returns (bool) {
+        return game.verify(address(verifier), rootId, proof);
+    }
+
     /*//////////////////////////////////////////////////////////////
                                CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
@@ -186,16 +211,28 @@ contract SP1ValidityVerifierTest is Test {
         AggregationPublicValues memory outputs = _publicValuesStruct();
         _expectSp1Call(outputs);
 
-        assertTrue(verifier.verify(_rootId(), _proof(outputs)));
+        assertTrue(_verify(_rootId(), _proof(outputs)));
     }
 
     function test_Verify_HappyPath_WithAnchorRegistryParent() public {
+        _setGameContext(address(anchor));
         AggregationPublicValues memory outputs = _publicValuesStruct();
         _expectSp1Call(outputs);
 
         bytes memory proof = _proof(DOMAIN_HASH, address(anchor), L1_ORIGIN_NUMBER, outputs, SP1_PROOF_BYTES);
 
-        assertTrue(verifier.verify(_rootId(address(anchor)), proof));
+        assertTrue(_verify(_rootId(address(anchor)), proof));
+    }
+
+    function test_Verify_UsesGameSnapshotAfterAnchorAdvances() public {
+        _setGameContext(address(anchor));
+        anchor.setCurrentRootClaim(keccak256("new-anchor-root"));
+
+        AggregationPublicValues memory outputs = _publicValuesStruct();
+        _expectSp1Call(outputs);
+        bytes memory proof = _proof(DOMAIN_HASH, address(anchor), L1_ORIGIN_NUMBER, outputs, SP1_PROOF_BYTES);
+
+        assertTrue(_verify(_rootId(address(anchor)), proof));
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -203,13 +240,13 @@ contract SP1ValidityVerifierTest is Test {
     //////////////////////////////////////////////////////////////*/
 
     function test_Verify_FalseForMalformedOuterProof() public view {
-        assertFalse(verifier.verify(_rootId(), hex"deadbeef"));
+        assertFalse(_verify(_rootId(), hex"deadbeef"));
     }
 
     function test_Verify_FalseForMalformedPublicValues() public view {
         bytes memory proof = abi.encode(DOMAIN_HASH, address(parent), L1_ORIGIN_NUMBER, hex"deadbeef", SP1_PROOF_BYTES);
 
-        assertFalse(verifier.verify(_rootId(), proof));
+        assertFalse(_verify(_rootId(), proof));
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -221,14 +258,14 @@ contract SP1ValidityVerifierTest is Test {
         _expectSp1Call(outputs);
         sp1.setReject(true);
 
-        assertFalse(verifier.verify(_rootId(), _proof(outputs)));
+        assertFalse(_verify(_rootId(), _proof(outputs)));
     }
 
     function test_Verify_FalseWhenUnexpectedProofBytesForwarded() public {
         AggregationPublicValues memory outputs = _publicValuesStruct();
         sp1.setExpectation(AGGREGATION_VKEY, _publicValues(outputs), bytes("unexpected"));
 
-        assertFalse(verifier.verify(_rootId(), _proof(outputs)));
+        assertFalse(_verify(_rootId(), _proof(outputs)));
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -239,29 +276,37 @@ contract SP1ValidityVerifierTest is Test {
         AggregationPublicValues memory outputs = _publicValuesStruct();
         outputs.transitionPublicValues.rollupConfigHash = keccak256("wrong-rollup-config");
 
-        assertFalse(verifier.verify(_rootId(), _proof(outputs)));
+        assertFalse(_verify(_rootId(), _proof(outputs)));
     }
 
     function test_Verify_FalseForRangeVKeyMismatch() public view {
         AggregationPublicValues memory outputs = _publicValuesStruct();
         outputs.multiBlockVKey = keccak256("wrong-range-vkey");
 
-        assertFalse(verifier.verify(_rootId(), _proof(outputs)));
+        assertFalse(_verify(_rootId(), _proof(outputs)));
     }
 
     function test_Verify_FalseForParentGamePreRootMismatch() public view {
         AggregationPublicValues memory outputs = _publicValuesStruct();
         outputs.transitionPublicValues.l2PreRoot = keccak256("wrong-pre-root");
 
-        assertFalse(verifier.verify(_rootId(), _proof(outputs)));
+        assertFalse(_verify(_rootId(), _proof(outputs)));
     }
 
-    function test_Verify_FalseForAnchorRegistryPreRootMismatch() public view {
+    function test_Verify_FalseForAnchorRegistryPreRootMismatch() public {
+        _setGameContext(address(anchor));
         AggregationPublicValues memory outputs = _publicValuesStruct();
         outputs.transitionPublicValues.l2PreRoot = keccak256("wrong-pre-root");
         bytes memory proof = _proof(DOMAIN_HASH, address(anchor), L1_ORIGIN_NUMBER, outputs, SP1_PROOF_BYTES);
 
-        assertFalse(verifier.verify(_rootId(address(anchor)), proof));
+        assertFalse(_verify(_rootId(address(anchor)), proof));
+    }
+
+    function test_Verify_FalseForPreBlockNumberMismatch() public view {
+        AggregationPublicValues memory outputs = _publicValuesStruct();
+        outputs.transitionPublicValues.l2PreBlockNumber = L2_PRE_BLOCK_NUMBER + 1;
+
+        assertFalse(_verify(_rootId(), _proof(outputs)));
     }
 
     function test_Verify_FalseForUnreadableParentRef() public view {
@@ -269,7 +314,7 @@ contract SP1ValidityVerifierTest is Test {
         address unreadableParentRef = address(0xBEEF);
         bytes memory proof = _proof(DOMAIN_HASH, unreadableParentRef, L1_ORIGIN_NUMBER, outputs, SP1_PROOF_BYTES);
 
-        assertFalse(verifier.verify(_rootId(unreadableParentRef), proof));
+        assertFalse(_verify(_rootId(unreadableParentRef), proof));
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -280,7 +325,7 @@ contract SP1ValidityVerifierTest is Test {
         AggregationPublicValues memory outputs = _publicValuesStruct();
         _expectSp1Call(outputs);
 
-        assertFalse(verifier.verify(bytes32(uint256(0xdead)), _proof(outputs)));
+        assertFalse(_verify(bytes32(uint256(0xdead)), _proof(outputs)));
     }
 
     function test_Verify_FalseForDomainHashMismatch() public view {
@@ -288,41 +333,41 @@ contract SP1ValidityVerifierTest is Test {
         bytes memory proof =
             _proof(keccak256("wrong-domain"), address(parent), L1_ORIGIN_NUMBER, outputs, SP1_PROOF_BYTES);
 
-        assertFalse(verifier.verify(_rootId(), proof));
+        assertFalse(_verify(_rootId(), proof));
     }
 
     function test_Verify_FalseForParentRefMismatch() public view {
         AggregationPublicValues memory outputs = _publicValuesStruct();
         bytes memory proof = _proof(DOMAIN_HASH, address(0xBAD), L1_ORIGIN_NUMBER, outputs, SP1_PROOF_BYTES);
 
-        assertFalse(verifier.verify(_rootId(), proof));
+        assertFalse(_verify(_rootId(), proof));
     }
 
     function test_Verify_FalseForPostRootMismatch() public view {
         AggregationPublicValues memory outputs = _publicValuesStruct();
         outputs.transitionPublicValues.l2PostRoot = keccak256("wrong-post-root");
 
-        assertFalse(verifier.verify(_rootId(), _proof(outputs)));
+        assertFalse(_verify(_rootId(), _proof(outputs)));
     }
 
     function test_Verify_FalseForBlockNumberMismatch() public view {
         AggregationPublicValues memory outputs = _publicValuesStruct();
         outputs.transitionPublicValues.l2PostBlockNumber = L2_BLOCK_NUMBER + 1;
 
-        assertFalse(verifier.verify(_rootId(), _proof(outputs)));
+        assertFalse(_verify(_rootId(), _proof(outputs)));
     }
 
     function test_Verify_FalseForL1HeadMismatch() public view {
         AggregationPublicValues memory outputs = _publicValuesStruct();
         outputs.transitionPublicValues.l1Head = keccak256("wrong-l1-head");
 
-        assertFalse(verifier.verify(_rootId(), _proof(outputs)));
+        assertFalse(_verify(_rootId(), _proof(outputs)));
     }
 
     function test_Verify_FalseForL1OriginNumberMismatch() public view {
         AggregationPublicValues memory outputs = _publicValuesStruct();
         bytes memory proof = _proof(DOMAIN_HASH, address(parent), L1_ORIGIN_NUMBER + 1, outputs, SP1_PROOF_BYTES);
 
-        assertFalse(verifier.verify(_rootId(), proof));
+        assertFalse(_verify(_rootId(), proof));
     }
 }

--- a/pkg/contracts/test/sp1/SP1ValidityVerifier.t.sol
+++ b/pkg/contracts/test/sp1/SP1ValidityVerifier.t.sol
@@ -6,7 +6,7 @@ import {Test} from "forge-std/Test.sol";
 import {ISP1Verifier} from "@sp1-contracts/src/ISP1Verifier.sol";
 import {AggregationPublicValues, SP1ValidityVerifier} from "../../src/proofs/sp1/SP1ValidityVerifier.sol";
 import {WorldChainProofLib} from "../../src/proofs/WorldChainProofLib.sol";
-import {MockProofSystemGame} from "../mocks/MockProofSystemGame.sol";
+import {MockProofSystemFactory, MockProofSystemGame} from "../mocks/MockProofSystemGame.sol";
 
 contract StubSP1Verifier is ISP1Verifier {
     bool public reject;
@@ -62,12 +62,13 @@ contract SP1ValidityVerifierTest is Test {
     StubParentGame internal parent;
     SP1ValidityVerifier internal verifier;
     MockProofSystemGame internal game;
+    MockProofSystemFactory internal proofSystemFactory;
+    bytes32 internal domainHash;
 
     bytes32 internal constant AGGREGATION_VKEY = bytes32(uint256(0xA66));
     bytes32 internal constant ROLLUP_CONFIG_HASH = keccak256("world-chain-rollup-config");
     bytes32 internal constant RANGE_VKEY_COMMITMENT = keccak256("range-vkey");
 
-    bytes32 internal constant DOMAIN_HASH = keccak256("domain");
     bytes32 internal constant L1_ORIGIN_HASH = keccak256("l1-origin");
     uint256 internal constant L1_ORIGIN_NUMBER = 9_001;
 
@@ -82,9 +83,15 @@ contract SP1ValidityVerifierTest is Test {
         sp1 = new StubSP1Verifier();
         anchor = new StubAnchorStateRegistry(L2_PRE_ROOT);
         parent = new StubParentGame(L2_PRE_ROOT);
-        verifier = new SP1ValidityVerifier(
-            ISP1Verifier(address(sp1)), AGGREGATION_VKEY, ROLLUP_CONFIG_HASH, RANGE_VKEY_COMMITMENT
-        );
+        WorldChainProofLib.Domain memory domain = WorldChainProofLib.Domain({
+            chainId: 480,
+            proofSystemVersion: 1,
+            rollupConfigHash: ROLLUP_CONFIG_HASH,
+            blockInterval: L2_BLOCK_NUMBER - L2_PRE_BLOCK_NUMBER
+        });
+        proofSystemFactory = new MockProofSystemFactory(domain);
+        domainHash = WorldChainProofLib.domainHash(domain);
+        verifier = new SP1ValidityVerifier(ISP1Verifier(address(sp1)), AGGREGATION_VKEY, RANGE_VKEY_COMMITMENT);
         game = new MockProofSystemGame();
         _setGameContext(address(parent));
     }
@@ -112,26 +119,26 @@ contract SP1ValidityVerifierTest is Test {
     }
 
     function _proof(AggregationPublicValues memory values) internal view returns (bytes memory) {
-        return _proof(DOMAIN_HASH, address(parent), L1_ORIGIN_NUMBER, values, SP1_PROOF_BYTES);
+        return _proof(domainHash, address(parent), L1_ORIGIN_NUMBER, values, SP1_PROOF_BYTES);
     }
 
     function _proof(
-        bytes32 domainHash,
+        bytes32 domainHash_,
         address parentRef,
         uint256 l1OriginNumber,
         AggregationPublicValues memory values,
         bytes memory proofBytes
     ) internal pure returns (bytes memory) {
-        return abi.encode(domainHash, parentRef, l1OriginNumber, _publicValues(values), proofBytes);
+        return abi.encode(domainHash_, parentRef, l1OriginNumber, _publicValues(values), proofBytes);
     }
 
     function _rootId() internal view returns (bytes32) {
         return _rootId(address(parent));
     }
 
-    function _rootId(address parentRef) internal pure returns (bytes32) {
+    function _rootId(address parentRef) internal view returns (bytes32) {
         return WorldChainProofLib.rootId(
-            DOMAIN_HASH, parentRef, L2_POST_ROOT, uint256(L2_BLOCK_NUMBER), L1_ORIGIN_HASH, L1_ORIGIN_NUMBER
+            domainHash, parentRef, L2_POST_ROOT, uint256(L2_BLOCK_NUMBER), L1_ORIGIN_HASH, L1_ORIGIN_NUMBER
         );
     }
 
@@ -142,9 +149,10 @@ contract SP1ValidityVerifierTest is Test {
     function _setGameContext(address parentRef) internal {
         game.setContext(
             MockProofSystemGame.Context({
+                factory: address(proofSystemFactory),
                 rootId: _rootId(parentRef),
                 anchorStateRegistry: address(anchor),
-                domainHash: DOMAIN_HASH,
+                domainHash: domainHash,
                 parentRef: parentRef,
                 startingRootClaim: L2_PRE_ROOT,
                 startingL2BlockNumber: L2_PRE_BLOCK_NUMBER,
@@ -166,22 +174,17 @@ contract SP1ValidityVerifierTest is Test {
 
     function test_Constructor_RevertsForZeroSP1Verifier() public {
         vm.expectRevert(SP1ValidityVerifier.ZeroSP1Verifier.selector);
-        new SP1ValidityVerifier(ISP1Verifier(address(0)), AGGREGATION_VKEY, ROLLUP_CONFIG_HASH, RANGE_VKEY_COMMITMENT);
+        new SP1ValidityVerifier(ISP1Verifier(address(0)), AGGREGATION_VKEY, RANGE_VKEY_COMMITMENT);
     }
 
     function test_Constructor_RevertsForZeroAggregationVKey() public {
         vm.expectRevert(SP1ValidityVerifier.ZeroAggregationVKey.selector);
-        new SP1ValidityVerifier(ISP1Verifier(address(sp1)), bytes32(0), ROLLUP_CONFIG_HASH, RANGE_VKEY_COMMITMENT);
-    }
-
-    function test_Constructor_RevertsForZeroRollupConfigHash() public {
-        vm.expectRevert(SP1ValidityVerifier.ZeroRollupConfigHash.selector);
-        new SP1ValidityVerifier(ISP1Verifier(address(sp1)), AGGREGATION_VKEY, bytes32(0), RANGE_VKEY_COMMITMENT);
+        new SP1ValidityVerifier(ISP1Verifier(address(sp1)), bytes32(0), RANGE_VKEY_COMMITMENT);
     }
 
     function test_Constructor_RevertsForZeroRangeVKeyCommitment() public {
         vm.expectRevert(SP1ValidityVerifier.ZeroRangeVKeyCommitment.selector);
-        new SP1ValidityVerifier(ISP1Verifier(address(sp1)), AGGREGATION_VKEY, ROLLUP_CONFIG_HASH, bytes32(0));
+        new SP1ValidityVerifier(ISP1Verifier(address(sp1)), AGGREGATION_VKEY, bytes32(0));
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -200,7 +203,7 @@ contract SP1ValidityVerifierTest is Test {
         AggregationPublicValues memory outputs = _publicValuesStruct();
         _expectSp1Call(outputs);
 
-        bytes memory proof = _proof(DOMAIN_HASH, address(anchor), L1_ORIGIN_NUMBER, outputs, SP1_PROOF_BYTES);
+        bytes memory proof = _proof(domainHash, address(anchor), L1_ORIGIN_NUMBER, outputs, SP1_PROOF_BYTES);
 
         assertTrue(_verify(_rootId(address(anchor)), proof));
     }
@@ -211,7 +214,7 @@ contract SP1ValidityVerifierTest is Test {
 
         AggregationPublicValues memory outputs = _publicValuesStruct();
         _expectSp1Call(outputs);
-        bytes memory proof = _proof(DOMAIN_HASH, address(anchor), L1_ORIGIN_NUMBER, outputs, SP1_PROOF_BYTES);
+        bytes memory proof = _proof(domainHash, address(anchor), L1_ORIGIN_NUMBER, outputs, SP1_PROOF_BYTES);
 
         assertTrue(_verify(_rootId(address(anchor)), proof));
     }
@@ -225,7 +228,7 @@ contract SP1ValidityVerifierTest is Test {
     }
 
     function test_Verify_FalseForMalformedPublicValues() public view {
-        bytes memory proof = abi.encode(DOMAIN_HASH, address(parent), L1_ORIGIN_NUMBER, hex"deadbeef", SP1_PROOF_BYTES);
+        bytes memory proof = abi.encode(domainHash, address(parent), L1_ORIGIN_NUMBER, hex"deadbeef", SP1_PROOF_BYTES);
 
         assertFalse(_verify(_rootId(), proof));
     }
@@ -278,7 +281,7 @@ contract SP1ValidityVerifierTest is Test {
         _setGameContext(address(anchor));
         AggregationPublicValues memory outputs = _publicValuesStruct();
         outputs.transitionPublicValues.l2PreRoot = keccak256("wrong-pre-root");
-        bytes memory proof = _proof(DOMAIN_HASH, address(anchor), L1_ORIGIN_NUMBER, outputs, SP1_PROOF_BYTES);
+        bytes memory proof = _proof(domainHash, address(anchor), L1_ORIGIN_NUMBER, outputs, SP1_PROOF_BYTES);
 
         assertFalse(_verify(_rootId(address(anchor)), proof));
     }
@@ -293,7 +296,7 @@ contract SP1ValidityVerifierTest is Test {
     function test_Verify_FalseForUnreadableParentRef() public view {
         AggregationPublicValues memory outputs = _publicValuesStruct();
         address unreadableParentRef = address(0xBEEF);
-        bytes memory proof = _proof(DOMAIN_HASH, unreadableParentRef, L1_ORIGIN_NUMBER, outputs, SP1_PROOF_BYTES);
+        bytes memory proof = _proof(domainHash, unreadableParentRef, L1_ORIGIN_NUMBER, outputs, SP1_PROOF_BYTES);
 
         assertFalse(_verify(_rootId(unreadableParentRef), proof));
     }
@@ -319,7 +322,7 @@ contract SP1ValidityVerifierTest is Test {
 
     function test_Verify_FalseForParentRefMismatch() public view {
         AggregationPublicValues memory outputs = _publicValuesStruct();
-        bytes memory proof = _proof(DOMAIN_HASH, address(0xBAD), L1_ORIGIN_NUMBER, outputs, SP1_PROOF_BYTES);
+        bytes memory proof = _proof(domainHash, address(0xBAD), L1_ORIGIN_NUMBER, outputs, SP1_PROOF_BYTES);
 
         assertFalse(_verify(_rootId(), proof));
     }
@@ -347,7 +350,7 @@ contract SP1ValidityVerifierTest is Test {
 
     function test_Verify_FalseForL1OriginNumberMismatch() public view {
         AggregationPublicValues memory outputs = _publicValuesStruct();
-        bytes memory proof = _proof(DOMAIN_HASH, address(parent), L1_ORIGIN_NUMBER + 1, outputs, SP1_PROOF_BYTES);
+        bytes memory proof = _proof(domainHash, address(parent), L1_ORIGIN_NUMBER + 1, outputs, SP1_PROOF_BYTES);
 
         assertFalse(_verify(_rootId(), proof));
     }

--- a/pkg/contracts/test/sp1/SP1ValidityVerifier.t.sol
+++ b/pkg/contracts/test/sp1/SP1ValidityVerifier.t.sol
@@ -4,11 +4,7 @@ pragma solidity 0.8.28;
 import {Test} from "forge-std/Test.sol";
 
 import {ISP1Verifier} from "@sp1-contracts/src/ISP1Verifier.sol";
-import {
-    AggregationPublicValues,
-    SP1ValidityVerifier,
-    TransitionPublicValues
-} from "../../src/proofs/sp1/SP1ValidityVerifier.sol";
+import {AggregationPublicValues, SP1ValidityVerifier} from "../../src/proofs/sp1/SP1ValidityVerifier.sol";
 import {WorldChainProofLib} from "../../src/proofs/WorldChainProofLib.sol";
 import {MockProofSystemGame} from "../mocks/MockProofSystemGame.sol";
 
@@ -99,7 +95,7 @@ contract SP1ValidityVerifierTest is Test {
 
     function _publicValuesStruct() internal pure returns (AggregationPublicValues memory) {
         return AggregationPublicValues({
-            transitionPublicValues: TransitionPublicValues({
+            transitionPublicValues: WorldChainProofLib.TransitionPublicValues({
                 l1Head: L1_ORIGIN_HASH,
                 l2PreRoot: L2_PRE_ROOT,
                 l2PreBlockNumber: L2_PRE_BLOCK_NUMBER,

--- a/pkg/contracts/test/sp1/SP1ValidityVerifier.t.sol
+++ b/pkg/contracts/test/sp1/SP1ValidityVerifier.t.sol
@@ -83,7 +83,7 @@ contract SP1ValidityVerifierTest is Test {
         anchor = new StubAnchorStateRegistry(L2_PRE_ROOT);
         parent = new StubParentGame(L2_PRE_ROOT);
         verifier = new SP1ValidityVerifier(
-            ISP1Verifier(address(sp1)), AGGREGATION_VKEY, ROLLUP_CONFIG_HASH, RANGE_VKEY_COMMITMENT, address(anchor)
+            ISP1Verifier(address(sp1)), AGGREGATION_VKEY, ROLLUP_CONFIG_HASH, RANGE_VKEY_COMMITMENT
         );
         game = new MockProofSystemGame();
         _setGameContext(address(parent));
@@ -166,37 +166,22 @@ contract SP1ValidityVerifierTest is Test {
 
     function test_Constructor_RevertsForZeroSP1Verifier() public {
         vm.expectRevert(SP1ValidityVerifier.ZeroSP1Verifier.selector);
-        new SP1ValidityVerifier(
-            ISP1Verifier(address(0)), AGGREGATION_VKEY, ROLLUP_CONFIG_HASH, RANGE_VKEY_COMMITMENT, address(anchor)
-        );
+        new SP1ValidityVerifier(ISP1Verifier(address(0)), AGGREGATION_VKEY, ROLLUP_CONFIG_HASH, RANGE_VKEY_COMMITMENT);
     }
 
     function test_Constructor_RevertsForZeroAggregationVKey() public {
         vm.expectRevert(SP1ValidityVerifier.ZeroAggregationVKey.selector);
-        new SP1ValidityVerifier(
-            ISP1Verifier(address(sp1)), bytes32(0), ROLLUP_CONFIG_HASH, RANGE_VKEY_COMMITMENT, address(anchor)
-        );
+        new SP1ValidityVerifier(ISP1Verifier(address(sp1)), bytes32(0), ROLLUP_CONFIG_HASH, RANGE_VKEY_COMMITMENT);
     }
 
     function test_Constructor_RevertsForZeroRollupConfigHash() public {
         vm.expectRevert(SP1ValidityVerifier.ZeroRollupConfigHash.selector);
-        new SP1ValidityVerifier(
-            ISP1Verifier(address(sp1)), AGGREGATION_VKEY, bytes32(0), RANGE_VKEY_COMMITMENT, address(anchor)
-        );
+        new SP1ValidityVerifier(ISP1Verifier(address(sp1)), AGGREGATION_VKEY, bytes32(0), RANGE_VKEY_COMMITMENT);
     }
 
     function test_Constructor_RevertsForZeroRangeVKeyCommitment() public {
         vm.expectRevert(SP1ValidityVerifier.ZeroRangeVKeyCommitment.selector);
-        new SP1ValidityVerifier(
-            ISP1Verifier(address(sp1)), AGGREGATION_VKEY, ROLLUP_CONFIG_HASH, bytes32(0), address(anchor)
-        );
-    }
-
-    function test_Constructor_RevertsForZeroAnchorStateRegistry() public {
-        vm.expectRevert(SP1ValidityVerifier.ZeroAnchorStateRegistry.selector);
-        new SP1ValidityVerifier(
-            ISP1Verifier(address(sp1)), AGGREGATION_VKEY, ROLLUP_CONFIG_HASH, RANGE_VKEY_COMMITMENT, address(0)
-        );
+        new SP1ValidityVerifier(ISP1Verifier(address(sp1)), AGGREGATION_VKEY, ROLLUP_CONFIG_HASH, bytes32(0));
     }
 
     /*//////////////////////////////////////////////////////////////


### PR DESCRIPTION
this PR
- Bind SP1 and Nitro proofs to the calling game’s immutable proposal transition.
- Introduce a shared TransitionPublicValues type.
- Centralize rootId reconstruction and game matching.
- Validate pre/post roots and block numbers, L1 origin, domain, and parent.
- Use the game’s snapshotted starting state instead of reading parent or anchor state live.
- Keep verifiers independent from AnchorStateRegistry.
- Preserve the existing verify(bytes32,bytes) ABI and proof encoding.

This ensures anchor updates cannot change an existing game’s expected transition and prevents valid proofs from being reused for a different game context.