### PR TITLE
refactor: world chain proposer

### DIFF
--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -15,11 +15,12 @@ use world_chain_challenger::{ChallengeSubmission, ChallengerClient, ChallengerEr
 use world_chain_defender::{DefenderClient, DefenderError, DefenderSubmission};
 use world_chain_proof_worker::{ClaimedProofJobHandler, ProofJob};
 use world_chain_proofs::{
-    ConsensusError, ConsensusProvider, GameCreated, PROOF_SYSTEM_VERSION, ProofDomain, ProofLane,
-    RootCommitment, RootState, has_threshold,
+    ConsensusError, ConsensusProvider, GameCreated, InvalidationReason, PROOF_SYSTEM_VERSION,
+    ProofDomain, ProofLane, ResolutionStatus, RootCommitment, RootState, has_threshold,
 };
 use world_chain_proposer::{
-    ParentRef, Proposal, ProposalSubmission, ProposerClient, ProposerError,
+    CloseGameSubmission, ParentRef, Proposal, ProposalSubmission, ProposerClient, ProposerError,
+    ResolveSubmission,
 };
 use world_chain_prover_service::{
     GetNextProofRequest, GetNextProofResponse, GetProofSessionRequest, GetProofSessionResponse,
@@ -311,6 +312,47 @@ impl ProposerClient for FakeExecution {
             .games_by_key
             .get(&proposal_key)
             .copied())
+    }
+
+    async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError> {
+        let root_state = self.game_state(game);
+        Ok(ResolutionStatus {
+            resolvable: root_state == RootState::Finalized,
+            root_state,
+            invalidation_reason: InvalidationReason::None,
+        })
+    }
+
+    async fn resolve_game(&self, game: Address) -> Result<ResolveSubmission, ProposerError> {
+        if self.game_state(game) != RootState::Finalized {
+            return Err(ProposerError::Contract(format!(
+                "game {game} is not positively resolvable"
+            )));
+        }
+        Ok(ResolveSubmission {
+            tx_hash: B256::with_last_byte(game.as_slice()[19]),
+        })
+    }
+
+    async fn close_game(&self, game: Address) -> Result<CloseGameSubmission, ProposerError> {
+        let mut state = self.state.lock().expect("fake execution mutex poisoned");
+        let record = state
+            .games_by_address
+            .get(&game)
+            .ok_or_else(|| ProposerError::Contract(format!("unknown game {game}")))?;
+        if record.state != STATE_FINALIZED {
+            return Err(ProposerError::Contract(format!(
+                "game {game} is not finalized"
+            )));
+        }
+        let l2_block_number = record.event.l2_block_number;
+        state.anchor = ParentRef {
+            address: game,
+            l2_block_number,
+        };
+        Ok(CloseGameSubmission {
+            tx_hash: B256::with_last_byte(game.as_slice()[19]),
+        })
     }
 
     async fn submit_proposal(

--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -315,20 +315,42 @@ impl ProposerClient for FakeExecution {
     }
 
     async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError> {
-        let root_state = self.game_state(game);
+        let state = self.state.lock().expect("fake execution mutex poisoned");
+        let record = state
+            .games_by_address
+            .get(&game)
+            .ok_or_else(|| ProposerError::Contract(format!("unknown game {game}")))?;
+
+        if record.state == STATE_CHALLENGED && has_threshold(record.proof_bitmap) {
+            return Ok(ResolutionStatus {
+                resolvable: true,
+                root_state: RootState::Finalized,
+                invalidation_reason: InvalidationReason::None,
+            });
+        }
+
+        let root_state = RootState::try_from(record.state)
+            .map_err(|error| ProposerError::Contract(error.to_string()))?;
         Ok(ResolutionStatus {
-            resolvable: root_state == RootState::Finalized,
+            resolvable: false,
             root_state,
             invalidation_reason: InvalidationReason::None,
         })
     }
 
     async fn resolve_game(&self, game: Address) -> Result<ResolveSubmission, ProposerError> {
-        if self.game_state(game) != RootState::Finalized {
+        let mut state = self.state.lock().expect("fake execution mutex poisoned");
+        let record = state
+            .games_by_address
+            .get_mut(&game)
+            .ok_or_else(|| ProposerError::Contract(format!("unknown game {game}")))?;
+        if record.state != STATE_CHALLENGED || !has_threshold(record.proof_bitmap) {
             return Err(ProposerError::Contract(format!(
                 "game {game} is not positively resolvable"
             )));
         }
+        record.state = STATE_FINALIZED;
+
         Ok(ResolveSubmission {
             tx_hash: B256::with_last_byte(game.as_slice()[19]),
         })
@@ -518,9 +540,6 @@ impl DefenderClient for FakeExecution {
         if record.proof_bitmap & mask == 0 {
             record.proof_bitmap |= mask;
             record.submitted_lanes.push(lane);
-            if has_threshold(record.proof_bitmap) {
-                record.state = STATE_FINALIZED;
-            }
         }
 
         Ok(DefenderSubmission {

--- a/proofs/integration-tests/tests/orchestration.rs
+++ b/proofs/integration-tests/tests/orchestration.rs
@@ -154,12 +154,12 @@ async fn invalid_root_is_challenged_by_real_challenger() {
 
     let proposer =
         WorldChainProposer::new(proposer_config(), chain.clone(), bad_proposer_consensus);
-    let canonical_line = proposer
+    let canonical_scan = proposer
         .anchor_and_canonical_line()
         .await
         .expect("canonical line reconstructed");
     proposer
-        .propose(&canonical_line)
+        .propose(&canonical_scan)
         .await
         .expect("bad proposal posted");
     let game = chain.latest_game().expect("game created").game;
@@ -182,12 +182,12 @@ async fn valid_challenged_root_is_defended_through_workers() {
     let consensus = FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
 
     let proposer = WorldChainProposer::new(proposer_config(), chain.clone(), consensus.clone());
-    let canonical_line = proposer
+    let canonical_scan = proposer
         .anchor_and_canonical_line()
         .await
         .expect("canonical line reconstructed");
     proposer
-        .propose(&canonical_line)
+        .propose(&canonical_scan)
         .await
         .expect("proposal posted");
     let game = chain.latest_game().expect("game created").game;
@@ -224,12 +224,12 @@ async fn valid_challenged_root_survives_transient_proof_failure() {
     let consensus = FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
 
     let proposer = WorldChainProposer::new(proposer_config(), chain.clone(), consensus.clone());
-    let canonical_line = proposer
+    let canonical_scan = proposer
         .anchor_and_canonical_line()
         .await
         .expect("canonical line reconstructed");
     proposer
-        .propose(&canonical_line)
+        .propose(&canonical_scan)
         .await
         .expect("proposal posted");
     let game = chain.latest_game().expect("game created").game;
@@ -276,12 +276,12 @@ async fn defender_ignores_challenged_invalid_root() {
 
     let proposer =
         WorldChainProposer::new(proposer_config(), chain.clone(), bad_proposer_consensus);
-    let canonical_line = proposer
+    let canonical_scan = proposer
         .anchor_and_canonical_line()
         .await
         .expect("canonical line reconstructed");
     proposer
-        .propose(&canonical_line)
+        .propose(&canonical_scan)
         .await
         .expect("bad proposal posted");
     let game = chain.latest_game().expect("game created").game;

--- a/proofs/integration-tests/tests/orchestration.rs
+++ b/proofs/integration-tests/tests/orchestration.rs
@@ -1,20 +1,20 @@
 use std::time::Duration;
 
-use alloy_primitives::{B256, U256};
+use alloy_primitives::{B256, Bytes, U256};
 use testcontainers::{ContainerAsync, runners::AsyncRunner};
 use testcontainers_modules::postgres;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use world_chain_challenger::{ChallengerConfig, WorldChainChallenger};
-use world_chain_defender::{DefenderConfig, WorldChainDefender};
+use world_chain_defender::{DefenderClient, DefenderConfig, WorldChainDefender};
 use world_chain_proof_integration_tests::{
     BLOCK_INTERVAL, FakeConsensus, FakeExecution, FakeProofBackend, SharedProverService,
 };
 use world_chain_proof_worker::{
     ProofWorker, ProofWorkerConfig, RetryConfig, WorkerHeartbeatConfig,
 };
-use world_chain_proofs::{ProofLane, RootState};
-use world_chain_proposer::{ProposerConfig, WorldChainProposer};
+use world_chain_proofs::{ProofLane, RootState, has_threshold};
+use world_chain_proposer::{ProposerClient, ProposerConfig, WorldChainProposer};
 use world_chain_prover_service::{ProofBackend, ProverServiceConfig};
 
 fn proposer_config() -> ProposerConfig {
@@ -45,6 +45,75 @@ fn assert_defense_lanes(lanes: Vec<ProofLane>) {
     assert_eq!(lanes.len(), 2);
     assert!(lanes.contains(&ProofLane::ValidityProof));
     assert!(lanes.contains(&ProofLane::TeeAttestation));
+}
+
+async fn settle_with_proposer(proposer: &WorldChainProposer<FakeExecution, FakeConsensus>) {
+    let canonical_scan = proposer
+        .anchor_and_canonical_line()
+        .await
+        .expect("canonical line reconstructed");
+    let finalized_games = proposer
+        .resolve_games(canonical_scan.canonical_line())
+        .await
+        .expect("canonical games resolved");
+    proposer
+        .advance_anchor(finalized_games)
+        .await
+        .expect("anchor advanced");
+}
+
+#[tokio::test]
+async fn fake_resolution_matches_contract_transition_semantics() {
+    let chain = FakeExecution::new();
+    let canonical_root = B256::repeat_byte(0x20);
+    let consensus = FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
+    let proposer = WorldChainProposer::new(proposer_config(), chain.clone(), consensus);
+
+    let canonical_scan = proposer
+        .anchor_and_canonical_line()
+        .await
+        .expect("canonical line reconstructed");
+    proposer
+        .propose(&canonical_scan)
+        .await
+        .expect("proposal posted");
+    let game = chain.latest_game().expect("game created").game;
+    chain.challenge_game(game);
+
+    chain
+        .submit_proof(
+            game,
+            ProofLane::ValidityProof as u8,
+            Bytes::from_static(&[1]),
+        )
+        .await
+        .expect("validity proof submitted");
+    chain
+        .submit_proof(
+            game,
+            ProofLane::TeeAttestation as u8,
+            Bytes::from_static(&[1]),
+        )
+        .await
+        .expect("TEE proof submitted");
+
+    let ready = chain
+        .resolution_status(game)
+        .await
+        .expect("resolution status available");
+    assert!(ready.resolvable);
+    assert_eq!(ready.root_state, RootState::Finalized);
+    assert_eq!(chain.game_state(game), RootState::Challenged);
+
+    settle_with_proposer(&proposer).await;
+
+    let finalized = chain
+        .resolution_status(game)
+        .await
+        .expect("resolution status available");
+    assert!(!finalized.resolvable);
+    assert_eq!(finalized.root_state, RootState::Finalized);
+    assert!(chain.resolve_game(game).await.is_err());
 }
 
 struct ProofStack {
@@ -205,14 +274,18 @@ async fn valid_challenged_root_is_defended_through_workers() {
 
     for _ in 0..200 {
         defender.scan_once().await.expect("defender scan succeeds");
-        if chain.game_state(game) == RootState::Finalized {
+        if has_threshold(chain.proof_bitmap(game)) {
             break;
         }
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
 
-    assert_eq!(chain.game_state(game), RootState::Finalized);
+    assert_eq!(chain.game_state(game), RootState::Challenged);
     assert_defense_lanes(chain.submitted_lanes(game));
+
+    settle_with_proposer(&proposer).await;
+
+    assert_eq!(chain.game_state(game), RootState::Finalized);
 
     stop_proof_stack(stack).await;
 }
@@ -252,14 +325,18 @@ async fn valid_challenged_root_survives_transient_proof_failure() {
 
     for _ in 0..200 {
         defender.scan_once().await.expect("defender scan succeeds");
-        if chain.game_state(game) == RootState::Finalized {
+        if has_threshold(chain.proof_bitmap(game)) {
             break;
         }
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
 
-    assert_eq!(chain.game_state(game), RootState::Finalized);
+    assert_eq!(chain.game_state(game), RootState::Challenged);
     assert_defense_lanes(chain.submitted_lanes(game));
+
+    settle_with_proposer(&proposer).await;
+
+    assert_eq!(chain.game_state(game), RootState::Finalized);
 
     stop_proof_stack(stack).await;
 }

--- a/proofs/integration-tests/tests/orchestration.rs
+++ b/proofs/integration-tests/tests/orchestration.rs
@@ -154,7 +154,14 @@ async fn invalid_root_is_challenged_by_real_challenger() {
 
     let proposer =
         WorldChainProposer::new(proposer_config(), chain.clone(), bad_proposer_consensus);
-    proposer.propose_once().await.expect("bad proposal posted");
+    let canonical_line = proposer
+        .anchor_and_canonical_line()
+        .await
+        .expect("canonical line reconstructed");
+    proposer
+        .propose(&canonical_line)
+        .await
+        .expect("bad proposal posted");
     let game = chain.latest_game().expect("game created").game;
 
     let mut challenger =
@@ -175,7 +182,14 @@ async fn valid_challenged_root_is_defended_through_workers() {
     let consensus = FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
 
     let proposer = WorldChainProposer::new(proposer_config(), chain.clone(), consensus.clone());
-    proposer.propose_once().await.expect("proposal posted");
+    let canonical_line = proposer
+        .anchor_and_canonical_line()
+        .await
+        .expect("canonical line reconstructed");
+    proposer
+        .propose(&canonical_line)
+        .await
+        .expect("proposal posted");
     let game = chain.latest_game().expect("game created").game;
     chain.challenge_game(game);
 
@@ -210,7 +224,14 @@ async fn valid_challenged_root_survives_transient_proof_failure() {
     let consensus = FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
 
     let proposer = WorldChainProposer::new(proposer_config(), chain.clone(), consensus.clone());
-    proposer.propose_once().await.expect("proposal posted");
+    let canonical_line = proposer
+        .anchor_and_canonical_line()
+        .await
+        .expect("canonical line reconstructed");
+    proposer
+        .propose(&canonical_line)
+        .await
+        .expect("proposal posted");
     let game = chain.latest_game().expect("game created").game;
     chain.challenge_game(game);
 
@@ -255,7 +276,14 @@ async fn defender_ignores_challenged_invalid_root() {
 
     let proposer =
         WorldChainProposer::new(proposer_config(), chain.clone(), bad_proposer_consensus);
-    proposer.propose_once().await.expect("bad proposal posted");
+    let canonical_line = proposer
+        .anchor_and_canonical_line()
+        .await
+        .expect("canonical line reconstructed");
+    proposer
+        .propose(&canonical_line)
+        .await
+        .expect("bad proposal posted");
     let game = chain.latest_game().expect("game created").game;
     chain.challenge_game(game);
 

--- a/proofs/primitives/src/bindings.rs
+++ b/proofs/primitives/src/bindings.rs
@@ -15,8 +15,18 @@ sol! {
             uint256 l1OriginNumber
         );
 
+        function domain()
+            external
+            view
+            returns (
+                uint256 chainId,
+                uint256 proofSystemVersion,
+                bytes32 rollupConfigHash,
+                uint256 blockInterval
+            );
         function domainHash() external view returns (bytes32);
         function games(bytes32 proposalKey) external view returns (address);
+        function isFactoryGame(address game) external view returns (bool);
         function propose(
             address parentRef,
             bytes32 rootClaim,
@@ -39,25 +49,46 @@ sol! {
     #[sol(rpc)]
     interface IWorldChainProofSystemGame {
         function rootId() external view returns (bytes32);
+        function factory() external view returns (address);
+        function anchorStateRegistry() external view returns (address);
+        function domainHash() external view returns (bytes32);
+        function attempt() external view returns (uint256);
         function parentRef() external view returns (address);
+        function startingRootClaim() external view returns (bytes32);
+        function startingL2BlockNumber() external view returns (uint256);
         function rootClaim() external view returns (bytes32);
         function l2BlockNumber() external view returns (uint256);
+        function l1OriginHash() external view returns (bytes32);
+        function l1OriginNumber() external view returns (uint256);
         function challengeDeadline() external view returns (uint64);
+        function proofDeadline() external view returns (uint64);
+        function finalizedAt() external view returns (uint64);
         function state() external view returns (uint8);
+        function invalidationReason() external view returns (uint8);
         function proofBitmap() external view returns (uint8);
         function proofCount() external view returns (uint8);
+        function resolutionStatus()
+            external
+            view
+            returns (bool resolvable, uint8 outcome, uint8 reason);
+        function resolve() external returns (uint8 outcome, uint8 reason);
+        function closeGame() external;
+        function claimable(address recipient) external view returns (uint256);
+        function withdraw(address payable recipient) external;
         function challenge() external payable;
         function submitProofLane(uint8 laneId, bytes calldata proof) external;
-        function finalize() external;
-        function invalidate() external;
     }
 
     #[sol(rpc)]
     interface IWorldChainAnchorStateRegistry {
-        function currentRootId() external view returns (bytes32);
+        function setAnchorState(address game) external;
+        function isGameFinalized(address game) external view returns (bool);
+        function isGameClaimValid(address game) external view returns (bool);
+        function proofSystemFactory() external view returns (address);
+        function paused() external view returns (bool);
         function currentRootClaim() external view returns (bytes32);
         function currentL2BlockNumber() external view returns (uint256);
         function anchorGame() external view returns (address);
-        function setAnchorState(address game) external;
+        function blacklistedGames(address game) external view returns (bool);
     }
 }

--- a/proofs/primitives/src/lib.rs
+++ b/proofs/primitives/src/lib.rs
@@ -16,5 +16,5 @@ pub use consensus_provider::{ConsensusError, ConsensusProvider, OptimismConsensu
 pub use types::{
     GameCreated, InvalidationReason, InvalidationReasonError, PROOF_LANE_COUNT,
     PROOF_SYSTEM_VERSION, PROOF_THRESHOLD, ProofDomain, ProofLane, ProposalCommitment,
-    ResolutionStatus, RootCommitment, RootState, RootStateError, has_threshold, proof_count, w,
+    ResolutionStatus, RootCommitment, RootState, RootStateError, has_threshold, proof_count,
 };

--- a/proofs/primitives/src/lib.rs
+++ b/proofs/primitives/src/lib.rs
@@ -14,6 +14,7 @@ pub use bindings::{
 };
 pub use consensus_provider::{ConsensusError, ConsensusProvider, OptimismConsensusClient};
 pub use types::{
-    GameCreated, PROOF_LANE_COUNT, PROOF_SYSTEM_VERSION, PROOF_THRESHOLD, ProofDomain, ProofLane,
-    ProposalCommitment, RootCommitment, RootState, RootStateError, has_threshold, proof_count,
+    GameCreated, InvalidationReason, InvalidationReasonError, PROOF_LANE_COUNT,
+    PROOF_SYSTEM_VERSION, PROOF_THRESHOLD, ProofDomain, ProofLane, ProposalCommitment,
+    ResolutionStatus, RootCommitment, RootState, RootStateError, has_threshold, proof_count, w,
 };

--- a/proofs/primitives/src/types.rs
+++ b/proofs/primitives/src/types.rs
@@ -185,6 +185,50 @@ pub const fn has_threshold(bitmap: u8) -> bool {
     proof_count(bitmap) >= PROOF_THRESHOLD
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum InvalidationReason {
+    None,
+    ProofTimeout,
+    InvalidParent,
+    Blacklisted,
+}
+
+#[derive(Debug, Error)]
+pub enum InvalidationReasonError {
+    #[error("Invalid invalidation reason: {0}")]
+    InvalidReason(u8),
+}
+
+impl TryFrom<u8> for InvalidationReason {
+    type Error = InvalidationReasonError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(InvalidationReason::None),
+            1 => Ok(InvalidationReason::ProofTimeout),
+            2 => Ok(InvalidationReason::InvalidParent),
+            3 => Ok(InvalidationReason::Blacklisted),
+            _ => Err(InvalidationReasonError::InvalidReason(value)),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ResolutionStatus {
+    pub resolvable: bool,
+    pub root_state: RootState,
+    pub invalidation_reason: InvalidationReason,
+}
+
+impl ResolutionStatus {
+    /// Returns true whether this resolution status is positive resolvable:
+    /// - `resolvable` is true AND
+    /// - the expected root state outcome is `Finalized`.
+    pub fn positive_resolvable(&self) -> bool {
+        self.resolvable && self.root_state == RootState::Finalized
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/proofs/proposer/src/alloy.rs
+++ b/proofs/proposer/src/alloy.rs
@@ -3,10 +3,13 @@ use alloy_provider::Provider;
 use async_trait::async_trait;
 use world_chain_proofs::{
     IWorldChainAnchorStateRegistry, IWorldChainProofSystemFactory, IWorldChainProofSystemGame,
-    ProposalCommitment,
+    ProposalCommitment, ResolutionStatus,
 };
 
-use crate::{ParentRef, Proposal, ProposalSubmission, ProposerClient, ProposerError};
+use crate::{
+    ParentRef, Proposal, ProposalSubmission, ProposerClient, ProposerError,
+    types::{CloseGameSubmission, ResolveSubmission},
+};
 
 /// Alloy-backed implementation of [`ProofSystemClient`].
 #[derive(Debug, Clone)]
@@ -88,6 +91,79 @@ where
             .map_err(|error| ProposerError::Contract(error.to_string()))?;
 
         Ok((game != Address::ZERO).then_some(game))
+    }
+
+    async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError> {
+        let game = IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance::new(
+            game,
+            self.provider.clone(),
+        );
+        let resolution_status_result = game
+            .resolutionStatus()
+            .call()
+            .await
+            .map_err(|err| ProposerError::Contract(err.to_string()))?;
+        let resolvable = resolution_status_result.resolvable;
+        let root_state = resolution_status_result
+            .outcome
+            .try_into()
+            .map_err(|err| ProposerError::Contract(err.to_string()))?;
+        let invalidation_reason = resolution_status_result
+            .reason
+            .try_into()
+            .map_err(|err| ProposerError::Contract(err.to_string()))?;
+        let resolution_status = ResolutionStatus {
+            resolvable,
+            root_state,
+            invalidation_reason,
+        };
+        Ok(resolution_status)
+    }
+
+    async fn resolve_game(&self, game: Address) -> Result<ResolveSubmission, ProposerError> {
+        let game = IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance::new(
+            game,
+            self.provider.clone(),
+        );
+        let pending = game
+            .resolve()
+            .send()
+            .await
+            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+
+        let tx_hash = *pending.tx_hash();
+        let receipt = pending
+            .get_receipt()
+            .await
+            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+        if !receipt.status() {
+            return Err(ProposerError::Revert(tx_hash));
+        }
+
+        Ok(ResolveSubmission { tx_hash })
+    }
+
+    async fn close_game(&self, game: Address) -> Result<CloseGameSubmission, ProposerError> {
+        let game = IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance::new(
+            game,
+            self.provider.clone(),
+        );
+        let pending = game
+            .closeGame()
+            .send()
+            .await
+            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+
+        let tx_hash = *pending.tx_hash();
+        let receipt = pending
+            .get_receipt()
+            .await
+            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+        if !receipt.status() {
+            return Err(ProposerError::Revert(tx_hash));
+        }
+
+        Ok(CloseGameSubmission { tx_hash })
     }
 
     async fn submit_proposal(

--- a/proofs/proposer/src/alloy.rs
+++ b/proofs/proposer/src/alloy.rs
@@ -3,7 +3,7 @@ use alloy_provider::Provider;
 use async_trait::async_trait;
 use world_chain_proofs::{
     IWorldChainAnchorStateRegistry, IWorldChainProofSystemFactory, IWorldChainProofSystemGame,
-    ProposalCommitment, ResolutionStatus,
+    InvalidationReasonError, ProposalCommitment, ResolutionStatus, RootStateError,
 };
 
 use crate::{
@@ -107,11 +107,11 @@ where
         let root_state = resolution_status_result
             .outcome
             .try_into()
-            .map_err(|err| ProposerError::Contract(err.to_string()))?;
+            .map_err(|err: RootStateError| ProposerError::Contract(err.to_string()))?;
         let invalidation_reason = resolution_status_result
             .reason
             .try_into()
-            .map_err(|err| ProposerError::Contract(err.to_string()))?;
+            .map_err(|err: InvalidationReasonError| ProposerError::Contract(err.to_string()))?;
         let resolution_status = ResolutionStatus {
             resolvable,
             root_state,

--- a/proofs/proposer/src/error.rs
+++ b/proofs/proposer/src/error.rs
@@ -23,14 +23,4 @@ pub enum ProposerError {
     OutputRoot(#[from] ConsensusError),
     #[error("The proposal transaction didn't execute succesfully: {0}")]
     Revert(TxHash),
-    /// The next proposal target is ahead of the op-node L2 finalized block.
-    #[error(
-        "next proposal target {target_block} is ahead of the finalized block {finalized_block}"
-    )]
-    ProposalNotReady {
-        /// L2 block number the proposer wants to propose next.
-        target_block: u64,
-        /// Current L2 head reported by the op-node.
-        finalized_block: u64,
-    },
 }

--- a/proofs/proposer/src/lib.rs
+++ b/proofs/proposer/src/lib.rs
@@ -16,7 +16,10 @@ pub use config::ProposerConfig;
 pub use error::ProposerError;
 pub use proposer::WorldChainProposer;
 pub use traits::ProposerClient;
-pub use types::{ParentRef, Proposal, ProposalSubmission};
+pub use types::{
+    CanonicalLine, CloseGameSubmission, ParentRef, Proposal, ProposalSubmission, ResolveSubmission,
+    ResolvedGames,
+};
 
 #[cfg(test)]
 mod tests;

--- a/proofs/proposer/src/lib.rs
+++ b/proofs/proposer/src/lib.rs
@@ -17,8 +17,8 @@ pub use error::ProposerError;
 pub use proposer::WorldChainProposer;
 pub use traits::ProposerClient;
 pub use types::{
-    CanonicalLine, CloseGameSubmission, ParentRef, Proposal, ProposalSubmission, ResolveSubmission,
-    ResolvedGames,
+    CanonicalLine, CloseGameSubmission, FinalizedGames, ParentRef, Proposal, ProposalSubmission,
+    ResolveSubmission,
 };
 
 #[cfg(test)]

--- a/proofs/proposer/src/lib.rs
+++ b/proofs/proposer/src/lib.rs
@@ -17,8 +17,8 @@ pub use error::ProposerError;
 pub use proposer::WorldChainProposer;
 pub use traits::ProposerClient;
 pub use types::{
-    CanonicalLine, CloseGameSubmission, FinalizedGames, ParentRef, Proposal, ProposalSubmission,
-    ResolveSubmission,
+    CanonicalLine, CanonicalScan, CloseGameSubmission, FinalizedGames, NextProposalAction,
+    ParentRef, Proposal, ProposalSubmission, ResolveSubmission,
 };
 
 #[cfg(test)]

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -1,9 +1,9 @@
 use alloy_primitives::B256;
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 use world_chain_proofs::ConsensusProvider;
 
 use crate::{
-    ParentRef, Proposal, ProposalSubmission, ProposerClient, ProposerConfig, ProposerError,
+    ParentRef, Proposal, ProposerClient, ProposerConfig, ProposerError,
     types::{CanonicalLine, ResolvedGames},
 };
 

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -1,10 +1,10 @@
 use alloy_primitives::B256;
 use tracing::{info, warn};
-use world_chain_proofs::ConsensusProvider;
+use world_chain_proofs::{ConsensusProvider, RootState};
 
 use crate::{
     ParentRef, Proposal, ProposerClient, ProposerConfig, ProposerError,
-    types::{CanonicalLine, ResolvedGames},
+    types::{CanonicalLine, FinalizedGames},
 };
 
 /// World Chain Proposer.
@@ -103,8 +103,8 @@ where
     pub async fn resolve_games(
         &self,
         canonical_line: &CanonicalLine,
-    ) -> Result<ResolvedGames, ProposerError> {
-        let mut resolved_games = ResolvedGames::default();
+    ) -> Result<FinalizedGames, ProposerError> {
+        let mut finalized_games = FinalizedGames::default();
         for game in canonical_line.games() {
             let resolution_status = self
                 .execution_provider
@@ -119,25 +119,30 @@ where
                     tx_hash = ?resolve_submission.tx_hash,
                     "resolved World Chain proof-system game"
                 );
-                // add resolved game to the result list
-                resolved_games.push(*game);
+                finalized_games.push(*game);
+            } else if resolution_status.root_state == RootState::Finalized {
+                // the game was finalized in an earlier iteration or by another keeper
+                finalized_games.push(*game);
             }
         }
-        Ok(resolved_games)
+        Ok(finalized_games)
     }
 
-    pub async fn advance_anchor(&self, resolved_games: ResolvedGames) -> Result<(), ProposerError> {
+    pub async fn advance_anchor(
+        &self,
+        finalized_games: FinalizedGames,
+    ) -> Result<(), ProposerError> {
         // games are ordered by l2 block number, therefore taking the last one
         // means taking the one with the highest l2 block number
-        let maybe_highest_resolved_game = resolved_games.last();
-        if let Some(highest_resolved_game) = maybe_highest_resolved_game {
+        let maybe_highest_finalized_game = finalized_games.last();
+        if let Some(highest_finalized_game) = maybe_highest_finalized_game {
             let close_game_submission = self
                 .execution_provider
-                .close_game(highest_resolved_game.address)
+                .close_game(highest_finalized_game.address)
                 .await?;
             info!(
-                game_address = %highest_resolved_game.address,
-                l2_block_number = highest_resolved_game.l2_block_number,
+                game_address = %highest_finalized_game.address,
+                l2_block_number = highest_finalized_game.l2_block_number,
                 tx_hash = ?close_game_submission.tx_hash,
                 "closed World Chain proof-system game"
             );
@@ -214,9 +219,9 @@ where
                 // 1. refresh the anchor and canonical line
                 let canonical_line = self.anchor_and_canonical_line().await?;
                 // 2. resolve positive-ready games parent-first
-                let resolved_games = self.resolve_games(&canonical_line).await?;
+                let finalized_games = self.resolve_games(&canonical_line).await?;
                 // 3. advance the anchor to the highest finalized canonical game
-                self.advance_anchor(resolved_games).await?;
+                self.advance_anchor(finalized_games).await?;
                 // 4. attempt a new canonical proposal or retry
                 self.propose(&canonical_line).await?;
                 // 5. withdraw known proposer credits

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -107,7 +107,7 @@ where
 
     pub async fn resolve_games(
         &self,
-        canonical_line: CanonicalLine,
+        canonical_line: &CanonicalLine,
     ) -> Result<ResolvedGames, ProposerError> {
         let mut resolved_games = ResolvedGames::default();
         for game in canonical_line {
@@ -150,7 +150,7 @@ where
         Ok(())
     }
 
-    pub async fn propose(&self, canonical_line: CanonicalLine) -> Result<(), ProposerError> {
+    pub async fn propose(&self, canonical_line: &CanonicalLine) -> Result<(), ProposerError> {
         let maybe_last_canonical_game = canonical_line.last();
         if let Some(last_canonical_game) = maybe_last_canonical_game {
             let mut cursor = last_canonical_game;
@@ -221,16 +221,24 @@ where
         let mut interval = tokio::time::interval(self.config.poll_interval);
         loop {
             interval.tick().await;
-            // 1. refresh the anchor and canonical line
-            let canonical_line = self.anchor_and_canonical_line().await?;
-            // 2. resolve positive-ready games parent-first
-            let resolved_games = self.resolve_games(canonical_line).await?;
-            // 3. advance the anchor to the highest finalized canonical game
-            self.advance_anchor(resolved_games).await?;
-            // 4. attempt a new canonical proposal or retry
-            let new_proposal = self.propose(canonical_line).await?;
-            // 5. withdraw known proposer credits
-            // TODO: add withdraw credits logic
+            let iteration: Result<(), ProposerError> = async {
+                // 1. refresh the anchor and canonical line
+                let canonical_line = self.anchor_and_canonical_line().await?;
+                // 2. resolve positive-ready games parent-first
+                let resolved_games = self.resolve_games(&canonical_line).await?;
+                // 3. advance the anchor to the highest finalized canonical game
+                self.advance_anchor(resolved_games).await?;
+                // 4. attempt a new canonical proposal or retry
+                self.propose(&canonical_line).await?;
+                // 5. withdraw known proposer credits
+                // TODO: add withdraw credits logic
+                Ok(())
+            }
+            .await;
+
+            if let Err(error) = iteration {
+                warn!(%error, "proposer iteration failed; retrying on next tick");
+            }
         }
     }
 }

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -1,10 +1,10 @@
 use alloy_primitives::B256;
 use tracing::{info, warn};
-use world_chain_proofs::{ConsensusProvider, RootState};
+use world_chain_proofs::{ConsensusProvider, InvalidationReason, RootState};
 
 use crate::{
     ParentRef, Proposal, ProposerClient, ProposerConfig, ProposerError,
-    types::{CanonicalLine, FinalizedGames},
+    types::{CanonicalLine, CanonicalScan, FinalizedGames, NextProposalAction},
 };
 
 /// World Chain Proposer.
@@ -37,13 +37,11 @@ where
     E: ProposerClient,
     C: ConsensusProvider,
 {
-    /// Fetch the anchor game and reconconstruct the canonical line of games that is built on
-    /// top of the current anchor (if any) until the last created canonical game.
-    ///
+    /// Fetches the anchor, reconstructs its canonical descendants, and determines the next action.
     ///
     /// A game is considered canonical if it's built on top of a valid game and its root_claim
     /// is correct - i.e. it matches the one computed by the proposer itself.
-    pub async fn anchor_and_canonical_line(&self) -> Result<CanonicalLine, ProposerError> {
+    pub async fn anchor_and_canonical_line(&self) -> Result<CanonicalScan, ProposerError> {
         self.config.validate()?;
 
         let anchor_parent = self.execution_provider.anchor_parent().await?;
@@ -64,7 +62,13 @@ where
             let latest_finalized_l2_block =
                 self.consensus_provider.latest_l2_finalized_block().await?;
             if next_l2_block_number > latest_finalized_l2_block {
-                break;
+                return Ok(CanonicalScan::new(
+                    canonical_line,
+                    NextProposalAction::CaughtUp {
+                        target_block: next_l2_block_number,
+                        finalized_block: latest_finalized_l2_block,
+                    },
+                ));
             }
 
             let root_claim = self
@@ -87,6 +91,32 @@ where
                 .game_for_proposal_key(proposal.proposal_key)
                 .await?
             {
+                let resolution_status = self
+                    .execution_provider
+                    .resolution_status(next_game_addr)
+                    .await?;
+                if resolution_status.root_state == RootState::Invalidated {
+                    let next_action = if resolution_status.resolvable {
+                        NextProposalAction::AwaitNegativeResolution {
+                            game: next_game_addr,
+                            reason: resolution_status.invalidation_reason,
+                        }
+                    } else if resolution_status.invalidation_reason
+                        == InvalidationReason::ProofTimeout
+                    {
+                        NextProposalAction::RetryTimedOut {
+                            proposal,
+                            invalidated_game: next_game_addr,
+                        }
+                    } else {
+                        NextProposalAction::BlockedByInvalidation {
+                            game: next_game_addr,
+                            reason: resolution_status.invalidation_reason,
+                        }
+                    };
+                    return Ok(CanonicalScan::new(canonical_line, next_action));
+                }
+
                 let next_game = ParentRef {
                     address: next_game_addr,
                     l2_block_number: next_l2_block_number,
@@ -94,10 +124,12 @@ where
                 canonical_line.push_game(next_game);
                 cursor = next_game;
             } else {
-                break;
+                return Ok(CanonicalScan::new(
+                    canonical_line,
+                    NextProposalAction::Propose(proposal),
+                ));
             }
         }
-        Ok(canonical_line)
     }
 
     pub async fn resolve_games(
@@ -150,59 +182,42 @@ where
         Ok(())
     }
 
-    pub async fn propose(&self, canonical_line: &CanonicalLine) -> Result<(), ProposerError> {
-        let mut cursor = canonical_line.tip();
-        let proposal = loop {
-            let next_l2_block_number = cursor
-                .l2_block_number
-                .checked_add(self.config.block_interval)
-                .ok_or(ProposerError::BlockNumberOverflow {
-                    parent_block: cursor.l2_block_number,
-                    block_interval: self.config.block_interval,
-                })?;
-
-            let latest_finalized_l2_block =
-                self.consensus_provider.latest_l2_finalized_block().await?;
-            if next_l2_block_number > latest_finalized_l2_block {
+    pub async fn propose(&self, scan: &CanonicalScan) -> Result<(), ProposerError> {
+        let (proposal, retry_of) = match scan.next_action() {
+            NextProposalAction::Propose(proposal) => (proposal, None),
+            NextProposalAction::RetryTimedOut {
+                proposal,
+                invalidated_game,
+            } => (proposal, Some(*invalidated_game)),
+            NextProposalAction::AwaitNegativeResolution { game, reason } => {
+                info!(
+                    game_address = %game,
+                    invalidation_reason = ?reason,
+                    "waiting for challenger to resolve game with negative outcome"
+                );
                 return Ok(());
             }
-            let root_claim = self
-                .consensus_provider
-                .output_root_at_block(next_l2_block_number)
-                .await?;
-            let mut proposal = Proposal {
-                parent_ref: cursor.address,
-                root_claim,
-                l2_block_number: next_l2_block_number,
-                proposal_key: B256::ZERO,
-            };
-            proposal.proposal_key = self
-                .execution_provider
-                .proposal_key(proposal.commitment())
-                .await?;
-            if let Some(next_game_addr) = self
-                .execution_provider
-                .game_for_proposal_key(proposal.proposal_key)
-                .await?
-            {
-                // game already exists, build on top of it
-                cursor = ParentRef {
-                    address: next_game_addr,
-                    l2_block_number: next_l2_block_number,
-                };
-            } else {
-                break proposal;
+            NextProposalAction::BlockedByInvalidation { game, reason } => {
+                warn!(
+                    game_address = %game,
+                    invalidation_reason = ?reason,
+                    "invalidated transition is not automatically retryable; governance intervention required"
+                );
+                return Ok(());
             }
+            NextProposalAction::CaughtUp { .. } => return Ok(()),
         };
+
         let submission = self
             .execution_provider
-            .submit_proposal(&proposal, self.config.proposer_bond)
+            .submit_proposal(proposal, self.config.proposer_bond)
             .await?;
         info!(
             tx_hash = ?submission.tx_hash,
             l2_block_number = proposal.l2_block_number,
             parent_ref = %proposal.parent_ref,
             proposal_key = ?proposal.proposal_key,
+            retry_of = ?retry_of,
             "submitted World Chain proof-system game"
         );
         Ok(())
@@ -217,13 +232,13 @@ where
             interval.tick().await;
             let iteration: Result<(), ProposerError> = async {
                 // 1. refresh the anchor and canonical line
-                let canonical_line = self.anchor_and_canonical_line().await?;
+                let canonical_scan = self.anchor_and_canonical_line().await?;
                 // 2. resolve positive-ready games parent-first
-                let finalized_games = self.resolve_games(&canonical_line).await?;
+                let finalized_games = self.resolve_games(canonical_scan.canonical_line()).await?;
                 // 3. advance the anchor to the highest finalized canonical game
                 self.advance_anchor(finalized_games).await?;
                 // 4. attempt a new canonical proposal or retry
-                self.propose(&canonical_line).await?;
+                self.propose(&canonical_scan).await?;
                 // 5. withdraw known proposer credits
                 // TODO: add withdraw credits logic
                 Ok(())

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -64,10 +64,7 @@ where
             let latest_finalized_l2_block =
                 self.consensus_provider.latest_l2_finalized_block().await?;
             if next_l2_block_number > latest_finalized_l2_block {
-                return Err(ProposerError::ProposalNotReady {
-                    target_block: next_l2_block_number,
-                    finalized_block: latest_finalized_l2_block,
-                });
+                break;
             }
 
             let root_claim = self
@@ -162,10 +159,7 @@ where
             let latest_finalized_l2_block =
                 self.consensus_provider.latest_l2_finalized_block().await?;
             if next_l2_block_number > latest_finalized_l2_block {
-                return Err(ProposerError::ProposalNotReady {
-                    target_block: next_l2_block_number,
-                    finalized_block: latest_finalized_l2_block,
-                });
+                return Ok(());
             }
             let root_claim = self
                 .consensus_provider

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -48,6 +48,7 @@ where
         let mut canonical_line = CanonicalLine::new(anchor_parent);
 
         let mut cursor = anchor_parent;
+        let latest_finalized_l2_block = self.consensus_provider.latest_l2_finalized_block().await?;
 
         // loop to the next canonical game until it reaches the last one
         loop {
@@ -59,8 +60,6 @@ where
                     block_interval: self.config.block_interval,
                 })?;
 
-            let latest_finalized_l2_block =
-                self.consensus_provider.latest_l2_finalized_block().await?;
             if next_l2_block_number > latest_finalized_l2_block {
                 return Ok(CanonicalScan::new(
                     canonical_line,

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -4,6 +4,7 @@ use world_chain_proofs::ConsensusProvider;
 
 use crate::{
     ParentRef, Proposal, ProposalSubmission, ProposerClient, ProposerConfig, ProposerError,
+    types::{CanonicalLine, ResolvedGames},
 };
 
 /// World Chain Proposer.
@@ -36,38 +37,49 @@ where
     E: ProposerClient,
     C: ConsensusProvider,
 {
-    /// Finds the first missing proposal after the current anchor.
-    pub async fn prepare_next_proposal(&self) -> Result<Proposal, ProposerError> {
+    /// Fetch the anchor game and reconconstruct the canonical line of games that is built on
+    /// top of the current anchor (if any) until the last created canonical game.
+    ///
+    ///
+    /// A game is considered canonical if it's built on top of a valid game and its root_claim
+    /// is correct - i.e. it matches the one computed by the proposer itself.
+    pub async fn anchor_and_canonical_line(&self) -> Result<CanonicalLine, ProposerError> {
         self.config.validate()?;
 
-        let mut parent = self.execution_provider.anchor_parent().await?;
+        let mut canonical_line = CanonicalLine::default();
 
+        let anchor_game = self.execution_provider.anchor_parent().await?;
+        canonical_line.push(anchor_game);
+
+        let mut cursor = anchor_game;
+
+        // loop to the next canonical game until it reaches the last one
         loop {
-            let l2_block_number = parent
+            let next_l2_block_number = cursor
                 .l2_block_number
                 .checked_add(self.config.block_interval)
                 .ok_or(ProposerError::BlockNumberOverflow {
-                    parent_block: parent.l2_block_number,
+                    parent_block: cursor.l2_block_number,
                     block_interval: self.config.block_interval,
                 })?;
 
             let latest_finalized_l2_block =
                 self.consensus_provider.latest_l2_finalized_block().await?;
-            if l2_block_number > latest_finalized_l2_block {
+            if next_l2_block_number > latest_finalized_l2_block {
                 return Err(ProposerError::ProposalNotReady {
-                    target_block: l2_block_number,
+                    target_block: next_l2_block_number,
                     finalized_block: latest_finalized_l2_block,
                 });
             }
 
             let root_claim = self
                 .consensus_provider
-                .output_root_at_block(l2_block_number)
+                .output_root_at_block(next_l2_block_number)
                 .await?;
             let mut proposal = Proposal {
-                parent_ref: parent.address,
+                parent_ref: cursor.address,
                 root_claim,
-                l2_block_number,
+                l2_block_number: next_l2_block_number,
                 proposal_key: B256::ZERO,
             };
             proposal.proposal_key = self
@@ -75,30 +87,131 @@ where
                 .proposal_key(proposal.commitment())
                 .await?;
 
-            if let Some(game) = self
+            if let Some(next_game_addr) = self
                 .execution_provider
                 .game_for_proposal_key(proposal.proposal_key)
                 .await?
             {
-                parent = ParentRef {
-                    address: game,
-                    l2_block_number,
+                let next_game = ParentRef {
+                    address: next_game_addr,
+                    l2_block_number: next_l2_block_number,
                 };
-                continue;
+                canonical_line.push(next_game);
+                cursor = next_game;
+            } else {
+                break;
             }
-
-            return Ok(proposal);
         }
+        Ok(canonical_line)
     }
 
-    /// Prepares and submits one proposal, if the next expected game is missing.
-    pub async fn propose_once(&self) -> Result<(Proposal, ProposalSubmission), ProposerError> {
-        let proposal = self.prepare_next_proposal().await?;
-        let submission = self
-            .execution_provider
-            .submit_proposal(&proposal, self.config.proposer_bond)
-            .await?;
-        Ok((proposal, submission))
+    pub async fn resolve_games(
+        &self,
+        canonical_line: CanonicalLine,
+    ) -> Result<ResolvedGames, ProposerError> {
+        let mut resolved_games = ResolvedGames::default();
+        for game in canonical_line {
+            let resolution_status = self
+                .execution_provider
+                .resolution_status(game.address)
+                .await?;
+            if resolution_status.positive_resolvable() {
+                // resolve the game
+                let resolve_submission = self.execution_provider.resolve_game(game.address).await?;
+                info!(
+                    game_address = %game.address,
+                    l2_block_number = game.l2_block_number,
+                    tx_hash = ?resolve_submission.tx_hash,
+                    "resolved World Chain proof-system game"
+                );
+                // add resolved game to the result list
+                resolved_games.push(game);
+            }
+        }
+        Ok(resolved_games)
+    }
+
+    pub async fn advance_anchor(&self, resolved_games: ResolvedGames) -> Result<(), ProposerError> {
+        // games are ordered by l2 block number, therefore taking the last one
+        // means taking the one with the highest l2 block number
+        let maybe_highest_resolved_game = resolved_games.last();
+        if let Some(highest_resolved_game) = maybe_highest_resolved_game {
+            let close_game_submission = self
+                .execution_provider
+                .close_game(highest_resolved_game.address)
+                .await?;
+            info!(
+                game_address = %highest_resolved_game.address,
+                l2_block_number = highest_resolved_game.l2_block_number,
+                tx_hash = ?close_game_submission.tx_hash,
+                "closed World Chain proof-system game"
+            );
+        }
+        Ok(())
+    }
+
+    pub async fn propose(&self, canonical_line: CanonicalLine) -> Result<(), ProposerError> {
+        let maybe_last_canonical_game = canonical_line.last();
+        if let Some(last_canonical_game) = maybe_last_canonical_game {
+            let mut cursor = last_canonical_game;
+            let proposal = loop {
+                let next_l2_block_number = cursor
+                    .l2_block_number
+                    .checked_add(self.config.block_interval)
+                    .ok_or(ProposerError::BlockNumberOverflow {
+                        parent_block: cursor.l2_block_number,
+                        block_interval: self.config.block_interval,
+                    })?;
+
+                let latest_finalized_l2_block =
+                    self.consensus_provider.latest_l2_finalized_block().await?;
+                if next_l2_block_number > latest_finalized_l2_block {
+                    return Err(ProposerError::ProposalNotReady {
+                        target_block: next_l2_block_number,
+                        finalized_block: latest_finalized_l2_block,
+                    });
+                }
+                let root_claim = self
+                    .consensus_provider
+                    .output_root_at_block(next_l2_block_number)
+                    .await?;
+                let mut proposal = Proposal {
+                    parent_ref: cursor.address,
+                    root_claim,
+                    l2_block_number: next_l2_block_number,
+                    proposal_key: B256::ZERO,
+                };
+                proposal.proposal_key = self
+                    .execution_provider
+                    .proposal_key(proposal.commitment())
+                    .await?;
+                if let Some(next_game_addr) = self
+                    .execution_provider
+                    .game_for_proposal_key(proposal.proposal_key)
+                    .await?
+                {
+                    // game already exists, build on top of it
+                    cursor = ParentRef {
+                        address: next_game_addr,
+                        l2_block_number: next_l2_block_number,
+                    };
+                } else {
+                    break proposal;
+                }
+            };
+            let submission = self
+                .execution_provider
+                .submit_proposal(&proposal, self.config.proposer_bond)
+                .await?;
+            info!(
+                tx_hash = ?submission.tx_hash,
+                l2_block_number = proposal.l2_block_number,
+                parent_ref = %proposal.parent_ref,
+                proposal_key = ?proposal.proposal_key,
+                "submitted World Chain proof-system game"
+            );
+        }
+        Ok(())
     }
 
     /// Runs the proposer forever, logging transient failures and retrying on each tick.
@@ -108,29 +221,16 @@ where
         let mut interval = tokio::time::interval(self.config.poll_interval);
         loop {
             interval.tick().await;
-            match self.propose_once().await {
-                Ok((proposal, submission)) => {
-                    info!(
-                        l2_block_number = proposal.l2_block_number,
-                        parent_ref = %proposal.parent_ref,
-                        proposal_key = ?proposal.proposal_key,
-                        tx_hash = ?submission.tx_hash,
-                        "submitted World Chain proof-system game"
-                    );
-                }
-                Err(ProposerError::ProposalNotReady {
-                    target_block,
-                    finalized_block: l2_finalized_block,
-                }) => {
-                    debug!(
-                        target_block,
-                        l2_finalized_block, "waiting for L2 to finalize the next proposal height"
-                    );
-                }
-                Err(error) => {
-                    warn!(%error, "proposal attempt failed");
-                }
-            }
+            // 1. refresh the anchor and canonical line
+            let canonical_line = self.anchor_and_canonical_line().await?;
+            // 2. resolve positive-ready games parent-first
+            let resolved_games = self.resolve_games(canonical_line).await?;
+            // 3. advance the anchor to the highest finalized canonical game
+            self.advance_anchor(resolved_games).await?;
+            // 4. attempt a new canonical proposal or retry
+            let new_proposal = self.propose(canonical_line).await?;
+            // 5. withdraw known proposer credits
+            // TODO: add withdraw credits logic
         }
     }
 }

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -132,6 +132,10 @@ where
         }
     }
 
+    /// Resolves positively resolvable games parent-first and returns all finalized games.
+    ///
+    /// Games finalized by an earlier iteration or another keeper are included so anchor
+    /// advancement can be retried.
     pub async fn resolve_games(
         &self,
         canonical_line: &CanonicalLine,
@@ -160,6 +164,7 @@ where
         Ok(finalized_games)
     }
 
+    /// Advances the anchor to the highest finalized game, if one is available.
     pub async fn advance_anchor(
         &self,
         finalized_games: FinalizedGames,
@@ -182,6 +187,10 @@ where
         Ok(())
     }
 
+    /// Executes the next proposal action selected during canonical-line scanning.
+    ///
+    /// New and timed-out transitions are submitted, negative-ready games wait for the
+    /// challenger, and non-retryable invalidations stop with a governance warning.
     pub async fn propose(&self, scan: &CanonicalScan) -> Result<(), ProposerError> {
         let (proposal, retry_of) = match scan.next_action() {
             NextProposalAction::Propose(proposal) => (proposal, None),

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -46,12 +46,10 @@ where
     pub async fn anchor_and_canonical_line(&self) -> Result<CanonicalLine, ProposerError> {
         self.config.validate()?;
 
-        let mut canonical_line = CanonicalLine::default();
+        let anchor_parent = self.execution_provider.anchor_parent().await?;
+        let mut canonical_line = CanonicalLine::new(anchor_parent);
 
-        let anchor_game = self.execution_provider.anchor_parent().await?;
-        canonical_line.push(anchor_game);
-
-        let mut cursor = anchor_game;
+        let mut cursor = anchor_parent;
 
         // loop to the next canonical game until it reaches the last one
         loop {
@@ -96,7 +94,7 @@ where
                     address: next_game_addr,
                     l2_block_number: next_l2_block_number,
                 };
-                canonical_line.push(next_game);
+                canonical_line.push_game(next_game);
                 cursor = next_game;
             } else {
                 break;
@@ -110,7 +108,7 @@ where
         canonical_line: &CanonicalLine,
     ) -> Result<ResolvedGames, ProposerError> {
         let mut resolved_games = ResolvedGames::default();
-        for game in canonical_line {
+        for game in canonical_line.games() {
             let resolution_status = self
                 .execution_provider
                 .resolution_status(game.address)
@@ -151,66 +149,63 @@ where
     }
 
     pub async fn propose(&self, canonical_line: &CanonicalLine) -> Result<(), ProposerError> {
-        let maybe_last_canonical_game = canonical_line.last();
-        if let Some(last_canonical_game) = maybe_last_canonical_game {
-            let mut cursor = last_canonical_game;
-            let proposal = loop {
-                let next_l2_block_number = cursor
-                    .l2_block_number
-                    .checked_add(self.config.block_interval)
-                    .ok_or(ProposerError::BlockNumberOverflow {
-                        parent_block: cursor.l2_block_number,
-                        block_interval: self.config.block_interval,
-                    })?;
+        let mut cursor = canonical_line.tip();
+        let proposal = loop {
+            let next_l2_block_number = cursor
+                .l2_block_number
+                .checked_add(self.config.block_interval)
+                .ok_or(ProposerError::BlockNumberOverflow {
+                    parent_block: cursor.l2_block_number,
+                    block_interval: self.config.block_interval,
+                })?;
 
-                let latest_finalized_l2_block =
-                    self.consensus_provider.latest_l2_finalized_block().await?;
-                if next_l2_block_number > latest_finalized_l2_block {
-                    return Err(ProposerError::ProposalNotReady {
-                        target_block: next_l2_block_number,
-                        finalized_block: latest_finalized_l2_block,
-                    });
-                }
-                let root_claim = self
-                    .consensus_provider
-                    .output_root_at_block(next_l2_block_number)
-                    .await?;
-                let mut proposal = Proposal {
-                    parent_ref: cursor.address,
-                    root_claim,
-                    l2_block_number: next_l2_block_number,
-                    proposal_key: B256::ZERO,
-                };
-                proposal.proposal_key = self
-                    .execution_provider
-                    .proposal_key(proposal.commitment())
-                    .await?;
-                if let Some(next_game_addr) = self
-                    .execution_provider
-                    .game_for_proposal_key(proposal.proposal_key)
-                    .await?
-                {
-                    // game already exists, build on top of it
-                    cursor = ParentRef {
-                        address: next_game_addr,
-                        l2_block_number: next_l2_block_number,
-                    };
-                } else {
-                    break proposal;
-                }
-            };
-            let submission = self
-                .execution_provider
-                .submit_proposal(&proposal, self.config.proposer_bond)
+            let latest_finalized_l2_block =
+                self.consensus_provider.latest_l2_finalized_block().await?;
+            if next_l2_block_number > latest_finalized_l2_block {
+                return Err(ProposerError::ProposalNotReady {
+                    target_block: next_l2_block_number,
+                    finalized_block: latest_finalized_l2_block,
+                });
+            }
+            let root_claim = self
+                .consensus_provider
+                .output_root_at_block(next_l2_block_number)
                 .await?;
-            info!(
-                tx_hash = ?submission.tx_hash,
-                l2_block_number = proposal.l2_block_number,
-                parent_ref = %proposal.parent_ref,
-                proposal_key = ?proposal.proposal_key,
-                "submitted World Chain proof-system game"
-            );
-        }
+            let mut proposal = Proposal {
+                parent_ref: cursor.address,
+                root_claim,
+                l2_block_number: next_l2_block_number,
+                proposal_key: B256::ZERO,
+            };
+            proposal.proposal_key = self
+                .execution_provider
+                .proposal_key(proposal.commitment())
+                .await?;
+            if let Some(next_game_addr) = self
+                .execution_provider
+                .game_for_proposal_key(proposal.proposal_key)
+                .await?
+            {
+                // game already exists, build on top of it
+                cursor = ParentRef {
+                    address: next_game_addr,
+                    l2_block_number: next_l2_block_number,
+                };
+            } else {
+                break proposal;
+            }
+        };
+        let submission = self
+            .execution_provider
+            .submit_proposal(&proposal, self.config.proposer_bond)
+            .await?;
+        info!(
+            tx_hash = ?submission.tx_hash,
+            l2_block_number = proposal.l2_block_number,
+            parent_ref = %proposal.parent_ref,
+            proposal_key = ?proposal.proposal_key,
+            "submitted World Chain proof-system game"
+        );
         Ok(())
     }
 

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -125,7 +125,7 @@ where
                     "resolved World Chain proof-system game"
                 );
                 // add resolved game to the result list
-                resolved_games.push(game);
+                resolved_games.push(*game);
             }
         }
         Ok(resolved_games)

--- a/proofs/proposer/src/tests.rs
+++ b/proofs/proposer/src/tests.rs
@@ -211,7 +211,7 @@ async fn zero_block_interval_is_rejected() {
 }
 
 #[tokio::test]
-async fn anchor_and_canonical_line_waits_for_finalized_l2_block() {
+async fn anchor_and_canonical_line_stops_at_finalized_l2_block() {
     let contracts = MockContracts {
         anchor: ParentRef {
             address: ANCHOR,
@@ -226,11 +226,14 @@ async fn anchor_and_canonical_line_waits_for_finalized_l2_block() {
     };
     let proposer = WorldChainProposer::new(config(), contracts, output_roots);
 
-    assert!(matches!(
-        proposer.anchor_and_canonical_line().await,
-        Err(ProposerError::ProposalNotReady {
-            target_block: 10,
-            finalized_block: 9,
-        })
-    ));
+    let canonical_line = proposer.anchor_and_canonical_line().await.unwrap();
+
+    assert!(canonical_line.games().is_empty());
+    assert_eq!(
+        canonical_line.anchor(),
+        ParentRef {
+            address: ANCHOR,
+            l2_block_number: 0,
+        }
+    );
 }

--- a/proofs/proposer/src/tests.rs
+++ b/proofs/proposer/src/tests.rs
@@ -141,17 +141,11 @@ async fn anchor_and_canonical_line_walks_existing_games_until_gap() {
     let canonical_line = proposer.anchor_and_canonical_line().await.unwrap();
 
     assert_eq!(
-        canonical_line.games,
-        vec![
-            ParentRef {
-                address: ANCHOR,
-                l2_block_number: 0,
-            },
-            ParentRef {
-                address: GAME_1,
-                l2_block_number: 10,
-            },
-        ]
+        canonical_line.games(),
+        &[ParentRef {
+            address: GAME_1,
+            l2_block_number: 10,
+        }]
     );
 }
 
@@ -171,8 +165,7 @@ async fn propose_submits_proposal_after_last_canonical_game() {
         finalized_l2_block: 10,
     };
     let proposer = WorldChainProposer::new(config(), contracts, output_roots);
-    let mut canonical_line = CanonicalLine::default();
-    canonical_line.push(ParentRef {
+    let canonical_line = CanonicalLine::new(ParentRef {
         address: ANCHOR,
         l2_block_number: 0,
     });

--- a/proofs/proposer/src/tests.rs
+++ b/proofs/proposer/src/tests.rs
@@ -6,11 +6,15 @@ use std::{
 
 use alloy_primitives::{Address, B256, BlockNumber, U256, address, b256};
 use async_trait::async_trait;
-use world_chain_proofs::{ConsensusError, ConsensusProvider, ProposalCommitment};
+use world_chain_proofs::{
+    ConsensusError, ConsensusProvider, InvalidationReason, ProposalCommitment, ResolutionStatus,
+    RootState,
+};
 
 use crate::{
     ParentRef, Proposal, ProposalSubmission, ProposerClient, ProposerConfig, ProposerError,
     WorldChainProposer,
+    types::{CanonicalLine, CloseGameSubmission, ResolveSubmission},
 };
 
 const DOMAIN_HASH: B256 = b256!("1111111111111111111111111111111111111111111111111111111111111111");
@@ -39,6 +43,26 @@ impl ProposerClient for MockContracts {
         proposal_key: B256,
     ) -> Result<Option<Address>, ProposerError> {
         Ok(self.games.get(&proposal_key).copied())
+    }
+
+    async fn resolution_status(&self, _game: Address) -> Result<ResolutionStatus, ProposerError> {
+        Ok(ResolutionStatus {
+            resolvable: false,
+            root_state: RootState::Proposed,
+            invalidation_reason: InvalidationReason::None,
+        })
+    }
+
+    async fn resolve_game(&self, _game: Address) -> Result<ResolveSubmission, ProposerError> {
+        Ok(ResolveSubmission {
+            tx_hash: B256::repeat_byte(0xbb),
+        })
+    }
+
+    async fn close_game(&self, _game: Address) -> Result<CloseGameSubmission, ProposerError> {
+        Ok(CloseGameSubmission {
+            tx_hash: B256::repeat_byte(0xcc),
+        })
     }
 
     async fn submit_proposal(
@@ -94,7 +118,7 @@ fn proposal_key(parent_ref: Address, root_claim: B256, l2_block_number: u64) -> 
 }
 
 #[tokio::test]
-async fn prepare_next_proposal_walks_existing_games_until_gap() {
+async fn anchor_and_canonical_line_walks_existing_games_until_gap() {
     let root_10 = B256::repeat_byte(0x10);
     let root_20 = B256::repeat_byte(0x20);
     let mut games = HashMap::new();
@@ -114,16 +138,25 @@ async fn prepare_next_proposal_walks_existing_games_until_gap() {
     };
     let proposer = WorldChainProposer::new(config(), contracts, output_roots);
 
-    let proposal = proposer.prepare_next_proposal().await.unwrap();
+    let canonical_line = proposer.anchor_and_canonical_line().await.unwrap();
 
-    assert_eq!(proposal.parent_ref, GAME_1);
-    assert_eq!(proposal.root_claim, root_20);
-    assert_eq!(proposal.l2_block_number, 20);
-    assert_eq!(proposal.proposal_key, proposal_key(GAME_1, root_20, 20));
+    assert_eq!(
+        canonical_line.games,
+        vec![
+            ParentRef {
+                address: ANCHOR,
+                l2_block_number: 0,
+            },
+            ParentRef {
+                address: GAME_1,
+                l2_block_number: 10,
+            },
+        ]
+    );
 }
 
 #[tokio::test]
-async fn propose_once_submits_prepared_proposal() {
+async fn propose_submits_proposal_after_last_canonical_game() {
     let submissions = Arc::default();
     let contracts = MockContracts {
         anchor: ParentRef {
@@ -138,13 +171,21 @@ async fn propose_once_submits_prepared_proposal() {
         finalized_l2_block: 10,
     };
     let proposer = WorldChainProposer::new(config(), contracts, output_roots);
+    let mut canonical_line = CanonicalLine::default();
+    canonical_line.push(ParentRef {
+        address: ANCHOR,
+        l2_block_number: 0,
+    });
 
-    let (proposal, submission) = proposer.propose_once().await.unwrap();
+    proposer.propose(&canonical_line).await.unwrap();
 
-    assert_eq!(submission.tx_hash, B256::repeat_byte(0xaa));
+    let proposal = submissions.lock().expect("not poisoned")[0];
+    assert_eq!(proposal.parent_ref, ANCHOR);
+    assert_eq!(proposal.root_claim, B256::repeat_byte(0x10));
+    assert_eq!(proposal.l2_block_number, 10);
     assert_eq!(
-        submissions.lock().expect("not poisoned").as_slice(),
-        &[proposal]
+        proposal.proposal_key,
+        proposal_key(ANCHOR, B256::repeat_byte(0x10), 10)
     );
 }
 
@@ -171,13 +212,13 @@ async fn zero_block_interval_is_rejected() {
     );
 
     assert!(matches!(
-        proposer.prepare_next_proposal().await,
+        proposer.anchor_and_canonical_line().await,
         Err(ProposerError::InvalidConfig(_))
     ));
 }
 
 #[tokio::test]
-async fn prepare_next_proposal_waits_for_finalized_l2_block() {
+async fn anchor_and_canonical_line_waits_for_finalized_l2_block() {
     let contracts = MockContracts {
         anchor: ParentRef {
             address: ANCHOR,
@@ -193,7 +234,7 @@ async fn prepare_next_proposal_waits_for_finalized_l2_block() {
     let proposer = WorldChainProposer::new(config(), contracts, output_roots);
 
     assert!(matches!(
-        proposer.prepare_next_proposal().await,
+        proposer.anchor_and_canonical_line().await,
         Err(ProposerError::ProposalNotReady {
             target_block: 10,
             finalized_block: 9,

--- a/proofs/proposer/src/tests.rs
+++ b/proofs/proposer/src/tests.rs
@@ -14,7 +14,7 @@ use world_chain_proofs::{
 use crate::{
     ParentRef, Proposal, ProposalSubmission, ProposerClient, ProposerConfig, ProposerError,
     WorldChainProposer,
-    types::{CanonicalLine, CloseGameSubmission, ResolveSubmission},
+    types::{CloseGameSubmission, ResolveSubmission},
 };
 
 const DOMAIN_HASH: B256 = b256!("1111111111111111111111111111111111111111111111111111111111111111");
@@ -138,10 +138,10 @@ async fn anchor_and_canonical_line_walks_existing_games_until_gap() {
     };
     let proposer = WorldChainProposer::new(config(), contracts, output_roots);
 
-    let canonical_line = proposer.anchor_and_canonical_line().await.unwrap();
+    let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
 
     assert_eq!(
-        canonical_line.games(),
+        canonical_scan.canonical_line().games(),
         &[ParentRef {
             address: GAME_1,
             l2_block_number: 10,
@@ -165,12 +165,9 @@ async fn propose_submits_proposal_after_last_canonical_game() {
         finalized_l2_block: 10,
     };
     let proposer = WorldChainProposer::new(config(), contracts, output_roots);
-    let canonical_line = CanonicalLine::new(ParentRef {
-        address: ANCHOR,
-        l2_block_number: 0,
-    });
+    let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
 
-    proposer.propose(&canonical_line).await.unwrap();
+    proposer.propose(&canonical_scan).await.unwrap();
 
     let proposal = submissions.lock().expect("not poisoned")[0];
     assert_eq!(proposal.parent_ref, ANCHOR);
@@ -226,11 +223,11 @@ async fn anchor_and_canonical_line_stops_at_finalized_l2_block() {
     };
     let proposer = WorldChainProposer::new(config(), contracts, output_roots);
 
-    let canonical_line = proposer.anchor_and_canonical_line().await.unwrap();
+    let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
 
-    assert!(canonical_line.games().is_empty());
+    assert!(canonical_scan.canonical_line().games().is_empty());
     assert_eq!(
-        canonical_line.anchor(),
+        canonical_scan.canonical_line().anchor(),
         ParentRef {
             address: ANCHOR,
             l2_block_number: 0,

--- a/proofs/proposer/src/traits.rs
+++ b/proofs/proposer/src/traits.rs
@@ -1,8 +1,11 @@
 use alloy_primitives::{Address, B256, U256};
 use async_trait::async_trait;
-use world_chain_proofs::ProposalCommitment;
+use world_chain_proofs::{ProposalCommitment, ResolutionStatus};
 
-use crate::{ParentRef, Proposal, ProposalSubmission, ProposerError};
+use crate::{
+    ParentRef, Proposal, ProposalSubmission, ProposerError,
+    types::{CloseGameSubmission, ResolveSubmission},
+};
 
 /// Minimal contract surface needed by the proposer.
 #[async_trait]
@@ -18,6 +21,14 @@ pub trait ProposerClient: Send + Sync {
         &self,
         proposal_key: B256,
     ) -> Result<Option<Address>, ProposerError>;
+
+    /// Returns the resolution status of the provided game, if game exists.
+    async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError>;
+
+    /// Submits a resolve transaction to the provided game.
+    async fn resolve_game(&self, game: Address) -> Result<ResolveSubmission, ProposerError>;
+
+    async fn close_game(&self, game: Address) -> Result<CloseGameSubmission, ProposerError>;
 
     /// Submits a proposal transaction to the factory.
     async fn submit_proposal(

--- a/proofs/proposer/src/types.rs
+++ b/proofs/proposer/src/types.rs
@@ -43,11 +43,11 @@ impl CanonicalLine {
 }
 
 #[derive(Debug, Default)]
-pub struct ResolvedGames {
+pub struct FinalizedGames {
     pub games: Vec<ParentRef>,
 }
 
-impl ResolvedGames {
+impl FinalizedGames {
     pub fn push(&mut self, game: ParentRef) {
         self.games.push(game);
     }

--- a/proofs/proposer/src/types.rs
+++ b/proofs/proposer/src/types.rs
@@ -16,19 +16,21 @@ impl CanonicalLine {
     }
 }
 
-impl Iterator for CanonicalLine {
+impl IntoIterator for CanonicalLine {
     type Item = ParentRef;
+    type IntoIter = std::vec::IntoIter<ParentRef>;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        self.games.iter().next().copied()
+    fn into_iter(self) -> Self::IntoIter {
+        self.games.into_iter()
     }
 }
 
-impl Iterator for &CanonicalLine {
-    type Item = ParentRef;
+impl<'a> IntoIterator for &'a CanonicalLine {
+    type Item = &'a ParentRef;
+    type IntoIter = std::slice::Iter<'a, ParentRef>;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        self.games.iter().next().copied()
+    fn into_iter(self) -> Self::IntoIter {
+        self.games.iter()
     }
 }
 

--- a/proofs/proposer/src/types.rs
+++ b/proofs/proposer/src/types.rs
@@ -24,6 +24,14 @@ impl Iterator for CanonicalLine {
     }
 }
 
+impl Iterator for &CanonicalLine {
+    type Item = ParentRef;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.games.iter().next().copied()
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct ResolvedGames {
     pub games: Vec<ParentRef>,

--- a/proofs/proposer/src/types.rs
+++ b/proofs/proposer/src/types.rs
@@ -108,16 +108,20 @@ impl CanonicalLine {
     }
 }
 
+/// Canonical games that have reached the finalized state and may advance the anchor.
 #[derive(Debug, Default)]
 pub struct FinalizedGames {
+    /// Finalized games ordered by increasing L2 block number.
     pub games: Vec<ParentRef>,
 }
 
 impl FinalizedGames {
+    /// Appends a finalized game to the ordered collection.
     pub fn push(&mut self, game: ParentRef) {
         self.games.push(game);
     }
 
+    /// Returns the finalized game with the highest L2 block number, if any.
     #[must_use]
     pub fn last(&self) -> Option<ParentRef> {
         self.games.last().copied()

--- a/proofs/proposer/src/types.rs
+++ b/proofs/proposer/src/types.rs
@@ -1,5 +1,71 @@
 use alloy_primitives::{Address, B256, TxHash};
-use world_chain_proofs::ProposalCommitment;
+use world_chain_proofs::{InvalidationReason, ProposalCommitment};
+
+/// The canonical lineage discovered by the proposer and the action available at its tip.
+#[derive(Debug)]
+pub struct CanonicalScan {
+    canonical_line: CanonicalLine,
+    next_action: NextProposalAction,
+}
+
+impl CanonicalScan {
+    pub(crate) const fn new(
+        canonical_line: CanonicalLine,
+        next_action: NextProposalAction,
+    ) -> Self {
+        Self {
+            canonical_line,
+            next_action,
+        }
+    }
+
+    /// Returns the valid canonical lineage found by the scan.
+    #[must_use]
+    pub const fn canonical_line(&self) -> &CanonicalLine {
+        &self.canonical_line
+    }
+
+    /// Returns the action available at the tip of the canonical lineage.
+    #[must_use]
+    pub const fn next_action(&self) -> &NextProposalAction {
+        &self.next_action
+    }
+}
+
+/// The action the proposer may take after scanning the canonical lineage.
+#[derive(Debug, PartialEq, Eq)]
+pub enum NextProposalAction {
+    /// Submit a new transition for which no game exists.
+    Propose(Proposal),
+    /// Replace a game invalidated by a direct proof timeout.
+    RetryTimedOut {
+        /// Proposal data for the replacement game.
+        proposal: Proposal,
+        /// Invalidated game that this proposal replaces.
+        invalidated_game: Address,
+    },
+    /// Wait for the challenger to resolve a game whose outcome is negative.
+    AwaitNegativeResolution {
+        /// Game that is ready to resolve negatively.
+        game: Address,
+        /// Negative outcome reported by the game.
+        reason: InvalidationReason,
+    },
+    /// Stop because the factory does not permit retrying this invalidated transition.
+    BlockedByInvalidation {
+        /// Invalidated game occupying the proposal key.
+        game: Address,
+        /// Reason the transition cannot be retried automatically.
+        reason: InvalidationReason,
+    },
+    /// No transition can be proposed beyond the current finalized L2 head.
+    CaughtUp {
+        /// Next L2 block the proposer would target.
+        target_block: u64,
+        /// Current finalized L2 block reported by the consensus client.
+        finalized_block: u64,
+    },
+}
 
 /// The current anchor checkpoint and the canonical games built on top of it.
 #[derive(Debug)]
@@ -52,6 +118,7 @@ impl FinalizedGames {
         self.games.push(game);
     }
 
+    #[must_use]
     pub fn last(&self) -> Option<ParentRef> {
         self.games.last().copied()
     }

--- a/proofs/proposer/src/types.rs
+++ b/proofs/proposer/src/types.rs
@@ -1,36 +1,44 @@
 use alloy_primitives::{Address, B256, TxHash};
 use world_chain_proofs::ProposalCommitment;
 
-#[derive(Debug, Default)]
+/// The current anchor checkpoint and the canonical games built on top of it.
+#[derive(Debug)]
 pub struct CanonicalLine {
-    pub games: Vec<ParentRef>,
+    anchor: ParentRef,
+    games: Vec<ParentRef>,
 }
 
 impl CanonicalLine {
-    pub fn push(&mut self, game: ParentRef) {
+    /// Creates an empty canonical line rooted at `anchor`.
+    #[must_use]
+    pub const fn new(anchor: ParentRef) -> Self {
+        Self {
+            anchor,
+            games: Vec::new(),
+        }
+    }
+
+    /// Returns the checkpoint this canonical line is rooted at.
+    #[must_use]
+    pub const fn anchor(&self) -> ParentRef {
+        self.anchor
+    }
+
+    /// Appends a canonical game built on the current tip.
+    pub fn push_game(&mut self, game: ParentRef) {
         self.games.push(game);
     }
 
-    pub fn last(&self) -> Option<ParentRef> {
-        self.games.last().copied()
+    /// Returns the canonical games built on top of the anchor.
+    #[must_use]
+    pub fn games(&self) -> &[ParentRef] {
+        &self.games
     }
-}
 
-impl IntoIterator for CanonicalLine {
-    type Item = ParentRef;
-    type IntoIter = std::vec::IntoIter<ParentRef>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.games.into_iter()
-    }
-}
-
-impl<'a> IntoIterator for &'a CanonicalLine {
-    type Item = &'a ParentRef;
-    type IntoIter = std::slice::Iter<'a, ParentRef>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.games.iter()
+    /// Returns the last canonical game, or the anchor when no game exists yet.
+    #[must_use]
+    pub fn tip(&self) -> ParentRef {
+        self.games.last().copied().unwrap_or(self.anchor)
     }
 }
 

--- a/proofs/proposer/src/types.rs
+++ b/proofs/proposer/src/types.rs
@@ -1,6 +1,44 @@
 use alloy_primitives::{Address, B256, TxHash};
 use world_chain_proofs::ProposalCommitment;
 
+#[derive(Debug, Default)]
+pub struct CanonicalLine {
+    pub games: Vec<ParentRef>,
+}
+
+impl CanonicalLine {
+    pub fn push(&mut self, game: ParentRef) {
+        self.games.push(game);
+    }
+
+    pub fn last(&self) -> Option<ParentRef> {
+        self.games.last().copied()
+    }
+}
+
+impl Iterator for CanonicalLine {
+    type Item = ParentRef;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.games.iter().next().copied()
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct ResolvedGames {
+    pub games: Vec<ParentRef>,
+}
+
+impl ResolvedGames {
+    pub fn push(&mut self, game: ParentRef) {
+        self.games.push(game);
+    }
+
+    pub fn last(&self) -> Option<ParentRef> {
+        self.games.last().copied()
+    }
+}
+
 /// A parent reference that the next proposal should build on.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ParentRef {
@@ -39,5 +77,19 @@ impl Proposal {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ProposalSubmission {
     /// Transaction hash for the proposal submission.
+    pub tx_hash: TxHash,
+}
+
+/// Result of a resolve transaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResolveSubmission {
+    /// Transaction hash for the resolve submission.
+    pub tx_hash: TxHash,
+}
+
+/// Result of a closeGame transaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CloseGameSubmission {
+    /// Transaction hash for the closeGame submission.
     pub tx_hash: TxHash,
 }

--- a/proofs/prover-service/src/tests.rs
+++ b/proofs/prover-service/src/tests.rs
@@ -50,6 +50,23 @@ async fn service(config: ProverServiceConfig) -> Option<TestService> {
     })
 }
 
+async fn expire_proof_lock(service: &ProverService, id: ProofRequestId, lock_id: LockId) {
+    let result = sqlx::query(
+        r#"
+        UPDATE proof_requests
+        SET lock_expires_at = NOW() - INTERVAL '1 hour'
+        WHERE proof_id = $1 AND lock_id = $2
+        "#,
+    )
+    .bind(id.0.as_slice().to_vec())
+    .bind(lock_id.0)
+    .execute(service.pool())
+    .await
+    .expect("expire proof lock");
+
+    assert_eq!(result.rows_affected(), 1);
+}
+
 fn request(backend: ProofBackend, seed: u8) -> ProofRequest {
     ProofRequest {
         backend,
@@ -225,12 +242,7 @@ async fn get_next_proof_on_empty_queue_returns_none() {
 
 #[tokio::test]
 async fn stale_lock_is_rejected_and_reclaim_succeeds() {
-    let Some(ctx) = service(ProverServiceConfig {
-        lock_timeout: Duration::from_millis(50),
-        ..test_config()
-    })
-    .await
-    else {
+    let Some(ctx) = service(test_config()).await else {
         return;
     };
     let service = ctx.service;
@@ -245,7 +257,7 @@ async fn stale_lock_is_rejected_and_reclaim_succeeds() {
         .expect("first lock");
 
     // Let the first lock expire so the job can be reclaimed.
-    tokio::time::sleep(Duration::from_millis(80)).await;
+    expire_proof_lock(&service, id, first.lock_id).await;
     let second = service
         .get_next_proof(get_next_proof_request(ProofBackend::Sp1))
         .await
@@ -310,10 +322,7 @@ async fn submit_proof_with_wrong_backend_is_rejected() {
 
 #[tokio::test]
 async fn status_poller_marks_expired_exhausted_jobs_failed() {
-    let config = ProverServiceConfig {
-        lock_timeout: Duration::from_millis(50),
-        ..test_config()
-    };
+    let config = test_config();
     let max_attempts = config.max_attempts;
     let expected_failure_reason = format!("proof request exhausted max attempts ({max_attempts})");
     let Some(ctx) = service(config).await else {
@@ -329,7 +338,7 @@ async fn status_poller_marks_expired_exhausted_jobs_failed() {
         .unwrap()
         .locked_request
         .expect("first lock");
-    tokio::time::sleep(Duration::from_millis(80)).await;
+    expire_proof_lock(&service, id, first.lock_id).await;
 
     let second = service
         .get_next_proof(get_next_proof_request(ProofBackend::Sp1))
@@ -364,7 +373,7 @@ async fn status_poller_marks_expired_exhausted_jobs_failed() {
         ProofStatus::Running
     );
 
-    tokio::time::sleep(Duration::from_millis(80)).await;
+    expire_proof_lock(&service, id, second.lock_id).await;
 
     // without status poller, this job is not claimable
     assert!(


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4959/proposer-refactor-proposer-for-the-new-contract-design

This PR refactors the `world-chain-proposer` to account for the new contract design.

### Next Steps

- add withdraw credit logic: https://linear.app/worldcoin/issue/PROTO-4976/proposer-add-withdraw-credits-logic
- refactor challenger
- refactor defender


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes L1 proposer behavior and on-chain interaction paths (resolve/close vs implicit finalize); mistakes could stall proposals or anchor advancement, though fakes and integration tests cover the new flow.
> 
> **Overview**
> Refactors **`world-chain-proposer`** for the new proof-system contract lifecycle: games are no longer finalized when proof threshold is met on-chain; the keeper must **`resolve()`** positively resolvable games and **`closeGame()`** on the highest finalized canonical game to advance the anchor.
> 
> The main loop is now **scan canonical line → resolve → advance anchor → propose/retry**, replacing **`propose_once` / `prepare_next_proposal`**. **`anchor_and_canonical_line`** walks from the anchor, classifies invalidated games (retry on proof timeout, wait on negative resolution, block on other invalidations), and returns **`CanonicalScan` / `NextProposalAction`**. **`ProposerClient`** and **`AlloyProofSystemClient`** gain **`resolution_status`**, **`resolve_game`**, and **`close_game`**; Solidity bindings swap **`finalize`/`invalidate`** for **`resolutionStatus`**, **`resolve`**, and **`closeGame`**.
> 
> Primitives add **`ResolutionStatus`**, **`InvalidationReason`**, and updated game/registry ABI surface. **`FakeExecution`** mirrors contract semantics (proofs only set bitmap; finalize via resolve; anchor via close). Integration tests wait on **`has_threshold`** then **`settle_with_proposer`**, plus a dedicated resolution-semantics test. Prover-service tests expire locks via SQL instead of sleeping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21e6558a5725356d625ebcc2782efee0b0ecc34c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->