### PR TITLE
feat: add historical game withdrawals

### DIFF
--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -53,7 +53,9 @@ use world_chain_proof_worker::{
     ProofWorker, ProofWorkerConfig, RetryConfig, WorkerHeartbeatConfig,
 };
 use world_chain_proofs::{OptimismConsensusClient, PROOF_SYSTEM_VERSION, PROOF_THRESHOLD};
-use world_chain_proposer::{AlloyProofSystemClient, ProposerConfig, WorldChainProposer};
+use world_chain_proposer::{
+    AlloyProofSystemClient, BondManager, BondManagerConfig, ProposerConfig, WorldChainProposer,
+};
 use world_chain_prover_service::{
     ProverService, ProverServiceConfig, RpcProverServiceClient, start_rpc_server,
 };
@@ -2418,13 +2420,14 @@ async fn start_world_chain_proposer(
         .connect_http(Url::parse(l1_rpc_url)?);
 
     let contracts = AlloyProofSystemClient::new(provider, factory_address, anchor_address);
+    let mut bond_manager = BondManager::new(BondManagerConfig::default(), contracts.clone());
     let output_roots = OptimismConsensusClient::new(output_root_rpc_url.to_string());
     let config = ProposerConfig {
         block_interval: deployment.block_interval,
         proposer_bond: U256::from(WORLD_PROPOSER_BOND_WEI),
         poll_interval: WORLD_PROPOSER_POLL_INTERVAL,
     };
-    let mut proposer = WorldChainProposer::new(config, contracts, output_roots);
+    let proposer = WorldChainProposer::new(config, contracts, output_roots);
 
     info!(
         l1_rpc_url,
@@ -2438,8 +2441,17 @@ async fn start_world_chain_proposer(
 
     let handle = tokio::spawn(
         async move {
-            if let Err(error) = proposer.run_forever().await {
-                warn!(%error, "World Chain proof-system proposer stopped");
+            tokio::select! {
+                result = proposer.run_forever() => {
+                    if let Err(error) = result {
+                        warn!(%error, "World Chain proof-system proposer stopped");
+                    }
+                }
+                result = bond_manager.run_forever() => {
+                    if let Err(error) = result {
+                        warn!(%error, "World Chain bond manager stopped");
+                    }
+                }
             }
         }
         .instrument(info_span!(

--- a/proofs/integration-tests/tests/orchestration.rs
+++ b/proofs/integration-tests/tests/orchestration.rs
@@ -67,7 +67,7 @@ async fn fake_resolution_matches_contract_transition_semantics() {
     let chain = FakeExecution::new();
     let canonical_root = B256::repeat_byte(0x20);
     let consensus = FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
-    let mut proposer = WorldChainProposer::new(proposer_config(), chain.clone(), consensus);
+    let proposer = WorldChainProposer::new(proposer_config(), chain.clone(), consensus);
 
     let canonical_scan = proposer
         .anchor_and_canonical_line()
@@ -221,7 +221,7 @@ async fn invalid_root_is_challenged_by_real_challenger() {
     let honest_consensus =
         FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
 
-    let mut proposer =
+    let proposer =
         WorldChainProposer::new(proposer_config(), chain.clone(), bad_proposer_consensus);
     let canonical_scan = proposer
         .anchor_and_canonical_line()
@@ -250,7 +250,7 @@ async fn valid_challenged_root_is_defended_through_workers() {
     let canonical_root = B256::repeat_byte(0x20);
     let consensus = FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
 
-    let mut proposer = WorldChainProposer::new(proposer_config(), chain.clone(), consensus.clone());
+    let proposer = WorldChainProposer::new(proposer_config(), chain.clone(), consensus.clone());
     let canonical_scan = proposer
         .anchor_and_canonical_line()
         .await
@@ -296,7 +296,7 @@ async fn valid_challenged_root_survives_transient_proof_failure() {
     let canonical_root = B256::repeat_byte(0x20);
     let consensus = FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
 
-    let mut proposer = WorldChainProposer::new(proposer_config(), chain.clone(), consensus.clone());
+    let proposer = WorldChainProposer::new(proposer_config(), chain.clone(), consensus.clone());
     let canonical_scan = proposer
         .anchor_and_canonical_line()
         .await
@@ -351,7 +351,7 @@ async fn defender_ignores_challenged_invalid_root() {
     let honest_consensus =
         FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
 
-    let mut proposer =
+    let proposer =
         WorldChainProposer::new(proposer_config(), chain.clone(), bad_proposer_consensus);
     let canonical_scan = proposer
         .anchor_and_canonical_line()

--- a/proofs/primitives/src/bindings.rs
+++ b/proofs/primitives/src/bindings.rs
@@ -26,6 +26,8 @@ sol! {
             );
         function domainHash() external view returns (bytes32);
         function games(bytes32 proposalKey) external view returns (address);
+        function gameCount() external view returns (uint256);
+        function gameAt(uint256 index) external view returns (address);
         function isFactoryGame(address game) external view returns (bool);
         function propose(
             address parentRef,
@@ -52,6 +54,7 @@ sol! {
 
         function rootId() external view returns (bytes32);
         function factory() external view returns (address);
+        function proposer() external view returns (address);
         function anchorStateRegistry() external view returns (address);
         function domainHash() external view returns (bytes32);
         function attempt() external view returns (uint256);

--- a/proofs/proposer/src/alloy.rs
+++ b/proofs/proposer/src/alloy.rs
@@ -7,7 +7,7 @@ use world_chain_proofs::{
 };
 
 use crate::{
-    ParentRef, Proposal, ProposalSubmission, ProposerClient, ProposerError,
+    BondManagerClient, ParentRef, Proposal, ProposalSubmission, ProposerClient, ProposerError,
     types::{CloseGameSubmission, ResolveSubmission, WithdrawSubmission},
 };
 
@@ -39,6 +39,57 @@ where
             anchor,
             provider,
         }
+    }
+}
+
+#[async_trait]
+impl<P> BondManagerClient for AlloyProofSystemClient<P>
+where
+    P: Provider + WalletProvider + Clone + Send + Sync + 'static,
+{
+    fn proposer_address(&self) -> Address {
+        self.provider.default_signer_address()
+    }
+
+    async fn game_count(&self) -> Result<u64, ProposerError> {
+        let count = self
+            .factory
+            .gameCount()
+            .call()
+            .await
+            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+        u256_to_u64(count, "gameCount")
+    }
+
+    async fn game_at(&self, index: u64) -> Result<Address, ProposerError> {
+        self.factory
+            .gameAt(U256::from(index))
+            .call()
+            .await
+            .map_err(|error| ProposerError::Contract(error.to_string()))
+    }
+
+    async fn game_proposer(&self, game: Address) -> Result<Address, ProposerError> {
+        IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance::new(
+            game,
+            self.provider.clone(),
+        )
+        .proposer()
+        .call()
+        .await
+        .map_err(|error| ProposerError::Contract(error.to_string()))
+    }
+
+    async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError> {
+        ProposerClient::resolution_status(self, game).await
+    }
+
+    async fn claimable(&self, game: Address) -> Result<U256, ProposerError> {
+        ProposerClient::claimable(self, game).await
+    }
+
+    async fn withdraw(&self, game: Address) -> Result<WithdrawSubmission, ProposerError> {
+        ProposerClient::withdraw(self, game).await
     }
 }
 

--- a/proofs/proposer/src/bond_manager.rs
+++ b/proofs/proposer/src/bond_manager.rs
@@ -1,0 +1,142 @@
+use std::collections::HashSet;
+
+use alloy_primitives::{Address, U256};
+use tracing::{info, warn};
+
+use crate::{BondManagerClient, BondManagerConfig, ProposerError};
+
+/// Discovers games created by the proposer and asynchronously withdraws resolved bond credits.
+#[derive(Debug)]
+pub struct BondManager<E> {
+    config: BondManagerConfig,
+    execution_provider: E,
+    proposed_games: HashSet<Address>,
+    next_game_index: Option<u64>,
+}
+
+impl<E> BondManager<E> {
+    /// Creates an empty bond manager. The initial game window is discovered on its first scan.
+    pub fn new(config: BondManagerConfig, execution_provider: E) -> Self {
+        Self {
+            config,
+            execution_provider,
+            proposed_games: HashSet::default(),
+            next_game_index: None,
+        }
+    }
+
+    /// Returns the bond-manager configuration.
+    #[must_use]
+    pub const fn config(&self) -> &BondManagerConfig {
+        &self.config
+    }
+
+    /// Returns the next factory game index to scan, once initialized.
+    #[must_use]
+    pub const fn next_game_index(&self) -> Option<u64> {
+        self.next_game_index
+    }
+
+    /// Returns whether a game is currently awaiting resolution or withdrawal.
+    #[must_use]
+    pub fn tracks_game(&self, game: Address) -> bool {
+        self.proposed_games.contains(&game)
+    }
+}
+
+impl<E> BondManager<E>
+where
+    E: BondManagerClient,
+{
+    /// Scans the initial bounded factory window or all games appended since the last scan.
+    ///
+    /// The cursor advances only after the complete range succeeds. Games inserted before a
+    /// partial failure are harmlessly deduplicated when that range is retried.
+    pub async fn scan_games(&mut self) -> Result<(), ProposerError> {
+        self.config.validate()?;
+
+        let game_count = self.execution_provider.game_count().await?;
+        let start = match self.next_game_index {
+            Some(next_game_index) if next_game_index <= game_count => next_game_index,
+            Some(_) | None => game_count.saturating_sub(self.config.initial_scan_limit),
+        };
+        let proposer = self.execution_provider.proposer_address();
+
+        for index in start..game_count {
+            let game = self.execution_provider.game_at(index).await?;
+            if self.execution_provider.game_proposer(game).await? == proposer {
+                self.proposed_games.insert(game);
+            }
+        }
+
+        self.next_game_index = Some(game_count);
+        info!(
+            start_game_index = start,
+            next_game_index = game_count,
+            tracked_games = self.proposed_games.len(),
+            "scanned proposer bond games"
+        );
+        Ok(())
+    }
+
+    /// Withdraws available credits and prunes games that have reached a terminal state.
+    pub async fn withdraw_credits(&mut self) -> Result<(), ProposerError> {
+        let proposed_games: Vec<_> = self.proposed_games.iter().copied().collect();
+
+        for game in proposed_games {
+            let result: Result<bool, ProposerError> = async {
+                let resolution_status = self.execution_provider.resolution_status(game).await?;
+                if !resolution_status.is_resolved() {
+                    return Ok(false);
+                }
+
+                let claimable_amount = self.execution_provider.claimable(game).await?;
+                if claimable_amount > U256::ZERO {
+                    let withdraw_submission = self.execution_provider.withdraw(game).await?;
+                    info!(
+                        tx_hash = ?withdraw_submission.tx_hash,
+                        amount = ?withdraw_submission.amount,
+                        game_address = %game,
+                        "withdrew claimable credits"
+                    );
+                }
+
+                Ok(true)
+            }
+            .await;
+
+            match result {
+                Ok(true) => {
+                    self.proposed_games.remove(&game);
+                }
+                Ok(false) => {}
+                Err(error) => {
+                    warn!(
+                        %error,
+                        game_address = %game,
+                        "failed to process proposer credits"
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Runs game discovery and withdrawals forever on an interval independent of proposals.
+    pub async fn run_forever(&mut self) -> Result<(), ProposerError> {
+        self.config.validate()?;
+
+        let mut interval = tokio::time::interval(self.config.poll_interval);
+        loop {
+            interval.tick().await;
+
+            if let Err(error) = self.scan_games().await {
+                warn!(%error, "bond-manager game scan failed; retrying on next tick");
+            }
+            if let Err(error) = self.withdraw_credits().await {
+                warn!(%error, "bond-manager withdrawal pass failed; retrying on next tick");
+            }
+        }
+    }
+}

--- a/proofs/proposer/src/config.rs
+++ b/proofs/proposer/src/config.rs
@@ -4,6 +4,46 @@ use alloy_primitives::U256;
 
 use crate::ProposerError;
 
+/// Default delay between bond-manager scans.
+pub const DEFAULT_BOND_MANAGER_POLL_INTERVAL: Duration = Duration::from_secs(5 * 60);
+
+/// Default number of recent games inspected when the bond manager starts.
+pub const DEFAULT_BOND_MANAGER_INITIAL_SCAN_LIMIT: u64 = 1_000;
+
+/// Configuration for asynchronous proposer-bond management.
+#[derive(Debug, Clone)]
+pub struct BondManagerConfig {
+    /// Delay between factory scans and withdrawal attempts.
+    pub poll_interval: Duration,
+    /// Number of most recently created games scanned on startup.
+    pub initial_scan_limit: u64,
+}
+
+impl BondManagerConfig {
+    pub(crate) fn validate(&self) -> Result<(), ProposerError> {
+        if self.poll_interval.is_zero() {
+            return Err(ProposerError::InvalidConfig(
+                "bond_manager.poll_interval must be greater than zero",
+            ));
+        }
+        if self.initial_scan_limit == 0 {
+            return Err(ProposerError::InvalidConfig(
+                "bond_manager.initial_scan_limit must be greater than zero",
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Default for BondManagerConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval: DEFAULT_BOND_MANAGER_POLL_INTERVAL,
+            initial_scan_limit: DEFAULT_BOND_MANAGER_INITIAL_SCAN_LIMIT,
+        }
+    }
+}
+
 /// Configuration for the proposer loop.
 #[derive(Debug, Clone)]
 pub struct ProposerConfig {

--- a/proofs/proposer/src/lib.rs
+++ b/proofs/proposer/src/lib.rs
@@ -4,6 +4,7 @@
 //! contracts on L1 through `WorldChainProofSystemFactory`.
 
 mod alloy;
+mod bond_manager;
 mod config;
 mod error;
 mod proposer;
@@ -12,10 +13,14 @@ mod types;
 
 // re-exports
 pub use alloy::AlloyProofSystemClient;
-pub use config::ProposerConfig;
+pub use bond_manager::BondManager;
+pub use config::{
+    BondManagerConfig, DEFAULT_BOND_MANAGER_INITIAL_SCAN_LIMIT, DEFAULT_BOND_MANAGER_POLL_INTERVAL,
+    ProposerConfig,
+};
 pub use error::ProposerError;
 pub use proposer::WorldChainProposer;
-pub use traits::ProposerClient;
+pub use traits::{BondManagerClient, ProposerClient};
 pub use types::{
     CanonicalLine, CanonicalScan, CloseGameSubmission, FinalizedGames, NextProposalAction,
     ParentRef, Proposal, ProposalSubmission, ResolveSubmission, WithdrawSubmission,

--- a/proofs/proposer/src/main.rs
+++ b/proofs/proposer/src/main.rs
@@ -16,7 +16,9 @@ use clap::Parser;
 use tracing::info;
 use url::Url;
 use world_chain_proofs::OptimismConsensusClient;
-use world_chain_proposer::{AlloyProofSystemClient, ProposerConfig, WorldChainProposer};
+use world_chain_proposer::{
+    AlloyProofSystemClient, BondManager, BondManagerConfig, ProposerConfig, WorldChainProposer,
+};
 
 #[derive(Debug, Parser)]
 #[command(
@@ -59,6 +61,18 @@ struct Cli {
     /// Seconds between output-root polls.
     #[arg(long, env = "POLL_INTERVAL_SECONDS", default_value_t = 12)]
     poll_interval_seconds: u64,
+
+    /// Seconds between proposer-bond discovery and withdrawal passes.
+    #[arg(
+        long,
+        env = "BOND_MANAGER_POLL_INTERVAL_SECONDS",
+        default_value_t = 300
+    )]
+    bond_manager_poll_interval_seconds: u64,
+
+    /// Number of recent factory games scanned when the bond manager starts.
+    #[arg(long, env = "BOND_MANAGER_INITIAL_SCAN_LIMIT", default_value_t = 1_000)]
+    bond_manager_initial_scan_limit: u64,
 }
 
 #[tokio::main]
@@ -77,13 +91,18 @@ async fn main() -> Result<()> {
 
     let contracts =
         AlloyProofSystemClient::new(provider, cli.factory_address, cli.anchor_registry_address);
+    let bond_manager_config = BondManagerConfig {
+        poll_interval: Duration::from_secs(cli.bond_manager_poll_interval_seconds),
+        initial_scan_limit: cli.bond_manager_initial_scan_limit,
+    };
+    let mut bond_manager = BondManager::new(bond_manager_config, contracts.clone());
     let output_roots = OptimismConsensusClient::new(cli.output_root_rpc.clone());
     let config = ProposerConfig {
         block_interval: cli.block_interval,
         proposer_bond: U256::from(cli.proposer_bond_wei),
         poll_interval: Duration::from_secs(cli.poll_interval_seconds),
     };
-    let mut proposer = WorldChainProposer::new(config, contracts, output_roots);
+    let proposer = WorldChainProposer::new(config, contracts, output_roots);
 
     info!(
         l1_rpc_url = %cli.l1_rpc,
@@ -92,11 +111,14 @@ async fn main() -> Result<()> {
         anchor = %cli.anchor_registry_address,
         proposer = %proposer_address,
         block_interval = cli.block_interval,
+        bond_manager_poll_interval_seconds = cli.bond_manager_poll_interval_seconds,
+        bond_manager_initial_scan_limit = cli.bond_manager_initial_scan_limit,
         "starting World Chain proof-system proposer"
     );
 
     tokio::select! {
         result = proposer.run_forever() => result.context("proposer stopped")?,
+        result = bond_manager.run_forever() => result.context("bond manager stopped")?,
         _ = tokio::signal::ctrl_c() => info!("received ctrl-c, shutting down"),
     }
     Ok(())

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -1,6 +1,4 @@
-use std::collections::HashSet;
-
-use alloy_primitives::{Address, B256, U256};
+use alloy_primitives::B256;
 use tracing::{info, warn};
 use world_chain_proofs::{ConsensusProvider, InvalidationReason, RootState};
 
@@ -15,7 +13,6 @@ pub struct WorldChainProposer<E, C> {
     config: ProposerConfig,
     execution_provider: E,
     consensus_provider: C,
-    proposed_games: HashSet<Address>,
 }
 
 impl<E, C> WorldChainProposer<E, C> {
@@ -25,7 +22,6 @@ impl<E, C> WorldChainProposer<E, C> {
             config,
             execution_provider,
             consensus_provider,
-            proposed_games: HashSet::default(),
         }
     }
 
@@ -195,8 +191,7 @@ where
     /// New and timed-out transitions are submitted, negative-ready games wait for the
     /// challenger, and non-retryable invalidations stop with a governance warning.
     ///
-    /// The newly created game is added to the `self.proposed_games` field.
-    pub async fn propose(&mut self, scan: &CanonicalScan) -> Result<(), ProposerError> {
+    pub async fn propose(&self, scan: &CanonicalScan) -> Result<(), ProposerError> {
         let (proposal, retry_of) = match scan.next_action() {
             NextProposalAction::Propose(proposal) => (proposal, None),
             NextProposalAction::RetryTimedOut {
@@ -235,72 +230,24 @@ where
             retry_of = ?retry_of,
             "submitted World Chain proof-system game"
         );
-        self.proposed_games.insert(submission.game_address);
-        Ok(())
-    }
-
-    /// Scans all games stored in `self.proposed_games`, withdrawing available credits and
-    /// pruning games that have already resolved.
-    pub async fn withdraw_credits(&mut self) -> Result<(), ProposerError> {
-        let proposed_games: Vec<_> = self.proposed_games.iter().copied().collect();
-
-        for game in proposed_games {
-            let result: Result<bool, ProposerError> = async {
-                let resolution_status = self.execution_provider.resolution_status(game).await?;
-                if !resolution_status.is_resolved() {
-                    return Ok(false);
-                }
-
-                let claimable_amount = self.execution_provider.claimable(game).await?;
-                if claimable_amount > U256::ZERO {
-                    let withdraw_submission = self.execution_provider.withdraw(game).await?;
-                    info!(
-                        tx_hash = ?withdraw_submission.tx_hash,
-                        amount = ?withdraw_submission.amount,
-                        game_address = %game,
-                        "withdrew claimable credits"
-                    );
-                }
-
-                Ok(true)
-            }
-            .await;
-
-            match result {
-                Ok(true) => {
-                    self.proposed_games.remove(&game);
-                }
-                Ok(false) => {}
-                Err(error) => {
-                    warn!(
-                        %error,
-                        game_address = %game,
-                        "failed to process proposer credits"
-                    );
-                }
-            }
-        }
-
         Ok(())
     }
 
     /// Runs the proposer forever, logging transient failures and retrying on each tick.
-    pub async fn run_forever(&mut self) -> Result<(), ProposerError> {
+    pub async fn run_forever(&self) -> Result<(), ProposerError> {
         self.config.validate()?;
 
         let mut interval = tokio::time::interval(self.config.poll_interval);
         loop {
             interval.tick().await;
             let iteration: Result<(), ProposerError> = async {
-                // 1. withdraw known proposer credits
-                self.withdraw_credits().await?;
-                // 2. refresh the anchor and canonical line
+                // 1. refresh the anchor and canonical line
                 let canonical_scan = self.anchor_and_canonical_line().await?;
-                // 3. resolve positive-ready games parent-first
+                // 2. resolve positive-ready games parent-first
                 let finalized_games = self.resolve_games(canonical_scan.canonical_line()).await?;
-                // 4. advance the anchor to the highest finalized canonical game
+                // 3. advance the anchor to the highest finalized canonical game
                 self.advance_anchor(finalized_games).await?;
-                // 5. attempt a new canonical proposal or retry
+                // 4. attempt a new canonical proposal or retry
                 self.propose(&canonical_scan).await?;
                 Ok(())
             }

--- a/proofs/proposer/src/tests.rs
+++ b/proofs/proposer/src/tests.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::{Arc, Mutex},
     time::Duration,
 };
@@ -12,8 +12,8 @@ use world_chain_proofs::{
 };
 
 use crate::{
-    ParentRef, Proposal, ProposalSubmission, ProposerClient, ProposerConfig, ProposerError,
-    WorldChainProposer,
+    BondManager, BondManagerClient, BondManagerConfig, ParentRef, Proposal, ProposalSubmission,
+    ProposerClient, ProposerConfig, ProposerError, WorldChainProposer,
     types::{CloseGameSubmission, ResolveSubmission, WithdrawSubmission},
 };
 
@@ -93,6 +93,122 @@ impl ProposerClient for MockContracts {
 }
 
 #[derive(Debug, Clone)]
+struct MockBondClient {
+    proposer: Address,
+    games: Arc<Mutex<Vec<(Address, Address)>>>,
+    requested_indices: Arc<Mutex<Vec<u64>>>,
+    resolved_games: Arc<Mutex<HashSet<Address>>>,
+    claimable: Arc<Mutex<HashMap<Address, U256>>>,
+    withdrawals: Arc<Mutex<Vec<Address>>>,
+    fail_game_at_once: Arc<Mutex<Option<u64>>>,
+    fail_withdraw_once: Arc<Mutex<HashSet<Address>>>,
+}
+
+impl MockBondClient {
+    fn new(proposer: Address, games: Vec<(Address, Address)>) -> Self {
+        Self {
+            proposer,
+            games: Arc::new(Mutex::new(games)),
+            requested_indices: Arc::default(),
+            resolved_games: Arc::default(),
+            claimable: Arc::default(),
+            withdrawals: Arc::default(),
+            fail_game_at_once: Arc::default(),
+            fail_withdraw_once: Arc::default(),
+        }
+    }
+}
+
+#[async_trait]
+impl BondManagerClient for MockBondClient {
+    fn proposer_address(&self) -> Address {
+        self.proposer
+    }
+
+    async fn game_count(&self) -> Result<u64, ProposerError> {
+        Ok(self.games.lock().expect("not poisoned").len() as u64)
+    }
+
+    async fn game_at(&self, index: u64) -> Result<Address, ProposerError> {
+        self.requested_indices
+            .lock()
+            .expect("not poisoned")
+            .push(index);
+        let mut fail_index = self.fail_game_at_once.lock().expect("not poisoned");
+        if *fail_index == Some(index) {
+            *fail_index = None;
+            return Err(ProposerError::Contract("injected gameAt failure".into()));
+        }
+        self.games
+            .lock()
+            .expect("not poisoned")
+            .get(index as usize)
+            .map(|(game, _)| *game)
+            .ok_or_else(|| ProposerError::Contract(format!("missing game at index {index}")))
+    }
+
+    async fn game_proposer(&self, game: Address) -> Result<Address, ProposerError> {
+        self.games
+            .lock()
+            .expect("not poisoned")
+            .iter()
+            .find_map(|(candidate, proposer)| (*candidate == game).then_some(*proposer))
+            .ok_or_else(|| ProposerError::Contract(format!("unknown game {game}")))
+    }
+
+    async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError> {
+        let resolved = self
+            .resolved_games
+            .lock()
+            .expect("not poisoned")
+            .contains(&game);
+        Ok(ResolutionStatus {
+            resolvable: false,
+            root_state: if resolved {
+                RootState::Finalized
+            } else {
+                RootState::Proposed
+            },
+            invalidation_reason: InvalidationReason::None,
+        })
+    }
+
+    async fn claimable(&self, game: Address) -> Result<U256, ProposerError> {
+        Ok(self
+            .claimable
+            .lock()
+            .expect("not poisoned")
+            .get(&game)
+            .copied()
+            .unwrap_or_default())
+    }
+
+    async fn withdraw(&self, game: Address) -> Result<WithdrawSubmission, ProposerError> {
+        if self
+            .fail_withdraw_once
+            .lock()
+            .expect("not poisoned")
+            .remove(&game)
+        {
+            return Err(ProposerError::Contract(
+                "injected withdrawal failure".into(),
+            ));
+        }
+        self.withdrawals.lock().expect("not poisoned").push(game);
+        Ok(WithdrawSubmission {
+            tx_hash: B256::repeat_byte(0xdd),
+            amount: self
+                .claimable
+                .lock()
+                .expect("not poisoned")
+                .get(&game)
+                .copied()
+                .unwrap_or_default(),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
 struct MockOutputRoots {
     roots: HashMap<u64, B256>,
     finalized_l2_block: BlockNumber,
@@ -127,6 +243,19 @@ fn proposal_key(parent_ref: Address, root_claim: B256, l2_block_number: u64) -> 
         l2_block_number,
     }
     .proposal_key(DOMAIN_HASH)
+}
+
+fn game_address(index: u64) -> Address {
+    let mut bytes = [0_u8; 20];
+    bytes[12..].copy_from_slice(&index.to_be_bytes());
+    Address::from(bytes)
+}
+
+fn bond_manager_config(initial_scan_limit: u64) -> BondManagerConfig {
+    BondManagerConfig {
+        poll_interval: Duration::from_secs(1),
+        initial_scan_limit,
+    }
 }
 
 #[tokio::test]
@@ -176,7 +305,7 @@ async fn propose_submits_proposal_after_last_canonical_game() {
         roots: HashMap::from([(10, B256::repeat_byte(0x10))]),
         finalized_l2_block: 10,
     };
-    let mut proposer = WorldChainProposer::new(config(), contracts, output_roots);
+    let proposer = WorldChainProposer::new(config(), contracts, output_roots);
     let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
 
     proposer.propose(&canonical_scan).await.unwrap();
@@ -245,4 +374,132 @@ async fn anchor_and_canonical_line_stops_at_finalized_l2_block() {
             l2_block_number: 0,
         }
     );
+}
+
+#[tokio::test]
+async fn bond_manager_scans_bounded_initial_window_then_only_new_games() {
+    let proposer = Address::repeat_byte(0xa1);
+    let other_proposer = Address::repeat_byte(0xb2);
+    let games: Vec<_> = (0..1_005)
+        .map(|index| {
+            (
+                game_address(index + 1),
+                if index == 1_003 {
+                    other_proposer
+                } else {
+                    proposer
+                },
+            )
+        })
+        .collect();
+    let client = MockBondClient::new(proposer, games);
+    let mut manager = BondManager::new(bond_manager_config(1_000), client.clone());
+
+    manager.scan_games().await.unwrap();
+
+    {
+        let requested = client.requested_indices.lock().expect("not poisoned");
+        assert_eq!(requested.len(), 1_000);
+        assert_eq!(requested.first(), Some(&5));
+        assert_eq!(requested.last(), Some(&1_004));
+    }
+    assert_eq!(manager.next_game_index(), Some(1_005));
+    assert!(manager.tracks_game(game_address(6)));
+    assert!(!manager.tracks_game(game_address(1_004)));
+
+    client
+        .games
+        .lock()
+        .expect("not poisoned")
+        .push((game_address(1_006), proposer));
+    client
+        .requested_indices
+        .lock()
+        .expect("not poisoned")
+        .clear();
+
+    manager.scan_games().await.unwrap();
+
+    assert_eq!(
+        *client.requested_indices.lock().expect("not poisoned"),
+        vec![1_005]
+    );
+    assert_eq!(manager.next_game_index(), Some(1_006));
+    assert!(manager.tracks_game(game_address(1_006)));
+}
+
+#[tokio::test]
+async fn bond_manager_retries_complete_range_after_partial_scan_failure() {
+    let proposer = Address::repeat_byte(0xa1);
+    let games: Vec<_> = (1..=3)
+        .map(|index| (game_address(index), proposer))
+        .collect();
+    let client = MockBondClient::new(proposer, games);
+    *client.fail_game_at_once.lock().expect("not poisoned") = Some(1);
+    let mut manager = BondManager::new(bond_manager_config(100), client.clone());
+
+    assert!(manager.scan_games().await.is_err());
+    assert_eq!(manager.next_game_index(), None);
+    assert!(manager.tracks_game(game_address(1)));
+
+    manager.scan_games().await.unwrap();
+
+    assert_eq!(manager.next_game_index(), Some(3));
+    assert!(manager.tracks_game(game_address(1)));
+    assert!(manager.tracks_game(game_address(2)));
+    assert!(manager.tracks_game(game_address(3)));
+    assert_eq!(
+        *client.requested_indices.lock().expect("not poisoned"),
+        vec![0, 1, 0, 1, 2]
+    );
+}
+
+#[tokio::test]
+async fn bond_manager_prunes_resolved_games_and_retries_failed_withdrawals() {
+    let proposer = Address::repeat_byte(0xa1);
+    let unresolved = game_address(1);
+    let zero_credit = game_address(2);
+    let withdrawable = game_address(3);
+    let retry_withdrawal = game_address(4);
+    let games = vec![
+        (unresolved, proposer),
+        (zero_credit, proposer),
+        (withdrawable, proposer),
+        (retry_withdrawal, proposer),
+    ];
+    let client = MockBondClient::new(proposer, games);
+    client.resolved_games.lock().expect("not poisoned").extend([
+        zero_credit,
+        withdrawable,
+        retry_withdrawal,
+    ]);
+    client.claimable.lock().expect("not poisoned").extend([
+        (withdrawable, U256::from(10)),
+        (retry_withdrawal, U256::from(20)),
+    ]);
+    client
+        .fail_withdraw_once
+        .lock()
+        .expect("not poisoned")
+        .insert(retry_withdrawal);
+    let mut manager = BondManager::new(bond_manager_config(100), client.clone());
+    manager.scan_games().await.unwrap();
+
+    manager.withdraw_credits().await.unwrap();
+
+    assert!(manager.tracks_game(unresolved));
+    assert!(!manager.tracks_game(zero_credit));
+    assert!(!manager.tracks_game(withdrawable));
+    assert!(manager.tracks_game(retry_withdrawal));
+    assert_eq!(
+        *client.withdrawals.lock().expect("not poisoned"),
+        vec![withdrawable]
+    );
+
+    manager.withdraw_credits().await.unwrap();
+
+    assert!(!manager.tracks_game(retry_withdrawal));
+    let withdrawals = client.withdrawals.lock().expect("not poisoned");
+    assert!(withdrawals.contains(&withdrawable));
+    assert!(withdrawals.contains(&retry_withdrawal));
 }

--- a/proofs/proposer/src/traits.rs
+++ b/proofs/proposer/src/traits.rs
@@ -7,6 +7,31 @@ use crate::{
     types::{CloseGameSubmission, ResolveSubmission, WithdrawSubmission},
 };
 
+/// Contract surface needed by the asynchronous bond manager.
+#[async_trait]
+pub trait BondManagerClient: Send + Sync {
+    /// Returns the address whose proposal credits are managed.
+    fn proposer_address(&self) -> Address;
+
+    /// Returns the number of games created by the factory.
+    async fn game_count(&self) -> Result<u64, ProposerError>;
+
+    /// Returns the game at the provided factory creation index.
+    async fn game_at(&self, index: u64) -> Result<Address, ProposerError>;
+
+    /// Returns the proposer that created the provided game.
+    async fn game_proposer(&self, game: Address) -> Result<Address, ProposerError>;
+
+    /// Returns the resolution status of the provided game.
+    async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError>;
+
+    /// Returns the claimable amount for the managed proposer.
+    async fn claimable(&self, game: Address) -> Result<U256, ProposerError>;
+
+    /// Withdraws credits for the managed proposer.
+    async fn withdraw(&self, game: Address) -> Result<WithdrawSubmission, ProposerError>;
+}
+
 /// Minimal contract surface needed by the proposer.
 #[async_trait]
 pub trait ProposerClient: Send + Sync {


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4979/proposer-historical-game-credits-withdrawals

This PR slightly changes the way proposer credits withdrawals are handled:

### Old

- credit withdrawals was mixed with the normal operations of the proposer
- if proposer had rpc issues / it was restarted, historical games withdrawals were not handled anymore

### New

- there is a new async process, the `BondManager` that specifically handles credits withdrawals
- every tick it scans past 1000 games (at startup, otherwise the difference between the latest scanned game and new games) and handled them
- if the proposer is restarted, it will nevertheless handle the past 1000 games. Of course there is the risk of losing games that are older than that. But 1000 is a very high number - in normal scenarios of 1 game each hour (and not lots of invalid games created), it's more than 40 days...

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches L1 bond withdrawal and factory enumeration; games older than the initial scan window may not be recovered after restart.
> 
> **Overview**
> **Proposer bond withdrawals move out of the proposal loop into a dedicated `BondManager`**, so restarts and RPC blips no longer drop tracking of games that were only known in-memory.
> 
> The manager runs on its own interval (default 5 minutes) alongside `WorldChainProposer` via `tokio::select!` in the binary and devnet harness. Each tick it scans the proof-system factory—on first run the last **1,000** games (`gameCount` / `gameAt`), then only new indices—and keeps games whose on-chain `proposer()` matches the signer. For tracked games it withdraws claimable credits once resolved, then prunes them from the set.
> 
> `WorldChainProposer` no longer maintains `proposed_games` or calls `withdraw_credits` each iteration; `propose` / `run_forever` are immutable again. `AlloyProofSystemClient` gains a `BondManagerClient` implementation using new factory/game bindings (`gameCount`, `gameAt`, `proposer`). CLI/env knobs: `BOND_MANAGER_POLL_INTERVAL_SECONDS` and `BOND_MANAGER_INITIAL_SCAN_LIMIT`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a8b9a76ab40455ff08ef36875c0aec5aa55f1e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->