### PR TITLE
feat(proposer): read proposer bond from contract

### DIFF
--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -54,7 +54,8 @@ use world_chain_proof_worker::{
 };
 use world_chain_proofs::{OptimismConsensusClient, PROOF_SYSTEM_VERSION, PROOF_THRESHOLD};
 use world_chain_proposer::{
-    AlloyProofSystemClient, BondManager, BondManagerConfig, ProposerConfig, WorldChainProposer,
+    AlloyProofSystemClient, BondManager, BondManagerConfig, ProposerClient, ProposerConfig,
+    WorldChainProposer,
 };
 use world_chain_prover_service::{
     ProverService, ProverServiceConfig, RpcProverServiceClient, start_rpc_server,
@@ -95,9 +96,6 @@ const SP1_WORKER_POLL_INTERVAL: Duration = Duration::from_secs(5);
 const SP1_WORKER_PROVER_ENV: &str = "DEVNET_SP1_WORKER_PROVER";
 /// SP1 network private key. Required when `DEVNET_SP1_WORKER_PROVER=network`.
 const SP1_PRIVATE_KEY_ENV: &str = "SP1_PRIVATE_KEY";
-/// Bond, in wei, sent with every `WorldChainProofSystemFactory.propose`.
-/// Matches `PROPOSER_BOND` (1 ether) in `scripts/devnet/DeployProofSystem.s.sol`.
-const WORLD_PROPOSER_BOND_WEI: u128 = 1_000_000_000_000_000_000;
 /// Delay between World Chain proof-system proposal attempts.
 const WORLD_PROPOSER_POLL_INTERVAL: Duration = Duration::from_secs(2);
 /// Bond, in wei, sent with every `WorldChainProofSystemGame.challenge`.
@@ -2422,9 +2420,13 @@ async fn start_world_chain_proposer(
     let contracts = AlloyProofSystemClient::new(provider, factory_address, anchor_address);
     let mut bond_manager = BondManager::new(BondManagerConfig::default(), contracts.clone());
     let output_roots = OptimismConsensusClient::new(output_root_rpc_url.to_string());
+    let proposer_bond = contracts
+        .proposer_bond()
+        .await
+        .wrap_err("failed to read proposer bond")?;
     let config = ProposerConfig {
         block_interval: deployment.block_interval,
-        proposer_bond: U256::from(WORLD_PROPOSER_BOND_WEI),
+        proposer_bond,
         poll_interval: WORLD_PROPOSER_POLL_INTERVAL,
         max_resolutions_per_tick: ProposerConfig::default().max_resolutions_per_tick,
     };

--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -388,6 +388,10 @@ impl ProposerClient for FakeExecution {
         })
     }
 
+    async fn proposer_bond(&self) -> Result<U256, ProposerError> {
+        Ok(U256::from(1))
+    }
+
     async fn submit_proposal(
         &self,
         proposal: &Proposal,

--- a/proofs/primitives/src/bindings.rs
+++ b/proofs/primitives/src/bindings.rs
@@ -25,6 +25,7 @@ sol! {
                 uint256 blockInterval
             );
         function domainHash() external view returns (bytes32);
+        function proposerBond() external view returns (uint256);
         function games(bytes32 proposalKey) external view returns (address);
         function gameCount() external view returns (uint256);
         function gameAt(uint256 index) external view returns (address);

--- a/proofs/proposer/src/alloy.rs
+++ b/proofs/proposer/src/alloy.rs
@@ -273,6 +273,17 @@ where
         Ok(WithdrawSubmission { tx_hash, amount })
     }
 
+    async fn proposer_bond(&self) -> Result<U256, ProposerError> {
+        let proposer_bond = self
+            .factory
+            .proposerBond()
+            .call()
+            .await
+            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+
+        Ok(proposer_bond)
+    }
+
     async fn submit_proposal(
         &self,
         proposal: &Proposal,

--- a/proofs/proposer/src/main.rs
+++ b/proofs/proposer/src/main.rs
@@ -8,7 +8,7 @@
 use std::time::Duration;
 
 use alloy_network::EthereumWallet;
-use alloy_primitives::{Address, U256};
+use alloy_primitives::Address;
 use alloy_provider::ProviderBuilder;
 use alloy_signer_local::PrivateKeySigner;
 use anyhow::{Context, Result};
@@ -17,7 +17,8 @@ use tracing::info;
 use url::Url;
 use world_chain_proofs::OptimismConsensusClient;
 use world_chain_proposer::{
-    AlloyProofSystemClient, BondManager, BondManagerConfig, ProposerConfig, WorldChainProposer,
+    AlloyProofSystemClient, BondManager, BondManagerConfig, ProposerClient, ProposerConfig,
+    WorldChainProposer,
 };
 
 #[derive(Debug, Parser)]
@@ -49,14 +50,6 @@ struct Cli {
     /// L2 blocks between a proposal's parent and its claimed block.
     #[arg(long, env = "BLOCK_INTERVAL")]
     block_interval: u64,
-
-    /// Bond posted with each proposal, in wei (default 1 ETH).
-    #[arg(
-        long,
-        env = "PROPOSER_BOND_WEI",
-        default_value_t = 1_000_000_000_000_000_000
-    )]
-    proposer_bond_wei: u128,
 
     /// Seconds between output-root polls.
     #[arg(long, env = "POLL_INTERVAL_SECONDS", default_value_t = 12)]
@@ -101,9 +94,13 @@ async fn main() -> Result<()> {
     };
     let mut bond_manager = BondManager::new(bond_manager_config, contracts.clone());
     let output_roots = OptimismConsensusClient::new(cli.output_root_rpc.clone());
+    let proposer_bond = contracts
+        .proposer_bond()
+        .await
+        .context("failed to read proposer bond")?;
     let config = ProposerConfig {
         block_interval: cli.block_interval,
-        proposer_bond: U256::from(cli.proposer_bond_wei),
+        proposer_bond,
         poll_interval: Duration::from_secs(cli.poll_interval_seconds),
         max_resolutions_per_tick: cli.max_resolutions_per_tick,
     };

--- a/proofs/proposer/src/tests.rs
+++ b/proofs/proposer/src/tests.rs
@@ -86,6 +86,10 @@ impl ProposerClient for MockContracts {
         })
     }
 
+    async fn proposer_bond(&self) -> Result<U256, ProposerError> {
+        Ok(U256::from(1))
+    }
+
     async fn submit_proposal(
         &self,
         proposal: &Proposal,

--- a/proofs/proposer/src/traits.rs
+++ b/proofs/proposer/src/traits.rs
@@ -62,6 +62,9 @@ pub trait ProposerClient: Send + Sync {
     /// Submits a withdraw transaction to the provided game.
     async fn withdraw(&self, game: Address) -> Result<WithdrawSubmission, ProposerError>;
 
+    /// Reads the proposer bond from the factory contract.
+    async fn proposer_bond(&self) -> Result<U256, ProposerError>;
+
     /// Submits a proposal transaction to the factory.
     async fn submit_proposal(
         &self,


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4981/proposer-read-config-values-from-contracts

This needs https://github.com/worldcoin/world-chain/pull/903 to be merged first - then rebase. For this PR review I suggest you to only review the last commit (the first one is just the previous PR squashed in a single commit to make the future rebase super easy)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Proposal txs now depend on a startup L1 read and correct on-chain bond; misconfiguration or RPC failure at boot blocks the proposer, and bond changes on-chain are not refreshed until restart.
> 
> **Overview**
> The proposer **no longer hardcodes or configures** the proposal bond in wei. It reads **`proposerBond()`** from `WorldChainProofSystemFactory` at startup and uses that value for `ProposerConfig` and payable `propose` calls.
> 
> **`ProposerClient`** gains **`proposer_bond()`**, implemented on **`AlloyProofSystemClient`** via the new binding. The standalone **`world-chain-proposer`** binary drops **`PROPOSER_BOND_WEI`** / the default 1 ETH flag; the devnet harness removes **`WORLD_PROPOSER_BOND_WEI`** and fetches the bond the same way. Test and integration fakes implement the new trait method.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ae87c66e8948c383158863640ef4c0567564e1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->