### PR TITLE
fix: set `proofDeadline` at creation time

### DIFF
--- a/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
@@ -94,7 +94,6 @@ contract WorldChainProofSystemGame is ReentrancyGuardTransient {
     bytes32 public immutable rootId;
 
     uint64 public immutable challengePeriod;
-    uint64 public immutable proofPeriod;
     uint256 public immutable proposerBond;
     uint256 public immutable challengerBond;
 
@@ -141,7 +140,6 @@ contract WorldChainProofSystemGame is ReentrancyGuardTransient {
             proposal.l1OriginNumber
         );
         challengePeriod = config.challengePeriod;
-        proofPeriod = config.proofPeriod;
         proposerBond = config.proposerBond;
         challengerBond = config.challengerBond;
         PROOF_THRESHOLD = config.proofThreshold;
@@ -152,6 +150,7 @@ contract WorldChainProofSystemGame is ReentrancyGuardTransient {
 
         createdAt = uint64(block.timestamp);
         challengeDeadline = uint64(block.timestamp + config.challengePeriod);
+        proofDeadline = uint64(block.timestamp + config.proofPeriod);
         state = WorldChainProofLib.RootState.PROPOSED;
     }
 
@@ -178,7 +177,6 @@ contract WorldChainProofSystemGame is ReentrancyGuardTransient {
         if (state == WorldChainProofLib.RootState.PROPOSED) {
             state = WorldChainProofLib.RootState.CHALLENGED;
             challengedAt = uint64(block.timestamp);
-            proofDeadline = uint64(block.timestamp + proofPeriod);
         }
 
         emit Challenged(msg.sender, proofDeadline);

--- a/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
+++ b/pkg/contracts/src/proofs/WorldChainProofSystemGame.sol
@@ -53,6 +53,7 @@ contract WorldChainProofSystemGame is ReentrancyGuardTransient {
     }
 
     error InvalidBond(uint256 expected, uint256 actual);
+    error InvalidPeriods(uint64 challengePeriod, uint64 proofPeriod);
     error InvalidState(WorldChainProofLib.RootState expected, WorldChainProofLib.RootState actual);
     error ChallengePeriodElapsed(uint256 timestamp, uint256 challengeDeadline);
     error ProofPeriodElapsed(uint256 timestamp, uint256 proofDeadline);
@@ -118,6 +119,9 @@ contract WorldChainProofSystemGame is ReentrancyGuardTransient {
 
     constructor(ProposalInit memory proposal, ActivationConfig memory config) payable {
         if (msg.value != config.proposerBond) revert InvalidBond(config.proposerBond, msg.value);
+        if (config.proofPeriod <= config.challengePeriod) {
+            revert InvalidPeriods(config.challengePeriod, config.proofPeriod);
+        }
 
         factory = proposal.factory;
         anchorStateRegistry = proposal.anchorStateRegistry;

--- a/wips/wip-1006.md
+++ b/wips/wip-1006.md
@@ -44,7 +44,7 @@ Activation parameters are set at hardfork activation and held as immutable value
 | Name | Initial Value | Meaning |
 | --- | --- | --- |
 | `CHALLENGE_PERIOD` | `1 day` | Duration after proposal creation during which a staked participant MAY challenge a root without submitting proof material. Per-proposal `challengeDeadline = createdAt + CHALLENGE_PERIOD`. |
-| `PROOF_PERIOD` | `7 days` | Duration after a root is challenged during which the proposer MAY defend the root by accumulating lane submissions toward `PROOF_THRESHOLD`. Per-proposal `proofDeadline = challengedAt + PROOF_PERIOD`. A challenged root that the proposer has not defended to `PROOF_THRESHOLD` by `proofDeadline` MUST be invalidated. |
+| `PROOF_PERIOD` | `7 days` | Duration after proposal creation during which the proposer MAY defend a challenged root by accumulating lane submissions toward `PROOF_THRESHOLD`. Per-proposal `proofDeadline = createdAt + PROOF_PERIOD`. `PROOF_PERIOD` MUST be greater than `CHALLENGE_PERIOD`. A challenged root that the proposer has not defended to `PROOF_THRESHOLD` by `proofDeadline` MUST be invalidated. |
 | `PROPOSER_BOND` | TBD | Slashable stake required of the proposer. Locked at proposal time, refunded if the root reaches `FINALIZED`, and forfeited if the root reaches `INVALIDATED`. |
 | `CHALLENGER_BOND` | TBD | Slashable stake required of each challenger. Locked at challenge time and forfeited if the challenged root finalizes; refunded if the root is invalidated. |
 
@@ -150,7 +150,7 @@ stateDiagram-v2
 A root enters the system in the `PROPOSED` state.
 
 1. The proposer submits the root commitment and locks `PROPOSER_BOND` as slashable collateral against the proposal.
-2. The contract records `createdAt = block.timestamp` and `challengeDeadline = createdAt + CHALLENGE_PERIOD`.
+2. The contract records `createdAt = block.timestamp`, `challengeDeadline = createdAt + CHALLENGE_PERIOD`, and `proofDeadline = createdAt + PROOF_PERIOD`. The contract MUST reject configurations where `proofDeadline <= challengeDeadline`.
 3. The root remains open to challenges until `challengeDeadline`.
 
 The proposer MUST NOT be required to submit material from any proof lane when creating the proposal, however they may choose to do so.
@@ -167,7 +167,7 @@ The challenge transaction:
 - MUST NOT require the caller to submit proof material.
 - MUST lock `CHALLENGER_BOND` of the caller's stake as slashable collateral against the challenged root.
 - MUST mark the root as `CHALLENGED`.
-- MUST record `challengedAt = block.timestamp` and `proofDeadline = challengedAt + PROOF_PERIOD` on the root, the first time it transitions to `CHALLENGED`. Subsequent challenges MUST NOT extend `proofDeadline`.
+- MUST record `challengedAt = block.timestamp` on the root the first time it transitions to `CHALLENGED`. The challenge MUST NOT change the `proofDeadline` recorded at proposal creation.
 
 If the challenged root finalizes through the proof-lane threshold, the locked `CHALLENGER_BOND` is forfeited. If the root is invalidated, the locked `CHALLENGER_BOND` is refunded to the challenger.
 
@@ -211,7 +211,7 @@ If `block.timestamp >= proofDeadline` and the root's proof bitmap contains fewer
 
 ### Invalidity and Conflicts
 
-Invalidation occurs only via the `CHALLENGED → INVALIDATED` transition described in [Proposer Defense and Challenged Finality](#proposer-defense-and-challenged-finality): a challenged root that the proposer has not defended to `PROOF_THRESHOLD` distinct supporting lanes by `proofDeadline` MUST be invalidated. There is no fast-path invalidation from `PROPOSED`. A party in possession of evidence that a proposed root is incorrect MUST challenge the root; absence of supporting proofs within `PROOF_PERIOD` is the protocol's sole in-band signal of invalidity.
+Invalidation occurs only via the `CHALLENGED → INVALIDATED` transition described in [Proposer Defense and Challenged Finality](#proposer-defense-and-challenged-finality): a challenged root that the proposer has not defended to `PROOF_THRESHOLD` distinct supporting lanes by `proofDeadline` MUST be invalidated. There is no fast-path invalidation from `PROPOSED`. A party in possession of evidence that a proposed root is incorrect MUST challenge the root; absence of supporting proofs before the creation-relative `proofDeadline` is the protocol's sole in-band signal of invalidity.
 
 An invalidated root MUST NOT finalize, and descendants of an invalidated root MUST NOT become accepted anchors.
 
@@ -287,11 +287,12 @@ Before this WIP can move beyond Draft, implementations SHOULD cover at least:
 - an unstaked account cannot challenge;
 - a staked account can challenge without proof before the deadline;
 - a challenge at or after the deadline reverts;
+- a configuration where `proofDeadline <= challengeDeadline` is rejected;
 - a challenged root with one supporting lane does not finalize;
 - a proposer defends a challenged root to finalization with two distinct supporting lanes;
 - a challenged root the proposer fails to defend to `PROOF_THRESHOLD` lanes by `proofDeadline` invalidates and forfeits `PROPOSER_BOND`;
 - a lane submission at or after `proofDeadline` reverts and does not affect the proof bitmap;
-- subsequent challenges on an already-challenged root do not extend `proofDeadline`;
+- challenging a root does not change its creation-time `proofDeadline`;
 - duplicate submissions from the same lane do not increase the threshold count;
 - every proof lane rejects material that does not bind to `rootId`;
 - anchor updates reject non-finalized, invalidated, paused, retired, or non-monotonic roots.


### PR DESCRIPTION
### Problem

Currently `proofDeadline` defaults to `0` at creation of the game and it's set only when the game is challenged. Therefore `proofDeadline` is not a monotonic value and this makes it impossible to perform a binary search over it to find the oldest game that is challenged and whose `proofDeadline` is not elapsed yet (which is what `world-chain-defender` should look for at startup).

### Solution

Set `proofDeadline` directly at creation time, requiring that it must be > than `challengeDeadline`.

Prod values are:

- `challengeDeadline`: 1 day
- `proofDeadline`: 7 days

This way, even if an attacker tries to challenge at the very last moment it can, the `defender` still has 6 days to provide proofs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes disputed-game timing and invalidation rules (core proof-system behavior), though bounded by an explicit period ordering check and spec alignment.
> 
> **Overview**
> **Proof defense window is now anchored to proposal time, not challenge time.** On game creation, the contract sets `proofDeadline = createdAt + PROOF_PERIOD` alongside `challengeDeadline`, and reverts with `InvalidPeriods` if `proofPeriod <= challengePeriod`. The per-game `proofPeriod` immutable is removed; `challenge()` only records `challengedAt` and no longer moves `proofDeadline`.
> 
> **WIP-1006 is updated** to match: `PROOF_PERIOD` is defined relative to creation, challenges must not extend `proofDeadline`, and new test cases cover invalid period configs and unchanged deadlines after challenge.
> 
> With typical values (1-day challenge, 7-day proof), a late challenge still leaves the full gap between the two deadlines for defense—e.g. six days if challenged at the end of day one—and offchain services can binary-search games by a monotonic `proofDeadline` from creation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83fadfa7247e057a7c911f906c376bbbbd9308b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->