### PR TITLE
fix(rpc): serve pending calls from executed Flashblock state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19250,6 +19250,7 @@ dependencies = [
  "reqwest 0.12.28",
  "reth-chain-state",
  "reth-chainspec",
+ "reth-errors",
  "reth-evm",
  "reth-node-api",
  "reth-node-builder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19491,6 +19491,7 @@ dependencies = [
  "reqwest 0.12.28",
  "reth-chain-state",
  "reth-chainspec",
+ "reth-errors",
  "reth-evm",
  "reth-node-api",
  "reth-node-builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0
 reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0", default-features = false }
 reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0", default-features = false }
 reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0", default-features = false }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0", default-features = false }
 reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0", default-features = false }
 reth-db-api = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0", default-features = false }
 reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,7 @@ reth-cli-commands = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef9211
 reth-cli-runner = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }
 reth-engine-primitives = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }
 reth-evm = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }
+reth-errors = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }
 reth-db = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }
 reth-db-api = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }
 reth-provider = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -21,6 +21,7 @@ reth-chainspec.workspace = true
 reth-provider.workspace = true
 reth-transaction-pool.workspace = true
 reth-evm.workspace = true
+reth-errors.workspace = true
 reth-node-api.workspace = true
 reth-primitives-traits.workspace = true
 reth-rpc-api.workspace = true

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -23,6 +23,7 @@ reth-chainspec.workspace = true
 reth-provider.workspace = true
 reth-transaction-pool.workspace = true
 reth-evm.workspace = true
+reth-errors.workspace = true
 reth-node-api.workspace = true
 reth-primitives-traits.workspace = true
 reth-rpc-api.workspace = true

--- a/crates/rpc/src/eth/pending_block.rs
+++ b/crates/rpc/src/eth/pending_block.rs
@@ -1,14 +1,21 @@
 //! Loads OP pending block for a RPC response.
 
 use alloy_eips::BlockNumberOrTag;
+use reth_chain_state::{BlockState, ExecutedBlock};
+use reth_errors::RethError;
+use reth_evm::ConfigureEvm;
 use reth_optimism_primitives::OpPrimitives;
 use reth_optimism_rpc::{OpEthApi, OpEthApiError};
-use reth_provider::{BlockReader, BlockReaderIdExt, ReceiptProvider};
+use reth_provider::{
+    BlockReader, BlockReaderIdExt, ReceiptProvider, StateProviderBox, StateProviderFactory,
+};
 use reth_rpc_eth_api::{
-    EthApiTypes, FromEvmError, RpcConvert, RpcNodeCore,
+    EthApiTypes, FromEthApiError, FromEvmError, RpcConvert, RpcNodeCore,
     helpers::{LoadPendingBlock, SpawnBlocking, pending_block::PendingEnvBuilder},
 };
-use reth_rpc_eth_types::{EthApiError, PendingBlock, block::BlockAndReceipts};
+use reth_rpc_eth_types::{
+    EthApiError, PendingBlock, PendingBlockEnv, PendingBlockEnvOrigin, block::BlockAndReceipts,
+};
 
 use crate::eth::FlashblocksEthApi;
 
@@ -34,6 +41,39 @@ where
     #[inline]
     fn pending_env_builder(&self) -> &dyn PendingEnvBuilder<Self::Evm> {
         self.inner.pending_env_builder()
+    }
+
+    fn pending_block_env_and_cfg(&self) -> Result<PendingBlockEnv<Self::Evm>, Self::Error> {
+        if let Some(pending_block) = self.flashblock_pending_block() {
+            let evm_env = self
+                .evm_config()
+                .evm_env(pending_block.recovered_block.header())
+                .map_err(RethError::other)
+                .map_err(Self::Error::from_eth_err)?;
+
+            return Ok(PendingBlockEnv::new(
+                evm_env,
+                PendingBlockEnvOrigin::ActualPending(
+                    pending_block.recovered_block,
+                    pending_block.execution_output.receipts.clone().into(),
+                ),
+            ));
+        }
+
+        self.inner.pending_block_env_and_cfg()
+    }
+
+    async fn local_pending_state(&self) -> Result<Option<StateProviderBox>, Self::Error> {
+        let Some(pending_block) = self.flashblock_pending_block() else {
+            return self.inner.local_pending_state().await;
+        };
+
+        let parent_state = self
+            .provider()
+            .state_by_block_hash(pending_block.recovered_block.parent_hash)
+            .map_err(Self::Error::from_eth_err)?;
+
+        Ok(Some(flashblock_state_provider(pending_block, parent_state)))
     }
 
     /// Returns the locally built pending block
@@ -87,5 +127,58 @@ where
 
     fn pending_block_kind(&self) -> reth_rpc_eth_types::builder::config::PendingBlockKind {
         self.inner.pending_block_kind()
+    }
+}
+
+impl<N, Rpc> FlashblocksEthApi<N, Rpc>
+where
+    N: RpcNodeCore<Primitives = OpPrimitives>,
+    Rpc: RpcConvert + Clone,
+{
+    fn flashblock_pending_block(&self) -> Option<ExecutedBlock<OpPrimitives>> {
+        self.pending_block.as_ref()?.borrow().clone()
+    }
+}
+
+fn flashblock_state_provider(
+    pending_block: ExecutedBlock<OpPrimitives>,
+    parent_state: StateProviderBox,
+) -> StateProviderBox {
+    Box::new(BlockState::new(pending_block).state_provider(parent_state))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use alloy_primitives::Address;
+    use reth_provider::{StateProvider, noop::NoopProvider};
+    use revm::{database::BundleAccount, state::AccountInfo};
+
+    use super::*;
+
+    #[test]
+    fn flashblock_state_overlays_historical_state() {
+        let address = Address::random();
+        let mut pending_block = ExecutedBlock::<OpPrimitives>::default();
+        Arc::make_mut(&mut pending_block.execution_output)
+            .state
+            .state
+            .insert(
+                address,
+                BundleAccount {
+                    info: Some(AccountInfo {
+                        nonce: 7,
+                        ..Default::default()
+                    }),
+                    original_info: None,
+                    storage: Default::default(),
+                    status: Default::default(),
+                },
+            );
+
+        let state = flashblock_state_provider(pending_block, Box::new(NoopProvider::default()));
+
+        assert_eq!(state.account_nonce(&address).unwrap(), Some(7));
     }
 }

--- a/crates/rpc/src/eth/pending_block.rs
+++ b/crates/rpc/src/eth/pending_block.rs
@@ -68,12 +68,12 @@ where
             return self.inner.local_pending_state().await;
         };
 
-        let historical = self
+        let parent_state = self
             .provider()
-            .history_by_block_hash(pending_block.recovered_block.parent_hash)
+            .state_by_block_hash(pending_block.recovered_block.parent_hash)
             .map_err(Self::Error::from_eth_err)?;
 
-        Ok(Some(flashblock_state_provider(pending_block, historical)))
+        Ok(Some(flashblock_state_provider(pending_block, parent_state)))
     }
 
     /// Returns the locally built pending block
@@ -142,9 +142,9 @@ where
 
 fn flashblock_state_provider(
     pending_block: ExecutedBlock<OpPrimitives>,
-    historical: StateProviderBox,
+    parent_state: StateProviderBox,
 ) -> StateProviderBox {
-    Box::new(BlockState::new(pending_block).state_provider(historical))
+    Box::new(BlockState::new(pending_block).state_provider(parent_state))
 }
 
 #[cfg(test)]

--- a/crates/rpc/src/eth/pending_block.rs
+++ b/crates/rpc/src/eth/pending_block.rs
@@ -1,14 +1,21 @@
 //! Loads OP pending block for a RPC response.
 
 use alloy_eips::BlockNumberOrTag;
+use reth_chain_state::{BlockState, ExecutedBlock};
+use reth_errors::RethError;
+use reth_evm::ConfigureEvm;
 use reth_optimism_primitives::OpPrimitives;
 use reth_optimism_rpc::{OpEthApi, OpEthApiError};
-use reth_provider::{BlockReader, BlockReaderIdExt, ReceiptProvider};
+use reth_provider::{
+    BlockReader, BlockReaderIdExt, ReceiptProvider, StateProviderBox, StateProviderFactory,
+};
 use reth_rpc_eth_api::{
-    EthApiTypes, FromEvmError, RpcConvert, RpcNodeCore,
+    EthApiTypes, FromEthApiError, FromEvmError, RpcConvert, RpcNodeCore,
     helpers::{LoadPendingBlock, SpawnBlocking, pending_block::PendingEnvBuilder},
 };
-use reth_rpc_eth_types::{EthApiError, PendingBlock, block::BlockAndReceipts};
+use reth_rpc_eth_types::{
+    EthApiError, PendingBlock, PendingBlockEnv, PendingBlockEnvOrigin, block::BlockAndReceipts,
+};
 
 use crate::eth::FlashblocksEthApi;
 
@@ -34,6 +41,39 @@ where
     #[inline]
     fn pending_env_builder(&self) -> &dyn PendingEnvBuilder<Self::Evm> {
         self.inner.pending_env_builder()
+    }
+
+    fn pending_block_env_and_cfg(&self) -> Result<PendingBlockEnv<Self::Evm>, Self::Error> {
+        if let Some(pending_block) = self.flashblock_pending_block() {
+            let evm_env = self
+                .evm_config()
+                .evm_env(pending_block.recovered_block.header())
+                .map_err(RethError::other)
+                .map_err(Self::Error::from_eth_err)?;
+
+            return Ok(PendingBlockEnv::new(
+                evm_env,
+                PendingBlockEnvOrigin::ActualPending(
+                    pending_block.recovered_block,
+                    pending_block.execution_output.receipts.clone().into(),
+                ),
+            ));
+        }
+
+        self.inner.pending_block_env_and_cfg()
+    }
+
+    async fn local_pending_state(&self) -> Result<Option<StateProviderBox>, Self::Error> {
+        let Some(pending_block) = self.flashblock_pending_block() else {
+            return self.inner.local_pending_state().await;
+        };
+
+        let historical = self
+            .provider()
+            .history_by_block_hash(pending_block.recovered_block.parent_hash)
+            .map_err(Self::Error::from_eth_err)?;
+
+        Ok(Some(flashblock_state_provider(pending_block, historical)))
     }
 
     /// Returns the locally built pending block
@@ -87,5 +127,58 @@ where
 
     fn pending_block_kind(&self) -> reth_rpc_eth_types::builder::config::PendingBlockKind {
         self.inner.pending_block_kind()
+    }
+}
+
+impl<N, Rpc> FlashblocksEthApi<N, Rpc>
+where
+    N: RpcNodeCore<Primitives = OpPrimitives>,
+    Rpc: RpcConvert + Clone,
+{
+    fn flashblock_pending_block(&self) -> Option<ExecutedBlock<OpPrimitives>> {
+        self.pending_block.as_ref()?.borrow().clone()
+    }
+}
+
+fn flashblock_state_provider(
+    pending_block: ExecutedBlock<OpPrimitives>,
+    historical: StateProviderBox,
+) -> StateProviderBox {
+    Box::new(BlockState::new(pending_block).state_provider(historical))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use alloy_primitives::Address;
+    use reth_provider::{StateProvider, noop::NoopProvider};
+    use revm::{database::BundleAccount, state::AccountInfo};
+
+    use super::*;
+
+    #[test]
+    fn flashblock_state_overlays_historical_state() {
+        let address = Address::random();
+        let mut pending_block = ExecutedBlock::<OpPrimitives>::default();
+        Arc::make_mut(&mut pending_block.execution_output)
+            .state
+            .state
+            .insert(
+                address,
+                BundleAccount {
+                    info: Some(AccountInfo {
+                        nonce: 7,
+                        ..Default::default()
+                    }),
+                    original_info: None,
+                    storage: Default::default(),
+                    status: Default::default(),
+                },
+            );
+
+        let state = flashblock_state_provider(pending_block, Box::new(NoopProvider::default()));
+
+        assert_eq!(state.account_nonce(&address).unwrap(), Some(7));
     }
 }

--- a/e2e-tests/src/it/testsuite.rs
+++ b/e2e-tests/src/it/testsuite.rs
@@ -1525,18 +1525,25 @@ async fn test_event_stream_invariants() -> eyre::Result<()> {
 /// Eth JSON-RPC API at each block boundary.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_engine_driver_pending_block_queries() -> eyre::Result<()> {
-    use alloy_eips::BlockNumberOrTag;
+    use alloy_eips::{BlockId, BlockNumberOrTag};
     use reth_rpc_api::EthApiClient;
 
     reth_tracing::init_test_tracing();
 
     const NUM_BLOCKS: usize = 3;
     const BLOCK_INTERVAL: Duration = Duration::from_millis(2000);
+    const FORCED_TX_SIGNER: u32 = 19;
 
     tokio::time::sleep(Duration::from_millis(100)).await;
 
+    let mut forced_transactions = Vec::with_capacity(NUM_BLOCKS);
+    for nonce in 0..NUM_BLOCKS as u64 {
+        let (transaction, _) = create_test_transaction(FORCED_TX_SIGNER, nonce).await;
+        forced_transactions.push(transaction);
+    }
+
     // 2 nodes: builder + follower
-    let (_, nodes, _tasks, mut env, tx_spammer) = WorldChainTestBuilder::builder()
+    let (_, nodes, _tasks, mut env, _tx_spammer) = WorldChainTestBuilder::builder()
         .nodes(2)
         .flashblocks(true)
         .build()
@@ -1546,15 +1553,11 @@ async fn test_engine_driver_pending_block_queries() -> eyre::Result<()> {
     let builder_context = nodes[0].ext_context.clone().unwrap();
     let block_hash = nodes[0].node.block_hash(0);
     let chain_spec = nodes[0].node.inner.chain_spec().clone();
-    let rpc_url = nodes[0].node.rpc_url();
 
     // Initialize forkchoice on all nodes to genesis
     for node in &nodes {
         node.node.update_forkchoice(block_hash, block_hash).await?;
     }
-
-    // Spawn background transactions so blocks have content
-    tx_spammer.spawn(10, rpc_url);
 
     let builder_vk = builder_context
         .flashblocks_handle
@@ -1606,16 +1609,60 @@ async fn test_engine_driver_pending_block_queries() -> eyre::Result<()> {
         authorization_gen,
         attributes_gen: Box::new({
             let chain_spec = chain_spec.clone();
-            move |_block_number, timestamp| {
+            move |block_number, timestamp| {
                 let eip1559 = encode_eip1559_params(chain_spec.as_ref(), timestamp)?;
+                let forced_transaction = forced_transactions
+                    .get(block_number.saturating_sub(1) as usize)
+                    .cloned()
+                    .ok_or_else(|| eyre!("missing forced transaction for block {block_number}"))?;
                 Ok(build_payload_attributes(
                     timestamp,
                     eip1559,
-                    Some(vec![TX_SET_L1_BLOCK.clone()]),
+                    Some(vec![TX_SET_L1_BLOCK.clone(), forced_transaction]),
                 ))
             }
         }),
-        during_build: None,
+        during_build: Some(Box::new({
+            let builder_rpc = builder_rpc.clone();
+            move |block_num| {
+                let builder_rpc = builder_rpc.clone();
+                Box::pin(async move {
+                    let address = account(FORCED_TX_SIGNER);
+                    let pending_nonce: U256 = EthApiClient::<
+                        TransactionRequest,
+                        alloy_rpc_types::Transaction,
+                        alloy_rpc_types_eth::Block,
+                        alloy_consensus::Receipt,
+                        alloy_consensus::Header,
+                        reth_optimism_primitives::OpTransactionSigned,
+                    >::transaction_count(
+                        &builder_rpc, address, Some(BlockId::pending())
+                    )
+                    .await?;
+                    let latest_nonce: U256 = EthApiClient::<
+                        TransactionRequest,
+                        alloy_rpc_types::Transaction,
+                        alloy_rpc_types_eth::Block,
+                        alloy_consensus::Receipt,
+                        alloy_consensus::Header,
+                        reth_optimism_primitives::OpTransactionSigned,
+                    >::transaction_count(
+                        &builder_rpc,
+                        address,
+                        Some(BlockNumberOrTag::Latest.into()),
+                    )
+                    .await?;
+
+                    assert_eq!(
+                        pending_nonce,
+                        latest_nonce + U256::from(1),
+                        "block {block_num}: pending state must include the executed Flashblock transaction"
+                    );
+
+                    Ok(())
+                })
+            }
+        })),
         on_block: Some(Box::new({
             let builder_rpc = builder_rpc.clone();
             let latest_stream_fb = latest_stream_fb.clone();

--- a/e2e-tests/src/it/testsuite.rs
+++ b/e2e-tests/src/it/testsuite.rs
@@ -1528,18 +1528,25 @@ async fn test_event_stream_invariants() -> eyre::Result<()> {
 /// Eth JSON-RPC API at each block boundary.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_engine_driver_pending_block_queries() -> eyre::Result<()> {
-    use alloy_eips::BlockNumberOrTag;
+    use alloy_eips::{BlockId, BlockNumberOrTag};
     use reth_rpc_api::EthApiClient;
 
     reth_tracing::init_test_tracing();
 
     const NUM_BLOCKS: usize = 3;
     const BLOCK_INTERVAL: Duration = Duration::from_millis(2000);
+    const FORCED_TX_SIGNER: u32 = 19;
 
     tokio::time::sleep(Duration::from_millis(100)).await;
 
+    let mut forced_transactions = Vec::with_capacity(NUM_BLOCKS);
+    for nonce in 0..NUM_BLOCKS as u64 {
+        let (transaction, _) = create_test_transaction(FORCED_TX_SIGNER, nonce).await;
+        forced_transactions.push(transaction);
+    }
+
     // 2 nodes: builder + follower
-    let (_, nodes, _tasks, mut env, tx_spammer) = WorldChainTestBuilder::builder()
+    let (_, nodes, _tasks, mut env, _tx_spammer) = WorldChainTestBuilder::builder()
         .nodes(2)
         .flashblocks(true)
         .build()
@@ -1549,15 +1556,11 @@ async fn test_engine_driver_pending_block_queries() -> eyre::Result<()> {
     let builder_context = nodes[0].ext_context.clone().unwrap();
     let block_hash = nodes[0].node.block_hash(0);
     let chain_spec = nodes[0].node.inner.chain_spec().clone();
-    let rpc_url = nodes[0].node.rpc_url();
 
     // Initialize forkchoice on all nodes to genesis
     for node in &nodes {
         node.node.update_forkchoice(block_hash, block_hash).await?;
     }
-
-    // Spawn background transactions so blocks have content
-    tx_spammer.spawn(10, rpc_url);
 
     let builder_vk = builder_context
         .flashblocks_handle
@@ -1609,16 +1612,60 @@ async fn test_engine_driver_pending_block_queries() -> eyre::Result<()> {
         authorization_gen,
         attributes_gen: Box::new({
             let chain_spec = chain_spec.clone();
-            move |_block_number, timestamp| {
+            move |block_number, timestamp| {
                 let eip1559 = encode_eip1559_params(chain_spec.as_ref(), timestamp)?;
+                let forced_transaction = forced_transactions
+                    .get(block_number.saturating_sub(1) as usize)
+                    .cloned()
+                    .ok_or_else(|| eyre!("missing forced transaction for block {block_number}"))?;
                 Ok(build_payload_attributes(
                     timestamp,
                     eip1559,
-                    Some(vec![TX_SET_L1_BLOCK.clone()]),
+                    Some(vec![TX_SET_L1_BLOCK.clone(), forced_transaction]),
                 ))
             }
         }),
-        during_build: None,
+        during_build: Some(Box::new({
+            let builder_rpc = builder_rpc.clone();
+            move |block_num| {
+                let builder_rpc = builder_rpc.clone();
+                Box::pin(async move {
+                    let address = account(FORCED_TX_SIGNER);
+                    let pending_nonce: U256 = EthApiClient::<
+                        TransactionRequest,
+                        alloy_rpc_types::Transaction,
+                        alloy_rpc_types_eth::Block,
+                        alloy_consensus::Receipt,
+                        alloy_consensus::Header,
+                        reth_optimism_primitives::OpTransactionSigned,
+                    >::transaction_count(
+                        &builder_rpc, address, Some(BlockId::pending())
+                    )
+                    .await?;
+                    let latest_nonce: U256 = EthApiClient::<
+                        TransactionRequest,
+                        alloy_rpc_types::Transaction,
+                        alloy_rpc_types_eth::Block,
+                        alloy_consensus::Receipt,
+                        alloy_consensus::Header,
+                        reth_optimism_primitives::OpTransactionSigned,
+                    >::transaction_count(
+                        &builder_rpc,
+                        address,
+                        Some(BlockNumberOrTag::Latest.into()),
+                    )
+                    .await?;
+
+                    assert_eq!(
+                        pending_nonce,
+                        latest_nonce + U256::from(1),
+                        "block {block_num}: pending state must include the executed Flashblock transaction"
+                    );
+
+                    Ok(())
+                })
+            }
+        })),
         on_block: Some(Box::new({
             let builder_rpc = builder_rpc.clone();
             let latest_stream_fb = latest_stream_fb.clone();


### PR DESCRIPTION
## Summary

- derive the `pending` EVM environment from the latest executed Flashblock
- overlay the Flashblock execution output on its parent state for pending RPC reads and calls
- preserve the existing OP-Reth fallback when no executed Flashblock snapshot is available
- add unit coverage plus a deterministic two-node regression for state visible before canonicalization

## Why

World Chain already exposes the executed Flashblock through pending block queries, but standard state and execution RPCs can still resolve against canonical or pool-derived state. That can make `eth_getBalance`, `eth_getTransactionCount`, `eth_call`, `eth_estimateGas`, and `eth_simulateV1` disagree with the pending block clients can see.

Keeping the pending block, EVM environment, and state on the same executed snapshot is especially useful for automated wallets and AI agents operating at Flashblock cadence: they can simulate and decide against the state that has actually executed instead of waiting for full-block canonicalization.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p world-chain-rpc --all-targets`
- `cargo test -p world-chain-rpc --lib` (12 passed)

The end-to-end regression is included in `test_engine_driver_pending_block_queries`; the local full-harness invocation entered the repository's Docker-based SP1 aggregation-program build, so execution is left to CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `pending` resolves for state and execution RPCs (balances, nonces, calls, gas estimation), which is user-visible but scoped behind Flashblock snapshots with a safe fallback to existing OP-Reth behavior.
> 
> **Overview**
> **Pending RPC state and EVM env now follow the latest executed Flashblock** when `FlashblocksEthApi` has a snapshot in its pending block mutex, instead of only exposing that block via `local_pending_block` while other `pending` queries fell back to OP-Reth canonical/pool behavior.
> 
> When a Flashblock snapshot exists, `pending_block_env_and_cfg` builds the pending EVM environment from that block’s header and marks the origin as actual pending with its receipts; `local_pending_state` loads parent state by hash and wraps it with `BlockState` so account/storage reads reflect Flashblock execution. If no snapshot is present, both paths delegate to the inner `OpEthApi` unchanged.
> 
> Workspace adds **`reth-errors`** for error mapping in the new env path. A unit test checks the overlay nonce behavior; **`test_engine_driver_pending_block_queries`** is tightened with per-block forced txs and a `during_build` assertion that `eth_getTransactionCount` at `pending` is one ahead of `latest` while the Flashblock tx is executed but not yet canonical.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4743e709b8796418a5c60f93d632b30412632647. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->