### PR TITLE
chore (ci): add alchemy dev acceptance target

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -13,7 +13,7 @@ on:
           - prod
           - stage
           - betanet
-          - alphanet
+          - alchemy-dev
       bundler_rpc_url:
         description: Optional Rundler RPC URL for ERC-4337 sponsored user operation checks
         required: false
@@ -87,7 +87,7 @@ jobs:
             karst_deposit_enabled: "true"
             optimism_portal: "0x081a60097c9e1fbe7f55a950eaf77c81dbe3c7af"
             allow_failure: true
-          - network: alphanet
+          - network: alchemy-dev
             environment: dev-eu-central-2
             include_in_all: true
             rpc_url: https://tx-proxy-devnet-eu-central-2.worldcoin.dev
@@ -151,7 +151,7 @@ jobs:
           ACCEPTANCE_NETWORK: ${{ matrix.network }}
           ACCEPTANCE_RPC_URL: ${{ matrix.rpc_url }}
           ACCEPTANCE_L1_RPC_URL: ${{ secrets.SEPOLIA_RPC_URL }}
-          ACCEPTANCE_BUNDLER_RPC_URL: ${{ matrix.network == 'alphanet' && inputs.bundler_rpc_url != '' && inputs.bundler_rpc_url || matrix.bundler_rpc_url }}
+          ACCEPTANCE_BUNDLER_RPC_URL: ${{ matrix.network == 'alchemy-dev' && inputs.bundler_rpc_url != '' && inputs.bundler_rpc_url || matrix.bundler_rpc_url }}
           ACCEPTANCE_CHAIN_ID: ${{ matrix.expected_chain_id }}
           ACCEPTANCE_4337_RPC_URL: ${{ matrix.erc4337_rpc_url }}
           ACCEPTANCE_4337_ENTRY_POINT: ${{ matrix.entry_point }}

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -98,7 +98,7 @@ jobs:
             entry_point: ""
             safe_4337_module: ""
             safe_4337_wallet_deployer: ""
-            karst_enabled: "false"
+            karst_enabled: "true"
             karst_deposit_enabled: "false"
             optimism_portal: ""
             allow_failure: true
@@ -153,6 +153,7 @@ jobs:
           ACCEPTANCE_L1_RPC_URL: ${{ secrets.SEPOLIA_RPC_URL }}
           ACCEPTANCE_BUNDLER_RPC_URL: ${{ matrix.network == 'alchemy-dev' && inputs.bundler_rpc_url != '' && inputs.bundler_rpc_url || matrix.bundler_rpc_url }}
           ACCEPTANCE_CHAIN_ID: ${{ matrix.expected_chain_id }}
+          ACCEPTANCE_L2_KEY: ${{ secrets.ACCEPTANCE_L2_KEY }}
           ACCEPTANCE_4337_RPC_URL: ${{ matrix.erc4337_rpc_url }}
           ACCEPTANCE_4337_ENTRY_POINT: ${{ matrix.entry_point }}
           ACCEPTANCE_4337_MODULE: ${{ matrix.safe_4337_module }}

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -99,8 +99,8 @@ jobs:
             safe_4337_module: ""
             safe_4337_wallet_deployer: ""
             karst_enabled: "true"
-            karst_deposit_enabled: "false"
-            optimism_portal: ""
+            karst_deposit_enabled: "true"
+            optimism_portal: "0x58b38d8155f5bf9bfde8c8435cfbb3eb7dc66bb5"
             allow_failure: true
     steps:
       - name: Skip unselected network

--- a/e2e-tests/src/it/acceptance_tests/karst.rs
+++ b/e2e-tests/src/it/acceptance_tests/karst.rs
@@ -61,16 +61,23 @@ const CLZ_INIT_CODE: &[u8] = &[
 pub(super) async fn l2_execution_checks(env: &RpcEnv) -> eyre::Result<()> {
     if !env.config().karst_enabled {
         info!("ACCEPTANCE_KARST_ENABLED not set, skipping Karst L2 acceptance tests");
+        eprintln!("karst: ACCEPTANCE_KARST_ENABLED not set, skipping L2 execution checks");
         return Ok(());
     }
     let l2_key = env.config().l2_key.clone();
 
+    eprintln!(
+        "karst: running L2 execution checks: network={}, l2_key_address={}",
+        env.config().network,
+        l2_key.address()
+    );
     info!(
         network = %env.config().network,
         l2_key_address = %l2_key.address(),
         "running Karst L2 execution acceptance tests"
     );
 
+    eprintln!("karst: checking EIP-7910 eth_config");
     check_eip_7910_eth_config(env).await?;
 
     let mut sender = L2TxSender::new(
@@ -81,14 +88,22 @@ pub(super) async fn l2_execution_checks(env: &RpcEnv) -> eyre::Result<()> {
     )
     .await?;
 
+    eprintln!("karst: checking EIP-7823 MODEXP input bound");
     check_eip_7823_modexp_upper_bound(&mut sender).await?;
+    eprintln!("karst: checking EIP-7883 MODEXP gas floor");
     check_eip_7883_modexp_gas_floor_increase(&mut sender).await?;
+    eprintln!("karst: checking EIP-7951 P256VERIFY gas cost");
     check_eip_7951_p256verify_gas_cost(&mut sender).await?;
+    eprintln!("karst: checking bn256 pairing input limit");
     check_karst_bn256_pairing_input_size_reduction(&mut sender).await?;
+    eprintln!("karst: checking EIP-7939 CLZ opcode activation");
     check_eip_7939_clz_opcode_activation(&mut sender).await?;
+    eprintln!("karst: checking EIP-7825 transaction gas cap");
     check_eip_7825_tx_gas_limit_cap(&mut sender).await?;
+    eprintln!("karst: checking EIP-7825 deposit bypass");
     check_eip_7825_deposit_bypasses_tx_gas_limit_cap(env).await?;
 
+    eprintln!("karst: L2 execution checks completed");
     info!("Karst L2 execution acceptance tests completed");
     Ok(())
 }
@@ -314,6 +329,9 @@ async fn check_eip_7825_deposit_bypasses_tx_gas_limit_cap(env: &RpcEnv) -> eyre:
         info!(
             "ACCEPTANCE_KARST_DEPOSIT_ENABLED not set, skipping Karst deposit bypass acceptance test"
         );
+        eprintln!(
+            "karst: ACCEPTANCE_KARST_DEPOSIT_ENABLED not set, skipping EIP-7825 deposit bypass"
+        );
         return Ok(());
     };
     let l1_provider = env
@@ -330,6 +348,13 @@ async fn check_eip_7825_deposit_bypasses_tx_gas_limit_cap(env: &RpcEnv) -> eyre:
         deposit_transaction_request(l1_sender, config.optimism_portal, config.deposit_value);
     // Send-time fee fillers do not run during our explicit eth_estimateGas preflight.
     let request = with_estimated_l1_fees(&l1_provider, request).await?;
+    eprintln!(
+        "karst: preflighting EIP-7825 deposit bypass: l1_rpc={}, l1_sender={}, optimism_portal={}, deposit_gas_limit={}",
+        config.l1_rpc_target(),
+        l1_sender,
+        config.optimism_portal,
+        MAX_TX_GAS + 1
+    );
 
     let estimated_gas = match l1_provider.estimate_gas(request.clone()).await {
         Ok(estimated_gas) if estimated_gas <= config.deposit_max_l1_gas => estimated_gas,
@@ -338,6 +363,10 @@ async fn check_eip_7825_deposit_bypasses_tx_gas_limit_cap(env: &RpcEnv) -> eyre:
                 estimated_gas,
                 max_l1_gas = config.deposit_max_l1_gas,
                 "EIP-7825 deposit bypass preflight exceeded the configured L1 gas limit; skipping environment-dependent check"
+            );
+            eprintln!(
+                "karst: skipping EIP-7825 deposit bypass: estimated_l1_gas={} exceeds max_l1_gas={}",
+                estimated_gas, config.deposit_max_l1_gas
             );
             return Ok(());
         }
@@ -360,11 +389,16 @@ async fn check_eip_7825_deposit_bypasses_tx_gas_limit_cap(env: &RpcEnv) -> eyre:
             .min(config.deposit_max_l1_gas),
     );
 
+    eprintln!(
+        "karst: submitting EIP-7825 deposit bypass L1 tx: estimated_l1_gas={}, max_l1_gas={}",
+        estimated_gas, config.deposit_max_l1_gas
+    );
     let pending_tx = l1_provider
         .send_transaction(request)
         .await
         .context("EIP-7825 deposit bypass: failed to submit L1 deposit transaction")?;
     let l1_hash = *pending_tx.tx_hash();
+    eprintln!("karst: waiting for EIP-7825 deposit bypass L1 receipt: l1_tx={l1_hash:?}");
     let l1_receipt = wait_for_transaction_receipt(
         &l1_provider,
         "EIP-7825 deposit bypass L1 deposit",
@@ -378,6 +412,10 @@ async fn check_eip_7825_deposit_bypasses_tx_gas_limit_cap(env: &RpcEnv) -> eyre:
         "EIP-7825 deposit bypass: L1 deposit tx {l1_hash:?} reverted in block {:?}",
         l1_receipt.block_number
     );
+    eprintln!(
+        "karst: EIP-7825 deposit bypass L1 receipt included: l1_tx={l1_hash:?}, l1_block={:?}",
+        l1_receipt.block_number
+    );
 
     let deposit_tx = deposit_tx_from_receipt(&l1_receipt, config.optimism_portal)?;
     ensure!(
@@ -387,6 +425,7 @@ async fn check_eip_7825_deposit_bypasses_tx_gas_limit_cap(env: &RpcEnv) -> eyre:
         deposit_tx.gas_limit
     );
     let l2_hash = deposit_tx.tx_hash();
+    eprintln!("karst: waiting for EIP-7825 deposit bypass L2 receipt: l2_tx={l2_hash:?}");
     let l2_receipt = wait_for_deposit_receipt(
         env.optimism_provider(),
         "EIP-7825 deposit bypass L2 deposit",
@@ -401,6 +440,10 @@ async fn check_eip_7825_deposit_bypasses_tx_gas_limit_cap(env: &RpcEnv) -> eyre:
         l2_receipt.block_number
     );
 
+    eprintln!(
+        "karst: EIP-7825 deposit bypass included successfully: l1_tx={l1_hash:?}, l1_block={:?}, l2_tx={l2_hash:?}, l2_block={}",
+        l1_receipt.block_number, l2_receipt.block_number
+    );
     info!(
         l1_tx = ?l1_hash,
         l1_block = ?l1_receipt.block_number,

--- a/e2e-tests/src/it/acceptance_tests/utils.rs
+++ b/e2e-tests/src/it/acceptance_tests/utils.rs
@@ -63,6 +63,7 @@ impl L2TxSender {
         expected_success: bool,
     ) -> eyre::Result<TransactionReceipt> {
         let request = self.transaction_request(to, data, gas_limit);
+        eprintln!("karst: submitting {label} transaction");
         let pending_tx = self
             .provider
             .send_transaction(request)
@@ -90,6 +91,11 @@ impl L2TxSender {
             success = receipt.status(),
             "{label}"
         );
+        eprintln!(
+            "karst: {label} receipt: success={}, block={:?}, tx={hash:?}",
+            receipt.status(),
+            receipt.block_number
+        );
 
         Ok(receipt)
     }
@@ -102,6 +108,7 @@ impl L2TxSender {
         gas_limit: u64,
     ) -> eyre::Result<()> {
         let request = self.transaction_request(to, data, gas_limit);
+        eprintln!("karst: expecting {label} transaction submission to be rejected");
 
         match self.provider.send_transaction(request).await {
             Ok(pending_tx) => {
@@ -125,6 +132,7 @@ impl L2TxSender {
                     err = %err,
                     "{label}: transaction rejected as expected"
                 );
+                eprintln!("karst: {label} transaction rejected as expected: {err}");
                 Ok(())
             }
         }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only naming and wiring for an existing dev acceptance target; no application or production runtime changes.
> 
> **Overview**
> Renames the dev EU acceptance test target from **`alphanet`** to **`alchemy-dev`** in the GitHub Actions acceptance workflow.
> 
> The workflow dispatch **network** choice, matrix job key, and the conditional that lets a manual **`bundler_rpc_url`** override the matrix default now use **`alchemy-dev`** instead of **`alphanet`**. Endpoints and chain ID for that matrix row are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5f13114b27604ae579a16b32f523825d38aa1e2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->