### PR TITLE
refactor: new world-chain-defender

### DIFF
--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -2586,7 +2586,12 @@ async fn start_world_chain_defender(
     let output_roots = OptimismConsensusClient::new(output_root_rpc_url.to_string());
     let proof_requester = RpcProverServiceClient::new(prover_service_url)
         .map_err(|error| eyre!("failed to connect defender to prover-service: {error}"))?;
+    let allowed_proposer = DEVNET_PRIVATE_KEY
+        .parse::<PrivateKeySigner>()
+        .wrap_err("invalid allowed World Chain proposer key")?
+        .address();
     let config = DefenderConfig {
+        allowed_proposer,
         poll_interval: WORLD_DEFENDER_POLL_INTERVAL,
         ..DefenderConfig::default()
     };
@@ -2598,6 +2603,7 @@ async fn start_world_chain_defender(
         prover_service = %prover_service_url,
         factory = %deployment.proof_system_factory,
         defender = %defender_address,
+        allowed_proposer = %allowed_proposer,
         "starting native World Chain proof-system defender"
     );
 

--- a/proofs/defender/src/alloy.rs
+++ b/proofs/defender/src/alloy.rs
@@ -1,10 +1,14 @@
-use crate::{error::DefenderError, traits::DefenderClient, types::DefenderSubmission};
-use alloy_primitives::{Address, BlockNumber, Bytes, U256};
+use crate::{
+    error::DefenderError,
+    traits::DefenderClient,
+    types::{DefenderSubmission, GameMetadata},
+};
+use alloy_primitives::{Address, Bytes, U256};
 use alloy_provider::Provider;
 use alloy_rpc_types_eth::BlockId;
 use async_trait::async_trait;
 use world_chain_proofs::{
-    GameCreated, IWorldChainProofSystemFactory, IWorldChainProofSystemGame, RootState,
+    IWorldChainProofSystemFactory, IWorldChainProofSystemGame, ResolutionStatus, RootState,
 };
 
 /// Alloy-backed implementation of [`DefenderClient`].
@@ -27,6 +31,16 @@ where
 
         Self { factory, provider }
     }
+
+    fn game(
+        &self,
+        address: Address,
+    ) -> IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance<P> {
+        IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance::new(
+            address,
+            self.provider.clone(),
+        )
+    }
 }
 
 #[async_trait]
@@ -34,84 +48,120 @@ impl<P> DefenderClient for AlloyDefenderClient<P>
 where
     P: Provider + Clone + Send + Sync + 'static,
 {
-    async fn root_state(&self, game: Address) -> Result<RootState, DefenderError> {
-        let game = IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance::new(
-            game,
-            self.provider.clone(),
-        );
-        let root_state_raw = game
+    async fn game_count(&self) -> Result<u64, DefenderError> {
+        let count = self
+            .factory
+            .gameCount()
+            .block(BlockId::finalized())
+            .call()
+            .await
+            .map_err(|error| DefenderError::Contract(error.to_string()))?;
+        u256_to_u64(count, "gameCount")
+    }
+
+    async fn game_address_at(&self, index: u64) -> Result<Address, DefenderError> {
+        self.factory
+            .gameAt(U256::from(index))
+            .block(BlockId::finalized())
+            .call()
+            .await
+            .map_err(|error| DefenderError::Contract(error.to_string()))
+    }
+
+    async fn game_proposer(&self, address: Address) -> Result<Address, DefenderError> {
+        self.game(address)
+            .proposer()
+            .call()
+            .await
+            .map_err(|error| DefenderError::Contract(error.to_string()))
+    }
+
+    async fn game_metadata(&self, address: Address) -> Result<GameMetadata, DefenderError> {
+        let game = self.game(address);
+        let (root_claim, l2_block_number, l1_origin_hash, challenge_deadline, proof_deadline) = tokio::try_join!(
+            async {
+                game.rootClaim()
+                    .call()
+                    .await
+                    .map_err(|error| DefenderError::Contract(error.to_string()))
+            },
+            async {
+                game.l2BlockNumber()
+                    .call()
+                    .await
+                    .map_err(|error| DefenderError::Contract(error.to_string()))
+            },
+            async {
+                game.l1OriginHash()
+                    .call()
+                    .await
+                    .map_err(|error| DefenderError::Contract(error.to_string()))
+            },
+            async {
+                game.challengeDeadline()
+                    .call()
+                    .await
+                    .map_err(|error| DefenderError::Contract(error.to_string()))
+            },
+            async {
+                game.proofDeadline()
+                    .call()
+                    .await
+                    .map_err(|error| DefenderError::Contract(error.to_string()))
+            },
+        )?;
+
+        Ok(GameMetadata {
+            address,
+            root_claim,
+            l2_block_number: u256_to_u64(l2_block_number, "l2BlockNumber")?,
+            l1_origin_hash,
+            challenge_deadline,
+            proof_deadline,
+        })
+    }
+
+    async fn root_state(&self, address: Address) -> Result<RootState, DefenderError> {
+        let root_state_raw = self
+            .game(address)
             .state()
             .call()
             .await
-            .map_err(|err| DefenderError::Contract(err.to_string()))?;
-        let root_state: RootState = root_state_raw.try_into()?;
-        Ok(root_state)
+            .map_err(|error| DefenderError::Contract(error.to_string()))?;
+        root_state_raw.try_into().map_err(Into::into)
     }
 
-    async fn finalized_l1_block_num(&self) -> Result<BlockNumber, DefenderError> {
-        self.provider
-            .get_block(BlockId::finalized())
-            .await
-            .map_err(|err| DefenderError::Rpc(err.to_string()))?
-            .map(|block| block.number())
-            .ok_or(DefenderError::L1FinalizedBlockNotFound)
-    }
-
-    async fn games_created(
-        &self,
-        from: BlockNumber,
-        to: BlockNumber,
-    ) -> Result<Vec<GameCreated>, DefenderError> {
-        let logs = self
-            .factory
-            .GameCreated_filter()
-            .from_block(from)
-            .to_block(to)
-            .query()
-            .await
-            .map_err(|err| DefenderError::Rpc(err.to_string()))?;
-
-        logs.into_iter()
-            .map(|(event, _log)| {
-                Ok(GameCreated {
-                    proposal_key: event.proposalKey,
-                    root_id: event.rootId,
-                    game: event.game,
-                    proposer: event.proposer,
-                    root_claim: event.rootClaim,
-                    l2_block_number: u256_to_u64(event.l2BlockNumber, "l2BlockNumber")?,
-                    parent_ref: event.parentRef,
-                    l1_origin_hash: event.l1OriginHash,
-                    l1_origin_number: u256_to_u64(event.l1OriginNumber, "l1OriginNumber")?,
-                })
-            })
-            .collect()
-    }
-
-    async fn challenge_deadline(&self, game: Address) -> Result<u64, DefenderError> {
-        let game = IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance::new(
-            game,
-            self.provider.clone(),
-        );
-        let challenge_deadline = game
-            .challengeDeadline()
+    async fn proof_deadline(&self, address: Address) -> Result<u64, DefenderError> {
+        self.game(address)
+            .proofDeadline()
             .call()
             .await
-            .map_err(|err| DefenderError::Contract(err.to_string()))?;
-        Ok(challenge_deadline)
+            .map_err(|error| DefenderError::Contract(error.to_string()))
     }
 
-    async fn proof_bitmap(&self, game: Address) -> Result<u8, DefenderError> {
-        let game = IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance::new(
-            game,
-            self.provider.clone(),
-        );
-        let proof_bitmap = game
+    async fn resolution_status(&self, address: Address) -> Result<ResolutionStatus, DefenderError> {
+        let result = self
+            .game(address)
+            .resolutionStatus()
+            .call()
+            .await
+            .map_err(|error| DefenderError::Contract(error.to_string()))?;
+        let root_state = result.outcome.try_into()?;
+        let invalidation_reason = result.reason.try_into()?;
+
+        Ok(ResolutionStatus {
+            resolvable: result.resolvable,
+            root_state,
+            invalidation_reason,
+        })
+    }
+
+    async fn proof_bitmap(&self, address: Address) -> Result<u8, DefenderError> {
+        self.game(address)
             .proofBitmap()
             .call()
             .await
-            .map_err(|err| DefenderError::Contract(err.to_string()))?;
-        Ok(proof_bitmap)
+            .map_err(|error| DefenderError::Contract(error.to_string()))
     }
 
     async fn submit_proof(
@@ -120,11 +170,8 @@ where
         lane: u8,
         proof: Bytes,
     ) -> Result<DefenderSubmission, DefenderError> {
-        let game = IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance::new(
-            game,
-            self.provider.clone(),
-        );
-        let pending = game
+        let pending = self
+            .game(game)
             .submitProofLane(lane, proof)
             .send()
             .await

--- a/proofs/defender/src/alloy.rs
+++ b/proofs/defender/src/alloy.rs
@@ -8,7 +8,7 @@ use alloy_provider::Provider;
 use alloy_rpc_types_eth::BlockId;
 use async_trait::async_trait;
 use world_chain_proofs::{
-    IWorldChainProofSystemFactory, IWorldChainProofSystemGame, ResolutionStatus, RootState,
+    IWorldChainProofSystemFactory, IWorldChainProofSystemGame, ResolutionStatus,
 };
 
 /// Alloy-backed implementation of [`DefenderClient`].
@@ -119,16 +119,6 @@ where
             challenge_deadline,
             proof_deadline,
         })
-    }
-
-    async fn root_state(&self, address: Address) -> Result<RootState, DefenderError> {
-        let root_state_raw = self
-            .game(address)
-            .state()
-            .call()
-            .await
-            .map_err(|error| DefenderError::Contract(error.to_string()))?;
-        root_state_raw.try_into().map_err(Into::into)
     }
 
     async fn proof_deadline(&self, address: Address) -> Result<u64, DefenderError> {

--- a/proofs/defender/src/alloy.rs
+++ b/proofs/defender/src/alloy.rs
@@ -8,7 +8,7 @@ use alloy_provider::Provider;
 use alloy_rpc_types_eth::BlockId;
 use async_trait::async_trait;
 use world_chain_proofs::{
-    IWorldChainProofSystemFactory, IWorldChainProofSystemGame, ResolutionStatus,
+    IWorldChainProofSystemFactory, IWorldChainProofSystemGame, PROOF_LANE_COUNT, ResolutionStatus,
 };
 
 /// Alloy-backed implementation of [`DefenderClient`].
@@ -78,7 +78,14 @@ where
 
     async fn game_metadata(&self, address: Address) -> Result<GameMetadata, DefenderError> {
         let game = self.game(address);
-        let (root_claim, l2_block_number, l1_origin_hash, challenge_deadline, proof_deadline) = tokio::try_join!(
+        let (
+            root_claim,
+            l2_block_number,
+            l1_origin_hash,
+            challenge_deadline,
+            proof_deadline,
+            proof_threshold,
+        ) = tokio::try_join!(
             async {
                 game.rootClaim()
                     .call()
@@ -109,7 +116,18 @@ where
                     .await
                     .map_err(|error| DefenderError::Contract(error.to_string()))
             },
+            async {
+                game.PROOF_THRESHOLD()
+                    .call()
+                    .await
+                    .map_err(|error| DefenderError::Contract(error.to_string()))
+            },
         )?;
+        if proof_threshold == 0 || proof_threshold > PROOF_LANE_COUNT {
+            return Err(DefenderError::Contract(format!(
+                "invalid proof threshold {proof_threshold} for game {address}"
+            )));
+        }
 
         Ok(GameMetadata {
             address,
@@ -118,6 +136,7 @@ where
             l1_origin_hash,
             challenge_deadline,
             proof_deadline,
+            proof_threshold,
         })
     }
 

--- a/proofs/defender/src/alloy.rs
+++ b/proofs/defender/src/alloy.rs
@@ -85,44 +85,18 @@ where
             challenge_deadline,
             proof_deadline,
             proof_threshold,
-        ) = tokio::try_join!(
-            async {
-                game.rootClaim()
-                    .call()
-                    .await
-                    .map_err(|error| DefenderError::Contract(error.to_string()))
-            },
-            async {
-                game.l2BlockNumber()
-                    .call()
-                    .await
-                    .map_err(|error| DefenderError::Contract(error.to_string()))
-            },
-            async {
-                game.l1OriginHash()
-                    .call()
-                    .await
-                    .map_err(|error| DefenderError::Contract(error.to_string()))
-            },
-            async {
-                game.challengeDeadline()
-                    .call()
-                    .await
-                    .map_err(|error| DefenderError::Contract(error.to_string()))
-            },
-            async {
-                game.proofDeadline()
-                    .call()
-                    .await
-                    .map_err(|error| DefenderError::Contract(error.to_string()))
-            },
-            async {
-                game.PROOF_THRESHOLD()
-                    .call()
-                    .await
-                    .map_err(|error| DefenderError::Contract(error.to_string()))
-            },
-        )?;
+        ) = self
+            .provider
+            .multicall()
+            .add(game.rootClaim())
+            .add(game.l2BlockNumber())
+            .add(game.l1OriginHash())
+            .add(game.challengeDeadline())
+            .add(game.proofDeadline())
+            .add(game.PROOF_THRESHOLD())
+            .aggregate()
+            .await
+            .map_err(|error| DefenderError::Contract(error.to_string()))?;
         if proof_threshold == 0 || proof_threshold > PROOF_LANE_COUNT {
             return Err(DefenderError::Contract(format!(
                 "invalid proof threshold {proof_threshold} for game {address}"

--- a/proofs/defender/src/config.rs
+++ b/proofs/defender/src/config.rs
@@ -1,8 +1,12 @@
 use crate::error::DefenderError;
+use alloy_primitives::Address;
 use std::time::Duration;
 
 /// Default number of games processed concurrently.
 pub const DEFAULT_MAX_GAME_CONCURRENCY: usize = 10;
+
+/// Default maximum number of new factory games discovered per defender tick.
+pub const DEFAULT_MAX_GAMES_PER_TICK: u64 = 100;
 
 /// Default number of proving attempts per lane before abandoning it.
 pub const DEFAULT_MAX_PROOF_ATTEMPTS: u32 = 3;
@@ -10,16 +14,25 @@ pub const DEFAULT_MAX_PROOF_ATTEMPTS: u32 = 3;
 /// Configuration for the defender.
 #[derive(Debug, Clone)]
 pub struct DefenderConfig {
+    /// The only proposer whose games this defender is allowed to defend.
+    pub allowed_proposer: Address,
     /// Delay between periodic scan attempts.
     pub poll_interval: Duration,
     /// Maximum number of games to process concurrently.
     pub max_game_concurrency: usize,
+    /// Maximum number of newly created games discovered during one tick.
+    pub max_games_per_tick: u64,
     /// Maximum number of proving attempts per lane before abandoning it.
     pub max_proof_attempts: u32,
 }
 
 impl DefenderConfig {
     pub(crate) fn validate(&self) -> Result<(), DefenderError> {
+        if self.allowed_proposer.is_zero() {
+            return Err(DefenderError::InvalidConfig(
+                "allowed_proposer must not be the zero address",
+            ));
+        }
         if self.poll_interval.is_zero() {
             return Err(DefenderError::InvalidConfig(
                 "poll_interval must be greater than zero",
@@ -28,6 +41,11 @@ impl DefenderConfig {
         if self.max_game_concurrency == 0 {
             return Err(DefenderError::InvalidConfig(
                 "max_game_concurrency must be greater than zero",
+            ));
+        }
+        if self.max_games_per_tick == 0 {
+            return Err(DefenderError::InvalidConfig(
+                "max_games_per_tick must be greater than zero",
             ));
         }
         if self.max_proof_attempts == 0 {
@@ -42,8 +60,10 @@ impl DefenderConfig {
 impl Default for DefenderConfig {
     fn default() -> Self {
         Self {
+            allowed_proposer: Address::ZERO,
             poll_interval: Duration::from_mins(1),
             max_game_concurrency: DEFAULT_MAX_GAME_CONCURRENCY,
+            max_games_per_tick: DEFAULT_MAX_GAMES_PER_TICK,
             max_proof_attempts: DEFAULT_MAX_PROOF_ATTEMPTS,
         }
     }

--- a/proofs/defender/src/defender.rs
+++ b/proofs/defender/src/defender.rs
@@ -552,6 +552,9 @@ where
     pub(crate) async fn scan_once_with_timestamp(&mut self, now: u64) -> Result<(), DefenderError> {
         self.config.validate()?;
 
+        let defense_results = self.scan_active_defenses(now).await;
+        self.handle_defense_progress(defense_results);
+
         let game_count = self.execution_provider.game_count().await?;
         if self
             .next_game_index
@@ -587,7 +590,7 @@ where
         self.handle_game_scan_results(scan_results);
         self.next_game_index = Some(end);
 
-        if self.watched_games.is_empty() && self.active_defenses.is_empty() {
+        if self.watched_games.is_empty() {
             return Ok(());
         }
 
@@ -597,9 +600,6 @@ where
             .scan_watched_games(latest_finalized_l2_block, now)
             .await;
         self.handle_watch_outcomes(watch_results);
-
-        let defense_results = self.scan_active_defenses(now).await;
-        self.handle_defense_progress(defense_results);
         Ok(())
     }
 

--- a/proofs/defender/src/defender.rs
+++ b/proofs/defender/src/defender.rs
@@ -2,7 +2,10 @@ use crate::{
     config::DefenderConfig,
     error::DefenderError,
     traits::DefenderClient,
-    types::{ActiveDefense, DEFENDED_LANES, DefenseProgress, LaneState, WatchOutcome, WatchedGame},
+    types::{
+        ActiveDefense, DEFENDED_LANES, DefenseProgress, GameMetadata, GameScanOutcome, LaneState,
+        WatchOutcome,
+    },
 };
 use alloy_primitives::{Address, BlockNumber, Bytes};
 use futures_util::{StreamExt, stream};
@@ -11,31 +14,26 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 use tracing::{error, info, warn};
-use world_chain_proofs::{ConsensusProvider, GameCreated, ProofLane, RootState};
+use world_chain_proofs::{ConsensusProvider, InvalidationReason, ProofLane, RootState};
 use world_chain_prover_service::{
     ProofBackend, ProofData, ProofRequest, ProofRequester, ProofResponse, ProofStatus,
 };
 
-/// The number of L1 blocks published in 24h.
-const ONE_DAY_OF_L1_BLOCKS: u64 = 7_200;
-/// The safety margin of blocks.
-const MARGIN: u64 = 500;
-
 /// World Chain Defender.
 ///
-/// Watches every created game until it leaves the `Proposed` state. When a
-/// game is challenged and its root claim matches the canonical output root,
-/// the defender requests one proof per defended lane from the
-/// `prover-service` and submits each completed proof on-chain via
-/// `submitProofLane`.
+/// Discovers allowlisted games through the factory index and watches them until
+/// they no longer need defense. When a game is challenged and its root claim
+/// matches the canonical output root, the defender requests one proof per
+/// defended lane from the `prover-service` and submits each completed proof
+/// on-chain via `submitProofLane`.
 #[derive(Debug)]
 pub struct WorldChainDefender<E, C, P> {
     config: DefenderConfig,
     execution_provider: E,
     consensus_provider: C,
     proof_requester: P,
-    cursor: BlockNumber,
-    watched_games: HashMap<Address, WatchedGame>,
+    next_game_index: Option<u64>,
+    watched_games: HashMap<Address, GameMetadata>,
     active_defenses: HashMap<Address, ActiveDefense>,
 }
 
@@ -52,7 +50,7 @@ impl<E, C, P> WorldChainDefender<E, C, P> {
             execution_provider,
             consensus_provider,
             proof_requester,
-            cursor: 0,
+            next_game_index: None,
             watched_games: HashMap::default(),
             active_defenses: HashMap::default(),
         }
@@ -62,6 +60,12 @@ impl<E, C, P> WorldChainDefender<E, C, P> {
     #[must_use]
     pub const fn config(&self) -> &DefenderConfig {
         &self.config
+    }
+
+    /// Returns the next factory game index to scan, once initialized.
+    #[must_use]
+    pub const fn next_game_index(&self) -> Option<u64> {
+        self.next_game_index
     }
 
     #[cfg(test)]
@@ -81,48 +85,190 @@ where
     C: ConsensusProvider,
     P: ProofRequester + Sync,
 {
+    async fn first_unexpired_game_index(
+        &self,
+        game_count: u64,
+        now: u64,
+    ) -> Result<u64, DefenderError> {
+        let mut low = 0;
+        let mut high = game_count;
+
+        while low < high {
+            let middle = low + (high - low) / 2;
+            let game = self.execution_provider.game_address_at(middle).await?;
+            let deadline = self.execution_provider.proof_deadline(game).await?;
+            if deadline <= now {
+                low = middle + 1;
+            } else {
+                high = middle;
+            }
+        }
+
+        Ok(low)
+    }
+
+    async fn scan_game(
+        &self,
+        game: &GameMetadata,
+        now: u64,
+    ) -> Result<GameScanOutcome, DefenderError> {
+        match self.execution_provider.root_state(game.address).await? {
+            RootState::Proposed => {
+                if now < game.challenge_deadline {
+                    Ok(GameScanOutcome::Track)
+                } else {
+                    Ok(GameScanOutcome::Skip)
+                }
+            }
+            RootState::Challenged => {
+                if now < game.proof_deadline {
+                    return Ok(GameScanOutcome::Track);
+                }
+
+                let status = self
+                    .execution_provider
+                    .resolution_status(game.address)
+                    .await?;
+                if status.positive_resolvable() {
+                    info!(
+                        game = %game.address,
+                        "challenged game already has sufficient proof support"
+                    );
+                } else if status.resolvable
+                    && status.root_state == RootState::Invalidated
+                    && status.invalidation_reason != InvalidationReason::ProofTimeout
+                {
+                    warn!(
+                        game = %game.address,
+                        reason = ?status.invalidation_reason,
+                        "challenged game is invalidatable without defense"
+                    );
+                } else {
+                    error!(
+                        game = %game.address,
+                        proof_deadline = game.proof_deadline,
+                        "challenged game proof deadline elapsed before defense completed"
+                    );
+                }
+                Ok(GameScanOutcome::Skip)
+            }
+            RootState::Finalized | RootState::Invalidated => Ok(GameScanOutcome::Skip),
+            RootState::None => {
+                error!(game = %game.address, "factory game has unset root state");
+                Ok(GameScanOutcome::Skip)
+            }
+        }
+    }
+
+    async fn scan_games(
+        &self,
+        games: impl IntoIterator<Item = GameMetadata>,
+        now: u64,
+    ) -> Vec<(GameMetadata, Result<GameScanOutcome, DefenderError>)> {
+        stream::iter(games)
+            .map(|game| async move {
+                let result = self.scan_game(&game, now).await;
+                (game, result)
+            })
+            .buffer_unordered(self.config.max_game_concurrency)
+            .collect()
+            .await
+    }
+
+    fn handle_game_scan_results(
+        &mut self,
+        results: Vec<(GameMetadata, Result<GameScanOutcome, DefenderError>)>,
+    ) {
+        for (game, result) in results {
+            match result {
+                Ok(GameScanOutcome::Track) => {
+                    self.watched_games.insert(game.address, game);
+                }
+                Ok(GameScanOutcome::Skip) => {}
+                Err(error) => {
+                    warn!(
+                        game = %game.address,
+                        %error,
+                        "game scan failed; retaining for monitoring"
+                    );
+                    self.watched_games.insert(game.address, game);
+                }
+            }
+        }
+    }
+
     async fn watch_game(
         &self,
-        watched: &WatchedGame,
+        game: &GameMetadata,
         latest_finalized_l2_block: BlockNumber,
         now: u64,
     ) -> Result<WatchOutcome, DefenderError> {
-        let game_created = &watched.game_created;
-        let game = game_created.game;
-        match self.execution_provider.root_state(game).await? {
+        let address = game.address;
+        match self.execution_provider.root_state(address).await? {
             RootState::Proposed => {
-                let challenge_deadline = match watched.challenge_deadline {
-                    Some(challenge_deadline) => challenge_deadline,
-                    None => self.execution_provider.challenge_deadline(game).await?,
-                };
-                if now >= challenge_deadline {
+                if now >= game.challenge_deadline {
                     // the game can no longer be challenged
                     return Ok(WatchOutcome::Drop);
                 }
-                Ok(WatchOutcome::Keep {
-                    challenge_deadline: Some(challenge_deadline),
-                })
+                Ok(WatchOutcome::Keep)
             }
             RootState::Challenged => {
+                let status = self.execution_provider.resolution_status(address).await?;
+                if status.positive_resolvable() {
+                    info!(game = %address, "challenged game already has sufficient proof support");
+                    return Ok(WatchOutcome::Drop);
+                }
+                if status.resolvable && status.root_state == RootState::Invalidated {
+                    if status.invalidation_reason == InvalidationReason::ProofTimeout {
+                        error!(
+                            game = %address,
+                            proof_deadline = game.proof_deadline,
+                            "challenged game proof deadline elapsed before defense completed"
+                        );
+                    } else {
+                        warn!(
+                            game = %address,
+                            reason = ?status.invalidation_reason,
+                            "challenged game is invalidatable without defense"
+                        );
+                    }
+                    return Ok(WatchOutcome::Drop);
+                }
+                if status.is_resolved() {
+                    return Ok(WatchOutcome::Drop);
+                }
+                if now >= game.proof_deadline {
+                    error!(
+                        game = %address,
+                        proof_deadline = game.proof_deadline,
+                        "challenged game proof deadline elapsed before defense completed"
+                    );
+                    return Ok(WatchOutcome::Drop);
+                }
+
                 // only judge the root against finalized L2 state
-                if game_created.l2_block_number > latest_finalized_l2_block {
-                    return Ok(WatchOutcome::Keep {
-                        challenge_deadline: watched.challenge_deadline,
-                    });
+                if game.l2_block_number > latest_finalized_l2_block {
+                    return Ok(WatchOutcome::Keep);
                 }
                 let root = self
                     .consensus_provider
-                    .output_root_at_block(game_created.l2_block_number)
+                    .output_root_at_block(game.l2_block_number)
                     .await?;
-                if root == game_created.root_claim {
+                if root == game.root_claim {
                     Ok(WatchOutcome::Defend)
                 } else {
-                    // invalid root, leave the game to the challenger
+                    error!(
+                        game = %address,
+                        claimed_root = %game.root_claim,
+                        canonical_root = %root,
+                        "allowlisted proposer published a non-canonical root; refusing to defend"
+                    );
                     Ok(WatchOutcome::Drop)
                 }
             }
-            // the game already reached a terminal state
-            RootState::None | RootState::Finalized | RootState::Invalidated => {
+            RootState::Finalized | RootState::Invalidated => Ok(WatchOutcome::Drop),
+            RootState::None => {
+                error!(game = %address, "factory game has unset root state");
                 Ok(WatchOutcome::Drop)
             }
         }
@@ -132,13 +278,11 @@ where
         &self,
         latest_finalized_l2_block: BlockNumber,
         now: u64,
-    ) -> Vec<(WatchedGame, Result<WatchOutcome, DefenderError>)> {
+    ) -> Vec<(GameMetadata, Result<WatchOutcome, DefenderError>)> {
         stream::iter(self.watched_games.values().copied().collect::<Vec<_>>())
-            .map(|watched| async move {
-                let result = self
-                    .watch_game(&watched, latest_finalized_l2_block, now)
-                    .await;
-                (watched, result)
+            .map(|game| async move {
+                let result = self.watch_game(&game, latest_finalized_l2_block, now).await;
+                (game, result)
             })
             .buffer_unordered(self.config.max_game_concurrency)
             .collect()
@@ -147,25 +291,21 @@ where
 
     fn handle_watch_outcomes(
         &mut self,
-        results: Vec<(WatchedGame, Result<WatchOutcome, DefenderError>)>,
+        results: Vec<(GameMetadata, Result<WatchOutcome, DefenderError>)>,
     ) {
-        for (watched, result) in results {
-            let game = watched.game_created.game;
+        for (metadata, result) in results {
+            let game = metadata.address;
             match result {
                 Ok(WatchOutcome::Defend) => {
                     info!(%game, "challenged game has a valid root; starting defense");
                     self.watched_games.remove(&game);
                     self.active_defenses
-                        .insert(game, ActiveDefense::new(watched.game_created));
+                        .insert(game, ActiveDefense::new(metadata));
                 }
                 Ok(WatchOutcome::Drop) => {
                     self.watched_games.remove(&game);
                 }
-                Ok(WatchOutcome::Keep { challenge_deadline }) => {
-                    if let Some(watched) = self.watched_games.get_mut(&game) {
-                        watched.challenge_deadline = challenge_deadline;
-                    }
-                }
+                Ok(WatchOutcome::Keep) => {}
                 Err(err) => {
                     warn!(game = %game, error = %err, "game watch failed; retrying next tick");
                 }
@@ -175,18 +315,18 @@ where
 
     async fn advance_lane(
         &self,
-        game_created: &GameCreated,
+        metadata: &GameMetadata,
         lane: ProofLane,
         backend: ProofBackend,
         state: LaneState,
     ) -> LaneState {
-        let game = game_created.game;
+        let game = metadata.address;
         match state {
             LaneState::Proven | LaneState::Abandoned => state,
             LaneState::Pending => {
                 match self
                     .proof_requester
-                    .request_proof(proof_request(game_created, backend))
+                    .request_proof(proof_request(metadata, backend))
                     .await
                 {
                     Ok(id) => LaneState::Requested { id, attempts: 1 },
@@ -260,7 +400,7 @@ where
                         // re-requesting a failed proof re-queues it
                         match self
                             .proof_requester
-                            .request_proof(proof_request(game_created, backend))
+                            .request_proof(proof_request(metadata, backend))
                             .await
                         {
                             Ok(id) => {
@@ -292,12 +432,31 @@ where
     async fn advance_defense(
         &self,
         defense: &ActiveDefense,
+        now: u64,
     ) -> Result<DefenseProgress, DefenderError> {
-        let game_created = &defense.game_created;
-        let game = game_created.game;
+        let metadata = &defense.game;
+        let game = metadata.address;
         if self.execution_provider.root_state(game).await? != RootState::Challenged {
-            return Ok(DefenseProgress::Resolved);
+            return Ok(DefenseProgress::Closed);
         }
+
+        let status = self.execution_provider.resolution_status(game).await?;
+        if status.positive_resolvable() {
+            return Ok(DefenseProgress::Complete);
+        }
+        if status.resolvable && status.root_state == RootState::Invalidated {
+            if status.invalidation_reason == InvalidationReason::ProofTimeout {
+                return Ok(DefenseProgress::DeadlineElapsed);
+            }
+            return Ok(DefenseProgress::Closed);
+        }
+        if status.is_resolved() {
+            return Ok(DefenseProgress::Closed);
+        }
+        if now >= metadata.proof_deadline {
+            return Ok(DefenseProgress::DeadlineElapsed);
+        }
+
         let proof_bitmap = self.execution_provider.proof_bitmap(game).await?;
 
         let mut lanes = defense.lanes;
@@ -308,7 +467,7 @@ where
                 continue;
             }
             lanes[slot] = self
-                .advance_lane(game_created, lane, backend, lanes[slot])
+                .advance_lane(metadata, lane, backend, lanes[slot])
                 .await;
         }
         Ok(DefenseProgress::Lanes(lanes))
@@ -316,10 +475,11 @@ where
 
     async fn scan_active_defenses(
         &self,
+        now: u64,
     ) -> Vec<(ActiveDefense, Result<DefenseProgress, DefenderError>)> {
         stream::iter(self.active_defenses.values().copied().collect::<Vec<_>>())
             .map(|defense| async move {
-                let result = self.advance_defense(&defense).await;
+                let result = self.advance_defense(&defense, now).await;
                 (defense, result)
             })
             .buffer_unordered(self.config.max_game_concurrency)
@@ -332,10 +492,22 @@ where
         results: Vec<(ActiveDefense, Result<DefenseProgress, DefenderError>)>,
     ) {
         for (defense, result) in results {
-            let game = defense.game_created.game;
+            let game = defense.game.address;
             match result {
-                Ok(DefenseProgress::Resolved) => {
-                    info!(%game, "game left the challenged state; defense closed");
+                Ok(DefenseProgress::Closed) => {
+                    info!(%game, "game no longer needs proof support; defense closed");
+                    self.active_defenses.remove(&game);
+                }
+                Ok(DefenseProgress::Complete) => {
+                    info!(%game, "game has sufficient proof support; defense completed");
+                    self.active_defenses.remove(&game);
+                }
+                Ok(DefenseProgress::DeadlineElapsed) => {
+                    error!(
+                        %game,
+                        proof_deadline = defense.game.proof_deadline,
+                        "challenged game proof deadline elapsed before defense completed"
+                    );
                     self.active_defenses.remove(&game);
                 }
                 Ok(DefenseProgress::Lanes(lanes)) => {
@@ -356,49 +528,63 @@ where
         }
     }
 
-    pub async fn scan_once(&mut self) -> Result<(), DefenderError> {
-        let target = self.execution_provider.finalized_l1_block_num().await?;
-        let from = if self.cursor == 0 {
-            target.saturating_sub(ONE_DAY_OF_L1_BLOCKS + MARGIN)
-        } else {
-            self.cursor
-        };
-        if from <= target {
-            let games_created = self.execution_provider.games_created(from, target).await?;
-            for game_created in games_created {
-                let game = game_created.game;
-                if self.watched_games.contains_key(&game)
-                    || self.active_defenses.contains_key(&game)
-                {
-                    continue;
-                }
-                self.watched_games.insert(
-                    game,
-                    WatchedGame {
-                        game_created,
-                        challenge_deadline: None,
-                    },
-                );
-            }
-            // games are tracked in memory from here on, so the cursor can advance
-            self.cursor = target + 1;
+    pub(crate) async fn scan_once_with_timestamp(&mut self, now: u64) -> Result<(), DefenderError> {
+        self.config.validate()?;
+
+        let game_count = self.execution_provider.game_count().await?;
+        if self
+            .next_game_index
+            .is_none_or(|next_game_index| next_game_index > game_count)
+        {
+            let first_unexpired = self.first_unexpired_game_index(game_count, now).await?;
+            info!(
+                first_unexpired_game_index = first_unexpired,
+                game_count, "initialized defender game cursor"
+            );
+            self.next_game_index = Some(first_unexpired);
         }
+
+        let start = self.next_game_index.unwrap_or(game_count);
+        let end = start
+            .saturating_add(self.config.max_games_per_tick)
+            .min(game_count);
+        let mut new_games = Vec::with_capacity((end - start) as usize);
+        for index in start..end {
+            let game = self.execution_provider.game_address_at(index).await?;
+            if self.watched_games.contains_key(&game) || self.active_defenses.contains_key(&game) {
+                continue;
+            }
+
+            let proposer = self.execution_provider.game_proposer(game).await?;
+            if proposer != self.config.allowed_proposer {
+                continue;
+            }
+            new_games.push(self.execution_provider.game_metadata(game).await?);
+        }
+
+        let scan_results = self.scan_games(new_games, now).await;
+        self.handle_game_scan_results(scan_results);
+        self.next_game_index = Some(end);
 
         if self.watched_games.is_empty() && self.active_defenses.is_empty() {
             return Ok(());
         }
 
         let latest_finalized_l2_block = self.consensus_provider.latest_l2_finalized_block().await?;
-        let now = unix_now();
 
         let watch_results = self
             .scan_watched_games(latest_finalized_l2_block, now)
             .await;
         self.handle_watch_outcomes(watch_results);
 
-        let defense_results = self.scan_active_defenses().await;
+        let defense_results = self.scan_active_defenses(now).await;
         self.handle_defense_progress(defense_results);
         Ok(())
+    }
+
+    /// Scans one bounded factory range and advances every tracked defense.
+    pub async fn scan_once(&mut self) -> Result<(), DefenderError> {
+        self.scan_once_with_timestamp(unix_now()).await
     }
 
     /// Runs the defender forever, logging transient failures and retrying on each tick.
@@ -416,15 +602,15 @@ where
 }
 
 /// Builds the proof request for one lane of a defended game.
-fn proof_request(game_created: &GameCreated, backend: ProofBackend) -> ProofRequest {
+fn proof_request(game: &GameMetadata, backend: ProofBackend) -> ProofRequest {
     ProofRequest {
         backend,
-        game: game_created.game,
-        root_claim: game_created.root_claim,
-        l2_block_number: game_created.l2_block_number,
+        game: game.address,
+        root_claim: game.root_claim,
+        l2_block_number: game.l2_block_number,
         // pin the witness to the L1 origin committed at proposal time, so
         // the request id stays stable across defender restarts
-        l1_head: game_created.l1_origin_hash,
+        l1_head: game.l1_origin_hash,
     }
 }
 

--- a/proofs/defender/src/defender.rs
+++ b/proofs/defender/src/defender.rs
@@ -112,7 +112,11 @@ where
         game: &GameMetadata,
         now: u64,
     ) -> Result<GameScanOutcome, DefenderError> {
-        match self.execution_provider.root_state(game.address).await? {
+        let status = self
+            .execution_provider
+            .resolution_status(game.address)
+            .await?;
+        match status.root_state {
             RootState::Proposed => {
                 if now < game.challenge_deadline {
                     Ok(GameScanOutcome::Track)
@@ -125,34 +129,36 @@ where
                     return Ok(GameScanOutcome::Track);
                 }
 
-                let status = self
-                    .execution_provider
-                    .resolution_status(game.address)
-                    .await?;
-                if status.positive_resolvable() {
-                    info!(
-                        game = %game.address,
-                        "challenged game already has sufficient proof support"
-                    );
-                } else if status.resolvable
-                    && status.root_state == RootState::Invalidated
-                    && status.invalidation_reason != InvalidationReason::ProofTimeout
-                {
-                    warn!(
-                        game = %game.address,
-                        reason = ?status.invalidation_reason,
-                        "challenged game is invalidatable without defense"
-                    );
-                } else {
+                error!(
+                    game = %game.address,
+                    proof_deadline = game.proof_deadline,
+                    "challenged game proof deadline elapsed before defense completed"
+                );
+                Ok(GameScanOutcome::Skip)
+            }
+            RootState::Finalized => {
+                info!(
+                    game = %game.address,
+                    "game already has a positive resolution outcome"
+                );
+                Ok(GameScanOutcome::Skip)
+            }
+            RootState::Invalidated => {
+                if status.invalidation_reason == InvalidationReason::ProofTimeout {
                     error!(
                         game = %game.address,
                         proof_deadline = game.proof_deadline,
                         "challenged game proof deadline elapsed before defense completed"
                     );
+                } else {
+                    warn!(
+                        game = %game.address,
+                        reason = ?status.invalidation_reason,
+                        "game is invalidatable without defense"
+                    );
                 }
                 Ok(GameScanOutcome::Skip)
             }
-            RootState::Finalized | RootState::Invalidated => Ok(GameScanOutcome::Skip),
             RootState::None => {
                 error!(game = %game.address, "factory game has unset root state");
                 Ok(GameScanOutcome::Skip)
@@ -204,7 +210,8 @@ where
         now: u64,
     ) -> Result<WatchOutcome, DefenderError> {
         let address = game.address;
-        match self.execution_provider.root_state(address).await? {
+        let status = self.execution_provider.resolution_status(address).await?;
+        match status.root_state {
             RootState::Proposed => {
                 if now >= game.challenge_deadline {
                     // the game can no longer be challenged
@@ -213,30 +220,6 @@ where
                 Ok(WatchOutcome::Keep)
             }
             RootState::Challenged => {
-                let status = self.execution_provider.resolution_status(address).await?;
-                if status.positive_resolvable() {
-                    info!(game = %address, "challenged game already has sufficient proof support");
-                    return Ok(WatchOutcome::Drop);
-                }
-                if status.resolvable && status.root_state == RootState::Invalidated {
-                    if status.invalidation_reason == InvalidationReason::ProofTimeout {
-                        error!(
-                            game = %address,
-                            proof_deadline = game.proof_deadline,
-                            "challenged game proof deadline elapsed before defense completed"
-                        );
-                    } else {
-                        warn!(
-                            game = %address,
-                            reason = ?status.invalidation_reason,
-                            "challenged game is invalidatable without defense"
-                        );
-                    }
-                    return Ok(WatchOutcome::Drop);
-                }
-                if status.is_resolved() {
-                    return Ok(WatchOutcome::Drop);
-                }
                 if now >= game.proof_deadline {
                     error!(
                         game = %address,
@@ -266,7 +249,26 @@ where
                     Ok(WatchOutcome::Drop)
                 }
             }
-            RootState::Finalized | RootState::Invalidated => Ok(WatchOutcome::Drop),
+            RootState::Finalized => {
+                info!(game = %address, "game has a positive resolution outcome");
+                Ok(WatchOutcome::Drop)
+            }
+            RootState::Invalidated => {
+                if status.invalidation_reason == InvalidationReason::ProofTimeout {
+                    error!(
+                        game = %address,
+                        proof_deadline = game.proof_deadline,
+                        "challenged game proof deadline elapsed before defense completed"
+                    );
+                } else {
+                    warn!(
+                        game = %address,
+                        reason = ?status.invalidation_reason,
+                        "game is invalidatable without defense"
+                    );
+                }
+                Ok(WatchOutcome::Drop)
+            }
             RootState::None => {
                 error!(game = %address, "factory game has unset root state");
                 Ok(WatchOutcome::Drop)
@@ -436,22 +438,17 @@ where
     ) -> Result<DefenseProgress, DefenderError> {
         let metadata = &defense.game;
         let game = metadata.address;
-        if self.execution_provider.root_state(game).await? != RootState::Challenged {
-            return Ok(DefenseProgress::Closed);
-        }
-
         let status = self.execution_provider.resolution_status(game).await?;
-        if status.positive_resolvable() {
-            return Ok(DefenseProgress::Complete);
-        }
-        if status.resolvable && status.root_state == RootState::Invalidated {
-            if status.invalidation_reason == InvalidationReason::ProofTimeout {
-                return Ok(DefenseProgress::DeadlineElapsed);
+        match status.root_state {
+            RootState::Finalized => return Ok(DefenseProgress::Complete),
+            RootState::Invalidated => {
+                if status.invalidation_reason == InvalidationReason::ProofTimeout {
+                    return Ok(DefenseProgress::DeadlineElapsed);
+                }
+                return Ok(DefenseProgress::Closed);
             }
-            return Ok(DefenseProgress::Closed);
-        }
-        if status.is_resolved() {
-            return Ok(DefenseProgress::Closed);
+            RootState::Challenged => {}
+            RootState::None | RootState::Proposed => return Ok(DefenseProgress::Closed),
         }
         if now >= metadata.proof_deadline {
             return Ok(DefenseProgress::DeadlineElapsed);

--- a/proofs/defender/src/defender.rs
+++ b/proofs/defender/src/defender.rs
@@ -1,25 +1,50 @@
 use crate::{
     config::DefenderConfig,
     error::DefenderError,
+    game::{GameEvaluator, GameObservation, GameOutcome},
+    lane::{DEFENDED_LANE_COUNT, DEFENDED_LANES, LaneDriver, LaneState},
     traits::DefenderClient,
-    types::{
-        ActiveDefense, DEFENDED_LANES, DefenseProgress, GameMetadata, GameScanOutcome, LaneState,
-        WatchOutcome,
-    },
+    types::GameMetadata,
 };
-use alloy_primitives::{Address, BlockNumber, Bytes};
+use alloy_primitives::{Address, BlockNumber};
 use futures_util::{StreamExt, stream};
 use std::{
     collections::HashMap,
     time::{SystemTime, UNIX_EPOCH},
 };
 use tracing::{error, info, warn};
-use world_chain_proofs::{
-    ConsensusProvider, InvalidationReason, ProofLane, RootState, proof_count,
-};
-use world_chain_prover_service::{
-    ProofBackend, ProofData, ProofRequest, ProofRequester, ProofResponse, ProofStatus,
-};
+use world_chain_proofs::{ConsensusProvider, InvalidationReason};
+use world_chain_prover_service::ProofRequester;
+
+/// An active defense of a challenged game with a valid root.
+#[derive(Debug, Clone, Copy)]
+struct ActiveDefense {
+    game: GameMetadata,
+    /// Lane progress, indexed like [`DEFENDED_LANES`].
+    lanes: [LaneState; DEFENDED_LANE_COUNT],
+}
+
+impl ActiveDefense {
+    const fn new(game: GameMetadata) -> Self {
+        Self {
+            game,
+            lanes: [LaneState::Pending; DEFENDED_LANE_COUNT],
+        }
+    }
+}
+
+/// Result of advancing a single defense for one tick.
+#[derive(Debug, Clone, Copy)]
+enum DefenseProgress {
+    /// The game left the `Challenged` state on-chain.
+    Closed,
+    /// The game already has enough proof support to complete the defense.
+    Complete,
+    /// The proof deadline elapsed before the defense completed.
+    DeadlineElapsed,
+    /// Lane progress after this tick.
+    Lanes([LaneState; DEFENDED_LANE_COUNT]),
+}
 
 /// World Chain Defender.
 ///
@@ -109,100 +134,36 @@ where
         Ok(low)
     }
 
-    async fn scan_game(
-        &self,
-        game: &GameMetadata,
-        now: u64,
-    ) -> Result<GameScanOutcome, DefenderError> {
-        let status = self
-            .execution_provider
-            .resolution_status(game.address)
-            .await?;
-        match status.root_state {
-            RootState::Proposed => {
-                if now < game.challenge_deadline {
-                    Ok(GameScanOutcome::Track)
-                } else {
-                    Ok(GameScanOutcome::Skip)
-                }
-            }
-            RootState::Challenged => {
-                let proof_bitmap = self.execution_provider.proof_bitmap(game.address).await?;
-                if has_required_proof_support(game, proof_bitmap) {
-                    info!(
-                        game = %game.address,
-                        proof_bitmap,
-                        proof_threshold = game.proof_threshold,
-                        "challenged game already has sufficient proof support"
-                    );
-                    return Ok(GameScanOutcome::Skip);
-                }
-                if now < game.proof_deadline {
-                    return Ok(GameScanOutcome::Track);
-                }
-
-                error!(
-                    game = %game.address,
-                    proof_deadline = game.proof_deadline,
-                    "challenged game proof deadline elapsed before defense completed"
-                );
-                Ok(GameScanOutcome::Skip)
-            }
-            RootState::Finalized => {
-                info!(
-                    game = %game.address,
-                    "game already has a positive resolution outcome"
-                );
-                Ok(GameScanOutcome::Skip)
-            }
-            RootState::Invalidated => {
-                if status.invalidation_reason == InvalidationReason::ProofTimeout {
-                    error!(
-                        game = %game.address,
-                        proof_deadline = game.proof_deadline,
-                        "challenged game proof deadline elapsed before defense completed"
-                    );
-                } else {
-                    warn!(
-                        game = %game.address,
-                        reason = ?status.invalidation_reason,
-                        "game is invalidatable without defense"
-                    );
-                }
-                Ok(GameScanOutcome::Skip)
-            }
-            RootState::None => {
-                error!(game = %game.address, "factory game has unset root state");
-                Ok(GameScanOutcome::Skip)
-            }
-        }
-    }
-
-    async fn scan_games(
+    async fn evaluate_discovered_games(
         &self,
         games: impl IntoIterator<Item = GameMetadata>,
         now: u64,
-    ) -> Vec<(GameMetadata, Result<GameScanOutcome, DefenderError>)> {
+    ) -> Vec<(GameMetadata, Result<GameOutcome, DefenderError>)> {
+        let evaluator = GameEvaluator::new(&self.execution_provider, &self.consensus_provider);
         stream::iter(games)
-            .map(|game| async move {
-                let result = self.scan_game(&game, now).await;
-                (game, result)
+            .map(move |game| {
+                let evaluator = evaluator;
+                async move {
+                    let result = evaluator.evaluate_discovered(&game, now).await;
+                    (game, result)
+                }
             })
             .buffer_unordered(self.config.max_game_concurrency)
             .collect()
             .await
     }
 
-    fn handle_game_scan_results(
+    fn handle_discovered_game_outcomes(
         &mut self,
-        results: Vec<(GameMetadata, Result<GameScanOutcome, DefenderError>)>,
+        outcomes: Vec<(GameMetadata, Result<GameOutcome, DefenderError>)>,
     ) {
-        for (game, result) in results {
-            match result {
-                Ok(GameScanOutcome::Track) => {
+        for (game, outcome) in outcomes {
+            match outcome {
+                Ok(GameOutcome::Track) => {
                     self.watched_games.insert(game.address, game);
                 }
-                Ok(GameScanOutcome::Skip) => {}
+                Ok(GameOutcome::Defend) => self.start_defense(game),
+                Ok(GameOutcome::Drop) => {}
                 Err(error) => {
                     warn!(
                         game = %game.address,
@@ -215,121 +176,39 @@ where
         }
     }
 
-    async fn watch_game(
-        &self,
-        game: &GameMetadata,
-        latest_finalized_l2_block: BlockNumber,
-        now: u64,
-    ) -> Result<WatchOutcome, DefenderError> {
-        let address = game.address;
-        let status = self.execution_provider.resolution_status(address).await?;
-        match status.root_state {
-            RootState::Proposed => {
-                if now >= game.challenge_deadline {
-                    // the game can no longer be challenged
-                    return Ok(WatchOutcome::Drop);
-                }
-                Ok(WatchOutcome::Keep)
-            }
-            RootState::Challenged => {
-                let proof_bitmap = self.execution_provider.proof_bitmap(address).await?;
-                if has_required_proof_support(game, proof_bitmap) {
-                    info!(
-                        game = %address,
-                        proof_bitmap,
-                        proof_threshold = game.proof_threshold,
-                        "challenged game already has sufficient proof support"
-                    );
-                    return Ok(WatchOutcome::Drop);
-                }
-                if now >= game.proof_deadline {
-                    error!(
-                        game = %address,
-                        proof_deadline = game.proof_deadline,
-                        "challenged game proof deadline elapsed before defense completed"
-                    );
-                    return Ok(WatchOutcome::Drop);
-                }
-
-                // only judge the root against finalized L2 state
-                if game.l2_block_number > latest_finalized_l2_block {
-                    return Ok(WatchOutcome::Keep);
-                }
-                let root = self
-                    .consensus_provider
-                    .output_root_at_block(game.l2_block_number)
-                    .await?;
-                if root == game.root_claim {
-                    Ok(WatchOutcome::Defend)
-                } else {
-                    error!(
-                        game = %address,
-                        claimed_root = %game.root_claim,
-                        canonical_root = %root,
-                        "allowlisted proposer published a non-canonical root; refusing to defend"
-                    );
-                    Ok(WatchOutcome::Drop)
-                }
-            }
-            RootState::Finalized => {
-                info!(game = %address, "game has a positive resolution outcome");
-                Ok(WatchOutcome::Drop)
-            }
-            RootState::Invalidated => {
-                if status.invalidation_reason == InvalidationReason::ProofTimeout {
-                    error!(
-                        game = %address,
-                        proof_deadline = game.proof_deadline,
-                        "challenged game proof deadline elapsed before defense completed"
-                    );
-                } else {
-                    warn!(
-                        game = %address,
-                        reason = ?status.invalidation_reason,
-                        "game is invalidatable without defense"
-                    );
-                }
-                Ok(WatchOutcome::Drop)
-            }
-            RootState::None => {
-                error!(game = %address, "factory game has unset root state");
-                Ok(WatchOutcome::Drop)
-            }
-        }
-    }
-
-    async fn scan_watched_games(
+    async fn evaluate_tracked_games(
         &self,
         latest_finalized_l2_block: BlockNumber,
         now: u64,
-    ) -> Vec<(GameMetadata, Result<WatchOutcome, DefenderError>)> {
+    ) -> Vec<(GameMetadata, Result<GameOutcome, DefenderError>)> {
+        let evaluator = GameEvaluator::new(&self.execution_provider, &self.consensus_provider);
         stream::iter(self.watched_games.values().copied().collect::<Vec<_>>())
-            .map(|game| async move {
-                let result = self.watch_game(&game, latest_finalized_l2_block, now).await;
-                (game, result)
+            .map(move |game| {
+                let evaluator = evaluator;
+                async move {
+                    let result = evaluator
+                        .evaluate_tracked(&game, latest_finalized_l2_block, now)
+                        .await;
+                    (game, result)
+                }
             })
             .buffer_unordered(self.config.max_game_concurrency)
             .collect()
             .await
     }
 
-    fn handle_watch_outcomes(
+    fn handle_tracked_game_outcomes(
         &mut self,
-        results: Vec<(GameMetadata, Result<WatchOutcome, DefenderError>)>,
+        outcomes: Vec<(GameMetadata, Result<GameOutcome, DefenderError>)>,
     ) {
-        for (metadata, result) in results {
+        for (metadata, outcome) in outcomes {
             let game = metadata.address;
-            match result {
-                Ok(WatchOutcome::Defend) => {
-                    info!(%game, "challenged game has a valid root; starting defense");
-                    self.watched_games.remove(&game);
-                    self.active_defenses
-                        .insert(game, ActiveDefense::new(metadata));
-                }
-                Ok(WatchOutcome::Drop) => {
+            match outcome {
+                Ok(GameOutcome::Defend) => self.start_defense(metadata),
+                Ok(GameOutcome::Drop) => {
                     self.watched_games.remove(&game);
                 }
-                Ok(WatchOutcome::Keep) => {}
+                Ok(GameOutcome::Track) => {}
                 Err(err) => {
                     warn!(game = %game, error = %err, "game watch failed; retrying next tick");
                 }
@@ -337,120 +216,12 @@ where
         }
     }
 
-    async fn advance_lane(
-        &self,
-        metadata: &GameMetadata,
-        lane: ProofLane,
-        backend: ProofBackend,
-        state: LaneState,
-    ) -> LaneState {
+    fn start_defense(&mut self, metadata: GameMetadata) {
         let game = metadata.address;
-        match state {
-            LaneState::Proven | LaneState::Abandoned => state,
-            LaneState::Pending => {
-                match self
-                    .proof_requester
-                    .request_proof(proof_request(metadata, backend))
-                    .await
-                {
-                    Ok(id) => LaneState::Requested { id, attempts: 1 },
-                    Err(error) => {
-                        warn!(%game, ?lane, %error, "proof request failed; retrying next tick");
-                        LaneState::Pending
-                    }
-                }
-            }
-            LaneState::Requested { id, attempts } => {
-                let status = match self.proof_requester.proof_status(id).await {
-                    Ok(status) => status,
-                    Err(error) => {
-                        warn!(%game, ?lane, %id, %error, "proof status check failed; retrying next tick");
-                        return state;
-                    }
-                };
-                match status {
-                    ProofStatus::Created | ProofStatus::Running => state,
-                    ProofStatus::Succeeded => {
-                        let response = match self.proof_requester.get_proof(id).await {
-                            Ok(ProofResponse::Succeeded(response)) => response,
-                            Ok(ProofResponse::Pending(response)) => {
-                                warn!(
-                                    %game,
-                                    ?lane,
-                                    %id,
-                                    status = %response.status,
-                                    "proof status was succeeded but proof response is pending; retrying next tick"
-                                );
-                                return state;
-                            }
-                            Ok(ProofResponse::Failed(response)) => {
-                                warn!(
-                                    %game,
-                                    ?lane,
-                                    %id,
-                                    reason = %response.reason,
-                                    "proof status was succeeded but proof response is failed; retrying next tick"
-                                );
-                                return state;
-                            }
-                            Err(error) => {
-                                warn!(%game, ?lane, %id, %error, "proof retrieval failed; retrying next tick");
-                                return state;
-                            }
-                        };
-                        match self
-                            .execution_provider
-                            .submit_proof(game, lane as u8, encode_proof(&response.proof))
-                            .await
-                        {
-                            Ok(submission) => {
-                                info!(%game, ?lane, tx_hash = %submission.tx_hash, "proof lane submitted");
-                                LaneState::Proven
-                            }
-                            Err(error) => {
-                                // if the transaction actually landed, the
-                                // proof bitmap check resolves the lane on the
-                                // next tick
-                                warn!(%game, ?lane, %error, "proof submission failed; retrying next tick");
-                                state
-                            }
-                        }
-                    }
-                    ProofStatus::Failed => {
-                        if attempts >= self.config.max_proof_attempts {
-                            error!(%game, ?lane, attempts, "proving permanently failed; abandoning lane");
-                            return LaneState::Abandoned;
-                        }
-                        // re-requesting a failed proof re-queues it
-                        match self
-                            .proof_requester
-                            .request_proof(proof_request(metadata, backend))
-                            .await
-                        {
-                            Ok(id) => {
-                                let next_attempt = attempts + 1;
-                                warn!(
-                                    %game,
-                                    ?lane,
-                                    %id,
-                                    attempts = next_attempt,
-                                    max_attempts = self.config.max_proof_attempts,
-                                    "proof failed; re-requested proof"
-                                );
-                                LaneState::Requested {
-                                    id,
-                                    attempts: next_attempt,
-                                }
-                            }
-                            Err(error) => {
-                                warn!(%game, ?lane, %error, "proof re-request failed; retrying next tick");
-                                state
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        info!(%game, "challenged game has a valid root; starting defense");
+        self.watched_games.remove(&game);
+        self.active_defenses
+            .insert(game, ActiveDefense::new(metadata));
     }
 
     async fn advance_defense(
@@ -459,36 +230,46 @@ where
         now: u64,
     ) -> Result<DefenseProgress, DefenderError> {
         let metadata = &defense.game;
-        let game = metadata.address;
-        let status = self.execution_provider.resolution_status(game).await?;
-        match status.root_state {
-            RootState::Finalized => return Ok(DefenseProgress::Complete),
-            RootState::Invalidated => {
-                if status.invalidation_reason == InvalidationReason::ProofTimeout {
+        let evaluator = GameEvaluator::new(&self.execution_provider, &self.consensus_provider);
+        let proof_bitmap = match evaluator.observe(metadata).await? {
+            GameObservation::Finalized => return Ok(DefenseProgress::Complete),
+            GameObservation::Invalidated(reason) => {
+                if reason == InvalidationReason::ProofTimeout {
                     return Ok(DefenseProgress::DeadlineElapsed);
                 }
                 return Ok(DefenseProgress::Closed);
             }
-            RootState::Challenged => {}
-            RootState::None | RootState::Proposed => return Ok(DefenseProgress::Closed),
-        }
-        let proof_bitmap = self.execution_provider.proof_bitmap(game).await?;
-        if has_required_proof_support(metadata, proof_bitmap) {
-            return Ok(DefenseProgress::Complete);
-        }
+            GameObservation::Challenged {
+                proof_bitmap,
+                has_required_support,
+            } => {
+                if has_required_support {
+                    return Ok(DefenseProgress::Complete);
+                }
+                proof_bitmap
+            }
+            GameObservation::Unset | GameObservation::Proposed => {
+                return Ok(DefenseProgress::Closed);
+            }
+        };
         if now >= metadata.proof_deadline {
             return Ok(DefenseProgress::DeadlineElapsed);
         }
 
         let mut lanes = defense.lanes;
-        for (slot, (lane, backend)) in DEFENDED_LANES.into_iter().enumerate() {
+        let lane_driver = LaneDriver::new(
+            &self.execution_provider,
+            &self.proof_requester,
+            self.config.max_proof_attempts,
+        );
+        for (slot, (proof_lane, backend)) in DEFENDED_LANES.into_iter().enumerate() {
             // skip lanes already proven on-chain, by us or by anyone else
-            if proof_bitmap & lane.mask() != 0 {
+            if proof_bitmap & proof_lane.mask() != 0 {
                 lanes[slot] = LaneState::Proven;
                 continue;
             }
-            lanes[slot] = self
-                .advance_lane(metadata, lane, backend, lanes[slot])
+            lanes[slot] = lane_driver
+                .advance(metadata, proof_lane, backend, lanes[slot])
                 .await;
         }
         Ok(DefenseProgress::Lanes(lanes))
@@ -549,12 +330,12 @@ where
         }
     }
 
-    pub(crate) async fn scan_once_with_timestamp(&mut self, now: u64) -> Result<(), DefenderError> {
-        self.config.validate()?;
-
+    async fn advance_active_defenses(&mut self, now: u64) {
         let defense_results = self.scan_active_defenses(now).await;
         self.handle_defense_progress(defense_results);
+    }
 
+    async fn discover_games(&mut self, now: u64) -> Result<(), DefenderError> {
         let game_count = self.execution_provider.game_count().await?;
         if self
             .next_game_index
@@ -586,26 +367,37 @@ where
             new_games.push(self.execution_provider.game_metadata(game).await?);
         }
 
-        let scan_results = self.scan_games(new_games, now).await;
-        self.handle_game_scan_results(scan_results);
+        let outcomes = self.evaluate_discovered_games(new_games, now).await;
+        self.handle_discovered_game_outcomes(outcomes);
         self.next_game_index = Some(end);
+        Ok(())
+    }
 
+    async fn advance_tracked_games(&mut self, now: u64) -> Result<(), DefenderError> {
         if self.watched_games.is_empty() {
             return Ok(());
         }
 
         let latest_finalized_l2_block = self.consensus_provider.latest_l2_finalized_block().await?;
 
-        let watch_results = self
-            .scan_watched_games(latest_finalized_l2_block, now)
+        let outcomes = self
+            .evaluate_tracked_games(latest_finalized_l2_block, now)
             .await;
-        self.handle_watch_outcomes(watch_results);
+        self.handle_tracked_game_outcomes(outcomes);
         Ok(())
     }
 
-    /// Scans one bounded factory range and advances every tracked defense.
-    pub async fn scan_once(&mut self) -> Result<(), DefenderError> {
-        self.scan_once_with_timestamp(unix_now()).await
+    pub(crate) async fn tick_at(&mut self, now: u64) -> Result<(), DefenderError> {
+        self.config.validate()?;
+
+        self.advance_active_defenses(now).await;
+        self.discover_games(now).await?;
+        self.advance_tracked_games(now).await
+    }
+
+    /// Advances the defender by one polling tick.
+    pub async fn tick(&mut self) -> Result<(), DefenderError> {
+        self.tick_at(unix_now()).await
     }
 
     /// Runs the defender forever, logging transient failures and retrying on each tick.
@@ -615,56 +407,11 @@ where
         let mut interval = tokio::time::interval(self.config.poll_interval);
         loop {
             interval.tick().await;
-            if let Err(e) = self.scan_once().await {
+            if let Err(e) = self.tick().await {
                 warn!(%e, "scan attempt failed");
             }
         }
     }
-}
-
-/// Builds the proof request for one lane of a defended game.
-fn proof_request(game: &GameMetadata, backend: ProofBackend) -> ProofRequest {
-    ProofRequest {
-        backend,
-        game: game.address,
-        root_claim: game.root_claim,
-        l2_block_number: game.l2_block_number,
-        // pin the witness to the L1 origin committed at proposal time, so
-        // the request id stays stable across defender restarts
-        l1_head: game.l1_origin_hash,
-    }
-}
-
-/// Encode a proof payload into the `bytes` argument of `submitProofLane`.
-///
-/// TODO: encode proofs for their concrete on-chain verifiers. SP1 proofs must
-/// match `SP1ValidityVerifier`'s ABI tuple:
-/// `(domainHash, parentRef, l1OriginNumber, publicValues, proofBytes)`.
-/// That requires proposal context in addition to `ProofData`, so this helper
-/// should move closer to the game/lane submission path before real SP1 lanes
-/// are enabled.
-fn encode_proof(proof: &ProofData) -> Bytes {
-    match proof {
-        ProofData::Sp1 {
-            proof,
-            public_values,
-        } => [public_values.as_ref(), proof.as_ref()].concat().into(),
-        ProofData::Nitro {
-            attestation,
-            public_values,
-            signature,
-        } => [
-            public_values.as_ref(),
-            attestation.as_ref(),
-            signature.as_ref(),
-        ]
-        .concat()
-        .into(),
-    }
-}
-
-fn has_required_proof_support(game: &GameMetadata, proof_bitmap: u8) -> bool {
-    proof_count(proof_bitmap) >= game.proof_threshold
 }
 
 fn unix_now() -> u64 {

--- a/proofs/defender/src/defender.rs
+++ b/proofs/defender/src/defender.rs
@@ -14,7 +14,9 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 use tracing::{error, info, warn};
-use world_chain_proofs::{ConsensusProvider, InvalidationReason, ProofLane, RootState};
+use world_chain_proofs::{
+    ConsensusProvider, InvalidationReason, ProofLane, RootState, proof_count,
+};
 use world_chain_prover_service::{
     ProofBackend, ProofData, ProofRequest, ProofRequester, ProofResponse, ProofStatus,
 };
@@ -125,6 +127,16 @@ where
                 }
             }
             RootState::Challenged => {
+                let proof_bitmap = self.execution_provider.proof_bitmap(game.address).await?;
+                if has_required_proof_support(game, proof_bitmap) {
+                    info!(
+                        game = %game.address,
+                        proof_bitmap,
+                        proof_threshold = game.proof_threshold,
+                        "challenged game already has sufficient proof support"
+                    );
+                    return Ok(GameScanOutcome::Skip);
+                }
                 if now < game.proof_deadline {
                     return Ok(GameScanOutcome::Track);
                 }
@@ -220,6 +232,16 @@ where
                 Ok(WatchOutcome::Keep)
             }
             RootState::Challenged => {
+                let proof_bitmap = self.execution_provider.proof_bitmap(address).await?;
+                if has_required_proof_support(game, proof_bitmap) {
+                    info!(
+                        game = %address,
+                        proof_bitmap,
+                        proof_threshold = game.proof_threshold,
+                        "challenged game already has sufficient proof support"
+                    );
+                    return Ok(WatchOutcome::Drop);
+                }
                 if now >= game.proof_deadline {
                     error!(
                         game = %address,
@@ -450,11 +472,13 @@ where
             RootState::Challenged => {}
             RootState::None | RootState::Proposed => return Ok(DefenseProgress::Closed),
         }
+        let proof_bitmap = self.execution_provider.proof_bitmap(game).await?;
+        if has_required_proof_support(metadata, proof_bitmap) {
+            return Ok(DefenseProgress::Complete);
+        }
         if now >= metadata.proof_deadline {
             return Ok(DefenseProgress::DeadlineElapsed);
         }
-
-        let proof_bitmap = self.execution_provider.proof_bitmap(game).await?;
 
         let mut lanes = defense.lanes;
         for (slot, (lane, backend)) in DEFENDED_LANES.into_iter().enumerate() {
@@ -637,6 +661,10 @@ fn encode_proof(proof: &ProofData) -> Bytes {
         .concat()
         .into(),
     }
+}
+
+fn has_required_proof_support(game: &GameMetadata, proof_bitmap: u8) -> bool {
+    proof_count(proof_bitmap) >= game.proof_threshold
 }
 
 fn unix_now() -> u64 {

--- a/proofs/defender/src/defender.rs
+++ b/proofs/defender/src/defender.rs
@@ -391,8 +391,9 @@ where
         self.config.validate()?;
 
         self.advance_active_defenses(now).await;
+        self.advance_tracked_games(now).await?;
         self.discover_games(now).await?;
-        self.advance_tracked_games(now).await
+        Ok(())
     }
 
     /// Advances the defender by one polling tick.

--- a/proofs/defender/src/error.rs
+++ b/proofs/defender/src/error.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::TxHash;
 use thiserror::Error;
-use world_chain_proofs::{ConsensusError, RootStateError};
+use world_chain_proofs::{ConsensusError, InvalidationReasonError, RootStateError};
 
 /// Errors returned by the defender.
 #[derive(Debug, Error)]
@@ -11,12 +11,10 @@ pub enum DefenderError {
     /// Contract call or transaction failure.
     #[error("contract error: {0}")]
     Contract(String),
-    #[error("RPC error: {0}")]
-    Rpc(String),
-    #[error("Latest L1 finalized block not found")]
-    L1FinalizedBlockNotFound,
     #[error(transparent)]
     InvalidRootState(#[from] RootStateError),
+    #[error(transparent)]
+    InvalidInvalidationReason(#[from] InvalidationReasonError),
     #[error(transparent)]
     OutputRoot(#[from] ConsensusError),
     #[error("The submitProofLane transaction didn't execute succesfully: {0}")]

--- a/proofs/defender/src/game.rs
+++ b/proofs/defender/src/game.rs
@@ -1,0 +1,204 @@
+use crate::{error::DefenderError, traits::DefenderClient, types::GameMetadata};
+use alloy_primitives::BlockNumber;
+use tracing::{error, info, warn};
+use world_chain_proofs::{ConsensusProvider, InvalidationReason, RootState, proof_count};
+
+/// On-chain state relevant to the defender for a single game.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum GameObservation {
+    Proposed,
+    Challenged {
+        proof_bitmap: u8,
+        has_required_support: bool,
+    },
+    Finalized,
+    Invalidated(InvalidationReason),
+    Unset,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum GameAssessment {
+    Proposed,
+    Challenged,
+    Finalized,
+    Closed,
+}
+
+/// Result of evaluating a game for one tick.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum GameOutcome {
+    /// Retain the game for monitoring.
+    Track,
+    /// The game was challenged and its root is valid: start a defense.
+    Defend,
+    /// The game no longer needs watching.
+    Drop,
+}
+
+pub(crate) struct GameEvaluator<'a, E, C> {
+    execution_client: &'a E,
+    consensus_provider: &'a C,
+}
+
+impl<'a, E, C> Clone for GameEvaluator<'a, E, C> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<E, C> Copy for GameEvaluator<'_, E, C> {}
+
+impl<'a, E, C> GameEvaluator<'a, E, C>
+where
+    E: DefenderClient,
+    C: ConsensusProvider,
+{
+    pub(crate) const fn new(execution_client: &'a E, consensus_provider: &'a C) -> Self {
+        Self {
+            execution_client,
+            consensus_provider,
+        }
+    }
+
+    pub(crate) async fn observe(
+        &self,
+        game: &GameMetadata,
+    ) -> Result<GameObservation, DefenderError> {
+        let status = self
+            .execution_client
+            .resolution_status(game.address)
+            .await?;
+        Ok(match status.root_state {
+            RootState::Proposed => GameObservation::Proposed,
+            RootState::Challenged => {
+                let proof_bitmap = self.execution_client.proof_bitmap(game.address).await?;
+                GameObservation::Challenged {
+                    proof_bitmap,
+                    has_required_support: has_required_proof_support(game, proof_bitmap),
+                }
+            }
+            RootState::Finalized => GameObservation::Finalized,
+            RootState::Invalidated => GameObservation::Invalidated(status.invalidation_reason),
+            RootState::None => GameObservation::Unset,
+        })
+    }
+
+    async fn assess(&self, game: &GameMetadata, now: u64) -> Result<GameAssessment, DefenderError> {
+        match self.observe(game).await? {
+            GameObservation::Proposed => {
+                if now < game.challenge_deadline {
+                    Ok(GameAssessment::Proposed)
+                } else {
+                    Ok(GameAssessment::Closed)
+                }
+            }
+            GameObservation::Challenged {
+                proof_bitmap,
+                has_required_support,
+            } => {
+                if has_required_support {
+                    info!(
+                        game = %game.address,
+                        proof_bitmap,
+                        proof_threshold = game.proof_threshold,
+                        "challenged game already has sufficient proof support"
+                    );
+                    return Ok(GameAssessment::Closed);
+                }
+                if now >= game.proof_deadline {
+                    error!(
+                        game = %game.address,
+                        proof_deadline = game.proof_deadline,
+                        "challenged game proof deadline elapsed before defense completed"
+                    );
+                    return Ok(GameAssessment::Closed);
+                }
+                Ok(GameAssessment::Challenged)
+            }
+            GameObservation::Finalized => Ok(GameAssessment::Finalized),
+            GameObservation::Invalidated(reason) => {
+                if reason == InvalidationReason::ProofTimeout {
+                    error!(
+                        game = %game.address,
+                        proof_deadline = game.proof_deadline,
+                        "challenged game proof deadline elapsed before defense completed"
+                    );
+                } else {
+                    warn!(
+                        game = %game.address,
+                        reason = ?reason,
+                        "game is invalidatable without defense"
+                    );
+                }
+                Ok(GameAssessment::Closed)
+            }
+            GameObservation::Unset => {
+                error!(game = %game.address, "factory game has unset root state");
+                Ok(GameAssessment::Closed)
+            }
+        }
+    }
+
+    pub(crate) async fn evaluate_discovered(
+        &self,
+        game: &GameMetadata,
+        now: u64,
+    ) -> Result<GameOutcome, DefenderError> {
+        Ok(match self.assess(game, now).await? {
+            GameAssessment::Proposed | GameAssessment::Challenged => GameOutcome::Track,
+            GameAssessment::Finalized => {
+                info!(
+                    game = %game.address,
+                    "game already has a positive resolution outcome"
+                );
+                GameOutcome::Drop
+            }
+            GameAssessment::Closed => GameOutcome::Drop,
+        })
+    }
+
+    pub(crate) async fn evaluate_tracked(
+        &self,
+        game: &GameMetadata,
+        latest_finalized_l2_block: BlockNumber,
+        now: u64,
+    ) -> Result<GameOutcome, DefenderError> {
+        let address = game.address;
+        match self.assess(game, now).await? {
+            GameAssessment::Proposed => Ok(GameOutcome::Track),
+            GameAssessment::Challenged => {
+                // only judge the root against finalized L2 state
+                if game.l2_block_number > latest_finalized_l2_block {
+                    return Ok(GameOutcome::Track);
+                }
+                let root = self
+                    .consensus_provider
+                    .output_root_at_block(game.l2_block_number)
+                    .await?;
+                if root == game.root_claim {
+                    Ok(GameOutcome::Defend)
+                } else {
+                    error!(
+                        game = %address,
+                        claimed_root = %game.root_claim,
+                        canonical_root = %root,
+                        "allowlisted proposer published a non-canonical root; refusing to defend"
+                    );
+                    Ok(GameOutcome::Drop)
+                }
+            }
+            GameAssessment::Finalized => {
+                info!(
+                    game = %game.address,
+                    "game has a positive resolution outcome"
+                );
+                Ok(GameOutcome::Drop)
+            }
+            GameAssessment::Closed => Ok(GameOutcome::Drop),
+        }
+    }
+}
+
+fn has_required_proof_support(game: &GameMetadata, proof_bitmap: u8) -> bool {
+    proof_count(proof_bitmap) >= game.proof_threshold
+}

--- a/proofs/defender/src/lane.rs
+++ b/proofs/defender/src/lane.rs
@@ -1,0 +1,264 @@
+use crate::{traits::DefenderClient, types::GameMetadata};
+use alloy_primitives::Bytes;
+use tracing::{error, info, warn};
+use world_chain_proofs::ProofLane;
+use world_chain_prover_service::{
+    ProofBackend, ProofData, ProofRequest, ProofRequestId, ProofRequester, ProofResponse,
+    ProofStatus,
+};
+
+/// Number of proof lanes the defender drives.
+pub(crate) const DEFENDED_LANE_COUNT: usize = 2;
+
+/// The proof lanes the defender drives, paired with the prover-service
+/// backend that generates each proof.
+pub(crate) const DEFENDED_LANES: [(ProofLane, ProofBackend); DEFENDED_LANE_COUNT] = [
+    (ProofLane::ValidityProof, ProofBackend::Sp1),
+    (ProofLane::TeeAttestation, ProofBackend::Nitro),
+];
+
+/// Progress of a single proof lane within an active defense.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LaneState {
+    /// The proof has not been requested yet.
+    Pending,
+    /// The proof was requested from the prover-service.
+    Requested { id: ProofRequestId, attempts: u32 },
+    /// The lane is proven on-chain.
+    Proven,
+    /// Proving permanently failed after exhausting all attempts.
+    Abandoned,
+}
+
+impl LaneState {
+    /// Whether the lane needs no further work.
+    pub(crate) const fn is_terminal(self) -> bool {
+        matches!(self, Self::Proven | Self::Abandoned)
+    }
+}
+
+pub(crate) struct LaneDriver<'a, E, P> {
+    execution_client: &'a E,
+    proof_requester: &'a P,
+    max_proof_attempts: u32,
+}
+
+impl<'a, E, P> LaneDriver<'a, E, P>
+where
+    E: DefenderClient,
+    P: ProofRequester + Sync,
+{
+    pub(crate) const fn new(
+        execution_client: &'a E,
+        proof_requester: &'a P,
+        max_proof_attempts: u32,
+    ) -> Self {
+        Self {
+            execution_client,
+            proof_requester,
+            max_proof_attempts,
+        }
+    }
+
+    pub(crate) async fn advance(
+        &self,
+        metadata: &GameMetadata,
+        lane: ProofLane,
+        backend: ProofBackend,
+        state: LaneState,
+    ) -> LaneState {
+        match state {
+            LaneState::Proven | LaneState::Abandoned => state,
+            LaneState::Pending => self.request_pending_lane(metadata, lane, backend).await,
+            LaneState::Requested { id, attempts } => {
+                self.advance_requested_lane(metadata, lane, backend, id, attempts)
+                    .await
+            }
+        }
+    }
+
+    async fn request_pending_lane(
+        &self,
+        metadata: &GameMetadata,
+        lane: ProofLane,
+        backend: ProofBackend,
+    ) -> LaneState {
+        let game = metadata.address;
+        match self
+            .proof_requester
+            .request_proof(proof_request(metadata, backend))
+            .await
+        {
+            Ok(id) => LaneState::Requested { id, attempts: 1 },
+            Err(error) => {
+                warn!(%game, ?lane, %error, "proof request failed; retrying next tick");
+                LaneState::Pending
+            }
+        }
+    }
+
+    async fn advance_requested_lane(
+        &self,
+        metadata: &GameMetadata,
+        lane: ProofLane,
+        backend: ProofBackend,
+        id: ProofRequestId,
+        attempts: u32,
+    ) -> LaneState {
+        let game = metadata.address;
+        let state = LaneState::Requested { id, attempts };
+        let status = match self.proof_requester.proof_status(id).await {
+            Ok(status) => status,
+            Err(error) => {
+                warn!(%game, ?lane, %id, %error, "proof status check failed; retrying next tick");
+                return state;
+            }
+        };
+
+        match status {
+            ProofStatus::Created | ProofStatus::Running => state,
+            ProofStatus::Succeeded => self.submit_succeeded_lane(metadata, lane, id, state).await,
+            ProofStatus::Failed => {
+                self.retry_failed_lane(metadata, lane, backend, attempts, state)
+                    .await
+            }
+        }
+    }
+
+    async fn submit_succeeded_lane(
+        &self,
+        metadata: &GameMetadata,
+        lane: ProofLane,
+        id: ProofRequestId,
+        state: LaneState,
+    ) -> LaneState {
+        let game = metadata.address;
+        let response = match self.proof_requester.get_proof(id).await {
+            Ok(ProofResponse::Succeeded(response)) => response,
+            Ok(ProofResponse::Pending(response)) => {
+                warn!(
+                    %game,
+                    ?lane,
+                    %id,
+                    status = %response.status,
+                    "proof status was succeeded but proof response is pending; retrying next tick"
+                );
+                return state;
+            }
+            Ok(ProofResponse::Failed(response)) => {
+                warn!(
+                    %game,
+                    ?lane,
+                    %id,
+                    reason = %response.reason,
+                    "proof status was succeeded but proof response is failed; retrying next tick"
+                );
+                return state;
+            }
+            Err(error) => {
+                warn!(%game, ?lane, %id, %error, "proof retrieval failed; retrying next tick");
+                return state;
+            }
+        };
+
+        match self
+            .execution_client
+            .submit_proof(game, lane as u8, encode_proof(&response.proof))
+            .await
+        {
+            Ok(submission) => {
+                info!(%game, ?lane, tx_hash = %submission.tx_hash, "proof lane submitted");
+                LaneState::Proven
+            }
+            Err(error) => {
+                // if the transaction actually landed, the proof bitmap check
+                // resolves the lane on the next tick
+                warn!(%game, ?lane, %error, "proof submission failed; retrying next tick");
+                state
+            }
+        }
+    }
+
+    async fn retry_failed_lane(
+        &self,
+        metadata: &GameMetadata,
+        lane: ProofLane,
+        backend: ProofBackend,
+        attempts: u32,
+        state: LaneState,
+    ) -> LaneState {
+        let game = metadata.address;
+        if attempts >= self.max_proof_attempts {
+            error!(%game, ?lane, attempts, "proving permanently failed; abandoning lane");
+            return LaneState::Abandoned;
+        }
+
+        // re-requesting a failed proof re-queues it
+        match self
+            .proof_requester
+            .request_proof(proof_request(metadata, backend))
+            .await
+        {
+            Ok(id) => {
+                let next_attempt = attempts + 1;
+                warn!(
+                    %game,
+                    ?lane,
+                    %id,
+                    attempts = next_attempt,
+                    max_attempts = self.max_proof_attempts,
+                    "proof failed; re-requested proof"
+                );
+                LaneState::Requested {
+                    id,
+                    attempts: next_attempt,
+                }
+            }
+            Err(error) => {
+                warn!(%game, ?lane, %error, "proof re-request failed; retrying next tick");
+                state
+            }
+        }
+    }
+}
+
+/// Builds the proof request for one lane of a defended game.
+fn proof_request(game: &GameMetadata, backend: ProofBackend) -> ProofRequest {
+    ProofRequest {
+        backend,
+        game: game.address,
+        root_claim: game.root_claim,
+        l2_block_number: game.l2_block_number,
+        // pin the witness to the L1 origin committed at proposal time, so
+        // the request id stays stable across defender restarts
+        l1_head: game.l1_origin_hash,
+    }
+}
+
+/// Encode a proof payload into the `bytes` argument of `submitProofLane`.
+///
+/// TODO: encode proofs for their concrete on-chain verifiers. SP1 proofs must
+/// match `SP1ValidityVerifier`'s ABI tuple:
+/// `(domainHash, parentRef, l1OriginNumber, publicValues, proofBytes)`.
+/// That requires proposal context in addition to `ProofData`, so this helper
+/// should move closer to the game/lane submission path before real SP1 lanes
+/// are enabled.
+fn encode_proof(proof: &ProofData) -> Bytes {
+    match proof {
+        ProofData::Sp1 {
+            proof,
+            public_values,
+        } => [public_values.as_ref(), proof.as_ref()].concat().into(),
+        ProofData::Nitro {
+            attestation,
+            public_values,
+            signature,
+        } => [
+            public_values.as_ref(),
+            attestation.as_ref(),
+            signature.as_ref(),
+        ]
+        .concat()
+        .into(),
+    }
+}

--- a/proofs/defender/src/lib.rs
+++ b/proofs/defender/src/lib.rs
@@ -4,6 +4,8 @@ mod alloy;
 mod config;
 mod defender;
 mod error;
+mod game;
+mod lane;
 mod traits;
 mod types;
 

--- a/proofs/defender/src/lib.rs
+++ b/proofs/defender/src/lib.rs
@@ -13,7 +13,7 @@ pub use config::DefenderConfig;
 pub use defender::WorldChainDefender;
 pub use error::DefenderError;
 pub use traits::DefenderClient;
-pub use types::DefenderSubmission;
+pub use types::{DefenderSubmission, GameMetadata};
 
 #[cfg(test)]
 mod tests;

--- a/proofs/defender/src/main.rs
+++ b/proofs/defender/src/main.rs
@@ -45,6 +45,10 @@ struct Cli {
     #[arg(long, env = "DEFENDER_KEY", hide_env_values = true)]
     defender_key: PrivateKeySigner,
 
+    /// The only proposer address whose games this defender will defend.
+    #[arg(long, env = "ALLOWED_PROPOSER")]
+    allowed_proposer: Address,
+
     /// Seconds between game-factory polls.
     #[arg(long, env = "POLL_INTERVAL_SECONDS", default_value_t = 12)]
     poll_interval_seconds: u64,
@@ -53,7 +57,11 @@ struct Cli {
     #[arg(long, env = "MAX_GAME_CONCURRENCY", default_value_t = 10)]
     max_game_concurrency: usize,
 
-    /// Maximum proof attempts per challenged game before giving up.
+    /// Maximum number of newly created games discovered per defender tick.
+    #[arg(long, env = "MAX_GAMES_PER_TICK", default_value_t = 100)]
+    max_games_per_tick: u64,
+
+    /// Maximum proof attempts per lane before giving up.
     #[arg(long, env = "MAX_PROOF_ATTEMPTS", default_value_t = 3)]
     max_proof_attempts: u32,
 }
@@ -77,8 +85,10 @@ async fn main() -> Result<()> {
     let proof_requester = RpcProverServiceClient::new(&cli.prover_service_url)
         .with_context(|| format!("failed to connect to {}", cli.prover_service_url))?;
     let config = DefenderConfig {
+        allowed_proposer: cli.allowed_proposer,
         poll_interval: Duration::from_secs(cli.poll_interval_seconds),
         max_game_concurrency: cli.max_game_concurrency,
+        max_games_per_tick: cli.max_games_per_tick,
         max_proof_attempts: cli.max_proof_attempts,
     };
     let mut defender = WorldChainDefender::new(config, client, output_roots, proof_requester);
@@ -89,6 +99,8 @@ async fn main() -> Result<()> {
         prover_service = %cli.prover_service_url,
         factory = %cli.factory_address,
         defender = %defender_address,
+        allowed_proposer = %cli.allowed_proposer,
+        max_games_per_tick = cli.max_games_per_tick,
         "starting World Chain proof-system defender"
     );
 

--- a/proofs/defender/src/tests.rs
+++ b/proofs/defender/src/tests.rs
@@ -8,16 +8,16 @@ use crate::{
 use alloy_primitives::{Address, B256, BlockNumber, Bytes, address};
 use async_trait::async_trait;
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::{
         Arc, Mutex,
-        atomic::{AtomicU64, Ordering},
+        atomic::{AtomicU64, AtomicUsize, Ordering},
     },
     time::Duration,
 };
 use world_chain_proofs::{
-    ConsensusError, ConsensusProvider, InvalidationReason, ProofLane, ResolutionStatus, RootState,
-    has_threshold,
+    ConsensusError, ConsensusProvider, InvalidationReason, PROOF_THRESHOLD, ProofLane,
+    ResolutionStatus, RootState, proof_count,
 };
 use world_chain_prover_service::{
     ProofBackend, ProofData, ProofRequest, ProofRequestError, ProofRequestId, ProofRequester,
@@ -45,7 +45,9 @@ struct MockClient {
     games: Vec<GameMetadata>,
     proposers: HashMap<Address, Address>,
     states: Arc<Mutex<HashMap<Address, u8>>>,
-    bitmaps: HashMap<Address, u8>,
+    bitmaps: Arc<Mutex<HashMap<Address, u8>>>,
+    parent_unresolved: Arc<Mutex<HashSet<Address>>>,
+    proof_bitmap_reads: Arc<AtomicUsize>,
     submissions: Arc<Mutex<Vec<(Address, u8)>>>,
 }
 
@@ -60,6 +62,7 @@ impl MockClient {
                 l1_origin_hash: L1_ORIGIN_HASH,
                 challenge_deadline: u64::MAX,
                 proof_deadline: u64::MAX,
+                proof_threshold: PROOF_THRESHOLD,
             })
             .collect();
         let proposers = games
@@ -70,7 +73,9 @@ impl MockClient {
             games,
             proposers,
             states: Arc::new(Mutex::new(states)),
-            bitmaps: HashMap::new(),
+            bitmaps: Arc::default(),
+            parent_unresolved: Arc::default(),
+            proof_bitmap_reads: Arc::default(),
             submissions: Arc::default(),
         }
     }
@@ -89,6 +94,14 @@ impl MockClient {
         metadata.proof_deadline = proof_deadline;
     }
 
+    fn set_proof_threshold(&mut self, game: Address, proof_threshold: u8) {
+        self.games
+            .iter_mut()
+            .find(|metadata| metadata.address == game)
+            .expect("game exists")
+            .proof_threshold = proof_threshold;
+    }
+
     fn set_state(&self, game: Address, state: u8) {
         self.states
             .lock()
@@ -105,6 +118,37 @@ impl MockClient {
             .copied()
             .unwrap_or(STATE_PROPOSED);
         RootState::try_from(raw).map_err(Into::into)
+    }
+
+    fn set_bitmap(&self, game: Address, bitmap: u8) {
+        self.bitmaps
+            .lock()
+            .expect("not poisoned")
+            .insert(game, bitmap);
+    }
+
+    fn bitmap(&self, game: Address) -> u8 {
+        self.bitmaps
+            .lock()
+            .expect("not poisoned")
+            .get(&game)
+            .copied()
+            .unwrap_or(0)
+    }
+
+    fn set_parent_unresolved(&self, game: Address) {
+        self.parent_unresolved
+            .lock()
+            .expect("not poisoned")
+            .insert(game);
+    }
+
+    fn reset_proof_bitmap_reads(&self) {
+        self.proof_bitmap_reads.store(0, Ordering::SeqCst);
+    }
+
+    fn proof_bitmap_reads(&self) -> usize {
+        self.proof_bitmap_reads.load(Ordering::SeqCst)
     }
 
     fn submissions(&self) -> Vec<(Address, u8)> {
@@ -150,8 +194,26 @@ impl DefenderClient for MockClient {
 
     async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, DefenderError> {
         let state = self.state(game)?;
+        if self
+            .parent_unresolved
+            .lock()
+            .expect("not poisoned")
+            .contains(&game)
+        {
+            return Ok(ResolutionStatus {
+                resolvable: false,
+                root_state: state,
+                invalidation_reason: InvalidationReason::None,
+            });
+        }
         if state == RootState::Challenged {
-            if has_threshold(self.proof_bitmap(game).await?) {
+            let proof_threshold = self
+                .games
+                .iter()
+                .find(|metadata| metadata.address == game)
+                .expect("game exists")
+                .proof_threshold;
+            if proof_count(self.bitmap(game)) >= proof_threshold {
                 return Ok(ResolutionStatus {
                     resolvable: true,
                     root_state: RootState::Finalized,
@@ -174,7 +236,8 @@ impl DefenderClient for MockClient {
     }
 
     async fn proof_bitmap(&self, game: Address) -> Result<u8, DefenderError> {
-        Ok(self.bitmaps.get(&game).copied().unwrap_or(0))
+        self.proof_bitmap_reads.fetch_add(1, Ordering::SeqCst);
+        Ok(self.bitmap(game))
     }
 
     async fn submit_proof(
@@ -183,6 +246,11 @@ impl DefenderClient for MockClient {
         lane: u8,
         _proof: Bytes,
     ) -> Result<DefenderSubmission, DefenderError> {
+        {
+            let mut bitmaps = self.bitmaps.lock().expect("not poisoned");
+            let bitmap = bitmaps.entry(game).or_default();
+            *bitmap |= 1 << lane;
+        }
         self.submissions
             .lock()
             .expect("not poisoned")
@@ -464,6 +532,103 @@ async fn active_defense_is_removed_after_proof_deadline() {
 }
 
 #[tokio::test]
+async fn scan_accepts_sufficient_proof_support_hidden_by_an_unresolved_parent() {
+    let canonical_root = B256::repeat_byte(0x20);
+    let mut client = MockClient::new(
+        vec![
+            (GAME_1, canonical_root, L2_BLOCK),
+            (GAME_2, canonical_root, L2_BLOCK),
+        ],
+        HashMap::from([(GAME_2, STATE_CHALLENGED)]),
+    );
+    client.set_deadlines(GAME_1, 20, 20);
+    client.set_deadlines(GAME_2, 20, 20);
+    client.set_proof_threshold(GAME_2, 1);
+    client.set_parent_unresolved(GAME_2);
+    client.set_bitmap(GAME_2, ProofLane::ValidityProof.mask());
+    let (output_roots, _finalized_l2_block) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
+    let mut limited_config = config();
+    limited_config.max_games_per_tick = 1;
+    let mut defender = WorldChainDefender::new(
+        limited_config,
+        client.clone(),
+        output_roots,
+        MockProver::default(),
+    );
+
+    defender.scan_once_with_timestamp(5).await.unwrap();
+    assert_eq!(defender.next_game_index(), Some(1));
+
+    client.reset_proof_bitmap_reads();
+    defender.scan_once_with_timestamp(20).await.unwrap();
+
+    assert_eq!(client.proof_bitmap_reads(), 1);
+    assert_eq!(defender.next_game_index(), Some(2));
+    assert!(defender.watched_games().is_empty());
+    assert!(defender.active_defenses().is_empty());
+}
+
+#[tokio::test]
+async fn watched_game_accepts_sufficient_proof_support_hidden_by_an_unresolved_parent() {
+    let canonical_root = B256::repeat_byte(0x20);
+    let mut client = MockClient::new(vec![(GAME_1, canonical_root, L2_BLOCK)], HashMap::new());
+    client.set_deadlines(GAME_1, 10, 20);
+    client.set_proof_threshold(GAME_1, 1);
+    client.set_parent_unresolved(GAME_1);
+    let (output_roots, _finalized_l2_block) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
+    let prover = MockProver::default();
+    let mut defender =
+        WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
+
+    defender.scan_once_with_timestamp(5).await.unwrap();
+    assert_eq!(defender.watched_games(), [GAME_1]);
+
+    client.set_state(GAME_1, STATE_CHALLENGED);
+    client.set_bitmap(GAME_1, ProofLane::ValidityProof.mask());
+    client.reset_proof_bitmap_reads();
+    defender.scan_once_with_timestamp(20).await.unwrap();
+
+    assert_eq!(client.proof_bitmap_reads(), 1);
+    assert!(prover.requests().is_empty());
+    assert!(defender.watched_games().is_empty());
+    assert!(defender.active_defenses().is_empty());
+}
+
+#[tokio::test]
+async fn active_defense_accepts_sufficient_proof_support_hidden_by_an_unresolved_parent() {
+    let canonical_root = B256::repeat_byte(0x20);
+    let mut client = MockClient::new(
+        vec![(GAME_1, canonical_root, L2_BLOCK)],
+        HashMap::from([(GAME_1, STATE_CHALLENGED)]),
+    );
+    client.set_deadlines(GAME_1, 10, 20);
+    client.set_parent_unresolved(GAME_1);
+    let (output_roots, _finalized_l2_block) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
+    let prover = MockProver::default();
+    let mut defender =
+        WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
+
+    defender.scan_once_with_timestamp(5).await.unwrap();
+    assert_eq!(defender.active_defenses(), [GAME_1]);
+    assert_eq!(prover.requests().len(), 2);
+
+    client.set_bitmap(
+        GAME_1,
+        ProofLane::ValidityProof.mask() | ProofLane::TeeAttestation.mask(),
+    );
+    client.reset_proof_bitmap_reads();
+    defender.scan_once_with_timestamp(20).await.unwrap();
+
+    assert_eq!(client.proof_bitmap_reads(), 1);
+    assert!(client.submissions().is_empty());
+    assert!(defender.watched_games().is_empty());
+    assert!(defender.active_defenses().is_empty());
+}
+
+#[tokio::test]
 async fn scan_once_defends_challenged_valid_root() {
     let canonical_root = B256::repeat_byte(0x20);
 
@@ -583,13 +748,11 @@ async fn scan_once_defers_validity_check_until_l2_block_is_finalized() {
 async fn scan_once_skips_lane_already_proven() {
     let canonical_root = B256::repeat_byte(0x20);
 
-    let mut client = MockClient::new(
+    let client = MockClient::new(
         vec![(GAME_1, canonical_root, L2_BLOCK)],
         HashMap::from([(GAME_1, STATE_CHALLENGED)]),
     );
-    client
-        .bitmaps
-        .insert(GAME_1, ProofLane::ValidityProof.mask());
+    client.set_bitmap(GAME_1, ProofLane::ValidityProof.mask());
     let (output_roots, _finalized_l2_block) =
         mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
     let prover = MockProver::default();

--- a/proofs/defender/src/tests.rs
+++ b/proofs/defender/src/tests.rs
@@ -394,7 +394,7 @@ fn config() -> DefenderConfig {
 }
 
 #[tokio::test]
-async fn scan_once_requires_an_allowed_proposer() {
+async fn tick_requires_an_allowed_proposer() {
     let client = MockClient::new(Vec::new(), HashMap::new());
     let (output_roots, _finalized_l2_block) = mock_output_roots(HashMap::new(), 0);
     let mut defender = WorldChainDefender::new(
@@ -404,12 +404,12 @@ async fn scan_once_requires_an_allowed_proposer() {
         MockProver::default(),
     );
 
-    let error = defender.scan_once().await.unwrap_err();
+    let error = defender.tick().await.unwrap_err();
     assert!(matches!(error, DefenderError::InvalidConfig(_)));
 }
 
 #[tokio::test]
-async fn scan_once_binary_searches_for_first_unexpired_proof_deadline() {
+async fn tick_binary_searches_for_first_unexpired_proof_deadline() {
     let canonical_root = B256::repeat_byte(0x20);
     let mut client = MockClient::new(
         vec![
@@ -424,14 +424,14 @@ async fn scan_once_binary_searches_for_first_unexpired_proof_deadline() {
     let mut defender =
         WorldChainDefender::new(config(), client, output_roots, MockProver::default());
 
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
 
     assert_eq!(defender.next_game_index(), Some(2));
     assert_eq!(defender.watched_games(), [GAME_2]);
 }
 
 #[tokio::test]
-async fn scan_once_respects_factory_scan_budget() {
+async fn tick_respects_factory_scan_budget() {
     let canonical_root = B256::repeat_byte(0x20);
     let client = MockClient::new(
         vec![
@@ -447,11 +447,11 @@ async fn scan_once_respects_factory_scan_budget() {
     let mut defender =
         WorldChainDefender::new(limited_config, client, output_roots, MockProver::default());
 
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
     assert_eq!(defender.next_game_index(), Some(1));
     assert_eq!(defender.watched_games(), [GAME_1]);
 
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
     assert_eq!(defender.next_game_index(), Some(2));
     let watched = defender.watched_games();
     assert_eq!(watched.len(), 2);
@@ -460,7 +460,7 @@ async fn scan_once_respects_factory_scan_budget() {
 }
 
 #[tokio::test]
-async fn scan_once_ignores_games_from_other_proposers() {
+async fn tick_ignores_games_from_other_proposers() {
     let canonical_root = B256::repeat_byte(0x20);
     let mut client = MockClient::new(
         vec![(GAME_1, canonical_root, L2_BLOCK)],
@@ -472,7 +472,7 @@ async fn scan_once_ignores_games_from_other_proposers() {
     let prover = MockProver::default();
     let mut defender = WorldChainDefender::new(config(), client, output_roots, prover.clone());
 
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
 
     assert_eq!(defender.next_game_index(), Some(1));
     assert!(prover.requests().is_empty());
@@ -481,7 +481,7 @@ async fn scan_once_ignores_games_from_other_proposers() {
 }
 
 #[tokio::test]
-async fn scan_once_discards_invalidated_games() {
+async fn tick_discards_invalidated_games() {
     let canonical_root = B256::repeat_byte(0x20);
     let client = MockClient::new(
         vec![(GAME_1, canonical_root, L2_BLOCK)],
@@ -492,7 +492,7 @@ async fn scan_once_discards_invalidated_games() {
     let prover = MockProver::default();
     let mut defender = WorldChainDefender::new(config(), client, output_roots, prover.clone());
 
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
 
     assert!(prover.requests().is_empty());
     assert!(defender.watched_games().is_empty());
@@ -509,10 +509,10 @@ async fn proposed_game_is_removed_after_challenge_deadline() {
     let mut defender =
         WorldChainDefender::new(config(), client, output_roots, MockProver::default());
 
-    defender.scan_once_with_timestamp(5).await.unwrap();
+    defender.tick_at(5).await.unwrap();
     assert_eq!(defender.watched_games(), [GAME_1]);
 
-    defender.scan_once_with_timestamp(10).await.unwrap();
+    defender.tick_at(10).await.unwrap();
     assert!(defender.watched_games().is_empty());
 }
 
@@ -529,19 +529,19 @@ async fn active_defense_is_removed_after_proof_deadline() {
     let prover = MockProver::default();
     let mut defender = WorldChainDefender::new(config(), client, output_roots, prover.clone());
 
-    defender.scan_once_with_timestamp(5).await.unwrap();
+    defender.tick_at(5).await.unwrap();
     assert_eq!(defender.active_defenses(), [GAME_1]);
     assert!(prover.requests().is_empty());
 
-    defender.scan_once_with_timestamp(6).await.unwrap();
+    defender.tick_at(6).await.unwrap();
     assert_eq!(prover.requests().len(), 2);
 
-    defender.scan_once_with_timestamp(20).await.unwrap();
+    defender.tick_at(20).await.unwrap();
     assert!(defender.active_defenses().is_empty());
     assert!(defender.watched_games().is_empty());
 
     // Removal makes the critical deadline condition one-shot.
-    defender.scan_once_with_timestamp(21).await.unwrap();
+    defender.tick_at(21).await.unwrap();
     assert!(defender.active_defenses().is_empty());
 }
 
@@ -560,12 +560,12 @@ async fn active_defense_advances_before_discovery_failure() {
 
     // Discovery and validation promote the game, but active work starts on
     // the next tick because existing defenses run first.
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
     assert_eq!(defender.active_defenses(), [GAME_1]);
     assert!(prover.requests().is_empty());
 
     client.set_game_count_failure(true);
-    let error = defender.scan_once().await.unwrap_err();
+    let error = defender.tick().await.unwrap_err();
 
     assert!(matches!(error, DefenderError::Contract(_)));
     assert_eq!(prover.requests().len(), 2);
@@ -598,11 +598,11 @@ async fn scan_accepts_sufficient_proof_support_hidden_by_an_unresolved_parent() 
         MockProver::default(),
     );
 
-    defender.scan_once_with_timestamp(5).await.unwrap();
+    defender.tick_at(5).await.unwrap();
     assert_eq!(defender.next_game_index(), Some(1));
 
     client.reset_proof_bitmap_reads();
-    defender.scan_once_with_timestamp(20).await.unwrap();
+    defender.tick_at(20).await.unwrap();
 
     assert_eq!(client.proof_bitmap_reads(), 1);
     assert_eq!(defender.next_game_index(), Some(2));
@@ -623,13 +623,13 @@ async fn watched_game_accepts_sufficient_proof_support_hidden_by_an_unresolved_p
     let mut defender =
         WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
 
-    defender.scan_once_with_timestamp(5).await.unwrap();
+    defender.tick_at(5).await.unwrap();
     assert_eq!(defender.watched_games(), [GAME_1]);
 
     client.set_state(GAME_1, STATE_CHALLENGED);
     client.set_bitmap(GAME_1, ProofLane::ValidityProof.mask());
     client.reset_proof_bitmap_reads();
-    defender.scan_once_with_timestamp(20).await.unwrap();
+    defender.tick_at(20).await.unwrap();
 
     assert_eq!(client.proof_bitmap_reads(), 1);
     assert!(prover.requests().is_empty());
@@ -652,11 +652,11 @@ async fn active_defense_accepts_sufficient_proof_support_hidden_by_an_unresolved
     let mut defender =
         WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
 
-    defender.scan_once_with_timestamp(5).await.unwrap();
+    defender.tick_at(5).await.unwrap();
     assert_eq!(defender.active_defenses(), [GAME_1]);
     assert!(prover.requests().is_empty());
 
-    defender.scan_once_with_timestamp(6).await.unwrap();
+    defender.tick_at(6).await.unwrap();
     assert_eq!(prover.requests().len(), 2);
 
     client.set_bitmap(
@@ -664,7 +664,7 @@ async fn active_defense_accepts_sufficient_proof_support_hidden_by_an_unresolved
         ProofLane::ValidityProof.mask() | ProofLane::TeeAttestation.mask(),
     );
     client.reset_proof_bitmap_reads();
-    defender.scan_once_with_timestamp(20).await.unwrap();
+    defender.tick_at(20).await.unwrap();
 
     assert_eq!(client.proof_bitmap_reads(), 1);
     assert!(client.submissions().is_empty());
@@ -673,7 +673,7 @@ async fn active_defense_accepts_sufficient_proof_support_hidden_by_an_unresolved
 }
 
 #[tokio::test]
-async fn scan_once_defends_challenged_valid_root() {
+async fn tick_defends_challenged_valid_root() {
     let canonical_root = B256::repeat_byte(0x20);
 
     let client = MockClient::new(
@@ -687,12 +687,12 @@ async fn scan_once_defends_challenged_valid_root() {
         WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
 
     // First tick: discovery and validation promote the challenged game.
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
     assert_eq!(defender.active_defenses(), [GAME_1]);
     assert!(prover.requests().is_empty());
 
     // Second tick: both lane proofs are requested.
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
     let requests = prover.requests();
     assert_eq!(requests.len(), 2);
     assert_eq!(requests[0].backend, ProofBackend::Sp1);
@@ -706,7 +706,7 @@ async fn scan_once_defends_challenged_valid_root() {
     assert!(client.submissions().is_empty());
 
     // Third tick: both proofs are completed, fetched and submitted on-chain.
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
 
     assert_eq!(
         client.submissions(),
@@ -720,7 +720,7 @@ async fn scan_once_defends_challenged_valid_root() {
 }
 
 #[tokio::test]
-async fn scan_once_waits_for_proposed_game_to_be_challenged() {
+async fn tick_waits_for_proposed_game_to_be_challenged() {
     let canonical_root = B256::repeat_byte(0x20);
 
     let client = MockClient::new(vec![(GAME_1, canonical_root, L2_BLOCK)], HashMap::new());
@@ -731,22 +731,22 @@ async fn scan_once_waits_for_proposed_game_to_be_challenged() {
         WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
 
     // the game is only proposed: keep watching, no proof requests
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
     assert!(prover.requests().is_empty());
     assert_eq!(defender.watched_games(), [GAME_1]);
 
     client.set_state(GAME_1, STATE_CHALLENGED);
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
 
     assert!(prover.requests().is_empty());
     assert_eq!(defender.active_defenses(), [GAME_1]);
 
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
     assert_eq!(prover.requests().len(), 2);
 }
 
 #[tokio::test]
-async fn scan_once_ignores_challenged_invalid_root() {
+async fn tick_ignores_challenged_invalid_root() {
     let proposed_root = B256::repeat_byte(0x10);
     let canonical_root = B256::repeat_byte(0x20);
 
@@ -760,7 +760,7 @@ async fn scan_once_ignores_challenged_invalid_root() {
     let mut defender =
         WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
 
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
 
     // an invalid root is the challenger's business, not ours
     assert!(prover.requests().is_empty());
@@ -769,7 +769,7 @@ async fn scan_once_ignores_challenged_invalid_root() {
 }
 
 #[tokio::test]
-async fn scan_once_defers_validity_check_until_l2_block_is_finalized() {
+async fn tick_defers_validity_check_until_l2_block_is_finalized() {
     let canonical_root = B256::repeat_byte(0x20);
 
     let client = MockClient::new(
@@ -783,22 +783,22 @@ async fn scan_once_defers_validity_check_until_l2_block_is_finalized() {
         WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
 
     // the game's L2 block is not finalized yet, so the root cannot be judged
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
     assert!(prover.requests().is_empty());
     assert_eq!(defender.watched_games(), [GAME_1]);
 
     finalized_l2_block.store(L2_BLOCK, Ordering::SeqCst);
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
 
     assert!(prover.requests().is_empty());
     assert_eq!(defender.active_defenses(), [GAME_1]);
 
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
     assert_eq!(prover.requests().len(), 2);
 }
 
 #[tokio::test]
-async fn scan_once_skips_lane_already_proven() {
+async fn tick_skips_lane_already_proven() {
     let canonical_root = B256::repeat_byte(0x20);
 
     let client = MockClient::new(
@@ -812,9 +812,9 @@ async fn scan_once_skips_lane_already_proven() {
     let mut defender =
         WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
 
-    defender.scan_once().await.unwrap();
-    defender.scan_once().await.unwrap();
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
+    defender.tick().await.unwrap();
+    defender.tick().await.unwrap();
 
     // the validity lane is already proven on-chain: only the TEE lane runs
     let requests = prover.requests();
@@ -850,10 +850,10 @@ async fn failed_proofs_are_rerequested_up_to_the_attempt_bound() {
 
     // Tick 1 promotes the game. Tick 2 makes the first request per lane;
     // tick 3 re-requests each failed proof; tick 4 exhausts the attempts.
-    defender.scan_once().await.unwrap();
-    defender.scan_once().await.unwrap();
-    defender.scan_once().await.unwrap();
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
+    defender.tick().await.unwrap();
+    defender.tick().await.unwrap();
+    defender.tick().await.unwrap();
 
     assert_eq!(prover.requests().len(), 4);
     assert!(client.submissions().is_empty());
@@ -874,11 +874,11 @@ async fn defense_closes_when_game_leaves_challenged_state() {
     let mut defender =
         WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
 
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
     assert_eq!(defender.active_defenses(), [GAME_1]);
 
     client.set_state(GAME_1, STATE_FINALIZED);
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
 
     assert!(client.submissions().is_empty());
     assert!(defender.active_defenses().is_empty());

--- a/proofs/defender/src/tests.rs
+++ b/proofs/defender/src/tests.rs
@@ -11,7 +11,7 @@ use std::{
     collections::{HashMap, HashSet},
     sync::{
         Arc, Mutex,
-        atomic::{AtomicU64, AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
     },
     time::Duration,
 };
@@ -48,6 +48,7 @@ struct MockClient {
     bitmaps: Arc<Mutex<HashMap<Address, u8>>>,
     parent_unresolved: Arc<Mutex<HashSet<Address>>>,
     proof_bitmap_reads: Arc<AtomicUsize>,
+    fail_game_count: Arc<AtomicBool>,
     submissions: Arc<Mutex<Vec<(Address, u8)>>>,
 }
 
@@ -76,6 +77,7 @@ impl MockClient {
             bitmaps: Arc::default(),
             parent_unresolved: Arc::default(),
             proof_bitmap_reads: Arc::default(),
+            fail_game_count: Arc::default(),
             submissions: Arc::default(),
         }
     }
@@ -151,6 +153,10 @@ impl MockClient {
         self.proof_bitmap_reads.load(Ordering::SeqCst)
     }
 
+    fn set_game_count_failure(&self, fail: bool) {
+        self.fail_game_count.store(fail, Ordering::SeqCst);
+    }
+
     fn submissions(&self) -> Vec<(Address, u8)> {
         self.submissions.lock().expect("not poisoned").clone()
     }
@@ -159,6 +165,11 @@ impl MockClient {
 #[async_trait]
 impl DefenderClient for MockClient {
     async fn game_count(&self) -> Result<u64, DefenderError> {
+        if self.fail_game_count.load(Ordering::SeqCst) {
+            return Err(DefenderError::Contract(
+                "configured game_count failure".into(),
+            ));
+        }
         Ok(self.games.len() as u64)
     }
 
@@ -520,6 +531,9 @@ async fn active_defense_is_removed_after_proof_deadline() {
 
     defender.scan_once_with_timestamp(5).await.unwrap();
     assert_eq!(defender.active_defenses(), [GAME_1]);
+    assert!(prover.requests().is_empty());
+
+    defender.scan_once_with_timestamp(6).await.unwrap();
     assert_eq!(prover.requests().len(), 2);
 
     defender.scan_once_with_timestamp(20).await.unwrap();
@@ -529,6 +543,33 @@ async fn active_defense_is_removed_after_proof_deadline() {
     // Removal makes the critical deadline condition one-shot.
     defender.scan_once_with_timestamp(21).await.unwrap();
     assert!(defender.active_defenses().is_empty());
+}
+
+#[tokio::test]
+async fn active_defense_advances_before_discovery_failure() {
+    let canonical_root = B256::repeat_byte(0x20);
+    let client = MockClient::new(
+        vec![(GAME_1, canonical_root, L2_BLOCK)],
+        HashMap::from([(GAME_1, STATE_CHALLENGED)]),
+    );
+    let (output_roots, _finalized_l2_block) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
+    let prover = MockProver::default();
+    let mut defender =
+        WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
+
+    // Discovery and validation promote the game, but active work starts on
+    // the next tick because existing defenses run first.
+    defender.scan_once().await.unwrap();
+    assert_eq!(defender.active_defenses(), [GAME_1]);
+    assert!(prover.requests().is_empty());
+
+    client.set_game_count_failure(true);
+    let error = defender.scan_once().await.unwrap_err();
+
+    assert!(matches!(error, DefenderError::Contract(_)));
+    assert_eq!(prover.requests().len(), 2);
+    assert_eq!(defender.active_defenses(), [GAME_1]);
 }
 
 #[tokio::test]
@@ -613,6 +654,9 @@ async fn active_defense_accepts_sufficient_proof_support_hidden_by_an_unresolved
 
     defender.scan_once_with_timestamp(5).await.unwrap();
     assert_eq!(defender.active_defenses(), [GAME_1]);
+    assert!(prover.requests().is_empty());
+
+    defender.scan_once_with_timestamp(6).await.unwrap();
     assert_eq!(prover.requests().len(), 2);
 
     client.set_bitmap(
@@ -642,10 +686,13 @@ async fn scan_once_defends_challenged_valid_root() {
     let mut defender =
         WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
 
-    // first tick: the challenged game is promoted to an active defense and
-    // both lane proofs are requested
+    // First tick: discovery and validation promote the challenged game.
     defender.scan_once().await.unwrap();
+    assert_eq!(defender.active_defenses(), [GAME_1]);
+    assert!(prover.requests().is_empty());
 
+    // Second tick: both lane proofs are requested.
+    defender.scan_once().await.unwrap();
     let requests = prover.requests();
     assert_eq!(requests.len(), 2);
     assert_eq!(requests[0].backend, ProofBackend::Sp1);
@@ -658,7 +705,7 @@ async fn scan_once_defends_challenged_valid_root() {
     }
     assert!(client.submissions().is_empty());
 
-    // second tick: both proofs are completed, fetched and submitted on-chain
+    // Third tick: both proofs are completed, fetched and submitted on-chain.
     defender.scan_once().await.unwrap();
 
     assert_eq!(
@@ -691,8 +738,11 @@ async fn scan_once_waits_for_proposed_game_to_be_challenged() {
     client.set_state(GAME_1, STATE_CHALLENGED);
     defender.scan_once().await.unwrap();
 
-    assert_eq!(prover.requests().len(), 2);
+    assert!(prover.requests().is_empty());
     assert_eq!(defender.active_defenses(), [GAME_1]);
+
+    defender.scan_once().await.unwrap();
+    assert_eq!(prover.requests().len(), 2);
 }
 
 #[tokio::test]
@@ -740,8 +790,11 @@ async fn scan_once_defers_validity_check_until_l2_block_is_finalized() {
     finalized_l2_block.store(L2_BLOCK, Ordering::SeqCst);
     defender.scan_once().await.unwrap();
 
-    assert_eq!(prover.requests().len(), 2);
+    assert!(prover.requests().is_empty());
     assert_eq!(defender.active_defenses(), [GAME_1]);
+
+    defender.scan_once().await.unwrap();
+    assert_eq!(prover.requests().len(), 2);
 }
 
 #[tokio::test]
@@ -759,6 +812,7 @@ async fn scan_once_skips_lane_already_proven() {
     let mut defender =
         WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
 
+    defender.scan_once().await.unwrap();
     defender.scan_once().await.unwrap();
     defender.scan_once().await.unwrap();
 
@@ -794,8 +848,9 @@ async fn failed_proofs_are_rerequested_up_to_the_attempt_bound() {
         prover.clone(),
     );
 
-    // tick 1: first request per lane; tick 2: failed, re-requested once per
-    // lane; tick 3: failed again, attempts exhausted, lanes abandoned
+    // Tick 1 promotes the game. Tick 2 makes the first request per lane;
+    // tick 3 re-requests each failed proof; tick 4 exhausts the attempts.
+    defender.scan_once().await.unwrap();
     defender.scan_once().await.unwrap();
     defender.scan_once().await.unwrap();
     defender.scan_once().await.unwrap();

--- a/proofs/defender/src/tests.rs
+++ b/proofs/defender/src/tests.rs
@@ -1,6 +1,9 @@
 use crate::{
-    config::DefenderConfig, defender::WorldChainDefender, error::DefenderError,
-    traits::DefenderClient, types::DefenderSubmission,
+    config::DefenderConfig,
+    defender::WorldChainDefender,
+    error::DefenderError,
+    traits::DefenderClient,
+    types::{DefenderSubmission, GameMetadata},
 };
 use alloy_primitives::{Address, B256, BlockNumber, Bytes, address};
 use async_trait::async_trait;
@@ -12,14 +15,19 @@ use std::{
     },
     time::Duration,
 };
-use world_chain_proofs::{ConsensusError, ConsensusProvider, GameCreated, ProofLane, RootState};
+use world_chain_proofs::{
+    ConsensusError, ConsensusProvider, InvalidationReason, ProofLane, ResolutionStatus, RootState,
+    has_threshold,
+};
 use world_chain_prover_service::{
     ProofBackend, ProofData, ProofRequest, ProofRequestError, ProofRequestId, ProofRequester,
     ProofResponse, ProofStatus, SucceededProofResponse,
 };
 
 const GAME_1: Address = address!("0000000000000000000000000000000000000001");
-const FINALIZED_L1_BLOCK: BlockNumber = 10_000;
+const GAME_2: Address = address!("0000000000000000000000000000000000000002");
+const ALLOWED_PROPOSER: Address = address!("00000000000000000000000000000000000000a1");
+const OTHER_PROPOSER: Address = address!("00000000000000000000000000000000000000b2");
 const L2_BLOCK: u64 = 100;
 const L1_ORIGIN_HASH: B256 = B256::repeat_byte(0x42);
 
@@ -29,27 +37,56 @@ const STATE_PROPOSED: u8 = 1;
 const STATE_CHALLENGED: u8 = 2;
 /// State discriminant matching [`RootState::Finalized`].
 const STATE_FINALIZED: u8 = 3;
+/// State discriminant matching [`RootState::Invalidated`].
+const STATE_INVALIDATED: u8 = 4;
 
 #[derive(Debug, Clone)]
 struct MockClient {
-    finalized: BlockNumber,
-    games: Vec<(Address, B256, u64)>,
+    games: Vec<GameMetadata>,
+    proposers: HashMap<Address, Address>,
     states: Arc<Mutex<HashMap<Address, u8>>>,
-    deadlines: HashMap<Address, u64>,
     bitmaps: HashMap<Address, u8>,
     submissions: Arc<Mutex<Vec<(Address, u8)>>>,
 }
 
 impl MockClient {
     fn new(games: Vec<(Address, B256, u64)>, states: HashMap<Address, u8>) -> Self {
+        let games: Vec<_> = games
+            .into_iter()
+            .map(|(address, root_claim, l2_block_number)| GameMetadata {
+                address,
+                root_claim,
+                l2_block_number,
+                l1_origin_hash: L1_ORIGIN_HASH,
+                challenge_deadline: u64::MAX,
+                proof_deadline: u64::MAX,
+            })
+            .collect();
+        let proposers = games
+            .iter()
+            .map(|game| (game.address, ALLOWED_PROPOSER))
+            .collect();
         Self {
-            finalized: FINALIZED_L1_BLOCK,
             games,
+            proposers,
             states: Arc::new(Mutex::new(states)),
-            deadlines: HashMap::new(),
             bitmaps: HashMap::new(),
             submissions: Arc::default(),
         }
+    }
+
+    fn set_proposer(&mut self, game: Address, proposer: Address) {
+        self.proposers.insert(game, proposer);
+    }
+
+    fn set_deadlines(&mut self, game: Address, challenge_deadline: u64, proof_deadline: u64) {
+        let metadata = self
+            .games
+            .iter_mut()
+            .find(|metadata| metadata.address == game)
+            .expect("game exists");
+        metadata.challenge_deadline = challenge_deadline;
+        metadata.proof_deadline = proof_deadline;
     }
 
     fn set_state(&self, game: Address, state: u8) {
@@ -66,6 +103,32 @@ impl MockClient {
 
 #[async_trait]
 impl DefenderClient for MockClient {
+    async fn game_count(&self) -> Result<u64, DefenderError> {
+        Ok(self.games.len() as u64)
+    }
+
+    async fn game_address_at(&self, index: u64) -> Result<Address, DefenderError> {
+        self.games
+            .get(index as usize)
+            .map(|game| game.address)
+            .ok_or_else(|| DefenderError::Contract(format!("unknown game index {index}")))
+    }
+
+    async fn game_proposer(&self, game: Address) -> Result<Address, DefenderError> {
+        self.proposers
+            .get(&game)
+            .copied()
+            .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))
+    }
+
+    async fn game_metadata(&self, game: Address) -> Result<GameMetadata, DefenderError> {
+        self.games
+            .iter()
+            .find(|metadata| metadata.address == game)
+            .copied()
+            .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))
+    }
+
     async fn root_state(&self, game: Address) -> Result<RootState, DefenderError> {
         let raw = self
             .states
@@ -77,34 +140,37 @@ impl DefenderClient for MockClient {
         RootState::try_from(raw).map_err(Into::into)
     }
 
-    async fn finalized_l1_block_num(&self) -> Result<BlockNumber, DefenderError> {
-        Ok(self.finalized)
-    }
-
-    async fn games_created(
-        &self,
-        _from: BlockNumber,
-        _to: BlockNumber,
-    ) -> Result<Vec<GameCreated>, DefenderError> {
-        Ok(self
-            .games
+    async fn proof_deadline(&self, game: Address) -> Result<u64, DefenderError> {
+        self.games
             .iter()
-            .map(|&(game, root_claim, l2_block_number)| GameCreated {
-                proposal_key: B256::ZERO,
-                root_id: B256::ZERO,
-                game,
-                proposer: Address::ZERO,
-                root_claim,
-                l2_block_number,
-                parent_ref: Address::ZERO,
-                l1_origin_hash: L1_ORIGIN_HASH,
-                l1_origin_number: 0,
-            })
-            .collect())
+            .find(|metadata| metadata.address == game)
+            .map(|metadata| metadata.proof_deadline)
+            .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))
     }
 
-    async fn challenge_deadline(&self, game: Address) -> Result<u64, DefenderError> {
-        Ok(self.deadlines.get(&game).copied().unwrap_or(u64::MAX))
+    async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, DefenderError> {
+        let state = self.root_state(game).await?;
+        if state == RootState::Challenged {
+            if has_threshold(self.proof_bitmap(game).await?) {
+                return Ok(ResolutionStatus {
+                    resolvable: true,
+                    root_state: RootState::Finalized,
+                    invalidation_reason: InvalidationReason::None,
+                });
+            }
+            if self.proof_deadline(game).await? == 0 {
+                return Ok(ResolutionStatus {
+                    resolvable: true,
+                    root_state: RootState::Invalidated,
+                    invalidation_reason: InvalidationReason::ProofTimeout,
+                });
+            }
+        }
+        Ok(ResolutionStatus {
+            resolvable: false,
+            root_state: state,
+            invalidation_reason: InvalidationReason::None,
+        })
     }
 
     async fn proof_bitmap(&self, game: Address) -> Result<u8, DefenderError> {
@@ -242,9 +308,159 @@ impl ProofRequester for MockProver {
 
 fn config() -> DefenderConfig {
     DefenderConfig {
+        allowed_proposer: ALLOWED_PROPOSER,
         poll_interval: Duration::from_secs(1),
         ..DefenderConfig::default()
     }
+}
+
+#[tokio::test]
+async fn scan_once_requires_an_allowed_proposer() {
+    let client = MockClient::new(Vec::new(), HashMap::new());
+    let (output_roots, _finalized_l2_block) = mock_output_roots(HashMap::new(), 0);
+    let mut defender = WorldChainDefender::new(
+        DefenderConfig::default(),
+        client,
+        output_roots,
+        MockProver::default(),
+    );
+
+    let error = defender.scan_once().await.unwrap_err();
+    assert!(matches!(error, DefenderError::InvalidConfig(_)));
+}
+
+#[tokio::test]
+async fn scan_once_binary_searches_for_first_unexpired_proof_deadline() {
+    let canonical_root = B256::repeat_byte(0x20);
+    let mut client = MockClient::new(
+        vec![
+            (GAME_1, canonical_root, L2_BLOCK),
+            (GAME_2, canonical_root, L2_BLOCK),
+        ],
+        HashMap::new(),
+    );
+    client.set_deadlines(GAME_1, 0, 0);
+    let (output_roots, _finalized_l2_block) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
+    let mut defender =
+        WorldChainDefender::new(config(), client, output_roots, MockProver::default());
+
+    defender.scan_once().await.unwrap();
+
+    assert_eq!(defender.next_game_index(), Some(2));
+    assert_eq!(defender.watched_games(), [GAME_2]);
+}
+
+#[tokio::test]
+async fn scan_once_respects_factory_scan_budget() {
+    let canonical_root = B256::repeat_byte(0x20);
+    let client = MockClient::new(
+        vec![
+            (GAME_1, canonical_root, L2_BLOCK),
+            (GAME_2, canonical_root, L2_BLOCK),
+        ],
+        HashMap::new(),
+    );
+    let (output_roots, _finalized_l2_block) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
+    let mut limited_config = config();
+    limited_config.max_games_per_tick = 1;
+    let mut defender =
+        WorldChainDefender::new(limited_config, client, output_roots, MockProver::default());
+
+    defender.scan_once().await.unwrap();
+    assert_eq!(defender.next_game_index(), Some(1));
+    assert_eq!(defender.watched_games(), [GAME_1]);
+
+    defender.scan_once().await.unwrap();
+    assert_eq!(defender.next_game_index(), Some(2));
+    let watched = defender.watched_games();
+    assert_eq!(watched.len(), 2);
+    assert!(watched.contains(&GAME_1));
+    assert!(watched.contains(&GAME_2));
+}
+
+#[tokio::test]
+async fn scan_once_ignores_games_from_other_proposers() {
+    let canonical_root = B256::repeat_byte(0x20);
+    let mut client = MockClient::new(
+        vec![(GAME_1, canonical_root, L2_BLOCK)],
+        HashMap::from([(GAME_1, STATE_CHALLENGED)]),
+    );
+    client.set_proposer(GAME_1, OTHER_PROPOSER);
+    let (output_roots, _finalized_l2_block) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
+    let prover = MockProver::default();
+    let mut defender = WorldChainDefender::new(config(), client, output_roots, prover.clone());
+
+    defender.scan_once().await.unwrap();
+
+    assert_eq!(defender.next_game_index(), Some(1));
+    assert!(prover.requests().is_empty());
+    assert!(defender.watched_games().is_empty());
+    assert!(defender.active_defenses().is_empty());
+}
+
+#[tokio::test]
+async fn scan_once_discards_invalidated_games() {
+    let canonical_root = B256::repeat_byte(0x20);
+    let client = MockClient::new(
+        vec![(GAME_1, canonical_root, L2_BLOCK)],
+        HashMap::from([(GAME_1, STATE_INVALIDATED)]),
+    );
+    let (output_roots, _finalized_l2_block) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
+    let prover = MockProver::default();
+    let mut defender = WorldChainDefender::new(config(), client, output_roots, prover.clone());
+
+    defender.scan_once().await.unwrap();
+
+    assert!(prover.requests().is_empty());
+    assert!(defender.watched_games().is_empty());
+    assert!(defender.active_defenses().is_empty());
+}
+
+#[tokio::test]
+async fn proposed_game_is_removed_after_challenge_deadline() {
+    let canonical_root = B256::repeat_byte(0x20);
+    let mut client = MockClient::new(vec![(GAME_1, canonical_root, L2_BLOCK)], HashMap::new());
+    client.set_deadlines(GAME_1, 10, 20);
+    let (output_roots, _finalized_l2_block) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
+    let mut defender =
+        WorldChainDefender::new(config(), client, output_roots, MockProver::default());
+
+    defender.scan_once_with_timestamp(5).await.unwrap();
+    assert_eq!(defender.watched_games(), [GAME_1]);
+
+    defender.scan_once_with_timestamp(10).await.unwrap();
+    assert!(defender.watched_games().is_empty());
+}
+
+#[tokio::test]
+async fn active_defense_is_removed_after_proof_deadline() {
+    let canonical_root = B256::repeat_byte(0x20);
+    let mut client = MockClient::new(
+        vec![(GAME_1, canonical_root, L2_BLOCK)],
+        HashMap::from([(GAME_1, STATE_CHALLENGED)]),
+    );
+    client.set_deadlines(GAME_1, 10, 20);
+    let (output_roots, _finalized_l2_block) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
+    let prover = MockProver::default();
+    let mut defender = WorldChainDefender::new(config(), client, output_roots, prover.clone());
+
+    defender.scan_once_with_timestamp(5).await.unwrap();
+    assert_eq!(defender.active_defenses(), [GAME_1]);
+    assert_eq!(prover.requests().len(), 2);
+
+    defender.scan_once_with_timestamp(20).await.unwrap();
+    assert!(defender.active_defenses().is_empty());
+    assert!(defender.watched_games().is_empty());
+
+    // Removal makes the critical deadline condition one-shot.
+    defender.scan_once_with_timestamp(21).await.unwrap();
+    assert!(defender.active_defenses().is_empty());
 }
 
 #[tokio::test]

--- a/proofs/defender/src/tests.rs
+++ b/proofs/defender/src/tests.rs
@@ -96,6 +96,17 @@ impl MockClient {
             .insert(game, state);
     }
 
+    fn state(&self, game: Address) -> Result<RootState, DefenderError> {
+        let raw = self
+            .states
+            .lock()
+            .expect("not poisoned")
+            .get(&game)
+            .copied()
+            .unwrap_or(STATE_PROPOSED);
+        RootState::try_from(raw).map_err(Into::into)
+    }
+
     fn submissions(&self) -> Vec<(Address, u8)> {
         self.submissions.lock().expect("not poisoned").clone()
     }
@@ -129,17 +140,6 @@ impl DefenderClient for MockClient {
             .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))
     }
 
-    async fn root_state(&self, game: Address) -> Result<RootState, DefenderError> {
-        let raw = self
-            .states
-            .lock()
-            .expect("not poisoned")
-            .get(&game)
-            .copied()
-            .unwrap_or(STATE_PROPOSED);
-        RootState::try_from(raw).map_err(Into::into)
-    }
-
     async fn proof_deadline(&self, game: Address) -> Result<u64, DefenderError> {
         self.games
             .iter()
@@ -149,7 +149,7 @@ impl DefenderClient for MockClient {
     }
 
     async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, DefenderError> {
-        let state = self.root_state(game).await?;
+        let state = self.state(game)?;
         if state == RootState::Challenged {
             if has_threshold(self.proof_bitmap(game).await?) {
                 return Ok(ResolutionStatus {

--- a/proofs/defender/src/tests.rs
+++ b/proofs/defender/src/tests.rs
@@ -530,10 +530,13 @@ async fn active_defense_is_removed_after_proof_deadline() {
     let mut defender = WorldChainDefender::new(config(), client, output_roots, prover.clone());
 
     defender.tick_at(5).await.unwrap();
+    assert_eq!(defender.watched_games(), [GAME_1]);
+
+    defender.tick_at(6).await.unwrap();
     assert_eq!(defender.active_defenses(), [GAME_1]);
     assert!(prover.requests().is_empty());
 
-    defender.tick_at(6).await.unwrap();
+    defender.tick_at(7).await.unwrap();
     assert_eq!(prover.requests().len(), 2);
 
     defender.tick_at(20).await.unwrap();
@@ -558,8 +561,12 @@ async fn active_defense_advances_before_discovery_failure() {
     let mut defender =
         WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
 
-    // Discovery and validation promote the game, but active work starts on
-    // the next tick because existing defenses run first.
+    // Discovery retains the game for monitoring, then validation promotes it
+    // on the next tick because tracked games run before discovery.
+    defender.tick().await.unwrap();
+    assert_eq!(defender.watched_games(), [GAME_1]);
+    assert!(prover.requests().is_empty());
+
     defender.tick().await.unwrap();
     assert_eq!(defender.active_defenses(), [GAME_1]);
     assert!(prover.requests().is_empty());
@@ -653,10 +660,13 @@ async fn active_defense_accepts_sufficient_proof_support_hidden_by_an_unresolved
         WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
 
     defender.tick_at(5).await.unwrap();
+    assert_eq!(defender.watched_games(), [GAME_1]);
+
+    defender.tick_at(6).await.unwrap();
     assert_eq!(defender.active_defenses(), [GAME_1]);
     assert!(prover.requests().is_empty());
 
-    defender.tick_at(6).await.unwrap();
+    defender.tick_at(7).await.unwrap();
     assert_eq!(prover.requests().len(), 2);
 
     client.set_bitmap(
@@ -686,12 +696,17 @@ async fn tick_defends_challenged_valid_root() {
     let mut defender =
         WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
 
-    // First tick: discovery and validation promote the challenged game.
+    // First tick: discovery retains the challenged game for monitoring.
+    defender.tick().await.unwrap();
+    assert_eq!(defender.watched_games(), [GAME_1]);
+    assert!(prover.requests().is_empty());
+
+    // Second tick: validation promotes the challenged game.
     defender.tick().await.unwrap();
     assert_eq!(defender.active_defenses(), [GAME_1]);
     assert!(prover.requests().is_empty());
 
-    // Second tick: both lane proofs are requested.
+    // Third tick: both lane proofs are requested.
     defender.tick().await.unwrap();
     let requests = prover.requests();
     assert_eq!(requests.len(), 2);
@@ -705,7 +720,7 @@ async fn tick_defends_challenged_valid_root() {
     }
     assert!(client.submissions().is_empty());
 
-    // Third tick: both proofs are completed, fetched and submitted on-chain.
+    // Fourth tick: both proofs are completed, fetched and submitted on-chain.
     defender.tick().await.unwrap();
 
     assert_eq!(
@@ -764,6 +779,10 @@ async fn tick_ignores_challenged_invalid_root() {
 
     // an invalid root is the challenger's business, not ours
     assert!(prover.requests().is_empty());
+    assert_eq!(defender.watched_games(), [GAME_1]);
+
+    defender.tick().await.unwrap();
+
     assert!(defender.watched_games().is_empty());
     assert!(defender.active_defenses().is_empty());
 }
@@ -815,6 +834,7 @@ async fn tick_skips_lane_already_proven() {
     defender.tick().await.unwrap();
     defender.tick().await.unwrap();
     defender.tick().await.unwrap();
+    defender.tick().await.unwrap();
 
     // the validity lane is already proven on-chain: only the TEE lane runs
     let requests = prover.requests();
@@ -848,8 +868,10 @@ async fn failed_proofs_are_rerequested_up_to_the_attempt_bound() {
         prover.clone(),
     );
 
-    // Tick 1 promotes the game. Tick 2 makes the first request per lane;
-    // tick 3 re-requests each failed proof; tick 4 exhausts the attempts.
+    // Tick 1 discovers the game and tick 2 promotes it. Tick 3 makes the first
+    // request per lane; tick 4 re-requests each failed proof; tick 5 exhausts
+    // the attempts.
+    defender.tick().await.unwrap();
     defender.tick().await.unwrap();
     defender.tick().await.unwrap();
     defender.tick().await.unwrap();
@@ -873,6 +895,9 @@ async fn defense_closes_when_game_leaves_challenged_state() {
     let prover = MockProver::default();
     let mut defender =
         WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
+
+    defender.tick().await.unwrap();
+    assert_eq!(defender.watched_games(), [GAME_1]);
 
     defender.tick().await.unwrap();
     assert_eq!(defender.active_defenses(), [GAME_1]);

--- a/proofs/defender/src/traits.rs
+++ b/proofs/defender/src/traits.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use alloy_primitives::{Address, Bytes};
 use async_trait::async_trait;
-use world_chain_proofs::{ResolutionStatus, RootState};
+use world_chain_proofs::ResolutionStatus;
 
 #[async_trait]
 pub trait DefenderClient: Send + Sync {
@@ -16,8 +16,6 @@ pub trait DefenderClient: Send + Sync {
     async fn game_proposer(&self, game: Address) -> Result<Address, DefenderError>;
     /// Reads the immutable game data needed to monitor and defend its root claim.
     async fn game_metadata(&self, game: Address) -> Result<GameMetadata, DefenderError>;
-    /// Reads the root state of the provided game.
-    async fn root_state(&self, game: Address) -> Result<RootState, DefenderError>;
     /// Reads the proof deadline used by startup cursor initialization.
     async fn proof_deadline(&self, game: Address) -> Result<u64, DefenderError>;
     /// Returns the current resolution evaluation for the provided game.

--- a/proofs/defender/src/traits.rs
+++ b/proofs/defender/src/traits.rs
@@ -1,22 +1,27 @@
-use crate::{error::DefenderError, types::DefenderSubmission};
-use alloy_primitives::{Address, BlockNumber, Bytes};
+use crate::{
+    error::DefenderError,
+    types::{DefenderSubmission, GameMetadata},
+};
+use alloy_primitives::{Address, Bytes};
 use async_trait::async_trait;
-use world_chain_proofs::{GameCreated, RootState};
+use world_chain_proofs::{ResolutionStatus, RootState};
 
 #[async_trait]
-pub trait DefenderClient {
+pub trait DefenderClient: Send + Sync {
+    /// Returns the number of games created by the factory.
+    async fn game_count(&self) -> Result<u64, DefenderError>;
+    /// Returns the game address at a factory creation index.
+    async fn game_address_at(&self, index: u64) -> Result<Address, DefenderError>;
+    /// Reads the proposer recorded by the provided game.
+    async fn game_proposer(&self, game: Address) -> Result<Address, DefenderError>;
+    /// Reads the immutable game data needed to monitor and defend its root claim.
+    async fn game_metadata(&self, game: Address) -> Result<GameMetadata, DefenderError>;
     /// Reads the root state of the provided game.
     async fn root_state(&self, game: Address) -> Result<RootState, DefenderError>;
-    /// Get the last finalized L1 block number.
-    async fn finalized_l1_block_num(&self) -> Result<BlockNumber, DefenderError>;
-    /// Get all `GameCreated` events between the provided block numbers.
-    async fn games_created(
-        &self,
-        from: BlockNumber,
-        to: BlockNumber,
-    ) -> Result<Vec<GameCreated>, DefenderError>;
-    /// Get the challenge deadline of the provided game.
-    async fn challenge_deadline(&self, game: Address) -> Result<u64, DefenderError>;
+    /// Reads the proof deadline used by startup cursor initialization.
+    async fn proof_deadline(&self, game: Address) -> Result<u64, DefenderError>;
+    /// Returns the current resolution evaluation for the provided game.
+    async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, DefenderError>;
     /// Get the bitmap of proof lanes already proven for the provided game.
     async fn proof_bitmap(&self, game: Address) -> Result<u8, DefenderError>;
     /// Submit a proof to support a challenged game.

--- a/proofs/defender/src/types.rs
+++ b/proofs/defender/src/types.rs
@@ -1,6 +1,4 @@
 use alloy_primitives::{Address, B256, TxHash};
-use world_chain_proofs::ProofLane;
-use world_chain_prover_service::{ProofBackend, ProofRequestId};
 
 /// Immutable game data needed to monitor and defend an output-root claim.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -19,84 +17,4 @@ pub struct GameMetadata {
 pub struct DefenderSubmission {
     /// Transaction hash for the challenge submission.
     pub tx_hash: TxHash,
-}
-
-/// Number of proof lanes the defender drives.
-pub(crate) const DEFENDED_LANE_COUNT: usize = 2;
-
-/// The proof lanes the defender drives, paired with the prover-service
-/// backend that generates each proof.
-pub(crate) const DEFENDED_LANES: [(ProofLane, ProofBackend); DEFENDED_LANE_COUNT] = [
-    (ProofLane::ValidityProof, ProofBackend::Sp1),
-    (ProofLane::TeeAttestation, ProofBackend::Nitro),
-];
-
-/// Result of watching a single game for one tick.
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum WatchOutcome {
-    /// Keep watching the game.
-    Keep,
-    /// The game was challenged and its root is valid: start a defense.
-    Defend,
-    /// The game no longer needs watching.
-    Drop,
-}
-
-/// Progress of a single proof lane within an active defense.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum LaneState {
-    /// The proof has not been requested yet.
-    Pending,
-    /// The proof was requested from the prover-service.
-    Requested { id: ProofRequestId, attempts: u32 },
-    /// The lane is proven on-chain.
-    Proven,
-    /// Proving permanently failed after exhausting all attempts.
-    Abandoned,
-}
-
-impl LaneState {
-    /// Whether the lane needs no further work.
-    pub(crate) const fn is_terminal(self) -> bool {
-        matches!(self, Self::Proven | Self::Abandoned)
-    }
-}
-
-/// An active defense of a challenged game with a valid root.
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct ActiveDefense {
-    pub game: GameMetadata,
-    /// Lane progress, indexed like [`DEFENDED_LANES`].
-    pub lanes: [LaneState; DEFENDED_LANE_COUNT],
-}
-
-impl ActiveDefense {
-    pub(crate) const fn new(game: GameMetadata) -> Self {
-        Self {
-            game,
-            lanes: [LaneState::Pending; DEFENDED_LANE_COUNT],
-        }
-    }
-}
-
-/// Result of advancing a single defense for one tick.
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum DefenseProgress {
-    /// The game left the `Challenged` state on-chain.
-    Closed,
-    /// The game already has enough proof support to complete the defense.
-    Complete,
-    /// The proof deadline elapsed before the defense completed.
-    DeadlineElapsed,
-    /// Lane progress after this tick.
-    Lanes([LaneState; DEFENDED_LANE_COUNT]),
-}
-
-/// Result of scanning a newly discovered allowlisted game.
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum GameScanOutcome {
-    /// Retain the game for monitoring.
-    Track,
-    /// The game does not need defense monitoring.
-    Skip,
 }

--- a/proofs/defender/src/types.rs
+++ b/proofs/defender/src/types.rs
@@ -11,6 +11,7 @@ pub struct GameMetadata {
     pub l1_origin_hash: B256,
     pub challenge_deadline: u64,
     pub proof_deadline: u64,
+    pub proof_threshold: u8,
 }
 
 /// Result of a submitted `submitProofLane` transaction.

--- a/proofs/defender/src/types.rs
+++ b/proofs/defender/src/types.rs
@@ -1,8 +1,19 @@
-use alloy_primitives::TxHash;
-use world_chain_proofs::{GameCreated, ProofLane};
+use alloy_primitives::{Address, B256, TxHash};
+use world_chain_proofs::ProofLane;
 use world_chain_prover_service::{ProofBackend, ProofRequestId};
 
-/// Result of a submitted `submitProofLane`` transaction.
+/// Immutable game data needed to monitor and defend an output-root claim.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GameMetadata {
+    pub address: Address,
+    pub root_claim: B256,
+    pub l2_block_number: u64,
+    pub l1_origin_hash: B256,
+    pub challenge_deadline: u64,
+    pub proof_deadline: u64,
+}
+
+/// Result of a submitted `submitProofLane` transaction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DefenderSubmission {
     /// Transaction hash for the challenge submission.
@@ -19,19 +30,11 @@ pub(crate) const DEFENDED_LANES: [(ProofLane, ProofBackend); DEFENDED_LANE_COUNT
     (ProofLane::TeeAttestation, ProofBackend::Nitro),
 ];
 
-/// A game watched until it leaves the `Proposed` state.
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct WatchedGame {
-    pub game_created: GameCreated,
-    /// Cached challenge deadline, fetched lazily on the first watch tick.
-    pub challenge_deadline: Option<u64>,
-}
-
 /// Result of watching a single game for one tick.
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum WatchOutcome {
     /// Keep watching the game.
-    Keep { challenge_deadline: Option<u64> },
+    Keep,
     /// The game was challenged and its root is valid: start a defense.
     Defend,
     /// The game no longer needs watching.
@@ -61,15 +64,15 @@ impl LaneState {
 /// An active defense of a challenged game with a valid root.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ActiveDefense {
-    pub game_created: GameCreated,
+    pub game: GameMetadata,
     /// Lane progress, indexed like [`DEFENDED_LANES`].
     pub lanes: [LaneState; DEFENDED_LANE_COUNT],
 }
 
 impl ActiveDefense {
-    pub(crate) const fn new(game_created: GameCreated) -> Self {
+    pub(crate) const fn new(game: GameMetadata) -> Self {
         Self {
-            game_created,
+            game,
             lanes: [LaneState::Pending; DEFENDED_LANE_COUNT],
         }
     }
@@ -79,7 +82,20 @@ impl ActiveDefense {
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum DefenseProgress {
     /// The game left the `Challenged` state on-chain.
-    Resolved,
+    Closed,
+    /// The game already has enough proof support to complete the defense.
+    Complete,
+    /// The proof deadline elapsed before the defense completed.
+    DeadlineElapsed,
     /// Lane progress after this tick.
     Lanes([LaneState; DEFENDED_LANE_COUNT]),
+}
+
+/// Result of scanning a newly discovered allowlisted game.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum GameScanOutcome {
+    /// Retain the game for monitoring.
+    Track,
+    /// The game does not need defense monitoring.
+    Skip,
 }

--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -20,7 +20,8 @@ use world_chain_defender::{
 use world_chain_proof_worker::{ClaimedProofJobHandler, ProofJob};
 use world_chain_proofs::{
     ConsensusError, ConsensusProvider, GameCreated, InvalidationReason, PROOF_SYSTEM_VERSION,
-    ProofDomain, ProofLane, ResolutionStatus, RootCommitment, RootState, has_threshold,
+    PROOF_THRESHOLD, ProofDomain, ProofLane, ResolutionStatus, RootCommitment, RootState,
+    has_threshold,
 };
 use world_chain_proposer::{
     CloseGameSubmission, ParentRef, Proposal, ProposalSubmission, ProposerClient, ProposerError,
@@ -286,6 +287,16 @@ fn proof_lane(lane: u8) -> Option<ProofLane> {
     }
 }
 
+fn parent_is_unresolved(state: &FakeExecutionState, record: &GameRecord) -> bool {
+    if record.event.parent_ref == ANCHOR {
+        return false;
+    }
+    state
+        .games_by_address
+        .get(&record.event.parent_ref)
+        .is_some_and(|parent| parent.state == STATE_PROPOSED || parent.state == STATE_CHALLENGED)
+}
+
 #[async_trait]
 impl ProposerClient for FakeExecution {
     async fn anchor_parent(&self) -> Result<ParentRef, ProposerError> {
@@ -328,6 +339,22 @@ impl ProposerClient for FakeExecution {
             .get(&game)
             .ok_or_else(|| ProposerError::Contract(format!("unknown game {game}")))?;
 
+        let root_state = RootState::try_from(record.state)
+            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+        if root_state == RootState::Finalized {
+            return Ok(ResolutionStatus {
+                resolvable: false,
+                root_state,
+                invalidation_reason: InvalidationReason::None,
+            });
+        }
+        if parent_is_unresolved(&state, record) {
+            return Ok(ResolutionStatus {
+                resolvable: false,
+                root_state,
+                invalidation_reason: InvalidationReason::None,
+            });
+        }
         if record.state == STATE_CHALLENGED && has_threshold(record.proof_bitmap) {
             return Ok(ResolutionStatus {
                 resolvable: true,
@@ -336,8 +363,6 @@ impl ProposerClient for FakeExecution {
             });
         }
 
-        let root_state = RootState::try_from(record.state)
-            .map_err(|error| ProposerError::Contract(error.to_string()))?;
         Ok(ResolutionStatus {
             resolvable: false,
             root_state,
@@ -347,11 +372,21 @@ impl ProposerClient for FakeExecution {
 
     async fn resolve_game(&self, game: Address) -> Result<ResolveSubmission, ProposerError> {
         let mut state = self.state.lock().expect("fake execution mutex poisoned");
+        let parent_unresolved = {
+            let record = state
+                .games_by_address
+                .get(&game)
+                .ok_or_else(|| ProposerError::Contract(format!("unknown game {game}")))?;
+            parent_is_unresolved(&state, record)
+        };
         let record = state
             .games_by_address
             .get_mut(&game)
             .ok_or_else(|| ProposerError::Contract(format!("unknown game {game}")))?;
-        if record.state != STATE_CHALLENGED || !has_threshold(record.proof_bitmap) {
+        if parent_unresolved
+            || record.state != STATE_CHALLENGED
+            || !has_threshold(record.proof_bitmap)
+        {
             return Err(ProposerError::Contract(format!(
                 "game {game} is not positively resolvable"
             )));
@@ -543,6 +578,7 @@ impl DefenderClient for FakeExecution {
                 l1_origin_hash: record.event.l1_origin_hash,
                 challenge_deadline: record.challenge_deadline,
                 proof_deadline: record.proof_deadline,
+                proof_threshold: PROOF_THRESHOLD,
             })
             .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))
     }
@@ -565,6 +601,20 @@ impl DefenderClient for FakeExecution {
             .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))?;
         let current_state = RootState::try_from(record.state)?;
 
+        if current_state == RootState::Finalized {
+            return Ok(ResolutionStatus {
+                resolvable: false,
+                root_state: current_state,
+                invalidation_reason: InvalidationReason::None,
+            });
+        }
+        if parent_is_unresolved(&state, record) {
+            return Ok(ResolutionStatus {
+                resolvable: false,
+                root_state: current_state,
+                invalidation_reason: InvalidationReason::None,
+            });
+        }
         if current_state == RootState::Challenged && has_threshold(record.proof_bitmap) {
             return Ok(ResolutionStatus {
                 resolvable: true,

--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -12,9 +12,11 @@ use std::{
     sync::{Arc, Mutex},
 };
 use world_chain_challenger::{
-    ChallengeSubmission, ChallengerClient, ChallengerError, GameMetadata,
+    ChallengeSubmission, ChallengerClient, ChallengerError, GameMetadata as ChallengerGameMetadata,
 };
-use world_chain_defender::{DefenderClient, DefenderError, DefenderSubmission};
+use world_chain_defender::{
+    DefenderClient, DefenderError, DefenderSubmission, GameMetadata as DefenderGameMetadata,
+};
 use world_chain_proof_worker::{ClaimedProofJobHandler, ProofJob};
 use world_chain_proofs::{
     ConsensusError, ConsensusProvider, GameCreated, InvalidationReason, PROOF_SYSTEM_VERSION,
@@ -35,6 +37,7 @@ use world_chain_prover_service::{
 pub const BLOCK_INTERVAL: u64 = 10;
 pub const CHAIN_ID: u64 = 4801;
 pub const ANCHOR: Address = address!("0000000000000000000000000000000000001006");
+pub const FAKE_PROPOSER: Address = address!("a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1");
 
 const STATE_NONE: u8 = 0;
 const STATE_PROPOSED: u8 = 1;
@@ -138,6 +141,7 @@ struct GameRecord {
     event: GameCreated,
     state: u8,
     challenge_deadline: u64,
+    proof_deadline: u64,
     proof_bitmap: u8,
     challenge_count: u32,
     submitted_lanes: Vec<ProofLane>,
@@ -240,7 +244,7 @@ impl FakeExecution {
             proposal_key: proposal.proposal_key,
             root_id: root.root_id(state.domain_hash),
             game,
-            proposer: Address::repeat_byte(0xa1),
+            proposer: FAKE_PROPOSER,
             root_claim: proposal.root_claim,
             l2_block_number: proposal.l2_block_number,
             parent_ref: proposal.parent_ref,
@@ -256,6 +260,7 @@ impl FakeExecution {
                 event,
                 state: STATE_PROPOSED,
                 challenge_deadline: u64::MAX,
+                proof_deadline: u64::MAX,
                 proof_bitmap: 0,
                 challenge_count: 0,
                 submitted_lanes: Vec::new(),
@@ -439,13 +444,16 @@ impl ChallengerClient for FakeExecution {
             .ok_or_else(|| ChallengerError::Contract(format!("unknown game index {index}")))
     }
 
-    async fn game_metadata(&self, game: Address) -> Result<GameMetadata, ChallengerError> {
+    async fn game_metadata(
+        &self,
+        game: Address,
+    ) -> Result<ChallengerGameMetadata, ChallengerError> {
         self.state
             .lock()
             .expect("fake execution mutex poisoned")
             .games_by_address
             .get(&game)
-            .map(|record| GameMetadata {
+            .map(|record| ChallengerGameMetadata {
                 address: game,
                 root_claim: record.event.root_claim,
                 l2_block_number: record.event.l2_block_number,
@@ -493,6 +501,52 @@ impl ChallengerClient for FakeExecution {
 
 #[async_trait]
 impl DefenderClient for FakeExecution {
+    async fn game_count(&self) -> Result<u64, DefenderError> {
+        Ok(self
+            .state
+            .lock()
+            .expect("fake execution mutex poisoned")
+            .game_order
+            .len() as u64)
+    }
+
+    async fn game_address_at(&self, index: u64) -> Result<Address, DefenderError> {
+        self.state
+            .lock()
+            .expect("fake execution mutex poisoned")
+            .game_order
+            .get(index as usize)
+            .copied()
+            .ok_or_else(|| DefenderError::Contract(format!("unknown game index {index}")))
+    }
+
+    async fn game_proposer(&self, game: Address) -> Result<Address, DefenderError> {
+        self.state
+            .lock()
+            .expect("fake execution mutex poisoned")
+            .games_by_address
+            .get(&game)
+            .map(|record| record.event.proposer)
+            .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))
+    }
+
+    async fn game_metadata(&self, game: Address) -> Result<DefenderGameMetadata, DefenderError> {
+        self.state
+            .lock()
+            .expect("fake execution mutex poisoned")
+            .games_by_address
+            .get(&game)
+            .map(|record| DefenderGameMetadata {
+                address: game,
+                root_claim: record.event.root_claim,
+                l2_block_number: record.event.l2_block_number,
+                l1_origin_hash: record.event.l1_origin_hash,
+                challenge_deadline: record.challenge_deadline,
+                proof_deadline: record.proof_deadline,
+            })
+            .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))
+    }
+
     async fn root_state(&self, game: Address) -> Result<RootState, DefenderError> {
         let raw = self
             .state
@@ -504,36 +558,44 @@ impl DefenderClient for FakeExecution {
         RootState::try_from(raw).map_err(Into::into)
     }
 
-    async fn finalized_l1_block_num(&self) -> Result<BlockNumber, DefenderError> {
-        Ok(self
-            .state
-            .lock()
-            .expect("fake execution mutex poisoned")
-            .finalized_l1_block)
-    }
-
-    async fn games_created(
-        &self,
-        _from: BlockNumber,
-        _to: BlockNumber,
-    ) -> Result<Vec<GameCreated>, DefenderError> {
-        let state = self.state.lock().expect("fake execution mutex poisoned");
-        Ok(state
-            .game_order
-            .iter()
-            .filter_map(|game| state.games_by_address.get(game))
-            .map(|record| record.event)
-            .collect())
-    }
-
-    async fn challenge_deadline(&self, game: Address) -> Result<u64, DefenderError> {
+    async fn proof_deadline(&self, game: Address) -> Result<u64, DefenderError> {
         self.state
             .lock()
             .expect("fake execution mutex poisoned")
             .games_by_address
             .get(&game)
-            .map(|record| record.challenge_deadline)
+            .map(|record| record.proof_deadline)
             .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))
+    }
+
+    async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, DefenderError> {
+        let state = self.state.lock().expect("fake execution mutex poisoned");
+        let record = state
+            .games_by_address
+            .get(&game)
+            .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))?;
+        let current_state = RootState::try_from(record.state)?;
+
+        if current_state == RootState::Challenged && has_threshold(record.proof_bitmap) {
+            return Ok(ResolutionStatus {
+                resolvable: true,
+                root_state: RootState::Finalized,
+                invalidation_reason: InvalidationReason::None,
+            });
+        }
+        if current_state == RootState::Challenged && record.proof_deadline == 0 {
+            return Ok(ResolutionStatus {
+                resolvable: true,
+                root_state: RootState::Invalidated,
+                invalidation_reason: InvalidationReason::ProofTimeout,
+            });
+        }
+
+        Ok(ResolutionStatus {
+            resolvable: false,
+            root_state: current_state,
+            invalidation_reason: InvalidationReason::None,
+        })
     }
 
     async fn proof_bitmap(&self, game: Address) -> Result<u8, DefenderError> {

--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -547,17 +547,6 @@ impl DefenderClient for FakeExecution {
             .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))
     }
 
-    async fn root_state(&self, game: Address) -> Result<RootState, DefenderError> {
-        let raw = self
-            .state
-            .lock()
-            .expect("fake execution mutex poisoned")
-            .games_by_address
-            .get(&game)
-            .map_or(STATE_NONE, |record| record.state);
-        RootState::try_from(raw).map_err(Into::into)
-    }
-
     async fn proof_deadline(&self, game: Address) -> Result<u64, DefenderError> {
         self.state
             .lock()

--- a/proofs/integration-tests/tests/orchestration.rs
+++ b/proofs/integration-tests/tests/orchestration.rs
@@ -8,7 +8,8 @@ use tokio_util::sync::CancellationToken;
 use world_chain_challenger::{ChallengerConfig, WorldChainChallenger};
 use world_chain_defender::{DefenderClient, DefenderConfig, WorldChainDefender};
 use world_chain_proof_integration_tests::{
-    BLOCK_INTERVAL, FakeConsensus, FakeExecution, FakeProofBackend, SharedProverService,
+    BLOCK_INTERVAL, FAKE_PROPOSER, FakeConsensus, FakeExecution, FakeProofBackend,
+    SharedProverService,
 };
 use world_chain_proof_worker::{
     ProofWorker, ProofWorkerConfig, RetryConfig, WorkerHeartbeatConfig,
@@ -36,6 +37,7 @@ fn challenger_config() -> ChallengerConfig {
 
 fn defender_config() -> DefenderConfig {
     DefenderConfig {
+        allowed_proposer: FAKE_PROPOSER,
         poll_interval: Duration::from_secs(1),
         max_proof_attempts: 2,
         ..DefenderConfig::default()
@@ -98,8 +100,7 @@ async fn fake_resolution_matches_contract_transition_semantics() {
         .await
         .expect("TEE proof submitted");
 
-    let ready = chain
-        .resolution_status(game)
+    let ready = ProposerClient::resolution_status(&chain, game)
         .await
         .expect("resolution status available");
     assert!(ready.resolvable);
@@ -108,8 +109,7 @@ async fn fake_resolution_matches_contract_transition_semantics() {
 
     settle_with_proposer(&proposer).await;
 
-    let finalized = chain
-        .resolution_status(game)
+    let finalized = ProposerClient::resolution_status(&chain, game)
         .await
         .expect("resolution status available");
     assert!(!finalized.resolvable);

--- a/proofs/integration-tests/tests/orchestration.rs
+++ b/proofs/integration-tests/tests/orchestration.rs
@@ -274,7 +274,7 @@ async fn valid_challenged_root_is_defended_through_workers() {
     );
 
     for _ in 0..200 {
-        defender.scan_once().await.expect("defender scan succeeds");
+        defender.tick().await.expect("defender scan succeeds");
         if has_threshold(chain.proof_bitmap(game)) {
             break;
         }
@@ -325,7 +325,7 @@ async fn valid_challenged_root_survives_transient_proof_failure() {
     );
 
     for _ in 0..200 {
-        defender.scan_once().await.expect("defender scan succeeds");
+        defender.tick().await.expect("defender scan succeeds");
         if has_threshold(chain.proof_bitmap(game)) {
             break;
         }
@@ -376,7 +376,7 @@ async fn defender_ignores_challenged_invalid_root() {
     );
 
     for _ in 0..10 {
-        defender.scan_once().await.expect("defender scan succeeds");
+        defender.tick().await.expect("defender scan succeeds");
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
 

--- a/proofs/primitives/src/bindings.rs
+++ b/proofs/primitives/src/bindings.rs
@@ -70,6 +70,7 @@ sol! {
         function l1OriginNumber() external view returns (uint256);
         function challengeDeadline() external view returns (uint64);
         function proofDeadline() external view returns (uint64);
+        function PROOF_THRESHOLD() external view returns (uint8);
         function finalizedAt() external view returns (uint64);
         function state() external view returns (uint8);
         function invalidationReason() external view returns (uint8);


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4978/defender-refactor-defender-for-the-new-contract-design

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large refactor of the L1 defender that submits proof transactions and changes how games are discovered and filtered; misconfiguration of `allowed_proposer` or cursor logic could skip or mishandle challenged games.
> 
> **Overview**
> **World Chain defender** is reworked for the new proof-system contracts: it no longer follows `GameCreated` logs over an L1 block range and instead walks the factory’s indexed games (`gameCount` / `gameAt`), with startup cursor placement via binary search on **proof deadlines** and a per-tick cap (`max_games_per_tick`).
> 
> Defense is scoped to a single **`allowed_proposer`** (required in config, CLI `ALLOWED_PROPOSER`, and devnet). Games from other proposers are skipped; non-canonical roots from the allowlisted proposer are explicitly not defended.
> 
> On-chain interaction goes through a slimmer **`DefenderClient`**: multicall **`game_metadata`** (including `PROOF_THRESHOLD`), **`resolution_status`**, and related reads replace separate root-state / log / challenge-deadline calls. **`GameEvaluator`** and **`LaneDriver`** own watch/defend decisions and lane proving; the main loop is **`tick` / `tick_at`** (active defenses → tracked games → discovery) instead of **`scan_once`**. Completion paths honor proof thresholds, proof deadlines, and invalidation (e.g. proof timeout) even when parent resolution is still pending on-chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3f745d89cf45506de57e4156bc910995f2830f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->