### PR TITLE
feat: Anchor State Registry jumping intermediate finalized games

### DIFF
--- a/pkg/contracts/scripts/devnet/DeployProofSystem.s.sol
+++ b/pkg/contracts/scripts/devnet/DeployProofSystem.s.sol
@@ -38,7 +38,8 @@ contract DeployProofSystem is Script {
         Config memory config = _readConfig();
 
         vm.startBroadcast(config.privateKey);
-        deployment.anchor = new WorldChainAnchorStateRegistry(bytes32(0), 0);
+        // Devnet advances anchors immediately after resolution; production deployments must configure a maturity delay.
+        deployment.anchor = new WorldChainAnchorStateRegistry(bytes32(0), 0, 0);
         deployment.staking = new MockStakingRegistry();
         deployment.validityVerifier = new MockRootIdVerifier(false);
         deployment.teeVerifier = new MockRootIdVerifier(false);

--- a/pkg/contracts/scripts/devnet/DeployProofSystem.s.sol
+++ b/pkg/contracts/scripts/devnet/DeployProofSystem.s.sol
@@ -38,8 +38,7 @@ contract DeployProofSystem is Script {
         Config memory config = _readConfig();
 
         vm.startBroadcast(config.privateKey);
-        // Devnet advances anchors immediately after resolution; production deployments must configure a maturity delay.
-        deployment.anchor = new WorldChainAnchorStateRegistry(bytes32(0), 0, 0);
+        deployment.anchor = new WorldChainAnchorStateRegistry(bytes32(0), 0);
         deployment.staking = new MockStakingRegistry();
         deployment.validityVerifier = new MockRootIdVerifier(false);
         deployment.teeVerifier = new MockRootIdVerifier(false);

--- a/pkg/contracts/src/proofs/WorldChainAnchorStateRegistry.sol
+++ b/pkg/contracts/src/proofs/WorldChainAnchorStateRegistry.sol
@@ -80,8 +80,8 @@ contract WorldChainAnchorStateRegistry {
 
     /// @notice Returns whether a game is recognized by this registry and currently has a valid finalized claim.
     /// @dev Anchor advancement additionally requires a newer L2 block number.
-    /// TODO: Before withdrawal integration, define Base-compatible retirement and emergency anchor recovery semantics,
-    /// implement the OP IAnchorStateRegistry surface, and wire OptimismPortal to this predicate.
+    /// TODO: Before withdrawal integration, define OP-compatible retirement and emergency anchor recovery semantics,
+    /// implement the IAnchorStateRegistry surface, and wire OptimismPortal to this predicate.
     function isGameClaimValid(address game) external view returns (bool) {
         address factory = proofSystemFactory;
         if (paused || factory == address(0) || blacklistedGames[game]) return false;

--- a/pkg/contracts/src/proofs/WorldChainAnchorStateRegistry.sol
+++ b/pkg/contracts/src/proofs/WorldChainAnchorStateRegistry.sol
@@ -111,6 +111,8 @@ contract WorldChainAnchorStateRegistry {
         // Finalization proves that the candidate's own ancestry settled, but not that it extends
         // the registry's currently accepted checkpoint. Transition snapshots preserve that link
         // even when the registry sentinel, rather than anchorGame, is used as the direct parent.
+        // Traversal is linear in skipped games; callers can advance through finalized checkpoints
+        // in smaller chunks when a single jump would exceed the transaction gas limit.
         while (true) {
             IWorldChainProofSystemGame cursorGame = IWorldChainProofSystemGame(cursor);
             uint256 startingL2BlockNumber = cursorGame.startingL2BlockNumber();

--- a/pkg/contracts/src/proofs/WorldChainAnchorStateRegistry.sol
+++ b/pkg/contracts/src/proofs/WorldChainAnchorStateRegistry.sol
@@ -147,6 +147,8 @@ contract WorldChainAnchorStateRegistry {
         // Finalization proves that the candidate's own ancestry settled, but not that it extends
         // the registry's currently accepted checkpoint. Transition snapshots preserve that link
         // even when the registry sentinel, rather than anchorGame, is used as the direct parent.
+        // TODO: Revisit after emergency anchor recovery is designed. Continuity prevents a finalized sibling branch
+        // from replacing accepted history, but also makes an incorrectly accepted anchor sticky.
         // Traversal is linear in skipped games; callers can advance through finalized checkpoints
         // in smaller chunks when a single jump would exceed the transaction gas limit.
         while (true) {

--- a/pkg/contracts/src/proofs/WorldChainAnchorStateRegistry.sol
+++ b/pkg/contracts/src/proofs/WorldChainAnchorStateRegistry.sol
@@ -17,6 +17,7 @@ contract WorldChainAnchorStateRegistry {
     error UnregisteredGame(address game);
     error GameNotFinalized(address game);
     error NonMonotonicRoot(uint256 currentL2BlockNumber, uint256 nextL2BlockNumber);
+    error AnchorStateNotInAncestry(address game, bytes32 currentRootClaim, uint256 currentL2BlockNumber);
 
     event AnchorUpdated(address indexed game, bytes32 indexed rootId, bytes32 rootClaim, uint256 l2BlockNumber);
     event FactoryInitialized(address indexed factory);
@@ -91,6 +92,7 @@ contract WorldChainAnchorStateRegistry {
         if (nextL2BlockNumber <= currentL2BlockNumber) {
             revert NonMonotonicRoot(currentL2BlockNumber, nextL2BlockNumber);
         }
+        _requireExtendsCurrentAnchor(game, factory);
 
         bytes32 nextRootId = proofGame.rootId();
         currentRootId = nextRootId;
@@ -99,5 +101,35 @@ contract WorldChainAnchorStateRegistry {
         anchorGame = game;
 
         emit AnchorUpdated(game, nextRootId, currentRootClaim, nextL2BlockNumber);
+    }
+
+    function _requireExtendsCurrentAnchor(address candidate, address factory) private view {
+        bytes32 anchorRootClaim = currentRootClaim;
+        uint256 anchorL2BlockNumber = currentL2BlockNumber;
+        address cursor = candidate;
+
+        // Finalization proves that the candidate's own ancestry settled, but not that it extends
+        // the registry's currently accepted checkpoint. Transition snapshots preserve that link
+        // even when the registry sentinel, rather than anchorGame, is used as the direct parent.
+        while (true) {
+            IWorldChainProofSystemGame cursorGame = IWorldChainProofSystemGame(cursor);
+            uint256 startingL2BlockNumber = cursorGame.startingL2BlockNumber();
+
+            if (startingL2BlockNumber == anchorL2BlockNumber) {
+                if (cursorGame.startingRootClaim() != anchorRootClaim) {
+                    revert AnchorStateNotInAncestry(candidate, anchorRootClaim, anchorL2BlockNumber);
+                }
+                return;
+            }
+            if (startingL2BlockNumber < anchorL2BlockNumber) {
+                revert AnchorStateNotInAncestry(candidate, anchorRootClaim, anchorL2BlockNumber);
+            }
+
+            address parent = cursorGame.parentRef();
+            if (parent == address(this) || !IWorldChainProofSystemFactory(factory).isFactoryGame(parent)) {
+                revert AnchorStateNotInAncestry(candidate, anchorRootClaim, anchorL2BlockNumber);
+            }
+            cursor = parent;
+        }
     }
 }

--- a/pkg/contracts/src/proofs/WorldChainAnchorStateRegistry.sol
+++ b/pkg/contracts/src/proofs/WorldChainAnchorStateRegistry.sol
@@ -32,7 +32,6 @@ contract WorldChainAnchorStateRegistry {
     uint256 public currentL2BlockNumber;
     address public anchorGame;
 
-    mapping(bytes32 rootId => bool accepted) public acceptedRoots;
     mapping(address game => bool blacklisted) public blacklistedGames;
 
     constructor(bytes32 startingRootClaim, uint256 startingL2BlockNumber) {
@@ -98,7 +97,6 @@ contract WorldChainAnchorStateRegistry {
         currentRootClaim = proofGame.rootClaim();
         currentL2BlockNumber = nextL2BlockNumber;
         anchorGame = game;
-        acceptedRoots[nextRootId] = true;
 
         emit AnchorUpdated(game, nextRootId, currentRootClaim, nextL2BlockNumber);
     }

--- a/pkg/contracts/src/proofs/WorldChainAnchorStateRegistry.sol
+++ b/pkg/contracts/src/proofs/WorldChainAnchorStateRegistry.sol
@@ -17,8 +17,6 @@ contract WorldChainAnchorStateRegistry {
     error UnregisteredGame(address game);
     error GameNotFinalized(address game);
     error GameNotMature(address game, uint256 eligibleAt);
-    error GameRetired(address game);
-    error CurrentAnchorInvalid(address game);
     error NonMonotonicRoot(uint256 currentL2BlockNumber, uint256 nextL2BlockNumber);
     error AnchorStateNotInAncestry(address game, bytes32 currentRootClaim, uint256 currentL2BlockNumber);
 
@@ -26,12 +24,10 @@ contract WorldChainAnchorStateRegistry {
     event FactoryInitialized(address indexed factory);
     event PausedSet(bool paused);
     event GameBlacklistedSet(address indexed game, bool blacklisted);
-    event RetirementTimestampUpdated(uint64 timestamp);
 
     address public owner;
     address public proofSystemFactory;
     uint64 public immutable finalityDelay;
-    uint64 public retirementTimestamp;
     bool public paused;
 
     bytes32 public currentRootId;
@@ -66,38 +62,13 @@ contract WorldChainAnchorStateRegistry {
     }
 
     function setPaused(bool nextPaused) external onlyOwner {
-        if (!nextPaused) {
-            address currentAnchor = anchorGame;
-            if (currentAnchor != address(0) && (blacklistedGames[currentAnchor] || isGameRetired(currentAnchor))) {
-                revert CurrentAnchorInvalid(currentAnchor);
-            }
-        }
-
         paused = nextPaused;
         emit PausedSet(nextPaused);
     }
 
-    /// @notice Blacklists one game. Use `updateRetirementTimestamp` to invalidate all existing games.
     function setGameBlacklisted(address game, bool blacklisted) external onlyOwner {
         blacklistedGames[game] = blacklisted;
         emit GameBlacklistedSet(game, blacklisted);
-
-        // Advancing from a newly distrusted accepted checkpoint must stop atomically.
-        if (blacklisted && game == anchorGame && !paused) {
-            paused = true;
-            emit PausedSet(true);
-        }
-    }
-
-    /// @notice Invalidates every game created up to the current timestamp and pauses anchor progression.
-    function updateRetirementTimestamp() external onlyOwner {
-        retirementTimestamp = uint64(block.timestamp);
-        emit RetirementTimestampUpdated(retirementTimestamp);
-
-        if (!paused) {
-            paused = true;
-            emit PausedSet(true);
-        }
     }
 
     /// @notice Returns whether a game has finalized and passed the registry's post-resolution delay.
@@ -118,27 +89,14 @@ contract WorldChainAnchorStateRegistry {
         }
     }
 
-    /// @notice Returns whether a game was created before the latest blanket invalidation.
-    function isGameRetired(address game) public view returns (bool) {
-        uint64 retiredAt = retirementTimestamp;
-        if (retiredAt == 0 || game.code.length == 0) return false;
-
-        try IWorldChainProofSystemGame(game).createdAt() returns (uint64 createdAt) {
-            return createdAt <= retiredAt;
-        } catch {
-            return false;
-        }
-    }
-
     /// @notice Returns whether a game is recognized by this registry and currently has a valid finalized claim.
     /// @dev Anchor advancement additionally requires a newer block and continuity with the current accepted anchor.
-    /// TODO: Before withdrawal integration, implement the OP IAnchorStateRegistry surface and wire OptimismPortal
-    /// to this predicate after confirming the emergency anchor recovery semantics.
+    /// TODO: Before withdrawal integration, define Base-compatible retirement and emergency anchor recovery semantics,
+    /// implement the OP IAnchorStateRegistry surface, and wire OptimismPortal to this predicate.
     function isGameClaimValid(address game) external view returns (bool) {
         address factory = proofSystemFactory;
         if (paused || factory == address(0) || blacklistedGames[game]) return false;
         if (!IWorldChainProofSystemFactory(factory).isFactoryGame(game)) return false;
-        if (isGameRetired(game)) return false;
 
         IWorldChainProofSystemGame proofGame = IWorldChainProofSystemGame(game);
         return
@@ -158,7 +116,6 @@ contract WorldChainAnchorStateRegistry {
             revert InvalidGameRegistry(address(this), proofGame.anchorStateRegistry());
         }
         if (!IWorldChainProofSystemFactory(factory).isFactoryGame(game)) revert UnregisteredGame(game);
-        if (isGameRetired(game)) revert GameRetired(game);
 
         if (proofGame.state() != WorldChainProofLib.RootState.FINALIZED) revert GameNotFinalized(game);
 

--- a/pkg/contracts/src/proofs/WorldChainAnchorStateRegistry.sol
+++ b/pkg/contracts/src/proofs/WorldChainAnchorStateRegistry.sol
@@ -16,9 +16,7 @@ contract WorldChainAnchorStateRegistry {
     error InvalidGameRegistry(address expectedRegistry, address actualRegistry);
     error UnregisteredGame(address game);
     error GameNotFinalized(address game);
-    error GameNotMature(address game, uint256 eligibleAt);
     error NonMonotonicRoot(uint256 currentL2BlockNumber, uint256 nextL2BlockNumber);
-    error AnchorStateNotInAncestry(address game, bytes32 currentRootClaim, uint256 currentL2BlockNumber);
 
     event AnchorUpdated(address indexed game, bytes32 indexed rootId, bytes32 rootClaim, uint256 l2BlockNumber);
     event FactoryInitialized(address indexed factory);
@@ -27,7 +25,6 @@ contract WorldChainAnchorStateRegistry {
 
     address public owner;
     address public proofSystemFactory;
-    uint64 public immutable finalityDelay;
     bool public paused;
 
     bytes32 public currentRootId;
@@ -37,9 +34,8 @@ contract WorldChainAnchorStateRegistry {
 
     mapping(address game => bool blacklisted) public blacklistedGames;
 
-    constructor(bytes32 startingRootClaim, uint256 startingL2BlockNumber, uint64 finalityDelay_) {
+    constructor(bytes32 startingRootClaim, uint256 startingL2BlockNumber) {
         owner = msg.sender;
-        finalityDelay = finalityDelay_;
         currentRootClaim = startingRootClaim;
         currentL2BlockNumber = startingL2BlockNumber;
     }
@@ -71,26 +67,19 @@ contract WorldChainAnchorStateRegistry {
         emit GameBlacklistedSet(game, blacklisted);
     }
 
-    /// @notice Returns whether a game has finalized and passed the registry's post-resolution delay.
+    /// @notice Returns whether a game has finalized.
     function isGameFinalized(address game) public view returns (bool) {
         if (game.code.length == 0) return false;
 
-        IWorldChainProofSystemGame proofGame = IWorldChainProofSystemGame(game);
-        try proofGame.state() returns (WorldChainProofLib.RootState gameState) {
-            if (gameState != WorldChainProofLib.RootState.FINALIZED) return false;
-        } catch {
-            return false;
-        }
-
-        try proofGame.finalizedAt() returns (uint64 finalizedAt) {
-            return block.timestamp >= uint256(finalizedAt) + finalityDelay;
+        try IWorldChainProofSystemGame(game).state() returns (WorldChainProofLib.RootState gameState) {
+            return gameState == WorldChainProofLib.RootState.FINALIZED;
         } catch {
             return false;
         }
     }
 
     /// @notice Returns whether a game is recognized by this registry and currently has a valid finalized claim.
-    /// @dev Anchor advancement additionally requires a newer block and continuity with the current accepted anchor.
+    /// @dev Anchor advancement additionally requires a newer L2 block number.
     /// TODO: Before withdrawal integration, define Base-compatible retirement and emergency anchor recovery semantics,
     /// implement the OP IAnchorStateRegistry surface, and wire OptimismPortal to this predicate.
     function isGameClaimValid(address game) external view returns (bool) {
@@ -119,16 +108,12 @@ contract WorldChainAnchorStateRegistry {
 
         if (proofGame.state() != WorldChainProofLib.RootState.FINALIZED) revert GameNotFinalized(game);
 
-        uint256 eligibleAt = uint256(proofGame.finalizedAt()) + finalityDelay;
-        if (block.timestamp < eligibleAt) revert GameNotMature(game, eligibleAt);
-
-        // Parent-aware resolution guarantees that every ancestor of a finalized game is finalized,
-        // so intermediate games do not need separate anchor transactions.
+        // A game can only finalize after its parent has finalized, so FINALIZED recursively certifies
+        // its parent chain at resolution time without walking the whole chain again here.
         uint256 nextL2BlockNumber = proofGame.l2BlockNumber();
         if (nextL2BlockNumber <= currentL2BlockNumber) {
             revert NonMonotonicRoot(currentL2BlockNumber, nextL2BlockNumber);
         }
-        _requireExtendsCurrentAnchor(game, factory);
 
         bytes32 nextRootId = proofGame.rootId();
         currentRootId = nextRootId;
@@ -137,43 +122,5 @@ contract WorldChainAnchorStateRegistry {
         anchorGame = game;
 
         emit AnchorUpdated(game, nextRootId, currentRootClaim, nextL2BlockNumber);
-    }
-
-    function _requireExtendsCurrentAnchor(address candidate, address factory) private view {
-        bytes32 anchorRootClaim = currentRootClaim;
-        uint256 anchorL2BlockNumber = currentL2BlockNumber;
-        address cursor = candidate;
-
-        // Finalization proves that the candidate's own ancestry settled, but not that it extends
-        // the registry's currently accepted checkpoint. Transition snapshots preserve that link
-        // even when the registry sentinel, rather than anchorGame, is used as the direct parent.
-        // TODO: Revisit after emergency anchor recovery is designed. Continuity prevents a finalized sibling branch
-        // from replacing accepted history, but also makes an incorrectly accepted anchor sticky.
-        // Traversal is linear in skipped games; callers can advance through finalized checkpoints
-        // in smaller chunks when a single jump would exceed the transaction gas limit.
-        while (true) {
-            if (blacklistedGames[cursor]) revert GameBlacklisted(cursor);
-
-            IWorldChainProofSystemGame cursorGame = IWorldChainProofSystemGame(cursor);
-            uint256 startingL2BlockNumber = cursorGame.startingL2BlockNumber();
-
-            // A transition starting from the current root and block proves that the candidate
-            // extends the accepted checkpoint, even if it uses a different game lineage.
-            if (startingL2BlockNumber == anchorL2BlockNumber) {
-                if (cursorGame.startingRootClaim() != anchorRootClaim) {
-                    revert AnchorStateNotInAncestry(candidate, anchorRootClaim, anchorL2BlockNumber);
-                }
-                return;
-            }
-            if (startingL2BlockNumber < anchorL2BlockNumber) {
-                revert AnchorStateNotInAncestry(candidate, anchorRootClaim, anchorL2BlockNumber);
-            }
-
-            address parent = cursorGame.parentRef();
-            if (parent == address(this) || !IWorldChainProofSystemFactory(factory).isFactoryGame(parent)) {
-                revert AnchorStateNotInAncestry(candidate, anchorRootClaim, anchorL2BlockNumber);
-            }
-            cursor = parent;
-        }
     }
 }

--- a/pkg/contracts/src/proofs/WorldChainAnchorStateRegistry.sol
+++ b/pkg/contracts/src/proofs/WorldChainAnchorStateRegistry.sol
@@ -117,6 +117,8 @@ contract WorldChainAnchorStateRegistry {
             IWorldChainProofSystemGame cursorGame = IWorldChainProofSystemGame(cursor);
             uint256 startingL2BlockNumber = cursorGame.startingL2BlockNumber();
 
+            // A transition starting from the current root and block proves that the candidate
+            // extends the accepted checkpoint, even if it uses a different game lineage.
             if (startingL2BlockNumber == anchorL2BlockNumber) {
                 if (cursorGame.startingRootClaim() != anchorRootClaim) {
                     revert AnchorStateNotInAncestry(candidate, anchorRootClaim, anchorL2BlockNumber);

--- a/pkg/contracts/src/proofs/WorldChainAnchorStateRegistry.sol
+++ b/pkg/contracts/src/proofs/WorldChainAnchorStateRegistry.sol
@@ -16,6 +16,9 @@ contract WorldChainAnchorStateRegistry {
     error InvalidGameRegistry(address expectedRegistry, address actualRegistry);
     error UnregisteredGame(address game);
     error GameNotFinalized(address game);
+    error GameNotMature(address game, uint256 eligibleAt);
+    error GameRetired(address game);
+    error CurrentAnchorInvalid(address game);
     error NonMonotonicRoot(uint256 currentL2BlockNumber, uint256 nextL2BlockNumber);
     error AnchorStateNotInAncestry(address game, bytes32 currentRootClaim, uint256 currentL2BlockNumber);
 
@@ -23,9 +26,12 @@ contract WorldChainAnchorStateRegistry {
     event FactoryInitialized(address indexed factory);
     event PausedSet(bool paused);
     event GameBlacklistedSet(address indexed game, bool blacklisted);
+    event RetirementTimestampUpdated(uint64 timestamp);
 
     address public owner;
     address public proofSystemFactory;
+    uint64 public immutable finalityDelay;
+    uint64 public retirementTimestamp;
     bool public paused;
 
     bytes32 public currentRootId;
@@ -35,8 +41,9 @@ contract WorldChainAnchorStateRegistry {
 
     mapping(address game => bool blacklisted) public blacklistedGames;
 
-    constructor(bytes32 startingRootClaim, uint256 startingL2BlockNumber) {
+    constructor(bytes32 startingRootClaim, uint256 startingL2BlockNumber, uint64 finalityDelay_) {
         owner = msg.sender;
+        finalityDelay = finalityDelay_;
         currentRootClaim = startingRootClaim;
         currentL2BlockNumber = startingL2BlockNumber;
     }
@@ -59,13 +66,83 @@ contract WorldChainAnchorStateRegistry {
     }
 
     function setPaused(bool nextPaused) external onlyOwner {
+        if (!nextPaused) {
+            address currentAnchor = anchorGame;
+            if (currentAnchor != address(0) && (blacklistedGames[currentAnchor] || isGameRetired(currentAnchor))) {
+                revert CurrentAnchorInvalid(currentAnchor);
+            }
+        }
+
         paused = nextPaused;
         emit PausedSet(nextPaused);
     }
 
+    /// @notice Blacklists one game. Use `updateRetirementTimestamp` to invalidate all existing games.
     function setGameBlacklisted(address game, bool blacklisted) external onlyOwner {
         blacklistedGames[game] = blacklisted;
         emit GameBlacklistedSet(game, blacklisted);
+
+        // Advancing from a newly distrusted accepted checkpoint must stop atomically.
+        if (blacklisted && game == anchorGame && !paused) {
+            paused = true;
+            emit PausedSet(true);
+        }
+    }
+
+    /// @notice Invalidates every game created up to the current timestamp and pauses anchor progression.
+    function updateRetirementTimestamp() external onlyOwner {
+        retirementTimestamp = uint64(block.timestamp);
+        emit RetirementTimestampUpdated(retirementTimestamp);
+
+        if (!paused) {
+            paused = true;
+            emit PausedSet(true);
+        }
+    }
+
+    /// @notice Returns whether a game has finalized and passed the registry's post-resolution delay.
+    function isGameFinalized(address game) public view returns (bool) {
+        if (game.code.length == 0) return false;
+
+        IWorldChainProofSystemGame proofGame = IWorldChainProofSystemGame(game);
+        try proofGame.state() returns (WorldChainProofLib.RootState gameState) {
+            if (gameState != WorldChainProofLib.RootState.FINALIZED) return false;
+        } catch {
+            return false;
+        }
+
+        try proofGame.finalizedAt() returns (uint64 finalizedAt) {
+            return block.timestamp >= uint256(finalizedAt) + finalityDelay;
+        } catch {
+            return false;
+        }
+    }
+
+    /// @notice Returns whether a game was created before the latest blanket invalidation.
+    function isGameRetired(address game) public view returns (bool) {
+        uint64 retiredAt = retirementTimestamp;
+        if (retiredAt == 0 || game.code.length == 0) return false;
+
+        try IWorldChainProofSystemGame(game).createdAt() returns (uint64 createdAt) {
+            return createdAt <= retiredAt;
+        } catch {
+            return false;
+        }
+    }
+
+    /// @notice Returns whether a game is recognized by this registry and currently has a valid finalized claim.
+    /// @dev Anchor advancement additionally requires a newer block and continuity with the current accepted anchor.
+    /// TODO: Before withdrawal integration, implement the OP IAnchorStateRegistry surface and wire OptimismPortal
+    /// to this predicate after confirming the emergency anchor recovery semantics.
+    function isGameClaimValid(address game) external view returns (bool) {
+        address factory = proofSystemFactory;
+        if (paused || factory == address(0) || blacklistedGames[game]) return false;
+        if (!IWorldChainProofSystemFactory(factory).isFactoryGame(game)) return false;
+        if (isGameRetired(game)) return false;
+
+        IWorldChainProofSystemGame proofGame = IWorldChainProofSystemGame(game);
+        return
+            proofGame.factory() == factory && proofGame.anchorStateRegistry() == address(this) && isGameFinalized(game);
     }
 
     function setAnchorState(address game) external {
@@ -81,10 +158,12 @@ contract WorldChainAnchorStateRegistry {
             revert InvalidGameRegistry(address(this), proofGame.anchorStateRegistry());
         }
         if (!IWorldChainProofSystemFactory(factory).isFactoryGame(game)) revert UnregisteredGame(game);
+        if (isGameRetired(game)) revert GameRetired(game);
 
-        if (proofGame.state() != WorldChainProofLib.RootState.FINALIZED) {
-            revert GameNotFinalized(game);
-        }
+        if (proofGame.state() != WorldChainProofLib.RootState.FINALIZED) revert GameNotFinalized(game);
+
+        uint256 eligibleAt = uint256(proofGame.finalizedAt()) + finalityDelay;
+        if (block.timestamp < eligibleAt) revert GameNotMature(game, eligibleAt);
 
         // Parent-aware resolution guarantees that every ancestor of a finalized game is finalized,
         // so intermediate games do not need separate anchor transactions.
@@ -114,6 +193,8 @@ contract WorldChainAnchorStateRegistry {
         // Traversal is linear in skipped games; callers can advance through finalized checkpoints
         // in smaller chunks when a single jump would exceed the transaction gas limit.
         while (true) {
+            if (blacklistedGames[cursor]) revert GameBlacklisted(cursor);
+
             IWorldChainProofSystemGame cursorGame = IWorldChainProofSystemGame(cursor);
             uint256 startingL2BlockNumber = cursorGame.startingL2BlockNumber();
 

--- a/pkg/contracts/src/proofs/WorldChainAnchorStateRegistry.sol
+++ b/pkg/contracts/src/proofs/WorldChainAnchorStateRegistry.sol
@@ -32,7 +32,6 @@ contract WorldChainAnchorStateRegistry {
     uint256 public currentL2BlockNumber;
     address public anchorGame;
 
-    mapping(address game => bool accepted) public acceptedGames;
     mapping(bytes32 rootId => bool accepted) public acceptedRoots;
     mapping(address game => bool blacklisted) public blacklistedGames;
 
@@ -99,7 +98,6 @@ contract WorldChainAnchorStateRegistry {
         currentRootClaim = proofGame.rootClaim();
         currentL2BlockNumber = nextL2BlockNumber;
         anchorGame = game;
-        acceptedGames[game] = true;
         acceptedRoots[nextRootId] = true;
 
         emit AnchorUpdated(game, nextRootId, currentRootClaim, nextL2BlockNumber);

--- a/pkg/contracts/src/proofs/WorldChainAnchorStateRegistry.sol
+++ b/pkg/contracts/src/proofs/WorldChainAnchorStateRegistry.sol
@@ -17,7 +17,6 @@ contract WorldChainAnchorStateRegistry {
     error UnregisteredGame(address game);
     error GameNotFinalized(address game);
     error NonMonotonicRoot(uint256 currentL2BlockNumber, uint256 nextL2BlockNumber);
-    error InvalidParent(address parentRef);
 
     event AnchorUpdated(address indexed game, bytes32 indexed rootId, bytes32 rootClaim, uint256 l2BlockNumber);
     event FactoryInitialized(address indexed factory);
@@ -88,11 +87,8 @@ contract WorldChainAnchorStateRegistry {
             revert GameNotFinalized(game);
         }
 
-        address parent = proofGame.parentRef();
-        if (parent != address(this) && !acceptedGames[parent]) {
-            revert InvalidParent(parent);
-        }
-
+        // Parent-aware resolution guarantees that every ancestor of a finalized game is finalized,
+        // so intermediate games do not need separate anchor transactions.
         uint256 nextL2BlockNumber = proofGame.l2BlockNumber();
         if (nextL2BlockNumber <= currentL2BlockNumber) {
             revert NonMonotonicRoot(currentL2BlockNumber, nextL2BlockNumber);

--- a/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
@@ -243,6 +243,12 @@ contract WorldChainProofSystemGame {
         return (evaluation.outcome, evaluation.reason);
     }
 
+    /// @notice Asks the registry to advance its accepted anchor to this game.
+    /// @dev The registry remains authoritative because eligibility depends on its current global anchor and policy.
+    function closeGame() external {
+        IWorldChainAnchorStateRegistry(anchorStateRegistry).setAnchorState(address(this));
+    }
+
     function _evaluateResolution() internal view returns (ResolutionEvaluation memory evaluation) {
         WorldChainProofLib.RootState currentState = state;
         if (

--- a/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
@@ -302,6 +302,7 @@ contract WorldChainProofSystemGame {
                 return evaluation;
             }
             // 5. An unchallenged proposal finalizes after its challenge window expires.
+            // Safety therefore relies on every incorrect claim being challenged before this deadline.
             evaluation.status = ResolutionStatus.RESOLVABLE;
             evaluation.outcome = WorldChainProofLib.RootState.FINALIZED;
             return evaluation;

--- a/pkg/contracts/src/proofs/interfaces/IWorldChainAnchorStateRegistry.sol
+++ b/pkg/contracts/src/proofs/interfaces/IWorldChainAnchorStateRegistry.sol
@@ -5,10 +5,8 @@ interface IWorldChainAnchorStateRegistry {
     function setAnchorState(address game) external;
     function isGameFinalized(address game) external view returns (bool);
     function isGameClaimValid(address game) external view returns (bool);
-    function isGameRetired(address game) external view returns (bool);
     function proofSystemFactory() external view returns (address);
     function finalityDelay() external view returns (uint64);
-    function retirementTimestamp() external view returns (uint64);
     function paused() external view returns (bool);
     function currentRootClaim() external view returns (bytes32);
     function currentL2BlockNumber() external view returns (uint256);

--- a/pkg/contracts/src/proofs/interfaces/IWorldChainAnchorStateRegistry.sol
+++ b/pkg/contracts/src/proofs/interfaces/IWorldChainAnchorStateRegistry.sol
@@ -2,7 +2,13 @@
 pragma solidity 0.8.28;
 
 interface IWorldChainAnchorStateRegistry {
+    function setAnchorState(address game) external;
+    function isGameFinalized(address game) external view returns (bool);
+    function isGameClaimValid(address game) external view returns (bool);
+    function isGameRetired(address game) external view returns (bool);
     function proofSystemFactory() external view returns (address);
+    function finalityDelay() external view returns (uint64);
+    function retirementTimestamp() external view returns (uint64);
     function paused() external view returns (bool);
     function currentRootClaim() external view returns (bytes32);
     function currentL2BlockNumber() external view returns (uint256);

--- a/pkg/contracts/src/proofs/interfaces/IWorldChainAnchorStateRegistry.sol
+++ b/pkg/contracts/src/proofs/interfaces/IWorldChainAnchorStateRegistry.sol
@@ -6,7 +6,6 @@ interface IWorldChainAnchorStateRegistry {
     function isGameFinalized(address game) external view returns (bool);
     function isGameClaimValid(address game) external view returns (bool);
     function proofSystemFactory() external view returns (address);
-    function finalityDelay() external view returns (uint64);
     function paused() external view returns (bool);
     function currentRootClaim() external view returns (bytes32);
     function currentL2BlockNumber() external view returns (uint256);

--- a/pkg/contracts/src/proofs/interfaces/IWorldChainProofSystemGame.sol
+++ b/pkg/contracts/src/proofs/interfaces/IWorldChainProofSystemGame.sol
@@ -19,7 +19,6 @@ interface IWorldChainProofSystemGame {
     function proofBitmap() external view returns (uint8);
     function proofDeadline() external view returns (uint64);
     function challengeDeadline() external view returns (uint64);
-    function createdAt() external view returns (uint64);
     function finalizedAt() external view returns (uint64);
     function resolutionStatus()
         external

--- a/pkg/contracts/src/proofs/interfaces/IWorldChainProofSystemGame.sol
+++ b/pkg/contracts/src/proofs/interfaces/IWorldChainProofSystemGame.sol
@@ -19,6 +19,7 @@ interface IWorldChainProofSystemGame {
     function proofBitmap() external view returns (uint8);
     function proofDeadline() external view returns (uint64);
     function challengeDeadline() external view returns (uint64);
+    function createdAt() external view returns (uint64);
     function finalizedAt() external view returns (uint64);
     function resolutionStatus()
         external
@@ -27,4 +28,5 @@ interface IWorldChainProofSystemGame {
     function resolve()
         external
         returns (WorldChainProofLib.RootState outcome, WorldChainProofLib.InvalidationReason reason);
+    function closeGame() external;
 }

--- a/pkg/contracts/test/WorldChainProofSystem.t.sol
+++ b/pkg/contracts/test/WorldChainProofSystem.t.sol
@@ -520,9 +520,6 @@ contract WorldChainProofSystemTest is Test {
 
         anchor.setAnchorState(address(third));
 
-        assertFalse(anchor.acceptedGames(address(first)));
-        assertFalse(anchor.acceptedGames(address(second)));
-        assertTrue(anchor.acceptedGames(address(third)));
         assertEq(anchor.currentRootId(), third.rootId());
         assertEq(anchor.currentRootClaim(), third.rootClaim());
         assertEq(anchor.currentL2BlockNumber(), third.l2BlockNumber());

--- a/pkg/contracts/test/WorldChainProofSystem.t.sol
+++ b/pkg/contracts/test/WorldChainProofSystem.t.sol
@@ -526,6 +526,54 @@ contract WorldChainProofSystemTest is Test {
         assertEq(anchor.anchorGame(), address(third));
     }
 
+    function testAnchorRejectsFinalizedParallelBranch() public {
+        (WorldChainProofSystemGame acceptedBranch,) = _propose(10);
+        (WorldChainProofSystemGame parallelParent,) = _propose(10);
+        (WorldChainProofSystemGame parallelChild,) = _proposeChild(parallelParent, keccak256("parallel-child-root"));
+
+        vm.warp(block.timestamp + CHALLENGE_PERIOD);
+        acceptedBranch.resolve();
+        parallelParent.resolve();
+        parallelChild.resolve();
+
+        anchor.setAnchorState(address(acceptedBranch));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                WorldChainAnchorStateRegistry.AnchorStateNotInAncestry.selector,
+                address(parallelChild),
+                acceptedBranch.rootClaim(),
+                acceptedBranch.l2BlockNumber()
+            )
+        );
+        anchor.setAnchorState(address(parallelChild));
+    }
+
+    function testAnchorAcceptsAlternativeLineageFromSameCheckpoint() public {
+        bytes32 sharedRootClaim = keccak256("shared-root");
+        (WorldChainProofSystemGame first,) = _propose(10);
+        (WorldChainProofSystemGame acceptedCheckpoint,) = _proposeChild(first, sharedRootClaim);
+        (WorldChainProofSystemGame alternativeFirst,) = _propose(10);
+        (WorldChainProofSystemGame equivalentCheckpoint,) = _proposeChild(alternativeFirst, sharedRootClaim);
+
+        vm.warp(block.timestamp + CHALLENGE_PERIOD);
+        first.resolve();
+        acceptedCheckpoint.resolve();
+        alternativeFirst.resolve();
+        equivalentCheckpoint.resolve();
+        anchor.setAnchorState(address(acceptedCheckpoint));
+
+        (WorldChainProofSystemGame alternativeSuccessor,) =
+            _proposeChild(equivalentCheckpoint, keccak256("alternative-successor-root"));
+        vm.warp(block.timestamp + CHALLENGE_PERIOD);
+        alternativeSuccessor.resolve();
+        anchor.setAnchorState(address(alternativeSuccessor));
+
+        assertEq(anchor.anchorGame(), address(alternativeSuccessor));
+        assertEq(anchor.currentRootClaim(), alternativeSuccessor.rootClaim());
+        assertEq(anchor.currentL2BlockNumber(), alternativeSuccessor.l2BlockNumber());
+    }
+
     function testAnchorRejectsNonFinalizedInvalidatedPausedAndNonMonotonicRoots() public {
         (WorldChainProofSystemGame nonFinalized,) = _propose(10);
         vm.expectRevert();

--- a/pkg/contracts/test/WorldChainProofSystem.t.sol
+++ b/pkg/contracts/test/WorldChainProofSystem.t.sol
@@ -37,7 +37,7 @@ contract WorldChainProofSystemTest is Test {
         vm.deal(secondChallenger, 100 ether);
         vm.deal(keeper, 100 ether);
 
-        anchor = new WorldChainAnchorStateRegistry(bytes32(uint256(1)), 0, 0);
+        anchor = new WorldChainAnchorStateRegistry(bytes32(uint256(1)), 0);
         staking = new MockStakingRegistry();
         staking.setStaked(challenger, true);
         staking.setStaked(secondChallenger, true);
@@ -138,7 +138,7 @@ contract WorldChainProofSystemTest is Test {
     }
 
     function testThresholdOneRequiresExplicitSettlementAfterSingleLane() public {
-        WorldChainAnchorStateRegistry thresholdAnchor = new WorldChainAnchorStateRegistry(bytes32(uint256(1)), 0, 0);
+        WorldChainAnchorStateRegistry thresholdAnchor = new WorldChainAnchorStateRegistry(bytes32(uint256(1)), 0);
         WorldChainProofSystemFactory thresholdOne = _newFactory(thresholdAnchor, 1);
         thresholdAnchor.initializeFactory(address(thresholdOne));
 
@@ -160,7 +160,7 @@ contract WorldChainProofSystemTest is Test {
     }
 
     function testFactoryRejectsOutOfRangeThreshold() public {
-        WorldChainAnchorStateRegistry thresholdAnchor = new WorldChainAnchorStateRegistry(bytes32(uint256(1)), 0, 0);
+        WorldChainAnchorStateRegistry thresholdAnchor = new WorldChainAnchorStateRegistry(bytes32(uint256(1)), 0);
 
         vm.expectRevert(WorldChainProofSystemFactory.InvalidActivationParameters.selector);
         _newFactory(thresholdAnchor, 0);
@@ -511,7 +511,7 @@ contract WorldChainProofSystemTest is Test {
     }
 
     function testFactoryRequiresRegistryInitializationBeforePropose() public {
-        WorldChainAnchorStateRegistry uninitializedAnchor = new WorldChainAnchorStateRegistry(bytes32(uint256(1)), 0, 0);
+        WorldChainAnchorStateRegistry uninitializedAnchor = new WorldChainAnchorStateRegistry(bytes32(uint256(1)), 0);
         WorldChainProofSystemFactory uninitializedFactory =
             _newFactory(uninitializedAnchor, WorldChainProofLib.PROOF_THRESHOLD);
 
@@ -603,40 +603,18 @@ contract WorldChainProofSystemTest is Test {
         game.closeGame();
     }
 
-    function testGameCannotCloseBeforeRegistryFinalityDelay() public {
-        uint64 finalityDelay = 1 days;
-        WorldChainAnchorStateRegistry delayedAnchor =
-            new WorldChainAnchorStateRegistry(bytes32(uint256(1)), 0, finalityDelay);
-        WorldChainProofSystemFactory delayedFactory = _newFactory(delayedAnchor, WorldChainProofLib.PROOF_THRESHOLD);
-        delayedAnchor.initializeFactory(address(delayedFactory));
+    function testFinalizedGameIsImmediatelyEligibleToClose() public {
+        (WorldChainProofSystemGame game,) = _finalizedGame(10);
 
-        vm.prank(proposer);
-        (address gameAddress, bytes32 rootId) =
-            delayedFactory.propose{value: PROPOSER_BOND}(address(delayedAnchor), keccak256("delayed-root"), 10);
-        WorldChainProofSystemGame game = WorldChainProofSystemGame(payable(gameAddress));
-        _challenge(game, challenger);
-        game.submitProofLane(uint8(WorldChainProofLib.ProofLane.VALIDITY_PROOF), abi.encode(rootId));
-        game.submitProofLane(uint8(WorldChainProofLib.ProofLane.TEE_ATTESTATION), abi.encode(rootId));
-        game.resolve();
+        assertTrue(anchor.isGameFinalized(address(game)));
+        assertTrue(anchor.isGameClaimValid(address(game)));
 
-        uint256 eligibleAt = uint256(game.finalizedAt()) + finalityDelay;
-        assertFalse(delayedAnchor.isGameFinalized(address(game)));
-        assertFalse(delayedAnchor.isGameClaimValid(address(game)));
-        vm.expectRevert(
-            abi.encodeWithSelector(WorldChainAnchorStateRegistry.GameNotMature.selector, address(game), eligibleAt)
-        );
-        game.closeGame();
-
-        vm.warp(eligibleAt);
-        assertTrue(delayedAnchor.isGameFinalized(address(game)));
-        assertTrue(delayedAnchor.isGameClaimValid(address(game)));
-
-        delayedAnchor.setPaused(true);
-        assertFalse(delayedAnchor.isGameClaimValid(address(game)));
-        delayedAnchor.setPaused(false);
+        anchor.setPaused(true);
+        assertFalse(anchor.isGameClaimValid(address(game)));
+        anchor.setPaused(false);
 
         game.closeGame();
-        assertEq(delayedAnchor.anchorGame(), address(game));
+        assertEq(anchor.anchorGame(), address(game));
     }
 
     function testAnchorCanJumpToHighestFinalizedDescendant() public {
@@ -657,7 +635,7 @@ contract WorldChainProofSystemTest is Test {
         assertEq(anchor.anchorGame(), address(third));
     }
 
-    function testAnchorRejectsFinalizedParallelBranch() public {
+    function testAnchorAcceptsNewerFinalizedParallelBranch() public {
         (WorldChainProofSystemGame acceptedBranch,) = _propose(10);
         (WorldChainProofSystemGame parallelParent,) = _propose(10);
         (WorldChainProofSystemGame parallelChild,) = _proposeChild(parallelParent, keccak256("parallel-child-root"));
@@ -668,19 +646,14 @@ contract WorldChainProofSystemTest is Test {
         parallelChild.resolve();
 
         anchor.setAnchorState(address(acceptedBranch));
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                WorldChainAnchorStateRegistry.AnchorStateNotInAncestry.selector,
-                address(parallelChild),
-                acceptedBranch.rootClaim(),
-                acceptedBranch.l2BlockNumber()
-            )
-        );
         anchor.setAnchorState(address(parallelChild));
+
+        assertEq(anchor.anchorGame(), address(parallelChild));
+        assertEq(anchor.currentRootClaim(), parallelChild.rootClaim());
+        assertEq(anchor.currentL2BlockNumber(), parallelChild.l2BlockNumber());
     }
 
-    function testAnchorRejectsBlacklistedSkippedAncestor() public {
+    function testAnchorDoesNotRecheckFinalizedSkippedAncestor() public {
         (WorldChainProofSystemGame first,) = _propose(10);
         (WorldChainProofSystemGame second,) = _proposeChild(first, keccak256("second-root"));
         (WorldChainProofSystemGame third,) = _proposeChild(second, keccak256("third-root"));
@@ -691,8 +664,9 @@ contract WorldChainProofSystemTest is Test {
         third.resolve();
         anchor.setGameBlacklisted(address(second), true);
 
-        vm.expectRevert(abi.encodeWithSelector(WorldChainAnchorStateRegistry.GameBlacklisted.selector, address(second)));
         third.closeGame();
+
+        assertEq(anchor.anchorGame(), address(third));
     }
 
     function testAnchorAcceptsAlternativeLineageFromSameCheckpoint() public {
@@ -744,7 +718,7 @@ contract WorldChainProofSystemTest is Test {
     }
 
     function testAnchorRejectsFinalizedGameFromDifferentFactory() public {
-        WorldChainAnchorStateRegistry otherAnchor = new WorldChainAnchorStateRegistry(bytes32(uint256(1)), 0, 0);
+        WorldChainAnchorStateRegistry otherAnchor = new WorldChainAnchorStateRegistry(bytes32(uint256(1)), 0);
         WorldChainProofSystemFactory otherFactory = _newFactory(otherAnchor, WorldChainProofLib.PROOF_THRESHOLD);
         otherAnchor.initializeFactory(address(otherFactory));
 

--- a/pkg/contracts/test/WorldChainProofSystem.t.sol
+++ b/pkg/contracts/test/WorldChainProofSystem.t.sol
@@ -35,7 +35,7 @@ contract WorldChainProofSystemTest is Test {
         vm.deal(challenger, 100 ether);
         vm.deal(secondChallenger, 100 ether);
 
-        anchor = new WorldChainAnchorStateRegistry(bytes32(uint256(1)), 0);
+        anchor = new WorldChainAnchorStateRegistry(bytes32(uint256(1)), 0, 0);
         staking = new MockStakingRegistry();
         staking.setStaked(challenger, true);
         staking.setStaked(secondChallenger, true);
@@ -117,7 +117,7 @@ contract WorldChainProofSystemTest is Test {
     }
 
     function testThresholdOneRequiresExplicitSettlementAfterSingleLane() public {
-        WorldChainAnchorStateRegistry thresholdAnchor = new WorldChainAnchorStateRegistry(bytes32(uint256(1)), 0);
+        WorldChainAnchorStateRegistry thresholdAnchor = new WorldChainAnchorStateRegistry(bytes32(uint256(1)), 0, 0);
         WorldChainProofSystemFactory thresholdOne = _newFactory(thresholdAnchor, 1);
         thresholdAnchor.initializeFactory(address(thresholdOne));
 
@@ -139,7 +139,7 @@ contract WorldChainProofSystemTest is Test {
     }
 
     function testFactoryRejectsOutOfRangeThreshold() public {
-        WorldChainAnchorStateRegistry thresholdAnchor = new WorldChainAnchorStateRegistry(bytes32(uint256(1)), 0);
+        WorldChainAnchorStateRegistry thresholdAnchor = new WorldChainAnchorStateRegistry(bytes32(uint256(1)), 0, 0);
 
         vm.expectRevert(WorldChainProofSystemFactory.InvalidActivationParameters.selector);
         _newFactory(thresholdAnchor, 0);
@@ -434,7 +434,7 @@ contract WorldChainProofSystemTest is Test {
     }
 
     function testFactoryRequiresRegistryInitializationBeforePropose() public {
-        WorldChainAnchorStateRegistry uninitializedAnchor = new WorldChainAnchorStateRegistry(bytes32(uint256(1)), 0);
+        WorldChainAnchorStateRegistry uninitializedAnchor = new WorldChainAnchorStateRegistry(bytes32(uint256(1)), 0, 0);
         WorldChainProofSystemFactory uninitializedFactory =
             _newFactory(uninitializedAnchor, WorldChainProofLib.PROOF_THRESHOLD);
 
@@ -508,6 +508,115 @@ contract WorldChainProofSystemTest is Test {
         assertEq(anchor.anchorGame(), address(game));
     }
 
+    function testGameCanCloseThroughAnchorRegistry() public {
+        (WorldChainProofSystemGame game,) = _finalizedGame(10);
+
+        game.closeGame();
+
+        assertEq(anchor.currentRootId(), game.rootId());
+        assertEq(anchor.currentRootClaim(), game.rootClaim());
+        assertEq(anchor.currentL2BlockNumber(), game.l2BlockNumber());
+        assertEq(anchor.anchorGame(), address(game));
+    }
+
+    function testGameClosePropagatesAnchorRegistryRejection() public {
+        (WorldChainProofSystemGame game,) = _propose(10);
+
+        vm.expectRevert(abi.encodeWithSelector(WorldChainAnchorStateRegistry.GameNotFinalized.selector, address(game)));
+        game.closeGame();
+    }
+
+    function testGameCannotCloseBeforeRegistryFinalityDelay() public {
+        uint64 finalityDelay = 1 days;
+        WorldChainAnchorStateRegistry delayedAnchor =
+            new WorldChainAnchorStateRegistry(bytes32(uint256(1)), 0, finalityDelay);
+        WorldChainProofSystemFactory delayedFactory = _newFactory(delayedAnchor, WorldChainProofLib.PROOF_THRESHOLD);
+        delayedAnchor.initializeFactory(address(delayedFactory));
+
+        vm.prank(proposer);
+        (address gameAddress, bytes32 rootId) =
+            delayedFactory.propose{value: PROPOSER_BOND}(address(delayedAnchor), keccak256("delayed-root"), 10);
+        WorldChainProofSystemGame game = WorldChainProofSystemGame(payable(gameAddress));
+        _challenge(game, challenger);
+        game.submitProofLane(uint8(WorldChainProofLib.ProofLane.VALIDITY_PROOF), abi.encode(rootId));
+        game.submitProofLane(uint8(WorldChainProofLib.ProofLane.TEE_ATTESTATION), abi.encode(rootId));
+        game.resolve();
+
+        uint256 eligibleAt = uint256(game.finalizedAt()) + finalityDelay;
+        assertFalse(delayedAnchor.isGameFinalized(address(game)));
+        assertFalse(delayedAnchor.isGameClaimValid(address(game)));
+        vm.expectRevert(
+            abi.encodeWithSelector(WorldChainAnchorStateRegistry.GameNotMature.selector, address(game), eligibleAt)
+        );
+        game.closeGame();
+
+        vm.warp(eligibleAt);
+        assertTrue(delayedAnchor.isGameFinalized(address(game)));
+        assertTrue(delayedAnchor.isGameClaimValid(address(game)));
+
+        delayedAnchor.setPaused(true);
+        assertFalse(delayedAnchor.isGameClaimValid(address(game)));
+        delayedAnchor.setPaused(false);
+
+        game.closeGame();
+        assertEq(delayedAnchor.anchorGame(), address(game));
+    }
+
+    function testBlacklistingCurrentAnchorPausesUntilItIsUnblacklisted() public {
+        (WorldChainProofSystemGame game,) = _finalizedGame(10);
+        game.closeGame();
+
+        anchor.setGameBlacklisted(address(game), true);
+
+        assertTrue(anchor.paused());
+        assertFalse(anchor.isGameClaimValid(address(game)));
+        vm.expectRevert(
+            abi.encodeWithSelector(WorldChainAnchorStateRegistry.CurrentAnchorInvalid.selector, address(game))
+        );
+        anchor.setPaused(false);
+
+        vm.prank(proposer);
+        vm.expectRevert(WorldChainProofSystemFactory.RegistryPaused.selector);
+        factory.propose{value: PROPOSER_BOND}(address(anchor), keccak256("blocked-root"), 20);
+
+        anchor.setGameBlacklisted(address(game), false);
+        anchor.setPaused(false);
+        assertFalse(anchor.paused());
+    }
+
+    function testRetirementInvalidatesExistingDescendants() public {
+        (WorldChainProofSystemGame parent,) = _propose(10);
+        (WorldChainProofSystemGame child,) = _proposeChild(parent, keccak256("child-root"));
+
+        vm.warp(block.timestamp + CHALLENGE_PERIOD);
+        parent.resolve();
+        child.resolve();
+        anchor.updateRetirementTimestamp();
+
+        assertTrue(anchor.paused());
+        assertTrue(anchor.isGameRetired(address(parent)));
+        assertTrue(anchor.isGameRetired(address(child)));
+        assertFalse(anchor.isGameClaimValid(address(child)));
+
+        anchor.setPaused(false);
+        vm.expectRevert(abi.encodeWithSelector(WorldChainAnchorStateRegistry.GameRetired.selector, address(child)));
+        child.closeGame();
+    }
+
+    function testRetiringCurrentAnchorBlocksUnpause() public {
+        (WorldChainProofSystemGame game,) = _finalizedGame(10);
+        game.closeGame();
+
+        anchor.updateRetirementTimestamp();
+
+        assertTrue(anchor.paused());
+        assertTrue(anchor.isGameRetired(address(game)));
+        vm.expectRevert(
+            abi.encodeWithSelector(WorldChainAnchorStateRegistry.CurrentAnchorInvalid.selector, address(game))
+        );
+        anchor.setPaused(false);
+    }
+
     function testAnchorCanJumpToHighestFinalizedDescendant() public {
         (WorldChainProofSystemGame first,) = _propose(10);
         (WorldChainProofSystemGame second,) = _proposeChild(first, keccak256("second-root"));
@@ -547,6 +656,21 @@ contract WorldChainProofSystemTest is Test {
             )
         );
         anchor.setAnchorState(address(parallelChild));
+    }
+
+    function testAnchorRejectsBlacklistedSkippedAncestor() public {
+        (WorldChainProofSystemGame first,) = _propose(10);
+        (WorldChainProofSystemGame second,) = _proposeChild(first, keccak256("second-root"));
+        (WorldChainProofSystemGame third,) = _proposeChild(second, keccak256("third-root"));
+
+        vm.warp(block.timestamp + CHALLENGE_PERIOD);
+        first.resolve();
+        second.resolve();
+        third.resolve();
+        anchor.setGameBlacklisted(address(second), true);
+
+        vm.expectRevert(abi.encodeWithSelector(WorldChainAnchorStateRegistry.GameBlacklisted.selector, address(second)));
+        third.closeGame();
     }
 
     function testAnchorAcceptsAlternativeLineageFromSameCheckpoint() public {
@@ -598,7 +722,7 @@ contract WorldChainProofSystemTest is Test {
     }
 
     function testAnchorRejectsFinalizedGameFromDifferentFactory() public {
-        WorldChainAnchorStateRegistry otherAnchor = new WorldChainAnchorStateRegistry(bytes32(uint256(1)), 0);
+        WorldChainAnchorStateRegistry otherAnchor = new WorldChainAnchorStateRegistry(bytes32(uint256(1)), 0, 0);
         WorldChainProofSystemFactory otherFactory = _newFactory(otherAnchor, WorldChainProofLib.PROOF_THRESHOLD);
         otherAnchor.initializeFactory(address(otherFactory));
 

--- a/pkg/contracts/test/WorldChainProofSystem.t.sol
+++ b/pkg/contracts/test/WorldChainProofSystem.t.sol
@@ -562,61 +562,6 @@ contract WorldChainProofSystemTest is Test {
         assertEq(delayedAnchor.anchorGame(), address(game));
     }
 
-    function testBlacklistingCurrentAnchorPausesUntilItIsUnblacklisted() public {
-        (WorldChainProofSystemGame game,) = _finalizedGame(10);
-        game.closeGame();
-
-        anchor.setGameBlacklisted(address(game), true);
-
-        assertTrue(anchor.paused());
-        assertFalse(anchor.isGameClaimValid(address(game)));
-        vm.expectRevert(
-            abi.encodeWithSelector(WorldChainAnchorStateRegistry.CurrentAnchorInvalid.selector, address(game))
-        );
-        anchor.setPaused(false);
-
-        vm.prank(proposer);
-        vm.expectRevert(WorldChainProofSystemFactory.RegistryPaused.selector);
-        factory.propose{value: PROPOSER_BOND}(address(anchor), keccak256("blocked-root"), 20);
-
-        anchor.setGameBlacklisted(address(game), false);
-        anchor.setPaused(false);
-        assertFalse(anchor.paused());
-    }
-
-    function testRetirementInvalidatesExistingDescendants() public {
-        (WorldChainProofSystemGame parent,) = _propose(10);
-        (WorldChainProofSystemGame child,) = _proposeChild(parent, keccak256("child-root"));
-
-        vm.warp(block.timestamp + CHALLENGE_PERIOD);
-        parent.resolve();
-        child.resolve();
-        anchor.updateRetirementTimestamp();
-
-        assertTrue(anchor.paused());
-        assertTrue(anchor.isGameRetired(address(parent)));
-        assertTrue(anchor.isGameRetired(address(child)));
-        assertFalse(anchor.isGameClaimValid(address(child)));
-
-        anchor.setPaused(false);
-        vm.expectRevert(abi.encodeWithSelector(WorldChainAnchorStateRegistry.GameRetired.selector, address(child)));
-        child.closeGame();
-    }
-
-    function testRetiringCurrentAnchorBlocksUnpause() public {
-        (WorldChainProofSystemGame game,) = _finalizedGame(10);
-        game.closeGame();
-
-        anchor.updateRetirementTimestamp();
-
-        assertTrue(anchor.paused());
-        assertTrue(anchor.isGameRetired(address(game)));
-        vm.expectRevert(
-            abi.encodeWithSelector(WorldChainAnchorStateRegistry.CurrentAnchorInvalid.selector, address(game))
-        );
-        anchor.setPaused(false);
-    }
-
     function testAnchorCanJumpToHighestFinalizedDescendant() public {
         (WorldChainProofSystemGame first,) = _propose(10);
         (WorldChainProofSystemGame second,) = _proposeChild(first, keccak256("second-root"));

--- a/pkg/contracts/test/WorldChainProofSystem.t.sol
+++ b/pkg/contracts/test/WorldChainProofSystem.t.sol
@@ -508,6 +508,27 @@ contract WorldChainProofSystemTest is Test {
         assertEq(anchor.anchorGame(), address(game));
     }
 
+    function testAnchorCanJumpToHighestFinalizedDescendant() public {
+        (WorldChainProofSystemGame first,) = _propose(10);
+        (WorldChainProofSystemGame second,) = _proposeChild(first, keccak256("second-root"));
+        (WorldChainProofSystemGame third,) = _proposeChild(second, keccak256("third-root"));
+
+        vm.warp(block.timestamp + CHALLENGE_PERIOD);
+        first.resolve();
+        second.resolve();
+        third.resolve();
+
+        anchor.setAnchorState(address(third));
+
+        assertFalse(anchor.acceptedGames(address(first)));
+        assertFalse(anchor.acceptedGames(address(second)));
+        assertTrue(anchor.acceptedGames(address(third)));
+        assertEq(anchor.currentRootId(), third.rootId());
+        assertEq(anchor.currentRootClaim(), third.rootClaim());
+        assertEq(anchor.currentL2BlockNumber(), third.l2BlockNumber());
+        assertEq(anchor.anchorGame(), address(third));
+    }
+
     function testAnchorRejectsNonFinalizedInvalidatedPausedAndNonMonotonicRoots() public {
         (WorldChainProofSystemGame nonFinalized,) = _propose(10);
         vm.expectRevert();


### PR DESCRIPTION
## Summary

- Allow the registry to jump directly to a finalized descendant game.
- Require the candidate’s ancestry to reach the current anchor root and block.
- Reject parallel branches and blacklisted ancestors.
- Add a post-resolution finality delay and game validity helpers.
- Add `game.closeGame()` as a convenience wrapper around `setAnchorState()`.

This removes the now-unused `acceptedGames` and `acceptedRoots` mappings.