### PR TITLE
feat(proposer): add tick budget for `resolve_games`

### DIFF
--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -2426,6 +2426,7 @@ async fn start_world_chain_proposer(
         block_interval: deployment.block_interval,
         proposer_bond: U256::from(WORLD_PROPOSER_BOND_WEI),
         poll_interval: WORLD_PROPOSER_POLL_INTERVAL,
+        max_resolutions_per_tick: ProposerConfig::default().max_resolutions_per_tick,
     };
     let proposer = WorldChainProposer::new(config, contracts, output_roots);
 

--- a/proofs/integration-tests/tests/orchestration.rs
+++ b/proofs/integration-tests/tests/orchestration.rs
@@ -22,6 +22,7 @@ fn proposer_config() -> ProposerConfig {
         block_interval: BLOCK_INTERVAL,
         proposer_bond: U256::from(1),
         poll_interval: Duration::from_secs(1),
+        max_resolutions_per_tick: 1,
     }
 }
 

--- a/proofs/proposer/src/config.rs
+++ b/proofs/proposer/src/config.rs
@@ -53,6 +53,8 @@ pub struct ProposerConfig {
     pub proposer_bond: U256,
     /// Delay between periodic proposal attempts.
     pub poll_interval: Duration,
+    /// Maximum number of game-resolution transactions submitted per proposer tick.
+    pub max_resolutions_per_tick: usize,
 }
 
 impl ProposerConfig {
@@ -67,6 +69,11 @@ impl ProposerConfig {
                 "poll_interval must be greater than zero",
             ));
         }
+        if self.max_resolutions_per_tick == 0 {
+            return Err(ProposerError::InvalidConfig(
+                "max_resolutions_per_tick must be greater than zero",
+            ));
+        }
         Ok(())
     }
 }
@@ -77,6 +84,7 @@ impl Default for ProposerConfig {
             block_interval: 6,
             proposer_bond: U256::ZERO,
             poll_interval: Duration::from_secs(12),
+            max_resolutions_per_tick: 1,
         }
     }
 }

--- a/proofs/proposer/src/main.rs
+++ b/proofs/proposer/src/main.rs
@@ -62,6 +62,10 @@ struct Cli {
     #[arg(long, env = "POLL_INTERVAL_SECONDS", default_value_t = 12)]
     poll_interval_seconds: u64,
 
+    /// Maximum game-resolution transactions submitted during one proposer tick.
+    #[arg(long, env = "MAX_RESOLUTIONS_PER_TICK", default_value_t = 1)]
+    max_resolutions_per_tick: usize,
+
     /// Seconds between proposer-bond discovery and withdrawal passes.
     #[arg(
         long,
@@ -101,6 +105,7 @@ async fn main() -> Result<()> {
         block_interval: cli.block_interval,
         proposer_bond: U256::from(cli.proposer_bond_wei),
         poll_interval: Duration::from_secs(cli.poll_interval_seconds),
+        max_resolutions_per_tick: cli.max_resolutions_per_tick,
     };
     let proposer = WorldChainProposer::new(config, contracts, output_roots);
 
@@ -111,6 +116,7 @@ async fn main() -> Result<()> {
         anchor = %cli.anchor_registry_address,
         proposer = %proposer_address,
         block_interval = cli.block_interval,
+        max_resolutions_per_tick = cli.max_resolutions_per_tick,
         bond_manager_poll_interval_seconds = cli.bond_manager_poll_interval_seconds,
         bond_manager_initial_scan_limit = cli.bond_manager_initial_scan_limit,
         "starting World Chain proof-system proposer"

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -147,12 +147,22 @@ where
         canonical_line: &CanonicalLine,
     ) -> Result<FinalizedGames, ProposerError> {
         let mut finalized_games = FinalizedGames::default();
+        let mut resolutions_submitted = 0;
         for game in canonical_line.games() {
             let resolution_status = self
                 .execution_provider
                 .resolution_status(game.address)
                 .await?;
             if resolution_status.positive_resolvable() {
+                if resolutions_submitted >= self.config.max_resolutions_per_tick {
+                    info!(
+                        game_address = %game.address,
+                        l2_block_number = game.l2_block_number,
+                        max_resolutions_per_tick = self.config.max_resolutions_per_tick,
+                        "skipping game resolution because proposer tick budget is exhausted"
+                    );
+                    continue;
+                }
                 // resolve the game
                 let resolve_submission = self.execution_provider.resolve_game(game.address).await?;
                 info!(
@@ -162,6 +172,7 @@ where
                     "resolved World Chain proof-system game"
                 );
                 finalized_games.push(*game);
+                resolutions_submitted += 1;
             } else if resolution_status.root_state == RootState::Finalized {
                 // the game was finalized in an earlier iteration or by another keeper
                 finalized_games.push(*game);

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -127,6 +127,9 @@ where
                 canonical_line.push_game(next_game);
                 cursor = next_game;
             } else {
+                // game doesn't exist onchain yet, exit the loop with a
+                // `NextProposalAction::Propose`. The `propose` fn will
+                // later publish this proposal onchain
                 return Ok(CanonicalScan::new(
                     canonical_line,
                     NextProposalAction::Propose(proposal),

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -90,6 +90,10 @@ where
                 .game_for_proposal_key(proposal.proposal_key)
                 .await?
             {
+                // game already exists onchain, look at the resolution status now:
+                // - if the root_state becomes `Invalidated`, then immediately return
+                //   because we don't want to keep building on top of an invalid game
+                // - otherwise, add the game to the canonical line and continue the loop
                 let resolution_status = self
                     .execution_provider
                     .resolution_status(next_game_addr)

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -206,7 +206,7 @@ where
                 invalidated_game,
             } => (proposal, Some(*invalidated_game)),
             NextProposalAction::AwaitNegativeResolution { game, reason } => {
-                info!(
+                warn!(
                     game_address = %game,
                     invalidation_reason = ?reason,
                     "waiting for challenger to resolve game with negative outcome"

--- a/proofs/proposer/src/tests.rs
+++ b/proofs/proposer/src/tests.rs
@@ -12,8 +12,8 @@ use world_chain_proofs::{
 };
 
 use crate::{
-    BondManager, BondManagerClient, BondManagerConfig, ParentRef, Proposal, ProposalSubmission,
-    ProposerClient, ProposerConfig, ProposerError, WorldChainProposer,
+    BondManager, BondManagerClient, BondManagerConfig, CanonicalLine, ParentRef, Proposal,
+    ProposalSubmission, ProposerClient, ProposerConfig, ProposerError, WorldChainProposer,
     types::{CloseGameSubmission, ResolveSubmission, WithdrawSubmission},
 };
 
@@ -26,6 +26,9 @@ struct MockContracts {
     anchor: ParentRef,
     games: HashMap<B256, Address>,
     submissions: Arc<Mutex<Vec<Proposal>>>,
+    resolution_statuses: Arc<Mutex<HashMap<Address, ResolutionStatus>>>,
+    resolutions: Arc<Mutex<Vec<Address>>>,
+    closures: Arc<Mutex<Vec<Address>>>,
 }
 
 #[async_trait]
@@ -45,21 +48,28 @@ impl ProposerClient for MockContracts {
         Ok(self.games.get(&proposal_key).copied())
     }
 
-    async fn resolution_status(&self, _game: Address) -> Result<ResolutionStatus, ProposerError> {
-        Ok(ResolutionStatus {
-            resolvable: false,
-            root_state: RootState::Proposed,
-            invalidation_reason: InvalidationReason::None,
-        })
+    async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError> {
+        Ok(self
+            .resolution_statuses
+            .lock()
+            .expect("not poisoned")
+            .remove(&game)
+            .unwrap_or(ResolutionStatus {
+                resolvable: false,
+                root_state: RootState::Proposed,
+                invalidation_reason: InvalidationReason::None,
+            }))
     }
 
-    async fn resolve_game(&self, _game: Address) -> Result<ResolveSubmission, ProposerError> {
+    async fn resolve_game(&self, game: Address) -> Result<ResolveSubmission, ProposerError> {
+        self.resolutions.lock().expect("not poisoned").push(game);
         Ok(ResolveSubmission {
             tx_hash: B256::repeat_byte(0xbb),
         })
     }
 
-    async fn close_game(&self, _game: Address) -> Result<CloseGameSubmission, ProposerError> {
+    async fn close_game(&self, game: Address) -> Result<CloseGameSubmission, ProposerError> {
+        self.closures.lock().expect("not poisoned").push(game);
         Ok(CloseGameSubmission {
             tx_hash: B256::repeat_byte(0xcc),
         })
@@ -233,6 +243,15 @@ fn config() -> ProposerConfig {
         block_interval: 10,
         proposer_bond: U256::from(1),
         poll_interval: Duration::from_secs(1),
+        max_resolutions_per_tick: 1,
+    }
+}
+
+fn positive_ready_status() -> ResolutionStatus {
+    ResolutionStatus {
+        resolvable: true,
+        root_state: RootState::Finalized,
+        invalidation_reason: InvalidationReason::None,
     }
 }
 
@@ -272,6 +291,9 @@ async fn anchor_and_canonical_line_walks_existing_games_until_gap() {
         },
         games,
         submissions: Arc::default(),
+        resolution_statuses: Arc::default(),
+        resolutions: Arc::default(),
+        closures: Arc::default(),
     };
     let output_roots = MockOutputRoots {
         roots: HashMap::from([(10, root_10), (20, root_20)]),
@@ -300,6 +322,9 @@ async fn propose_submits_proposal_after_last_canonical_game() {
         },
         games: HashMap::new(),
         submissions: Arc::clone(&submissions),
+        resolution_statuses: Arc::default(),
+        resolutions: Arc::default(),
+        closures: Arc::default(),
     };
     let output_roots = MockOutputRoots {
         roots: HashMap::from([(10, B256::repeat_byte(0x10))]),
@@ -329,6 +354,9 @@ async fn zero_block_interval_is_rejected() {
         },
         games: HashMap::new(),
         submissions: Arc::default(),
+        resolution_statuses: Arc::default(),
+        resolutions: Arc::default(),
+        closures: Arc::default(),
     };
     let proposer = WorldChainProposer::new(
         ProposerConfig {
@@ -357,6 +385,9 @@ async fn anchor_and_canonical_line_stops_at_finalized_l2_block() {
         },
         games: HashMap::new(),
         submissions: Arc::default(),
+        resolution_statuses: Arc::default(),
+        resolutions: Arc::default(),
+        closures: Arc::default(),
     };
     let output_roots = MockOutputRoots {
         roots: HashMap::from([(10, B256::repeat_byte(0x10))]),
@@ -374,6 +405,168 @@ async fn anchor_and_canonical_line_stops_at_finalized_l2_block() {
             l2_block_number: 0,
         }
     );
+}
+
+#[tokio::test]
+async fn resolve_games_caps_submissions_and_keeps_scanning_finalized_games() {
+    let game_2 = game_address(2);
+    let game_3 = game_address(3);
+    let resolutions = Arc::default();
+    let closures = Arc::default();
+    let contracts = MockContracts {
+        anchor: ParentRef {
+            address: ANCHOR,
+            l2_block_number: 0,
+        },
+        games: HashMap::new(),
+        submissions: Arc::default(),
+        resolution_statuses: Arc::new(Mutex::new(HashMap::from([
+            (GAME_1, positive_ready_status()),
+            (game_2, positive_ready_status()),
+            (
+                game_3,
+                ResolutionStatus {
+                    resolvable: false,
+                    root_state: RootState::Finalized,
+                    invalidation_reason: InvalidationReason::None,
+                },
+            ),
+        ]))),
+        resolutions: Arc::clone(&resolutions),
+        closures: Arc::clone(&closures),
+    };
+    let proposer = WorldChainProposer::new(
+        ProposerConfig {
+            max_resolutions_per_tick: 2,
+            ..config()
+        },
+        contracts,
+        MockOutputRoots {
+            roots: HashMap::new(),
+            finalized_l2_block: 0,
+        },
+    );
+    let mut canonical_line = CanonicalLine::new(ParentRef {
+        address: ANCHOR,
+        l2_block_number: 0,
+    });
+    canonical_line.push_game(ParentRef {
+        address: GAME_1,
+        l2_block_number: 10,
+    });
+    canonical_line.push_game(ParentRef {
+        address: game_2,
+        l2_block_number: 20,
+    });
+    canonical_line.push_game(ParentRef {
+        address: game_3,
+        l2_block_number: 30,
+    });
+
+    let finalized_games = proposer.resolve_games(&canonical_line).await.unwrap();
+    assert_eq!(
+        *resolutions.lock().expect("not poisoned"),
+        vec![GAME_1, game_2]
+    );
+    assert_eq!(
+        finalized_games.last(),
+        Some(ParentRef {
+            address: game_3,
+            l2_block_number: 30,
+        })
+    );
+
+    proposer.advance_anchor(finalized_games).await.unwrap();
+    assert_eq!(*closures.lock().expect("not poisoned"), vec![game_3]);
+}
+
+#[tokio::test]
+async fn finalized_games_do_not_consume_resolution_budget() {
+    let game_2 = game_address(2);
+    let game_3 = game_address(3);
+    let resolutions = Arc::default();
+    let contracts = MockContracts {
+        anchor: ParentRef {
+            address: ANCHOR,
+            l2_block_number: 0,
+        },
+        games: HashMap::new(),
+        submissions: Arc::default(),
+        resolution_statuses: Arc::new(Mutex::new(HashMap::from([
+            (
+                GAME_1,
+                ResolutionStatus {
+                    resolvable: false,
+                    root_state: RootState::Finalized,
+                    invalidation_reason: InvalidationReason::None,
+                },
+            ),
+            (game_2, positive_ready_status()),
+            (game_3, positive_ready_status()),
+        ]))),
+        resolutions: Arc::clone(&resolutions),
+        closures: Arc::default(),
+    };
+    let proposer = WorldChainProposer::new(
+        config(),
+        contracts,
+        MockOutputRoots {
+            roots: HashMap::new(),
+            finalized_l2_block: 0,
+        },
+    );
+    let mut canonical_line = CanonicalLine::new(ParentRef {
+        address: ANCHOR,
+        l2_block_number: 0,
+    });
+    for (address, l2_block_number) in [(GAME_1, 10), (game_2, 20), (game_3, 30)] {
+        canonical_line.push_game(ParentRef {
+            address,
+            l2_block_number,
+        });
+    }
+
+    let finalized_games = proposer.resolve_games(&canonical_line).await.unwrap();
+
+    assert_eq!(*resolutions.lock().expect("not poisoned"), vec![game_2]);
+    assert_eq!(
+        finalized_games.last(),
+        Some(ParentRef {
+            address: game_2,
+            l2_block_number: 20,
+        })
+    );
+}
+
+#[tokio::test]
+async fn zero_resolution_budget_is_rejected() {
+    let contracts = MockContracts {
+        anchor: ParentRef {
+            address: ANCHOR,
+            l2_block_number: 0,
+        },
+        games: HashMap::new(),
+        submissions: Arc::default(),
+        resolution_statuses: Arc::default(),
+        resolutions: Arc::default(),
+        closures: Arc::default(),
+    };
+    let proposer = WorldChainProposer::new(
+        ProposerConfig {
+            max_resolutions_per_tick: 0,
+            ..config()
+        },
+        contracts,
+        MockOutputRoots {
+            roots: HashMap::new(),
+            finalized_l2_block: 0,
+        },
+    );
+
+    assert!(matches!(
+        proposer.anchor_and_canonical_line().await,
+        Err(ProposerError::InvalidConfig(_))
+    ));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4985/proposer-add-budget-per-tick-to-avoid-starvation-on-a-single-operation and https://linear.app/worldcoin/issue/PROTO-4982/proposer-add-more-docs-for-anchor-and-canonical-line-fn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes L1 resolution pacing on the proof-system proposer; a low cap can defer anchor advancement when many games become resolvable at once, though that is intentional to avoid tick starvation.
> 
> **Overview**
> Adds **`max_resolutions_per_tick`** to the World Chain proposer so each poll cycle submits only a bounded number of positive **game-resolution** L1 transactions, reducing the chance that long resolution backlogs starve proposals and other work in the same tick.
> 
> **`resolve_games`** now tracks a per-tick counter: positively resolvable games are resolved parent-first until the budget is hit; further resolvable games are skipped with an info log. Games already **`Finalized`** on-chain are still collected for anchor advancement and **do not** count toward the budget. Config validation rejects zero; default and CLI/env **`MAX_RESOLUTIONS_PER_TICK`** are **1**. Devnet and integration test harnesses set the field explicitly.
> 
> Minor behavior/docs tweaks: inline comments in canonical-line scanning when an on-chain game exists vs. a gap, and **`AwaitNegativeResolution`** is logged at **warn** instead of info.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a431183202da832f411e5691a2fd7bb838331c81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->