### PR TITLE
chore: world-chain-defender improvements

### DIFF
--- a/proofs/defender/src/defender.rs
+++ b/proofs/defender/src/defender.rs
@@ -1,12 +1,10 @@
 use crate::{
     config::DefenderConfig,
     error::DefenderError,
+    game::{GameEvaluator, GameObservation, GameScanOutcome, WatchOutcome},
     lane::LaneDriver,
     traits::DefenderClient,
-    types::{
-        ActiveDefense, DEFENDED_LANES, DefenseProgress, GameMetadata, GameObservation,
-        GameScanOutcome, LaneState, WatchOutcome,
-    },
+    types::{ActiveDefense, DEFENDED_LANES, DefenseProgress, GameMetadata, LaneState},
 };
 use alloy_primitives::{Address, BlockNumber};
 use futures_util::{StreamExt, stream};
@@ -15,7 +13,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 use tracing::{error, info, warn};
-use world_chain_proofs::{ConsensusProvider, InvalidationReason, RootState, proof_count};
+use world_chain_proofs::{ConsensusProvider, InvalidationReason};
 use world_chain_prover_service::ProofRequester;
 
 /// World Chain Defender.
@@ -106,102 +104,19 @@ where
         Ok(low)
     }
 
-    async fn observe_game(&self, game: &GameMetadata) -> Result<GameObservation, DefenderError> {
-        let status = self
-            .execution_provider
-            .resolution_status(game.address)
-            .await?;
-        Ok(match status.root_state {
-            RootState::Proposed => GameObservation::Proposed,
-            RootState::Challenged => {
-                let proof_bitmap = self.execution_provider.proof_bitmap(game.address).await?;
-                GameObservation::Challenged {
-                    proof_bitmap,
-                    has_required_support: has_required_proof_support(game, proof_bitmap),
-                }
-            }
-            RootState::Finalized => GameObservation::Finalized,
-            RootState::Invalidated => GameObservation::Invalidated(status.invalidation_reason),
-            RootState::None => GameObservation::Unset,
-        })
-    }
-
-    async fn scan_game(
-        &self,
-        game: &GameMetadata,
-        now: u64,
-    ) -> Result<GameScanOutcome, DefenderError> {
-        match self.observe_game(game).await? {
-            GameObservation::Proposed => {
-                if now < game.challenge_deadline {
-                    Ok(GameScanOutcome::Track)
-                } else {
-                    Ok(GameScanOutcome::Skip)
-                }
-            }
-            GameObservation::Challenged {
-                proof_bitmap,
-                has_required_support,
-            } => {
-                if has_required_support {
-                    info!(
-                        game = %game.address,
-                        proof_bitmap,
-                        proof_threshold = game.proof_threshold,
-                        "challenged game already has sufficient proof support"
-                    );
-                    return Ok(GameScanOutcome::Skip);
-                }
-                if now < game.proof_deadline {
-                    return Ok(GameScanOutcome::Track);
-                }
-
-                error!(
-                    game = %game.address,
-                    proof_deadline = game.proof_deadline,
-                    "challenged game proof deadline elapsed before defense completed"
-                );
-                Ok(GameScanOutcome::Skip)
-            }
-            GameObservation::Finalized => {
-                info!(
-                    game = %game.address,
-                    "game already has a positive resolution outcome"
-                );
-                Ok(GameScanOutcome::Skip)
-            }
-            GameObservation::Invalidated(reason) => {
-                if reason == InvalidationReason::ProofTimeout {
-                    error!(
-                        game = %game.address,
-                        proof_deadline = game.proof_deadline,
-                        "challenged game proof deadline elapsed before defense completed"
-                    );
-                } else {
-                    warn!(
-                        game = %game.address,
-                        reason = ?reason,
-                        "game is invalidatable without defense"
-                    );
-                }
-                Ok(GameScanOutcome::Skip)
-            }
-            GameObservation::Unset => {
-                error!(game = %game.address, "factory game has unset root state");
-                Ok(GameScanOutcome::Skip)
-            }
-        }
-    }
-
     async fn scan_games(
         &self,
         games: impl IntoIterator<Item = GameMetadata>,
         now: u64,
     ) -> Vec<(GameMetadata, Result<GameScanOutcome, DefenderError>)> {
+        let evaluator = GameEvaluator::new(&self.execution_provider, &self.consensus_provider);
         stream::iter(games)
-            .map(|game| async move {
-                let result = self.scan_game(&game, now).await;
-                (game, result)
+            .map(move |game| {
+                let evaluator = evaluator;
+                async move {
+                    let result = evaluator.scan(&game, now).await;
+                    (game, result)
+                }
             })
             .buffer_unordered(self.config.max_game_concurrency)
             .collect()
@@ -230,99 +145,19 @@ where
         }
     }
 
-    async fn watch_game(
-        &self,
-        game: &GameMetadata,
-        latest_finalized_l2_block: BlockNumber,
-        now: u64,
-    ) -> Result<WatchOutcome, DefenderError> {
-        let address = game.address;
-        match self.observe_game(game).await? {
-            GameObservation::Proposed => {
-                if now >= game.challenge_deadline {
-                    // the game can no longer be challenged
-                    return Ok(WatchOutcome::Drop);
-                }
-                Ok(WatchOutcome::Keep)
-            }
-            GameObservation::Challenged {
-                proof_bitmap,
-                has_required_support,
-            } => {
-                if has_required_support {
-                    info!(
-                        game = %address,
-                        proof_bitmap,
-                        proof_threshold = game.proof_threshold,
-                        "challenged game already has sufficient proof support"
-                    );
-                    return Ok(WatchOutcome::Drop);
-                }
-                if now >= game.proof_deadline {
-                    error!(
-                        game = %address,
-                        proof_deadline = game.proof_deadline,
-                        "challenged game proof deadline elapsed before defense completed"
-                    );
-                    return Ok(WatchOutcome::Drop);
-                }
-
-                // only judge the root against finalized L2 state
-                if game.l2_block_number > latest_finalized_l2_block {
-                    return Ok(WatchOutcome::Keep);
-                }
-                let root = self
-                    .consensus_provider
-                    .output_root_at_block(game.l2_block_number)
-                    .await?;
-                if root == game.root_claim {
-                    Ok(WatchOutcome::Defend)
-                } else {
-                    error!(
-                        game = %address,
-                        claimed_root = %game.root_claim,
-                        canonical_root = %root,
-                        "allowlisted proposer published a non-canonical root; refusing to defend"
-                    );
-                    Ok(WatchOutcome::Drop)
-                }
-            }
-            GameObservation::Finalized => {
-                info!(game = %address, "game has a positive resolution outcome");
-                Ok(WatchOutcome::Drop)
-            }
-            GameObservation::Invalidated(reason) => {
-                if reason == InvalidationReason::ProofTimeout {
-                    error!(
-                        game = %address,
-                        proof_deadline = game.proof_deadline,
-                        "challenged game proof deadline elapsed before defense completed"
-                    );
-                } else {
-                    warn!(
-                        game = %address,
-                        reason = ?reason,
-                        "game is invalidatable without defense"
-                    );
-                }
-                Ok(WatchOutcome::Drop)
-            }
-            GameObservation::Unset => {
-                error!(game = %address, "factory game has unset root state");
-                Ok(WatchOutcome::Drop)
-            }
-        }
-    }
-
     async fn scan_watched_games(
         &self,
         latest_finalized_l2_block: BlockNumber,
         now: u64,
     ) -> Vec<(GameMetadata, Result<WatchOutcome, DefenderError>)> {
+        let evaluator = GameEvaluator::new(&self.execution_provider, &self.consensus_provider);
         stream::iter(self.watched_games.values().copied().collect::<Vec<_>>())
-            .map(|game| async move {
-                let result = self.watch_game(&game, latest_finalized_l2_block, now).await;
-                (game, result)
+            .map(move |game| {
+                let evaluator = evaluator;
+                async move {
+                    let result = evaluator.watch(&game, latest_finalized_l2_block, now).await;
+                    (game, result)
+                }
             })
             .buffer_unordered(self.config.max_game_concurrency)
             .collect()
@@ -359,7 +194,8 @@ where
         now: u64,
     ) -> Result<DefenseProgress, DefenderError> {
         let metadata = &defense.game;
-        let proof_bitmap = match self.observe_game(metadata).await? {
+        let evaluator = GameEvaluator::new(&self.execution_provider, &self.consensus_provider);
+        let proof_bitmap = match evaluator.observe(metadata).await? {
             GameObservation::Finalized => return Ok(DefenseProgress::Complete),
             GameObservation::Invalidated(reason) => {
                 if reason == InvalidationReason::ProofTimeout {
@@ -540,10 +376,6 @@ where
             }
         }
     }
-}
-
-fn has_required_proof_support(game: &GameMetadata, proof_bitmap: u8) -> bool {
-    proof_count(proof_bitmap) >= game.proof_threshold
 }
 
 fn unix_now() -> u64 {

--- a/proofs/defender/src/defender.rs
+++ b/proofs/defender/src/defender.rs
@@ -629,7 +629,7 @@ where
         Ok(())
     }
 
-    pub(crate) async fn scan_once_with_timestamp(&mut self, now: u64) -> Result<(), DefenderError> {
+    pub(crate) async fn tick_at(&mut self, now: u64) -> Result<(), DefenderError> {
         self.config.validate()?;
 
         self.advance_active_defenses(now).await;
@@ -637,9 +637,9 @@ where
         self.advance_watched_games(now).await
     }
 
-    /// Scans one bounded factory range and advances every tracked defense.
-    pub async fn scan_once(&mut self) -> Result<(), DefenderError> {
-        self.scan_once_with_timestamp(unix_now()).await
+    /// Advances the defender by one polling tick.
+    pub async fn tick(&mut self) -> Result<(), DefenderError> {
+        self.tick_at(unix_now()).await
     }
 
     /// Runs the defender forever, logging transient failures and retrying on each tick.
@@ -649,7 +649,7 @@ where
         let mut interval = tokio::time::interval(self.config.poll_interval);
         loop {
             interval.tick().await;
-            if let Err(e) = self.scan_once().await {
+            if let Err(e) = self.tick().await {
                 warn!(%e, "scan attempt failed");
             }
         }

--- a/proofs/defender/src/defender.rs
+++ b/proofs/defender/src/defender.rs
@@ -2,9 +2,9 @@ use crate::{
     config::DefenderConfig,
     error::DefenderError,
     game::{GameEvaluator, GameObservation, GameScanOutcome, WatchOutcome},
-    lane::LaneDriver,
+    lane::{DEFENDED_LANE_COUNT, DEFENDED_LANES, LaneDriver, LaneState},
     traits::DefenderClient,
-    types::{ActiveDefense, DEFENDED_LANES, DefenseProgress, GameMetadata, LaneState},
+    types::GameMetadata,
 };
 use alloy_primitives::{Address, BlockNumber};
 use futures_util::{StreamExt, stream};
@@ -15,6 +15,36 @@ use std::{
 use tracing::{error, info, warn};
 use world_chain_proofs::{ConsensusProvider, InvalidationReason};
 use world_chain_prover_service::ProofRequester;
+
+/// An active defense of a challenged game with a valid root.
+#[derive(Debug, Clone, Copy)]
+struct ActiveDefense {
+    game: GameMetadata,
+    /// Lane progress, indexed like [`DEFENDED_LANES`].
+    lanes: [LaneState; DEFENDED_LANE_COUNT],
+}
+
+impl ActiveDefense {
+    const fn new(game: GameMetadata) -> Self {
+        Self {
+            game,
+            lanes: [LaneState::Pending; DEFENDED_LANE_COUNT],
+        }
+    }
+}
+
+/// Result of advancing a single defense for one tick.
+#[derive(Debug, Clone, Copy)]
+enum DefenseProgress {
+    /// The game left the `Challenged` state on-chain.
+    Closed,
+    /// The game already has enough proof support to complete the defense.
+    Complete,
+    /// The proof deadline elapsed before the defense completed.
+    DeadlineElapsed,
+    /// Lane progress after this tick.
+    Lanes([LaneState; DEFENDED_LANE_COUNT]),
+}
 
 /// World Chain Defender.
 ///

--- a/proofs/defender/src/defender.rs
+++ b/proofs/defender/src/defender.rs
@@ -1,25 +1,22 @@
 use crate::{
     config::DefenderConfig,
     error::DefenderError,
+    lane,
     traits::DefenderClient,
     types::{
         ActiveDefense, DEFENDED_LANES, DefenseProgress, GameMetadata, GameObservation,
         GameScanOutcome, LaneState, WatchOutcome,
     },
 };
-use alloy_primitives::{Address, BlockNumber, Bytes};
+use alloy_primitives::{Address, BlockNumber};
 use futures_util::{StreamExt, stream};
 use std::{
     collections::HashMap,
     time::{SystemTime, UNIX_EPOCH},
 };
 use tracing::{error, info, warn};
-use world_chain_proofs::{
-    ConsensusProvider, InvalidationReason, ProofLane, RootState, proof_count,
-};
-use world_chain_prover_service::{
-    ProofBackend, ProofData, ProofRequest, ProofRequester, ProofResponse, ProofStatus,
-};
+use world_chain_proofs::{ConsensusProvider, InvalidationReason, RootState, proof_count};
+use world_chain_prover_service::ProofRequester;
 
 /// World Chain Defender.
 ///
@@ -356,122 +353,6 @@ where
         }
     }
 
-    async fn advance_lane(
-        &self,
-        metadata: &GameMetadata,
-        lane: ProofLane,
-        backend: ProofBackend,
-        state: LaneState,
-    ) -> LaneState {
-        let game = metadata.address;
-        match state {
-            LaneState::Proven | LaneState::Abandoned => state,
-            LaneState::Pending => {
-                match self
-                    .proof_requester
-                    .request_proof(proof_request(metadata, backend))
-                    .await
-                {
-                    Ok(id) => LaneState::Requested { id, attempts: 1 },
-                    Err(error) => {
-                        warn!(%game, ?lane, %error, "proof request failed; retrying next tick");
-                        LaneState::Pending
-                    }
-                }
-            }
-            LaneState::Requested { id, attempts } => {
-                let status = match self.proof_requester.proof_status(id).await {
-                    Ok(status) => status,
-                    Err(error) => {
-                        warn!(%game, ?lane, %id, %error, "proof status check failed; retrying next tick");
-                        return state;
-                    }
-                };
-                match status {
-                    ProofStatus::Created | ProofStatus::Running => state,
-                    ProofStatus::Succeeded => {
-                        let response = match self.proof_requester.get_proof(id).await {
-                            Ok(ProofResponse::Succeeded(response)) => response,
-                            Ok(ProofResponse::Pending(response)) => {
-                                warn!(
-                                    %game,
-                                    ?lane,
-                                    %id,
-                                    status = %response.status,
-                                    "proof status was succeeded but proof response is pending; retrying next tick"
-                                );
-                                return state;
-                            }
-                            Ok(ProofResponse::Failed(response)) => {
-                                warn!(
-                                    %game,
-                                    ?lane,
-                                    %id,
-                                    reason = %response.reason,
-                                    "proof status was succeeded but proof response is failed; retrying next tick"
-                                );
-                                return state;
-                            }
-                            Err(error) => {
-                                warn!(%game, ?lane, %id, %error, "proof retrieval failed; retrying next tick");
-                                return state;
-                            }
-                        };
-                        match self
-                            .execution_provider
-                            .submit_proof(game, lane as u8, encode_proof(&response.proof))
-                            .await
-                        {
-                            Ok(submission) => {
-                                info!(%game, ?lane, tx_hash = %submission.tx_hash, "proof lane submitted");
-                                LaneState::Proven
-                            }
-                            Err(error) => {
-                                // if the transaction actually landed, the
-                                // proof bitmap check resolves the lane on the
-                                // next tick
-                                warn!(%game, ?lane, %error, "proof submission failed; retrying next tick");
-                                state
-                            }
-                        }
-                    }
-                    ProofStatus::Failed => {
-                        if attempts >= self.config.max_proof_attempts {
-                            error!(%game, ?lane, attempts, "proving permanently failed; abandoning lane");
-                            return LaneState::Abandoned;
-                        }
-                        // re-requesting a failed proof re-queues it
-                        match self
-                            .proof_requester
-                            .request_proof(proof_request(metadata, backend))
-                            .await
-                        {
-                            Ok(id) => {
-                                let next_attempt = attempts + 1;
-                                warn!(
-                                    %game,
-                                    ?lane,
-                                    %id,
-                                    attempts = next_attempt,
-                                    max_attempts = self.config.max_proof_attempts,
-                                    "proof failed; re-requested proof"
-                                );
-                                LaneState::Requested {
-                                    id,
-                                    attempts: next_attempt,
-                                }
-                            }
-                            Err(error) => {
-                                warn!(%game, ?lane, %error, "proof re-request failed; retrying next tick");
-                                state
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
     async fn advance_defense(
         &self,
         defense: &ActiveDefense,
@@ -504,15 +385,22 @@ where
         }
 
         let mut lanes = defense.lanes;
-        for (slot, (lane, backend)) in DEFENDED_LANES.into_iter().enumerate() {
+        for (slot, (proof_lane, backend)) in DEFENDED_LANES.into_iter().enumerate() {
             // skip lanes already proven on-chain, by us or by anyone else
-            if proof_bitmap & lane.mask() != 0 {
+            if proof_bitmap & proof_lane.mask() != 0 {
                 lanes[slot] = LaneState::Proven;
                 continue;
             }
-            lanes[slot] = self
-                .advance_lane(metadata, lane, backend, lanes[slot])
-                .await;
+            lanes[slot] = lane::advance_lane(
+                &self.execution_provider,
+                &self.proof_requester,
+                self.config.max_proof_attempts,
+                metadata,
+                proof_lane,
+                backend,
+                lanes[slot],
+            )
+            .await;
         }
         Ok(DefenseProgress::Lanes(lanes))
     }
@@ -653,47 +541,6 @@ where
                 warn!(%e, "scan attempt failed");
             }
         }
-    }
-}
-
-/// Builds the proof request for one lane of a defended game.
-fn proof_request(game: &GameMetadata, backend: ProofBackend) -> ProofRequest {
-    ProofRequest {
-        backend,
-        game: game.address,
-        root_claim: game.root_claim,
-        l2_block_number: game.l2_block_number,
-        // pin the witness to the L1 origin committed at proposal time, so
-        // the request id stays stable across defender restarts
-        l1_head: game.l1_origin_hash,
-    }
-}
-
-/// Encode a proof payload into the `bytes` argument of `submitProofLane`.
-///
-/// TODO: encode proofs for their concrete on-chain verifiers. SP1 proofs must
-/// match `SP1ValidityVerifier`'s ABI tuple:
-/// `(domainHash, parentRef, l1OriginNumber, publicValues, proofBytes)`.
-/// That requires proposal context in addition to `ProofData`, so this helper
-/// should move closer to the game/lane submission path before real SP1 lanes
-/// are enabled.
-fn encode_proof(proof: &ProofData) -> Bytes {
-    match proof {
-        ProofData::Sp1 {
-            proof,
-            public_values,
-        } => [public_values.as_ref(), proof.as_ref()].concat().into(),
-        ProofData::Nitro {
-            attestation,
-            public_values,
-            signature,
-        } => [
-            public_values.as_ref(),
-            attestation.as_ref(),
-            signature.as_ref(),
-        ]
-        .concat()
-        .into(),
     }
 }
 

--- a/proofs/defender/src/defender.rs
+++ b/proofs/defender/src/defender.rs
@@ -3,8 +3,8 @@ use crate::{
     error::DefenderError,
     traits::DefenderClient,
     types::{
-        ActiveDefense, DEFENDED_LANES, DefenseProgress, GameMetadata, GameScanOutcome, LaneState,
-        WatchOutcome,
+        ActiveDefense, DEFENDED_LANES, DefenseProgress, GameMetadata, GameObservation,
+        GameScanOutcome, LaneState, WatchOutcome,
     },
 };
 use alloy_primitives::{Address, BlockNumber, Bytes};
@@ -109,26 +109,44 @@ where
         Ok(low)
     }
 
+    async fn observe_game(&self, game: &GameMetadata) -> Result<GameObservation, DefenderError> {
+        let status = self
+            .execution_provider
+            .resolution_status(game.address)
+            .await?;
+        Ok(match status.root_state {
+            RootState::Proposed => GameObservation::Proposed,
+            RootState::Challenged => {
+                let proof_bitmap = self.execution_provider.proof_bitmap(game.address).await?;
+                GameObservation::Challenged {
+                    proof_bitmap,
+                    has_required_support: has_required_proof_support(game, proof_bitmap),
+                }
+            }
+            RootState::Finalized => GameObservation::Finalized,
+            RootState::Invalidated => GameObservation::Invalidated(status.invalidation_reason),
+            RootState::None => GameObservation::Unset,
+        })
+    }
+
     async fn scan_game(
         &self,
         game: &GameMetadata,
         now: u64,
     ) -> Result<GameScanOutcome, DefenderError> {
-        let status = self
-            .execution_provider
-            .resolution_status(game.address)
-            .await?;
-        match status.root_state {
-            RootState::Proposed => {
+        match self.observe_game(game).await? {
+            GameObservation::Proposed => {
                 if now < game.challenge_deadline {
                     Ok(GameScanOutcome::Track)
                 } else {
                     Ok(GameScanOutcome::Skip)
                 }
             }
-            RootState::Challenged => {
-                let proof_bitmap = self.execution_provider.proof_bitmap(game.address).await?;
-                if has_required_proof_support(game, proof_bitmap) {
+            GameObservation::Challenged {
+                proof_bitmap,
+                has_required_support,
+            } => {
+                if has_required_support {
                     info!(
                         game = %game.address,
                         proof_bitmap,
@@ -148,15 +166,15 @@ where
                 );
                 Ok(GameScanOutcome::Skip)
             }
-            RootState::Finalized => {
+            GameObservation::Finalized => {
                 info!(
                     game = %game.address,
                     "game already has a positive resolution outcome"
                 );
                 Ok(GameScanOutcome::Skip)
             }
-            RootState::Invalidated => {
-                if status.invalidation_reason == InvalidationReason::ProofTimeout {
+            GameObservation::Invalidated(reason) => {
+                if reason == InvalidationReason::ProofTimeout {
                     error!(
                         game = %game.address,
                         proof_deadline = game.proof_deadline,
@@ -165,13 +183,13 @@ where
                 } else {
                     warn!(
                         game = %game.address,
-                        reason = ?status.invalidation_reason,
+                        reason = ?reason,
                         "game is invalidatable without defense"
                     );
                 }
                 Ok(GameScanOutcome::Skip)
             }
-            RootState::None => {
+            GameObservation::Unset => {
                 error!(game = %game.address, "factory game has unset root state");
                 Ok(GameScanOutcome::Skip)
             }
@@ -222,18 +240,19 @@ where
         now: u64,
     ) -> Result<WatchOutcome, DefenderError> {
         let address = game.address;
-        let status = self.execution_provider.resolution_status(address).await?;
-        match status.root_state {
-            RootState::Proposed => {
+        match self.observe_game(game).await? {
+            GameObservation::Proposed => {
                 if now >= game.challenge_deadline {
                     // the game can no longer be challenged
                     return Ok(WatchOutcome::Drop);
                 }
                 Ok(WatchOutcome::Keep)
             }
-            RootState::Challenged => {
-                let proof_bitmap = self.execution_provider.proof_bitmap(address).await?;
-                if has_required_proof_support(game, proof_bitmap) {
+            GameObservation::Challenged {
+                proof_bitmap,
+                has_required_support,
+            } => {
+                if has_required_support {
                     info!(
                         game = %address,
                         proof_bitmap,
@@ -271,12 +290,12 @@ where
                     Ok(WatchOutcome::Drop)
                 }
             }
-            RootState::Finalized => {
+            GameObservation::Finalized => {
                 info!(game = %address, "game has a positive resolution outcome");
                 Ok(WatchOutcome::Drop)
             }
-            RootState::Invalidated => {
-                if status.invalidation_reason == InvalidationReason::ProofTimeout {
+            GameObservation::Invalidated(reason) => {
+                if reason == InvalidationReason::ProofTimeout {
                     error!(
                         game = %address,
                         proof_deadline = game.proof_deadline,
@@ -285,13 +304,13 @@ where
                 } else {
                     warn!(
                         game = %address,
-                        reason = ?status.invalidation_reason,
+                        reason = ?reason,
                         "game is invalidatable without defense"
                     );
                 }
                 Ok(WatchOutcome::Drop)
             }
-            RootState::None => {
+            GameObservation::Unset => {
                 error!(game = %address, "factory game has unset root state");
                 Ok(WatchOutcome::Drop)
             }
@@ -459,23 +478,27 @@ where
         now: u64,
     ) -> Result<DefenseProgress, DefenderError> {
         let metadata = &defense.game;
-        let game = metadata.address;
-        let status = self.execution_provider.resolution_status(game).await?;
-        match status.root_state {
-            RootState::Finalized => return Ok(DefenseProgress::Complete),
-            RootState::Invalidated => {
-                if status.invalidation_reason == InvalidationReason::ProofTimeout {
+        let proof_bitmap = match self.observe_game(metadata).await? {
+            GameObservation::Finalized => return Ok(DefenseProgress::Complete),
+            GameObservation::Invalidated(reason) => {
+                if reason == InvalidationReason::ProofTimeout {
                     return Ok(DefenseProgress::DeadlineElapsed);
                 }
                 return Ok(DefenseProgress::Closed);
             }
-            RootState::Challenged => {}
-            RootState::None | RootState::Proposed => return Ok(DefenseProgress::Closed),
-        }
-        let proof_bitmap = self.execution_provider.proof_bitmap(game).await?;
-        if has_required_proof_support(metadata, proof_bitmap) {
-            return Ok(DefenseProgress::Complete);
-        }
+            GameObservation::Challenged {
+                proof_bitmap,
+                has_required_support,
+            } => {
+                if has_required_support {
+                    return Ok(DefenseProgress::Complete);
+                }
+                proof_bitmap
+            }
+            GameObservation::Unset | GameObservation::Proposed => {
+                return Ok(DefenseProgress::Closed);
+            }
+        };
         if now >= metadata.proof_deadline {
             return Ok(DefenseProgress::DeadlineElapsed);
         }

--- a/proofs/defender/src/defender.rs
+++ b/proofs/defender/src/defender.rs
@@ -134,7 +134,7 @@ where
         Ok(low)
     }
 
-    async fn scan_games(
+    async fn evaluate_discovered_games(
         &self,
         games: impl IntoIterator<Item = GameMetadata>,
         now: u64,
@@ -144,7 +144,7 @@ where
             .map(move |game| {
                 let evaluator = evaluator;
                 async move {
-                    let result = evaluator.scan(&game, now).await;
+                    let result = evaluator.evaluate_discovered(&game, now).await;
                     (game, result)
                 }
             })
@@ -153,12 +153,12 @@ where
             .await
     }
 
-    fn handle_game_scan_results(
+    fn handle_discovered_game_outcomes(
         &mut self,
-        results: Vec<(GameMetadata, Result<GameOutcome, DefenderError>)>,
+        outcomes: Vec<(GameMetadata, Result<GameOutcome, DefenderError>)>,
     ) {
-        for (game, result) in results {
-            match result {
+        for (game, outcome) in outcomes {
+            match outcome {
                 Ok(GameOutcome::Track) => {
                     self.watched_games.insert(game.address, game);
                 }
@@ -176,7 +176,7 @@ where
         }
     }
 
-    async fn scan_watched_games(
+    async fn evaluate_tracked_games(
         &self,
         latest_finalized_l2_block: BlockNumber,
         now: u64,
@@ -186,7 +186,9 @@ where
             .map(move |game| {
                 let evaluator = evaluator;
                 async move {
-                    let result = evaluator.watch(&game, latest_finalized_l2_block, now).await;
+                    let result = evaluator
+                        .evaluate_tracked(&game, latest_finalized_l2_block, now)
+                        .await;
                     (game, result)
                 }
             })
@@ -195,13 +197,13 @@ where
             .await
     }
 
-    fn handle_watch_outcomes(
+    fn handle_tracked_game_outcomes(
         &mut self,
-        results: Vec<(GameMetadata, Result<GameOutcome, DefenderError>)>,
+        outcomes: Vec<(GameMetadata, Result<GameOutcome, DefenderError>)>,
     ) {
-        for (metadata, result) in results {
+        for (metadata, outcome) in outcomes {
             let game = metadata.address;
-            match result {
+            match outcome {
                 Ok(GameOutcome::Defend) => self.start_defense(metadata),
                 Ok(GameOutcome::Drop) => {
                     self.watched_games.remove(&game);
@@ -365,23 +367,23 @@ where
             new_games.push(self.execution_provider.game_metadata(game).await?);
         }
 
-        let scan_results = self.scan_games(new_games, now).await;
-        self.handle_game_scan_results(scan_results);
+        let outcomes = self.evaluate_discovered_games(new_games, now).await;
+        self.handle_discovered_game_outcomes(outcomes);
         self.next_game_index = Some(end);
         Ok(())
     }
 
-    async fn advance_watched_games(&mut self, now: u64) -> Result<(), DefenderError> {
+    async fn advance_tracked_games(&mut self, now: u64) -> Result<(), DefenderError> {
         if self.watched_games.is_empty() {
             return Ok(());
         }
 
         let latest_finalized_l2_block = self.consensus_provider.latest_l2_finalized_block().await?;
 
-        let watch_results = self
-            .scan_watched_games(latest_finalized_l2_block, now)
+        let outcomes = self
+            .evaluate_tracked_games(latest_finalized_l2_block, now)
             .await;
-        self.handle_watch_outcomes(watch_results);
+        self.handle_tracked_game_outcomes(outcomes);
         Ok(())
     }
 
@@ -390,7 +392,7 @@ where
 
         self.advance_active_defenses(now).await;
         self.discover_games(now).await?;
-        self.advance_watched_games(now).await
+        self.advance_tracked_games(now).await
     }
 
     /// Advances the defender by one polling tick.

--- a/proofs/defender/src/defender.rs
+++ b/proofs/defender/src/defender.rs
@@ -549,12 +549,12 @@ where
         }
     }
 
-    pub(crate) async fn scan_once_with_timestamp(&mut self, now: u64) -> Result<(), DefenderError> {
-        self.config.validate()?;
-
+    async fn advance_active_defenses(&mut self, now: u64) {
         let defense_results = self.scan_active_defenses(now).await;
         self.handle_defense_progress(defense_results);
+    }
 
+    async fn discover_games(&mut self, now: u64) -> Result<(), DefenderError> {
         let game_count = self.execution_provider.game_count().await?;
         if self
             .next_game_index
@@ -589,7 +589,10 @@ where
         let scan_results = self.scan_games(new_games, now).await;
         self.handle_game_scan_results(scan_results);
         self.next_game_index = Some(end);
+        Ok(())
+    }
 
+    async fn advance_watched_games(&mut self, now: u64) -> Result<(), DefenderError> {
         if self.watched_games.is_empty() {
             return Ok(());
         }
@@ -601,6 +604,14 @@ where
             .await;
         self.handle_watch_outcomes(watch_results);
         Ok(())
+    }
+
+    pub(crate) async fn scan_once_with_timestamp(&mut self, now: u64) -> Result<(), DefenderError> {
+        self.config.validate()?;
+
+        self.advance_active_defenses(now).await;
+        self.discover_games(now).await?;
+        self.advance_watched_games(now).await
     }
 
     /// Scans one bounded factory range and advances every tracked defense.

--- a/proofs/defender/src/defender.rs
+++ b/proofs/defender/src/defender.rs
@@ -1,7 +1,7 @@
 use crate::{
     config::DefenderConfig,
     error::DefenderError,
-    lane,
+    lane::LaneDriver,
     traits::DefenderClient,
     types::{
         ActiveDefense, DEFENDED_LANES, DefenseProgress, GameMetadata, GameObservation,
@@ -385,22 +385,20 @@ where
         }
 
         let mut lanes = defense.lanes;
+        let lane_driver = LaneDriver::new(
+            &self.execution_provider,
+            &self.proof_requester,
+            self.config.max_proof_attempts,
+        );
         for (slot, (proof_lane, backend)) in DEFENDED_LANES.into_iter().enumerate() {
             // skip lanes already proven on-chain, by us or by anyone else
             if proof_bitmap & proof_lane.mask() != 0 {
                 lanes[slot] = LaneState::Proven;
                 continue;
             }
-            lanes[slot] = lane::advance_lane(
-                &self.execution_provider,
-                &self.proof_requester,
-                self.config.max_proof_attempts,
-                metadata,
-                proof_lane,
-                backend,
-                lanes[slot],
-            )
-            .await;
+            lanes[slot] = lane_driver
+                .advance(metadata, proof_lane, backend, lanes[slot])
+                .await;
         }
         Ok(DefenseProgress::Lanes(lanes))
     }

--- a/proofs/defender/src/defender.rs
+++ b/proofs/defender/src/defender.rs
@@ -1,7 +1,7 @@
 use crate::{
     config::DefenderConfig,
     error::DefenderError,
-    game::{GameEvaluator, GameObservation, GameScanOutcome, WatchOutcome},
+    game::{GameEvaluator, GameObservation, GameOutcome},
     lane::{DEFENDED_LANE_COUNT, DEFENDED_LANES, LaneDriver, LaneState},
     traits::DefenderClient,
     types::GameMetadata,
@@ -138,7 +138,7 @@ where
         &self,
         games: impl IntoIterator<Item = GameMetadata>,
         now: u64,
-    ) -> Vec<(GameMetadata, Result<GameScanOutcome, DefenderError>)> {
+    ) -> Vec<(GameMetadata, Result<GameOutcome, DefenderError>)> {
         let evaluator = GameEvaluator::new(&self.execution_provider, &self.consensus_provider);
         stream::iter(games)
             .map(move |game| {
@@ -155,14 +155,15 @@ where
 
     fn handle_game_scan_results(
         &mut self,
-        results: Vec<(GameMetadata, Result<GameScanOutcome, DefenderError>)>,
+        results: Vec<(GameMetadata, Result<GameOutcome, DefenderError>)>,
     ) {
         for (game, result) in results {
             match result {
-                Ok(GameScanOutcome::Track) => {
+                Ok(GameOutcome::Track) => {
                     self.watched_games.insert(game.address, game);
                 }
-                Ok(GameScanOutcome::Skip) => {}
+                Ok(GameOutcome::Defend) => self.start_defense(game),
+                Ok(GameOutcome::Drop) => {}
                 Err(error) => {
                     warn!(
                         game = %game.address,
@@ -179,7 +180,7 @@ where
         &self,
         latest_finalized_l2_block: BlockNumber,
         now: u64,
-    ) -> Vec<(GameMetadata, Result<WatchOutcome, DefenderError>)> {
+    ) -> Vec<(GameMetadata, Result<GameOutcome, DefenderError>)> {
         let evaluator = GameEvaluator::new(&self.execution_provider, &self.consensus_provider);
         stream::iter(self.watched_games.values().copied().collect::<Vec<_>>())
             .map(move |game| {
@@ -196,26 +197,29 @@ where
 
     fn handle_watch_outcomes(
         &mut self,
-        results: Vec<(GameMetadata, Result<WatchOutcome, DefenderError>)>,
+        results: Vec<(GameMetadata, Result<GameOutcome, DefenderError>)>,
     ) {
         for (metadata, result) in results {
             let game = metadata.address;
             match result {
-                Ok(WatchOutcome::Defend) => {
-                    info!(%game, "challenged game has a valid root; starting defense");
-                    self.watched_games.remove(&game);
-                    self.active_defenses
-                        .insert(game, ActiveDefense::new(metadata));
-                }
-                Ok(WatchOutcome::Drop) => {
+                Ok(GameOutcome::Defend) => self.start_defense(metadata),
+                Ok(GameOutcome::Drop) => {
                     self.watched_games.remove(&game);
                 }
-                Ok(WatchOutcome::Keep) => {}
+                Ok(GameOutcome::Track) => {}
                 Err(err) => {
                     warn!(game = %game, error = %err, "game watch failed; retrying next tick");
                 }
             }
         }
+    }
+
+    fn start_defense(&mut self, metadata: GameMetadata) {
+        let game = metadata.address;
+        info!(%game, "challenged game has a valid root; starting defense");
+        self.watched_games.remove(&game);
+        self.active_defenses
+            .insert(game, ActiveDefense::new(metadata));
     }
 
     async fn advance_defense(

--- a/proofs/defender/src/game.rs
+++ b/proofs/defender/src/game.rs
@@ -16,20 +16,19 @@ pub(crate) enum GameObservation {
     Unset,
 }
 
-/// Result of scanning a newly discovered allowlisted game.
 #[derive(Debug, Clone, Copy)]
-pub(crate) enum GameScanOutcome {
-    /// Retain the game for monitoring.
-    Track,
-    /// The game does not need defense monitoring.
-    Skip,
+enum GameAssessment {
+    Proposed,
+    Challenged,
+    Finalized,
+    Closed,
 }
 
-/// Result of watching a single game for one tick.
+/// Result of evaluating a game for one tick.
 #[derive(Debug, Clone, Copy)]
-pub(crate) enum WatchOutcome {
-    /// Keep watching the game.
-    Keep,
+pub(crate) enum GameOutcome {
+    /// Retain the game for monitoring.
+    Track,
     /// The game was challenged and its root is valid: start a defense.
     Defend,
     /// The game no longer needs watching.
@@ -84,17 +83,13 @@ where
         })
     }
 
-    pub(crate) async fn scan(
-        &self,
-        game: &GameMetadata,
-        now: u64,
-    ) -> Result<GameScanOutcome, DefenderError> {
+    async fn assess(&self, game: &GameMetadata, now: u64) -> Result<GameAssessment, DefenderError> {
         match self.observe(game).await? {
             GameObservation::Proposed => {
                 if now < game.challenge_deadline {
-                    Ok(GameScanOutcome::Track)
+                    Ok(GameAssessment::Proposed)
                 } else {
-                    Ok(GameScanOutcome::Skip)
+                    Ok(GameAssessment::Closed)
                 }
             }
             GameObservation::Challenged {
@@ -108,26 +103,19 @@ where
                         proof_threshold = game.proof_threshold,
                         "challenged game already has sufficient proof support"
                     );
-                    return Ok(GameScanOutcome::Skip);
+                    return Ok(GameAssessment::Closed);
                 }
-                if now < game.proof_deadline {
-                    return Ok(GameScanOutcome::Track);
+                if now >= game.proof_deadline {
+                    error!(
+                        game = %game.address,
+                        proof_deadline = game.proof_deadline,
+                        "challenged game proof deadline elapsed before defense completed"
+                    );
+                    return Ok(GameAssessment::Closed);
                 }
-
-                error!(
-                    game = %game.address,
-                    proof_deadline = game.proof_deadline,
-                    "challenged game proof deadline elapsed before defense completed"
-                );
-                Ok(GameScanOutcome::Skip)
+                Ok(GameAssessment::Challenged)
             }
-            GameObservation::Finalized => {
-                info!(
-                    game = %game.address,
-                    "game already has a positive resolution outcome"
-                );
-                Ok(GameScanOutcome::Skip)
-            }
+            GameObservation::Finalized => Ok(GameAssessment::Finalized),
             GameObservation::Invalidated(reason) => {
                 if reason == InvalidationReason::ProofTimeout {
                     error!(
@@ -142,13 +130,31 @@ where
                         "game is invalidatable without defense"
                     );
                 }
-                Ok(GameScanOutcome::Skip)
+                Ok(GameAssessment::Closed)
             }
             GameObservation::Unset => {
                 error!(game = %game.address, "factory game has unset root state");
-                Ok(GameScanOutcome::Skip)
+                Ok(GameAssessment::Closed)
             }
         }
+    }
+
+    pub(crate) async fn scan(
+        &self,
+        game: &GameMetadata,
+        now: u64,
+    ) -> Result<GameOutcome, DefenderError> {
+        Ok(match self.assess(game, now).await? {
+            GameAssessment::Proposed | GameAssessment::Challenged => GameOutcome::Track,
+            GameAssessment::Finalized => {
+                info!(
+                    game = %game.address,
+                    "game already has a positive resolution outcome"
+                );
+                GameOutcome::Drop
+            }
+            GameAssessment::Closed => GameOutcome::Drop,
+        })
     }
 
     pub(crate) async fn watch(
@@ -156,48 +162,21 @@ where
         game: &GameMetadata,
         latest_finalized_l2_block: BlockNumber,
         now: u64,
-    ) -> Result<WatchOutcome, DefenderError> {
+    ) -> Result<GameOutcome, DefenderError> {
         let address = game.address;
-        match self.observe(game).await? {
-            GameObservation::Proposed => {
-                if now >= game.challenge_deadline {
-                    // the game can no longer be challenged
-                    return Ok(WatchOutcome::Drop);
-                }
-                Ok(WatchOutcome::Keep)
-            }
-            GameObservation::Challenged {
-                proof_bitmap,
-                has_required_support,
-            } => {
-                if has_required_support {
-                    info!(
-                        game = %address,
-                        proof_bitmap,
-                        proof_threshold = game.proof_threshold,
-                        "challenged game already has sufficient proof support"
-                    );
-                    return Ok(WatchOutcome::Drop);
-                }
-                if now >= game.proof_deadline {
-                    error!(
-                        game = %address,
-                        proof_deadline = game.proof_deadline,
-                        "challenged game proof deadline elapsed before defense completed"
-                    );
-                    return Ok(WatchOutcome::Drop);
-                }
-
+        match self.assess(game, now).await? {
+            GameAssessment::Proposed => Ok(GameOutcome::Track),
+            GameAssessment::Challenged => {
                 // only judge the root against finalized L2 state
                 if game.l2_block_number > latest_finalized_l2_block {
-                    return Ok(WatchOutcome::Keep);
+                    return Ok(GameOutcome::Track);
                 }
                 let root = self
                     .consensus_provider
                     .output_root_at_block(game.l2_block_number)
                     .await?;
                 if root == game.root_claim {
-                    Ok(WatchOutcome::Defend)
+                    Ok(GameOutcome::Defend)
                 } else {
                     error!(
                         game = %address,
@@ -205,33 +184,17 @@ where
                         canonical_root = %root,
                         "allowlisted proposer published a non-canonical root; refusing to defend"
                     );
-                    Ok(WatchOutcome::Drop)
+                    Ok(GameOutcome::Drop)
                 }
             }
-            GameObservation::Finalized => {
-                info!(game = %address, "game has a positive resolution outcome");
-                Ok(WatchOutcome::Drop)
+            GameAssessment::Finalized => {
+                info!(
+                    game = %game.address,
+                    "game has a positive resolution outcome"
+                );
+                Ok(GameOutcome::Drop)
             }
-            GameObservation::Invalidated(reason) => {
-                if reason == InvalidationReason::ProofTimeout {
-                    error!(
-                        game = %address,
-                        proof_deadline = game.proof_deadline,
-                        "challenged game proof deadline elapsed before defense completed"
-                    );
-                } else {
-                    warn!(
-                        game = %address,
-                        reason = ?reason,
-                        "game is invalidatable without defense"
-                    );
-                }
-                Ok(WatchOutcome::Drop)
-            }
-            GameObservation::Unset => {
-                error!(game = %address, "factory game has unset root state");
-                Ok(WatchOutcome::Drop)
-            }
+            GameAssessment::Closed => Ok(GameOutcome::Drop),
         }
     }
 }

--- a/proofs/defender/src/game.rs
+++ b/proofs/defender/src/game.rs
@@ -1,0 +1,241 @@
+use crate::{error::DefenderError, traits::DefenderClient, types::GameMetadata};
+use alloy_primitives::BlockNumber;
+use tracing::{error, info, warn};
+use world_chain_proofs::{ConsensusProvider, InvalidationReason, RootState, proof_count};
+
+/// On-chain state relevant to the defender for a single game.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum GameObservation {
+    Proposed,
+    Challenged {
+        proof_bitmap: u8,
+        has_required_support: bool,
+    },
+    Finalized,
+    Invalidated(InvalidationReason),
+    Unset,
+}
+
+/// Result of scanning a newly discovered allowlisted game.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum GameScanOutcome {
+    /// Retain the game for monitoring.
+    Track,
+    /// The game does not need defense monitoring.
+    Skip,
+}
+
+/// Result of watching a single game for one tick.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum WatchOutcome {
+    /// Keep watching the game.
+    Keep,
+    /// The game was challenged and its root is valid: start a defense.
+    Defend,
+    /// The game no longer needs watching.
+    Drop,
+}
+
+pub(crate) struct GameEvaluator<'a, E, C> {
+    execution_client: &'a E,
+    consensus_provider: &'a C,
+}
+
+impl<'a, E, C> Clone for GameEvaluator<'a, E, C> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<E, C> Copy for GameEvaluator<'_, E, C> {}
+
+impl<'a, E, C> GameEvaluator<'a, E, C>
+where
+    E: DefenderClient,
+    C: ConsensusProvider,
+{
+    pub(crate) const fn new(execution_client: &'a E, consensus_provider: &'a C) -> Self {
+        Self {
+            execution_client,
+            consensus_provider,
+        }
+    }
+
+    pub(crate) async fn observe(
+        &self,
+        game: &GameMetadata,
+    ) -> Result<GameObservation, DefenderError> {
+        let status = self
+            .execution_client
+            .resolution_status(game.address)
+            .await?;
+        Ok(match status.root_state {
+            RootState::Proposed => GameObservation::Proposed,
+            RootState::Challenged => {
+                let proof_bitmap = self.execution_client.proof_bitmap(game.address).await?;
+                GameObservation::Challenged {
+                    proof_bitmap,
+                    has_required_support: has_required_proof_support(game, proof_bitmap),
+                }
+            }
+            RootState::Finalized => GameObservation::Finalized,
+            RootState::Invalidated => GameObservation::Invalidated(status.invalidation_reason),
+            RootState::None => GameObservation::Unset,
+        })
+    }
+
+    pub(crate) async fn scan(
+        &self,
+        game: &GameMetadata,
+        now: u64,
+    ) -> Result<GameScanOutcome, DefenderError> {
+        match self.observe(game).await? {
+            GameObservation::Proposed => {
+                if now < game.challenge_deadline {
+                    Ok(GameScanOutcome::Track)
+                } else {
+                    Ok(GameScanOutcome::Skip)
+                }
+            }
+            GameObservation::Challenged {
+                proof_bitmap,
+                has_required_support,
+            } => {
+                if has_required_support {
+                    info!(
+                        game = %game.address,
+                        proof_bitmap,
+                        proof_threshold = game.proof_threshold,
+                        "challenged game already has sufficient proof support"
+                    );
+                    return Ok(GameScanOutcome::Skip);
+                }
+                if now < game.proof_deadline {
+                    return Ok(GameScanOutcome::Track);
+                }
+
+                error!(
+                    game = %game.address,
+                    proof_deadline = game.proof_deadline,
+                    "challenged game proof deadline elapsed before defense completed"
+                );
+                Ok(GameScanOutcome::Skip)
+            }
+            GameObservation::Finalized => {
+                info!(
+                    game = %game.address,
+                    "game already has a positive resolution outcome"
+                );
+                Ok(GameScanOutcome::Skip)
+            }
+            GameObservation::Invalidated(reason) => {
+                if reason == InvalidationReason::ProofTimeout {
+                    error!(
+                        game = %game.address,
+                        proof_deadline = game.proof_deadline,
+                        "challenged game proof deadline elapsed before defense completed"
+                    );
+                } else {
+                    warn!(
+                        game = %game.address,
+                        reason = ?reason,
+                        "game is invalidatable without defense"
+                    );
+                }
+                Ok(GameScanOutcome::Skip)
+            }
+            GameObservation::Unset => {
+                error!(game = %game.address, "factory game has unset root state");
+                Ok(GameScanOutcome::Skip)
+            }
+        }
+    }
+
+    pub(crate) async fn watch(
+        &self,
+        game: &GameMetadata,
+        latest_finalized_l2_block: BlockNumber,
+        now: u64,
+    ) -> Result<WatchOutcome, DefenderError> {
+        let address = game.address;
+        match self.observe(game).await? {
+            GameObservation::Proposed => {
+                if now >= game.challenge_deadline {
+                    // the game can no longer be challenged
+                    return Ok(WatchOutcome::Drop);
+                }
+                Ok(WatchOutcome::Keep)
+            }
+            GameObservation::Challenged {
+                proof_bitmap,
+                has_required_support,
+            } => {
+                if has_required_support {
+                    info!(
+                        game = %address,
+                        proof_bitmap,
+                        proof_threshold = game.proof_threshold,
+                        "challenged game already has sufficient proof support"
+                    );
+                    return Ok(WatchOutcome::Drop);
+                }
+                if now >= game.proof_deadline {
+                    error!(
+                        game = %address,
+                        proof_deadline = game.proof_deadline,
+                        "challenged game proof deadline elapsed before defense completed"
+                    );
+                    return Ok(WatchOutcome::Drop);
+                }
+
+                // only judge the root against finalized L2 state
+                if game.l2_block_number > latest_finalized_l2_block {
+                    return Ok(WatchOutcome::Keep);
+                }
+                let root = self
+                    .consensus_provider
+                    .output_root_at_block(game.l2_block_number)
+                    .await?;
+                if root == game.root_claim {
+                    Ok(WatchOutcome::Defend)
+                } else {
+                    error!(
+                        game = %address,
+                        claimed_root = %game.root_claim,
+                        canonical_root = %root,
+                        "allowlisted proposer published a non-canonical root; refusing to defend"
+                    );
+                    Ok(WatchOutcome::Drop)
+                }
+            }
+            GameObservation::Finalized => {
+                info!(game = %address, "game has a positive resolution outcome");
+                Ok(WatchOutcome::Drop)
+            }
+            GameObservation::Invalidated(reason) => {
+                if reason == InvalidationReason::ProofTimeout {
+                    error!(
+                        game = %address,
+                        proof_deadline = game.proof_deadline,
+                        "challenged game proof deadline elapsed before defense completed"
+                    );
+                } else {
+                    warn!(
+                        game = %address,
+                        reason = ?reason,
+                        "game is invalidatable without defense"
+                    );
+                }
+                Ok(WatchOutcome::Drop)
+            }
+            GameObservation::Unset => {
+                error!(game = %address, "factory game has unset root state");
+                Ok(WatchOutcome::Drop)
+            }
+        }
+    }
+}
+
+fn has_required_proof_support(game: &GameMetadata, proof_bitmap: u8) -> bool {
+    proof_count(proof_bitmap) >= game.proof_threshold
+}

--- a/proofs/defender/src/game.rs
+++ b/proofs/defender/src/game.rs
@@ -139,7 +139,7 @@ where
         }
     }
 
-    pub(crate) async fn scan(
+    pub(crate) async fn evaluate_discovered(
         &self,
         game: &GameMetadata,
         now: u64,
@@ -157,7 +157,7 @@ where
         })
     }
 
-    pub(crate) async fn watch(
+    pub(crate) async fn evaluate_tracked(
         &self,
         game: &GameMetadata,
         latest_finalized_l2_block: BlockNumber,

--- a/proofs/defender/src/lane.rs
+++ b/proofs/defender/src/lane.rs
@@ -1,0 +1,254 @@
+use crate::{
+    traits::DefenderClient,
+    types::{GameMetadata, LaneState},
+};
+use alloy_primitives::Bytes;
+use tracing::{error, info, warn};
+use world_chain_proofs::ProofLane;
+use world_chain_prover_service::{
+    ProofBackend, ProofData, ProofRequest, ProofRequestId, ProofRequester, ProofResponse,
+    ProofStatus,
+};
+
+pub(crate) async fn advance_lane<E, P>(
+    execution_client: &E,
+    proof_requester: &P,
+    max_proof_attempts: u32,
+    metadata: &GameMetadata,
+    lane: ProofLane,
+    backend: ProofBackend,
+    state: LaneState,
+) -> LaneState
+where
+    E: DefenderClient,
+    P: ProofRequester + Sync,
+{
+    match state {
+        LaneState::Proven | LaneState::Abandoned => state,
+        LaneState::Pending => request_pending_lane(proof_requester, metadata, lane, backend).await,
+        LaneState::Requested { id, attempts } => {
+            advance_requested_lane(
+                execution_client,
+                proof_requester,
+                max_proof_attempts,
+                metadata,
+                lane,
+                backend,
+                id,
+                attempts,
+            )
+            .await
+        }
+    }
+}
+
+async fn request_pending_lane<P>(
+    proof_requester: &P,
+    metadata: &GameMetadata,
+    lane: ProofLane,
+    backend: ProofBackend,
+) -> LaneState
+where
+    P: ProofRequester + Sync,
+{
+    let game = metadata.address;
+    match proof_requester
+        .request_proof(proof_request(metadata, backend))
+        .await
+    {
+        Ok(id) => LaneState::Requested { id, attempts: 1 },
+        Err(error) => {
+            warn!(%game, ?lane, %error, "proof request failed; retrying next tick");
+            LaneState::Pending
+        }
+    }
+}
+
+async fn advance_requested_lane<E, P>(
+    execution_client: &E,
+    proof_requester: &P,
+    max_proof_attempts: u32,
+    metadata: &GameMetadata,
+    lane: ProofLane,
+    backend: ProofBackend,
+    id: ProofRequestId,
+    attempts: u32,
+) -> LaneState
+where
+    E: DefenderClient,
+    P: ProofRequester + Sync,
+{
+    let game = metadata.address;
+    let state = LaneState::Requested { id, attempts };
+    let status = match proof_requester.proof_status(id).await {
+        Ok(status) => status,
+        Err(error) => {
+            warn!(%game, ?lane, %id, %error, "proof status check failed; retrying next tick");
+            return state;
+        }
+    };
+
+    match status {
+        ProofStatus::Created | ProofStatus::Running => state,
+        ProofStatus::Succeeded => {
+            submit_succeeded_lane(execution_client, proof_requester, metadata, lane, id, state)
+                .await
+        }
+        ProofStatus::Failed => {
+            retry_failed_lane(
+                proof_requester,
+                max_proof_attempts,
+                metadata,
+                lane,
+                backend,
+                attempts,
+                state,
+            )
+            .await
+        }
+    }
+}
+
+async fn submit_succeeded_lane<E, P>(
+    execution_client: &E,
+    proof_requester: &P,
+    metadata: &GameMetadata,
+    lane: ProofLane,
+    id: ProofRequestId,
+    state: LaneState,
+) -> LaneState
+where
+    E: DefenderClient,
+    P: ProofRequester + Sync,
+{
+    let game = metadata.address;
+    let response = match proof_requester.get_proof(id).await {
+        Ok(ProofResponse::Succeeded(response)) => response,
+        Ok(ProofResponse::Pending(response)) => {
+            warn!(
+                %game,
+                ?lane,
+                %id,
+                status = %response.status,
+                "proof status was succeeded but proof response is pending; retrying next tick"
+            );
+            return state;
+        }
+        Ok(ProofResponse::Failed(response)) => {
+            warn!(
+                %game,
+                ?lane,
+                %id,
+                reason = %response.reason,
+                "proof status was succeeded but proof response is failed; retrying next tick"
+            );
+            return state;
+        }
+        Err(error) => {
+            warn!(%game, ?lane, %id, %error, "proof retrieval failed; retrying next tick");
+            return state;
+        }
+    };
+
+    match execution_client
+        .submit_proof(game, lane as u8, encode_proof(&response.proof))
+        .await
+    {
+        Ok(submission) => {
+            info!(%game, ?lane, tx_hash = %submission.tx_hash, "proof lane submitted");
+            LaneState::Proven
+        }
+        Err(error) => {
+            // if the transaction actually landed, the proof bitmap check
+            // resolves the lane on the next tick
+            warn!(%game, ?lane, %error, "proof submission failed; retrying next tick");
+            state
+        }
+    }
+}
+
+async fn retry_failed_lane<P>(
+    proof_requester: &P,
+    max_proof_attempts: u32,
+    metadata: &GameMetadata,
+    lane: ProofLane,
+    backend: ProofBackend,
+    attempts: u32,
+    state: LaneState,
+) -> LaneState
+where
+    P: ProofRequester + Sync,
+{
+    let game = metadata.address;
+    if attempts >= max_proof_attempts {
+        error!(%game, ?lane, attempts, "proving permanently failed; abandoning lane");
+        return LaneState::Abandoned;
+    }
+
+    // re-requesting a failed proof re-queues it
+    match proof_requester
+        .request_proof(proof_request(metadata, backend))
+        .await
+    {
+        Ok(id) => {
+            let next_attempt = attempts + 1;
+            warn!(
+                %game,
+                ?lane,
+                %id,
+                attempts = next_attempt,
+                max_attempts = max_proof_attempts,
+                "proof failed; re-requested proof"
+            );
+            LaneState::Requested {
+                id,
+                attempts: next_attempt,
+            }
+        }
+        Err(error) => {
+            warn!(%game, ?lane, %error, "proof re-request failed; retrying next tick");
+            state
+        }
+    }
+}
+
+/// Builds the proof request for one lane of a defended game.
+fn proof_request(game: &GameMetadata, backend: ProofBackend) -> ProofRequest {
+    ProofRequest {
+        backend,
+        game: game.address,
+        root_claim: game.root_claim,
+        l2_block_number: game.l2_block_number,
+        // pin the witness to the L1 origin committed at proposal time, so
+        // the request id stays stable across defender restarts
+        l1_head: game.l1_origin_hash,
+    }
+}
+
+/// Encode a proof payload into the `bytes` argument of `submitProofLane`.
+///
+/// TODO: encode proofs for their concrete on-chain verifiers. SP1 proofs must
+/// match `SP1ValidityVerifier`'s ABI tuple:
+/// `(domainHash, parentRef, l1OriginNumber, publicValues, proofBytes)`.
+/// That requires proposal context in addition to `ProofData`, so this helper
+/// should move closer to the game/lane submission path before real SP1 lanes
+/// are enabled.
+fn encode_proof(proof: &ProofData) -> Bytes {
+    match proof {
+        ProofData::Sp1 {
+            proof,
+            public_values,
+        } => [public_values.as_ref(), proof.as_ref()].concat().into(),
+        ProofData::Nitro {
+            attestation,
+            public_values,
+            signature,
+        } => [
+            public_values.as_ref(),
+            attestation.as_ref(),
+            signature.as_ref(),
+        ]
+        .concat()
+        .into(),
+    }
+}

--- a/proofs/defender/src/lane.rs
+++ b/proofs/defender/src/lane.rs
@@ -1,7 +1,4 @@
-use crate::{
-    traits::DefenderClient,
-    types::{GameMetadata, LaneState},
-};
+use crate::{traits::DefenderClient, types::GameMetadata};
 use alloy_primitives::Bytes;
 use tracing::{error, info, warn};
 use world_chain_proofs::ProofLane;
@@ -9,6 +6,36 @@ use world_chain_prover_service::{
     ProofBackend, ProofData, ProofRequest, ProofRequestId, ProofRequester, ProofResponse,
     ProofStatus,
 };
+
+/// Number of proof lanes the defender drives.
+pub(crate) const DEFENDED_LANE_COUNT: usize = 2;
+
+/// The proof lanes the defender drives, paired with the prover-service
+/// backend that generates each proof.
+pub(crate) const DEFENDED_LANES: [(ProofLane, ProofBackend); DEFENDED_LANE_COUNT] = [
+    (ProofLane::ValidityProof, ProofBackend::Sp1),
+    (ProofLane::TeeAttestation, ProofBackend::Nitro),
+];
+
+/// Progress of a single proof lane within an active defense.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LaneState {
+    /// The proof has not been requested yet.
+    Pending,
+    /// The proof was requested from the prover-service.
+    Requested { id: ProofRequestId, attempts: u32 },
+    /// The lane is proven on-chain.
+    Proven,
+    /// Proving permanently failed after exhausting all attempts.
+    Abandoned,
+}
+
+impl LaneState {
+    /// Whether the lane needs no further work.
+    pub(crate) const fn is_terminal(self) -> bool {
+        matches!(self, Self::Proven | Self::Abandoned)
+    }
+}
 
 pub(crate) struct LaneDriver<'a, E, P> {
     execution_client: &'a E,

--- a/proofs/defender/src/lane.rs
+++ b/proofs/defender/src/lane.rs
@@ -10,204 +10,187 @@ use world_chain_prover_service::{
     ProofStatus,
 };
 
-pub(crate) async fn advance_lane<E, P>(
-    execution_client: &E,
-    proof_requester: &P,
+pub(crate) struct LaneDriver<'a, E, P> {
+    execution_client: &'a E,
+    proof_requester: &'a P,
     max_proof_attempts: u32,
-    metadata: &GameMetadata,
-    lane: ProofLane,
-    backend: ProofBackend,
-    state: LaneState,
-) -> LaneState
+}
+
+impl<'a, E, P> LaneDriver<'a, E, P>
 where
     E: DefenderClient,
     P: ProofRequester + Sync,
 {
-    match state {
-        LaneState::Proven | LaneState::Abandoned => state,
-        LaneState::Pending => request_pending_lane(proof_requester, metadata, lane, backend).await,
-        LaneState::Requested { id, attempts } => {
-            advance_requested_lane(
-                execution_client,
-                proof_requester,
-                max_proof_attempts,
-                metadata,
-                lane,
-                backend,
-                id,
-                attempts,
-            )
-            .await
+    pub(crate) const fn new(
+        execution_client: &'a E,
+        proof_requester: &'a P,
+        max_proof_attempts: u32,
+    ) -> Self {
+        Self {
+            execution_client,
+            proof_requester,
+            max_proof_attempts,
         }
     }
-}
 
-async fn request_pending_lane<P>(
-    proof_requester: &P,
-    metadata: &GameMetadata,
-    lane: ProofLane,
-    backend: ProofBackend,
-) -> LaneState
-where
-    P: ProofRequester + Sync,
-{
-    let game = metadata.address;
-    match proof_requester
-        .request_proof(proof_request(metadata, backend))
-        .await
-    {
-        Ok(id) => LaneState::Requested { id, attempts: 1 },
-        Err(error) => {
-            warn!(%game, ?lane, %error, "proof request failed; retrying next tick");
-            LaneState::Pending
-        }
-    }
-}
-
-async fn advance_requested_lane<E, P>(
-    execution_client: &E,
-    proof_requester: &P,
-    max_proof_attempts: u32,
-    metadata: &GameMetadata,
-    lane: ProofLane,
-    backend: ProofBackend,
-    id: ProofRequestId,
-    attempts: u32,
-) -> LaneState
-where
-    E: DefenderClient,
-    P: ProofRequester + Sync,
-{
-    let game = metadata.address;
-    let state = LaneState::Requested { id, attempts };
-    let status = match proof_requester.proof_status(id).await {
-        Ok(status) => status,
-        Err(error) => {
-            warn!(%game, ?lane, %id, %error, "proof status check failed; retrying next tick");
-            return state;
-        }
-    };
-
-    match status {
-        ProofStatus::Created | ProofStatus::Running => state,
-        ProofStatus::Succeeded => {
-            submit_succeeded_lane(execution_client, proof_requester, metadata, lane, id, state)
-                .await
-        }
-        ProofStatus::Failed => {
-            retry_failed_lane(
-                proof_requester,
-                max_proof_attempts,
-                metadata,
-                lane,
-                backend,
-                attempts,
-                state,
-            )
-            .await
-        }
-    }
-}
-
-async fn submit_succeeded_lane<E, P>(
-    execution_client: &E,
-    proof_requester: &P,
-    metadata: &GameMetadata,
-    lane: ProofLane,
-    id: ProofRequestId,
-    state: LaneState,
-) -> LaneState
-where
-    E: DefenderClient,
-    P: ProofRequester + Sync,
-{
-    let game = metadata.address;
-    let response = match proof_requester.get_proof(id).await {
-        Ok(ProofResponse::Succeeded(response)) => response,
-        Ok(ProofResponse::Pending(response)) => {
-            warn!(
-                %game,
-                ?lane,
-                %id,
-                status = %response.status,
-                "proof status was succeeded but proof response is pending; retrying next tick"
-            );
-            return state;
-        }
-        Ok(ProofResponse::Failed(response)) => {
-            warn!(
-                %game,
-                ?lane,
-                %id,
-                reason = %response.reason,
-                "proof status was succeeded but proof response is failed; retrying next tick"
-            );
-            return state;
-        }
-        Err(error) => {
-            warn!(%game, ?lane, %id, %error, "proof retrieval failed; retrying next tick");
-            return state;
-        }
-    };
-
-    match execution_client
-        .submit_proof(game, lane as u8, encode_proof(&response.proof))
-        .await
-    {
-        Ok(submission) => {
-            info!(%game, ?lane, tx_hash = %submission.tx_hash, "proof lane submitted");
-            LaneState::Proven
-        }
-        Err(error) => {
-            // if the transaction actually landed, the proof bitmap check
-            // resolves the lane on the next tick
-            warn!(%game, ?lane, %error, "proof submission failed; retrying next tick");
-            state
-        }
-    }
-}
-
-async fn retry_failed_lane<P>(
-    proof_requester: &P,
-    max_proof_attempts: u32,
-    metadata: &GameMetadata,
-    lane: ProofLane,
-    backend: ProofBackend,
-    attempts: u32,
-    state: LaneState,
-) -> LaneState
-where
-    P: ProofRequester + Sync,
-{
-    let game = metadata.address;
-    if attempts >= max_proof_attempts {
-        error!(%game, ?lane, attempts, "proving permanently failed; abandoning lane");
-        return LaneState::Abandoned;
-    }
-
-    // re-requesting a failed proof re-queues it
-    match proof_requester
-        .request_proof(proof_request(metadata, backend))
-        .await
-    {
-        Ok(id) => {
-            let next_attempt = attempts + 1;
-            warn!(
-                %game,
-                ?lane,
-                %id,
-                attempts = next_attempt,
-                max_attempts = max_proof_attempts,
-                "proof failed; re-requested proof"
-            );
-            LaneState::Requested {
-                id,
-                attempts: next_attempt,
+    pub(crate) async fn advance(
+        &self,
+        metadata: &GameMetadata,
+        lane: ProofLane,
+        backend: ProofBackend,
+        state: LaneState,
+    ) -> LaneState {
+        match state {
+            LaneState::Proven | LaneState::Abandoned => state,
+            LaneState::Pending => self.request_pending_lane(metadata, lane, backend).await,
+            LaneState::Requested { id, attempts } => {
+                self.advance_requested_lane(metadata, lane, backend, id, attempts)
+                    .await
             }
         }
-        Err(error) => {
-            warn!(%game, ?lane, %error, "proof re-request failed; retrying next tick");
-            state
+    }
+
+    async fn request_pending_lane(
+        &self,
+        metadata: &GameMetadata,
+        lane: ProofLane,
+        backend: ProofBackend,
+    ) -> LaneState {
+        let game = metadata.address;
+        match self
+            .proof_requester
+            .request_proof(proof_request(metadata, backend))
+            .await
+        {
+            Ok(id) => LaneState::Requested { id, attempts: 1 },
+            Err(error) => {
+                warn!(%game, ?lane, %error, "proof request failed; retrying next tick");
+                LaneState::Pending
+            }
+        }
+    }
+
+    async fn advance_requested_lane(
+        &self,
+        metadata: &GameMetadata,
+        lane: ProofLane,
+        backend: ProofBackend,
+        id: ProofRequestId,
+        attempts: u32,
+    ) -> LaneState {
+        let game = metadata.address;
+        let state = LaneState::Requested { id, attempts };
+        let status = match self.proof_requester.proof_status(id).await {
+            Ok(status) => status,
+            Err(error) => {
+                warn!(%game, ?lane, %id, %error, "proof status check failed; retrying next tick");
+                return state;
+            }
+        };
+
+        match status {
+            ProofStatus::Created | ProofStatus::Running => state,
+            ProofStatus::Succeeded => self.submit_succeeded_lane(metadata, lane, id, state).await,
+            ProofStatus::Failed => {
+                self.retry_failed_lane(metadata, lane, backend, attempts, state)
+                    .await
+            }
+        }
+    }
+
+    async fn submit_succeeded_lane(
+        &self,
+        metadata: &GameMetadata,
+        lane: ProofLane,
+        id: ProofRequestId,
+        state: LaneState,
+    ) -> LaneState {
+        let game = metadata.address;
+        let response = match self.proof_requester.get_proof(id).await {
+            Ok(ProofResponse::Succeeded(response)) => response,
+            Ok(ProofResponse::Pending(response)) => {
+                warn!(
+                    %game,
+                    ?lane,
+                    %id,
+                    status = %response.status,
+                    "proof status was succeeded but proof response is pending; retrying next tick"
+                );
+                return state;
+            }
+            Ok(ProofResponse::Failed(response)) => {
+                warn!(
+                    %game,
+                    ?lane,
+                    %id,
+                    reason = %response.reason,
+                    "proof status was succeeded but proof response is failed; retrying next tick"
+                );
+                return state;
+            }
+            Err(error) => {
+                warn!(%game, ?lane, %id, %error, "proof retrieval failed; retrying next tick");
+                return state;
+            }
+        };
+
+        match self
+            .execution_client
+            .submit_proof(game, lane as u8, encode_proof(&response.proof))
+            .await
+        {
+            Ok(submission) => {
+                info!(%game, ?lane, tx_hash = %submission.tx_hash, "proof lane submitted");
+                LaneState::Proven
+            }
+            Err(error) => {
+                // if the transaction actually landed, the proof bitmap check
+                // resolves the lane on the next tick
+                warn!(%game, ?lane, %error, "proof submission failed; retrying next tick");
+                state
+            }
+        }
+    }
+
+    async fn retry_failed_lane(
+        &self,
+        metadata: &GameMetadata,
+        lane: ProofLane,
+        backend: ProofBackend,
+        attempts: u32,
+        state: LaneState,
+    ) -> LaneState {
+        let game = metadata.address;
+        if attempts >= self.max_proof_attempts {
+            error!(%game, ?lane, attempts, "proving permanently failed; abandoning lane");
+            return LaneState::Abandoned;
+        }
+
+        // re-requesting a failed proof re-queues it
+        match self
+            .proof_requester
+            .request_proof(proof_request(metadata, backend))
+            .await
+        {
+            Ok(id) => {
+                let next_attempt = attempts + 1;
+                warn!(
+                    %game,
+                    ?lane,
+                    %id,
+                    attempts = next_attempt,
+                    max_attempts = self.max_proof_attempts,
+                    "proof failed; re-requested proof"
+                );
+                LaneState::Requested {
+                    id,
+                    attempts: next_attempt,
+                }
+            }
+            Err(error) => {
+                warn!(%game, ?lane, %error, "proof re-request failed; retrying next tick");
+                state
+            }
         }
     }
 }

--- a/proofs/defender/src/lib.rs
+++ b/proofs/defender/src/lib.rs
@@ -4,6 +4,7 @@ mod alloy;
 mod config;
 mod defender;
 mod error;
+mod game;
 mod lane;
 mod traits;
 mod types;

--- a/proofs/defender/src/lib.rs
+++ b/proofs/defender/src/lib.rs
@@ -4,6 +4,7 @@ mod alloy;
 mod config;
 mod defender;
 mod error;
+mod lane;
 mod traits;
 mod types;
 

--- a/proofs/defender/src/tests.rs
+++ b/proofs/defender/src/tests.rs
@@ -394,7 +394,7 @@ fn config() -> DefenderConfig {
 }
 
 #[tokio::test]
-async fn scan_once_requires_an_allowed_proposer() {
+async fn tick_requires_an_allowed_proposer() {
     let client = MockClient::new(Vec::new(), HashMap::new());
     let (output_roots, _finalized_l2_block) = mock_output_roots(HashMap::new(), 0);
     let mut defender = WorldChainDefender::new(
@@ -404,12 +404,12 @@ async fn scan_once_requires_an_allowed_proposer() {
         MockProver::default(),
     );
 
-    let error = defender.scan_once().await.unwrap_err();
+    let error = defender.tick().await.unwrap_err();
     assert!(matches!(error, DefenderError::InvalidConfig(_)));
 }
 
 #[tokio::test]
-async fn scan_once_binary_searches_for_first_unexpired_proof_deadline() {
+async fn tick_binary_searches_for_first_unexpired_proof_deadline() {
     let canonical_root = B256::repeat_byte(0x20);
     let mut client = MockClient::new(
         vec![
@@ -424,14 +424,14 @@ async fn scan_once_binary_searches_for_first_unexpired_proof_deadline() {
     let mut defender =
         WorldChainDefender::new(config(), client, output_roots, MockProver::default());
 
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
 
     assert_eq!(defender.next_game_index(), Some(2));
     assert_eq!(defender.watched_games(), [GAME_2]);
 }
 
 #[tokio::test]
-async fn scan_once_respects_factory_scan_budget() {
+async fn tick_respects_factory_scan_budget() {
     let canonical_root = B256::repeat_byte(0x20);
     let client = MockClient::new(
         vec![
@@ -447,11 +447,11 @@ async fn scan_once_respects_factory_scan_budget() {
     let mut defender =
         WorldChainDefender::new(limited_config, client, output_roots, MockProver::default());
 
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
     assert_eq!(defender.next_game_index(), Some(1));
     assert_eq!(defender.watched_games(), [GAME_1]);
 
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
     assert_eq!(defender.next_game_index(), Some(2));
     let watched = defender.watched_games();
     assert_eq!(watched.len(), 2);
@@ -460,7 +460,7 @@ async fn scan_once_respects_factory_scan_budget() {
 }
 
 #[tokio::test]
-async fn scan_once_ignores_games_from_other_proposers() {
+async fn tick_ignores_games_from_other_proposers() {
     let canonical_root = B256::repeat_byte(0x20);
     let mut client = MockClient::new(
         vec![(GAME_1, canonical_root, L2_BLOCK)],
@@ -472,7 +472,7 @@ async fn scan_once_ignores_games_from_other_proposers() {
     let prover = MockProver::default();
     let mut defender = WorldChainDefender::new(config(), client, output_roots, prover.clone());
 
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
 
     assert_eq!(defender.next_game_index(), Some(1));
     assert!(prover.requests().is_empty());
@@ -481,7 +481,7 @@ async fn scan_once_ignores_games_from_other_proposers() {
 }
 
 #[tokio::test]
-async fn scan_once_discards_invalidated_games() {
+async fn tick_discards_invalidated_games() {
     let canonical_root = B256::repeat_byte(0x20);
     let client = MockClient::new(
         vec![(GAME_1, canonical_root, L2_BLOCK)],
@@ -492,7 +492,7 @@ async fn scan_once_discards_invalidated_games() {
     let prover = MockProver::default();
     let mut defender = WorldChainDefender::new(config(), client, output_roots, prover.clone());
 
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
 
     assert!(prover.requests().is_empty());
     assert!(defender.watched_games().is_empty());
@@ -509,10 +509,10 @@ async fn proposed_game_is_removed_after_challenge_deadline() {
     let mut defender =
         WorldChainDefender::new(config(), client, output_roots, MockProver::default());
 
-    defender.scan_once_with_timestamp(5).await.unwrap();
+    defender.tick_at(5).await.unwrap();
     assert_eq!(defender.watched_games(), [GAME_1]);
 
-    defender.scan_once_with_timestamp(10).await.unwrap();
+    defender.tick_at(10).await.unwrap();
     assert!(defender.watched_games().is_empty());
 }
 
@@ -529,19 +529,19 @@ async fn active_defense_is_removed_after_proof_deadline() {
     let prover = MockProver::default();
     let mut defender = WorldChainDefender::new(config(), client, output_roots, prover.clone());
 
-    defender.scan_once_with_timestamp(5).await.unwrap();
+    defender.tick_at(5).await.unwrap();
     assert_eq!(defender.active_defenses(), [GAME_1]);
     assert!(prover.requests().is_empty());
 
-    defender.scan_once_with_timestamp(6).await.unwrap();
+    defender.tick_at(6).await.unwrap();
     assert_eq!(prover.requests().len(), 2);
 
-    defender.scan_once_with_timestamp(20).await.unwrap();
+    defender.tick_at(20).await.unwrap();
     assert!(defender.active_defenses().is_empty());
     assert!(defender.watched_games().is_empty());
 
     // Removal makes the critical deadline condition one-shot.
-    defender.scan_once_with_timestamp(21).await.unwrap();
+    defender.tick_at(21).await.unwrap();
     assert!(defender.active_defenses().is_empty());
 }
 
@@ -560,12 +560,12 @@ async fn active_defense_advances_before_discovery_failure() {
 
     // Discovery and validation promote the game, but active work starts on
     // the next tick because existing defenses run first.
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
     assert_eq!(defender.active_defenses(), [GAME_1]);
     assert!(prover.requests().is_empty());
 
     client.set_game_count_failure(true);
-    let error = defender.scan_once().await.unwrap_err();
+    let error = defender.tick().await.unwrap_err();
 
     assert!(matches!(error, DefenderError::Contract(_)));
     assert_eq!(prover.requests().len(), 2);
@@ -598,11 +598,11 @@ async fn scan_accepts_sufficient_proof_support_hidden_by_an_unresolved_parent() 
         MockProver::default(),
     );
 
-    defender.scan_once_with_timestamp(5).await.unwrap();
+    defender.tick_at(5).await.unwrap();
     assert_eq!(defender.next_game_index(), Some(1));
 
     client.reset_proof_bitmap_reads();
-    defender.scan_once_with_timestamp(20).await.unwrap();
+    defender.tick_at(20).await.unwrap();
 
     assert_eq!(client.proof_bitmap_reads(), 1);
     assert_eq!(defender.next_game_index(), Some(2));
@@ -623,13 +623,13 @@ async fn watched_game_accepts_sufficient_proof_support_hidden_by_an_unresolved_p
     let mut defender =
         WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
 
-    defender.scan_once_with_timestamp(5).await.unwrap();
+    defender.tick_at(5).await.unwrap();
     assert_eq!(defender.watched_games(), [GAME_1]);
 
     client.set_state(GAME_1, STATE_CHALLENGED);
     client.set_bitmap(GAME_1, ProofLane::ValidityProof.mask());
     client.reset_proof_bitmap_reads();
-    defender.scan_once_with_timestamp(20).await.unwrap();
+    defender.tick_at(20).await.unwrap();
 
     assert_eq!(client.proof_bitmap_reads(), 1);
     assert!(prover.requests().is_empty());
@@ -652,11 +652,11 @@ async fn active_defense_accepts_sufficient_proof_support_hidden_by_an_unresolved
     let mut defender =
         WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
 
-    defender.scan_once_with_timestamp(5).await.unwrap();
+    defender.tick_at(5).await.unwrap();
     assert_eq!(defender.active_defenses(), [GAME_1]);
     assert!(prover.requests().is_empty());
 
-    defender.scan_once_with_timestamp(6).await.unwrap();
+    defender.tick_at(6).await.unwrap();
     assert_eq!(prover.requests().len(), 2);
 
     client.set_bitmap(
@@ -664,7 +664,7 @@ async fn active_defense_accepts_sufficient_proof_support_hidden_by_an_unresolved
         ProofLane::ValidityProof.mask() | ProofLane::TeeAttestation.mask(),
     );
     client.reset_proof_bitmap_reads();
-    defender.scan_once_with_timestamp(20).await.unwrap();
+    defender.tick_at(20).await.unwrap();
 
     assert_eq!(client.proof_bitmap_reads(), 1);
     assert!(client.submissions().is_empty());
@@ -673,7 +673,7 @@ async fn active_defense_accepts_sufficient_proof_support_hidden_by_an_unresolved
 }
 
 #[tokio::test]
-async fn scan_once_defends_challenged_valid_root() {
+async fn tick_defends_challenged_valid_root() {
     let canonical_root = B256::repeat_byte(0x20);
 
     let client = MockClient::new(
@@ -687,12 +687,12 @@ async fn scan_once_defends_challenged_valid_root() {
         WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
 
     // First tick: discovery and validation promote the challenged game.
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
     assert_eq!(defender.active_defenses(), [GAME_1]);
     assert!(prover.requests().is_empty());
 
     // Second tick: both lane proofs are requested.
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
     let requests = prover.requests();
     assert_eq!(requests.len(), 2);
     assert_eq!(requests[0].backend, ProofBackend::Sp1);
@@ -706,7 +706,7 @@ async fn scan_once_defends_challenged_valid_root() {
     assert!(client.submissions().is_empty());
 
     // Third tick: both proofs are completed, fetched and submitted on-chain.
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
 
     assert_eq!(
         client.submissions(),
@@ -720,7 +720,7 @@ async fn scan_once_defends_challenged_valid_root() {
 }
 
 #[tokio::test]
-async fn scan_once_waits_for_proposed_game_to_be_challenged() {
+async fn tick_waits_for_proposed_game_to_be_challenged() {
     let canonical_root = B256::repeat_byte(0x20);
 
     let client = MockClient::new(vec![(GAME_1, canonical_root, L2_BLOCK)], HashMap::new());
@@ -731,22 +731,22 @@ async fn scan_once_waits_for_proposed_game_to_be_challenged() {
         WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
 
     // the game is only proposed: keep watching, no proof requests
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
     assert!(prover.requests().is_empty());
     assert_eq!(defender.watched_games(), [GAME_1]);
 
     client.set_state(GAME_1, STATE_CHALLENGED);
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
 
     assert!(prover.requests().is_empty());
     assert_eq!(defender.active_defenses(), [GAME_1]);
 
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
     assert_eq!(prover.requests().len(), 2);
 }
 
 #[tokio::test]
-async fn scan_once_ignores_challenged_invalid_root() {
+async fn tick_ignores_challenged_invalid_root() {
     let proposed_root = B256::repeat_byte(0x10);
     let canonical_root = B256::repeat_byte(0x20);
 
@@ -760,7 +760,7 @@ async fn scan_once_ignores_challenged_invalid_root() {
     let mut defender =
         WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
 
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
 
     // an invalid root is the challenger's business, not ours
     assert!(prover.requests().is_empty());
@@ -769,7 +769,7 @@ async fn scan_once_ignores_challenged_invalid_root() {
 }
 
 #[tokio::test]
-async fn scan_once_defers_validity_check_until_l2_block_is_finalized() {
+async fn tick_defers_validity_check_until_l2_block_is_finalized() {
     let canonical_root = B256::repeat_byte(0x20);
 
     let client = MockClient::new(
@@ -783,22 +783,22 @@ async fn scan_once_defers_validity_check_until_l2_block_is_finalized() {
         WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
 
     // the game's L2 block is not finalized yet, so the root cannot be judged
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
     assert!(prover.requests().is_empty());
     assert_eq!(defender.watched_games(), [GAME_1]);
 
     finalized_l2_block.store(L2_BLOCK, Ordering::SeqCst);
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
 
     assert!(prover.requests().is_empty());
     assert_eq!(defender.active_defenses(), [GAME_1]);
 
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
     assert_eq!(prover.requests().len(), 2);
 }
 
 #[tokio::test]
-async fn scan_once_skips_lane_already_proven() {
+async fn tick_skips_lane_already_proven() {
     let canonical_root = B256::repeat_byte(0x20);
 
     let client = MockClient::new(
@@ -812,9 +812,9 @@ async fn scan_once_skips_lane_already_proven() {
     let mut defender =
         WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
 
-    defender.scan_once().await.unwrap();
-    defender.scan_once().await.unwrap();
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
+    defender.tick().await.unwrap();
+    defender.tick().await.unwrap();
 
     // the validity lane is already proven on-chain: only the TEE lane runs
     let requests = prover.requests();
@@ -850,10 +850,10 @@ async fn failed_proofs_are_rerequested_up_to_the_attempt_bound() {
 
     // Tick 1 promotes the game. Tick 2 makes the first request per lane;
     // tick 3 re-requests each failed proof; tick 4 exhausts the attempts.
-    defender.scan_once().await.unwrap();
-    defender.scan_once().await.unwrap();
-    defender.scan_once().await.unwrap();
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
+    defender.tick().await.unwrap();
+    defender.tick().await.unwrap();
+    defender.tick().await.unwrap();
 
     assert_eq!(prover.requests().len(), 4);
     assert!(client.submissions().is_empty());
@@ -874,11 +874,11 @@ async fn defense_closes_when_game_leaves_challenged_state() {
     let mut defender =
         WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
 
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
     assert_eq!(defender.active_defenses(), [GAME_1]);
 
     client.set_state(GAME_1, STATE_FINALIZED);
-    defender.scan_once().await.unwrap();
+    defender.tick().await.unwrap();
 
     assert!(client.submissions().is_empty());
     assert!(defender.active_defenses().is_empty());

--- a/proofs/defender/src/types.rs
+++ b/proofs/defender/src/types.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::{Address, B256, TxHash};
-use world_chain_proofs::ProofLane;
+use world_chain_proofs::{InvalidationReason, ProofLane};
 use world_chain_prover_service::{ProofBackend, ProofRequestId};
 
 /// Immutable game data needed to monitor and defend an output-root claim.
@@ -30,6 +30,19 @@ pub(crate) const DEFENDED_LANES: [(ProofLane, ProofBackend); DEFENDED_LANE_COUNT
     (ProofLane::ValidityProof, ProofBackend::Sp1),
     (ProofLane::TeeAttestation, ProofBackend::Nitro),
 ];
+
+/// On-chain state relevant to the defender for a single game.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum GameObservation {
+    Proposed,
+    Challenged {
+        proof_bitmap: u8,
+        has_required_support: bool,
+    },
+    Finalized,
+    Invalidated(InvalidationReason),
+    Unset,
+}
 
 /// Result of watching a single game for one tick.
 #[derive(Debug, Clone, Copy)]

--- a/proofs/defender/src/types.rs
+++ b/proofs/defender/src/types.rs
@@ -1,6 +1,4 @@
 use alloy_primitives::{Address, B256, TxHash};
-use world_chain_proofs::ProofLane;
-use world_chain_prover_service::{ProofBackend, ProofRequestId};
 
 /// Immutable game data needed to monitor and defend an output-root claim.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -19,64 +17,4 @@ pub struct GameMetadata {
 pub struct DefenderSubmission {
     /// Transaction hash for the challenge submission.
     pub tx_hash: TxHash,
-}
-
-/// Number of proof lanes the defender drives.
-pub(crate) const DEFENDED_LANE_COUNT: usize = 2;
-
-/// The proof lanes the defender drives, paired with the prover-service
-/// backend that generates each proof.
-pub(crate) const DEFENDED_LANES: [(ProofLane, ProofBackend); DEFENDED_LANE_COUNT] = [
-    (ProofLane::ValidityProof, ProofBackend::Sp1),
-    (ProofLane::TeeAttestation, ProofBackend::Nitro),
-];
-
-/// Progress of a single proof lane within an active defense.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum LaneState {
-    /// The proof has not been requested yet.
-    Pending,
-    /// The proof was requested from the prover-service.
-    Requested { id: ProofRequestId, attempts: u32 },
-    /// The lane is proven on-chain.
-    Proven,
-    /// Proving permanently failed after exhausting all attempts.
-    Abandoned,
-}
-
-impl LaneState {
-    /// Whether the lane needs no further work.
-    pub(crate) const fn is_terminal(self) -> bool {
-        matches!(self, Self::Proven | Self::Abandoned)
-    }
-}
-
-/// An active defense of a challenged game with a valid root.
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct ActiveDefense {
-    pub game: GameMetadata,
-    /// Lane progress, indexed like [`DEFENDED_LANES`].
-    pub lanes: [LaneState; DEFENDED_LANE_COUNT],
-}
-
-impl ActiveDefense {
-    pub(crate) const fn new(game: GameMetadata) -> Self {
-        Self {
-            game,
-            lanes: [LaneState::Pending; DEFENDED_LANE_COUNT],
-        }
-    }
-}
-
-/// Result of advancing a single defense for one tick.
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum DefenseProgress {
-    /// The game left the `Challenged` state on-chain.
-    Closed,
-    /// The game already has enough proof support to complete the defense.
-    Complete,
-    /// The proof deadline elapsed before the defense completed.
-    DeadlineElapsed,
-    /// Lane progress after this tick.
-    Lanes([LaneState; DEFENDED_LANE_COUNT]),
 }

--- a/proofs/defender/src/types.rs
+++ b/proofs/defender/src/types.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::{Address, B256, TxHash};
-use world_chain_proofs::{InvalidationReason, ProofLane};
+use world_chain_proofs::ProofLane;
 use world_chain_prover_service::{ProofBackend, ProofRequestId};
 
 /// Immutable game data needed to monitor and defend an output-root claim.
@@ -30,30 +30,6 @@ pub(crate) const DEFENDED_LANES: [(ProofLane, ProofBackend); DEFENDED_LANE_COUNT
     (ProofLane::ValidityProof, ProofBackend::Sp1),
     (ProofLane::TeeAttestation, ProofBackend::Nitro),
 ];
-
-/// On-chain state relevant to the defender for a single game.
-#[derive(Debug, PartialEq, Eq)]
-pub(crate) enum GameObservation {
-    Proposed,
-    Challenged {
-        proof_bitmap: u8,
-        has_required_support: bool,
-    },
-    Finalized,
-    Invalidated(InvalidationReason),
-    Unset,
-}
-
-/// Result of watching a single game for one tick.
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum WatchOutcome {
-    /// Keep watching the game.
-    Keep,
-    /// The game was challenged and its root is valid: start a defense.
-    Defend,
-    /// The game no longer needs watching.
-    Drop,
-}
 
 /// Progress of a single proof lane within an active defense.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -103,13 +79,4 @@ pub(crate) enum DefenseProgress {
     DeadlineElapsed,
     /// Lane progress after this tick.
     Lanes([LaneState; DEFENDED_LANE_COUNT]),
-}
-
-/// Result of scanning a newly discovered allowlisted game.
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum GameScanOutcome {
-    /// Retain the game for monitoring.
-    Track,
-    /// The game does not need defense monitoring.
-    Skip,
 }

--- a/proofs/integration-tests/tests/orchestration.rs
+++ b/proofs/integration-tests/tests/orchestration.rs
@@ -274,7 +274,7 @@ async fn valid_challenged_root_is_defended_through_workers() {
     );
 
     for _ in 0..200 {
-        defender.scan_once().await.expect("defender scan succeeds");
+        defender.tick().await.expect("defender scan succeeds");
         if has_threshold(chain.proof_bitmap(game)) {
             break;
         }
@@ -325,7 +325,7 @@ async fn valid_challenged_root_survives_transient_proof_failure() {
     );
 
     for _ in 0..200 {
-        defender.scan_once().await.expect("defender scan succeeds");
+        defender.tick().await.expect("defender scan succeeds");
         if has_threshold(chain.proof_bitmap(game)) {
             break;
         }
@@ -376,7 +376,7 @@ async fn defender_ignores_challenged_invalid_root() {
     );
 
     for _ in 0..10 {
-        defender.scan_once().await.expect("defender scan succeeds");
+        defender.tick().await.expect("defender scan succeeds");
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Large structural move in challenged-game defense and proof submission paths; behavior is intended to be unchanged and is heavily test-covered, but regressions in timing or state transitions would affect on-chain defense.
> 
> **Overview**
> Refactors **`WorldChainDefender`** by pulling game lifecycle decisions and per-lane proving into **`game::GameEvaluator`** and **`lane::LaneDriver`**, so `defender.rs` mostly orchestrates discovery, watches, and active defenses.
> 
> **Game evaluation** is unified on **`GameOutcome`** (`Track` / `Defend` / `Drop`) instead of separate scan/watch enums. **`GameEvaluator::observe`** centralizes on-chain reads (including proof bitmap and threshold checks) and is reused when advancing active defenses. Discovery and tracked paths call **`evaluate_discovered`** and **`evaluate_tracked`** (canonical root check still only on tracked games).
> 
> **Lane work** (proof request, status polling, submission, encoding, retries) moves to **`LaneDriver`** with lane constants/types relocated from `types.rs`. **`ActiveDefense`** / **`DefenseProgress`** stay on the defender type.
> 
> The public polling API is renamed **`scan_once` → `tick`** and **`scan_once_with_timestamp` → `tick_at`**; each tick is split into **`advance_active_defenses`**, **`discover_games`**, and **`advance_tracked_games`**. Tests and integration orchestration call sites are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f758007d733c88e2ead08b69733ab83c31f1e52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->