### PR TITLE
chore: update rust toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2026-05-26"
+channel = "nightly-2026-07-01"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
This PR makes the `rust-toolchain` use the same nightly version that our rust CI already uses as you can see in `rust-ci.yml` file

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single toolchain version bump with no application code changes; only affects which compiler developers and `rustup` use locally.
> 
> **Overview**
> Updates **`rust-toolchain.toml`** from `nightly-2026-05-26` to **`nightly-2026-07-01`** so local `rustup` defaults match the nightly already pinned in **`rust-ci.yml`**, the **`Justfile`**, and **`xtask` preflight** (`cargo fmt` / clippy).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf5f5d7e87c8a8569ac25050f1c624095226b9ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->