### PR TITLE
fix: prevent blacklisting finalized proof games

### DIFF
--- a/pkg/contracts/src/proofs/WorldChainAnchorStateRegistry.sol
+++ b/pkg/contracts/src/proofs/WorldChainAnchorStateRegistry.sol
@@ -12,6 +12,7 @@ contract WorldChainAnchorStateRegistry {
     error FactoryNotInitialized();
     error RegistryPaused();
     error GameBlacklisted(address game);
+    error FinalizedGameCannotBeBlacklisted(address game);
     error InvalidGameFactory(address expectedFactory, address actualFactory);
     error InvalidGameRegistry(address expectedRegistry, address actualRegistry);
     error UnregisteredGame(address game);
@@ -63,6 +64,9 @@ contract WorldChainAnchorStateRegistry {
     }
 
     function setGameBlacklisted(address game, bool blacklisted) external onlyOwner {
+        // Descendant finality relies on finalized ancestor validity remaining immutable.
+        if (blacklisted && isGameFinalized(game)) revert FinalizedGameCannotBeBlacklisted(game);
+
         blacklistedGames[game] = blacklisted;
         emit GameBlacklistedSet(game, blacklisted);
     }

--- a/pkg/contracts/test/WorldChainProofSystem.t.sol
+++ b/pkg/contracts/test/WorldChainProofSystem.t.sol
@@ -653,7 +653,7 @@ contract WorldChainProofSystemTest is Test {
         assertEq(anchor.currentL2BlockNumber(), parallelChild.l2BlockNumber());
     }
 
-    function testAnchorDoesNotRecheckFinalizedSkippedAncestor() public {
+    function testFinalizedSkippedAncestorCannotBeBlacklisted() public {
         (WorldChainProofSystemGame first,) = _propose(10);
         (WorldChainProofSystemGame second,) = _proposeChild(first, keccak256("second-root"));
         (WorldChainProofSystemGame third,) = _proposeChild(second, keccak256("third-root"));
@@ -662,7 +662,14 @@ contract WorldChainProofSystemTest is Test {
         first.resolve();
         second.resolve();
         third.resolve();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                WorldChainAnchorStateRegistry.FinalizedGameCannotBeBlacklisted.selector, address(second)
+            )
+        );
         anchor.setGameBlacklisted(address(second), true);
+        assertFalse(anchor.blacklistedGames(address(second)));
 
         third.closeGame();
 


### PR DESCRIPTION
closes https://linear.app/worldcoin/issue/PROTO-4962/prevent-blacklisting-of-already-finalized-games

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Tightens owner-controlled emergency blacklist behavior on the anchor registry, which affects proof lineage and anchor advancement, but removes a retroactive invalidation path rather than expanding privileged control.
> 
> **Overview**
> **Owner blacklisting of proof games can no longer apply once a game has reached `FINALIZED`.** `setGameBlacklisted` now reverts with `FinalizedGameCannotBeBlacklisted` when `blacklisted == true` and `isGameFinalized(game)` is true, so finalized ancestors in a chain cannot be retroactively marked invalid.
> 
> The forge test is renamed and extended to expect that revert for a middle finalized game in a three-deep chain, assert the blacklist mapping is unchanged, and still allow a finalized descendant to close the anchor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b03ec433980e9676db7233b3d6be66ce19947e8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->