### PR TITLE
feat: world chain proof system game: pull based value resolving

### DIFF
--- a/pkg/contracts/README.md
+++ b/pkg/contracts/README.md
@@ -8,6 +8,12 @@
 
 This repository contains smart contracts for World Chain, including PBH (Priority Blockspace for Humans) and Fee Vault contracts.
 
+## Proof System Bond Claims
+
+`WorldChainProofSystemGame.resolve()` records the game outcome and assigns pull-based bond claims. It does not transfer ETH during resolution. After a game resolves, automation such as the challenger, the defender/prover-service flow, or any keeper should call `withdraw(recipient)` for claimable proposers and challengers.
+
+`claimable(recipient)` returns the amount currently owed to `recipient`. `withdraw(recipient)` is permissionless, but funds are always sent to `recipient`, so the caller cannot redirect or steal another account's claim.
+
 ## PBH Contracts
 
 [Priority blockspace for humans (PBH)](https://github.com/worldcoin/world-chain?tab=readme-ov-file#world-chain-builder) enables verified World ID users to execute transactions with top of block priority, enabling a more frictionless user experience onchain. This mechanism is designed to ensure that ordinary users aren't unfairly disadvantaged by automated systems and greatly mitigates the negative impact of MEV.
@@ -64,4 +70,3 @@ The `FeeEscrow` contract handles the conversion of ETH to WLD for burning. Key f
 - Includes slippage protection (0.03%) to ensure fair execution
 
 The burn mechanism requires executors to implement the `IBurnCallback` interface, providing flexibility in how the ETH-to-WLD swap is performed (e.g., via Uniswap V3).
-

--- a/pkg/contracts/README.md
+++ b/pkg/contracts/README.md
@@ -10,7 +10,7 @@ This repository contains smart contracts for World Chain, including PBH (Priorit
 
 ## Proof System Bond Claims
 
-`WorldChainProofSystemGame.resolve()` records the game outcome and assigns pull-based bond claims. It does not transfer ETH during resolution. After a game resolves, automation such as the challenger, the defender/prover-service flow, or any keeper should call `withdraw(recipient)` for claimable proposers and challengers.
+`WorldChainProofSystemGame.resolve()` records the game outcome and assigns pull-based bond claims. It does not transfer ETH during resolution. After a game resolves, automation such as the challenger, the defender/prover-service flow, or any keeper should call `withdraw(recipient)` for the claimable proposer or challenger.
 
 `claimable(recipient)` returns the amount currently owed to `recipient`. `withdraw(recipient)` is permissionless, but funds are always sent to `recipient`, so the caller cannot redirect or steal another account's claim.
 

--- a/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
@@ -194,12 +194,11 @@ contract WorldChainProofSystemGame is ReentrancyGuardTransient {
     ///      the caller cannot redirect funds away from `recipient`.
     function withdraw(address payable recipient) external nonReentrant {
         address account = recipient;
-        uint256 credit = payoutCredits[account];
-        uint256 refundablePrincipal = _refundableChallengerPrincipal(account);
-        uint256 amount = credit + refundablePrincipal;
+        uint256 amount = _claimable(account);
         if (amount == 0) revert NoClaim(account);
 
-        if (credit != 0) payoutCredits[account] = 0;
+        uint256 refundablePrincipal = _refundableChallengerPrincipal(account);
+        payoutCredits[account] = 0;
         if (refundablePrincipal != 0) postedChallengerBond = 0;
 
         _transfer(recipient, amount);
@@ -360,6 +359,7 @@ contract WorldChainProofSystemGame is ReentrancyGuardTransient {
         uint256 balance = address(this).balance;
         if (reason == WorldChainProofLib.InvalidationReason.PROOF_TIMEOUT) {
             payoutCredits[challenger] += balance;
+            // The full-balance credit already includes the challenger bond, so it is no longer separately refundable.
             postedChallengerBond = 0;
         } else {
             uint256 proposerRefund = balance - postedChallengerBond;
@@ -394,8 +394,7 @@ contract WorldChainProofSystemGame is ReentrancyGuardTransient {
     function _refundableChallengerPrincipal(address recipient) internal view returns (uint256) {
         if (state != WorldChainProofLib.RootState.INVALIDATED) return 0;
         if (
-            invalidationReason != WorldChainProofLib.InvalidationReason.PROOF_TIMEOUT
-                && invalidationReason != WorldChainProofLib.InvalidationReason.INVALID_PARENT
+            invalidationReason != WorldChainProofLib.InvalidationReason.INVALID_PARENT
                 && invalidationReason != WorldChainProofLib.InvalidationReason.BLACKLISTED
         ) {
             return 0;

--- a/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
@@ -358,7 +358,7 @@ contract WorldChainProofSystemGame is ReentrancyGuardTransient {
         invalidatedAt = uint64(block.timestamp);
 
         uint256 balance = address(this).balance;
-        if (reason == WorldChainProofLib.InvalidationReason.PROOF_TIMEOUT && challenger != address(0)) {
+        if (reason == WorldChainProofLib.InvalidationReason.PROOF_TIMEOUT) {
             payoutCredits[challenger] += balance;
             postedChallengerBond = 0;
         } else {

--- a/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
@@ -394,15 +394,11 @@ contract WorldChainProofSystemGame is ReentrancyGuardTransient {
     /// @dev Proof timeout credits the full balance to the challenger, so only inherited or governance invalidations
     ///      refund the challenger bond separately.
     function _refundableChallengerPrincipal(address recipient) internal view returns (uint256) {
-        if (state != WorldChainProofLib.RootState.INVALIDATED) return 0;
-        if (
-            invalidationReason != WorldChainProofLib.InvalidationReason.INVALID_PARENT
-                && invalidationReason != WorldChainProofLib.InvalidationReason.BLACKLISTED
-        ) {
-            return 0;
-        }
-        if (recipient != challenger) return 0;
-        return postedChallengerBond;
+        bool challengerBondIsRefundable = state == WorldChainProofLib.RootState.INVALIDATED && recipient == challenger
+            && (invalidationReason == WorldChainProofLib.InvalidationReason.INVALID_PARENT
+                || invalidationReason == WorldChainProofLib.InvalidationReason.BLACKLISTED);
+
+        return challengerBondIsRefundable ? postedChallengerBond : 0;
     }
 
     function _transfer(address payable recipient, uint256 amount) internal {

--- a/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
@@ -113,6 +113,8 @@ contract WorldChainProofSystemGame is ReentrancyGuardTransient {
     WorldChainProofLib.RootState public state;
     WorldChainProofLib.InvalidationReason public invalidationReason;
 
+    // TODO: Revisit whether the game should allow only one challenger; additional challengers do not
+    // extend the proof deadline or receive the timeout reward.
     address[] public challengers;
     mapping(address challenger => uint256 amount) public challengerBonds;
     uint256 public totalChallengerBonds;

--- a/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
@@ -391,6 +391,8 @@ contract WorldChainProofSystemGame is ReentrancyGuardTransient {
         return payoutCredits[recipient] + _refundableChallengerPrincipal(recipient);
     }
 
+    /// @dev Proof timeout credits the full balance to the challenger, so only inherited or governance invalidations
+    ///      refund the challenger bond separately.
     function _refundableChallengerPrincipal(address recipient) internal view returns (uint256) {
         if (state != WorldChainProofLib.RootState.INVALIDATED) return 0;
         if (

--- a/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
@@ -359,12 +359,14 @@ contract WorldChainProofSystemGame is ReentrancyGuardTransient {
         invalidationReason = reason;
         invalidatedAt = uint64(block.timestamp);
 
-        if (proposerBond != 0) {
+        uint256 payout = address(this).balance - totalChallengerBonds;
+        if (payout != 0) {
+            // Challenger principal stays claimable through `challengerBonds`; route any remaining balance, including surplus.
             // Only a direct proof timeout is attributable to this proposer; inherited and governance failures refund it.
             if (reason == WorldChainProofLib.InvalidationReason.PROOF_TIMEOUT && challengers.length != 0) {
-                payoutCredits[challengers[0]] += proposerBond;
+                payoutCredits[challengers[0]] += payout;
             } else {
-                payoutCredits[proposer] += proposerBond;
+                payoutCredits[proposer] += payout;
             }
         }
 
@@ -375,7 +377,7 @@ contract WorldChainProofSystemGame is ReentrancyGuardTransient {
         state = WorldChainProofLib.RootState.FINALIZED;
         finalizedAt = uint64(block.timestamp);
 
-        uint256 payout = proposerBond + totalChallengerBonds;
+        uint256 payout = address(this).balance;
         if (payout != 0) {
             payoutCredits[proposer] += payout;
         }

--- a/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
@@ -357,15 +357,13 @@ contract WorldChainProofSystemGame is ReentrancyGuardTransient {
         invalidationReason = reason;
         invalidatedAt = uint64(block.timestamp);
 
-        uint256 residualPayout = address(this).balance - postedChallengerBond;
-        if (residualPayout != 0) {
-            // Reserve the challenger bond for its own withdraw(); route the remaining balance, including surplus.
-            // Only a direct proof timeout is attributable to this proposer; inherited and governance failures refund it.
-            if (reason == WorldChainProofLib.InvalidationReason.PROOF_TIMEOUT && challenger != address(0)) {
-                payoutCredits[challenger] += residualPayout;
-            } else {
-                payoutCredits[proposer] += residualPayout;
-            }
+        uint256 balance = address(this).balance;
+        if (reason == WorldChainProofLib.InvalidationReason.PROOF_TIMEOUT && challenger != address(0)) {
+            payoutCredits[challenger] += balance;
+            postedChallengerBond = 0;
+        } else {
+            uint256 proposerRefund = balance - postedChallengerBond;
+            if (proposerRefund != 0) payoutCredits[proposer] += proposerRefund;
         }
 
         emit Invalidated(rootId, reason);

--- a/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
@@ -113,11 +113,8 @@ contract WorldChainProofSystemGame is ReentrancyGuardTransient {
     WorldChainProofLib.RootState public state;
     WorldChainProofLib.InvalidationReason public invalidationReason;
 
-    // TODO: Revisit whether the game should allow only one challenger; additional challengers do not
-    // extend the proof deadline or receive the timeout reward.
-    address[] public challengers;
-    mapping(address challenger => uint256 amount) public challengerBonds;
-    uint256 public totalChallengerBonds;
+    address payable public challenger;
+    uint256 public postedChallengerBond;
     mapping(address recipient => uint256 amount) internal payoutCredits;
 
     constructor(ProposalInit memory proposal, ActivationConfig memory config) payable {
@@ -173,11 +170,10 @@ contract WorldChainProofSystemGame is ReentrancyGuardTransient {
         }
         if (!stakingRegistry.isStaked(msg.sender)) revert UnstakedChallenger(msg.sender);
         if (msg.value != challengerBond) revert InvalidBond(challengerBond, msg.value);
-        if (challengerBonds[msg.sender] != 0) revert DuplicateChallenge(msg.sender);
+        if (challenger != address(0)) revert DuplicateChallenge(challenger);
 
-        challengerBonds[msg.sender] = msg.value;
-        totalChallengerBonds += msg.value;
-        challengers.push(msg.sender);
+        challenger = payable(msg.sender);
+        postedChallengerBond = msg.value;
 
         if (state == WorldChainProofLib.RootState.PROPOSED) {
             state = WorldChainProofLib.RootState.CHALLENGED;
@@ -194,7 +190,7 @@ contract WorldChainProofSystemGame is ReentrancyGuardTransient {
     }
 
     /// @notice Permissionlessly withdraws `recipient`'s claim to `recipient`.
-    /// @dev Challengers, defender/prover-service automation, or keepers can call this after resolution;
+    /// @dev The challenger, defender/prover-service automation, or keepers can call this after resolution;
     ///      the caller cannot redirect funds away from `recipient`.
     function withdraw(address payable recipient) external nonReentrant {
         address account = recipient;
@@ -204,7 +200,7 @@ contract WorldChainProofSystemGame is ReentrancyGuardTransient {
         if (amount == 0) revert NoClaim(account);
 
         if (credit != 0) payoutCredits[account] = 0;
-        if (refundablePrincipal != 0) challengerBonds[account] = 0;
+        if (refundablePrincipal != 0) postedChallengerBond = 0;
 
         _transfer(recipient, amount);
         emit Withdrawn(account, amount);
@@ -361,14 +357,14 @@ contract WorldChainProofSystemGame is ReentrancyGuardTransient {
         invalidationReason = reason;
         invalidatedAt = uint64(block.timestamp);
 
-        uint256 payout = address(this).balance - totalChallengerBonds;
-        if (payout != 0) {
-            // Challenger principal stays claimable through `challengerBonds`; route any remaining balance, including surplus.
+        uint256 residualPayout = address(this).balance - postedChallengerBond;
+        if (residualPayout != 0) {
+            // Reserve the challenger bond for its own withdraw(); route the remaining balance, including surplus.
             // Only a direct proof timeout is attributable to this proposer; inherited and governance failures refund it.
-            if (reason == WorldChainProofLib.InvalidationReason.PROOF_TIMEOUT && challengers.length != 0) {
-                payoutCredits[challengers[0]] += payout;
+            if (reason == WorldChainProofLib.InvalidationReason.PROOF_TIMEOUT && challenger != address(0)) {
+                payoutCredits[challenger] += residualPayout;
             } else {
-                payoutCredits[proposer] += payout;
+                payoutCredits[proposer] += residualPayout;
             }
         }
 
@@ -406,7 +402,8 @@ contract WorldChainProofSystemGame is ReentrancyGuardTransient {
         ) {
             return 0;
         }
-        return challengerBonds[recipient];
+        if (recipient != challenger) return 0;
+        return postedChallengerBond;
     }
 
     function _transfer(address payable recipient, uint256 amount) internal {

--- a/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
@@ -6,8 +6,9 @@ import {IWorldChainAnchorStateRegistry} from "./interfaces/IWorldChainAnchorStat
 import {IWorldChainProofVerifier} from "./interfaces/IWorldChainProofVerifier.sol";
 import {IWorldChainProofSystemGame} from "./interfaces/IWorldChainProofSystemGame.sol";
 import {IWorldChainStakingRegistry} from "./interfaces/IWorldChainStakingRegistry.sol";
+import {ReentrancyGuardTransient} from "@openzeppelin/contracts/utils/ReentrancyGuardTransient.sol";
 
-contract WorldChainProofSystemGame {
+contract WorldChainProofSystemGame is ReentrancyGuardTransient {
     using WorldChainProofLib for uint8;
 
     struct ProposalInit {
@@ -62,6 +63,7 @@ contract WorldChainProofSystemGame {
     error DuplicateChallenge(address challenger);
     error InvalidLane(uint8 lane);
     error InvalidProof(WorldChainProofLib.ProofLane lane, bytes32 rootId);
+    error NoClaim(address recipient);
     error TransferFailed(address recipient, uint256 amount);
 
     event Challenged(address indexed challenger, uint64 proofDeadline);
@@ -70,6 +72,7 @@ contract WorldChainProofSystemGame {
     event DuplicateProofLane(WorldChainProofLib.ProofLane indexed lane, bytes32 indexed rootId, uint8 proofBitmap);
     event Finalized(bytes32 indexed rootId);
     event Invalidated(bytes32 indexed rootId, WorldChainProofLib.InvalidationReason reason);
+    event Withdrawn(address indexed recipient, uint256 amount);
 
     /// Number of distinct proof lanes required to finalize a challenged root.
     /// Set per-deployment by the factory (defaults to `WorldChainProofLib.PROOF_THRESHOLD`).
@@ -112,6 +115,8 @@ contract WorldChainProofSystemGame {
 
     address[] public challengers;
     mapping(address challenger => uint256 amount) public challengerBonds;
+    uint256 public totalChallengerBonds;
+    mapping(address recipient => uint256 amount) internal payoutCredits;
 
     constructor(ProposalInit memory proposal, ActivationConfig memory config) payable {
         if (msg.value != config.proposerBond) revert InvalidBond(config.proposerBond, msg.value);
@@ -169,6 +174,7 @@ contract WorldChainProofSystemGame {
         if (challengerBonds[msg.sender] != 0) revert DuplicateChallenge(msg.sender);
 
         challengerBonds[msg.sender] = msg.value;
+        totalChallengerBonds += msg.value;
         challengers.push(msg.sender);
 
         if (state == WorldChainProofLib.RootState.PROPOSED) {
@@ -178,6 +184,28 @@ contract WorldChainProofSystemGame {
         }
 
         emit Challenged(msg.sender, proofDeadline);
+    }
+
+    /// @notice Returns the ETH amount `recipient` can withdraw from this game.
+    function claimable(address recipient) external view returns (uint256) {
+        return _claimable(recipient);
+    }
+
+    /// @notice Permissionlessly withdraws `recipient`'s claim to `recipient`.
+    /// @dev Challengers, defender/prover-service automation, or keepers can call this after resolution;
+    ///      the caller cannot redirect funds away from `recipient`.
+    function withdraw(address payable recipient) external nonReentrant {
+        address account = recipient;
+        uint256 credit = payoutCredits[account];
+        uint256 refundablePrincipal = _refundableChallengerPrincipal(account);
+        uint256 amount = credit + refundablePrincipal;
+        if (amount == 0) revert NoClaim(account);
+
+        if (credit != 0) payoutCredits[account] = 0;
+        if (refundablePrincipal != 0) challengerBonds[account] = 0;
+
+        _transfer(recipient, amount);
+        emit Withdrawn(account, amount);
     }
 
     function submitProofLane(uint8 laneId, bytes calldata proof) external {
@@ -221,6 +249,7 @@ contract WorldChainProofSystemGame {
     }
 
     /// @notice Settles this game after evaluating its blacklist, parent, deadline, and proof-threshold conditions.
+    /// @dev Resolution assigns pull-based bond claims; call `withdraw(recipient)` to transfer claimable ETH.
     function resolve()
         external
         returns (WorldChainProofLib.RootState outcome, WorldChainProofLib.InvalidationReason reason)
@@ -330,22 +359,13 @@ contract WorldChainProofSystemGame {
         invalidationReason = reason;
         invalidatedAt = uint64(block.timestamp);
 
-        // TODO: Replace temporary push payouts with pull-based credits so recipient callbacks cannot block resolution.
-        for (uint256 i = 0; i < challengers.length; i++) {
-            address challenger = challengers[i];
-            uint256 amount = challengerBonds[challenger];
-            challengerBonds[challenger] = 0;
-            _transfer(payable(challenger), amount);
-        }
-
-        uint256 forfeited = address(this).balance;
-        // TODO: Confirm that INVALID_PARENT and BLACKLISTED should refund the proposer bond as currently specified.
-        // Only a direct proof timeout is attributable to this proposer; inherited and governance failures refund it.
-        if (forfeited != 0 && reason == WorldChainProofLib.InvalidationReason.PROOF_TIMEOUT && challengers.length != 0)
-        {
-            _transfer(payable(challengers[0]), forfeited);
-        } else if (forfeited != 0) {
-            _transfer(proposer, forfeited);
+        if (proposerBond != 0) {
+            // Only a direct proof timeout is attributable to this proposer; inherited and governance failures refund it.
+            if (reason == WorldChainProofLib.InvalidationReason.PROOF_TIMEOUT && challengers.length != 0) {
+                payoutCredits[challengers[0]] += proposerBond;
+            } else {
+                payoutCredits[proposer] += proposerBond;
+            }
         }
 
         emit Invalidated(rootId, reason);
@@ -355,9 +375,9 @@ contract WorldChainProofSystemGame {
         state = WorldChainProofLib.RootState.FINALIZED;
         finalizedAt = uint64(block.timestamp);
 
-        uint256 payout = address(this).balance;
+        uint256 payout = proposerBond + totalChallengerBonds;
         if (payout != 0) {
-            _transfer(proposer, payout);
+            payoutCredits[proposer] += payout;
         }
 
         emit Finalized(rootId);
@@ -367,6 +387,22 @@ contract WorldChainProofSystemGame {
         if (lane == WorldChainProofLib.ProofLane.VALIDITY_PROOF) return validityProofVerifier;
         if (lane == WorldChainProofLib.ProofLane.TEE_ATTESTATION) return teeVerifier;
         return securityCouncil;
+    }
+
+    function _claimable(address recipient) internal view returns (uint256) {
+        return payoutCredits[recipient] + _refundableChallengerPrincipal(recipient);
+    }
+
+    function _refundableChallengerPrincipal(address recipient) internal view returns (uint256) {
+        if (state != WorldChainProofLib.RootState.INVALIDATED) return 0;
+        if (
+            invalidationReason != WorldChainProofLib.InvalidationReason.PROOF_TIMEOUT
+                && invalidationReason != WorldChainProofLib.InvalidationReason.INVALID_PARENT
+                && invalidationReason != WorldChainProofLib.InvalidationReason.BLACKLISTED
+        ) {
+            return 0;
+        }
+        return challengerBonds[recipient];
     }
 
     function _transfer(address payable recipient, uint256 amount) internal {

--- a/pkg/contracts/src/proofs/interfaces/IWorldChainProofSystemGame.sol
+++ b/pkg/contracts/src/proofs/interfaces/IWorldChainProofSystemGame.sol
@@ -30,7 +30,7 @@ interface IWorldChainProofSystemGame {
     /// @notice Returns the ETH amount `recipient` can withdraw from this game.
     function claimable(address recipient) external view returns (uint256);
     /// @notice Permissionlessly withdraws `recipient`'s claim to `recipient`.
-    /// @dev Challengers, defender/prover-service automation, or keepers can call this after resolution;
+    /// @dev The challenger, defender/prover-service automation, or keepers can call this after resolution;
     ///      the caller cannot redirect funds away from `recipient`.
     function withdraw(address payable recipient) external;
 }

--- a/pkg/contracts/src/proofs/interfaces/IWorldChainProofSystemGame.sol
+++ b/pkg/contracts/src/proofs/interfaces/IWorldChainProofSystemGame.sol
@@ -27,4 +27,10 @@ interface IWorldChainProofSystemGame {
     function resolve()
         external
         returns (WorldChainProofLib.RootState outcome, WorldChainProofLib.InvalidationReason reason);
+    /// @notice Returns the ETH amount `recipient` can withdraw from this game.
+    function claimable(address recipient) external view returns (uint256);
+    /// @notice Permissionlessly withdraws `recipient`'s claim to `recipient`.
+    /// @dev Challengers, defender/prover-service automation, or keepers can call this after resolution;
+    ///      the caller cannot redirect funds away from `recipient`.
+    function withdraw(address payable recipient) external;
 }

--- a/pkg/contracts/test/WorldChainProofSystem.t.sol
+++ b/pkg/contracts/test/WorldChainProofSystem.t.sol
@@ -75,6 +75,8 @@ contract WorldChainProofSystemTest is Test {
         _challenge(game, challenger);
 
         assertEq(uint8(game.state()), uint8(WorldChainProofLib.RootState.CHALLENGED));
+        assertEq(game.challenger(), challenger);
+        assertEq(game.postedChallengerBond(), CHALLENGER_BOND);
         assertEq(game.proofDeadline(), block.timestamp + PROOF_PERIOD);
     }
 
@@ -273,11 +275,10 @@ contract WorldChainProofSystemTest is Test {
         _assertWithdraws(child, secondChallenger, CHALLENGER_BOND);
     }
 
-    function testBlacklistInvalidationRefundsAllBonds() public {
+    function testBlacklistInvalidationRefundsBondAndSurplus() public {
         (WorldChainProofSystemGame parent,) = _propose(10);
         (WorldChainProofSystemGame game,) = _proposeChild(parent, keccak256("blacklisted-child"));
         _challenge(game, challenger);
-        _challenge(game, secondChallenger);
         anchor.setGameBlacklisted(address(game), true);
         uint256 surplus = 0.25 ether;
         vm.prank(keeper);
@@ -285,18 +286,15 @@ contract WorldChainProofSystemTest is Test {
         assertTrue(ok);
 
         uint256 proposerBalance = proposer.balance;
-        uint256 firstChallengerBalance = challenger.balance;
-        uint256 secondChallengerBalance = secondChallenger.balance;
+        uint256 challengerBalance = challenger.balance;
         game.resolve();
 
         assertEq(uint8(game.state()), uint8(WorldChainProofLib.RootState.INVALIDATED));
         assertEq(uint8(game.invalidationReason()), uint8(WorldChainProofLib.InvalidationReason.BLACKLISTED));
         assertEq(proposer.balance, proposerBalance);
-        assertEq(challenger.balance, firstChallengerBalance);
-        assertEq(secondChallenger.balance, secondChallengerBalance);
+        assertEq(challenger.balance, challengerBalance);
         _assertWithdraws(game, proposer, PROPOSER_BOND + surplus);
         _assertWithdraws(game, challenger, CHALLENGER_BOND);
-        _assertWithdraws(game, secondChallenger, CHALLENGER_BOND);
         assertEq(address(game).balance, 0);
     }
 
@@ -328,27 +326,22 @@ contract WorldChainProofSystemTest is Test {
         game.resolve();
     }
 
-    function testDirectProofTimeoutRewardsFirstChallenger() public {
+    function testDirectProofTimeoutRewardsChallenger() public {
         (WorldChainProofSystemGame game,) = _proposeAndChallenge(10);
-        _challenge(game, secondChallenger);
         vm.warp(block.timestamp + PROOF_PERIOD);
 
         uint256 proposerBalance = proposer.balance;
-        uint256 firstChallengerBalance = challenger.balance;
-        uint256 secondChallengerBalance = secondChallenger.balance;
+        uint256 challengerBalance = challenger.balance;
         game.resolve();
 
         assertEq(proposer.balance, proposerBalance);
-        assertEq(challenger.balance, firstChallengerBalance);
-        assertEq(secondChallenger.balance, secondChallengerBalance);
+        assertEq(challenger.balance, challengerBalance);
         _assertWithdraws(game, challenger, CHALLENGER_BOND + PROPOSER_BOND);
-        _assertWithdraws(game, secondChallenger, CHALLENGER_BOND);
         assertEq(game.claimable(proposer), 0);
     }
 
-    function testDirectProofTimeoutCreditsSurplusEthToFirstChallenger() public {
+    function testDirectProofTimeoutCreditsSurplusEthToChallenger() public {
         (WorldChainProofSystemGame game,) = _proposeAndChallenge(10);
-        _challenge(game, secondChallenger);
         uint256 surplus = 0.25 ether;
         vm.deal(address(game), address(game).balance + surplus);
 
@@ -356,7 +349,6 @@ contract WorldChainProofSystemTest is Test {
         game.resolve();
 
         _assertWithdraws(game, challenger, CHALLENGER_BOND + PROPOSER_BOND + surplus);
-        _assertWithdraws(game, secondChallenger, CHALLENGER_BOND);
         assertEq(game.claimable(proposer), 0);
         assertEq(address(game).balance, 0);
     }
@@ -403,12 +395,14 @@ contract WorldChainProofSystemTest is Test {
         game.submitProofLane(uint8(WorldChainProofLib.ProofLane.VALIDITY_PROOF), abi.encode(rootId));
     }
 
-    function testSubsequentChallengeDoesNotExtendProofDeadline() public {
+    function testSecondChallengeReverts() public {
         (WorldChainProofSystemGame game,) = _proposeAndChallenge(10);
         uint64 firstDeadline = game.proofDeadline();
 
         vm.warp(block.timestamp + 1 hours);
-        _challenge(game, secondChallenger);
+        vm.prank(secondChallenger);
+        vm.expectRevert(abi.encodeWithSelector(WorldChainProofSystemGame.DuplicateChallenge.selector, challenger));
+        game.challenge{value: CHALLENGER_BOND}();
 
         assertEq(game.proofDeadline(), firstDeadline);
     }

--- a/pkg/contracts/test/WorldChainProofSystem.t.sol
+++ b/pkg/contracts/test/WorldChainProofSystem.t.sol
@@ -336,6 +336,7 @@ contract WorldChainProofSystemTest is Test {
 
         assertEq(proposer.balance, proposerBalance);
         assertEq(challenger.balance, challengerBalance);
+        assertEq(game.postedChallengerBond(), 0);
         _assertWithdraws(game, challenger, CHALLENGER_BOND + PROPOSER_BOND);
         assertEq(game.claimable(proposer), 0);
     }
@@ -348,6 +349,7 @@ contract WorldChainProofSystemTest is Test {
         vm.warp(block.timestamp + PROOF_PERIOD);
         game.resolve();
 
+        assertEq(game.postedChallengerBond(), 0);
         _assertWithdraws(game, challenger, CHALLENGER_BOND + PROPOSER_BOND + surplus);
         assertEq(game.claimable(proposer), 0);
         assertEq(address(game).balance, 0);

--- a/pkg/contracts/test/WorldChainProofSystem.t.sol
+++ b/pkg/contracts/test/WorldChainProofSystem.t.sol
@@ -21,6 +21,7 @@ contract WorldChainProofSystemTest is Test {
     address internal proposer = address(0xA11CE);
     address internal challenger = address(0xB0B);
     address internal secondChallenger = address(0xCAFE);
+    address internal keeper = address(0xD00D);
 
     WorldChainAnchorStateRegistry internal anchor;
     WorldChainProofSystemFactory internal factory;
@@ -34,6 +35,7 @@ contract WorldChainProofSystemTest is Test {
         vm.deal(proposer, 100 ether);
         vm.deal(challenger, 100 ether);
         vm.deal(secondChallenger, 100 ether);
+        vm.deal(keeper, 100 ether);
 
         anchor = new WorldChainAnchorStateRegistry(bytes32(uint256(1)), 0);
         staking = new MockStakingRegistry();
@@ -55,6 +57,7 @@ contract WorldChainProofSystemTest is Test {
         game.resolve();
 
         assertEq(uint8(game.state()), uint8(WorldChainProofLib.RootState.FINALIZED));
+        assertEq(game.claimable(proposer), PROPOSER_BOND);
     }
 
     function testUnstakedAccountCannotChallenge() public {
@@ -114,6 +117,8 @@ contract WorldChainProofSystemTest is Test {
         game.resolve();
 
         assertEq(uint8(game.state()), uint8(WorldChainProofLib.RootState.FINALIZED));
+        assertEq(game.claimable(proposer), PROPOSER_BOND + CHALLENGER_BOND);
+        assertEq(game.claimable(challenger), 0);
     }
 
     function testThresholdOneRequiresExplicitSettlementAfterSingleLane() public {
@@ -248,8 +253,10 @@ contract WorldChainProofSystemTest is Test {
 
         assertEq(uint8(child.state()), uint8(WorldChainProofLib.RootState.INVALIDATED));
         assertEq(uint8(child.invalidationReason()), uint8(WorldChainProofLib.InvalidationReason.INVALID_PARENT));
-        assertEq(proposer.balance, proposerBalance + PROPOSER_BOND);
-        assertEq(secondChallenger.balance, childChallengerBalance + CHALLENGER_BOND);
+        assertEq(proposer.balance, proposerBalance);
+        assertEq(secondChallenger.balance, childChallengerBalance);
+        _assertWithdraws(child, proposer, PROPOSER_BOND);
+        _assertWithdraws(child, secondChallenger, CHALLENGER_BOND);
     }
 
     function testBlacklistInvalidationRefundsAllBonds() public {
@@ -266,9 +273,12 @@ contract WorldChainProofSystemTest is Test {
 
         assertEq(uint8(game.state()), uint8(WorldChainProofLib.RootState.INVALIDATED));
         assertEq(uint8(game.invalidationReason()), uint8(WorldChainProofLib.InvalidationReason.BLACKLISTED));
-        assertEq(proposer.balance, proposerBalance + PROPOSER_BOND);
-        assertEq(challenger.balance, firstChallengerBalance + CHALLENGER_BOND);
-        assertEq(secondChallenger.balance, secondChallengerBalance + CHALLENGER_BOND);
+        assertEq(proposer.balance, proposerBalance);
+        assertEq(challenger.balance, firstChallengerBalance);
+        assertEq(secondChallenger.balance, secondChallengerBalance);
+        _assertWithdraws(game, proposer, PROPOSER_BOND);
+        _assertWithdraws(game, challenger, CHALLENGER_BOND);
+        _assertWithdraws(game, secondChallenger, CHALLENGER_BOND);
     }
 
     function testBlacklistedParentInvalidatesChild() public {
@@ -310,8 +320,45 @@ contract WorldChainProofSystemTest is Test {
         game.resolve();
 
         assertEq(proposer.balance, proposerBalance);
-        assertEq(challenger.balance, firstChallengerBalance + CHALLENGER_BOND + PROPOSER_BOND);
-        assertEq(secondChallenger.balance, secondChallengerBalance + CHALLENGER_BOND);
+        assertEq(challenger.balance, firstChallengerBalance);
+        assertEq(secondChallenger.balance, secondChallengerBalance);
+        _assertWithdraws(game, challenger, CHALLENGER_BOND + PROPOSER_BOND);
+        _assertWithdraws(game, secondChallenger, CHALLENGER_BOND);
+        assertEq(game.claimable(proposer), 0);
+    }
+
+    function testPermissionlessWithdrawPaysRecipientNotCaller() public {
+        (WorldChainProofSystemGame game,) = _propose(10);
+
+        vm.warp(block.timestamp + CHALLENGE_PERIOD);
+        game.resolve();
+
+        uint256 proposerBalance = proposer.balance;
+        uint256 keeperBalance = keeper.balance;
+        vm.prank(keeper);
+        game.withdraw(payable(proposer));
+
+        assertEq(proposer.balance, proposerBalance + PROPOSER_BOND);
+        assertEq(game.claimable(proposer), 0);
+        assertLe(keeper.balance, keeperBalance);
+    }
+
+    function testResolveDoesNotCallRevertingRecipient() public {
+        RevertingReceiver rejecting = new RevertingReceiver();
+        address rejectingProposer = address(rejecting);
+        vm.deal(rejectingProposer, 100 ether);
+        (WorldChainProofSystemGame game,) = _proposeFrom(rejectingProposer, 10);
+
+        vm.warp(block.timestamp + CHALLENGE_PERIOD);
+        game.resolve();
+
+        assertEq(uint8(game.state()), uint8(WorldChainProofLib.RootState.FINALIZED));
+        assertEq(game.claimable(rejectingProposer), PROPOSER_BOND);
+        vm.expectRevert(
+            abi.encodeWithSelector(WorldChainProofSystemGame.TransferFailed.selector, rejectingProposer, PROPOSER_BOND)
+        );
+        game.withdraw(payable(rejectingProposer));
+        assertEq(game.claimable(rejectingProposer), PROPOSER_BOND);
     }
 
     function testLaneSubmissionAtProofDeadlineReverts() public {
@@ -554,8 +601,15 @@ contract WorldChainProofSystemTest is Test {
     }
 
     function _propose(uint256 l2BlockNumber) internal returns (WorldChainProofSystemGame game, bytes32 rootId) {
+        return _proposeFrom(proposer, l2BlockNumber);
+    }
+
+    function _proposeFrom(address account, uint256 l2BlockNumber)
+        internal
+        returns (WorldChainProofSystemGame game, bytes32 rootId)
+    {
         proposalSalt++;
-        vm.prank(proposer);
+        vm.prank(account);
         (address gameAddress, bytes32 id) = factory.propose{value: PROPOSER_BOND}(
             address(anchor), keccak256(abi.encode("root", l2BlockNumber, proposalSalt)), l2BlockNumber
         );
@@ -591,5 +645,19 @@ contract WorldChainProofSystemTest is Test {
     function _challenge(WorldChainProofSystemGame game, address account) internal {
         vm.prank(account);
         game.challenge{value: CHALLENGER_BOND}();
+    }
+
+    function _assertWithdraws(WorldChainProofSystemGame game, address account, uint256 amount) internal {
+        assertEq(game.claimable(account), amount);
+        uint256 balance = account.balance;
+        game.withdraw(payable(account));
+        assertEq(account.balance, balance + amount);
+        assertEq(game.claimable(account), 0);
+    }
+}
+
+contract RevertingReceiver {
+    receive() external payable {
+        revert("reject eth");
     }
 }

--- a/pkg/contracts/test/WorldChainProofSystem.t.sol
+++ b/pkg/contracts/test/WorldChainProofSystem.t.sol
@@ -121,6 +121,20 @@ contract WorldChainProofSystemTest is Test {
         assertEq(game.claimable(challenger), 0);
     }
 
+    function testFinalizationCreditsSurplusEthToProposer() public {
+        (WorldChainProofSystemGame game,) = _propose(10);
+        uint256 surplus = 0.25 ether;
+        vm.prank(keeper);
+        (bool ok,) = address(game).call{value: surplus}("");
+        assertTrue(ok);
+
+        vm.warp(block.timestamp + CHALLENGE_PERIOD);
+        game.resolve();
+
+        _assertWithdraws(game, proposer, PROPOSER_BOND + surplus);
+        assertEq(address(game).balance, 0);
+    }
+
     function testThresholdOneRequiresExplicitSettlementAfterSingleLane() public {
         WorldChainAnchorStateRegistry thresholdAnchor = new WorldChainAnchorStateRegistry(bytes32(uint256(1)), 0);
         WorldChainProofSystemFactory thresholdOne = _newFactory(thresholdAnchor, 1);
@@ -265,6 +279,10 @@ contract WorldChainProofSystemTest is Test {
         _challenge(game, challenger);
         _challenge(game, secondChallenger);
         anchor.setGameBlacklisted(address(game), true);
+        uint256 surplus = 0.25 ether;
+        vm.prank(keeper);
+        (bool ok,) = address(game).call{value: surplus}("");
+        assertTrue(ok);
 
         uint256 proposerBalance = proposer.balance;
         uint256 firstChallengerBalance = challenger.balance;
@@ -276,9 +294,10 @@ contract WorldChainProofSystemTest is Test {
         assertEq(proposer.balance, proposerBalance);
         assertEq(challenger.balance, firstChallengerBalance);
         assertEq(secondChallenger.balance, secondChallengerBalance);
-        _assertWithdraws(game, proposer, PROPOSER_BOND);
+        _assertWithdraws(game, proposer, PROPOSER_BOND + surplus);
         _assertWithdraws(game, challenger, CHALLENGER_BOND);
         _assertWithdraws(game, secondChallenger, CHALLENGER_BOND);
+        assertEq(address(game).balance, 0);
     }
 
     function testBlacklistedParentInvalidatesChild() public {
@@ -325,6 +344,21 @@ contract WorldChainProofSystemTest is Test {
         _assertWithdraws(game, challenger, CHALLENGER_BOND + PROPOSER_BOND);
         _assertWithdraws(game, secondChallenger, CHALLENGER_BOND);
         assertEq(game.claimable(proposer), 0);
+    }
+
+    function testDirectProofTimeoutCreditsSurplusEthToFirstChallenger() public {
+        (WorldChainProofSystemGame game,) = _proposeAndChallenge(10);
+        _challenge(game, secondChallenger);
+        uint256 surplus = 0.25 ether;
+        vm.deal(address(game), address(game).balance + surplus);
+
+        vm.warp(block.timestamp + PROOF_PERIOD);
+        game.resolve();
+
+        _assertWithdraws(game, challenger, CHALLENGER_BOND + PROPOSER_BOND + surplus);
+        _assertWithdraws(game, secondChallenger, CHALLENGER_BOND);
+        assertEq(game.claimable(proposer), 0);
+        assertEq(address(game).balance, 0);
     }
 
     function testPermissionlessWithdrawPaysRecipientNotCaller() public {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
## Summary

Converts proof-game bond settlement from push payments during `resolve()` to pull-based claims:

- `resolve()` records bond credits without making external ETH calls.
- Adds `claimable(recipient)` and permissionless `withdraw(recipient)`.
- Withdrawals always pay the named recipient, never the caller.
- Protects withdrawals with `ReentrancyGuardTransient`.
- Preserves existing finalization and invalidation bond economics.
- Documents the keeper/automation withdrawal flow.
- Exposes the new methods through `IWorldChainProofSystemGame`.

## Why

A reverting proposer or challenger could previously block game resolution because settlement transferred ETH synchronously. Separating resolution from payment keeps game progression independent of recipient behavior.

## Bond distribution

- Finalization: the proposer receives the proposer bond and all challenger bonds.
- Proof timeout: the first challenger receives the proposer bond; every challenger recovers their principal.
- Invalid parent or blacklist: the proposer and all challengers recover their principal.

## Tests

Adds coverage for:

- Finalization and invalidation claim accounting
- First-challenger rewards after proof timeout
- Invalid-parent and blacklist refunds
- Permissionless keeper withdrawals
- Prevention of withdrawal redirection
- Resolution involving recipients that reject ETH
- Preservation of claims after failed withdrawals

## Risk

High: this changes funds-critical bond accounting and introduces a new withdrawal path. The settlement API from the base branch remains intact, with `claimable` and `withdraw` added for payout collection.
<!-- /CURSOR_SUMMARY -->