### PR TITLE
feat: proposer includes a proof when creating a new game

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19148,6 +19148,7 @@ dependencies = [
 name = "world-chain-proposer"
 version = "2.4.0"
 dependencies = [
+ "alloy-eips 2.0.5",
  "alloy-network 2.0.5",
  "alloy-primitives",
  "alloy-provider",
@@ -19165,6 +19166,7 @@ dependencies = [
  "tracing-subscriber 0.3.23",
  "url",
  "world-chain-proofs",
+ "world-chain-prover-service",
 ]
 
 [[package]]

--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -303,7 +303,7 @@ impl Drop for DefenderTask {
     }
 }
 
-/// In-process defender prover-service RPC server. Stopped on devnet drop.
+/// In-process proof-system prover-service RPC server. Stopped on devnet drop.
 #[derive(Debug)]
 struct ProverServiceTask {
     handle: ServerHandle,
@@ -549,14 +549,33 @@ impl FullStackWorldDevnet {
             (Some(batcher), Some(proposer), None)
         };
 
-        let world_proposer = if let Some(deployment) = proof_system.as_ref() {
+        // The proposer always needs the prover-service for its creation-time Nitro proof.
+        // Defender and SP1 worker startup remains optional below.
+        let (prover_service, prover_service_url) = if proof_system.is_some() {
+            let (service, url) = start_prover_service().await?;
+            (Some(service), Some(url))
+        } else {
+            (None, None)
+        };
+
+        let world_proposer = if let (Some(deployment), Some(prover_service_url)) =
+            (proof_system.as_ref(), prover_service_url.as_deref())
+        {
             let output_root_rpc = op_nodes
                 .first()
                 .map(|node| node.rpc_url.clone())
                 .ok_or_else(|| {
                     eyre!("full-stack devnet has no op-node for the World Chain proposer")
                 })?;
-            Some(start_world_chain_proposer(&l1_public_rpc, &output_root_rpc, deployment).await?)
+            Some(
+                start_world_chain_proposer(
+                    &l1_public_rpc,
+                    &output_root_rpc,
+                    prover_service_url,
+                    deployment,
+                )
+                .await?,
+            )
         } else {
             None
         };
@@ -573,46 +592,46 @@ impl FullStackWorldDevnet {
             None
         };
 
-        // Defender proving loop: an in-process defender, prover-service, and SP1 worker,
-        // enabled by the `DEVNET_SP1_WORKER_PROVER` env var. The defender enqueues proof
-        // requests for challenged valid games; the worker leases SP1 jobs, builds witnesses
-        // from the devnet L1/L2 RPCs, and proves them with the selected backend.
-        let (prover_service, sp1_worker, world_defender, prover_service_url) =
-            match (proof_system.as_ref(), sp1_worker_prover_kind()?) {
-                (Some(deployment), Some(kind)) => {
-                    let output_root_rpc = op_nodes
-                        .first()
-                        .map(|node| node.rpc_url.clone())
-                        .ok_or_else(|| {
-                            eyre!("full-stack devnet has no op-node for the World Chain defender")
-                        })?;
-                    let l2_rpc = sequencers
-                        .first()
-                        .map(|sequencer| sequencer.rpc_url.clone())
-                        .ok_or_else(|| {
-                            eyre!("full-stack devnet has no sequencer for the SP1 worker")
-                        })?;
-                    let (service, url) = start_prover_service().await?;
-                    let defender = start_world_chain_defender(
-                        &l1_public_rpc,
-                        &output_root_rpc,
-                        &url,
-                        deployment,
-                    )
-                    .await?;
-                    let worker = start_sp1_worker(
-                        &l1_public_rpc,
-                        &l2_rpc,
-                        &url,
-                        &artifacts.rollup_path,
-                        deployment,
-                        kind,
-                    )
-                    .await?;
-                    (Some(service), Some(worker), Some(defender), Some(url))
-                }
-                _ => (None, None, None, None),
-            };
+        // Optional defender proving loop: an in-process defender and SP1 worker, enabled by
+        // `DEVNET_SP1_WORKER_PROVER`. They share the prover-service started for the proposer.
+        let (sp1_worker, world_defender) = match (
+            proof_system.as_ref(),
+            sp1_worker_prover_kind()?,
+            prover_service_url.as_deref(),
+        ) {
+            (Some(deployment), Some(kind), Some(prover_service_url)) => {
+                let output_root_rpc = op_nodes
+                    .first()
+                    .map(|node| node.rpc_url.clone())
+                    .ok_or_else(|| {
+                        eyre!("full-stack devnet has no op-node for the World Chain defender")
+                    })?;
+                let l2_rpc = sequencers
+                    .first()
+                    .map(|sequencer| sequencer.rpc_url.clone())
+                    .ok_or_else(|| {
+                        eyre!("full-stack devnet has no sequencer for the SP1 worker")
+                    })?;
+                let defender = start_world_chain_defender(
+                    &l1_public_rpc,
+                    &output_root_rpc,
+                    prover_service_url,
+                    deployment,
+                )
+                .await?;
+                let worker = start_sp1_worker(
+                    &l1_public_rpc,
+                    &l2_rpc,
+                    prover_service_url,
+                    &artifacts.rollup_path,
+                    deployment,
+                    kind,
+                )
+                .await?;
+                (Some(worker), Some(defender))
+            }
+            _ => (None, None),
+        };
 
         let mut metrics_targets = Vec::new();
         metrics_targets.extend(
@@ -2399,6 +2418,7 @@ async fn start_challenger(
 async fn start_world_chain_proposer(
     l1_rpc_url: &str,
     output_root_rpc_url: &str,
+    prover_service_url: &str,
     deployment: &WorldProofSystemDeployment,
 ) -> Result<ProposerTask> {
     let factory_address: Address = deployment
@@ -2421,6 +2441,8 @@ async fn start_world_chain_proposer(
     let contracts = AlloyProofSystemClient::new(provider, factory_address, anchor_address);
     let mut bond_manager = BondManager::new(BondManagerConfig::default(), contracts.clone());
     let output_roots = OptimismConsensusClient::new(output_root_rpc_url.to_string());
+    let proof_requester = RpcProverServiceClient::new(prover_service_url)
+        .map_err(|error| eyre!("failed to connect proposer to prover-service: {error}"))?;
     let proposer_bond = contracts
         .proposer_bond()
         .await
@@ -2431,11 +2453,12 @@ async fn start_world_chain_proposer(
         poll_interval: WORLD_PROPOSER_POLL_INTERVAL,
         max_resolutions_per_tick: ProposerConfig::default().max_resolutions_per_tick,
     };
-    let proposer = WorldChainProposer::new(config, contracts, output_roots);
+    let mut proposer = WorldChainProposer::new(config, contracts, output_roots, proof_requester);
 
     info!(
         l1_rpc_url,
         output_root_rpc_url,
+        prover_service = %prover_service_url,
         factory = %deployment.proof_system_factory,
         anchor = %deployment.anchor_state_registry,
         proposer = %proposer_address,

--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -434,9 +434,14 @@ impl ProposerClient for FakeExecution {
         Ok(U256::from(1))
     }
 
+    async fn latest_finalized_l1_block(&self) -> Result<B256, ProposerError> {
+        Ok(B256::repeat_byte(0xf1))
+    }
+
     async fn submit_proposal(
         &self,
         proposal: &Proposal,
+        _proof: ProofData,
         _proposer_bond: U256,
     ) -> Result<ProposalSubmission, ProposerError> {
         let mut state = self.state.lock().expect("fake execution mutex poisoned");

--- a/proofs/integration-tests/tests/orchestration.rs
+++ b/proofs/integration-tests/tests/orchestration.rs
@@ -16,7 +16,9 @@ use world_chain_proof_worker::{
     ProofWorker, ProofWorkerConfig, RetryConfig, WorkerHeartbeatConfig,
 };
 use world_chain_proofs::{ProofLane, RootState, has_threshold};
-use world_chain_proposer::{ProposerClient, ProposerConfig, WorldChainProposer};
+use world_chain_proposer::{
+    CanonicalScan, ProposerClient, ProposerConfig, ProposerError, WorldChainProposer,
+};
 use world_chain_prover_service::{
     ProofBackend, ProofData, ProofRequest, ProofRequestError, ProofRequestId, ProofRequester,
     ProofResponse, ProofStatus, ProverServiceConfig, SucceededProofResponse,
@@ -106,6 +108,17 @@ where
         .expect("anchor advanced");
 }
 
+async fn post_proposal<P>(
+    proposer: &mut WorldChainProposer<FakeExecution, FakeConsensus, P>,
+    scan: &CanonicalScan,
+) -> Result<(), ProposerError>
+where
+    P: ProofRequester,
+{
+    proposer.request_proof(scan).await?;
+    proposer.poll_and_submit().await
+}
+
 #[tokio::test]
 async fn fake_resolution_matches_contract_transition_semantics() {
     let chain = FakeExecution::new();
@@ -122,8 +135,7 @@ async fn fake_resolution_matches_contract_transition_semantics() {
         .anchor_and_canonical_line()
         .await
         .expect("canonical line reconstructed");
-    proposer
-        .propose(&canonical_scan)
+    post_proposal(&mut proposer, &canonical_scan)
         .await
         .expect("proposal posted");
     let game = chain.latest_game().expect("game created").game;
@@ -278,8 +290,7 @@ async fn invalid_root_is_challenged_by_real_challenger() {
         .anchor_and_canonical_line()
         .await
         .expect("canonical line reconstructed");
-    proposer
-        .propose(&canonical_scan)
+    post_proposal(&mut proposer, &canonical_scan)
         .await
         .expect("bad proposal posted");
     let game = chain.latest_game().expect("game created").game;
@@ -311,8 +322,7 @@ async fn valid_challenged_root_is_defended_through_workers() {
         .anchor_and_canonical_line()
         .await
         .expect("canonical line reconstructed");
-    proposer
-        .propose(&canonical_scan)
+    post_proposal(&mut proposer, &canonical_scan)
         .await
         .expect("proposal posted");
     let game = chain.latest_game().expect("game created").game;
@@ -362,8 +372,7 @@ async fn valid_challenged_root_survives_transient_proof_failure() {
         .anchor_and_canonical_line()
         .await
         .expect("canonical line reconstructed");
-    proposer
-        .propose(&canonical_scan)
+    post_proposal(&mut proposer, &canonical_scan)
         .await
         .expect("proposal posted");
     let game = chain.latest_game().expect("game created").game;
@@ -422,8 +431,7 @@ async fn defender_ignores_challenged_invalid_root() {
         .anchor_and_canonical_line()
         .await
         .expect("canonical line reconstructed");
-    proposer
-        .propose(&canonical_scan)
+    post_proposal(&mut proposer, &canonical_scan)
         .await
         .expect("bad proposal posted");
     let game = chain.latest_game().expect("game created").game;

--- a/proofs/integration-tests/tests/orchestration.rs
+++ b/proofs/integration-tests/tests/orchestration.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use alloy_primitives::{B256, Bytes, U256};
+use async_trait::async_trait;
 use testcontainers::{ContainerAsync, runners::AsyncRunner};
 use testcontainers_modules::postgres;
 use tokio::task::JoinHandle;
@@ -16,7 +17,10 @@ use world_chain_proof_worker::{
 };
 use world_chain_proofs::{ProofLane, RootState, has_threshold};
 use world_chain_proposer::{ProposerClient, ProposerConfig, WorldChainProposer};
-use world_chain_prover_service::{ProofBackend, ProverServiceConfig};
+use world_chain_prover_service::{
+    ProofBackend, ProofData, ProofRequest, ProofRequestError, ProofRequestId, ProofRequester,
+    ProofResponse, ProofStatus, ProverServiceConfig, SucceededProofResponse,
+};
 
 fn proposer_config() -> ProposerConfig {
     ProposerConfig {
@@ -50,7 +54,44 @@ fn assert_defense_lanes(lanes: Vec<ProofLane>) {
     assert!(lanes.contains(&ProofLane::TeeAttestation));
 }
 
-async fn settle_with_proposer(proposer: &WorldChainProposer<FakeExecution, FakeConsensus>) {
+#[derive(Debug, Clone, Copy)]
+struct InstantProofRequester;
+
+#[async_trait]
+impl ProofRequester for InstantProofRequester {
+    async fn request_proof(
+        &self,
+        request: ProofRequest,
+    ) -> Result<ProofRequestId, ProofRequestError> {
+        Ok(request.id())
+    }
+
+    async fn proof_status(
+        &self,
+        _proof_id: ProofRequestId,
+    ) -> Result<ProofStatus, ProofRequestError> {
+        Ok(ProofStatus::Succeeded)
+    }
+
+    async fn get_proof(
+        &self,
+        proof_id: ProofRequestId,
+    ) -> Result<ProofResponse, ProofRequestError> {
+        Ok(ProofResponse::Succeeded(SucceededProofResponse {
+            id: proof_id,
+            proof: ProofData::Nitro {
+                attestation: Bytes::from_static(&[1]),
+                public_values: Bytes::from_static(&[2]),
+                signature: Bytes::from_static(&[3]),
+            },
+        }))
+    }
+}
+
+async fn settle_with_proposer<P>(proposer: &WorldChainProposer<FakeExecution, FakeConsensus, P>)
+where
+    P: ProofRequester,
+{
     let canonical_scan = proposer
         .anchor_and_canonical_line()
         .await
@@ -70,7 +111,12 @@ async fn fake_resolution_matches_contract_transition_semantics() {
     let chain = FakeExecution::new();
     let canonical_root = B256::repeat_byte(0x20);
     let consensus = FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
-    let proposer = WorldChainProposer::new(proposer_config(), chain.clone(), consensus);
+    let mut proposer = WorldChainProposer::new(
+        proposer_config(),
+        chain.clone(),
+        consensus,
+        InstantProofRequester,
+    );
 
     let canonical_scan = proposer
         .anchor_and_canonical_line()
@@ -222,8 +268,12 @@ async fn invalid_root_is_challenged_by_real_challenger() {
     let honest_consensus =
         FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
 
-    let proposer =
-        WorldChainProposer::new(proposer_config(), chain.clone(), bad_proposer_consensus);
+    let mut proposer = WorldChainProposer::new(
+        proposer_config(),
+        chain.clone(),
+        bad_proposer_consensus,
+        InstantProofRequester,
+    );
     let canonical_scan = proposer
         .anchor_and_canonical_line()
         .await
@@ -251,7 +301,12 @@ async fn valid_challenged_root_is_defended_through_workers() {
     let canonical_root = B256::repeat_byte(0x20);
     let consensus = FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
 
-    let proposer = WorldChainProposer::new(proposer_config(), chain.clone(), consensus.clone());
+    let mut proposer = WorldChainProposer::new(
+        proposer_config(),
+        chain.clone(),
+        consensus.clone(),
+        InstantProofRequester,
+    );
     let canonical_scan = proposer
         .anchor_and_canonical_line()
         .await
@@ -297,7 +352,12 @@ async fn valid_challenged_root_survives_transient_proof_failure() {
     let canonical_root = B256::repeat_byte(0x20);
     let consensus = FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
 
-    let proposer = WorldChainProposer::new(proposer_config(), chain.clone(), consensus.clone());
+    let mut proposer = WorldChainProposer::new(
+        proposer_config(),
+        chain.clone(),
+        consensus.clone(),
+        InstantProofRequester,
+    );
     let canonical_scan = proposer
         .anchor_and_canonical_line()
         .await
@@ -352,8 +412,12 @@ async fn defender_ignores_challenged_invalid_root() {
     let honest_consensus =
         FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
 
-    let proposer =
-        WorldChainProposer::new(proposer_config(), chain.clone(), bad_proposer_consensus);
+    let mut proposer = WorldChainProposer::new(
+        proposer_config(),
+        chain.clone(),
+        bad_proposer_consensus,
+        InstantProofRequester,
+    );
     let canonical_scan = proposer
         .anchor_and_canonical_line()
         .await

--- a/proofs/proposer/Cargo.toml
+++ b/proofs/proposer/Cargo.toml
@@ -17,9 +17,11 @@ workspace = true
 [dependencies]
 # workspace
 world-chain-proofs.workspace = true
+world-chain-prover-service.workspace = true
 
 # alloy
 alloy-network.workspace = true
+alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-provider = { workspace = true, features = ["reqwest"] }
 alloy-signer-local.workspace = true

--- a/proofs/proposer/src/alloy.rs
+++ b/proofs/proposer/src/alloy.rs
@@ -1,10 +1,12 @@
-use alloy_primitives::{Address, B256, U256};
+use alloy_eips::BlockId;
+use alloy_primitives::{Address, B256, BlockHash, U256};
 use alloy_provider::{Provider, WalletProvider};
 use async_trait::async_trait;
 use world_chain_proofs::{
     IWorldChainAnchorStateRegistry, IWorldChainProofSystemFactory, IWorldChainProofSystemGame,
     InvalidationReasonError, ProposalCommitment, ResolutionStatus, RootStateError,
 };
+use world_chain_prover_service::ProofData;
 
 use crate::{
     BondManagerClient, ParentRef, Proposal, ProposalSubmission, ProposerClient, ProposerError,
@@ -284,9 +286,21 @@ where
         Ok(proposer_bond)
     }
 
+    async fn latest_finalized_l1_block(&self) -> Result<BlockHash, ProposerError> {
+        let block = self
+            .provider
+            .get_block(BlockId::finalized())
+            .await
+            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+        let block = block.ok_or_else(|| ProposerError::FinalizedBlockNotFound)?;
+        let hash = block.hash();
+        Ok(hash)
+    }
+
     async fn submit_proposal(
         &self,
         proposal: &Proposal,
+        proof: ProofData,
         proposer_bond: U256,
     ) -> Result<ProposalSubmission, ProposerError> {
         let pending = self

--- a/proofs/proposer/src/alloy.rs
+++ b/proofs/proposer/src/alloy.rs
@@ -300,7 +300,7 @@ where
     async fn submit_proposal(
         &self,
         proposal: &Proposal,
-        proof: ProofData,
+        _proof: ProofData,
         proposer_bond: U256,
     ) -> Result<ProposalSubmission, ProposerError> {
         let pending = self

--- a/proofs/proposer/src/error.rs
+++ b/proofs/proposer/src/error.rs
@@ -19,6 +19,8 @@ pub enum ProposerError {
     /// Contract call or transaction failure.
     #[error("contract error: {0}")]
     Contract(String),
+    #[error("L1 finalized block not found")]
+    FinalizedBlockNotFound,
     #[error(transparent)]
     OutputRoot(#[from] ConsensusError),
     #[error("The proposal transaction didn't execute succesfully: {0}")]

--- a/proofs/proposer/src/error.rs
+++ b/proofs/proposer/src/error.rs
@@ -1,6 +1,7 @@
 use alloy_primitives::TxHash;
 use thiserror::Error;
 use world_chain_proofs::ConsensusError;
+use world_chain_prover_service::ProofRequestError;
 
 /// Errors returned by the proposer.
 #[derive(Debug, Error)]
@@ -21,6 +22,12 @@ pub enum ProposerError {
     Contract(String),
     #[error("L1 finalized block not found")]
     FinalizedBlockNotFound,
+    /// Prover-service request failure.
+    #[error(transparent)]
+    ProofRequest(#[from] ProofRequestError),
+    /// Prover-service returned data inconsistent with the requested proof.
+    #[error("invalid proof response: {0}")]
+    InvalidProofResponse(String),
     #[error(transparent)]
     OutputRoot(#[from] ConsensusError),
     #[error("The proposal transaction didn't execute succesfully: {0}")]

--- a/proofs/proposer/src/main.rs
+++ b/proofs/proposer/src/main.rs
@@ -20,6 +20,7 @@ use world_chain_proposer::{
     AlloyProofSystemClient, BondManager, BondManagerConfig, ProposerClient, ProposerConfig,
     WorldChainProposer,
 };
+use world_chain_prover_service::RpcProverServiceClient;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -34,6 +35,10 @@ struct Cli {
     /// op-node rollup RPC URL used to read canonical L2 output roots.
     #[arg(long, env = "OUTPUT_ROOT_RPC_URL")]
     output_root_rpc: String,
+
+    /// prover-service JSON-RPC URL.
+    #[arg(long, env = "PROVER_SERVICE_URL")]
+    prover_service_url: String,
 
     /// `WorldChainProofSystemFactory` address on L1.
     #[arg(long, env = "FACTORY_ADDRESS")]
@@ -94,6 +99,8 @@ async fn main() -> Result<()> {
     };
     let mut bond_manager = BondManager::new(bond_manager_config, contracts.clone());
     let output_roots = OptimismConsensusClient::new(cli.output_root_rpc.clone());
+    let proof_requester = RpcProverServiceClient::new(&cli.prover_service_url)
+        .with_context(|| format!("failed to connect to {}", cli.prover_service_url))?;
     let proposer_bond = contracts
         .proposer_bond()
         .await
@@ -104,11 +111,12 @@ async fn main() -> Result<()> {
         poll_interval: Duration::from_secs(cli.poll_interval_seconds),
         max_resolutions_per_tick: cli.max_resolutions_per_tick,
     };
-    let proposer = WorldChainProposer::new(config, contracts, output_roots);
+    let mut proposer = WorldChainProposer::new(config, contracts, output_roots, proof_requester);
 
     info!(
         l1_rpc_url = %cli.l1_rpc,
         output_root_rpc_url = %cli.output_root_rpc,
+        prover_service = %cli.prover_service_url,
         factory = %cli.factory_address,
         anchor = %cli.anchor_registry_address,
         proposer = %proposer_address,

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -235,12 +235,11 @@ where
         Ok(())
     }
 
-    /// Executes the next proposal action selected during canonical-line scanning.
+    /// Reconciles and requests the proof for the next canonical proposal action.
     ///
-    /// New and timed-out transitions are submitted, negative-ready games wait for the
-    /// challenger, and non-retryable invalidations stop with a governance warning.
-    ///
-    pub async fn propose(&mut self, scan: &CanonicalScan) -> Result<(), ProposerError> {
+    /// New and timed-out transitions request a Nitro proof, negative-ready games wait for the
+    /// challenger, and non-retryable invalidations clear any pending proposal.
+    pub async fn request_proof(&mut self, scan: &CanonicalScan) -> Result<(), ProposerError> {
         let (proposal, retry_of) = match scan.next_action() {
             NextProposalAction::Propose(proposal) => (*proposal, None),
             NextProposalAction::RetryTimedOut {
@@ -324,7 +323,17 @@ where
                 pending.proof_id
             )));
         }
+        Ok(())
+    }
 
+    /// Polls the pending Nitro proof and submits its proposal once the proof is ready.
+    ///
+    /// Pending and failed proofs remain queued for a later tick. Proof retrieval and proposal
+    /// submission errors retain the pending state so the same completed proof can be retried.
+    pub async fn poll_and_submit(&mut self) -> Result<(), ProposerError> {
+        let Some(pending) = self.pending_proposal.as_ref() else {
+            return Ok(());
+        };
         match self.proof_requester.proof_status(pending.proof_id).await? {
             ProofStatus::Created | ProofStatus::Running => return Ok(()),
             ProofStatus::Failed => {
@@ -402,8 +411,10 @@ where
                 let finalized_games = self.resolve_games(canonical_scan.canonical_line()).await?;
                 // 3. advance the anchor to the highest finalized canonical game
                 self.advance_anchor(finalized_games).await?;
-                // 4. attempt a new canonical proposal or retry
-                self.propose(&canonical_scan).await?;
+                // 4. request the proof for a new canonical proposal or retry
+                self.request_proof(&canonical_scan).await?;
+                // 5. submit the proposal once its proof is ready
+                self.poll_and_submit().await?;
                 Ok(())
             }
             .await;

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -1,6 +1,9 @@
-use alloy_primitives::B256;
+use std::collections::HashSet;
+
+use alloy_primitives::{Address, B256};
 use tracing::{info, warn};
 use world_chain_proofs::{ConsensusProvider, InvalidationReason, RootState};
+use world_chain_prover_service::{ProofBackend, ProofRequest, ProofRequestId, ProofRequester};
 
 use crate::{
     ParentRef, Proposal, ProposerClient, ProposerConfig, ProposerError,
@@ -9,19 +12,27 @@ use crate::{
 
 /// World Chain Proposer.
 #[derive(Debug)]
-pub struct WorldChainProposer<E, C> {
+pub struct WorldChainProposer<E, C, P> {
     config: ProposerConfig,
     execution_provider: E,
     consensus_provider: C,
+    proof_requester: P,
+    proof_ids: HashSet<ProofRequestId>
 }
 
-impl<E, C> WorldChainProposer<E, C> {
+impl<E, C, P> WorldChainProposer<E, C, P> {
     /// Creates a proposer from execution and consensus providers.
-    pub fn new(config: ProposerConfig, execution_provider: E, consensus_provider: C) -> Self {
+    pub fn new(
+        config: ProposerConfig,
+        execution_provider: E,
+        consensus_provider: C,
+        proof_requester: P,
+    ) -> Self {
         Self {
             config,
             execution_provider,
             consensus_provider,
+            proof_requester,
         }
     }
 
@@ -32,10 +43,11 @@ impl<E, C> WorldChainProposer<E, C> {
     }
 }
 
-impl<E, C> WorldChainProposer<E, C>
+impl<E, C, P> WorldChainProposer<E, C, P>
 where
     E: ProposerClient,
     C: ConsensusProvider,
+    P: ProofRequester,
 {
     /// Fetches the anchor, reconstructs its canonical descendants, and determines the next action.
     ///
@@ -235,6 +247,21 @@ where
             NextProposalAction::CaughtUp { .. } => return Ok(()),
         };
 
+        self.proof_ids.get(value)
+        let latest_finalized_l1 = self.execution_provider.latest_finalized_l1_block().await?;
+        let proof_request = ProofRequest {
+            backend: ProofBackend::Nitro,
+            game: Address::ZERO, // TODO: think about this
+            root_claim: proposal.root_claim,
+            l2_block_number: proposal.l2_block_number,
+            l1_head: latest_finalized_l1,
+        };
+        // TODO: add error handling
+        let proof_id = self
+            .proof_requester
+            .request_proof(proof_request)
+            .await
+            .unwrap();
         let submission = self
             .execution_provider
             .submit_proposal(proposal, self.config.proposer_bond)

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -1,14 +1,26 @@
-use std::collections::HashSet;
-
 use alloy_primitives::{Address, B256};
 use tracing::{info, warn};
 use world_chain_proofs::{ConsensusProvider, InvalidationReason, RootState};
-use world_chain_prover_service::{ProofBackend, ProofRequest, ProofRequestId, ProofRequester};
+use world_chain_prover_service::{
+    ProofBackend, ProofRequest, ProofRequestId, ProofRequester, ProofResponse, ProofStatus,
+};
 
 use crate::{
     ParentRef, Proposal, ProposerClient, ProposerConfig, ProposerError,
     types::{CanonicalLine, CanonicalScan, FinalizedGames, NextProposalAction},
 };
+
+/// Proposal and exact Nitro request retained while proof generation is in flight.
+///
+/// This state is intentionally process-local. After a restart, the proposer builds a new request
+/// from the then-current finalized L1 head; persistent proof-session recovery is handled separately.
+#[derive(Debug, Clone)]
+struct PendingProposal {
+    proposal: Proposal,
+    retry_of: Option<Address>,
+    proof_request: ProofRequest,
+    proof_id: ProofRequestId,
+}
 
 /// World Chain Proposer.
 #[derive(Debug)]
@@ -17,11 +29,11 @@ pub struct WorldChainProposer<E, C, P> {
     execution_provider: E,
     consensus_provider: C,
     proof_requester: P,
-    proof_ids: HashSet<ProofRequestId>
+    pending_proposal: Option<PendingProposal>,
 }
 
 impl<E, C, P> WorldChainProposer<E, C, P> {
-    /// Creates a proposer from execution and consensus providers.
+    /// Creates a proposer from execution, consensus, and proof-requester providers.
     pub fn new(
         config: ProposerConfig,
         execution_provider: E,
@@ -33,6 +45,7 @@ impl<E, C, P> WorldChainProposer<E, C, P> {
             execution_provider,
             consensus_provider,
             proof_requester,
+            pending_proposal: None,
         }
     }
 
@@ -40,6 +53,12 @@ impl<E, C, P> WorldChainProposer<E, C, P> {
     #[must_use]
     pub const fn config(&self) -> &ProposerConfig {
         &self.config
+    }
+
+    /// Returns whether a proposal is waiting for its Nitro proof or L1 submission.
+    #[must_use]
+    pub const fn has_pending_proposal(&self) -> bool {
+        self.pending_proposal.is_some()
     }
 }
 
@@ -221,19 +240,20 @@ where
     /// New and timed-out transitions are submitted, negative-ready games wait for the
     /// challenger, and non-retryable invalidations stop with a governance warning.
     ///
-    pub async fn propose(&self, scan: &CanonicalScan) -> Result<(), ProposerError> {
+    pub async fn propose(&mut self, scan: &CanonicalScan) -> Result<(), ProposerError> {
         let (proposal, retry_of) = match scan.next_action() {
-            NextProposalAction::Propose(proposal) => (proposal, None),
+            NextProposalAction::Propose(proposal) => (*proposal, None),
             NextProposalAction::RetryTimedOut {
                 proposal,
                 invalidated_game,
-            } => (proposal, Some(*invalidated_game)),
+            } => (*proposal, Some(*invalidated_game)),
             NextProposalAction::AwaitNegativeResolution { game, reason } => {
                 warn!(
                     game_address = %game,
                     invalidation_reason = ?reason,
                     "waiting for challenger to resolve game with negative outcome"
                 );
+                self.pending_proposal = None;
                 return Ok(());
             }
             NextProposalAction::BlockedByInvalidation { game, reason } => {
@@ -242,44 +262,134 @@ where
                     invalidation_reason = ?reason,
                     "invalidated transition is not automatically retryable; governance intervention required"
                 );
+                self.pending_proposal = None;
                 return Ok(());
             }
-            NextProposalAction::CaughtUp { .. } => return Ok(()),
+            NextProposalAction::CaughtUp { .. } => {
+                self.pending_proposal = None;
+                return Ok(());
+            }
         };
 
-        self.proof_ids.get(value)
-        let latest_finalized_l1 = self.execution_provider.latest_finalized_l1_block().await?;
-        let proof_request = ProofRequest {
-            backend: ProofBackend::Nitro,
-            game: Address::ZERO, // TODO: think about this
-            root_claim: proposal.root_claim,
-            l2_block_number: proposal.l2_block_number,
-            l1_head: latest_finalized_l1,
-        };
-        // TODO: add error handling
-        let proof_id = self
+        if self
+            .pending_proposal
+            .as_ref()
+            .is_some_and(|pending| pending.proposal.proposal_key != proposal.proposal_key)
+        {
+            let pending = self
+                .pending_proposal
+                .take()
+                .expect("pending proposal exists");
+            warn!(
+                old_proposal_key = ?pending.proposal.proposal_key,
+                new_proposal_key = ?proposal.proposal_key,
+                "canonical proposal changed; discarding stale pending proof"
+            );
+        }
+
+        if self.pending_proposal.is_none() {
+            let latest_finalized_l1 = self.execution_provider.latest_finalized_l1_block().await?;
+            let proof_request = ProofRequest {
+                backend: ProofBackend::Nitro,
+                // No game exists until the proof-backed proposal transaction is submitted.
+                game: Address::ZERO,
+                root_claim: proposal.root_claim,
+                l2_block_number: proposal.l2_block_number,
+                l1_head: latest_finalized_l1,
+            };
+            let proof_id = proof_request.id();
+            self.pending_proposal = Some(PendingProposal {
+                proposal,
+                retry_of,
+                proof_request,
+                proof_id,
+            });
+        }
+
+        let pending = self
+            .pending_proposal
+            .as_ref()
+            .expect("pending proposal initialized")
+            .clone();
+
+        // Reissuing the exact request is idempotent and requeues a failed request
+        // according to the prover-service retry policy.
+        let returned_id = self
             .proof_requester
-            .request_proof(proof_request)
-            .await
-            .unwrap();
+            .request_proof(pending.proof_request.clone())
+            .await?;
+        if returned_id != pending.proof_id {
+            return Err(ProposerError::InvalidProofResponse(format!(
+                "prover-service returned proof id {returned_id}, expected {}",
+                pending.proof_id
+            )));
+        }
+
+        match self.proof_requester.proof_status(pending.proof_id).await? {
+            ProofStatus::Created | ProofStatus::Running => return Ok(()),
+            ProofStatus::Failed => {
+                warn!(
+                    proof_id = %pending.proof_id,
+                    proposal_key = ?pending.proposal.proposal_key,
+                    "proposal proof failed; retrying the same request next tick"
+                );
+                return Ok(());
+            }
+            ProofStatus::Succeeded => {}
+        }
+
+        let proof = match self.proof_requester.get_proof(pending.proof_id).await? {
+            ProofResponse::Succeeded(response) if response.id == pending.proof_id => response.proof,
+            ProofResponse::Succeeded(response) => {
+                return Err(ProposerError::InvalidProofResponse(format!(
+                    "proof response id {} does not match requested id {}",
+                    response.id, pending.proof_id
+                )));
+            }
+            ProofResponse::Pending(response) => {
+                warn!(
+                    proof_id = %pending.proof_id,
+                    status = %response.status,
+                    "proof status succeeded but proof response is pending; retrying next tick"
+                );
+                return Ok(());
+            }
+            ProofResponse::Failed(response) => {
+                warn!(
+                    proof_id = %pending.proof_id,
+                    reason = %response.reason,
+                    "proof status succeeded but proof response failed; retrying next tick"
+                );
+                return Ok(());
+            }
+        };
+        if proof.backend() != ProofBackend::Nitro {
+            return Err(ProposerError::InvalidProofResponse(format!(
+                "proof {} was produced by {}, expected nitro",
+                pending.proof_id,
+                proof.backend()
+            )));
+        }
+
         let submission = self
             .execution_provider
-            .submit_proposal(proposal, self.config.proposer_bond)
+            .submit_proposal(&pending.proposal, proof, self.config.proposer_bond)
             .await?;
         info!(
             tx_hash = ?submission.tx_hash,
             game_address = %submission.game_address,
-            l2_block_number = proposal.l2_block_number,
-            parent_ref = %proposal.parent_ref,
-            proposal_key = ?proposal.proposal_key,
-            retry_of = ?retry_of,
+            l2_block_number = pending.proposal.l2_block_number,
+            parent_ref = %pending.proposal.parent_ref,
+            proposal_key = ?pending.proposal.proposal_key,
+            retry_of = ?pending.retry_of,
             "submitted World Chain proof-system game"
         );
+        self.pending_proposal = None;
         Ok(())
     }
 
     /// Runs the proposer forever, logging transient failures and retrying on each tick.
-    pub async fn run_forever(&self) -> Result<(), ProposerError> {
+    pub async fn run_forever(&mut self) -> Result<(), ProposerError> {
         self.config.validate()?;
 
         let mut interval = tokio::time::interval(self.config.poll_interval);

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -11,9 +11,6 @@ use crate::{
 };
 
 /// Proposal and exact Nitro request retained while proof generation is in flight.
-///
-/// This state is intentionally process-local. After a restart, the proposer builds a new request
-/// from the then-current finalized L1 head; persistent proof-session recovery is handled separately.
 #[derive(Debug, Clone)]
 struct PendingProposal {
     proposal: Proposal,

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -236,9 +236,6 @@ where
     }
 
     /// Reconciles and requests the proof for the next canonical proposal action.
-    ///
-    /// New and timed-out transitions request a Nitro proof, negative-ready games wait for the
-    /// challenger, and non-retryable invalidations clear any pending proposal.
     pub async fn request_proof(&mut self, scan: &CanonicalScan) -> Result<(), ProposerError> {
         let (proposal, retry_of) = match scan.next_action() {
             NextProposalAction::Propose(proposal) => (*proposal, None),
@@ -310,8 +307,6 @@ where
             .as_ref()
             .expect("pending proposal initialized");
 
-        // Reissuing the exact request is idempotent and requeues a failed request
-        // according to the prover-service retry policy.
         let returned_id = self
             .proof_requester
             .request_proof(pending.proof_request.clone())

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -308,8 +308,7 @@ where
         let pending = self
             .pending_proposal
             .as_ref()
-            .expect("pending proposal initialized")
-            .clone();
+            .expect("pending proposal initialized");
 
         // Reissuing the exact request is idempotent and requeues a failed request
         // according to the prover-service retry policy.

--- a/proofs/proposer/src/tests.rs
+++ b/proofs/proposer/src/tests.rs
@@ -4,17 +4,24 @@ use std::{
     time::Duration,
 };
 
-use alloy_primitives::{Address, B256, BlockNumber, U256, address, b256};
+use alloy_primitives::{Address, B256, BlockNumber, Bytes, U256, address, b256};
 use async_trait::async_trait;
 use world_chain_proofs::{
     ConsensusError, ConsensusProvider, InvalidationReason, ProposalCommitment, ResolutionStatus,
     RootState,
 };
+use world_chain_prover_service::{
+    ProofBackend, ProofData, ProofRequest, ProofRequestError, ProofRequestId, ProofRequester,
+    ProofResponse, ProofStatus, SucceededProofResponse,
+};
 
 use crate::{
     BondManager, BondManagerClient, BondManagerConfig, CanonicalLine, ParentRef, Proposal,
     ProposalSubmission, ProposerClient, ProposerConfig, ProposerError, WorldChainProposer,
-    types::{CloseGameSubmission, ResolveSubmission, WithdrawSubmission},
+    types::{
+        CanonicalScan, CloseGameSubmission, NextProposalAction, ResolveSubmission,
+        WithdrawSubmission,
+    },
 };
 
 const DOMAIN_HASH: B256 = b256!("1111111111111111111111111111111111111111111111111111111111111111");
@@ -25,10 +32,11 @@ const GAME_1: Address = address!("0000000000000000000000000000000000000001");
 struct MockContracts {
     anchor: ParentRef,
     games: HashMap<B256, Address>,
-    submissions: Arc<Mutex<Vec<Proposal>>>,
+    submissions: Arc<Mutex<Vec<(Proposal, ProofData)>>>,
     resolution_statuses: Arc<Mutex<HashMap<Address, ResolutionStatus>>>,
     resolutions: Arc<Mutex<Vec<Address>>>,
     closures: Arc<Mutex<Vec<Address>>>,
+    submission_failures: Arc<Mutex<usize>>,
 }
 
 #[async_trait]
@@ -90,19 +98,104 @@ impl ProposerClient for MockContracts {
         Ok(U256::from(1))
     }
 
+    async fn latest_finalized_l1_block(&self) -> Result<B256, ProposerError> {
+        Ok(B256::repeat_byte(0xf1))
+    }
+
     async fn submit_proposal(
         &self,
         proposal: &Proposal,
+        proof: ProofData,
         _proposer_bond: U256,
     ) -> Result<ProposalSubmission, ProposerError> {
+        let mut failures = self.submission_failures.lock().expect("not poisoned");
+        if *failures > 0 {
+            *failures -= 1;
+            return Err(ProposerError::Contract(
+                "injected proposal submission failure".into(),
+            ));
+        }
+        drop(failures);
         self.submissions
             .lock()
             .expect("not poisoned")
-            .push(*proposal);
+            .push((*proposal, proof));
         Ok(ProposalSubmission {
             tx_hash: B256::repeat_byte(0xaa),
             game_address: Address::repeat_byte(0xaa),
         })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MockProofRequester {
+    requests: Arc<Mutex<Vec<ProofRequest>>>,
+    status: Arc<Mutex<ProofStatus>>,
+    fail_status_once: Arc<Mutex<bool>>,
+}
+
+impl Default for MockProofRequester {
+    fn default() -> Self {
+        Self {
+            requests: Arc::default(),
+            status: Arc::new(Mutex::new(ProofStatus::Succeeded)),
+            fail_status_once: Arc::default(),
+        }
+    }
+}
+
+impl MockProofRequester {
+    fn with_status(status: ProofStatus) -> Self {
+        Self {
+            status: Arc::new(Mutex::new(status)),
+            ..Self::default()
+        }
+    }
+
+    fn set_status(&self, status: ProofStatus) {
+        *self.status.lock().expect("not poisoned") = status;
+    }
+
+    fn fail_next_status(&self) {
+        *self.fail_status_once.lock().expect("not poisoned") = true;
+    }
+}
+
+#[async_trait]
+impl ProofRequester for MockProofRequester {
+    async fn request_proof(
+        &self,
+        request: ProofRequest,
+    ) -> Result<ProofRequestId, ProofRequestError> {
+        let id = request.id();
+        self.requests.lock().expect("not poisoned").push(request);
+        Ok(id)
+    }
+
+    async fn proof_status(
+        &self,
+        _proof_id: ProofRequestId,
+    ) -> Result<ProofStatus, ProofRequestError> {
+        let mut fail_once = self.fail_status_once.lock().expect("not poisoned");
+        if *fail_once {
+            *fail_once = false;
+            return Err(ProofRequestError::RemoteInternal);
+        }
+        Ok(*self.status.lock().expect("not poisoned"))
+    }
+
+    async fn get_proof(
+        &self,
+        proof_id: ProofRequestId,
+    ) -> Result<ProofResponse, ProofRequestError> {
+        Ok(ProofResponse::Succeeded(SucceededProofResponse {
+            id: proof_id,
+            proof: ProofData::Nitro {
+                attestation: Bytes::from_static(&[1]),
+                public_values: Bytes::from_static(&[2]),
+                signature: Bytes::from_static(&[3]),
+            },
+        }))
     }
 }
 
@@ -298,12 +391,18 @@ async fn anchor_and_canonical_line_walks_existing_games_until_gap() {
         resolution_statuses: Arc::default(),
         resolutions: Arc::default(),
         closures: Arc::default(),
+        submission_failures: Arc::default(),
     };
     let output_roots = MockOutputRoots {
         roots: HashMap::from([(10, root_10), (20, root_20)]),
         finalized_l2_block: 20,
     };
-    let proposer = WorldChainProposer::new(config(), contracts, output_roots);
+    let proposer = WorldChainProposer::new(
+        config(),
+        contracts,
+        output_roots,
+        MockProofRequester::default(),
+    );
 
     let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
 
@@ -329,17 +428,23 @@ async fn propose_submits_proposal_after_last_canonical_game() {
         resolution_statuses: Arc::default(),
         resolutions: Arc::default(),
         closures: Arc::default(),
+        submission_failures: Arc::default(),
     };
     let output_roots = MockOutputRoots {
         roots: HashMap::from([(10, B256::repeat_byte(0x10))]),
         finalized_l2_block: 10,
     };
-    let proposer = WorldChainProposer::new(config(), contracts, output_roots);
+    let mut proposer = WorldChainProposer::new(
+        config(),
+        contracts,
+        output_roots,
+        MockProofRequester::default(),
+    );
     let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
 
     proposer.propose(&canonical_scan).await.unwrap();
 
-    let proposal = submissions.lock().expect("not poisoned")[0];
+    let proposal = submissions.lock().expect("not poisoned")[0].0;
     assert_eq!(proposal.parent_ref, ANCHOR);
     assert_eq!(proposal.root_claim, B256::repeat_byte(0x10));
     assert_eq!(proposal.l2_block_number, 10);
@@ -347,6 +452,233 @@ async fn propose_submits_proposal_after_last_canonical_game() {
         proposal.proposal_key,
         proposal_key(ANCHOR, B256::repeat_byte(0x10), 10)
     );
+}
+
+#[tokio::test]
+async fn propose_waits_for_pending_proof_and_reuses_exact_request() {
+    let submissions = Arc::default();
+    let contracts = MockContracts {
+        anchor: ParentRef {
+            address: ANCHOR,
+            l2_block_number: 0,
+        },
+        games: HashMap::new(),
+        submissions: Arc::clone(&submissions),
+        resolution_statuses: Arc::default(),
+        resolutions: Arc::default(),
+        closures: Arc::default(),
+        submission_failures: Arc::default(),
+    };
+    let output_roots = MockOutputRoots {
+        roots: HashMap::from([(10, B256::repeat_byte(0x10))]),
+        finalized_l2_block: 10,
+    };
+    let proof_requester = MockProofRequester::with_status(ProofStatus::Running);
+    let mut proposer =
+        WorldChainProposer::new(config(), contracts, output_roots, proof_requester.clone());
+    let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
+
+    proposer.propose(&canonical_scan).await.unwrap();
+
+    assert!(submissions.lock().expect("not poisoned").is_empty());
+    let first_request = proof_requester.requests.lock().expect("not poisoned")[0].clone();
+    assert_eq!(first_request.backend, ProofBackend::Nitro);
+    assert_eq!(first_request.game, Address::ZERO);
+    assert_eq!(first_request.l1_head, B256::repeat_byte(0xf1));
+
+    proof_requester.set_status(ProofStatus::Succeeded);
+    proposer.propose(&canonical_scan).await.unwrap();
+
+    let requests = proof_requester.requests.lock().expect("not poisoned");
+    assert_eq!(requests.as_slice(), &[first_request.clone(), first_request]);
+    assert_eq!(submissions.lock().expect("not poisoned").len(), 1);
+}
+
+#[tokio::test]
+async fn propose_rerequests_failed_proof_without_submitting() {
+    let submissions = Arc::default();
+    let contracts = MockContracts {
+        anchor: ParentRef {
+            address: ANCHOR,
+            l2_block_number: 0,
+        },
+        games: HashMap::new(),
+        submissions: Arc::clone(&submissions),
+        resolution_statuses: Arc::default(),
+        resolutions: Arc::default(),
+        closures: Arc::default(),
+        submission_failures: Arc::default(),
+    };
+    let output_roots = MockOutputRoots {
+        roots: HashMap::from([(10, B256::repeat_byte(0x10))]),
+        finalized_l2_block: 10,
+    };
+    let proof_requester = MockProofRequester::with_status(ProofStatus::Failed);
+    let mut proposer =
+        WorldChainProposer::new(config(), contracts, output_roots, proof_requester.clone());
+    let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
+
+    proposer.propose(&canonical_scan).await.unwrap();
+    proposer.propose(&canonical_scan).await.unwrap();
+
+    let requests = proof_requester.requests.lock().expect("not poisoned");
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[0], requests[1]);
+    assert!(submissions.lock().expect("not poisoned").is_empty());
+}
+
+#[tokio::test]
+async fn propose_retains_request_after_transient_status_error() {
+    let submissions = Arc::default();
+    let contracts = MockContracts {
+        anchor: ParentRef {
+            address: ANCHOR,
+            l2_block_number: 0,
+        },
+        games: HashMap::new(),
+        submissions: Arc::clone(&submissions),
+        resolution_statuses: Arc::default(),
+        resolutions: Arc::default(),
+        closures: Arc::default(),
+        submission_failures: Arc::default(),
+    };
+    let output_roots = MockOutputRoots {
+        roots: HashMap::from([(10, B256::repeat_byte(0x10))]),
+        finalized_l2_block: 10,
+    };
+    let proof_requester = MockProofRequester::default();
+    proof_requester.fail_next_status();
+    let mut proposer =
+        WorldChainProposer::new(config(), contracts, output_roots, proof_requester.clone());
+    let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
+
+    assert!(matches!(
+        proposer.propose(&canonical_scan).await,
+        Err(ProposerError::ProofRequest(
+            ProofRequestError::RemoteInternal
+        ))
+    ));
+    assert!(submissions.lock().expect("not poisoned").is_empty());
+
+    proposer.propose(&canonical_scan).await.unwrap();
+
+    let requests = proof_requester.requests.lock().expect("not poisoned");
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[0], requests[1]);
+    assert_eq!(submissions.lock().expect("not poisoned").len(), 1);
+}
+
+#[tokio::test]
+async fn propose_retries_submission_with_same_completed_proof() {
+    let submissions = Arc::default();
+    let submission_failures = Arc::new(Mutex::new(1));
+    let contracts = MockContracts {
+        anchor: ParentRef {
+            address: ANCHOR,
+            l2_block_number: 0,
+        },
+        games: HashMap::new(),
+        submissions: Arc::clone(&submissions),
+        resolution_statuses: Arc::default(),
+        resolutions: Arc::default(),
+        closures: Arc::default(),
+        submission_failures,
+    };
+    let output_roots = MockOutputRoots {
+        roots: HashMap::from([(10, B256::repeat_byte(0x10))]),
+        finalized_l2_block: 10,
+    };
+    let proof_requester = MockProofRequester::default();
+    let mut proposer =
+        WorldChainProposer::new(config(), contracts, output_roots, proof_requester.clone());
+    let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
+
+    assert!(matches!(
+        proposer.propose(&canonical_scan).await,
+        Err(ProposerError::Contract(_))
+    ));
+    assert!(submissions.lock().expect("not poisoned").is_empty());
+
+    proposer.propose(&canonical_scan).await.unwrap();
+
+    let requests = proof_requester.requests.lock().expect("not poisoned");
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[0], requests[1]);
+    assert_eq!(submissions.lock().expect("not poisoned").len(), 1);
+}
+
+#[tokio::test]
+async fn propose_replaces_pending_request_when_canonical_candidate_changes() {
+    let contracts = MockContracts {
+        anchor: ParentRef {
+            address: ANCHOR,
+            l2_block_number: 0,
+        },
+        games: HashMap::new(),
+        submissions: Arc::default(),
+        resolution_statuses: Arc::default(),
+        resolutions: Arc::default(),
+        closures: Arc::default(),
+        submission_failures: Arc::default(),
+    };
+    let proof_requester = MockProofRequester::with_status(ProofStatus::Running);
+    let mut proposer = WorldChainProposer::new(
+        config(),
+        contracts,
+        MockOutputRoots {
+            roots: HashMap::new(),
+            finalized_l2_block: 0,
+        },
+        proof_requester.clone(),
+    );
+    let canonical_line = CanonicalLine::new(ParentRef {
+        address: ANCHOR,
+        l2_block_number: 0,
+    });
+    let first = CanonicalScan::new(
+        canonical_line,
+        NextProposalAction::Propose(Proposal {
+            parent_ref: ANCHOR,
+            root_claim: B256::repeat_byte(0x10),
+            l2_block_number: 10,
+            proposal_key: B256::repeat_byte(0xa1),
+        }),
+    );
+    proposer.propose(&first).await.unwrap();
+
+    let second = CanonicalScan::new(
+        CanonicalLine::new(ParentRef {
+            address: ANCHOR,
+            l2_block_number: 0,
+        }),
+        NextProposalAction::Propose(Proposal {
+            parent_ref: ANCHOR,
+            root_claim: B256::repeat_byte(0x20),
+            l2_block_number: 10,
+            proposal_key: B256::repeat_byte(0xa2),
+        }),
+    );
+    proposer.propose(&second).await.unwrap();
+
+    {
+        let requests = proof_requester.requests.lock().expect("not poisoned");
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].root_claim, B256::repeat_byte(0x10));
+        assert_eq!(requests[1].root_claim, B256::repeat_byte(0x20));
+    }
+
+    let caught_up = CanonicalScan::new(
+        CanonicalLine::new(ParentRef {
+            address: ANCHOR,
+            l2_block_number: 10,
+        }),
+        NextProposalAction::CaughtUp {
+            target_block: 20,
+            finalized_block: 10,
+        },
+    );
+    proposer.propose(&caught_up).await.unwrap();
+    assert!(!proposer.has_pending_proposal());
 }
 
 #[tokio::test]
@@ -361,6 +693,7 @@ async fn zero_block_interval_is_rejected() {
         resolution_statuses: Arc::default(),
         resolutions: Arc::default(),
         closures: Arc::default(),
+        submission_failures: Arc::default(),
     };
     let proposer = WorldChainProposer::new(
         ProposerConfig {
@@ -372,6 +705,7 @@ async fn zero_block_interval_is_rejected() {
             roots: HashMap::new(),
             finalized_l2_block: 0,
         },
+        MockProofRequester::default(),
     );
 
     assert!(matches!(
@@ -392,12 +726,18 @@ async fn anchor_and_canonical_line_stops_at_finalized_l2_block() {
         resolution_statuses: Arc::default(),
         resolutions: Arc::default(),
         closures: Arc::default(),
+        submission_failures: Arc::default(),
     };
     let output_roots = MockOutputRoots {
         roots: HashMap::from([(10, B256::repeat_byte(0x10))]),
         finalized_l2_block: 9,
     };
-    let proposer = WorldChainProposer::new(config(), contracts, output_roots);
+    let proposer = WorldChainProposer::new(
+        config(),
+        contracts,
+        output_roots,
+        MockProofRequester::default(),
+    );
 
     let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
 
@@ -438,6 +778,7 @@ async fn resolve_games_caps_submissions_and_keeps_scanning_finalized_games() {
         ]))),
         resolutions: Arc::clone(&resolutions),
         closures: Arc::clone(&closures),
+        submission_failures: Arc::default(),
     };
     let proposer = WorldChainProposer::new(
         ProposerConfig {
@@ -449,6 +790,7 @@ async fn resolve_games_caps_submissions_and_keeps_scanning_finalized_games() {
             roots: HashMap::new(),
             finalized_l2_block: 0,
         },
+        MockProofRequester::default(),
     );
     let mut canonical_line = CanonicalLine::new(ParentRef {
         address: ANCHOR,
@@ -510,6 +852,7 @@ async fn finalized_games_do_not_consume_resolution_budget() {
         ]))),
         resolutions: Arc::clone(&resolutions),
         closures: Arc::default(),
+        submission_failures: Arc::default(),
     };
     let proposer = WorldChainProposer::new(
         config(),
@@ -518,6 +861,7 @@ async fn finalized_games_do_not_consume_resolution_budget() {
             roots: HashMap::new(),
             finalized_l2_block: 0,
         },
+        MockProofRequester::default(),
     );
     let mut canonical_line = CanonicalLine::new(ParentRef {
         address: ANCHOR,
@@ -554,6 +898,7 @@ async fn zero_resolution_budget_is_rejected() {
         resolution_statuses: Arc::default(),
         resolutions: Arc::default(),
         closures: Arc::default(),
+        submission_failures: Arc::default(),
     };
     let proposer = WorldChainProposer::new(
         ProposerConfig {
@@ -565,6 +910,7 @@ async fn zero_resolution_budget_is_rejected() {
             roots: HashMap::new(),
             finalized_l2_block: 0,
         },
+        MockProofRequester::default(),
     );
 
     assert!(matches!(

--- a/proofs/proposer/src/tests.rs
+++ b/proofs/proposer/src/tests.rs
@@ -344,6 +344,14 @@ fn config() -> ProposerConfig {
     }
 }
 
+async fn advance_proposal(
+    proposer: &mut WorldChainProposer<MockContracts, MockOutputRoots, MockProofRequester>,
+    scan: &CanonicalScan,
+) -> Result<(), ProposerError> {
+    proposer.request_proof(scan).await?;
+    proposer.poll_and_submit().await
+}
+
 fn positive_ready_status() -> ResolutionStatus {
     ResolutionStatus {
         resolvable: true,
@@ -442,7 +450,9 @@ async fn propose_submits_proposal_after_last_canonical_game() {
     );
     let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
 
-    proposer.propose(&canonical_scan).await.unwrap();
+    advance_proposal(&mut proposer, &canonical_scan)
+        .await
+        .unwrap();
 
     let proposal = submissions.lock().expect("not poisoned")[0].0;
     assert_eq!(proposal.parent_ref, ANCHOR);
@@ -478,7 +488,9 @@ async fn propose_waits_for_pending_proof_and_reuses_exact_request() {
         WorldChainProposer::new(config(), contracts, output_roots, proof_requester.clone());
     let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
 
-    proposer.propose(&canonical_scan).await.unwrap();
+    advance_proposal(&mut proposer, &canonical_scan)
+        .await
+        .unwrap();
 
     assert!(submissions.lock().expect("not poisoned").is_empty());
     let first_request = proof_requester.requests.lock().expect("not poisoned")[0].clone();
@@ -487,7 +499,9 @@ async fn propose_waits_for_pending_proof_and_reuses_exact_request() {
     assert_eq!(first_request.l1_head, B256::repeat_byte(0xf1));
 
     proof_requester.set_status(ProofStatus::Succeeded);
-    proposer.propose(&canonical_scan).await.unwrap();
+    advance_proposal(&mut proposer, &canonical_scan)
+        .await
+        .unwrap();
 
     let requests = proof_requester.requests.lock().expect("not poisoned");
     assert_eq!(requests.as_slice(), &[first_request.clone(), first_request]);
@@ -518,8 +532,12 @@ async fn propose_rerequests_failed_proof_without_submitting() {
         WorldChainProposer::new(config(), contracts, output_roots, proof_requester.clone());
     let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
 
-    proposer.propose(&canonical_scan).await.unwrap();
-    proposer.propose(&canonical_scan).await.unwrap();
+    advance_proposal(&mut proposer, &canonical_scan)
+        .await
+        .unwrap();
+    advance_proposal(&mut proposer, &canonical_scan)
+        .await
+        .unwrap();
 
     let requests = proof_requester.requests.lock().expect("not poisoned");
     assert_eq!(requests.len(), 2);
@@ -553,14 +571,16 @@ async fn propose_retains_request_after_transient_status_error() {
     let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
 
     assert!(matches!(
-        proposer.propose(&canonical_scan).await,
+        advance_proposal(&mut proposer, &canonical_scan).await,
         Err(ProposerError::ProofRequest(
             ProofRequestError::RemoteInternal
         ))
     ));
     assert!(submissions.lock().expect("not poisoned").is_empty());
 
-    proposer.propose(&canonical_scan).await.unwrap();
+    advance_proposal(&mut proposer, &canonical_scan)
+        .await
+        .unwrap();
 
     let requests = proof_requester.requests.lock().expect("not poisoned");
     assert_eq!(requests.len(), 2);
@@ -594,12 +614,14 @@ async fn propose_retries_submission_with_same_completed_proof() {
     let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
 
     assert!(matches!(
-        proposer.propose(&canonical_scan).await,
+        advance_proposal(&mut proposer, &canonical_scan).await,
         Err(ProposerError::Contract(_))
     ));
     assert!(submissions.lock().expect("not poisoned").is_empty());
 
-    proposer.propose(&canonical_scan).await.unwrap();
+    advance_proposal(&mut proposer, &canonical_scan)
+        .await
+        .unwrap();
 
     let requests = proof_requester.requests.lock().expect("not poisoned");
     assert_eq!(requests.len(), 2);
@@ -644,7 +666,7 @@ async fn propose_replaces_pending_request_when_canonical_candidate_changes() {
             proposal_key: B256::repeat_byte(0xa1),
         }),
     );
-    proposer.propose(&first).await.unwrap();
+    advance_proposal(&mut proposer, &first).await.unwrap();
 
     let second = CanonicalScan::new(
         CanonicalLine::new(ParentRef {
@@ -658,7 +680,7 @@ async fn propose_replaces_pending_request_when_canonical_candidate_changes() {
             proposal_key: B256::repeat_byte(0xa2),
         }),
     );
-    proposer.propose(&second).await.unwrap();
+    advance_proposal(&mut proposer, &second).await.unwrap();
 
     {
         let requests = proof_requester.requests.lock().expect("not poisoned");
@@ -677,7 +699,7 @@ async fn propose_replaces_pending_request_when_canonical_candidate_changes() {
             finalized_block: 10,
         },
     );
-    proposer.propose(&caught_up).await.unwrap();
+    advance_proposal(&mut proposer, &caught_up).await.unwrap();
     assert!(!proposer.has_pending_proposal());
 }
 

--- a/proofs/proposer/src/traits.rs
+++ b/proofs/proposer/src/traits.rs
@@ -1,6 +1,7 @@
-use alloy_primitives::{Address, B256, U256};
+use alloy_primitives::{Address, B256, BlockHash, U256};
 use async_trait::async_trait;
 use world_chain_proofs::{ProposalCommitment, ResolutionStatus};
+use world_chain_prover_service::ProofData;
 
 use crate::{
     ParentRef, Proposal, ProposalSubmission, ProposerError,
@@ -65,10 +66,14 @@ pub trait ProposerClient: Send + Sync {
     /// Reads the proposer bond from the factory contract.
     async fn proposer_bond(&self) -> Result<U256, ProposerError>;
 
+    /// Gets the latest L1 finalized block hash.
+    async fn latest_finalized_l1_block(&self) -> Result<BlockHash, ProposerError>;
+
     /// Submits a proposal transaction to the factory.
     async fn submit_proposal(
         &self,
         proposal: &Proposal,
+        proof: ProofData,
         proposer_bond: U256,
     ) -> Result<ProposalSubmission, ProposerError>;
 }


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-4995/proposer-it-must-include-a-proof-when-creating-a-game

### Notes

- This PR doesn't take care of contracts and bindings change. It only handles the Rust side.
- Follow up PRs will need to:
    - take care of changing the world chain game contract to require a proof when created
    - take care of changing the rust bindings accordingly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the critical path for opening L1 games (new external dependency, async proof lifecycle, and L1 finalized-block reads); on-chain `propose` in the Alloy client still ignores the proof payload for now.
> 
> **Overview**
> **Game creation now goes through prover-service:** the proposer no longer calls `propose` directly from canonical scan. It takes a **`ProofRequester`** (CLI/env **`PROVER_SERVICE_URL`**, **`RpcProverServiceClient`**), builds a **Nitro** `ProofRequest` from the candidate proposal and **`latest_finalized_l1_block`**, then runs **`request_proof`** and **`poll_and_submit`** on each tick with pending-state handling (stale canonical keys, failed/running proofs, submission retries).
> 
> **`ProposerClient::submit_proposal`** gains a **`ProofData`** argument; **`run_forever`** is **`&mut self`** because of in-flight **`PendingProposal`**. Integration tests use **`InstantProofRequester`** and a **`post_proposal`** helper instead of **`propose`**.
> 
> **Full-stack devnet:** when the proof system is deployed, **prover-service starts for the proposer** (not only when the optional SP1 worker is on). Defender/worker still share that URL when **`DEVNET_SP1_WORKER_PROVER`** is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdd24a0e0bdfa2d5c15d883fecc696e267da4f21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->