### PR TITLE
refactor(challenger): add new challenger logic

### DIFF
--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -11,7 +11,7 @@ use std::{
 use alloy_eips::{BlockNumberOrTag, eip1559::BaseFeeParams};
 use alloy_genesis::Genesis;
 use alloy_network::EthereumWallet;
-use alloy_primitives::{Address, B64, U256, hex, keccak256};
+use alloy_primitives::{Address, B64, hex, keccak256};
 use alloy_provider::{Provider, ProviderBuilder};
 use alloy_signer_local::PrivateKeySigner;
 use base64::prelude::{BASE64_STANDARD, Engine};
@@ -40,7 +40,11 @@ use tokio::{
 use tracing::{Instrument, debug, info, info_span, warn};
 use url::{Host, Url};
 use world_chain_chainspec::{WorldChainHardfork, WorldChainSpec};
-use world_chain_challenger::{AlloyChallengerClient, ChallengerConfig, WorldChainChallenger};
+use world_chain_challenger::{
+    AlloyChallengerClient, BondManager as ChallengerBondManager,
+    BondManagerConfig as ChallengerBondManagerConfig, ChallengerClient, ChallengerConfig,
+    OwnedGames, ResolutionManager, ResolutionManagerConfig, WorldChainChallenger,
+};
 use world_chain_defender::{AlloyDefenderClient, DefenderConfig, WorldChainDefender};
 use world_chain_proof_kona_host_utils::online::OnlineHostConfig;
 use world_chain_proof_succinct_host_utils::{
@@ -98,9 +102,6 @@ const SP1_WORKER_PROVER_ENV: &str = "DEVNET_SP1_WORKER_PROVER";
 const SP1_PRIVATE_KEY_ENV: &str = "SP1_PRIVATE_KEY";
 /// Delay between World Chain proof-system proposal attempts.
 const WORLD_PROPOSER_POLL_INTERVAL: Duration = Duration::from_secs(2);
-/// Bond, in wei, sent with every `WorldChainProofSystemGame.challenge`.
-/// Matches `CHALLENGER_BOND` (0.1 ether) in `scripts/devnet/DeployProofSystem.s.sol`.
-const WORLD_CHALLENGER_BOND_WEI: u128 = 100_000_000_000_000_000;
 /// Delay between World Chain proof-system challenger scans.
 const WORLD_CHALLENGER_POLL_INTERVAL: Duration = Duration::from_secs(2);
 /// Delay between World Chain proof-system defender scans.
@@ -2471,7 +2472,7 @@ async fn start_world_chain_proposer(
 /// The challenger signs with [`WORLD_CHALLENGER_PRIVATE_KEY`], a dedicated dev
 /// account that is funded through the L1 genesis (see [`fund_world_challenger`])
 /// and staked in the `MockStakingRegistry` by `DeployProofSystem.s.sol`. It scans
-/// `WorldChainProofSystemFactory.GameCreated` events, recomputes the expected
+/// indexed factory games, recomputes the expected
 /// output root from the op-node rollup RPC, and challenges any game whose
 /// `rootClaim` disagrees by calling `WorldChainProofSystemGame.challenge` on L1.
 async fn start_world_chain_challenger(
@@ -2494,25 +2495,57 @@ async fn start_world_chain_challenger(
 
     let client = AlloyChallengerClient::new(provider, factory_address);
     let output_roots = OptimismConsensusClient::new(output_root_rpc_url.to_string());
+    let challenger_bond = client
+        .challenger_bond()
+        .await
+        .wrap_err("failed to read challenger bond")?;
     let config = ChallengerConfig {
-        challenger_bond: U256::from(WORLD_CHALLENGER_BOND_WEI),
+        challenger_bond,
         poll_interval: WORLD_CHALLENGER_POLL_INTERVAL,
         ..ChallengerConfig::default()
     };
-    let mut challenger = WorldChainChallenger::new(config, client, output_roots);
+    let owned_games = OwnedGames::default();
+    let mut challenger = WorldChainChallenger::with_owned_games(
+        config,
+        client.clone(),
+        output_roots,
+        owned_games.clone(),
+    );
+    let resolution_manager = ResolutionManager::new(
+        ResolutionManagerConfig::default(),
+        client.clone(),
+        owned_games.clone(),
+    );
+    let mut bond_manager =
+        ChallengerBondManager::new(ChallengerBondManagerConfig::default(), client, owned_games);
 
     info!(
         l1_rpc_url,
         output_root_rpc_url,
         factory = %deployment.proof_system_factory,
         challenger = %challenger_address,
+        challenger_bond = ?challenger_bond,
         "starting native World Chain proof-system challenger"
     );
 
     let handle = tokio::spawn(
         async move {
-            if let Err(error) = challenger.run_forever().await {
-                warn!(%error, "World Chain proof-system challenger stopped");
+            tokio::select! {
+                result = challenger.run_forever() => {
+                    if let Err(error) = result {
+                        warn!(%error, "World Chain proof-system challenger stopped");
+                    }
+                }
+                result = resolution_manager.run_forever() => {
+                    if let Err(error) = result {
+                        warn!(%error, "World Chain challenger resolution manager stopped");
+                    }
+                }
+                result = bond_manager.run_forever() => {
+                    if let Err(error) = result {
+                        warn!(%error, "World Chain challenger bond manager stopped");
+                    }
+                }
             }
         }
         .instrument(info_span!(

--- a/proofs/challenger/Cargo.toml
+++ b/proofs/challenger/Cargo.toml
@@ -35,7 +35,7 @@ reqwest = { workspace = true, features = ["json", "rustls-tls"] }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "time"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "sync", "time"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
 url.workspace = true

--- a/proofs/challenger/Cargo.toml
+++ b/proofs/challenger/Cargo.toml
@@ -35,7 +35,7 @@ reqwest = { workspace = true, features = ["json", "rustls-tls"] }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "sync", "time"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "time"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
 url.workspace = true

--- a/proofs/challenger/src/alloy.rs
+++ b/proofs/challenger/src/alloy.rs
@@ -1,31 +1,103 @@
-use crate::{error::ChallengerError, traits::ChallengerClient, types::ChallengeSubmission};
-use alloy_primitives::{Address, BlockNumber, U256};
-use alloy_provider::Provider;
+use std::sync::Arc;
+
+use crate::{
+    error::ChallengerError,
+    traits::{BondManagerClient, ChallengerClient, ResolutionManagerClient},
+    types::{ChallengeSubmission, GameMetadata, ResolveSubmission, WithdrawSubmission},
+};
+use alloy_primitives::{Address, U256};
+use alloy_provider::{Provider, WalletProvider};
 use alloy_rpc_types_eth::BlockId;
 use async_trait::async_trait;
+use tokio::sync::Mutex;
 use world_chain_proofs::{
-    GameCreated, IWorldChainProofSystemFactory, IWorldChainProofSystemGame, RootState,
+    IWorldChainProofSystemFactory, IWorldChainProofSystemGame, InvalidationReasonError,
+    ResolutionStatus, RootState, RootStateError,
 };
 
-/// Alloy-backed implementation of [`ChallengerClient`].
+/// Alloy-backed implementation of the challenger contract clients.
 #[derive(Debug, Clone)]
 pub struct AlloyChallengerClient<P> {
     factory: IWorldChainProofSystemFactory::IWorldChainProofSystemFactoryInstance<P>,
     provider: P,
+    transaction_lock: Arc<Mutex<()>>,
 }
 
 impl<P> AlloyChallengerClient<P>
 where
     P: Provider + Clone,
 {
-    /// Creates a new Alloy-backed contract client.
+    /// Creates an Alloy-backed contract client.
     pub fn new(provider: P, factory_address: Address) -> Self {
         let factory = IWorldChainProofSystemFactory::IWorldChainProofSystemFactoryInstance::new(
             factory_address,
             provider.clone(),
         );
 
-        Self { factory, provider }
+        Self {
+            factory,
+            provider,
+            transaction_lock: Arc::new(Mutex::new(())),
+        }
+    }
+
+    fn game(
+        &self,
+        address: Address,
+    ) -> IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance<P> {
+        IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance::new(
+            address,
+            self.provider.clone(),
+        )
+    }
+
+    async fn read_game_count(&self) -> Result<u64, ChallengerError> {
+        let count = self
+            .factory
+            .gameCount()
+            .block(BlockId::finalized())
+            .call()
+            .await
+            .map_err(|error| ChallengerError::Contract(error.to_string()))?;
+        u256_to_u64(count, "gameCount")
+    }
+
+    async fn read_game_address(&self, index: u64) -> Result<Address, ChallengerError> {
+        self.factory
+            .gameAt(U256::from(index))
+            .block(BlockId::finalized())
+            .call()
+            .await
+            .map_err(|error| ChallengerError::Contract(error.to_string()))
+    }
+
+    async fn read_resolution_status(
+        &self,
+        address: Address,
+    ) -> Result<ResolutionStatus, ChallengerError> {
+        let result = self
+            .game(address)
+            .resolutionStatus()
+            .call()
+            .await
+            .map_err(|error| ChallengerError::Contract(error.to_string()))?;
+        let root_state = result
+            .outcome
+            .try_into()
+            .map_err(|error: RootStateError| ChallengerError::Contract(error.to_string()))?;
+        let invalidation_reason =
+            result
+                .reason
+                .try_into()
+                .map_err(|error: InvalidationReasonError| {
+                    ChallengerError::Contract(error.to_string())
+                })?;
+
+        Ok(ResolutionStatus {
+            resolvable: result.resolvable,
+            root_state,
+            invalidation_reason,
+        })
     }
 }
 
@@ -34,97 +106,188 @@ impl<P> ChallengerClient for AlloyChallengerClient<P>
 where
     P: Provider + Clone + Send + Sync + 'static,
 {
-    async fn root_state(&self, game: Address) -> Result<RootState, ChallengerError> {
-        let game = IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance::new(
-            game,
-            self.provider.clone(),
-        );
-        let root_state_raw = game
+    async fn challenger_bond(&self) -> Result<U256, ChallengerError> {
+        self.factory
+            .challengerBond()
+            .call()
+            .await
+            .map_err(|error| ChallengerError::Contract(error.to_string()))
+    }
+
+    async fn game_count(&self) -> Result<u64, ChallengerError> {
+        self.read_game_count().await
+    }
+
+    async fn game_address_at(&self, index: u64) -> Result<Address, ChallengerError> {
+        self.read_game_address(index).await
+    }
+
+    async fn game_metadata(&self, address: Address) -> Result<GameMetadata, ChallengerError> {
+        let game = self.game(address);
+        let (root_claim, l2_block_number) = tokio::try_join!(
+            async {
+                game.rootClaim()
+                    .call()
+                    .await
+                    .map_err(|error| ChallengerError::Contract(error.to_string()))
+            },
+            async {
+                game.l2BlockNumber()
+                    .call()
+                    .await
+                    .map_err(|error| ChallengerError::Contract(error.to_string()))
+            }
+        )?;
+
+        Ok(GameMetadata {
+            address,
+            root_claim,
+            l2_block_number: u256_to_u64(l2_block_number, "l2BlockNumber")?,
+        })
+    }
+
+    async fn root_state(&self, address: Address) -> Result<RootState, ChallengerError> {
+        let raw = self
+            .game(address)
             .state()
             .call()
             .await
-            .map_err(|err| ChallengerError::Contract(err.to_string()))?;
-        let root_state: RootState = root_state_raw.try_into()?;
-        Ok(root_state)
+            .map_err(|error| ChallengerError::Contract(error.to_string()))?;
+        raw.try_into().map_err(Into::into)
     }
 
-    async fn finalized_l1_block_num(&self) -> Result<BlockNumber, ChallengerError> {
-        self.provider
-            .get_block(BlockId::finalized())
-            .await
-            .map_err(|err| ChallengerError::Rpc(err.to_string()))?
-            .map(|block| block.number())
-            .ok_or(ChallengerError::L1FinalizedBlockNotFound)
-    }
-
-    async fn games_created(
-        &self,
-        from: BlockNumber,
-        to: BlockNumber,
-    ) -> Result<Vec<GameCreated>, ChallengerError> {
-        let logs = self
-            .factory
-            .GameCreated_filter()
-            .from_block(from)
-            .to_block(to)
-            .query()
-            .await
-            .map_err(|err| ChallengerError::Rpc(err.to_string()))?;
-
-        logs.into_iter()
-            .map(|(event, _log)| {
-                Ok(GameCreated {
-                    proposal_key: event.proposalKey,
-                    root_id: event.rootId,
-                    game: event.game,
-                    proposer: event.proposer,
-                    root_claim: event.rootClaim,
-                    l2_block_number: u256_to_u64(event.l2BlockNumber, "l2BlockNumber")?,
-                    parent_ref: event.parentRef,
-                    l1_origin_hash: event.l1OriginHash,
-                    l1_origin_number: u256_to_u64(event.l1OriginNumber, "l1OriginNumber")?,
-                })
-            })
-            .collect()
-    }
-
-    async fn challenge_deadline(&self, game: Address) -> Result<u64, ChallengerError> {
-        let game = IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance::new(
-            game,
-            self.provider.clone(),
-        );
-        let challenge_deadline = game
+    async fn challenge_deadline(&self, address: Address) -> Result<u64, ChallengerError> {
+        self.game(address)
             .challengeDeadline()
             .call()
             .await
-            .map_err(|err| ChallengerError::Contract(err.to_string()))?;
-        Ok(challenge_deadline)
+            .map_err(|error| ChallengerError::Contract(error.to_string()))
     }
 
     async fn submit_challenge(
         &self,
-        game: Address,
+        address: Address,
         challenger_bond: U256,
     ) -> Result<ChallengeSubmission, ChallengerError> {
-        let game = IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance::new(
-            game,
-            self.provider.clone(),
-        );
-        let pending = game
+        let _guard = self.transaction_lock.lock().await;
+        let pending = self
+            .game(address)
             .challenge()
             .value(challenger_bond)
             .send()
             .await
-            .map_err(|err| ChallengerError::Contract(err.to_string()))?;
+            .map_err(|error| ChallengerError::Contract(error.to_string()))?;
         let tx_hash = *pending.tx_hash();
         let receipt = pending
             .get_receipt()
             .await
-            .map_err(|err| ChallengerError::Contract(err.to_string()))?;
+            .map_err(|error| ChallengerError::Contract(error.to_string()))?;
         if !receipt.status() {
             return Err(ChallengerError::Revert(tx_hash));
         }
         Ok(ChallengeSubmission { tx_hash })
+    }
+}
+
+#[async_trait]
+impl<P> ResolutionManagerClient for AlloyChallengerClient<P>
+where
+    P: Provider + Clone + Send + Sync + 'static,
+{
+    async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ChallengerError> {
+        self.read_resolution_status(game).await
+    }
+
+    async fn resolve(&self, address: Address) -> Result<ResolveSubmission, ChallengerError> {
+        let _guard = self.transaction_lock.lock().await;
+        let pending = self
+            .game(address)
+            .resolve()
+            .send()
+            .await
+            .map_err(|error| ChallengerError::Contract(error.to_string()))?;
+        let tx_hash = *pending.tx_hash();
+        let receipt = pending
+            .get_receipt()
+            .await
+            .map_err(|error| ChallengerError::Contract(error.to_string()))?;
+        if !receipt.status() {
+            return Err(ChallengerError::Revert(tx_hash));
+        }
+        Ok(ResolveSubmission { tx_hash })
+    }
+}
+
+#[async_trait]
+impl<P> BondManagerClient for AlloyChallengerClient<P>
+where
+    P: Provider + WalletProvider + Clone + Send + Sync + 'static,
+{
+    fn challenger_address(&self) -> Address {
+        self.provider.default_signer_address()
+    }
+
+    async fn game_count(&self) -> Result<u64, ChallengerError> {
+        self.read_game_count().await
+    }
+
+    async fn game_address_at(&self, index: u64) -> Result<Address, ChallengerError> {
+        self.read_game_address(index).await
+    }
+
+    async fn game_challenger(&self, address: Address) -> Result<Address, ChallengerError> {
+        self.game(address)
+            .challenger()
+            .call()
+            .await
+            .map_err(|error| ChallengerError::Contract(error.to_string()))
+    }
+
+    async fn claimable(&self, address: Address) -> Result<U256, ChallengerError> {
+        let challenger = self.challenger_address();
+        self.game(address)
+            .claimable(challenger)
+            .call()
+            .await
+            .map_err(|error| ChallengerError::Contract(error.to_string()))
+    }
+
+    async fn withdraw(&self, address: Address) -> Result<WithdrawSubmission, ChallengerError> {
+        let challenger = self.challenger_address();
+        let _guard = self.transaction_lock.lock().await;
+        let game = self.game(address);
+        let pending = game
+            .withdraw(challenger)
+            .send()
+            .await
+            .map_err(|error| ChallengerError::Contract(error.to_string()))?;
+        let tx_hash = *pending.tx_hash();
+        let receipt = pending
+            .get_receipt()
+            .await
+            .map_err(|error| ChallengerError::Contract(error.to_string()))?;
+        if !receipt.status() {
+            return Err(ChallengerError::Revert(tx_hash));
+        }
+
+        let amount = receipt
+            .logs()
+            .iter()
+            .filter(|log| log.address() == address)
+            .find_map(|log| {
+                log.log_decode_validate::<IWorldChainProofSystemGame::Withdrawn>()
+                    .ok()
+                    .map(|decoded| decoded.inner.data)
+            })
+            .filter(|event| event.recipient == challenger)
+            .map(|event| event.amount)
+            .ok_or_else(|| {
+                ChallengerError::Contract(format!(
+                    "Withdrawn event missing from withdraw transaction {tx_hash}"
+                ))
+            })?;
+
+        Ok(WithdrawSubmission { tx_hash, amount })
     }
 }
 

--- a/proofs/challenger/src/alloy.rs
+++ b/proofs/challenger/src/alloy.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::{
     error::ChallengerError,
     traits::{BondManagerClient, ChallengerClient, ResolutionManagerClient},
@@ -9,7 +7,6 @@ use alloy_primitives::{Address, U256};
 use alloy_provider::{Provider, WalletProvider};
 use alloy_rpc_types_eth::BlockId;
 use async_trait::async_trait;
-use tokio::sync::Mutex;
 use world_chain_proofs::{
     IWorldChainProofSystemFactory, IWorldChainProofSystemGame, InvalidationReasonError,
     ResolutionStatus, RootState, RootStateError,
@@ -20,7 +17,6 @@ use world_chain_proofs::{
 pub struct AlloyChallengerClient<P> {
     factory: IWorldChainProofSystemFactory::IWorldChainProofSystemFactoryInstance<P>,
     provider: P,
-    transaction_lock: Arc<Mutex<()>>,
 }
 
 impl<P> AlloyChallengerClient<P>
@@ -34,11 +30,7 @@ where
             provider.clone(),
         );
 
-        Self {
-            factory,
-            provider,
-            transaction_lock: Arc::new(Mutex::new(())),
-        }
+        Self { factory, provider }
     }
 
     fn game(
@@ -169,7 +161,6 @@ where
         address: Address,
         challenger_bond: U256,
     ) -> Result<ChallengeSubmission, ChallengerError> {
-        let _guard = self.transaction_lock.lock().await;
         let pending = self
             .game(address)
             .challenge()
@@ -199,7 +190,6 @@ where
     }
 
     async fn resolve(&self, address: Address) -> Result<ResolveSubmission, ChallengerError> {
-        let _guard = self.transaction_lock.lock().await;
         let pending = self
             .game(address)
             .resolve()
@@ -254,7 +244,6 @@ where
 
     async fn withdraw(&self, address: Address) -> Result<WithdrawSubmission, ChallengerError> {
         let challenger = self.challenger_address();
-        let _guard = self.transaction_lock.lock().await;
         let game = self.game(address);
         let pending = game
             .withdraw(challenger)

--- a/proofs/challenger/src/bond_manager.rs
+++ b/proofs/challenger/src/bond_manager.rs
@@ -1,0 +1,127 @@
+use alloy_primitives::U256;
+use tracing::{info, warn};
+
+use crate::{BondManagerClient, BondManagerConfig, ChallengerError, OwnedGames};
+
+/// Discovers challenger-owned games and withdraws their resolved bond credits.
+#[derive(Debug)]
+pub struct BondManager<E> {
+    config: BondManagerConfig,
+    execution_provider: E,
+    owned_games: OwnedGames,
+    next_game_index: Option<u64>,
+}
+
+impl<E> BondManager<E> {
+    /// Creates an empty bond manager. Its bounded recovery window is scanned on the first pass.
+    pub const fn new(
+        config: BondManagerConfig,
+        execution_provider: E,
+        owned_games: OwnedGames,
+    ) -> Self {
+        Self {
+            config,
+            execution_provider,
+            owned_games,
+            next_game_index: None,
+        }
+    }
+
+    /// Returns the bond-manager configuration.
+    #[must_use]
+    pub const fn config(&self) -> &BondManagerConfig {
+        &self.config
+    }
+
+    /// Returns the next factory game index to scan, once initialized.
+    #[must_use]
+    pub const fn next_game_index(&self) -> Option<u64> {
+        self.next_game_index
+    }
+}
+
+impl<E> BondManager<E>
+where
+    E: BondManagerClient,
+{
+    /// Scans the bounded startup window or games appended since the last scan.
+    pub async fn scan_games(&mut self) -> Result<(), ChallengerError> {
+        self.config.validate()?;
+
+        let game_count = self.execution_provider.game_count().await?;
+        let start = match self.next_game_index {
+            Some(next_game_index) if next_game_index <= game_count => next_game_index,
+            Some(_) | None => game_count.saturating_sub(self.config.initial_scan_limit),
+        };
+        let challenger = self.execution_provider.challenger_address();
+
+        for index in start..game_count {
+            let game = self.execution_provider.game_address_at(index).await?;
+            if self.execution_provider.game_challenger(game).await? == challenger {
+                self.owned_games.insert(game);
+            }
+        }
+
+        self.next_game_index = Some(game_count);
+        info!(
+            start_game_index = start,
+            next_game_index = game_count,
+            tracked_games = self.owned_games.snapshot().len(),
+            "scanned challenger bond games"
+        );
+        Ok(())
+    }
+
+    /// Withdraws available credits and prunes owned games that reached a terminal state.
+    pub async fn withdraw_credits(&self) -> Result<(), ChallengerError> {
+        let games = self.owned_games.snapshot();
+
+        for game in games {
+            let result: Result<bool, ChallengerError> = async {
+                let status = self.execution_provider.resolution_status(game).await?;
+                if !status.is_resolved() {
+                    return Ok(false);
+                }
+
+                let claimable = self.execution_provider.claimable(game).await?;
+                if claimable > U256::ZERO {
+                    let submission = self.execution_provider.withdraw(game).await?;
+                    info!(
+                        game_address = %game,
+                        tx_hash = ?submission.tx_hash,
+                        amount = ?submission.amount,
+                        "withdrew challenger bond credits"
+                    );
+                }
+                Ok(true)
+            }
+            .await;
+
+            match result {
+                Ok(true) => self.owned_games.remove(game),
+                Ok(false) => {}
+                Err(error) => {
+                    warn!(%error, game_address = %game, "failed to process challenger bond credits");
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Runs recent-game discovery and withdrawals forever.
+    pub async fn run_forever(&mut self) -> Result<(), ChallengerError> {
+        self.config.validate()?;
+
+        let mut interval = tokio::time::interval(self.config.poll_interval);
+        loop {
+            interval.tick().await;
+            if let Err(error) = self.scan_games().await {
+                warn!(%error, "bond-manager game scan failed; retrying on next tick");
+            }
+            if let Err(error) = self.withdraw_credits().await {
+                warn!(%error, "bond-manager withdrawal pass failed; retrying on next tick");
+            }
+        }
+    }
+}

--- a/proofs/challenger/src/challenger.rs
+++ b/proofs/challenger/src/challenger.rs
@@ -2,7 +2,7 @@ use crate::{
     config::ChallengerConfig,
     error::{ChallengerError, GameScanError},
     traits::ChallengerClient,
-    types::{GameScanOutcome, RetryGame},
+    types::{GameMetadata, GameScanOutcome, OwnedGames, RetryGame},
 };
 use alloy_primitives::{Address, BlockNumber};
 use futures_util::{StreamExt, stream};
@@ -10,33 +10,45 @@ use std::{
     collections::HashMap,
     time::{SystemTime, UNIX_EPOCH},
 };
-use tracing::warn;
-use world_chain_proofs::{ConsensusProvider, GameCreated, RootState};
+use tracing::{info, warn};
+use world_chain_proofs::{ConsensusProvider, RootState};
 
-/// The number of L1 blocks published in 24h.
-const ONE_DAY_OF_L1_BLOCKS: u64 = 7_200;
-/// The safety margin of blocks.
-const MARGIN: u64 = 500;
-
-/// World Chain Challenger.
+/// World Chain output-root challenger.
 #[derive(Debug)]
 pub struct WorldChainChallenger<E, C> {
     config: ChallengerConfig,
     execution_provider: E,
     consensus_provider: C,
-    cursor: BlockNumber,
+    next_game_index: Option<u64>,
     retry_games: HashMap<Address, RetryGame>,
+    owned_games: OwnedGames,
 }
 
 impl<E, C> WorldChainChallenger<E, C> {
-    /// Creates a challenger from contract and output-root clients.
+    /// Creates a challenger with a private owned-game registry.
     pub fn new(config: ChallengerConfig, execution_provider: E, consensus_provider: C) -> Self {
+        Self::with_owned_games(
+            config,
+            execution_provider,
+            consensus_provider,
+            OwnedGames::default(),
+        )
+    }
+
+    /// Creates a challenger sharing owned games with lifecycle managers.
+    pub fn with_owned_games(
+        config: ChallengerConfig,
+        execution_provider: E,
+        consensus_provider: C,
+        owned_games: OwnedGames,
+    ) -> Self {
         Self {
             config,
             execution_provider,
             consensus_provider,
-            cursor: 0,
+            next_game_index: None,
             retry_games: HashMap::default(),
+            owned_games,
         }
     }
 
@@ -46,20 +58,26 @@ impl<E, C> WorldChainChallenger<E, C> {
         &self.config
     }
 
+    /// Returns the next factory game index to scan, once initialized.
+    #[must_use]
+    pub const fn next_game_index(&self) -> Option<u64> {
+        self.next_game_index
+    }
+
     #[cfg(test)]
     pub(crate) fn retry_games(&self) -> Vec<Address> {
         self.retry_games.keys().copied().collect()
     }
 
-    fn queue_retry_game(&mut self, game_created: GameCreated, challenge_deadline: Option<u64>) {
-        let existing = self.retry_games.get(&game_created.game);
+    fn queue_retry_game(&mut self, game: GameMetadata, challenge_deadline: Option<u64>) {
+        let existing = self.retry_games.get(&game.address);
         let retry_game = RetryGame {
-            game_created,
+            game,
             challenge_deadline: challenge_deadline
                 .or(existing.and_then(|retry| retry.challenge_deadline)),
             attempts: existing.map_or(1, |retry| retry.attempts.saturating_add(1)),
         };
-        self.retry_games.insert(game_created.game, retry_game);
+        self.retry_games.insert(game.address, retry_game);
     }
 }
 
@@ -68,83 +86,98 @@ where
     E: ChallengerClient,
     C: ConsensusProvider,
 {
+    async fn first_unexpired_game_index(
+        &self,
+        game_count: u64,
+        now: u64,
+    ) -> Result<u64, ChallengerError> {
+        let mut low = 0;
+        let mut high = game_count;
+
+        while low < high {
+            let middle = low + (high - low) / 2;
+            let game = self.execution_provider.game_address_at(middle).await?;
+            let deadline = self.execution_provider.challenge_deadline(game).await?;
+            if deadline <= now {
+                low = middle + 1;
+            } else {
+                high = middle;
+            }
+        }
+
+        Ok(low)
+    }
+
     async fn process_game(
         &self,
-        game_created: &GameCreated,
+        game: &GameMetadata,
         latest_finalized_l2_block: BlockNumber,
         now: u64,
     ) -> Result<GameScanOutcome, GameScanError> {
-        let game = game_created.game;
+        let address = game.address;
         let root_state = self
             .execution_provider
-            .root_state(game)
+            .root_state(address)
             .await
             .map_err(|error| GameScanError {
                 error,
                 challenge_deadline: None,
             })?;
         if root_state != RootState::Proposed {
-            // root state is not `Proposed` anymore, skip immediately
             return Ok(GameScanOutcome::Skip);
         }
+
         let challenge_deadline = self
             .execution_provider
-            .challenge_deadline(game)
+            .challenge_deadline(address)
             .await
             .map_err(|error| GameScanError {
                 error,
                 challenge_deadline: None,
             })?;
-        let challenge_deadline_value = challenge_deadline;
-        let challenge_deadline = Some(challenge_deadline_value);
-
-        if now >= challenge_deadline_value {
-            // challenge deadline has expired, skip immediately
+        if now >= challenge_deadline {
             return Ok(GameScanOutcome::Skip);
         }
-        // ensure that the l2 block is finalized
-        if game_created.l2_block_number > latest_finalized_l2_block {
+
+        if game.l2_block_number > latest_finalized_l2_block {
             return Err(GameScanError {
                 error: ChallengerError::L2BlockNotFinalized {
-                    game,
+                    game: address,
                     latest_finalized: latest_finalized_l2_block,
-                    given_block: game_created.l2_block_number,
+                    given_block: game.l2_block_number,
                 },
-                challenge_deadline,
+                challenge_deadline: Some(challenge_deadline),
             });
         }
 
         match self
             .consensus_provider
-            .output_root_at_block(game_created.l2_block_number)
+            .output_root_at_block(game.l2_block_number)
             .await
         {
-            Ok(root) if root != game_created.root_claim => Ok(GameScanOutcome::NeedsChallenge {
-                challenge_deadline: challenge_deadline_value,
-            }),
-            Ok(_root) => {
-                // valid root, leave it
-                Ok(GameScanOutcome::Valid)
+            Ok(root) if root != game.root_claim => {
+                Ok(GameScanOutcome::NeedsChallenge { challenge_deadline })
             }
-            Err(err) => Err(GameScanError {
-                error: ChallengerError::OutputRoot(err),
-                challenge_deadline,
+            Ok(_root) => Ok(GameScanOutcome::Valid),
+            Err(error) => Err(GameScanError {
+                error: ChallengerError::OutputRoot(error),
+                challenge_deadline: Some(challenge_deadline),
             }),
         }
     }
 
     async fn process_games(
         &self,
-        games: impl IntoIterator<Item = GameCreated>,
+        games: impl IntoIterator<Item = GameMetadata>,
         latest_finalized_l2_block: BlockNumber,
         now: u64,
-    ) -> Vec<(GameCreated, Result<GameScanOutcome, GameScanError>)> {
+    ) -> Vec<(GameMetadata, Result<GameScanOutcome, GameScanError>)> {
         stream::iter(games)
-            .map(|game_created| async move {
+            .map(|game| async move {
                 let result = self
-                    .process_game(&game_created, latest_finalized_l2_block, now)
+                    .process_game(&game, latest_finalized_l2_block, now)
                     .await;
-                (game_created, result)
+                (game, result)
             })
             .buffer_unordered(self.config.max_game_concurrency)
             .collect()
@@ -153,94 +186,108 @@ where
 
     async fn handle_game_results(
         &mut self,
-        results: Vec<(GameCreated, Result<GameScanOutcome, GameScanError>)>,
+        results: Vec<(GameMetadata, Result<GameScanOutcome, GameScanError>)>,
         failure_message: &'static str,
     ) {
         let mut challenge_games = Vec::new();
 
-        for (game_created, result) in results {
+        for (game, result) in results {
             match result {
                 Ok(GameScanOutcome::NeedsChallenge { challenge_deadline }) => {
-                    challenge_games.push((game_created, challenge_deadline));
+                    challenge_games.push((game, challenge_deadline));
                 }
                 Ok(_outcome) => {
-                    self.retry_games.remove(&game_created.game);
+                    self.retry_games.remove(&game.address);
                 }
-                Err(err) => {
-                    warn!(game = %game_created.game, error = %err.error, "{failure_message}");
-                    self.queue_retry_game(game_created, err.challenge_deadline);
+                Err(error) => {
+                    warn!(game = %game.address, error = %error.error, "{failure_message}");
+                    self.queue_retry_game(game, error.challenge_deadline);
                 }
             }
         }
 
-        challenge_games.sort_by_key(|(_game_created, challenge_deadline)| *challenge_deadline);
-
-        for (game_created, challenge_deadline) in challenge_games {
+        challenge_games.sort_by_key(|(_game, challenge_deadline)| *challenge_deadline);
+        for (game, challenge_deadline) in challenge_games {
             match self
                 .execution_provider
-                .submit_challenge(game_created.game, self.config.challenger_bond)
+                .submit_challenge(game.address, self.config.challenger_bond)
                 .await
             {
-                Ok(_submission) => {
-                    self.retry_games.remove(&game_created.game);
+                Ok(submission) => {
+                    self.retry_games.remove(&game.address);
+                    self.owned_games.insert(game.address);
+                    info!(
+                        game_address = %game.address,
+                        tx_hash = ?submission.tx_hash,
+                        "challenged invalid World Chain proof-system game"
+                    );
                 }
                 Err(error) => {
-                    warn!(game = %game_created.game, %error, "challenge submission failed; adding to retry list");
-                    self.queue_retry_game(game_created, Some(challenge_deadline));
+                    warn!(
+                        game = %game.address,
+                        %error,
+                        "challenge submission failed; adding to retry list"
+                    );
+                    self.queue_retry_game(game, Some(challenge_deadline));
                 }
             }
         }
     }
 
+    /// Scans one bounded factory range and retries transient validation failures.
     pub async fn scan_once(&mut self) -> Result<(), ChallengerError> {
-        let target = self.execution_provider.finalized_l1_block_num().await?;
-        let from = if self.cursor == 0 {
-            target.saturating_sub(ONE_DAY_OF_L1_BLOCKS + MARGIN)
-        } else {
-            self.cursor
-        };
-        let has_new_l1_blocks = from <= target;
-        let mut games_created = if has_new_l1_blocks {
-            self.execution_provider.games_created(from, target).await?
-        } else {
-            Vec::new()
-        };
+        self.config.validate()?;
 
-        if games_created.is_empty() && self.retry_games.is_empty() {
-            if has_new_l1_blocks {
-                self.cursor = target + 1;
+        let now = unix_now();
+        let game_count = self.execution_provider.game_count().await?;
+        if self
+            .next_game_index
+            .is_none_or(|next_game_index| next_game_index > game_count)
+        {
+            let first_unexpired = self.first_unexpired_game_index(game_count, now).await?;
+            info!(
+                first_unexpired_game_index = first_unexpired,
+                game_count, "initialized challenger game cursor"
+            );
+            self.next_game_index = Some(first_unexpired);
+        }
+
+        let start = self.next_game_index.unwrap_or(game_count);
+        let end = start
+            .saturating_add(self.config.max_games_per_tick)
+            .min(game_count);
+        let mut new_games = Vec::with_capacity((end - start) as usize);
+        for index in start..end {
+            let game = self.execution_provider.game_address_at(index).await?;
+            let metadata = self.execution_provider.game_metadata(game).await?;
+            if !self.retry_games.contains_key(&game) {
+                new_games.push(metadata);
             }
+        }
+
+        if new_games.is_empty() && self.retry_games.is_empty() {
+            self.next_game_index = Some(end);
             return Ok(());
         }
 
         let latest_finalized_l2_block = self.consensus_provider.latest_l2_finalized_block().await?;
-        let now = unix_now();
-
         let mut retry_games: Vec<RetryGame> = self.retry_games.values().copied().collect();
-        // sort retry games by deadline with unknown deadlines first
         retry_games.sort_by_key(|retry| retry.challenge_deadline.unwrap_or(0));
-        // retain only games that are not already in `retry_games`
-        games_created.retain(|game_created| !self.retry_games.contains_key(&game_created.game));
-
         retry_games.retain(|retry_game| {
-            let game = retry_game.game_created.game;
             if retry_game
                 .challenge_deadline
                 .is_some_and(|challenge_deadline| now >= challenge_deadline)
             {
-                warn!(game = %game, "dropping retry game after challenge deadline");
-                self.retry_games.remove(&game);
+                warn!(game = %retry_game.game.address, "dropping retry game after challenge deadline");
+                self.retry_games.remove(&retry_game.game.address);
                 return false;
             }
-
             true
         });
 
         let retry_results = self
             .process_games(
-                retry_games
-                    .into_iter()
-                    .map(|retry_game| retry_game.game_created),
+                retry_games.into_iter().map(|retry_game| retry_game.game),
                 latest_finalized_l2_block,
                 now,
             )
@@ -249,14 +296,12 @@ where
             .await;
 
         let scan_results = self
-            .process_games(games_created, latest_finalized_l2_block, now)
+            .process_games(new_games, latest_finalized_l2_block, now)
             .await;
         self.handle_game_results(scan_results, "game scan failed; adding to retry list")
             .await;
-        // if the scan goes well, update the cursor
-        if has_new_l1_blocks {
-            self.cursor = target + 1;
-        }
+
+        self.next_game_index = Some(end);
         Ok(())
     }
 
@@ -267,8 +312,8 @@ where
         let mut interval = tokio::time::interval(self.config.poll_interval);
         loop {
             interval.tick().await;
-            if let Err(e) = self.scan_once().await {
-                warn!(%e, "scan attempt failed");
+            if let Err(error) = self.scan_once().await {
+                warn!(%error, "scan attempt failed");
             }
         }
     }

--- a/proofs/challenger/src/config.rs
+++ b/proofs/challenger/src/config.rs
@@ -4,16 +4,28 @@ use std::time::Duration;
 
 /// Default number of games processed concurrently.
 pub const DEFAULT_MAX_GAME_CONCURRENCY: usize = 10;
+/// Default maximum number of new factory games discovered per challenger tick.
+pub const DEFAULT_MAX_GAMES_PER_TICK: u64 = 100;
+/// Default delay between challenger-owned game resolution passes.
+pub const DEFAULT_RESOLUTION_POLL_INTERVAL: Duration = Duration::from_secs(30);
+/// Default maximum number of resolution transactions submitted per pass.
+pub const DEFAULT_MAX_RESOLUTIONS_PER_TICK: usize = 1;
+/// Default delay between challenger-bond discovery and withdrawal passes.
+pub const DEFAULT_BOND_MANAGER_POLL_INTERVAL: Duration = Duration::from_secs(5 * 60);
+/// Default number of recent factory games inspected for challenger ownership.
+pub const DEFAULT_BOND_MANAGER_INITIAL_SCAN_LIMIT: u64 = 1_000;
 
 /// Configuration for the challenger.
 #[derive(Debug, Clone)]
 pub struct ChallengerConfig {
-    /// Bond sent with `WorldChainProofSystemGame.challenge`.
+    /// Bond read from the factory and sent with `WorldChainProofSystemGame.challenge`.
     pub challenger_bond: U256,
     /// Delay between periodic scan attempts.
     pub poll_interval: Duration,
     /// Maximum number of games to process concurrently.
     pub max_game_concurrency: usize,
+    /// Maximum number of newly created games discovered during one tick.
+    pub max_games_per_tick: u64,
 }
 
 impl ChallengerConfig {
@@ -28,6 +40,11 @@ impl ChallengerConfig {
                 "max_game_concurrency must be greater than zero",
             ));
         }
+        if self.max_games_per_tick == 0 {
+            return Err(ChallengerError::InvalidConfig(
+                "max_games_per_tick must be greater than zero",
+            ));
+        }
         Ok(())
     }
 }
@@ -38,6 +55,75 @@ impl Default for ChallengerConfig {
             challenger_bond: U256::ZERO,
             poll_interval: Duration::from_mins(1),
             max_game_concurrency: DEFAULT_MAX_GAME_CONCURRENCY,
+            max_games_per_tick: DEFAULT_MAX_GAMES_PER_TICK,
+        }
+    }
+}
+
+/// Configuration for asynchronous resolution of challenger-owned games.
+#[derive(Debug, Clone)]
+pub struct ResolutionManagerConfig {
+    /// Delay between resolution passes.
+    pub poll_interval: Duration,
+    /// Maximum number of resolution transactions submitted per pass.
+    pub max_resolutions_per_tick: usize,
+}
+
+impl ResolutionManagerConfig {
+    pub(crate) fn validate(&self) -> Result<(), ChallengerError> {
+        if self.poll_interval.is_zero() {
+            return Err(ChallengerError::InvalidConfig(
+                "resolution_manager.poll_interval must be greater than zero",
+            ));
+        }
+        if self.max_resolutions_per_tick == 0 {
+            return Err(ChallengerError::InvalidConfig(
+                "resolution_manager.max_resolutions_per_tick must be greater than zero",
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Default for ResolutionManagerConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval: DEFAULT_RESOLUTION_POLL_INTERVAL,
+            max_resolutions_per_tick: DEFAULT_MAX_RESOLUTIONS_PER_TICK,
+        }
+    }
+}
+
+/// Configuration for asynchronous challenger-bond management.
+#[derive(Debug, Clone)]
+pub struct BondManagerConfig {
+    /// Delay between factory scans and withdrawal attempts.
+    pub poll_interval: Duration,
+    /// Number of most recently created games scanned on startup.
+    pub initial_scan_limit: u64,
+}
+
+impl BondManagerConfig {
+    pub(crate) fn validate(&self) -> Result<(), ChallengerError> {
+        if self.poll_interval.is_zero() {
+            return Err(ChallengerError::InvalidConfig(
+                "bond_manager.poll_interval must be greater than zero",
+            ));
+        }
+        if self.initial_scan_limit == 0 {
+            return Err(ChallengerError::InvalidConfig(
+                "bond_manager.initial_scan_limit must be greater than zero",
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Default for BondManagerConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval: DEFAULT_BOND_MANAGER_POLL_INTERVAL,
+            initial_scan_limit: DEFAULT_BOND_MANAGER_INITIAL_SCAN_LIMIT,
         }
     }
 }

--- a/proofs/challenger/src/error.rs
+++ b/proofs/challenger/src/error.rs
@@ -2,7 +2,7 @@ use alloy_primitives::{Address, TxHash};
 use thiserror::Error;
 use world_chain_proofs::{ConsensusError, RootStateError};
 
-/// Errors returned by the proposer.
+/// Errors returned by the challenger and its lifecycle managers.
 #[derive(Debug, Error)]
 pub enum ChallengerError {
     /// Invalid challenger configuration.

--- a/proofs/challenger/src/lib.rs
+++ b/proofs/challenger/src/lib.rs
@@ -1,19 +1,29 @@
 //! World Chain Challenger.
 
 mod alloy;
+mod bond_manager;
 mod challenger;
 mod config;
 mod error;
+mod resolution_manager;
 mod traits;
 mod types;
 
 // re-exports
 pub use alloy::AlloyChallengerClient;
+pub use bond_manager::BondManager;
 pub use challenger::WorldChainChallenger;
-pub use config::ChallengerConfig;
+pub use config::{
+    BondManagerConfig, ChallengerConfig, DEFAULT_BOND_MANAGER_INITIAL_SCAN_LIMIT,
+    DEFAULT_BOND_MANAGER_POLL_INTERVAL, DEFAULT_MAX_GAME_CONCURRENCY, DEFAULT_MAX_GAMES_PER_TICK,
+    DEFAULT_MAX_RESOLUTIONS_PER_TICK, DEFAULT_RESOLUTION_POLL_INTERVAL, ResolutionManagerConfig,
+};
 pub use error::ChallengerError;
-pub use traits::ChallengerClient;
-pub use types::ChallengeSubmission;
+pub use resolution_manager::ResolutionManager;
+pub use traits::{BondManagerClient, ChallengerClient, ResolutionManagerClient};
+pub use types::{
+    ChallengeSubmission, GameMetadata, OwnedGames, ResolveSubmission, WithdrawSubmission,
+};
 
 #[cfg(test)]
 mod tests;

--- a/proofs/challenger/src/main.rs
+++ b/proofs/challenger/src/main.rs
@@ -8,14 +8,17 @@
 use std::time::Duration;
 
 use alloy_network::EthereumWallet;
-use alloy_primitives::{Address, U256};
+use alloy_primitives::Address;
 use alloy_provider::ProviderBuilder;
 use alloy_signer_local::PrivateKeySigner;
 use anyhow::{Context, Result};
 use clap::Parser;
 use tracing::info;
 use url::Url;
-use world_chain_challenger::{AlloyChallengerClient, ChallengerConfig, WorldChainChallenger};
+use world_chain_challenger::{
+    AlloyChallengerClient, BondManager, BondManagerConfig, ChallengerClient, ChallengerConfig,
+    OwnedGames, ResolutionManager, ResolutionManagerConfig, WorldChainChallenger,
+};
 use world_chain_proofs::OptimismConsensusClient;
 
 #[derive(Debug, Parser)]
@@ -40,14 +43,6 @@ struct Cli {
     #[arg(long, env = "CHALLENGER_KEY", hide_env_values = true)]
     challenger_key: PrivateKeySigner,
 
-    /// Bond posted with each challenge, in wei (default 0.1 ETH).
-    #[arg(
-        long,
-        env = "CHALLENGER_BOND_WEI",
-        default_value_t = 100_000_000_000_000_000
-    )]
-    challenger_bond_wei: u128,
-
     /// Seconds between game-factory polls.
     #[arg(long, env = "POLL_INTERVAL_SECONDS", default_value_t = 12)]
     poll_interval_seconds: u64,
@@ -55,6 +50,34 @@ struct Cli {
     /// Maximum number of games processed concurrently.
     #[arg(long, env = "MAX_GAME_CONCURRENCY", default_value_t = 10)]
     max_game_concurrency: usize,
+
+    /// Maximum number of newly created games discovered per challenger tick.
+    #[arg(long, env = "MAX_GAMES_PER_TICK", default_value_t = 100)]
+    max_games_per_tick: u64,
+
+    /// Seconds between challenger-owned game resolution passes.
+    #[arg(
+        long,
+        env = "RESOLUTION_MANAGER_POLL_INTERVAL_SECONDS",
+        default_value_t = 30
+    )]
+    resolution_manager_poll_interval_seconds: u64,
+
+    /// Maximum number of game resolutions submitted per resolution pass.
+    #[arg(long, env = "MAX_RESOLUTIONS_PER_TICK", default_value_t = 1)]
+    max_resolutions_per_tick: usize,
+
+    /// Seconds between challenger-bond discovery and withdrawal passes.
+    #[arg(
+        long,
+        env = "BOND_MANAGER_POLL_INTERVAL_SECONDS",
+        default_value_t = 300
+    )]
+    bond_manager_poll_interval_seconds: u64,
+
+    /// Number of recent factory games scanned when the bond manager starts.
+    #[arg(long, env = "BOND_MANAGER_INITIAL_SCAN_LIMIT", default_value_t = 1_000)]
+    bond_manager_initial_scan_limit: u64,
 }
 
 #[tokio::main]
@@ -73,23 +96,54 @@ async fn main() -> Result<()> {
 
     let client = AlloyChallengerClient::new(provider, cli.factory_address);
     let output_roots = OptimismConsensusClient::new(cli.output_root_rpc.clone());
+    let challenger_bond = client
+        .challenger_bond()
+        .await
+        .context("failed to read challenger bond")?;
     let config = ChallengerConfig {
-        challenger_bond: U256::from(cli.challenger_bond_wei),
+        challenger_bond,
         poll_interval: Duration::from_secs(cli.poll_interval_seconds),
         max_game_concurrency: cli.max_game_concurrency,
+        max_games_per_tick: cli.max_games_per_tick,
     };
-    let mut challenger = WorldChainChallenger::new(config, client, output_roots);
+    let resolution_config = ResolutionManagerConfig {
+        poll_interval: Duration::from_secs(cli.resolution_manager_poll_interval_seconds),
+        max_resolutions_per_tick: cli.max_resolutions_per_tick,
+    };
+    let bond_manager_config = BondManagerConfig {
+        poll_interval: Duration::from_secs(cli.bond_manager_poll_interval_seconds),
+        initial_scan_limit: cli.bond_manager_initial_scan_limit,
+    };
+    let owned_games = OwnedGames::default();
+    let mut challenger = WorldChainChallenger::with_owned_games(
+        config,
+        client.clone(),
+        output_roots,
+        owned_games.clone(),
+    );
+    let resolution_manager =
+        ResolutionManager::new(resolution_config, client.clone(), owned_games.clone());
+    let mut bond_manager = BondManager::new(bond_manager_config, client, owned_games);
 
     info!(
         l1_rpc_url = %cli.l1_rpc,
         output_root_rpc_url = %cli.output_root_rpc,
         factory = %cli.factory_address,
         challenger = %challenger_address,
+        challenger_bond = ?challenger_bond,
+        max_games_per_tick = cli.max_games_per_tick,
+        resolution_manager_poll_interval_seconds =
+            cli.resolution_manager_poll_interval_seconds,
+        max_resolutions_per_tick = cli.max_resolutions_per_tick,
+        bond_manager_poll_interval_seconds = cli.bond_manager_poll_interval_seconds,
+        bond_manager_initial_scan_limit = cli.bond_manager_initial_scan_limit,
         "starting World Chain proof-system challenger"
     );
 
     tokio::select! {
         result = challenger.run_forever() => result.context("challenger stopped")?,
+        result = resolution_manager.run_forever() => result.context("resolution manager stopped")?,
+        result = bond_manager.run_forever() => result.context("bond manager stopped")?,
         _ = tokio::signal::ctrl_c() => info!("received ctrl-c, shutting down"),
     }
     Ok(())

--- a/proofs/challenger/src/resolution_manager.rs
+++ b/proofs/challenger/src/resolution_manager.rs
@@ -1,0 +1,104 @@
+use tracing::{info, warn};
+use world_chain_proofs::{InvalidationReason, RootState};
+
+use crate::{ChallengerError, OwnedGames, ResolutionManagerClient, ResolutionManagerConfig};
+
+/// Resolves games challenged by the managed challenger once their outcome is ready.
+#[derive(Debug)]
+pub struct ResolutionManager<E> {
+    config: ResolutionManagerConfig,
+    execution_provider: E,
+    owned_games: OwnedGames,
+}
+
+impl<E> ResolutionManager<E> {
+    /// Creates a resolution manager backed by the shared owned-game registry.
+    pub const fn new(
+        config: ResolutionManagerConfig,
+        execution_provider: E,
+        owned_games: OwnedGames,
+    ) -> Self {
+        Self {
+            config,
+            execution_provider,
+            owned_games,
+        }
+    }
+
+    /// Returns the resolution-manager configuration.
+    #[must_use]
+    pub const fn config(&self) -> &ResolutionManagerConfig {
+        &self.config
+    }
+}
+
+impl<E> ResolutionManager<E>
+where
+    E: ResolutionManagerClient,
+{
+    /// Resolves at most the configured number of currently resolvable owned games.
+    pub async fn resolve_games(&self) -> Result<(), ChallengerError> {
+        self.config.validate()?;
+
+        let mut games = self.owned_games.snapshot();
+        // keep game selection deterministic when the per-tick resolution budget is reached
+        games.sort_unstable();
+        let mut resolutions_submitted = 0;
+
+        for game in games {
+            if resolutions_submitted >= self.config.max_resolutions_per_tick {
+                break;
+            }
+            let result: Result<(), ChallengerError> = async {
+                let status = self.execution_provider.resolution_status(game).await?;
+                if !status.resolvable {
+                    return Ok(());
+                }
+                if status.root_state != RootState::Invalidated
+                    || status.invalidation_reason != InvalidationReason::ProofTimeout
+                {
+                    warn!(
+                        game_address = %game,
+                        outcome = ?status.root_state,
+                        invalidation_reason = ?status.invalidation_reason,
+                        "challenger-owned invalid game has an unexpected resolvable outcome"
+                    );
+                }
+
+                let submission = self.execution_provider.resolve(game).await?;
+                info!(
+                    game_address = %game,
+                    tx_hash = ?submission.tx_hash,
+                    outcome = ?status.root_state,
+                    invalidation_reason = ?status.invalidation_reason,
+                    "resolved challenger-owned game"
+                );
+                resolutions_submitted += 1;
+                Ok(())
+            }
+            .await;
+
+            match result {
+                Ok(()) => {}
+                Err(error) => {
+                    warn!(%error, game_address = %game, "failed to resolve challenger-owned game");
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Runs resolution passes forever on an interval independent of game scanning.
+    pub async fn run_forever(&self) -> Result<(), ChallengerError> {
+        self.config.validate()?;
+
+        let mut interval = tokio::time::interval(self.config.poll_interval);
+        loop {
+            interval.tick().await;
+            if let Err(error) = self.resolve_games().await {
+                warn!(%error, "challenger resolution pass failed; retrying on next tick");
+            }
+        }
+    }
+}

--- a/proofs/challenger/src/tests.rs
+++ b/proofs/challenger/src/tests.rs
@@ -1,73 +1,161 @@
 use crate::{
-    challenger::WorldChainChallenger, config::ChallengerConfig, error::ChallengerError,
-    traits::ChallengerClient, types::ChallengeSubmission,
+    BondManager, BondManagerClient, BondManagerConfig, ChallengeSubmission, ChallengerClient,
+    ChallengerConfig, ChallengerError, GameMetadata, OwnedGames, ResolutionManager,
+    ResolutionManagerClient, ResolutionManagerConfig, ResolveSubmission, WithdrawSubmission,
+    challenger::WorldChainChallenger,
 };
 use alloy_primitives::{Address, B256, BlockNumber, U256, address};
 use async_trait::async_trait;
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::{
         Arc, Mutex,
         atomic::{AtomicU64, Ordering},
     },
     time::Duration,
 };
-use world_chain_proofs::{ConsensusError, ConsensusProvider, GameCreated, RootState};
+use world_chain_proofs::{
+    ConsensusError, ConsensusProvider, InvalidationReason, ResolutionStatus, RootState,
+};
 
+const CHALLENGER: Address = address!("00000000000000000000000000000000000000cc");
 const GAME_1: Address = address!("0000000000000000000000000000000000000001");
 const GAME_2: Address = address!("0000000000000000000000000000000000000002");
-const FINALIZED_L1_BLOCK: BlockNumber = 10_000;
+const GAME_3: Address = address!("0000000000000000000000000000000000000003");
 const L2_BLOCK: u64 = 100;
 
-/// State discriminant matching [`RootState::Proposed`].
 const STATE_PROPOSED: u8 = 1;
-/// State discriminant matching [`RootState::Challenged`].
 const STATE_CHALLENGED: u8 = 2;
+const STATE_FINALIZED: u8 = 3;
+const STATE_INVALIDATED: u8 = 4;
+const REASON_NONE: u8 = 0;
+const REASON_PROOF_TIMEOUT: u8 = 1;
+
+#[derive(Debug, Clone, Copy)]
+struct MockGame {
+    metadata: GameMetadata,
+    state: u8,
+    challenge_deadline: u64,
+    challenger: Address,
+    resolvable: bool,
+    resolution_outcome: u8,
+    resolution_reason: u8,
+    claimable: U256,
+}
+
+impl MockGame {
+    fn proposed(address: Address, root_claim: B256, l2_block_number: u64) -> Self {
+        Self {
+            metadata: GameMetadata {
+                address,
+                root_claim,
+                l2_block_number,
+            },
+            state: STATE_PROPOSED,
+            challenge_deadline: u64::MAX,
+            challenger: Address::ZERO,
+            resolvable: false,
+            resolution_outcome: STATE_PROPOSED,
+            resolution_reason: REASON_NONE,
+            claimable: U256::ZERO,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct MockState {
+    order: Vec<Address>,
+    games: HashMap<Address, MockGame>,
+    requested_indices: Vec<u64>,
+    challenges: Vec<Address>,
+    resolutions: Vec<Address>,
+    withdrawals: Vec<Address>,
+    fail_withdraw_once: HashSet<Address>,
+}
 
 #[derive(Debug, Clone)]
 struct MockClient {
-    finalized: BlockNumber,
-    games: Vec<(Address, B256, u64)>,
-    states: HashMap<Address, u8>,
-    deadlines: HashMap<Address, u64>,
-    submissions: Arc<Mutex<Vec<Address>>>,
+    state: Arc<Mutex<MockState>>,
+}
+
+impl MockClient {
+    fn new(games: Vec<MockGame>) -> Self {
+        let order = games.iter().map(|game| game.metadata.address).collect();
+        let games = games
+            .into_iter()
+            .map(|game| (game.metadata.address, game))
+            .collect();
+        Self {
+            state: Arc::new(Mutex::new(MockState {
+                order,
+                games,
+                ..MockState::default()
+            })),
+        }
+    }
+
+    fn challenges(&self) -> Vec<Address> {
+        self.state.lock().expect("not poisoned").challenges.clone()
+    }
+
+    fn resolutions(&self) -> Vec<Address> {
+        self.state.lock().expect("not poisoned").resolutions.clone()
+    }
+
+    fn withdrawals(&self) -> Vec<Address> {
+        self.state.lock().expect("not poisoned").withdrawals.clone()
+    }
 }
 
 #[async_trait]
 impl ChallengerClient for MockClient {
+    async fn challenger_bond(&self) -> Result<U256, ChallengerError> {
+        Ok(U256::from(1))
+    }
+
+    async fn game_count(&self) -> Result<u64, ChallengerError> {
+        Ok(self.state.lock().expect("not poisoned").order.len() as u64)
+    }
+
+    async fn game_address_at(&self, index: u64) -> Result<Address, ChallengerError> {
+        let mut state = self.state.lock().expect("not poisoned");
+        state.requested_indices.push(index);
+        state
+            .order
+            .get(index as usize)
+            .copied()
+            .ok_or_else(|| ChallengerError::Contract(format!("unknown game index {index}")))
+    }
+
+    async fn game_metadata(&self, game: Address) -> Result<GameMetadata, ChallengerError> {
+        self.state
+            .lock()
+            .expect("not poisoned")
+            .games
+            .get(&game)
+            .map(|game| game.metadata)
+            .ok_or_else(|| ChallengerError::Contract(format!("unknown game {game}")))
+    }
+
     async fn root_state(&self, game: Address) -> Result<RootState, ChallengerError> {
-        let raw = self.states.get(&game).copied().unwrap_or(STATE_PROPOSED);
+        let raw = self
+            .state
+            .lock()
+            .expect("not poisoned")
+            .games
+            .get(&game)
+            .map_or(0, |game| game.state);
         RootState::try_from(raw).map_err(Into::into)
     }
 
-    async fn finalized_l1_block_num(&self) -> Result<BlockNumber, ChallengerError> {
-        Ok(self.finalized)
-    }
-
-    async fn games_created(
-        &self,
-        _from: BlockNumber,
-        _to: BlockNumber,
-    ) -> Result<Vec<GameCreated>, ChallengerError> {
-        Ok(self
-            .games
-            .iter()
-            .map(|&(game, root_claim, l2_block_number)| GameCreated {
-                proposal_key: B256::ZERO,
-                root_id: B256::ZERO,
-                game,
-                proposer: Address::ZERO,
-                root_claim,
-                l2_block_number,
-                parent_ref: Address::ZERO,
-                l1_origin_hash: B256::ZERO,
-                l1_origin_number: 0,
-            })
-            .collect())
-    }
-
     async fn challenge_deadline(&self, game: Address) -> Result<u64, ChallengerError> {
-        Ok(self.deadlines.get(&game).copied().unwrap_or(u64::MAX))
+        self.state
+            .lock()
+            .expect("not poisoned")
+            .games
+            .get(&game)
+            .map(|game| game.challenge_deadline)
+            .ok_or_else(|| ChallengerError::Contract(format!("unknown game {game}")))
     }
 
     async fn submit_challenge(
@@ -75,9 +163,106 @@ impl ChallengerClient for MockClient {
         game: Address,
         _challenger_bond: U256,
     ) -> Result<ChallengeSubmission, ChallengerError> {
-        self.submissions.lock().expect("not poisoned").push(game);
+        let mut state = self.state.lock().expect("not poisoned");
+        let record = state
+            .games
+            .get_mut(&game)
+            .ok_or_else(|| ChallengerError::Contract(format!("unknown game {game}")))?;
+        record.state = STATE_CHALLENGED;
+        record.challenger = CHALLENGER;
+        record.resolution_outcome = STATE_CHALLENGED;
+        state.challenges.push(game);
         Ok(ChallengeSubmission {
-            tx_hash: B256::repeat_byte(0xaa),
+            tx_hash: B256::with_last_byte(state.challenges.len() as u8),
+        })
+    }
+}
+
+#[async_trait]
+impl ResolutionManagerClient for MockClient {
+    async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ChallengerError> {
+        let record = self
+            .state
+            .lock()
+            .expect("not poisoned")
+            .games
+            .get(&game)
+            .copied()
+            .ok_or_else(|| ChallengerError::Contract(format!("unknown game {game}")))?;
+        Ok(ResolutionStatus {
+            resolvable: record.resolvable,
+            root_state: RootState::try_from(record.resolution_outcome)?,
+            invalidation_reason: InvalidationReason::try_from(record.resolution_reason)
+                .map_err(|error| ChallengerError::Contract(error.to_string()))?,
+        })
+    }
+
+    async fn resolve(&self, game: Address) -> Result<ResolveSubmission, ChallengerError> {
+        let mut state = self.state.lock().expect("not poisoned");
+        let record = state
+            .games
+            .get_mut(&game)
+            .ok_or_else(|| ChallengerError::Contract(format!("unknown game {game}")))?;
+        record.state = record.resolution_outcome;
+        record.resolvable = false;
+        state.resolutions.push(game);
+        Ok(ResolveSubmission {
+            tx_hash: B256::with_last_byte(state.resolutions.len() as u8),
+        })
+    }
+}
+
+#[async_trait]
+impl BondManagerClient for MockClient {
+    fn challenger_address(&self) -> Address {
+        CHALLENGER
+    }
+
+    async fn game_count(&self) -> Result<u64, ChallengerError> {
+        ChallengerClient::game_count(self).await
+    }
+
+    async fn game_address_at(&self, index: u64) -> Result<Address, ChallengerError> {
+        ChallengerClient::game_address_at(self, index).await
+    }
+
+    async fn game_challenger(&self, game: Address) -> Result<Address, ChallengerError> {
+        self.state
+            .lock()
+            .expect("not poisoned")
+            .games
+            .get(&game)
+            .map(|game| game.challenger)
+            .ok_or_else(|| ChallengerError::Contract(format!("unknown game {game}")))
+    }
+
+    async fn claimable(&self, game: Address) -> Result<U256, ChallengerError> {
+        self.state
+            .lock()
+            .expect("not poisoned")
+            .games
+            .get(&game)
+            .map(|game| game.claimable)
+            .ok_or_else(|| ChallengerError::Contract(format!("unknown game {game}")))
+    }
+
+    async fn withdraw(&self, game: Address) -> Result<WithdrawSubmission, ChallengerError> {
+        let mut state = self.state.lock().expect("not poisoned");
+        if state.fail_withdraw_once.remove(&game) {
+            return Err(ChallengerError::Contract(
+                "injected withdrawal failure".into(),
+            ));
+        }
+        let record = state
+            .games
+            .get_mut(&game)
+            .ok_or_else(|| ChallengerError::Contract(format!("unknown game {game}")))?;
+        let amount = record.claimable;
+        record.claimable = U256::ZERO;
+        state.withdrawals.push(game);
+        Ok(WithdrawSubmission {
+            tx_hash: B256::with_last_byte(state.withdrawals.len() as u8),
+            amount,
         })
     }
 }
@@ -120,192 +305,242 @@ fn config() -> ChallengerConfig {
     ChallengerConfig {
         challenger_bond: U256::from(1),
         poll_interval: Duration::from_secs(1),
-        ..ChallengerConfig::default()
+        max_game_concurrency: 10,
+        max_games_per_tick: 100,
     }
 }
 
 #[tokio::test]
-async fn scan_once_challenges_invalid_root() {
+async fn scan_once_challenges_invalid_root_and_tracks_game() {
     let proposed_root = B256::repeat_byte(0x10);
     let canonical_root = B256::repeat_byte(0x20);
-
-    let submissions = Arc::default();
-    let client = MockClient {
-        finalized: FINALIZED_L1_BLOCK,
-        games: vec![(GAME_1, proposed_root, L2_BLOCK)],
-        states: HashMap::new(),
-        deadlines: HashMap::new(),
-        submissions: Arc::clone(&submissions),
-    };
-    let (output_roots, _finalized_l2_block) =
+    let client = MockClient::new(vec![MockGame::proposed(GAME_1, proposed_root, L2_BLOCK)]);
+    let (output_roots, _) =
         mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
-    let mut challenger = WorldChainChallenger::new(config(), client, output_roots);
-
-    challenger.scan_once().await.unwrap();
-
-    assert_eq!(
-        submissions.lock().expect("not poisoned").as_slice(),
-        &[GAME_1]
+    let owned_games = OwnedGames::default();
+    let mut challenger = WorldChainChallenger::with_owned_games(
+        config(),
+        client.clone(),
+        output_roots,
+        owned_games.clone(),
     );
-}
-
-#[tokio::test]
-async fn scan_once_leaves_valid_root() {
-    let canonical_root = B256::repeat_byte(0x20);
-
-    let submissions = Arc::default();
-    let client = MockClient {
-        finalized: FINALIZED_L1_BLOCK,
-        games: vec![(GAME_1, canonical_root, L2_BLOCK)],
-        states: HashMap::new(),
-        deadlines: HashMap::new(),
-        submissions: Arc::clone(&submissions),
-    };
-    let (output_roots, _finalized_l2_block) =
-        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
-    let mut challenger = WorldChainChallenger::new(config(), client, output_roots);
 
     challenger.scan_once().await.unwrap();
 
-    assert!(submissions.lock().expect("not poisoned").is_empty());
+    assert_eq!(client.challenges(), vec![GAME_1]);
+    assert!(owned_games.contains(GAME_1));
+    assert_eq!(challenger.next_game_index(), Some(1));
+}
+
+#[tokio::test]
+async fn startup_binary_search_skips_expired_games() {
+    let proposed_root = B256::repeat_byte(0x10);
+    let canonical_root = B256::repeat_byte(0x20);
+    let mut expired = MockGame::proposed(GAME_1, proposed_root, L2_BLOCK);
+    expired.challenge_deadline = 0;
+    let active = MockGame::proposed(GAME_2, proposed_root, L2_BLOCK);
+    let client = MockClient::new(vec![expired, active]);
+    let (output_roots, _) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
+    let mut challenger = WorldChainChallenger::new(config(), client.clone(), output_roots);
+
+    challenger.scan_once().await.unwrap();
+
+    assert_eq!(client.challenges(), vec![GAME_2]);
+    assert_eq!(challenger.next_game_index(), Some(2));
+}
+
+#[tokio::test]
+async fn scan_once_respects_new_game_tick_budget() {
+    let proposed_root = B256::repeat_byte(0x10);
+    let canonical_root = B256::repeat_byte(0x20);
+    let client = MockClient::new(vec![
+        MockGame::proposed(GAME_1, proposed_root, L2_BLOCK),
+        MockGame::proposed(GAME_2, proposed_root, L2_BLOCK),
+        MockGame::proposed(GAME_3, proposed_root, L2_BLOCK),
+    ]);
+    let (output_roots, _) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
+    let mut limited_config = config();
+    limited_config.max_games_per_tick = 2;
+    let mut challenger = WorldChainChallenger::new(limited_config, client.clone(), output_roots);
+
+    challenger.scan_once().await.unwrap();
+    assert_eq!(client.challenges(), vec![GAME_1, GAME_2]);
+    assert_eq!(challenger.next_game_index(), Some(2));
+
+    challenger.scan_once().await.unwrap();
+    assert_eq!(client.challenges(), vec![GAME_1, GAME_2, GAME_3]);
+    assert_eq!(challenger.next_game_index(), Some(3));
+}
+
+#[tokio::test]
+async fn scan_once_leaves_valid_and_non_proposed_games() {
+    let canonical_root = B256::repeat_byte(0x20);
+    let valid = MockGame::proposed(GAME_1, canonical_root, L2_BLOCK);
+    let mut challenged = MockGame::proposed(GAME_2, B256::repeat_byte(0x10), L2_BLOCK);
+    challenged.state = STATE_CHALLENGED;
+    let client = MockClient::new(vec![valid, challenged]);
+    let (output_roots, _) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
+    let mut challenger = WorldChainChallenger::new(config(), client.clone(), output_roots);
+
+    challenger.scan_once().await.unwrap();
+
+    assert!(client.challenges().is_empty());
     assert!(challenger.retry_games().is_empty());
 }
 
 #[tokio::test]
-async fn scan_once_skips_non_proposed_game() {
+async fn retry_game_is_challenged_after_l2_finalizes() {
     let proposed_root = B256::repeat_byte(0x10);
     let canonical_root = B256::repeat_byte(0x20);
-
-    let submissions = Arc::default();
-    let client = MockClient {
-        finalized: FINALIZED_L1_BLOCK,
-        games: vec![(GAME_1, proposed_root, L2_BLOCK)],
-        states: HashMap::from([(GAME_1, STATE_CHALLENGED)]),
-        deadlines: HashMap::new(),
-        submissions: Arc::clone(&submissions),
-    };
-    let (output_roots, _finalized_l2_block) =
-        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
-    let mut challenger = WorldChainChallenger::new(config(), client, output_roots);
-
-    challenger.scan_once().await.unwrap();
-
-    assert!(submissions.lock().expect("not poisoned").is_empty());
-    assert!(challenger.retry_games().is_empty());
-}
-
-#[tokio::test]
-async fn scan_once_skips_expired_challenge_deadline() {
-    let proposed_root = B256::repeat_byte(0x10);
-    let canonical_root = B256::repeat_byte(0x20);
-
-    let submissions = Arc::default();
-    let client = MockClient {
-        finalized: FINALIZED_L1_BLOCK,
-        games: vec![(GAME_1, proposed_root, L2_BLOCK)],
-        states: HashMap::new(),
-        deadlines: HashMap::from([(GAME_1, 0)]),
-        submissions: Arc::clone(&submissions),
-    };
-    let (output_roots, _finalized_l2_block) =
-        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
-    let mut challenger = WorldChainChallenger::new(config(), client, output_roots);
-
-    challenger.scan_once().await.unwrap();
-
-    assert!(submissions.lock().expect("not poisoned").is_empty());
-    assert!(challenger.retry_games().is_empty());
-}
-
-#[tokio::test]
-async fn scan_once_rejects_unfinalized_l2_block() {
-    let proposed_root = B256::repeat_byte(0x10);
-    let canonical_root = B256::repeat_byte(0x20);
-
-    let submissions = Arc::default();
-    let client = MockClient {
-        finalized: FINALIZED_L1_BLOCK,
-        games: vec![(GAME_1, proposed_root, L2_BLOCK)],
-        states: HashMap::new(),
-        deadlines: HashMap::new(),
-        submissions: Arc::clone(&submissions),
-    };
-    let (output_roots, _finalized_l2_block) =
-        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK - 1);
-    let mut challenger = WorldChainChallenger::new(config(), client, output_roots);
-
-    // The game references an L2 block that is not finalized yet. This is a
-    // transient failure, so the game must not be challenged and instead be
-    // queued for a later retry, while the scan itself succeeds.
-    challenger.scan_once().await.unwrap();
-
-    assert!(submissions.lock().expect("not poisoned").is_empty());
-    assert_eq!(challenger.retry_games(), [GAME_1]);
-}
-
-#[tokio::test]
-async fn scan_once_processes_retry_games_without_new_l1_blocks() {
-    let proposed_root = B256::repeat_byte(0x10);
-    let canonical_root = B256::repeat_byte(0x20);
-
-    let submissions = Arc::default();
-    let client = MockClient {
-        finalized: FINALIZED_L1_BLOCK,
-        games: vec![(GAME_1, proposed_root, L2_BLOCK)],
-        states: HashMap::new(),
-        deadlines: HashMap::new(),
-        submissions: Arc::clone(&submissions),
-    };
+    let client = MockClient::new(vec![MockGame::proposed(GAME_1, proposed_root, L2_BLOCK)]);
     let (output_roots, finalized_l2_block) =
         mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK - 1);
-    let mut challenger = WorldChainChallenger::new(config(), client, output_roots);
+    let mut challenger = WorldChainChallenger::new(config(), client.clone(), output_roots);
 
     challenger.scan_once().await.unwrap();
-    assert_eq!(challenger.retry_games(), [GAME_1]);
+    assert_eq!(challenger.retry_games(), vec![GAME_1]);
+    assert!(client.challenges().is_empty());
 
     finalized_l2_block.store(L2_BLOCK, Ordering::SeqCst);
     challenger.scan_once().await.unwrap();
 
-    assert_eq!(
-        submissions.lock().expect("not poisoned").as_slice(),
-        &[GAME_1]
-    );
+    assert_eq!(client.challenges(), vec![GAME_1]);
     assert!(challenger.retry_games().is_empty());
 }
 
 #[tokio::test]
-async fn scan_once_processes_retry_games_by_challenge_deadline() {
-    let proposed_root_1 = B256::repeat_byte(0x10);
-    let proposed_root_2 = B256::repeat_byte(0x11);
-    let canonical_root_1 = B256::repeat_byte(0x20);
-    let canonical_root_2 = B256::repeat_byte(0x21);
-    let l2_block_2 = L2_BLOCK + 1;
-
-    let submissions = Arc::default();
-    let client = MockClient {
-        finalized: FINALIZED_L1_BLOCK,
-        games: vec![
-            (GAME_1, proposed_root_1, L2_BLOCK),
-            (GAME_2, proposed_root_2, l2_block_2),
-        ],
-        states: HashMap::new(),
-        deadlines: HashMap::from([(GAME_1, u64::MAX), (GAME_2, u64::MAX - 1)]),
-        submissions: Arc::clone(&submissions),
-    };
-    let (output_roots, finalized_l2_block) = mock_output_roots(
-        HashMap::from([(L2_BLOCK, canonical_root_1), (l2_block_2, canonical_root_2)]),
-        L2_BLOCK - 1,
+async fn resolution_manager_obeys_transaction_budget() {
+    let mut first = MockGame::proposed(GAME_1, B256::ZERO, L2_BLOCK);
+    first.state = STATE_CHALLENGED;
+    first.resolvable = true;
+    first.resolution_outcome = STATE_INVALIDATED;
+    first.resolution_reason = REASON_PROOF_TIMEOUT;
+    let mut second = first;
+    second.metadata.address = GAME_2;
+    let client = MockClient::new(vec![first, second]);
+    let owned_games = OwnedGames::default();
+    owned_games.insert(GAME_1);
+    owned_games.insert(GAME_2);
+    let manager = ResolutionManager::new(
+        ResolutionManagerConfig {
+            poll_interval: Duration::from_secs(30),
+            max_resolutions_per_tick: 1,
+        },
+        client.clone(),
+        owned_games,
     );
-    let mut challenger = WorldChainChallenger::new(config(), client, output_roots);
 
-    challenger.scan_once().await.unwrap();
+    manager.resolve_games().await.unwrap();
 
-    finalized_l2_block.store(l2_block_2, Ordering::SeqCst);
-    challenger.scan_once().await.unwrap();
+    assert_eq!(client.resolutions(), vec![GAME_1]);
+}
 
-    assert_eq!(
-        submissions.lock().expect("not poisoned").as_slice(),
-        &[GAME_2, GAME_1]
+#[tokio::test]
+async fn bond_manager_recovers_only_recent_owned_games() {
+    let mut old_owned = MockGame::proposed(GAME_1, B256::ZERO, L2_BLOCK);
+    old_owned.challenger = CHALLENGER;
+    let unowned = MockGame::proposed(GAME_2, B256::ZERO, L2_BLOCK);
+    let mut recent_owned = MockGame::proposed(GAME_3, B256::ZERO, L2_BLOCK);
+    recent_owned.challenger = CHALLENGER;
+    let client = MockClient::new(vec![old_owned, unowned, recent_owned]);
+    let owned_games = OwnedGames::default();
+    let mut manager = BondManager::new(
+        BondManagerConfig {
+            poll_interval: Duration::from_secs(300),
+            initial_scan_limit: 2,
+        },
+        client,
+        owned_games.clone(),
     );
-    assert!(challenger.retry_games().is_empty());
+
+    manager.scan_games().await.unwrap();
+
+    assert!(!owned_games.contains(GAME_1));
+    assert!(owned_games.contains(GAME_3));
+    assert_eq!(manager.next_game_index(), Some(3));
+}
+
+#[tokio::test]
+async fn bond_manager_scans_games_appended_after_recovery() {
+    let client = MockClient::new(vec![MockGame::proposed(GAME_1, B256::ZERO, L2_BLOCK)]);
+    let owned_games = OwnedGames::default();
+    let mut manager = BondManager::new(
+        BondManagerConfig::default(),
+        client.clone(),
+        owned_games.clone(),
+    );
+    manager.scan_games().await.unwrap();
+
+    let mut appended = MockGame::proposed(GAME_2, B256::ZERO, L2_BLOCK);
+    appended.challenger = CHALLENGER;
+    {
+        let mut state = client.state.lock().expect("not poisoned");
+        state.order.push(GAME_2);
+        state.games.insert(GAME_2, appended);
+    }
+
+    manager.scan_games().await.unwrap();
+
+    assert!(owned_games.contains(GAME_2));
+    assert_eq!(manager.next_game_index(), Some(2));
+}
+
+#[tokio::test]
+async fn bond_manager_withdraws_and_prunes_terminal_games() {
+    let mut withdrawable = MockGame::proposed(GAME_1, B256::ZERO, L2_BLOCK);
+    withdrawable.state = STATE_INVALIDATED;
+    withdrawable.resolution_outcome = STATE_INVALIDATED;
+    withdrawable.resolution_reason = REASON_PROOF_TIMEOUT;
+    withdrawable.claimable = U256::from(10);
+    let mut zero_credit = MockGame::proposed(GAME_2, B256::ZERO, L2_BLOCK);
+    zero_credit.state = STATE_FINALIZED;
+    zero_credit.resolution_outcome = STATE_FINALIZED;
+    let client = MockClient::new(vec![withdrawable, zero_credit]);
+    let owned_games = OwnedGames::default();
+    owned_games.insert(GAME_1);
+    owned_games.insert(GAME_2);
+    let manager = BondManager::new(
+        BondManagerConfig::default(),
+        client.clone(),
+        owned_games.clone(),
+    );
+
+    manager.withdraw_credits().await.unwrap();
+
+    assert_eq!(client.withdrawals(), vec![GAME_1]);
+    assert!(!owned_games.contains(GAME_1));
+    assert!(!owned_games.contains(GAME_2));
+}
+
+#[tokio::test]
+async fn bond_manager_retries_failed_withdrawal() {
+    let mut game = MockGame::proposed(GAME_1, B256::ZERO, L2_BLOCK);
+    game.state = STATE_INVALIDATED;
+    game.resolution_outcome = STATE_INVALIDATED;
+    game.resolution_reason = REASON_PROOF_TIMEOUT;
+    game.claimable = U256::from(10);
+    let client = MockClient::new(vec![game]);
+    client
+        .state
+        .lock()
+        .expect("not poisoned")
+        .fail_withdraw_once
+        .insert(GAME_1);
+    let owned_games = OwnedGames::default();
+    owned_games.insert(GAME_1);
+    let manager = BondManager::new(
+        BondManagerConfig::default(),
+        client.clone(),
+        owned_games.clone(),
+    );
+
+    manager.withdraw_credits().await.unwrap();
+    assert!(owned_games.contains(GAME_1));
+
+    manager.withdraw_credits().await.unwrap();
+    assert!(!owned_games.contains(GAME_1));
+    assert_eq!(client.withdrawals(), vec![GAME_1]);
 }

--- a/proofs/challenger/src/traits.rs
+++ b/proofs/challenger/src/traits.rs
@@ -1,26 +1,56 @@
-use crate::{error::ChallengerError, types::ChallengeSubmission};
-use alloy_primitives::{Address, BlockNumber, U256};
+use crate::{
+    ChallengerError,
+    types::{ChallengeSubmission, GameMetadata, ResolveSubmission, WithdrawSubmission},
+};
+use alloy_primitives::{Address, U256};
 use async_trait::async_trait;
-use world_chain_proofs::{GameCreated, RootState};
+use world_chain_proofs::{ResolutionStatus, RootState};
 
+/// Contract surface needed by the output-root challenger.
 #[async_trait]
-pub trait ChallengerClient {
+pub trait ChallengerClient: Send + Sync {
+    /// Reads the challenge bond configured by the factory.
+    async fn challenger_bond(&self) -> Result<U256, ChallengerError>;
+    /// Returns the number of games created by the factory.
+    async fn game_count(&self) -> Result<u64, ChallengerError>;
+    /// Returns the game address at a factory creation index.
+    async fn game_address_at(&self, index: u64) -> Result<Address, ChallengerError>;
+    /// Reads the immutable game data needed to validate its root claim.
+    async fn game_metadata(&self, game: Address) -> Result<GameMetadata, ChallengerError>;
     /// Reads the root state of the provided game.
     async fn root_state(&self, game: Address) -> Result<RootState, ChallengerError>;
-    /// Get the last finalized L1 block number.
-    async fn finalized_l1_block_num(&self) -> Result<BlockNumber, ChallengerError>;
-    /// Get all `GameCreated` events between the provided block numbers.
-    async fn games_created(
-        &self,
-        from: BlockNumber,
-        to: BlockNumber,
-    ) -> Result<Vec<GameCreated>, ChallengerError>;
-    /// Get the challenge deadline of the provided game.
+    /// Reads the challenge deadline of the provided game.
     async fn challenge_deadline(&self, game: Address) -> Result<u64, ChallengerError>;
-    /// Submit a challenge against an invalid game.
+    /// Submits a challenge against an invalid game.
     async fn submit_challenge(
         &self,
         game: Address,
         challenger_bond: U256,
     ) -> Result<ChallengeSubmission, ChallengerError>;
+}
+
+/// Contract surface needed to resolve challenger-owned games.
+#[async_trait]
+pub trait ResolutionManagerClient: Send + Sync {
+    /// Returns the current resolution evaluation for the provided game.
+    async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ChallengerError>;
+    /// Submits a resolution transaction.
+    async fn resolve(&self, game: Address) -> Result<ResolveSubmission, ChallengerError>;
+}
+
+/// Contract surface needed by the asynchronous challenger bond manager.
+#[async_trait]
+pub trait BondManagerClient: ResolutionManagerClient {
+    /// Returns the address whose challenge bonds are managed.
+    fn challenger_address(&self) -> Address;
+    /// Returns the number of games created by the factory.
+    async fn game_count(&self) -> Result<u64, ChallengerError>;
+    /// Returns the game address at a factory creation index.
+    async fn game_address_at(&self, index: u64) -> Result<Address, ChallengerError>;
+    /// Returns the challenger recorded by the provided game.
+    async fn game_challenger(&self, game: Address) -> Result<Address, ChallengerError>;
+    /// Returns the amount claimable by the managed challenger.
+    async fn claimable(&self, game: Address) -> Result<U256, ChallengerError>;
+    /// Withdraws credits for the managed challenger.
+    async fn withdraw(&self, game: Address) -> Result<WithdrawSubmission, ChallengerError>;
 }

--- a/proofs/challenger/src/types.rs
+++ b/proofs/challenger/src/types.rs
@@ -1,5 +1,17 @@
-use alloy_primitives::TxHash;
-use world_chain_proofs::GameCreated;
+use std::{
+    collections::HashSet,
+    sync::{Arc, RwLock},
+};
+
+use alloy_primitives::{Address, B256, TxHash, U256};
+
+/// Minimal immutable game data needed to validate an output-root claim.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GameMetadata {
+    pub address: Address,
+    pub root_claim: B256,
+    pub l2_block_number: u64,
+}
 
 /// Result of a submitted challenge transaction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -8,10 +20,70 @@ pub struct ChallengeSubmission {
     pub tx_hash: TxHash,
 }
 
+/// Result of a resolve transaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResolveSubmission {
+    /// Transaction hash for the resolution.
+    pub tx_hash: TxHash,
+}
+
+/// Result of a withdraw transaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WithdrawSubmission {
+    /// Transaction hash for the withdrawal.
+    pub tx_hash: TxHash,
+    /// Amount withdrawn for the challenger.
+    pub amount: U256,
+}
+
+/// Challenger-owned games shared by scanning, resolution, and bond-management loops.
+#[derive(Debug, Clone, Default)]
+pub struct OwnedGames {
+    games: Arc<RwLock<HashSet<Address>>>,
+}
+
+impl OwnedGames {
+    /// Adds a game challenged by the managed challenger.
+    pub fn insert(&self, game: Address) {
+        self.games
+            .write()
+            .expect("owned-games lock poisoned")
+            .insert(game);
+    }
+
+    /// Removes a game that no longer needs lifecycle management.
+    pub fn remove(&self, game: Address) {
+        self.games
+            .write()
+            .expect("owned-games lock poisoned")
+            .remove(&game);
+    }
+
+    /// Returns whether a game is currently tracked.
+    #[must_use]
+    pub fn contains(&self, game: Address) -> bool {
+        self.games
+            .read()
+            .expect("owned-games lock poisoned")
+            .contains(&game)
+    }
+
+    /// Returns a snapshot suitable for asynchronous processing without holding the lock.
+    #[must_use]
+    pub fn snapshot(&self) -> Vec<Address> {
+        self.games
+            .read()
+            .expect("owned-games lock poisoned")
+            .iter()
+            .copied()
+            .collect()
+    }
+}
+
 /// A game queued for retry after a transient scan failure.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct RetryGame {
-    pub game_created: GameCreated,
+    pub game: GameMetadata,
     pub challenge_deadline: Option<u64>,
     pub attempts: u32,
 }

--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -11,7 +11,9 @@ use std::{
     collections::HashMap,
     sync::{Arc, Mutex},
 };
-use world_chain_challenger::{ChallengeSubmission, ChallengerClient, ChallengerError};
+use world_chain_challenger::{
+    ChallengeSubmission, ChallengerClient, ChallengerError, GameMetadata,
+};
 use world_chain_defender::{DefenderClient, DefenderError, DefenderSubmission};
 use world_chain_proof_worker::{ClaimedProofJobHandler, ProofJob};
 use world_chain_proofs::{
@@ -414,6 +416,43 @@ impl ProposerClient for FakeExecution {
 
 #[async_trait]
 impl ChallengerClient for FakeExecution {
+    async fn challenger_bond(&self) -> Result<U256, ChallengerError> {
+        Ok(U256::from(1))
+    }
+
+    async fn game_count(&self) -> Result<u64, ChallengerError> {
+        Ok(self
+            .state
+            .lock()
+            .expect("fake execution mutex poisoned")
+            .game_order
+            .len() as u64)
+    }
+
+    async fn game_address_at(&self, index: u64) -> Result<Address, ChallengerError> {
+        self.state
+            .lock()
+            .expect("fake execution mutex poisoned")
+            .game_order
+            .get(index as usize)
+            .copied()
+            .ok_or_else(|| ChallengerError::Contract(format!("unknown game index {index}")))
+    }
+
+    async fn game_metadata(&self, game: Address) -> Result<GameMetadata, ChallengerError> {
+        self.state
+            .lock()
+            .expect("fake execution mutex poisoned")
+            .games_by_address
+            .get(&game)
+            .map(|record| GameMetadata {
+                address: game,
+                root_claim: record.event.root_claim,
+                l2_block_number: record.event.l2_block_number,
+            })
+            .ok_or_else(|| ChallengerError::Contract(format!("unknown game {game}")))
+    }
+
     async fn root_state(&self, game: Address) -> Result<RootState, ChallengerError> {
         let raw = self
             .state
@@ -423,28 +462,6 @@ impl ChallengerClient for FakeExecution {
             .get(&game)
             .map_or(STATE_NONE, |record| record.state);
         RootState::try_from(raw).map_err(Into::into)
-    }
-
-    async fn finalized_l1_block_num(&self) -> Result<BlockNumber, ChallengerError> {
-        Ok(self
-            .state
-            .lock()
-            .expect("fake execution mutex poisoned")
-            .finalized_l1_block)
-    }
-
-    async fn games_created(
-        &self,
-        _from: BlockNumber,
-        _to: BlockNumber,
-    ) -> Result<Vec<GameCreated>, ChallengerError> {
-        let state = self.state.lock().expect("fake execution mutex poisoned");
-        Ok(state
-            .game_order
-            .iter()
-            .filter_map(|game| state.games_by_address.get(game))
-            .map(|record| record.event)
-            .collect())
     }
 
     async fn challenge_deadline(&self, game: Address) -> Result<u64, ChallengerError> {

--- a/proofs/primitives/src/bindings.rs
+++ b/proofs/primitives/src/bindings.rs
@@ -26,6 +26,7 @@ sol! {
             );
         function domainHash() external view returns (bytes32);
         function proposerBond() external view returns (uint256);
+        function challengerBond() external view returns (uint256);
         function games(bytes32 proposalKey) external view returns (address);
         function gameCount() external view returns (uint256);
         function gameAt(uint256 index) external view returns (address);
@@ -56,6 +57,7 @@ sol! {
         function rootId() external view returns (bytes32);
         function factory() external view returns (address);
         function proposer() external view returns (address);
+        function challenger() external view returns (address);
         function anchorStateRegistry() external view returns (address);
         function domainHash() external view returns (bytes32);
         function attempt() external view returns (uint256);


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4977/challenger-refactor-challenger-for-the-new-contract-design

### Design

The `world-chain-challenger` is made by 3 actors:

- `Challenger`: this scans games that are still challengeable, processes them and submits a challenge if needed (with retries). On restart, it always finds the oldest game that can be challenged and keep scanning and processing games from that game onward.
- `ResolutionManager`: this makes sure to `resolve` games that have been previously challenged by this challenger when they can be resolved
- `BondManager`: this makes sure to `withdraw` from games that have been previously challenged by this challenger after they are resolved. This actor also performs an initial (and then constant) look ups (default latest 1000 games) to last games to make sure that at startup the challenger takes ownership of games that have been challenged by this challenger before, previous to the recent restart. This makes sure that even if the challenger gets restarted, it will still handle resolution + withdrawal of owned games.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes L1 transaction behavior (challenge bond sourcing, new resolve/withdraw loops) and game-discovery semantics; mistakes could miss challenges or mishandle bonds, though scope is limited to the challenger service and devnet wiring.
> 
> **Overview**
> Refactors the World Chain proof-system **challenger** for the new factory contract design: discovery moves from L1 `GameCreated` log scans to **factory `gameCount` / `gameAt` indexing**, with a binary search on challenge deadlines to skip expired games and a per-tick cap on newly scanned games.
> 
> **Challenger bond** is read from the factory at runtime (devnet and CLI no longer hardcode bond wei). After a successful challenge, games are tracked in a shared **`OwnedGames`** registry used by two new background loops: **`ResolutionManager`** submits `resolve` for owned games when the contract reports them resolvable, and **`BondManager`** discovers challenger-owned games (including a bounded startup rescan), withdraws claimable credits, and prunes terminal games. **`AlloyChallengerClient`** grows `resolve`, `withdraw`, `challengerBond`, and related reads; contract bindings add `challengerBond()` and `challenger()`.
> 
> The standalone **`world-chain-challenger`** binary and devnet **`start_world_chain_challenger`** now run challenger, resolution manager, and bond manager concurrently via `tokio::select!`. Integration fakes and unit tests were updated for the new client surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b01129832022711093a90c216cab5cedb9c82d3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->