### PR TITLE
feat(proposer): add withdrawal credits logic

### DIFF
--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -2424,7 +2424,7 @@ async fn start_world_chain_proposer(
         proposer_bond: U256::from(WORLD_PROPOSER_BOND_WEI),
         poll_interval: WORLD_PROPOSER_POLL_INTERVAL,
     };
-    let proposer = WorldChainProposer::new(config, contracts, output_roots);
+    let mut proposer = WorldChainProposer::new(config, contracts, output_roots);
 
     info!(
         l1_rpc_url,

--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -20,7 +20,7 @@ use world_chain_proofs::{
 };
 use world_chain_proposer::{
     CloseGameSubmission, ParentRef, Proposal, ProposalSubmission, ProposerClient, ProposerError,
-    ResolveSubmission,
+    ResolveSubmission, WithdrawSubmission,
 };
 use world_chain_prover_service::{
     GetNextProofRequest, GetNextProofResponse, GetProofSessionRequest, GetProofSessionResponse,
@@ -374,6 +374,17 @@ impl ProposerClient for FakeExecution {
         };
         Ok(CloseGameSubmission {
             tx_hash: B256::with_last_byte(game.as_slice()[19]),
+        })
+    }
+
+    async fn claimable(&self, _game: Address) -> Result<U256, ProposerError> {
+        Ok(U256::ZERO)
+    }
+
+    async fn withdraw(&self, game: Address) -> Result<WithdrawSubmission, ProposerError> {
+        Ok(WithdrawSubmission {
+            tx_hash: B256::with_last_byte(game.as_slice()[19]),
+            amount: U256::ZERO,
         })
     }
 

--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -392,6 +392,7 @@ impl ProposerClient for FakeExecution {
         let event = Self::create_game(&mut state, proposal);
         Ok(ProposalSubmission {
             tx_hash: B256::with_last_byte(event.game.as_slice()[19]),
+            game_address: event.game,
         })
     }
 }

--- a/proofs/integration-tests/tests/orchestration.rs
+++ b/proofs/integration-tests/tests/orchestration.rs
@@ -67,7 +67,7 @@ async fn fake_resolution_matches_contract_transition_semantics() {
     let chain = FakeExecution::new();
     let canonical_root = B256::repeat_byte(0x20);
     let consensus = FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
-    let proposer = WorldChainProposer::new(proposer_config(), chain.clone(), consensus);
+    let mut proposer = WorldChainProposer::new(proposer_config(), chain.clone(), consensus);
 
     let canonical_scan = proposer
         .anchor_and_canonical_line()
@@ -221,7 +221,7 @@ async fn invalid_root_is_challenged_by_real_challenger() {
     let honest_consensus =
         FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
 
-    let proposer =
+    let mut proposer =
         WorldChainProposer::new(proposer_config(), chain.clone(), bad_proposer_consensus);
     let canonical_scan = proposer
         .anchor_and_canonical_line()
@@ -250,7 +250,7 @@ async fn valid_challenged_root_is_defended_through_workers() {
     let canonical_root = B256::repeat_byte(0x20);
     let consensus = FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
 
-    let proposer = WorldChainProposer::new(proposer_config(), chain.clone(), consensus.clone());
+    let mut proposer = WorldChainProposer::new(proposer_config(), chain.clone(), consensus.clone());
     let canonical_scan = proposer
         .anchor_and_canonical_line()
         .await
@@ -296,7 +296,7 @@ async fn valid_challenged_root_survives_transient_proof_failure() {
     let canonical_root = B256::repeat_byte(0x20);
     let consensus = FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
 
-    let proposer = WorldChainProposer::new(proposer_config(), chain.clone(), consensus.clone());
+    let mut proposer = WorldChainProposer::new(proposer_config(), chain.clone(), consensus.clone());
     let canonical_scan = proposer
         .anchor_and_canonical_line()
         .await
@@ -351,7 +351,7 @@ async fn defender_ignores_challenged_invalid_root() {
     let honest_consensus =
         FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
 
-    let proposer =
+    let mut proposer =
         WorldChainProposer::new(proposer_config(), chain.clone(), bad_proposer_consensus);
     let canonical_scan = proposer
         .anchor_and_canonical_line()

--- a/proofs/primitives/src/bindings.rs
+++ b/proofs/primitives/src/bindings.rs
@@ -48,6 +48,8 @@ sol! {
 
     #[sol(rpc)]
     interface IWorldChainProofSystemGame {
+        event Withdrawn(address indexed recipient, uint256 amount);
+
         function rootId() external view returns (bytes32);
         function factory() external view returns (address);
         function anchorStateRegistry() external view returns (address);

--- a/proofs/primitives/src/types.rs
+++ b/proofs/primitives/src/types.rs
@@ -227,6 +227,16 @@ impl ResolutionStatus {
     pub fn positive_resolvable(&self) -> bool {
         self.resolvable && self.root_state == RootState::Finalized
     }
+
+    /// Returns whether the game has already reached a terminal state.
+    ///
+    /// The root state may describe the expected outcome of a game that is currently resolvable,
+    /// so a terminal root state is considered resolved only when `resolvable` is false.
+    pub fn is_resolved(&self) -> bool {
+        !self.resolvable
+            && (self.root_state == RootState::Finalized
+                || self.root_state == RootState::Invalidated)
+    }
 }
 
 #[cfg(test)]

--- a/proofs/proposer/src/alloy.rs
+++ b/proofs/proposer/src/alloy.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::{Address, B256, U256};
-use alloy_provider::Provider;
+use alloy_provider::{Provider, WalletProvider};
 use async_trait::async_trait;
 use world_chain_proofs::{
     IWorldChainAnchorStateRegistry, IWorldChainProofSystemFactory, IWorldChainProofSystemGame,
@@ -8,7 +8,7 @@ use world_chain_proofs::{
 
 use crate::{
     ParentRef, Proposal, ProposalSubmission, ProposerClient, ProposerError,
-    types::{CloseGameSubmission, ResolveSubmission},
+    types::{CloseGameSubmission, ResolveSubmission, WithdrawSubmission},
 };
 
 /// Alloy-backed implementation of [`ProofSystemClient`].
@@ -45,7 +45,7 @@ where
 #[async_trait]
 impl<P> ProposerClient for AlloyProofSystemClient<P>
 where
-    P: Provider + Clone + Send + Sync + 'static,
+    P: Provider + WalletProvider + Clone + Send + Sync + 'static,
 {
     async fn anchor_parent(&self) -> Result<ParentRef, ProposerError> {
         let l2_block_number = self
@@ -166,6 +166,62 @@ where
         Ok(CloseGameSubmission { tx_hash })
     }
 
+    async fn claimable(&self, game: Address) -> Result<U256, ProposerError> {
+        let game = IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance::new(
+            game,
+            self.provider.clone(),
+        );
+        let proposer_address = self.provider.default_signer_address();
+        let amount = game
+            .claimable(proposer_address)
+            .call()
+            .await
+            .map_err(|err| ProposerError::Contract(err.to_string()))?;
+
+        Ok(amount)
+    }
+
+    async fn withdraw(&self, game: Address) -> Result<WithdrawSubmission, ProposerError> {
+        let game = IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance::new(
+            game,
+            self.provider.clone(),
+        );
+        let proposer_address = self.provider.default_signer_address();
+        let pending = game
+            .withdraw(proposer_address)
+            .send()
+            .await
+            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+
+        let tx_hash = *pending.tx_hash();
+        let receipt = pending
+            .get_receipt()
+            .await
+            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+        if !receipt.status() {
+            return Err(ProposerError::Revert(tx_hash));
+        }
+
+        let amount = receipt
+            .logs()
+            .iter()
+            .filter(|log| log.address() == *game.address())
+            .find_map(|log| {
+                log.log_decode_validate::<IWorldChainProofSystemGame::Withdrawn>()
+                    .ok()
+                    .map(|decoded| decoded.inner.data)
+            })
+            .filter(|event| event.recipient == proposer_address)
+            .map(|event| event.amount)
+            .ok_or_else(|| {
+                ProposerError::Contract(format!(
+                    "Withdrawn event missing from withdraw transaction {tx_hash}"
+                ))
+            })?;
+
+        Ok(WithdrawSubmission { tx_hash, amount })
+    }
+
     async fn submit_proposal(
         &self,
         proposal: &Proposal,
@@ -192,7 +248,27 @@ where
             return Err(ProposerError::Revert(tx_hash));
         }
 
-        Ok(ProposalSubmission { tx_hash })
+        let game_address = receipt
+            .logs()
+            .iter()
+            .filter(|log| log.address() == *self.factory.address())
+            .find_map(|log| {
+                log.log_decode_validate::<IWorldChainProofSystemFactory::GameCreated>()
+                    .ok()
+                    .map(|decoded| decoded.inner.data)
+            })
+            .filter(|event| event.proposalKey == proposal.proposal_key)
+            .map(|event| event.game)
+            .ok_or_else(|| {
+                ProposerError::Contract(format!(
+                    "GameCreated event missing from proposal transaction {tx_hash}"
+                ))
+            })?;
+
+        Ok(ProposalSubmission {
+            tx_hash,
+            game_address,
+        })
     }
 }
 

--- a/proofs/proposer/src/lib.rs
+++ b/proofs/proposer/src/lib.rs
@@ -18,7 +18,7 @@ pub use proposer::WorldChainProposer;
 pub use traits::ProposerClient;
 pub use types::{
     CanonicalLine, CanonicalScan, CloseGameSubmission, FinalizedGames, NextProposalAction,
-    ParentRef, Proposal, ProposalSubmission, ResolveSubmission,
+    ParentRef, Proposal, ProposalSubmission, ResolveSubmission, WithdrawSubmission,
 };
 
 #[cfg(test)]

--- a/proofs/proposer/src/main.rs
+++ b/proofs/proposer/src/main.rs
@@ -83,7 +83,7 @@ async fn main() -> Result<()> {
         proposer_bond: U256::from(cli.proposer_bond_wei),
         poll_interval: Duration::from_secs(cli.poll_interval_seconds),
     };
-    let proposer = WorldChainProposer::new(config, contracts, output_roots);
+    let mut proposer = WorldChainProposer::new(config, contracts, output_roots);
 
     info!(
         l1_rpc_url = %cli.l1_rpc,

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -6,7 +6,7 @@ use world_chain_proofs::{ConsensusProvider, InvalidationReason, RootState};
 
 use crate::{
     ParentRef, Proposal, ProposerClient, ProposerConfig, ProposerError,
-    types::{CanonicalLine, CanonicalScan,  FinalizedGames, NextProposalAction},
+    types::{CanonicalLine, CanonicalScan, FinalizedGames, NextProposalAction},
 };
 
 /// World Chain Proposer.
@@ -194,6 +194,8 @@ where
     ///
     /// New and timed-out transitions are submitted, negative-ready games wait for the
     /// challenger, and non-retryable invalidations stop with a governance warning.
+    ///
+    /// The newly created game is added to the `self.proposed_games` field.
     pub async fn propose(&mut self, scan: &CanonicalScan) -> Result<(), ProposerError> {
         let (proposal, retry_of) = match scan.next_action() {
             NextProposalAction::Propose(proposal) => (proposal, None),
@@ -237,6 +239,8 @@ where
         Ok(())
     }
 
+    /// Scan all games stored in `self.proposed_games` and withdraw from them
+    /// if `claimable_amount` is greater than zero.
     pub async fn withdraw_credits(&mut self) -> Result<(), ProposerError> {
         let mut withdrawn = Vec::new();
         for &game in &self.proposed_games {

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -1,10 +1,12 @@
-use alloy_primitives::B256;
+use std::collections::HashSet;
+
+use alloy_primitives::{Address, B256, U256};
 use tracing::{info, warn};
 use world_chain_proofs::{ConsensusProvider, InvalidationReason, RootState};
 
 use crate::{
     ParentRef, Proposal, ProposerClient, ProposerConfig, ProposerError,
-    types::{CanonicalLine, CanonicalScan, FinalizedGames, NextProposalAction},
+    types::{CanonicalLine, CanonicalScan,  FinalizedGames, NextProposalAction},
 };
 
 /// World Chain Proposer.
@@ -13,15 +15,17 @@ pub struct WorldChainProposer<E, C> {
     config: ProposerConfig,
     execution_provider: E,
     consensus_provider: C,
+    proposed_games: HashSet<Address>,
 }
 
 impl<E, C> WorldChainProposer<E, C> {
     /// Creates a proposer from execution and consensus providers.
-    pub const fn new(config: ProposerConfig, execution_provider: E, consensus_provider: C) -> Self {
+    pub fn new(config: ProposerConfig, execution_provider: E, consensus_provider: C) -> Self {
         Self {
             config,
             execution_provider,
             consensus_provider,
+            proposed_games: HashSet::default(),
         }
     }
 
@@ -190,7 +194,7 @@ where
     ///
     /// New and timed-out transitions are submitted, negative-ready games wait for the
     /// challenger, and non-retryable invalidations stop with a governance warning.
-    pub async fn propose(&self, scan: &CanonicalScan) -> Result<(), ProposerError> {
+    pub async fn propose(&mut self, scan: &CanonicalScan) -> Result<(), ProposerError> {
         let (proposal, retry_of) = match scan.next_action() {
             NextProposalAction::Propose(proposal) => (proposal, None),
             NextProposalAction::RetryTimedOut {
@@ -222,17 +226,40 @@ where
             .await?;
         info!(
             tx_hash = ?submission.tx_hash,
+            game_address = %submission.game_address,
             l2_block_number = proposal.l2_block_number,
             parent_ref = %proposal.parent_ref,
             proposal_key = ?proposal.proposal_key,
             retry_of = ?retry_of,
             "submitted World Chain proof-system game"
         );
+        self.proposed_games.insert(submission.game_address);
+        Ok(())
+    }
+
+    pub async fn withdraw_credits(&mut self) -> Result<(), ProposerError> {
+        let mut withdrawn = Vec::new();
+        for &game in &self.proposed_games {
+            let claimable_amount = self.execution_provider.claimable(game).await?;
+            if claimable_amount > U256::ZERO {
+                let withdraw_submission = self.execution_provider.withdraw(game).await?;
+                info!(
+                    tx_hash = ?withdraw_submission.tx_hash,
+                    amount = ?withdraw_submission.amount,
+                    game_address = %game,
+                    "withdrew claimable credits"
+                );
+                withdrawn.push(game);
+            }
+        }
+        for game in withdrawn {
+            self.proposed_games.remove(&game);
+        }
         Ok(())
     }
 
     /// Runs the proposer forever, logging transient failures and retrying on each tick.
-    pub async fn run_forever(&self) -> Result<(), ProposerError> {
+    pub async fn run_forever(&mut self) -> Result<(), ProposerError> {
         self.config.validate()?;
 
         let mut interval = tokio::time::interval(self.config.poll_interval);
@@ -248,7 +275,7 @@ where
                 // 4. attempt a new canonical proposal or retry
                 self.propose(&canonical_scan).await?;
                 // 5. withdraw known proposer credits
-                // TODO: add withdraw credits logic
+                self.withdraw_credits().await?;
                 Ok(())
             }
             .await;

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -270,16 +270,16 @@ where
         loop {
             interval.tick().await;
             let iteration: Result<(), ProposerError> = async {
-                // 1. refresh the anchor and canonical line
-                let canonical_scan = self.anchor_and_canonical_line().await?;
-                // 2. resolve positive-ready games parent-first
-                let finalized_games = self.resolve_games(canonical_scan.canonical_line()).await?;
-                // 3. advance the anchor to the highest finalized canonical game
-                self.advance_anchor(finalized_games).await?;
-                // 4. attempt a new canonical proposal or retry
-                self.propose(&canonical_scan).await?;
-                // 5. withdraw known proposer credits
+                // 1. withdraw known proposer credits
                 self.withdraw_credits().await?;
+                // 2. refresh the anchor and canonical line
+                let canonical_scan = self.anchor_and_canonical_line().await?;
+                // 3. resolve positive-ready games parent-first
+                let finalized_games = self.resolve_games(canonical_scan.canonical_line()).await?;
+                // 4. advance the anchor to the highest finalized canonical game
+                self.advance_anchor(finalized_games).await?;
+                // 5. attempt a new canonical proposal or retry
+                self.propose(&canonical_scan).await?;
                 Ok(())
             }
             .await;

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -239,26 +239,48 @@ where
         Ok(())
     }
 
-    /// Scan all games stored in `self.proposed_games` and withdraw from them
-    /// if `claimable_amount` is greater than zero.
+    /// Scans all games stored in `self.proposed_games`, withdrawing available credits and
+    /// pruning games that have already resolved.
     pub async fn withdraw_credits(&mut self) -> Result<(), ProposerError> {
-        let mut withdrawn = Vec::new();
-        for &game in &self.proposed_games {
-            let claimable_amount = self.execution_provider.claimable(game).await?;
-            if claimable_amount > U256::ZERO {
-                let withdraw_submission = self.execution_provider.withdraw(game).await?;
-                info!(
-                    tx_hash = ?withdraw_submission.tx_hash,
-                    amount = ?withdraw_submission.amount,
-                    game_address = %game,
-                    "withdrew claimable credits"
-                );
-                withdrawn.push(game);
+        let proposed_games: Vec<_> = self.proposed_games.iter().copied().collect();
+
+        for game in proposed_games {
+            let result: Result<bool, ProposerError> = async {
+                let resolution_status = self.execution_provider.resolution_status(game).await?;
+                if !resolution_status.is_resolved() {
+                    return Ok(false);
+                }
+
+                let claimable_amount = self.execution_provider.claimable(game).await?;
+                if claimable_amount > U256::ZERO {
+                    let withdraw_submission = self.execution_provider.withdraw(game).await?;
+                    info!(
+                        tx_hash = ?withdraw_submission.tx_hash,
+                        amount = ?withdraw_submission.amount,
+                        game_address = %game,
+                        "withdrew claimable credits"
+                    );
+                }
+
+                Ok(true)
+            }
+            .await;
+
+            match result {
+                Ok(true) => {
+                    self.proposed_games.remove(&game);
+                }
+                Ok(false) => {}
+                Err(error) => {
+                    warn!(
+                        %error,
+                        game_address = %game,
+                        "failed to process proposer credits"
+                    );
+                }
             }
         }
-        for game in withdrawn {
-            self.proposed_games.remove(&game);
-        }
+
         Ok(())
     }
 

--- a/proofs/proposer/src/tests.rs
+++ b/proofs/proposer/src/tests.rs
@@ -76,6 +76,7 @@ impl ProposerClient for MockContracts {
             .push(*proposal);
         Ok(ProposalSubmission {
             tx_hash: B256::repeat_byte(0xaa),
+            game_address: Address::repeat_byte(0xaa),
         })
     }
 }

--- a/proofs/proposer/src/tests.rs
+++ b/proofs/proposer/src/tests.rs
@@ -14,7 +14,7 @@ use world_chain_proofs::{
 use crate::{
     ParentRef, Proposal, ProposalSubmission, ProposerClient, ProposerConfig, ProposerError,
     WorldChainProposer,
-    types::{CloseGameSubmission, ResolveSubmission},
+    types::{CloseGameSubmission, ResolveSubmission, WithdrawSubmission},
 };
 
 const DOMAIN_HASH: B256 = b256!("1111111111111111111111111111111111111111111111111111111111111111");
@@ -62,6 +62,17 @@ impl ProposerClient for MockContracts {
     async fn close_game(&self, _game: Address) -> Result<CloseGameSubmission, ProposerError> {
         Ok(CloseGameSubmission {
             tx_hash: B256::repeat_byte(0xcc),
+        })
+    }
+
+    async fn claimable(&self, _game: Address) -> Result<U256, ProposerError> {
+        Ok(U256::ZERO)
+    }
+
+    async fn withdraw(&self, _game: Address) -> Result<WithdrawSubmission, ProposerError> {
+        Ok(WithdrawSubmission {
+            tx_hash: B256::repeat_byte(0xdd),
+            amount: U256::ZERO,
         })
     }
 
@@ -165,7 +176,7 @@ async fn propose_submits_proposal_after_last_canonical_game() {
         roots: HashMap::from([(10, B256::repeat_byte(0x10))]),
         finalized_l2_block: 10,
     };
-    let proposer = WorldChainProposer::new(config(), contracts, output_roots);
+    let mut proposer = WorldChainProposer::new(config(), contracts, output_roots);
     let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
 
     proposer.propose(&canonical_scan).await.unwrap();

--- a/proofs/proposer/src/traits.rs
+++ b/proofs/proposer/src/traits.rs
@@ -4,7 +4,7 @@ use world_chain_proofs::{ProposalCommitment, ResolutionStatus};
 
 use crate::{
     ParentRef, Proposal, ProposalSubmission, ProposerError,
-    types::{CloseGameSubmission, ResolveSubmission},
+    types::{CloseGameSubmission, ResolveSubmission, WithdrawSubmission},
 };
 
 /// Minimal contract surface needed by the proposer.
@@ -28,7 +28,14 @@ pub trait ProposerClient: Send + Sync {
     /// Submits a resolve transaction to the provided game.
     async fn resolve_game(&self, game: Address) -> Result<ResolveSubmission, ProposerError>;
 
+    /// Submits a closeGame transaction to the provided game.
     async fn close_game(&self, game: Address) -> Result<CloseGameSubmission, ProposerError>;
+
+    /// Returns the claimable amount the proposer can withdraw from the provided game.
+    async fn claimable(&self, game: Address) -> Result<U256, ProposerError>;
+
+    /// Submits a withdraw transaction to the provided game.
+    async fn withdraw(&self, game: Address) -> Result<WithdrawSubmission, ProposerError>;
 
     /// Submits a proposal transaction to the factory.
     async fn submit_proposal(

--- a/proofs/proposer/src/types.rs
+++ b/proofs/proposer/src/types.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{Address, B256, TxHash};
+use alloy_primitives::{Address, B256, TxHash, U256};
 use world_chain_proofs::{InvalidationReason, ProposalCommitment};
 
 /// The canonical lineage discovered by the proposer and the action available at its tip.
@@ -167,6 +167,8 @@ impl Proposal {
 pub struct ProposalSubmission {
     /// Transaction hash for the proposal submission.
     pub tx_hash: TxHash,
+    /// Address of the proof-system game created by the proposal.
+    pub game_address: Address,
 }
 
 /// Result of a resolve transaction.
@@ -181,4 +183,13 @@ pub struct ResolveSubmission {
 pub struct CloseGameSubmission {
     /// Transaction hash for the closeGame submission.
     pub tx_hash: TxHash,
+}
+
+/// Result of a withdraw transaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WithdrawSubmission {
+    /// Transaction hash for the withdraw submission.
+    pub tx_hash: TxHash,
+    /// Amount withdrawn from the game.
+    pub amount: U256,
 }


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4976/proposer-add-withdraw-credits-logic

### Notes

This PR adds the withdrawal credit logic into the `world-chain-proposer`. Proposed games are kept in-memory and each tick it tries to `withdraw` from them if possible.

If the `world-chain-proposer` shuts down and it gets restarted, historical games are forgotten. Therefore we need a separated binary to handle this case. Further, this binary will be agnostic to proposer because the `world-chain-challenger` will need it too.

### Next Steps

- create binary to handle historical game withdrawals: https://linear.app/worldcoin/issue/PROTO-4979/new-binary-handle-historical-games-withdrawals

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces recurring L1 `withdraw` transactions and bond-recovery logic tied to resolution semantics; incorrect `is_resolved` or receipt parsing could skip or mis-handle funds, though scope is limited to games proposed by this proposer.
> 
> **Overview**
> **Adds automatic withdrawal of proposer credits** for games this instance created. Each poll cycle runs `withdraw_credits` before canonical scanning: for tracked game addresses it checks terminal resolution via `ResolutionStatus::is_resolved()`, calls `claimable` / `withdraw` when balance is non-zero, then drops the game from the in-memory set.
> 
> `WorldChainProposer` is now **mutable** (`proposed_games: HashSet<Address>`); successful `propose` records `game_address` from the submission. `ProposerClient` gains `claimable` and `withdraw`; the Alloy client sends `withdraw`, requires `WalletProvider`, and parses `GameCreated` / `Withdrawn` from receipts. `ProposalSubmission` includes `game_address`. Fakes and integration tests follow the new trait and `mut` proposer.
> 
> **Note:** Tracked games live only in process memory—restart forgets prior proposals (historical withdrawal is planned separately).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d586e1f70e067bc24cf6004c488db5eba355d85a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->