### PR TITLE
fix(rpc): support eth_simulateV1 with flashblocks

### DIFF
--- a/crates/rpc/src/eth/call.rs
+++ b/crates/rpc/src/eth/call.rs
@@ -53,9 +53,8 @@ where
         self.inner.evm_memory_limit()
     }
 
+    #[inline]
     fn compute_state_root_for_eth_simulate(&self) -> bool {
-        unimplemented!(
-            "compute_state_root_for_eth_simulate is not supported by the flashblocks eth API"
-        )
+        self.inner.compute_state_root_for_eth_simulate()
     }
 }


### PR DESCRIPTION
## Summary

- remove the Flashblocks RPC panic path for `eth_simulateV1`
- delegate state-root configuration to the wrapped `OpEthApi`
- preserve the node's existing RPC configuration instead of introducing Flashblocks-specific behavior

## Why

`eth_simulateV1` consults `compute_state_root_for_eth_simulate` while serving simulations. The Flashblocks wrapper currently implements that method with `unimplemented!()`, so a standards-based simulation request can panic its RPC task.

Reliable simulation is especially important for automated wallets and AI agents that preflight multi-step state transitions before submitting transactions. This keeps World Chain's Flashblocks API aligned with the upstream OP-Reth implementation.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p world-chain-rpc --all-targets`
- `cargo test -p world-chain-rpc --lib` (11 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-method delegation with no new Flashblocks-specific logic; aligns behavior with the wrapped OP-Reth API.
> 
> **Overview**
> Fixes **`eth_simulateV1`** on the Flashblocks RPC wrapper by implementing `compute_state_root_for_eth_simulate` as a forward to the wrapped `OpEthApi` instead of **`unimplemented!()`**, which could panic the RPC task when simulations read that setting.
> 
> Behavior now matches the inner node’s RPC configuration (same pattern as `max_simulate_blocks` and `call_gas_limit`), with an **`#[inline]`** delegate added for consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f9d954fa36da8bd3410242b7a5c6afdf0d952d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->