### PR TITLE
fix: rebind rust services

### DIFF
--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -42,8 +42,8 @@ use url::{Host, Url};
 use world_chain_chainspec::{WorldChainHardfork, WorldChainSpec};
 use world_chain_challenger::{
     AlloyChallengerClient, BondManager as ChallengerBondManager,
-    BondManagerConfig as ChallengerBondManagerConfig, ChallengerClient, ChallengerConfig,
-    OwnedGames, ResolutionManager, ResolutionManagerConfig, WorldChainChallenger,
+    BondManagerConfig as ChallengerBondManagerConfig, ChallengerConfig, OwnedGames,
+    ResolutionManager, ResolutionManagerConfig, WorldChainChallenger,
 };
 use world_chain_defender::{AlloyDefenderClient, DefenderConfig, WorldChainDefender};
 use world_chain_proof_kona_host_utils::online::OnlineHostConfig;
@@ -58,8 +58,7 @@ use world_chain_proof_worker::{
 };
 use world_chain_proofs::{OptimismConsensusClient, PROOF_SYSTEM_VERSION, PROOF_THRESHOLD};
 use world_chain_proposer::{
-    AlloyProofSystemClient, BondManager, BondManagerConfig, ProposerClient, ProposerConfig,
-    WorldChainProposer,
+    AlloyProofSystemClient, BondManager, BondManagerConfig, ProposerConfig, WorldChainProposer,
 };
 use world_chain_prover_service::{
     ProverService, ProverServiceConfig, RpcProverServiceClient, start_rpc_server,
@@ -71,7 +70,7 @@ use crate::{
     DevnetComponent, DevnetComponentKind, DevnetComponentStatus, DevnetPortMode, L1DevChain,
     L1DevChainConfig, MetricsTarget, ObservabilityStack, WorldChainHardforkConfig,
     component::ContainerImage,
-    op_stack::{HaSequencerConfig, HaSequencerTopology, OP_NATIVE_PROOF_SERVICES_READY},
+    op_stack::{HaSequencerConfig, HaSequencerTopology},
     process_logs::{ProcessLogTarget, container_log_consumer, emit_process_log},
 };
 
@@ -558,9 +557,7 @@ impl FullStackWorldDevnet {
             (Some(batcher), Some(proposer), None)
         };
 
-        let proof_services = proof_system
-            .as_ref()
-            .filter(|_| OP_NATIVE_PROOF_SERVICES_READY);
+        let proof_services = proof_system.as_ref();
 
         // The proposer always needs the prover-service for its creation-time Nitro proof.
         // Defender and SP1 worker startup remains optional below.
@@ -2458,7 +2455,7 @@ async fn start_challenger(
 /// The proposer signs with the dev proposer key (Anvil account #1), which
 /// `DeployProofSystem.s.sol` stakes in the `MockStakingRegistry` and funds via
 /// `fundDevAccounts`. Output roots are read from the op-node rollup RPC and
-/// proposals are submitted to `WorldChainProofSystemFactory.propose` on L1.
+/// proposals are created through `DisputeGameFactory.create` on L1.
 async fn start_world_chain_proposer(
     l1_rpc_url: &str,
     output_root_rpc_url: &str,
@@ -2482,18 +2479,16 @@ async fn start_world_chain_proposer(
         .wallet(EthereumWallet::from(signer))
         .connect_http(Url::parse(l1_rpc_url)?);
 
-    let contracts = AlloyProofSystemClient::new(provider, factory_address, anchor_address);
+    let contracts = AlloyProofSystemClient::new(provider, factory_address, anchor_address)
+        .await
+        .wrap_err("failed to bind the World Chain proof system")?;
     let mut bond_manager = BondManager::new(BondManagerConfig::default(), contracts.clone());
     let output_roots = OptimismConsensusClient::new(output_root_rpc_url.to_string());
     let proof_requester = RpcProverServiceClient::new(prover_service_url)
         .map_err(|error| eyre!("failed to connect proposer to prover-service: {error}"))?;
-    let proposer_bond = contracts
-        .proposer_bond()
-        .await
-        .wrap_err("failed to read proposer bond")?;
+    let domain_hash = contracts.domain_hash();
     let config = ProposerConfig {
         block_interval: deployment.block_interval,
-        proposer_bond,
         poll_interval: WORLD_PROPOSER_POLL_INTERVAL,
         max_resolutions_per_tick: ProposerConfig::default().max_resolutions_per_tick,
     };
@@ -2503,9 +2498,10 @@ async fn start_world_chain_proposer(
         l1_rpc_url,
         output_root_rpc_url,
         prover_service = %prover_service_url,
-        factory = %deployment.proof_system_factory,
+        dispute_game_factory = %deployment.proof_system_factory,
         anchor = %deployment.anchor_state_registry,
         proposer = %proposer_address,
+        domain_hash = %domain_hash,
         block_interval = deployment.block_interval,
         "starting native World Chain proof-system proposer"
     );
@@ -2551,6 +2547,10 @@ async fn start_world_chain_challenger(
         .proof_system_factory
         .parse()
         .wrap_err("invalid proof-system factory address")?;
+    let anchor_address: Address = deployment
+        .anchor_state_registry
+        .parse()
+        .wrap_err("invalid anchor-state-registry address")?;
 
     let signer: PrivateKeySigner = WORLD_CHALLENGER_PRIVATE_KEY
         .parse()
@@ -2560,14 +2560,9 @@ async fn start_world_chain_challenger(
         .wallet(EthereumWallet::from(signer))
         .connect_http(Url::parse(l1_rpc_url)?);
 
-    let client = AlloyChallengerClient::new(provider, factory_address);
+    let client = AlloyChallengerClient::new(provider, factory_address, anchor_address);
     let output_roots = OptimismConsensusClient::new(output_root_rpc_url.to_string());
-    let challenger_bond = client
-        .challenger_bond()
-        .await
-        .wrap_err("failed to read challenger bond")?;
     let config = ChallengerConfig {
-        challenger_bond,
         poll_interval: WORLD_CHALLENGER_POLL_INTERVAL,
         ..ChallengerConfig::default()
     };
@@ -2589,9 +2584,9 @@ async fn start_world_chain_challenger(
     info!(
         l1_rpc_url,
         output_root_rpc_url,
-        factory = %deployment.proof_system_factory,
+        dispute_game_factory = %deployment.proof_system_factory,
+        anchor = %deployment.anchor_state_registry,
         challenger = %challenger_address,
-        challenger_bond = ?challenger_bond,
         "starting native World Chain proof-system challenger"
     );
 
@@ -2628,7 +2623,7 @@ async fn start_world_chain_challenger(
 ///
 /// The defender signs with [`WORLD_DEFENDER_PRIVATE_KEY`], a dedicated dev
 /// account that is funded through the L1 genesis. It watches challenged valid
-/// `WorldChainProofSystemFactory` games, requests proofs from the
+/// WIP-1006 games on the `DisputeGameFactory`, requests proofs from the
 /// prover-service, and submits completed proof lanes on L1.
 async fn start_world_chain_defender(
     l1_rpc_url: &str,
@@ -2668,7 +2663,7 @@ async fn start_world_chain_defender(
         l1_rpc_url,
         output_root_rpc_url,
         prover_service = %prover_service_url,
-        factory = %deployment.proof_system_factory,
+        dispute_game_factory = %deployment.proof_system_factory,
         defender = %defender_address,
         allowed_proposer = %allowed_proposer,
         "starting native World Chain proof-system defender"
@@ -3261,39 +3256,28 @@ fn build_components(
             DevnetComponent::new(
                 "world-chain-proposer",
                 DevnetComponentKind::WorldChainProposer,
-                if OP_NATIVE_PROOF_SERVICES_READY {
-                    DevnetComponentStatus::Running
-                } else {
-                    DevnetComponentStatus::Deferred
-                },
+                DevnetComponentStatus::Running,
             )
-            .with_endpoint("factory", deployment.proof_system_factory.clone())
+            .with_endpoint("dispute-game-factory", deployment.proof_system_factory.clone())
             .with_endpoint("anchor", deployment.anchor_state_registry.clone())
-            .with_note(if OP_NATIVE_PROOF_SERVICES_READY {
-                format!(
-                    "native in-process proposer posting OP output roots every {} L2 blocks",
-                    deployment.block_interval
-                )
-            } else {
-                "awaiting migration to the stock DisputeGameFactory API".to_string()
-            }),
+            .with_note(format!(
+                "native in-process proposer creating WIP-1006 games every {} L2 blocks via DisputeGameFactory.create",
+                deployment.block_interval
+            ))
+            .with_note("signs with the dev proposer key staked in the MockStakingRegistry"),
         );
         components.push(
             DevnetComponent::new(
                 "world-chain-challenger",
                 DevnetComponentKind::WorldChainChallenger,
-                if OP_NATIVE_PROOF_SERVICES_READY {
-                    DevnetComponentStatus::Running
-                } else {
-                    DevnetComponentStatus::Deferred
-                },
+                DevnetComponentStatus::Running,
             )
-            .with_endpoint("factory", deployment.proof_system_factory.clone())
-            .with_note(if OP_NATIVE_PROOF_SERVICES_READY {
-                "native in-process challenger for WIP-1006 games"
-            } else {
-                "awaiting migration to the stock DisputeGameFactory API"
-            }),
+            .with_endpoint("dispute-game-factory", deployment.proof_system_factory.clone())
+            .with_endpoint("anchor", deployment.anchor_state_registry.clone())
+            .with_note("native in-process challenger disputing invalid WIP-1006 games")
+            .with_note(
+                "signs with a dedicated dev key funded in the L1 genesis and staked in the MockStakingRegistry",
+            ),
         );
     }
 

--- a/crates/devnet/src/op_stack.rs
+++ b/crates/devnet/src/op_stack.rs
@@ -11,9 +11,6 @@ pub const DEFAULT_OP_CONTRACT_ARTIFACTS_LOCATOR: &str = "embedded";
 const DEFAULT_DEVNET_PRIVATE_KEY: &str =
     "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
 
-// TODO: Enable after the proof services use the stock DisputeGameFactory and game credit APIs.
-pub(crate) const OP_NATIVE_PROOF_SERVICES_READY: bool = false;
-
 /// OP Stack container images used by the HA topology.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct OpStackImages {
@@ -432,33 +429,17 @@ impl HaSequencerTopology {
                 DevnetComponent::new(
                     "world-chain-proposer",
                     DevnetComponentKind::WorldChainProposer,
-                    if OP_NATIVE_PROOF_SERVICES_READY {
-                        DevnetComponentStatus::Planned
-                    } else {
-                        DevnetComponentStatus::Deferred
-                    },
+                    DevnetComponentStatus::Planned,
                 )
-                .with_note(if OP_NATIVE_PROOF_SERVICES_READY {
-                    "native proposer posting OP output roots to the WIP-1006 proof system"
-                } else {
-                    "awaiting migration to the stock DisputeGameFactory API"
-                }),
+                .with_note("native proposer posting OP output roots to the WIP-1006 proof system"),
             );
             components.push(
                 DevnetComponent::new(
                     "world-chain-challenger",
                     DevnetComponentKind::WorldChainChallenger,
-                    if OP_NATIVE_PROOF_SERVICES_READY {
-                        DevnetComponentStatus::Planned
-                    } else {
-                        DevnetComponentStatus::Deferred
-                    },
+                    DevnetComponentStatus::Planned,
                 )
-                .with_note(if OP_NATIVE_PROOF_SERVICES_READY {
-                    "native challenger disputing invalid WIP-1006 proof-system games"
-                } else {
-                    "awaiting migration to the stock DisputeGameFactory API"
-                }),
+                .with_note("native challenger disputing invalid WIP-1006 proof-system games"),
             );
         }
 

--- a/proofs/challenger/src/alloy.rs
+++ b/proofs/challenger/src/alloy.rs
@@ -1,21 +1,28 @@
 use crate::{
     error::ChallengerError,
     traits::{BondManagerClient, ChallengerClient, ResolutionManagerClient},
-    types::{ChallengeSubmission, GameMetadata, ResolveSubmission, WithdrawSubmission},
+    types::{
+        ChallengeSubmission, ClaimSubmission, GameMetadata, PendingWithdrawal, ResolveSubmission,
+    },
 };
 use alloy_primitives::{Address, U256};
 use alloy_provider::{Provider, WalletProvider};
 use alloy_rpc_types_eth::BlockId;
 use async_trait::async_trait;
 use world_chain_proofs::{
-    IWorldChainProofSystemFactory, IWorldChainProofSystemGame, InvalidationReasonError,
-    ResolutionStatus, RootState, RootStateError,
+    IAnchorStateRegistry, IDelayedWETH, IDisputeGameFactory, IMultiProofGame,
+    InvalidationReasonError, MULTI_PROOF_GAME_TYPE, ResolutionStatus, RootState, RootStateError,
 };
 
 /// Alloy-backed implementation of the challenger contract clients.
+///
+/// Binds the stock OP Stack `DisputeGameFactory` and `AnchorStateRegistry`; WIP-1006 games are
+/// one game type among several on that factory, so every index-based read filters on
+/// [`MULTI_PROOF_GAME_TYPE`].
 #[derive(Debug, Clone)]
 pub struct AlloyChallengerClient<P> {
-    factory: IWorldChainProofSystemFactory::IWorldChainProofSystemFactoryInstance<P>,
+    factory: IDisputeGameFactory::IDisputeGameFactoryInstance<P>,
+    anchor: IAnchorStateRegistry::IAnchorStateRegistryInstance<P>,
     provider: P,
 }
 
@@ -24,23 +31,25 @@ where
     P: Provider + Clone,
 {
     /// Creates an Alloy-backed contract client.
-    pub fn new(provider: P, factory_address: Address) -> Self {
-        let factory = IWorldChainProofSystemFactory::IWorldChainProofSystemFactoryInstance::new(
+    pub fn new(provider: P, factory_address: Address, anchor_address: Address) -> Self {
+        let factory = IDisputeGameFactory::IDisputeGameFactoryInstance::new(
             factory_address,
             provider.clone(),
         );
+        let anchor = IAnchorStateRegistry::IAnchorStateRegistryInstance::new(
+            anchor_address,
+            provider.clone(),
+        );
 
-        Self { factory, provider }
+        Self {
+            factory,
+            anchor,
+            provider,
+        }
     }
 
-    fn game(
-        &self,
-        address: Address,
-    ) -> IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance<P> {
-        IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance::new(
-            address,
-            self.provider.clone(),
-        )
+    fn game(&self, address: Address) -> IMultiProofGame::IMultiProofGameInstance<P> {
+        IMultiProofGame::IMultiProofGameInstance::new(address, self.provider.clone())
     }
 
     async fn read_game_count(&self) -> Result<u64, ChallengerError> {
@@ -54,13 +63,17 @@ where
         u256_to_u64(count, "gameCount")
     }
 
-    async fn read_game_address(&self, index: u64) -> Result<Address, ChallengerError> {
-        self.factory
-            .gameAt(U256::from(index))
+    /// Resolves the WIP-1006 game at a factory index, skipping other game types.
+    async fn read_game_address(&self, index: u64) -> Result<Option<Address>, ChallengerError> {
+        let entry = self
+            .factory
+            .gameAtIndex(U256::from(index))
             .block(BlockId::finalized())
             .call()
             .await
-            .map_err(|error| ChallengerError::Contract(error.to_string()))
+            .map_err(|error| ChallengerError::Contract(error.to_string()))?;
+
+        Ok((entry.gameType == MULTI_PROOF_GAME_TYPE).then_some(entry.proxy))
     }
 
     async fn read_resolution_status(
@@ -91,6 +104,59 @@ where
             invalidation_reason,
         })
     }
+
+    async fn read_credit(
+        &self,
+        address: Address,
+        recipient: Address,
+    ) -> Result<U256, ChallengerError> {
+        self.game(address)
+            .credit(recipient)
+            .call()
+            .await
+            .map_err(|error| ChallengerError::Contract(error.to_string()))
+    }
+
+    async fn read_pending_withdrawal(
+        &self,
+        address: Address,
+        recipient: Address,
+    ) -> Result<PendingWithdrawal, ChallengerError> {
+        let weth_address = self
+            .game(address)
+            .weth()
+            .call()
+            .await
+            .map_err(|error| ChallengerError::Contract(error.to_string()))?;
+        let weth = IDelayedWETH::IDelayedWETHInstance::new(weth_address, self.provider.clone());
+
+        let (pending, delay) = tokio::try_join!(
+            async {
+                weth.withdrawals(address, recipient)
+                    .call()
+                    .await
+                    .map_err(|error| ChallengerError::Contract(error.to_string()))
+            },
+            async {
+                weth.delay()
+                    .call()
+                    .await
+                    .map_err(|error| ChallengerError::Contract(error.to_string()))
+            }
+        )?;
+
+        if pending.amount.is_zero() {
+            return Ok(PendingWithdrawal::default());
+        }
+        let unlock_at = pending.timestamp.checked_add(delay).ok_or_else(|| {
+            ChallengerError::Contract("DelayedWETH unlock time overflows".to_string())
+        })?;
+
+        Ok(PendingWithdrawal {
+            amount: pending.amount,
+            unlock_at: u256_to_u64(unlock_at, "DelayedWETH unlock time")?,
+        })
+    }
 }
 
 #[async_trait]
@@ -98,19 +164,11 @@ impl<P> ChallengerClient for AlloyChallengerClient<P>
 where
     P: Provider + Clone + Send + Sync + 'static,
 {
-    async fn challenger_bond(&self) -> Result<U256, ChallengerError> {
-        self.factory
-            .challengerBond()
-            .call()
-            .await
-            .map_err(|error| ChallengerError::Contract(error.to_string()))
-    }
-
     async fn game_count(&self) -> Result<u64, ChallengerError> {
         self.read_game_count().await
     }
 
-    async fn game_address_at(&self, index: u64) -> Result<Address, ChallengerError> {
+    async fn game_address_at(&self, index: u64) -> Result<Option<Address>, ChallengerError> {
         self.read_game_address(index).await
     }
 
@@ -159,10 +217,18 @@ where
     async fn submit_challenge(
         &self,
         address: Address,
-        challenger_bond: U256,
     ) -> Result<ChallengeSubmission, ChallengerError> {
-        let pending = self
-            .game(address)
+        // The bond is an immutable of whichever implementation this clone was created from, so
+        // it is read per game: a re-registered implementation would otherwise make every
+        // challenge revert with `IncorrectBondAmount`.
+        let game = self.game(address);
+        let challenger_bond = game
+            .challengerBond()
+            .call()
+            .await
+            .map_err(|error| ChallengerError::Contract(error.to_string()))?;
+
+        let pending = game
             .challenge()
             .value(challenger_bond)
             .send()
@@ -176,7 +242,10 @@ where
         if !receipt.status() {
             return Err(ChallengerError::Revert(tx_hash));
         }
-        Ok(ChallengeSubmission { tx_hash })
+        Ok(ChallengeSubmission {
+            tx_hash,
+            bond: challenger_bond,
+        })
     }
 }
 
@@ -221,7 +290,7 @@ where
         self.read_game_count().await
     }
 
-    async fn game_address_at(&self, index: u64) -> Result<Address, ChallengerError> {
+    async fn game_address_at(&self, index: u64) -> Result<Option<Address>, ChallengerError> {
         self.read_game_address(index).await
     }
 
@@ -233,25 +302,45 @@ where
             .map_err(|error| ChallengerError::Contract(error.to_string()))
     }
 
-    async fn claimable(&self, address: Address) -> Result<U256, ChallengerError> {
-        let challenger = self.challenger_address();
-        self.game(address)
-            .claimable(challenger)
+    async fn is_game_finalized(&self, address: Address) -> Result<bool, ChallengerError> {
+        self.anchor
+            .isGameFinalized(address)
             .call()
             .await
             .map_err(|error| ChallengerError::Contract(error.to_string()))
     }
 
-    async fn withdraw(&self, address: Address) -> Result<WithdrawSubmission, ChallengerError> {
-        let challenger = self.challenger_address();
-        let game = self.game(address);
-        let pending = game
-            .withdraw(challenger)
+    async fn credit(&self, address: Address) -> Result<U256, ChallengerError> {
+        self.read_credit(address, self.challenger_address()).await
+    }
+
+    async fn pending_withdrawal(
+        &self,
+        address: Address,
+    ) -> Result<PendingWithdrawal, ChallengerError> {
+        self.read_pending_withdrawal(address, self.challenger_address())
+            .await
+    }
+
+    async fn claim_credit(&self, address: Address) -> Result<ClaimSubmission, ChallengerError> {
+        let recipient = self.challenger_address();
+        // Read both phases up front so the submission can report what the call moved; the
+        // receipt carries no amount of its own.
+        let credit = self.read_credit(address, recipient).await?;
+        let pending = if credit.is_zero() {
+            self.read_pending_withdrawal(address, recipient).await?
+        } else {
+            PendingWithdrawal::default()
+        };
+
+        let pending_tx = self
+            .game(address)
+            .claimCredit(recipient)
             .send()
             .await
             .map_err(|error| ChallengerError::Contract(error.to_string()))?;
-        let tx_hash = *pending.tx_hash();
-        let receipt = pending
+        let tx_hash = *pending_tx.tx_hash();
+        let receipt = pending_tx
             .get_receipt()
             .await
             .map_err(|error| ChallengerError::Contract(error.to_string()))?;
@@ -259,24 +348,19 @@ where
             return Err(ChallengerError::Revert(tx_hash));
         }
 
-        let amount = receipt
-            .logs()
-            .iter()
-            .filter(|log| log.address() == address)
-            .find_map(|log| {
-                log.log_decode_validate::<IWorldChainProofSystemGame::Withdrawn>()
-                    .ok()
-                    .map(|decoded| decoded.inner.data)
-            })
-            .filter(|event| event.recipient == challenger)
-            .map(|event| event.amount)
-            .ok_or_else(|| {
-                ChallengerError::Contract(format!(
-                    "Withdrawn event missing from withdraw transaction {tx_hash}"
-                ))
-            })?;
-
-        Ok(WithdrawSubmission { tx_hash, amount })
+        Ok(if credit.is_zero() {
+            ClaimSubmission {
+                tx_hash,
+                amount: pending.amount,
+                withdrawn: true,
+            }
+        } else {
+            ClaimSubmission {
+                tx_hash,
+                amount: credit,
+                withdrawn: false,
+            }
+        })
     }
 }
 

--- a/proofs/challenger/src/bond_manager.rs
+++ b/proofs/challenger/src/bond_manager.rs
@@ -1,3 +1,5 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use alloy_primitives::U256;
 use tracing::{info, warn};
 
@@ -56,7 +58,10 @@ where
         let challenger = self.execution_provider.challenger_address();
 
         for index in start..game_count {
-            let game = self.execution_provider.game_address_at(index).await?;
+            // The dispute-game factory indexes every game type; skip the ones that are not ours.
+            let Some(game) = self.execution_provider.game_address_at(index).await? else {
+                continue;
+            };
             if self.execution_provider.game_challenger(game).await? == challenger {
                 self.owned_games.insert(game);
             }
@@ -72,9 +77,14 @@ where
         Ok(())
     }
 
-    /// Withdraws available credits and prunes owned games that reached a terminal state.
+    /// Advances the two-phase bond claim on owned games and prunes fully settled ones.
+    ///
+    /// `MultiProofGame.claimCredit` first unlocks the credit in `DelayedWETH` and only
+    /// transfers it on a second call after the WETH delay, so a game stays owned until its
+    /// pending withdrawal is drained. Dropping it after the unlock would strand the bond.
     pub async fn withdraw_credits(&self) -> Result<(), ChallengerError> {
         let games = self.owned_games.snapshot();
+        let now = unix_now();
 
         for game in games {
             let result: Result<bool, ChallengerError> = async {
@@ -82,17 +92,41 @@ where
                 if !status.is_resolved() {
                     return Ok(false);
                 }
+                // `claimCredit` calls `closeGame`, which reverts until the registry's finality
+                // airgap has elapsed.
+                if !self.execution_provider.is_game_finalized(game).await? {
+                    return Ok(false);
+                }
 
-                let claimable = self.execution_provider.claimable(game).await?;
-                if claimable > U256::ZERO {
-                    let submission = self.execution_provider.withdraw(game).await?;
+                let credit = self.execution_provider.credit(game).await?;
+                if credit > U256::ZERO {
+                    let submission = self.execution_provider.claim_credit(game).await?;
                     info!(
                         game_address = %game,
                         tx_hash = ?submission.tx_hash,
                         amount = ?submission.amount,
-                        "withdrew challenger bond credits"
+                        "unlocked challenger bond credits in DelayedWETH"
                     );
+                    // Keep tracking: the unlocked amount still needs the second claim.
+                    return Ok(false);
                 }
+
+                let pending = self.execution_provider.pending_withdrawal(game).await?;
+                if pending.amount.is_zero() {
+                    // Nothing owed on this game; stop tracking it.
+                    return Ok(true);
+                }
+                if now < pending.unlock_at {
+                    return Ok(false);
+                }
+
+                let submission = self.execution_provider.claim_credit(game).await?;
+                info!(
+                    game_address = %game,
+                    tx_hash = ?submission.tx_hash,
+                    amount = ?submission.amount,
+                    "withdrew challenger bond credits"
+                );
                 Ok(true)
             }
             .await;
@@ -124,4 +158,11 @@ where
             }
         }
     }
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time before unix epoch")
+        .as_secs()
 }

--- a/proofs/challenger/src/challenger.rs
+++ b/proofs/challenger/src/challenger.rs
@@ -13,6 +13,9 @@ use std::{
 use tracing::{info, warn};
 use world_chain_proofs::{ConsensusProvider, RootState};
 
+/// Maximum number of consecutive non-WIP-1006 factory indices skipped by one cursor probe.
+const FOREIGN_GAME_PROBE_LIMIT: u64 = 64;
+
 /// World Chain output-root challenger.
 #[derive(Debug)]
 pub struct WorldChainChallenger<E, C> {
@@ -86,6 +89,13 @@ where
     E: ChallengerClient,
     C: ConsensusProvider,
 {
+    /// Binary-searches the factory index for the first game whose challenge window is still
+    /// open.
+    ///
+    /// The dispute-game factory interleaves every game type, so a probe can land on an index
+    /// that holds no WIP-1006 game. The search then steps forward a bounded distance to the
+    /// next one; if it finds none it narrows downward, which only ever yields a smaller (more
+    /// conservative) cursor.
     async fn first_unexpired_game_index(
         &self,
         game_count: u64,
@@ -96,16 +106,37 @@ where
 
         while low < high {
             let middle = low + (high - low) / 2;
-            let game = self.execution_provider.game_address_at(middle).await?;
-            let deadline = self.execution_provider.challenge_deadline(game).await?;
-            if deadline <= now {
-                low = middle + 1;
-            } else {
-                high = middle;
+            match self.probe_forward(middle, high).await? {
+                None => high = middle,
+                Some((index, game)) => {
+                    let deadline = self.execution_provider.challenge_deadline(game).await?;
+                    if deadline <= now {
+                        low = index + 1;
+                    } else {
+                        high = middle;
+                    }
+                }
             }
         }
 
         Ok(low)
+    }
+
+    /// Returns the first WIP-1006 game at or after `start` and below `end`, scanning at most
+    /// [`FOREIGN_GAME_PROBE_LIMIT`] indices so a long run of foreign games cannot turn the
+    /// search into an unbounded RPC loop.
+    async fn probe_forward(
+        &self,
+        start: u64,
+        end: u64,
+    ) -> Result<Option<(u64, Address)>, ChallengerError> {
+        let limit = end.min(start.saturating_add(FOREIGN_GAME_PROBE_LIMIT));
+        for index in start..limit {
+            if let Some(game) = self.execution_provider.game_address_at(index).await? {
+                return Ok(Some((index, game)));
+            }
+        }
+        Ok(None)
     }
 
     async fn process_game(
@@ -208,17 +239,14 @@ where
 
         challenge_games.sort_by_key(|(_game, challenge_deadline)| *challenge_deadline);
         for (game, challenge_deadline) in challenge_games {
-            match self
-                .execution_provider
-                .submit_challenge(game.address, self.config.challenger_bond)
-                .await
-            {
+            match self.execution_provider.submit_challenge(game.address).await {
                 Ok(submission) => {
                     self.retry_games.remove(&game.address);
                     self.owned_games.insert(game.address);
                     info!(
                         game_address = %game.address,
                         tx_hash = ?submission.tx_hash,
+                        bond = ?submission.bond,
                         "challenged invalid World Chain proof-system game"
                     );
                 }
@@ -258,11 +286,14 @@ where
             .min(game_count);
         let mut new_games = Vec::with_capacity((end - start) as usize);
         for index in start..end {
-            let game = self.execution_provider.game_address_at(index).await?;
-            let metadata = self.execution_provider.game_metadata(game).await?;
-            if !self.retry_games.contains_key(&game) {
-                new_games.push(metadata);
+            // The dispute-game factory indexes every game type; skip the ones that are not ours.
+            let Some(game) = self.execution_provider.game_address_at(index).await? else {
+                continue;
+            };
+            if self.retry_games.contains_key(&game) {
+                continue;
             }
+            new_games.push(self.execution_provider.game_metadata(game).await?);
         }
 
         if new_games.is_empty() && self.retry_games.is_empty() {

--- a/proofs/challenger/src/config.rs
+++ b/proofs/challenger/src/config.rs
@@ -1,5 +1,4 @@
 use crate::error::ChallengerError;
-use alloy_primitives::U256;
 use std::time::Duration;
 
 /// Default number of games processed concurrently.
@@ -16,10 +15,12 @@ pub const DEFAULT_BOND_MANAGER_POLL_INTERVAL: Duration = Duration::from_secs(5 *
 pub const DEFAULT_BOND_MANAGER_INITIAL_SCAN_LIMIT: u64 = 1_000;
 
 /// Configuration for the challenger.
+///
+/// The challenge bond is deliberately absent: it is an immutable of whichever implementation
+/// each game was cloned from, so it is read per game rather than captured at startup where a
+/// re-registered implementation would make every challenge revert.
 #[derive(Debug, Clone)]
 pub struct ChallengerConfig {
-    /// Bond read from the factory and sent with `WorldChainProofSystemGame.challenge`.
-    pub challenger_bond: U256,
     /// Delay between periodic scan attempts.
     pub poll_interval: Duration,
     /// Maximum number of games to process concurrently.
@@ -52,7 +53,6 @@ impl ChallengerConfig {
 impl Default for ChallengerConfig {
     fn default() -> Self {
         Self {
-            challenger_bond: U256::ZERO,
             poll_interval: Duration::from_mins(1),
             max_game_concurrency: DEFAULT_MAX_GAME_CONCURRENCY,
             max_games_per_tick: DEFAULT_MAX_GAMES_PER_TICK,

--- a/proofs/challenger/src/lib.rs
+++ b/proofs/challenger/src/lib.rs
@@ -22,7 +22,8 @@ pub use error::ChallengerError;
 pub use resolution_manager::ResolutionManager;
 pub use traits::{BondManagerClient, ChallengerClient, ResolutionManagerClient};
 pub use types::{
-    ChallengeSubmission, GameMetadata, OwnedGames, ResolveSubmission, WithdrawSubmission,
+    ChallengeSubmission, ClaimSubmission, GameMetadata, OwnedGames, PendingWithdrawal,
+    ResolveSubmission,
 };
 
 #[cfg(test)]

--- a/proofs/challenger/src/main.rs
+++ b/proofs/challenger/src/main.rs
@@ -1,4 +1,4 @@
-//! `world-chain-challenger` binary: scans `WorldChainProofSystemFactory` games and
+//! `world-chain-challenger` binary: scans WIP-1006 games on the OP `DisputeGameFactory` and
 //! challenges any whose claimed output root disagrees with the canonical L2 root.
 //!
 //! Mirrors the in-process challenger wired by the devnet harness
@@ -16,8 +16,8 @@ use clap::Parser;
 use tracing::info;
 use url::Url;
 use world_chain_challenger::{
-    AlloyChallengerClient, BondManager, BondManagerConfig, ChallengerClient, ChallengerConfig,
-    OwnedGames, ResolutionManager, ResolutionManagerConfig, WorldChainChallenger,
+    AlloyChallengerClient, BondManager, BondManagerConfig, ChallengerConfig, OwnedGames,
+    ResolutionManager, ResolutionManagerConfig, WorldChainChallenger,
 };
 use world_chain_proofs::OptimismConsensusClient;
 
@@ -35,9 +35,13 @@ struct Cli {
     #[arg(long, env = "OUTPUT_ROOT_RPC_URL")]
     output_root_rpc: String,
 
-    /// `WorldChainProofSystemFactory` address on L1.
+    /// OP Stack `DisputeGameFactory` address on L1.
     #[arg(long, env = "FACTORY_ADDRESS")]
     factory_address: Address,
+
+    /// OP Stack `AnchorStateRegistry` address on L1.
+    #[arg(long, env = "ANCHOR_REGISTRY_ADDRESS")]
+    anchor_registry_address: Address,
 
     /// Hex-encoded private key the challenger signs L1 transactions with.
     #[arg(long, env = "CHALLENGER_KEY", hide_env_values = true)]
@@ -94,14 +98,10 @@ async fn main() -> Result<()> {
         .wallet(EthereumWallet::from(cli.challenger_key))
         .connect_http(Url::parse(&cli.l1_rpc).context("invalid L1 RPC URL")?);
 
-    let client = AlloyChallengerClient::new(provider, cli.factory_address);
+    let client =
+        AlloyChallengerClient::new(provider, cli.factory_address, cli.anchor_registry_address);
     let output_roots = OptimismConsensusClient::new(cli.output_root_rpc.clone());
-    let challenger_bond = client
-        .challenger_bond()
-        .await
-        .context("failed to read challenger bond")?;
     let config = ChallengerConfig {
-        challenger_bond,
         poll_interval: Duration::from_secs(cli.poll_interval_seconds),
         max_game_concurrency: cli.max_game_concurrency,
         max_games_per_tick: cli.max_games_per_tick,
@@ -128,9 +128,9 @@ async fn main() -> Result<()> {
     info!(
         l1_rpc_url = %cli.l1_rpc,
         output_root_rpc_url = %cli.output_root_rpc,
-        factory = %cli.factory_address,
+        dispute_game_factory = %cli.factory_address,
+        anchor = %cli.anchor_registry_address,
         challenger = %challenger_address,
-        challenger_bond = ?challenger_bond,
         max_games_per_tick = cli.max_games_per_tick,
         resolution_manager_poll_interval_seconds =
             cli.resolution_manager_poll_interval_seconds,

--- a/proofs/challenger/src/tests.rs
+++ b/proofs/challenger/src/tests.rs
@@ -1,8 +1,8 @@
 use crate::{
     BondManager, BondManagerClient, BondManagerConfig, ChallengeSubmission, ChallengerClient,
-    ChallengerConfig, ChallengerError, GameMetadata, OwnedGames, ResolutionManager,
-    ResolutionManagerClient, ResolutionManagerConfig, ResolveSubmission, WithdrawSubmission,
-    challenger::WorldChainChallenger,
+    ChallengerConfig, ChallengerError, ClaimSubmission, GameMetadata, OwnedGames,
+    PendingWithdrawal, ResolutionManager, ResolutionManagerClient, ResolutionManagerConfig,
+    ResolveSubmission, challenger::WorldChainChallenger,
 };
 use alloy_primitives::{Address, B256, BlockNumber, U256, address};
 use async_trait::async_trait;
@@ -40,7 +40,10 @@ struct MockGame {
     resolvable: bool,
     resolution_outcome: u8,
     resolution_reason: u8,
-    claimable: U256,
+    credit: U256,
+    pending: PendingWithdrawal,
+    /// Whether the registry's finality airgap has elapsed for this game.
+    finalized: bool,
 }
 
 impl MockGame {
@@ -57,7 +60,12 @@ impl MockGame {
             resolvable: false,
             resolution_outcome: STATE_PROPOSED,
             resolution_reason: REASON_NONE,
-            claimable: U256::ZERO,
+            credit: U256::ZERO,
+            pending: PendingWithdrawal {
+                amount: U256::ZERO,
+                unlock_at: 0,
+            },
+            finalized: true,
         }
     }
 }
@@ -69,8 +77,11 @@ struct MockState {
     requested_indices: Vec<u64>,
     challenges: Vec<Address>,
     resolutions: Vec<Address>,
+    unlocks: Vec<Address>,
     withdrawals: Vec<Address>,
-    fail_withdraw_once: HashSet<Address>,
+    fail_claim_once: HashSet<Address>,
+    /// Factory indices holding a game of a different type.
+    foreign_indices: HashSet<u64>,
 }
 
 #[derive(Debug, Clone)]
@@ -109,21 +120,21 @@ impl MockClient {
 
 #[async_trait]
 impl ChallengerClient for MockClient {
-    async fn challenger_bond(&self) -> Result<U256, ChallengerError> {
-        Ok(U256::from(1))
-    }
-
     async fn game_count(&self) -> Result<u64, ChallengerError> {
         Ok(self.state.lock().expect("not poisoned").order.len() as u64)
     }
 
-    async fn game_address_at(&self, index: u64) -> Result<Address, ChallengerError> {
+    async fn game_address_at(&self, index: u64) -> Result<Option<Address>, ChallengerError> {
         let mut state = self.state.lock().expect("not poisoned");
         state.requested_indices.push(index);
+        if state.foreign_indices.contains(&index) {
+            return Ok(None);
+        }
         state
             .order
             .get(index as usize)
             .copied()
+            .map(Some)
             .ok_or_else(|| ChallengerError::Contract(format!("unknown game index {index}")))
     }
 
@@ -161,7 +172,6 @@ impl ChallengerClient for MockClient {
     async fn submit_challenge(
         &self,
         game: Address,
-        _challenger_bond: U256,
     ) -> Result<ChallengeSubmission, ChallengerError> {
         let mut state = self.state.lock().expect("not poisoned");
         let record = state
@@ -174,6 +184,7 @@ impl ChallengerClient for MockClient {
         state.challenges.push(game);
         Ok(ChallengeSubmission {
             tx_hash: B256::with_last_byte(state.challenges.len() as u8),
+            bond: U256::from(1),
         })
     }
 }
@@ -222,7 +233,7 @@ impl BondManagerClient for MockClient {
         ChallengerClient::game_count(self).await
     }
 
-    async fn game_address_at(&self, index: u64) -> Result<Address, ChallengerError> {
+    async fn game_address_at(&self, index: u64) -> Result<Option<Address>, ChallengerError> {
         ChallengerClient::game_address_at(self, index).await
     }
 
@@ -236,33 +247,73 @@ impl BondManagerClient for MockClient {
             .ok_or_else(|| ChallengerError::Contract(format!("unknown game {game}")))
     }
 
-    async fn claimable(&self, game: Address) -> Result<U256, ChallengerError> {
+    async fn is_game_finalized(&self, game: Address) -> Result<bool, ChallengerError> {
         self.state
             .lock()
             .expect("not poisoned")
             .games
             .get(&game)
-            .map(|game| game.claimable)
+            .map(|game| game.finalized)
             .ok_or_else(|| ChallengerError::Contract(format!("unknown game {game}")))
     }
 
-    async fn withdraw(&self, game: Address) -> Result<WithdrawSubmission, ChallengerError> {
+    async fn credit(&self, game: Address) -> Result<U256, ChallengerError> {
+        self.state
+            .lock()
+            .expect("not poisoned")
+            .games
+            .get(&game)
+            .map(|game| game.credit)
+            .ok_or_else(|| ChallengerError::Contract(format!("unknown game {game}")))
+    }
+
+    async fn pending_withdrawal(
+        &self,
+        game: Address,
+    ) -> Result<PendingWithdrawal, ChallengerError> {
+        self.state
+            .lock()
+            .expect("not poisoned")
+            .games
+            .get(&game)
+            .map(|game| game.pending)
+            .ok_or_else(|| ChallengerError::Contract(format!("unknown game {game}")))
+    }
+
+    /// Mirrors `MultiProofGame.claimCredit`: the first call unlocks credit into a pending
+    /// `DelayedWETH` withdrawal, the second drains it.
+    async fn claim_credit(&self, game: Address) -> Result<ClaimSubmission, ChallengerError> {
         let mut state = self.state.lock().expect("not poisoned");
-        if state.fail_withdraw_once.remove(&game) {
-            return Err(ChallengerError::Contract(
-                "injected withdrawal failure".into(),
-            ));
+        if state.fail_claim_once.remove(&game) {
+            return Err(ChallengerError::Contract("injected claim failure".into()));
         }
         let record = state
             .games
             .get_mut(&game)
             .ok_or_else(|| ChallengerError::Contract(format!("unknown game {game}")))?;
-        let amount = record.claimable;
-        record.claimable = U256::ZERO;
+
+        if record.credit > U256::ZERO {
+            let amount = record.credit;
+            record.credit = U256::ZERO;
+            record.pending = PendingWithdrawal {
+                amount,
+                unlock_at: 0,
+            };
+            state.unlocks.push(game);
+            return Ok(ClaimSubmission {
+                tx_hash: B256::with_last_byte(state.unlocks.len() as u8),
+                amount,
+                withdrawn: false,
+            });
+        }
+
+        let amount = record.pending.amount;
+        record.pending = PendingWithdrawal::default();
         state.withdrawals.push(game);
-        Ok(WithdrawSubmission {
+        Ok(ClaimSubmission {
             tx_hash: B256::with_last_byte(state.withdrawals.len() as u8),
             amount,
+            withdrawn: true,
         })
     }
 }
@@ -303,7 +354,6 @@ fn mock_output_roots(
 
 fn config() -> ChallengerConfig {
     ChallengerConfig {
-        challenger_bond: U256::from(1),
         poll_interval: Duration::from_secs(1),
         max_game_concurrency: 10,
         max_games_per_tick: 100,
@@ -489,45 +539,66 @@ async fn bond_manager_scans_games_appended_after_recovery() {
 }
 
 #[tokio::test]
-async fn bond_manager_withdraws_and_prunes_terminal_games() {
-    let mut withdrawable = MockGame::proposed(GAME_1, B256::ZERO, L2_BLOCK);
-    withdrawable.state = STATE_INVALIDATED;
-    withdrawable.resolution_outcome = STATE_INVALIDATED;
-    withdrawable.resolution_reason = REASON_PROOF_TIMEOUT;
-    withdrawable.claimable = U256::from(10);
+async fn bond_manager_completes_two_phase_claim_and_prunes_terminal_games() {
+    let mut claimable = MockGame::proposed(GAME_1, B256::ZERO, L2_BLOCK);
+    claimable.state = STATE_INVALIDATED;
+    claimable.resolution_outcome = STATE_INVALIDATED;
+    claimable.resolution_reason = REASON_PROOF_TIMEOUT;
+    claimable.credit = U256::from(10);
     let mut zero_credit = MockGame::proposed(GAME_2, B256::ZERO, L2_BLOCK);
     zero_credit.state = STATE_FINALIZED;
     zero_credit.resolution_outcome = STATE_FINALIZED;
-    let client = MockClient::new(vec![withdrawable, zero_credit]);
+    // Resolved but still inside the registry's finality airgap: `closeGame` would revert.
+    let mut awaiting_airgap = MockGame::proposed(GAME_3, B256::ZERO, L2_BLOCK);
+    awaiting_airgap.state = STATE_FINALIZED;
+    awaiting_airgap.resolution_outcome = STATE_FINALIZED;
+    awaiting_airgap.credit = U256::from(5);
+    awaiting_airgap.finalized = false;
+    let client = MockClient::new(vec![claimable, zero_credit, awaiting_airgap]);
     let owned_games = OwnedGames::default();
     owned_games.insert(GAME_1);
     owned_games.insert(GAME_2);
+    owned_games.insert(GAME_3);
     let manager = BondManager::new(
         BondManagerConfig::default(),
         client.clone(),
         owned_games.clone(),
     );
 
+    // Pass 1 unlocks the credit in DelayedWETH; the bond is not paid out yet.
+    manager.withdraw_credits().await.unwrap();
+
+    assert!(client.withdrawals().is_empty());
+    assert!(
+        owned_games.contains(GAME_1),
+        "an unlocked bond must stay owned until it is withdrawn"
+    );
+    assert!(!owned_games.contains(GAME_2));
+    assert!(
+        owned_games.contains(GAME_3),
+        "a game inside the finality airgap must stay owned"
+    );
+
+    // Pass 2 drains the pending withdrawal and drops the game.
     manager.withdraw_credits().await.unwrap();
 
     assert_eq!(client.withdrawals(), vec![GAME_1]);
     assert!(!owned_games.contains(GAME_1));
-    assert!(!owned_games.contains(GAME_2));
 }
 
 #[tokio::test]
-async fn bond_manager_retries_failed_withdrawal() {
+async fn bond_manager_retries_failed_claim() {
     let mut game = MockGame::proposed(GAME_1, B256::ZERO, L2_BLOCK);
     game.state = STATE_INVALIDATED;
     game.resolution_outcome = STATE_INVALIDATED;
     game.resolution_reason = REASON_PROOF_TIMEOUT;
-    game.claimable = U256::from(10);
+    game.credit = U256::from(10);
     let client = MockClient::new(vec![game]);
     client
         .state
         .lock()
         .expect("not poisoned")
-        .fail_withdraw_once
+        .fail_claim_once
         .insert(GAME_1);
     let owned_games = OwnedGames::default();
     owned_games.insert(GAME_1);
@@ -537,10 +608,33 @@ async fn bond_manager_retries_failed_withdrawal() {
         owned_games.clone(),
     );
 
-    manager.withdraw_credits().await.unwrap();
-    assert!(owned_games.contains(GAME_1));
+    // Injected failure on the unlock, then unlock, then withdraw.
+    for _ in 0..2 {
+        manager.withdraw_credits().await.unwrap();
+        assert!(owned_games.contains(GAME_1));
+    }
 
     manager.withdraw_credits().await.unwrap();
     assert!(!owned_games.contains(GAME_1));
     assert_eq!(client.withdrawals(), vec![GAME_1]);
+}
+
+#[tokio::test]
+async fn scan_once_skips_foreign_game_types() {
+    let proposed_root = B256::repeat_byte(0x10);
+    let canonical_root = B256::repeat_byte(0x20);
+    let client = MockClient::new(vec![MockGame::proposed(GAME_1, proposed_root, L2_BLOCK)]);
+    // Index 0 belongs to another game type; the WIP-1006 game sits behind it.
+    {
+        let mut state = client.state.lock().expect("not poisoned");
+        state.order.insert(0, Address::ZERO);
+        state.foreign_indices.insert(0);
+    }
+    let (output_roots, _) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
+    let mut challenger = WorldChainChallenger::new(config(), client.clone(), output_roots);
+
+    challenger.scan_once().await.unwrap();
+
+    assert_eq!(client.challenges(), vec![GAME_1]);
 }

--- a/proofs/challenger/src/traits.rs
+++ b/proofs/challenger/src/traits.rs
@@ -1,6 +1,8 @@
 use crate::{
     ChallengerError,
-    types::{ChallengeSubmission, GameMetadata, ResolveSubmission, WithdrawSubmission},
+    types::{
+        ChallengeSubmission, ClaimSubmission, GameMetadata, PendingWithdrawal, ResolveSubmission,
+    },
 };
 use alloy_primitives::{Address, U256};
 use async_trait::async_trait;
@@ -9,24 +11,22 @@ use world_chain_proofs::{ResolutionStatus, RootState};
 /// Contract surface needed by the output-root challenger.
 #[async_trait]
 pub trait ChallengerClient: Send + Sync {
-    /// Reads the challenge bond configured by the factory.
-    async fn challenger_bond(&self) -> Result<U256, ChallengerError>;
-    /// Returns the number of games created by the factory.
+    /// Returns the total number of games indexed by the dispute-game factory, across all
+    /// game types.
     async fn game_count(&self) -> Result<u64, ChallengerError>;
-    /// Returns the game address at a factory creation index.
-    async fn game_address_at(&self, index: u64) -> Result<Address, ChallengerError>;
+    /// Returns the WIP-1006 game at the provided factory index, or `None` when that index
+    /// holds a game of a different type.
+    async fn game_address_at(&self, index: u64) -> Result<Option<Address>, ChallengerError>;
     /// Reads the immutable game data needed to validate its root claim.
     async fn game_metadata(&self, game: Address) -> Result<GameMetadata, ChallengerError>;
     /// Reads the root state of the provided game.
     async fn root_state(&self, game: Address) -> Result<RootState, ChallengerError>;
     /// Reads the challenge deadline of the provided game.
     async fn challenge_deadline(&self, game: Address) -> Result<u64, ChallengerError>;
-    /// Submits a challenge against an invalid game.
-    async fn submit_challenge(
-        &self,
-        game: Address,
-        challenger_bond: U256,
-    ) -> Result<ChallengeSubmission, ChallengerError>;
+    /// Submits a challenge against an invalid game, bonded with that game's own
+    /// `challengerBond`.
+    async fn submit_challenge(&self, game: Address)
+    -> Result<ChallengeSubmission, ChallengerError>;
 }
 
 /// Contract surface needed to resolve challenger-owned games.
@@ -43,14 +43,23 @@ pub trait ResolutionManagerClient: Send + Sync {
 pub trait BondManagerClient: ResolutionManagerClient {
     /// Returns the address whose challenge bonds are managed.
     fn challenger_address(&self) -> Address;
-    /// Returns the number of games created by the factory.
+    /// Returns the total number of games indexed by the dispute-game factory, across all
+    /// game types.
     async fn game_count(&self) -> Result<u64, ChallengerError>;
-    /// Returns the game address at a factory creation index.
-    async fn game_address_at(&self, index: u64) -> Result<Address, ChallengerError>;
+    /// Returns the WIP-1006 game at the provided factory index, or `None` when that index
+    /// holds a game of a different type.
+    async fn game_address_at(&self, index: u64) -> Result<Option<Address>, ChallengerError>;
     /// Returns the challenger recorded by the provided game.
     async fn game_challenger(&self, game: Address) -> Result<Address, ChallengerError>;
-    /// Returns the amount claimable by the managed challenger.
-    async fn claimable(&self, game: Address) -> Result<U256, ChallengerError>;
-    /// Withdraws credits for the managed challenger.
-    async fn withdraw(&self, game: Address) -> Result<WithdrawSubmission, ChallengerError>;
+    /// Returns whether the registry's finality airgap has elapsed for the provided game.
+    ///
+    /// `claimCredit` calls `closeGame`, which reverts until this holds.
+    async fn is_game_finalized(&self, game: Address) -> Result<bool, ChallengerError>;
+    /// Returns the credit the managed challenger can unlock from the provided game.
+    async fn credit(&self, game: Address) -> Result<U256, ChallengerError>;
+    /// Returns the managed challenger's pending `DelayedWETH` withdrawal for the game.
+    async fn pending_withdrawal(&self, game: Address)
+    -> Result<PendingWithdrawal, ChallengerError>;
+    /// Advances the managed challenger's two-phase bond claim on the provided game.
+    async fn claim_credit(&self, game: Address) -> Result<ClaimSubmission, ChallengerError>;
 }

--- a/proofs/challenger/src/types.rs
+++ b/proofs/challenger/src/types.rs
@@ -18,6 +18,8 @@ pub struct GameMetadata {
 pub struct ChallengeSubmission {
     /// Transaction hash for the challenge submission.
     pub tx_hash: TxHash,
+    /// Bond posted with the challenge, read from the game itself.
+    pub bond: U256,
 }
 
 /// Result of a resolve transaction.
@@ -27,13 +29,27 @@ pub struct ResolveSubmission {
     pub tx_hash: TxHash,
 }
 
-/// Result of a withdraw transaction.
+/// Result of a `claimCredit` transaction.
+///
+/// Bond payout is two-phase: the first call unlocks the credit in `DelayedWETH`, the second
+/// (after the WETH delay) withdraws and transfers it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct WithdrawSubmission {
-    /// Transaction hash for the withdrawal.
+pub struct ClaimSubmission {
+    /// Transaction hash for the claim.
     pub tx_hash: TxHash,
-    /// Amount withdrawn for the challenger.
+    /// Amount moved by this phase.
     pub amount: U256,
+    /// Whether this call finalized the withdrawal and transferred funds.
+    pub withdrawn: bool,
+}
+
+/// A pending `DelayedWETH` withdrawal opened by the first `claimCredit` call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct PendingWithdrawal {
+    /// Amount unlocked in `DelayedWETH` and awaiting the withdrawal delay.
+    pub amount: U256,
+    /// Unix timestamp at which the unlocked amount becomes withdrawable.
+    pub unlock_at: u64,
 }
 
 /// Challenger-owned games shared by scanning, resolution, and bond-management loops.

--- a/proofs/defender/src/alloy.rs
+++ b/proofs/defender/src/alloy.rs
@@ -8,13 +8,16 @@ use alloy_provider::Provider;
 use alloy_rpc_types_eth::BlockId;
 use async_trait::async_trait;
 use world_chain_proofs::{
-    IWorldChainProofSystemFactory, IWorldChainProofSystemGame, PROOF_LANE_COUNT, ResolutionStatus,
+    IDisputeGameFactory, IMultiProofGame, MULTI_PROOF_GAME_TYPE, PROOF_LANE_COUNT, ResolutionStatus,
 };
 
 /// Alloy-backed implementation of [`DefenderClient`].
+///
+/// Binds the stock OP Stack `DisputeGameFactory`; WIP-1006 games are one game type among
+/// several on that factory, so every index-based read filters on [`MULTI_PROOF_GAME_TYPE`].
 #[derive(Debug, Clone)]
 pub struct AlloyDefenderClient<P> {
-    factory: IWorldChainProofSystemFactory::IWorldChainProofSystemFactoryInstance<P>,
+    factory: IDisputeGameFactory::IDisputeGameFactoryInstance<P>,
     provider: P,
 }
 
@@ -24,7 +27,7 @@ where
 {
     /// Creates a new Alloy-backed contract client.
     pub fn new(provider: P, factory_address: Address) -> Self {
-        let factory = IWorldChainProofSystemFactory::IWorldChainProofSystemFactoryInstance::new(
+        let factory = IDisputeGameFactory::IDisputeGameFactoryInstance::new(
             factory_address,
             provider.clone(),
         );
@@ -32,14 +35,8 @@ where
         Self { factory, provider }
     }
 
-    fn game(
-        &self,
-        address: Address,
-    ) -> IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance<P> {
-        IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance::new(
-            address,
-            self.provider.clone(),
-        )
+    fn game(&self, address: Address) -> IMultiProofGame::IMultiProofGameInstance<P> {
+        IMultiProofGame::IMultiProofGameInstance::new(address, self.provider.clone())
     }
 }
 
@@ -59,18 +56,21 @@ where
         u256_to_u64(count, "gameCount")
     }
 
-    async fn game_address_at(&self, index: u64) -> Result<Address, DefenderError> {
-        self.factory
-            .gameAt(U256::from(index))
+    async fn game_address_at(&self, index: u64) -> Result<Option<Address>, DefenderError> {
+        let entry = self
+            .factory
+            .gameAtIndex(U256::from(index))
             .block(BlockId::finalized())
             .call()
             .await
-            .map_err(|error| DefenderError::Contract(error.to_string()))
+            .map_err(|error| DefenderError::Contract(error.to_string()))?;
+
+        Ok((entry.gameType == MULTI_PROOF_GAME_TYPE).then_some(entry.proxy))
     }
 
-    async fn game_proposer(&self, address: Address) -> Result<Address, DefenderError> {
+    async fn game_creator(&self, address: Address) -> Result<Address, DefenderError> {
         self.game(address)
-            .proposer()
+            .gameCreator()
             .call()
             .await
             .map_err(|error| DefenderError::Contract(error.to_string()))

--- a/proofs/defender/src/defender.rs
+++ b/proofs/defender/src/defender.rs
@@ -16,6 +16,9 @@ use tracing::{error, info, warn};
 use world_chain_proofs::{ConsensusProvider, InvalidationReason};
 use world_chain_prover_service::ProofRequester;
 
+/// Maximum number of consecutive non-WIP-1006 factory indices skipped by one cursor probe.
+const FOREIGN_GAME_PROBE_LIMIT: u64 = 64;
+
 /// An active defense of a challenged game with a valid root.
 #[derive(Debug, Clone, Copy)]
 struct ActiveDefense {
@@ -112,6 +115,12 @@ where
     C: ConsensusProvider,
     P: ProofRequester + Sync,
 {
+    /// Binary-searches the factory index for the first game whose proof window is still open.
+    ///
+    /// The dispute-game factory interleaves every game type, so a probe can land on an index
+    /// that holds no WIP-1006 game. The search then steps forward a bounded distance to the
+    /// next one; if it finds none it narrows downward, which only ever yields a smaller (more
+    /// conservative) cursor.
     async fn first_unexpired_game_index(
         &self,
         game_count: u64,
@@ -122,16 +131,37 @@ where
 
         while low < high {
             let middle = low + (high - low) / 2;
-            let game = self.execution_provider.game_address_at(middle).await?;
-            let deadline = self.execution_provider.proof_deadline(game).await?;
-            if deadline <= now {
-                low = middle + 1;
-            } else {
-                high = middle;
+            match self.probe_forward(middle, high).await? {
+                None => high = middle,
+                Some((index, game)) => {
+                    let deadline = self.execution_provider.proof_deadline(game).await?;
+                    if deadline <= now {
+                        low = index + 1;
+                    } else {
+                        high = middle;
+                    }
+                }
             }
         }
 
         Ok(low)
+    }
+
+    /// Returns the first WIP-1006 game at or after `start` and below `end`, scanning at most
+    /// [`FOREIGN_GAME_PROBE_LIMIT`] indices so a long run of foreign games cannot turn the
+    /// search into an unbounded RPC loop.
+    async fn probe_forward(
+        &self,
+        start: u64,
+        end: u64,
+    ) -> Result<Option<(u64, Address)>, DefenderError> {
+        let limit = end.min(start.saturating_add(FOREIGN_GAME_PROBE_LIMIT));
+        for index in start..limit {
+            if let Some(game) = self.execution_provider.game_address_at(index).await? {
+                return Ok(Some((index, game)));
+            }
+        }
+        Ok(None)
     }
 
     async fn evaluate_discovered_games(
@@ -355,13 +385,16 @@ where
             .min(game_count);
         let mut new_games = Vec::with_capacity((end - start) as usize);
         for index in start..end {
-            let game = self.execution_provider.game_address_at(index).await?;
+            // The dispute-game factory indexes every game type; skip the ones that are not ours.
+            let Some(game) = self.execution_provider.game_address_at(index).await? else {
+                continue;
+            };
             if self.watched_games.contains_key(&game) || self.active_defenses.contains_key(&game) {
                 continue;
             }
 
-            let proposer = self.execution_provider.game_proposer(game).await?;
-            if proposer != self.config.allowed_proposer {
+            let game_creator = self.execution_provider.game_creator(game).await?;
+            if game_creator != self.config.allowed_proposer {
                 continue;
             }
             new_games.push(self.execution_provider.game_metadata(game).await?);

--- a/proofs/defender/src/main.rs
+++ b/proofs/defender/src/main.rs
@@ -1,5 +1,6 @@
-//! `world-chain-defender` binary: watches challenged valid `WorldChainProofSystemFactory`
-//! games, requests proofs from the prover-service, and submits completed proof lanes on L1.
+//! `world-chain-defender` binary: watches challenged valid WIP-1006 games on the OP
+//! `DisputeGameFactory`, requests proofs from the prover-service, and submits completed
+//! proof lanes on L1.
 //!
 //! Mirrors the in-process defender wired by the devnet harness
 //! (`crates/devnet/src/full_stack.rs::start_world_chain_defender`), reading its
@@ -37,7 +38,7 @@ struct Cli {
     #[arg(long, env = "PROVER_SERVICE_URL")]
     prover_service_url: String,
 
-    /// `WorldChainProofSystemFactory` address on L1.
+    /// OP Stack `DisputeGameFactory` address on L1.
     #[arg(long, env = "FACTORY_ADDRESS")]
     factory_address: Address,
 
@@ -97,7 +98,7 @@ async fn main() -> Result<()> {
         l1_rpc_url = %cli.l1_rpc,
         output_root_rpc_url = %cli.output_root_rpc,
         prover_service = %cli.prover_service_url,
-        factory = %cli.factory_address,
+        dispute_game_factory = %cli.factory_address,
         defender = %defender_address,
         allowed_proposer = %cli.allowed_proposer,
         max_games_per_tick = cli.max_games_per_tick,

--- a/proofs/defender/src/tests.rs
+++ b/proofs/defender/src/tests.rs
@@ -173,14 +173,14 @@ impl DefenderClient for MockClient {
         Ok(self.games.len() as u64)
     }
 
-    async fn game_address_at(&self, index: u64) -> Result<Address, DefenderError> {
+    async fn game_address_at(&self, index: u64) -> Result<Option<Address>, DefenderError> {
         self.games
             .get(index as usize)
-            .map(|game| game.address)
+            .map(|game| Some(game.address))
             .ok_or_else(|| DefenderError::Contract(format!("unknown game index {index}")))
     }
 
-    async fn game_proposer(&self, game: Address) -> Result<Address, DefenderError> {
+    async fn game_creator(&self, game: Address) -> Result<Address, DefenderError> {
         self.proposers
             .get(&game)
             .copied()

--- a/proofs/defender/src/traits.rs
+++ b/proofs/defender/src/traits.rs
@@ -8,12 +8,14 @@ use world_chain_proofs::ResolutionStatus;
 
 #[async_trait]
 pub trait DefenderClient: Send + Sync {
-    /// Returns the number of games created by the factory.
+    /// Returns the total number of games indexed by the dispute-game factory, across all
+    /// game types.
     async fn game_count(&self) -> Result<u64, DefenderError>;
-    /// Returns the game address at a factory creation index.
-    async fn game_address_at(&self, index: u64) -> Result<Address, DefenderError>;
-    /// Reads the proposer recorded by the provided game.
-    async fn game_proposer(&self, game: Address) -> Result<Address, DefenderError>;
+    /// Returns the WIP-1006 game at the provided factory index, or `None` when that index
+    /// holds a game of a different type.
+    async fn game_address_at(&self, index: u64) -> Result<Option<Address>, DefenderError>;
+    /// Reads the account that created the provided game.
+    async fn game_creator(&self, game: Address) -> Result<Address, DefenderError>;
     /// Reads the immutable game data needed to monitor and defend its root claim.
     async fn game_metadata(&self, game: Address) -> Result<GameMetadata, DefenderError>;
     /// Reads the proof deadline used by startup cursor initialization.

--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -19,13 +19,13 @@ use world_chain_defender::{
 };
 use world_chain_proof_worker::{ClaimedProofJobHandler, ProofJob};
 use world_chain_proofs::{
-    ConsensusError, ConsensusProvider, GameCreated, InvalidationReason, PROOF_SYSTEM_VERSION,
-    PROOF_THRESHOLD, ProofDomain, ProofLane, ResolutionStatus, RootCommitment, RootState,
-    has_threshold,
+    ConsensusError, ConsensusProvider, InvalidationReason, PROOF_SYSTEM_VERSION, PROOF_THRESHOLD,
+    ProofDomain, ProofLane, ProposalCommitment, ResolutionStatus, RootCommitment, RootState,
+    WorldChainGameCreated, has_threshold,
 };
 use world_chain_proposer::{
-    CloseGameSubmission, ParentRef, Proposal, ProposalSubmission, ProposerClient, ProposerError,
-    ResolveSubmission, WithdrawSubmission,
+    AnchorRef, CloseGameSubmission, Proposal, ProposalSubmission, ProposerClient, ProposerError,
+    ResolveSubmission, TransitionGame,
 };
 use world_chain_prover_service::{
     GetNextProofRequest, GetNextProofResponse, GetProofSessionRequest, GetProofSessionResponse,
@@ -129,7 +129,7 @@ pub struct FakeExecution {
 #[derive(Debug)]
 struct FakeExecutionState {
     domain_hash: B256,
-    anchor: ParentRef,
+    anchor: AnchorRef,
     finalized_l1_block: BlockNumber,
     next_game_nonce: u8,
     games_by_key: HashMap<B256, Address>,
@@ -139,7 +139,7 @@ struct FakeExecutionState {
 
 #[derive(Debug, Clone)]
 struct GameRecord {
-    event: GameCreated,
+    event: WorldChainGameCreated,
     state: u8,
     challenge_deadline: u64,
     proof_deadline: u64,
@@ -160,8 +160,9 @@ impl FakeExecution {
         Self {
             state: Arc::new(Mutex::new(FakeExecutionState {
                 domain_hash: test_domain().hash(),
-                anchor: ParentRef {
-                    address: ANCHOR,
+                anchor: AnchorRef {
+                    registry: ANCHOR,
+                    anchor_game: None,
                     l2_block_number: 0,
                 },
                 finalized_l1_block: 10_000,
@@ -174,7 +175,7 @@ impl FakeExecution {
     }
 
     #[must_use]
-    pub fn latest_game(&self) -> Option<GameCreated> {
+    pub fn latest_game(&self) -> Option<WorldChainGameCreated> {
         let state = self.state.lock().expect("fake execution mutex poisoned");
         state
             .game_order
@@ -230,7 +231,7 @@ impl FakeExecution {
         challenge_record(state.games_by_address.get_mut(&game).expect("game exists"));
     }
 
-    fn create_game(state: &mut FakeExecutionState, proposal: &Proposal) -> GameCreated {
+    fn create_game(state: &mut FakeExecutionState, proposal: &Proposal) -> WorldChainGameCreated {
         let game = Address::with_last_byte(state.next_game_nonce);
         state.next_game_nonce = state.next_game_nonce.saturating_add(1);
 
@@ -241,19 +242,21 @@ impl FakeExecution {
             l1_origin_hash,
             l1_origin_number,
         };
-        let event = GameCreated {
-            proposal_key: proposal.proposal_key,
+        let event = WorldChainGameCreated {
             root_id: root.root_id(state.domain_hash),
             game,
-            proposer: FAKE_PROPOSER,
+            game_creator: FAKE_PROPOSER,
             root_claim: proposal.root_claim,
             l2_block_number: proposal.l2_block_number,
             parent_ref: proposal.parent_ref,
             l1_origin_hash,
             l1_origin_number,
+            attempt: proposal.attempt,
         };
 
-        state.games_by_key.insert(proposal.proposal_key, game);
+        state
+            .games_by_key
+            .insert(proposal.commitment().game_uuid(state.domain_hash), game);
         state.game_order.push(game);
         state.games_by_address.insert(
             game,
@@ -287,6 +290,9 @@ fn proof_lane(lane: u8) -> Option<ProofLane> {
     }
 }
 
+/// Mirrors the attempt walk in the real Alloy clients.
+const MAX_ATTEMPT_SCAN: u64 = 4;
+
 fn parent_is_unresolved(state: &FakeExecutionState, record: &GameRecord) -> bool {
     if record.event.parent_ref == ANCHOR {
         return false;
@@ -299,7 +305,7 @@ fn parent_is_unresolved(state: &FakeExecutionState, record: &GameRecord) -> bool
 
 #[async_trait]
 impl ProposerClient for FakeExecution {
-    async fn anchor_parent(&self) -> Result<ParentRef, ProposerError> {
+    async fn anchor_parent(&self) -> Result<AnchorRef, ProposerError> {
         Ok(self
             .state
             .lock()
@@ -307,29 +313,42 @@ impl ProposerClient for FakeExecution {
             .anchor)
     }
 
-    async fn proposal_key(
+    async fn latest_game_for_transition(
         &self,
-        commitment: world_chain_proofs::ProposalCommitment,
-    ) -> Result<B256, ProposerError> {
-        Ok(commitment.proposal_key(
-            self.state
-                .lock()
-                .expect("fake execution mutex poisoned")
-                .domain_hash,
-        ))
+        parent_candidates: &[Address],
+        root_claim: B256,
+        l2_block_number: u64,
+    ) -> Result<Option<TransitionGame>, ProposerError> {
+        let state = self.state.lock().expect("fake execution mutex poisoned");
+        for parent_ref in parent_candidates {
+            let mut found = None;
+            for attempt in 0..MAX_ATTEMPT_SCAN {
+                let uuid = ProposalCommitment {
+                    parent_ref: *parent_ref,
+                    root_claim,
+                    l2_block_number,
+                    attempt,
+                }
+                .game_uuid(state.domain_hash);
+                let Some(address) = state.games_by_key.get(&uuid).copied() else {
+                    break;
+                };
+                found = Some(TransitionGame {
+                    address,
+                    parent_ref: *parent_ref,
+                    attempt,
+                });
+            }
+            if found.is_some() {
+                return Ok(found);
+            }
+        }
+        Ok(None)
     }
 
-    async fn game_for_proposal_key(
-        &self,
-        proposal_key: B256,
-    ) -> Result<Option<Address>, ProposerError> {
-        Ok(self
-            .state
-            .lock()
-            .expect("fake execution mutex poisoned")
-            .games_by_key
-            .get(&proposal_key)
-            .copied())
+    /// The fake has no registry finality airgap: a resolved game is immediately closeable.
+    async fn is_game_finalized(&self, _game: Address) -> Result<bool, ProposerError> {
+        Ok(true)
     }
 
     async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError> {
@@ -410,28 +429,14 @@ impl ProposerClient for FakeExecution {
             )));
         }
         let l2_block_number = record.event.l2_block_number;
-        state.anchor = ParentRef {
-            address: game,
+        state.anchor = AnchorRef {
+            registry: ANCHOR,
+            anchor_game: Some(game),
             l2_block_number,
         };
         Ok(CloseGameSubmission {
             tx_hash: B256::with_last_byte(game.as_slice()[19]),
         })
-    }
-
-    async fn claimable(&self, _game: Address) -> Result<U256, ProposerError> {
-        Ok(U256::ZERO)
-    }
-
-    async fn withdraw(&self, game: Address) -> Result<WithdrawSubmission, ProposerError> {
-        Ok(WithdrawSubmission {
-            tx_hash: B256::with_last_byte(game.as_slice()[19]),
-            amount: U256::ZERO,
-        })
-    }
-
-    async fn proposer_bond(&self) -> Result<U256, ProposerError> {
-        Ok(U256::from(1))
     }
 
     async fn latest_finalized_l1_block(&self) -> Result<B256, ProposerError> {
@@ -442,13 +447,12 @@ impl ProposerClient for FakeExecution {
         &self,
         proposal: &Proposal,
         _proof: ProofData,
-        _proposer_bond: U256,
     ) -> Result<ProposalSubmission, ProposerError> {
         let mut state = self.state.lock().expect("fake execution mutex poisoned");
-        if let Some(existing) = state.games_by_key.get(&proposal.proposal_key) {
+        let uuid = proposal.commitment().game_uuid(state.domain_hash);
+        if let Some(existing) = state.games_by_key.get(&uuid) {
             return Err(ProposerError::Contract(format!(
-                "game already exists for proposal key {} at {existing}",
-                proposal.proposal_key
+                "game already exists for factory uuid {uuid} at {existing}"
             )));
         }
         let event = Self::create_game(&mut state, proposal);
@@ -461,10 +465,6 @@ impl ProposerClient for FakeExecution {
 
 #[async_trait]
 impl ChallengerClient for FakeExecution {
-    async fn challenger_bond(&self) -> Result<U256, ChallengerError> {
-        Ok(U256::from(1))
-    }
-
     async fn game_count(&self) -> Result<u64, ChallengerError> {
         Ok(self
             .state
@@ -474,13 +474,14 @@ impl ChallengerClient for FakeExecution {
             .len() as u64)
     }
 
-    async fn game_address_at(&self, index: u64) -> Result<Address, ChallengerError> {
+    async fn game_address_at(&self, index: u64) -> Result<Option<Address>, ChallengerError> {
         self.state
             .lock()
             .expect("fake execution mutex poisoned")
             .game_order
             .get(index as usize)
             .copied()
+            .map(Some)
             .ok_or_else(|| ChallengerError::Contract(format!("unknown game index {index}")))
     }
 
@@ -525,7 +526,6 @@ impl ChallengerClient for FakeExecution {
     async fn submit_challenge(
         &self,
         game: Address,
-        _challenger_bond: U256,
     ) -> Result<ChallengeSubmission, ChallengerError> {
         let mut state = self.state.lock().expect("fake execution mutex poisoned");
         let record = state
@@ -535,6 +535,7 @@ impl ChallengerClient for FakeExecution {
         challenge_record(record);
         Ok(ChallengeSubmission {
             tx_hash: B256::with_last_byte(record.challenge_count as u8),
+            bond: U256::from(1),
         })
     }
 }
@@ -550,23 +551,24 @@ impl DefenderClient for FakeExecution {
             .len() as u64)
     }
 
-    async fn game_address_at(&self, index: u64) -> Result<Address, DefenderError> {
+    async fn game_address_at(&self, index: u64) -> Result<Option<Address>, DefenderError> {
         self.state
             .lock()
             .expect("fake execution mutex poisoned")
             .game_order
             .get(index as usize)
             .copied()
+            .map(Some)
             .ok_or_else(|| DefenderError::Contract(format!("unknown game index {index}")))
     }
 
-    async fn game_proposer(&self, game: Address) -> Result<Address, DefenderError> {
+    async fn game_creator(&self, game: Address) -> Result<Address, DefenderError> {
         self.state
             .lock()
             .expect("fake execution mutex poisoned")
             .games_by_address
             .get(&game)
-            .map(|record| record.event.proposer)
+            .map(|record| record.event.game_creator)
             .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))
     }
 

--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -313,15 +313,16 @@ impl ProposerClient for FakeExecution {
             .anchor)
     }
 
-    async fn latest_game_for_transition(
+    async fn games_for_transition(
         &self,
         parent_candidates: &[Address],
         root_claim: B256,
         l2_block_number: u64,
-    ) -> Result<Option<TransitionGame>, ProposerError> {
+    ) -> Result<Vec<TransitionGame>, ProposerError> {
         let state = self.state.lock().expect("fake execution mutex poisoned");
+        let mut found = Vec::with_capacity(parent_candidates.len());
         for parent_ref in parent_candidates {
-            let mut found = None;
+            let mut latest = None;
             for attempt in 0..MAX_ATTEMPT_SCAN {
                 let uuid = ProposalCommitment {
                     parent_ref: *parent_ref,
@@ -333,17 +334,15 @@ impl ProposerClient for FakeExecution {
                 let Some(address) = state.games_by_key.get(&uuid).copied() else {
                     break;
                 };
-                found = Some(TransitionGame {
+                latest = Some(TransitionGame {
                     address,
                     parent_ref: *parent_ref,
                     attempt,
                 });
             }
-            if found.is_some() {
-                return Ok(found);
-            }
+            found.extend(latest);
         }
-        Ok(None)
+        Ok(found)
     }
 
     /// The fake has no registry finality airgap: a resolved game is immediately closeable.

--- a/proofs/integration-tests/tests/orchestration.rs
+++ b/proofs/integration-tests/tests/orchestration.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use alloy_primitives::{B256, Bytes, U256};
+use alloy_primitives::{B256, Bytes};
 use async_trait::async_trait;
 use testcontainers::{ContainerAsync, runners::AsyncRunner};
 use testcontainers_modules::postgres;
@@ -27,7 +27,6 @@ use world_chain_prover_service::{
 fn proposer_config() -> ProposerConfig {
     ProposerConfig {
         block_interval: BLOCK_INTERVAL,
-        proposer_bond: U256::from(1),
         poll_interval: Duration::from_secs(1),
         max_resolutions_per_tick: 1,
     }
@@ -35,7 +34,6 @@ fn proposer_config() -> ProposerConfig {
 
 fn challenger_config() -> ChallengerConfig {
     ChallengerConfig {
-        challenger_bond: U256::from(1),
         poll_interval: Duration::from_secs(1),
         ..ChallengerConfig::default()
     }

--- a/proofs/primitives/src/bindings.rs
+++ b/proofs/primitives/src/bindings.rs
@@ -1,103 +1,142 @@
 use alloy_sol_types::sol;
 
 sol! {
+    /// Stock OP Stack `DisputeGameFactory`. WIP-1006 games are created and indexed here
+    /// alongside every other game type registered on the chain, so every index-based read
+    /// must filter on `MULTI_PROOF_GAME_TYPE`.
     #[sol(rpc)]
-    interface IWorldChainProofSystemFactory {
-        event GameCreated(
-            bytes32 indexed proposalKey,
-            bytes32 indexed rootId,
-            address indexed game,
-            address proposer,
-            bytes32 rootClaim,
-            uint256 l2BlockNumber,
-            address parentRef,
-            bytes32 l1OriginHash,
-            uint256 l1OriginNumber
-        );
+    interface IDisputeGameFactory {
+        event DisputeGameCreated(address indexed disputeProxy, uint32 indexed gameType, bytes32 indexed rootClaim);
 
-        function domain()
+        function create(uint32 gameType, bytes32 rootClaim, bytes calldata extraData)
+            external
+            payable
+            returns (address proxy);
+        function games(uint32 gameType, bytes32 rootClaim, bytes calldata extraData)
             external
             view
-            returns (
-                uint256 chainId,
-                uint256 proofSystemVersion,
-                bytes32 rollupConfigHash,
-                uint256 blockInterval
-            );
-        function domainHash() external view returns (bytes32);
-        function proposerBond() external view returns (uint256);
-        function challengerBond() external view returns (uint256);
-        function games(bytes32 proposalKey) external view returns (address);
-        function gameCount() external view returns (uint256);
-        function gameAt(uint256 index) external view returns (address);
-        function isFactoryGame(address game) external view returns (bool);
-        function propose(
-            address parentRef,
-            bytes32 rootClaim,
-            uint256 l2BlockNumber
-        ) external payable returns (address game, bytes32 rootId);
-        function computeProposalKey(
-            address parentRef,
-            bytes32 rootClaim,
-            uint256 l2BlockNumber
-        ) external view returns (bytes32);
-        function computeRootId(
-            address parentRef,
+            returns (address proxy, uint64 timestamp);
+        function gameAtIndex(uint256 index)
+            external
+            view
+            returns (uint32 gameType, uint64 timestamp, address proxy);
+        function gameCount() external view returns (uint256 gameCount);
+        function gameImpls(uint32 gameType) external view returns (address impl);
+        function initBonds(uint32 gameType) external view returns (uint256 bond);
+        function getGameUUID(uint32 gameType, bytes32 rootClaim, bytes calldata extraData)
+            external
+            pure
+            returns (bytes32 uuid);
+    }
+
+    /// WIP-1006 `MultiProofGame`: the stock `IDisputeGame` surface plus the World Chain
+    /// proof-lane extensions.
+    #[sol(rpc)]
+    interface IMultiProofGame {
+        event WorldChainGameCreated(
+            bytes32 indexed rootId,
+            address indexed parentRef,
             bytes32 rootClaim,
             uint256 l2BlockNumber,
             bytes32 l1OriginHash,
-            uint256 l1OriginNumber
-        ) external view returns (bytes32);
-    }
+            uint256 l1OriginNumber,
+            uint256 attempt,
+            address gameCreator
+        );
+        event Challenged(address indexed challenger, uint64 proofDeadline);
+        event ProofLaneSupported(uint8 indexed lane, bytes32 indexed rootId, uint8 proofBitmap);
+        event ProofThresholdReached(bytes32 indexed rootId, uint8 proofBitmap);
+        event DuplicateProofLane(uint8 indexed lane, bytes32 indexed rootId, uint8 proofBitmap);
+        event GameClosed(uint8 bondDistributionMode);
+        event Resolved(uint8 indexed status);
 
-    #[sol(rpc)]
-    interface IWorldChainProofSystemGame {
-        event Withdrawn(address indexed recipient, uint256 amount);
-
-        function rootId() external view returns (bytes32);
-        function factory() external view returns (address);
-        function proposer() external view returns (address);
-        function challenger() external view returns (address);
-        function anchorStateRegistry() external view returns (address);
+        // Deployment parameters (immutables on the implementation).
+        function PROOF_THRESHOLD() external view returns (uint8);
+        function PROOF_LANE_COUNT() external view returns (uint8);
         function domainHash() external view returns (bytes32);
+        function challengePeriod() external view returns (uint64);
+        function proofPeriod() external view returns (uint64);
+        function proposerBond() external view returns (uint256);
+        function challengerBond() external view returns (uint256);
+        function disputeGameFactory() external view returns (address);
+        function anchorStateRegistry() external view returns (address);
+        function weth() external view returns (address);
+
+        // Proposal context.
+        function rootId() external view returns (bytes32);
+        function proposalDomainHash() external view returns (bytes32);
         function attempt() external view returns (uint256);
         function parentRef() external view returns (address);
         function startingRootClaim() external view returns (bytes32);
         function startingL2BlockNumber() external view returns (uint256);
-        function rootClaim() external view returns (bytes32);
         function l2BlockNumber() external view returns (uint256);
+        function l2SequenceNumber() external view returns (uint256);
         function l1OriginHash() external view returns (bytes32);
         function l1OriginNumber() external view returns (uint256);
-        function challengeDeadline() external view returns (uint64);
-        function proofDeadline() external view returns (uint64);
-        function PROOF_THRESHOLD() external view returns (uint8);
-        function finalizedAt() external view returns (uint64);
+        function rootClaim() external view returns (bytes32);
+        function gameCreator() external view returns (address);
+        function gameType() external view returns (uint32);
+        function extraData() external view returns (bytes memory);
+        function wasRespectedGameTypeWhenCreated() external view returns (bool);
+
+        // Game progress.
+        function createdAt() external view returns (uint64);
+        function resolvedAt() external view returns (uint64);
+        function status() external view returns (uint8);
         function state() external view returns (uint8);
         function invalidationReason() external view returns (uint8);
         function proofBitmap() external view returns (uint8);
         function proofCount() external view returns (uint8);
+        function challenger() external view returns (address);
+        function challengeDeadline() external view returns (uint64);
+        function proofDeadline() external view returns (uint64);
+        function challengedAt() external view returns (uint64);
+        function finalizedAt() external view returns (uint64);
+        function invalidatedAt() external view returns (uint64);
         function resolutionStatus()
             external
             view
             returns (bool resolvable, uint8 outcome, uint8 reason);
-        function resolve() external returns (uint8 outcome, uint8 reason);
-        function closeGame() external;
-        function claimable(address recipient) external view returns (uint256);
-        function withdraw(address payable recipient) external;
+
+        // Mutating entry points.
         function challenge() external payable;
         function submitProofLane(uint8 laneId, bytes calldata proof) external;
+        function resolve() external returns (uint8 status);
+        function closeGame() external;
+        function claimCredit(address recipient) external;
+
+        // Bond settlement.
+        function bondDistributionMode() external view returns (uint8);
+        function totalBonds() external view returns (uint256);
+        function normalModeCredit(address recipient) external view returns (uint256);
+        function refundModeCredit(address recipient) external view returns (uint256);
+        function credit(address recipient) external view returns (uint256);
     }
 
+    /// Stock OP Stack `AnchorStateRegistry`.
     #[sol(rpc)]
-    interface IWorldChainAnchorStateRegistry {
-        function setAnchorState(address game) external;
+    interface IAnchorStateRegistry {
+        function getAnchorRoot() external view returns (bytes32 root, uint256 l2SequenceNumber);
+        function anchorGame() external view returns (address);
+        function disputeGameFactory() external view returns (address);
+        function respectedGameType() external view returns (uint32);
+        function isGameBlacklisted(address game) external view returns (bool);
+        function isGameRetired(address game) external view returns (bool);
+        function isGameProper(address game) external view returns (bool);
+        function isGameResolved(address game) external view returns (bool);
         function isGameFinalized(address game) external view returns (bool);
         function isGameClaimValid(address game) external view returns (bool);
-        function proofSystemFactory() external view returns (address);
+        function setAnchorState(address game) external;
         function paused() external view returns (bool);
-        function currentRootClaim() external view returns (bytes32);
-        function currentL2BlockNumber() external view returns (uint256);
-        function anchorGame() external view returns (address);
-        function blacklistedGames(address game) external view returns (bool);
+    }
+
+    /// Stock OP Stack `DelayedWETH`, the bond custody contract behind every game.
+    #[sol(rpc)]
+    interface IDelayedWETH {
+        function delay() external view returns (uint256);
+        function withdrawals(address owner, address recipient)
+            external
+            view
+            returns (uint256 amount, uint256 timestamp);
     }
 }

--- a/proofs/primitives/src/lib.rs
+++ b/proofs/primitives/src/lib.rs
@@ -9,12 +9,11 @@ mod consensus_provider;
 mod types;
 
 // re-exports
-pub use bindings::{
-    IWorldChainAnchorStateRegistry, IWorldChainProofSystemFactory, IWorldChainProofSystemGame,
-};
+pub use bindings::{IAnchorStateRegistry, IDelayedWETH, IDisputeGameFactory, IMultiProofGame};
 pub use consensus_provider::{ConsensusError, ConsensusProvider, OptimismConsensusClient};
 pub use types::{
-    GameCreated, InvalidationReason, InvalidationReasonError, PROOF_LANE_COUNT,
+    InvalidationReason, InvalidationReasonError, MULTI_PROOF_GAME_TYPE, PROOF_LANE_COUNT,
     PROOF_SYSTEM_VERSION, PROOF_THRESHOLD, ProofDomain, ProofLane, ProposalCommitment,
-    ResolutionStatus, RootCommitment, RootState, RootStateError, has_threshold, proof_count,
+    ResolutionStatus, RootCommitment, RootState, RootStateError, WorldChainGameCreated,
+    has_threshold, proof_count,
 };

--- a/proofs/primitives/src/types.rs
+++ b/proofs/primitives/src/types.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{Address, B256, BlockNumber, U256, keccak256};
+use alloy_primitives::{Address, B256, BlockNumber, Bytes, U256, keccak256};
 use alloy_sol_types::SolValue;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -12,18 +12,24 @@ pub const PROOF_LANE_COUNT: u8 = 3;
 /// Version of the World Chain proof-domain encoding implemented here.
 pub const PROOF_SYSTEM_VERSION: u64 = 1;
 
-/// The `GameCreated` event.
+/// OP Stack dispute-game type allocated to WIP-1006 (`GameTypes.MULTI_PROOF_GAME_TYPE`).
+///
+/// The stock `DisputeGameFactory` indexes every game type in one array, so every
+/// index-based read must filter on this value.
+pub const MULTI_PROOF_GAME_TYPE: u32 = 1006;
+
+/// The `MultiProofGame.WorldChainGameCreated` event.
 #[derive(Debug, Clone, Copy)]
-pub struct GameCreated {
-    pub proposal_key: B256,
+pub struct WorldChainGameCreated {
     pub root_id: B256,
     pub game: Address,
-    pub proposer: Address,
+    pub game_creator: Address,
     pub root_claim: B256,
     pub l2_block_number: BlockNumber,
     pub parent_ref: Address,
     pub l1_origin_hash: B256,
     pub l1_origin_number: BlockNumber,
+    pub attempt: u64,
 }
 
 /// A game root state.
@@ -80,7 +86,7 @@ impl ProofDomain {
             self.rollup_config_hash,
             U256::from(self.block_interval),
         )
-            .abi_encode();
+            .abi_encode_params();
         keccak256(encoded)
     }
 }
@@ -94,19 +100,40 @@ pub struct ProposalCommitment {
     pub root_claim: B256,
     /// L2 block number for `root_claim`.
     pub l2_block_number: u64,
+    /// Retry nonce for this transition. Attempt N is only proposable once attempt N-1
+    /// has been invalidated by a proof timeout.
+    pub attempt: u64,
 }
 
 impl ProposalCommitment {
-    /// Compute the Solidity-compatible proposal key used for factory lookups.
+    /// ABI-encodes the CWIA payload `MultiProofGame` reads from its clone arguments.
+    ///
+    /// Must match `abi.encode(domainHash, l2BlockNumber, parentRef, attempt)` as consumed by
+    /// `MultiProofGame`'s CWIA getters.
     #[must_use]
-    pub fn proposal_key(self, domain_hash: B256) -> B256 {
-        let encoded = (
+    pub fn extra_data(self, domain_hash: B256) -> Bytes {
+        (
             domain_hash,
-            self.parent_ref,
-            self.root_claim,
             U256::from(self.l2_block_number),
+            self.parent_ref,
+            U256::from(self.attempt),
         )
-            .abi_encode();
+            .abi_encode_params()
+            .into()
+    }
+
+    /// Computes the `DisputeGameFactory` UUID that identifies this proposal's game.
+    ///
+    /// Mirrors `DisputeGameFactory.getGameUUID`, so the proposer can look a game up without
+    /// an extra round trip.
+    #[must_use]
+    pub fn game_uuid(self, domain_hash: B256) -> B256 {
+        let encoded = (
+            MULTI_PROOF_GAME_TYPE,
+            self.root_claim,
+            self.extra_data(domain_hash),
+        )
+            .abi_encode_params();
         keccak256(encoded)
     }
 }
@@ -123,10 +150,10 @@ pub struct RootCommitment {
 }
 
 impl RootCommitment {
-    /// Compute the Solidity-compatible proposal key used for factory lookups.
+    /// Compute the `DisputeGameFactory` UUID for this proposal.
     #[must_use]
-    pub fn proposal_key(self, domain_hash: B256) -> B256 {
-        self.proposal.proposal_key(domain_hash)
+    pub fn game_uuid(self, domain_hash: B256) -> B256 {
+        self.proposal.game_uuid(domain_hash)
     }
 
     /// Compute the Solidity-compatible root id for this proposal.
@@ -140,7 +167,7 @@ impl RootCommitment {
             self.l1_origin_hash,
             U256::from(self.l1_origin_number),
         )
-            .abi_encode();
+            .abi_encode_params();
         keccak256(encoded)
     }
 }
@@ -242,7 +269,7 @@ impl ResolutionStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::{address, b256};
+    use alloy_primitives::{address, b256, hex};
 
     #[test]
     fn lane_bitmap_counts_distinct_lanes() {
@@ -267,6 +294,7 @@ mod tests {
             parent_ref: address!("0000000000000000000000000000000000001006"),
             root_claim: b256!("2222222222222222222222222222222222222222222222222222222222222222"),
             l2_block_number: 10,
+            attempt: 0,
         };
         let commitment = RootCommitment {
             proposal,
@@ -276,13 +304,62 @@ mod tests {
             l1_origin_number: 1,
         };
 
+        // Reference values from `cast abi-encode` / `cast keccak`, pinning these encodings to
+        // `ProofLib.domainHash` and `ProofLib.rootId`.
+        assert_eq!(
+            domain.hash(),
+            b256!("2eadd7e0cde9ca6f758216655e263e8d197480ebc4d3478403000447fe62f4be")
+        );
         let root_id = commitment.root_id(domain.hash());
-        assert_ne!(B256::ZERO, proposal.proposal_key(domain.hash()));
+        assert_eq!(
+            root_id,
+            b256!("6cccba67d43368ae81da6cf22798e228b82b953c51c1bbce76959b166b888dd3")
+        );
+
+        assert_ne!(B256::ZERO, proposal.game_uuid(domain.hash()));
         let changed = ProofDomain {
             chain_id: 4802,
             ..domain
         };
 
         assert_ne!(root_id, commitment.root_id(changed.hash()));
+    }
+
+    #[test]
+    fn game_uuid_matches_dispute_game_factory_encoding() {
+        let domain_hash = b256!("1111111111111111111111111111111111111111111111111111111111111111");
+        let proposal = ProposalCommitment {
+            parent_ref: address!("0000000000000000000000000000000000001006"),
+            root_claim: b256!("2222222222222222222222222222222222222222222222222222222222222222"),
+            l2_block_number: 100,
+            attempt: 0,
+        };
+
+        // Reference values from `cast abi-encode` / `cast keccak`, pinning this encoding to the
+        // CWIA payload `MultiProofGame` reads at offsets 0x54/0x74/0x94/0xB4 and to
+        // `DisputeGameFactory.getGameUUID(GameType,Claim,bytes)`.
+        assert_eq!(
+            proposal.extra_data(domain_hash),
+            Bytes::from_static(&hex!(
+                "1111111111111111111111111111111111111111111111111111111111111111"
+                "0000000000000000000000000000000000000000000000000000000000000064"
+                "0000000000000000000000000000000000000000000000000000000000001006"
+                "0000000000000000000000000000000000000000000000000000000000000000"
+            ))
+        );
+        assert_eq!(
+            proposal.game_uuid(domain_hash),
+            b256!("97c09945ea02810652360265a6c8f070ce4d6fb10651f7f76126130d6209ee33")
+        );
+
+        // Retries occupy a distinct factory UUID.
+        let retry = ProposalCommitment {
+            attempt: 1,
+            ..proposal
+        };
+        assert_ne!(
+            proposal.game_uuid(domain_hash),
+            retry.game_uuid(domain_hash)
+        );
     }
 }

--- a/proofs/primitives/src/types.rs
+++ b/proofs/primitives/src/types.rs
@@ -33,7 +33,7 @@ pub struct WorldChainGameCreated {
 }
 
 /// A game root state.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RootState {
     None,
     Proposed,
@@ -212,7 +212,7 @@ pub const fn has_threshold(bitmap: u8) -> bool {
     proof_count(bitmap) >= PROOF_THRESHOLD
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InvalidationReason {
     None,
     ProofTimeout,
@@ -240,7 +240,7 @@ impl TryFrom<u8> for InvalidationReason {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ResolutionStatus {
     pub resolvable: bool,
     pub root_state: RootState,

--- a/proofs/proposer/README.md
+++ b/proofs/proposer/README.md
@@ -8,23 +8,34 @@ Periodically post L2 output root to L1.
 
 ## How
 
-Propose a new L2 output root by creating a new `WorldChainProofSystemGame` contract through the `WorldChainProofSystemFactory.propose(..)` contract fn.
+Propose a new L2 output root by creating a WIP-1006 `MultiProofGame` clone through the stock OP
+Stack `DisputeGameFactory.create(gameType, rootClaim, extraData)`.
 
 ## Items needed to propose a new L2 output root
 
-- `parent_ref`: address of the parent game, or the `WorldChainAnchorStateRegistry` contract address if there is no parent game.
+- `parent_ref`: address of the parent game, or the `AnchorStateRegistry` contract address when the
+  proposal extends the current anchor.
 - `root_claim`: OP stack output root.
 - `l2_block_number`: L2 block number for the root claim.
+- `attempt`: retry nonce, non-zero only when replacing a game invalidated by a proof timeout.
+
+These four fields determine the factory call: `extraData = abi.encode(domainHash, l2BlockNumber,
+parentRef, attempt)` and the game's factory UUID is
+`keccak256(abi.encode(gameType, rootClaim, extraData))`.
 
 ## How to get these items
 
-### `Parent_ref`
+### `parent_ref`
 
-- start with `parent_ref` equal to `WorldChainAnchorStateRegistry`
-- compute L2 output root for block equal to `parent_ref`'s `l2_block_number` + `BLOCK_INTERVAL` (a protocol constant that we don't currently have, therefore we need to add it)
-- compute the proposal key from `domain_hash`, `parent_ref`, `root_claim`, and `l2_block_number`
-- check whether the game already exists
-- if so, this game becomes the `parent_ref` and we continue this loop
+- start with `parent_ref` equal to the `AnchorStateRegistry` address. Once the anchor advances onto
+  a game, that game is no longer a valid parent — `MultiProofGame.initialize` rejects a parent at or
+  below the anchor — so new proposals extending the anchor always point at the registry.
+- compute L2 output root for block equal to `parent_ref`'s `l2_block_number` + `BLOCK_INTERVAL`
+- look the game up with `DisputeGameFactory.games(gameType, rootClaim, extraData)`, walking
+  `attempt` upward until the first gap. At the anchor tip both the registry and the current anchor
+  game are candidate parents, because a game created before the anchor advanced still references
+  the anchor game.
+- if a game exists, it becomes the `parent_ref` and we continue this loop
 - if it doesn't exist - i.e. the address is `0x00..00`, then the current `parent_ref` is returned
 
 ### `root_claim`
@@ -34,3 +45,11 @@ Propose a new L2 output root by creating a new `WorldChainProofSystemGame` contr
 ### `l2_block_number`
 
 - `parent_ref`'s `l2_block_number` field + `BLOCK_INTERVAL`
+
+## Bond settlement
+
+Bonds are custodied in `DelayedWETH` and paid out in two phases. The first `claimCredit(recipient)`
+call unlocks the credit; the second, after the WETH delay, withdraws and transfers it. Both are
+gated on `AnchorStateRegistry.isGameFinalized`, since `claimCredit` calls `closeGame`, which reverts
+until the registry's finality airgap has elapsed. The bond manager keeps a game tracked until its
+pending withdrawal is drained.

--- a/proofs/proposer/src/alloy.rs
+++ b/proofs/proposer/src/alloy.rs
@@ -320,14 +320,15 @@ where
         })
     }
 
-    async fn latest_game_for_transition(
+    async fn games_for_transition(
         &self,
         parent_candidates: &[Address],
         root_claim: B256,
         l2_block_number: u64,
-    ) -> Result<Option<TransitionGame>, ProposerError> {
+    ) -> Result<Vec<TransitionGame>, ProposerError> {
+        let mut found = Vec::with_capacity(parent_candidates.len());
         for parent_ref in parent_candidates {
-            let mut found: Option<TransitionGame> = None;
+            let mut latest: Option<TransitionGame> = None;
             // Attempts are strictly sequential: attempt N can only be created once attempt N-1
             // exists, so the walk stops at the first gap.
             for attempt in 0..MAX_ATTEMPT_SCAN {
@@ -350,17 +351,15 @@ where
                 if entry.proxy == Address::ZERO {
                     break;
                 }
-                found = Some(TransitionGame {
+                latest = Some(TransitionGame {
                     address: entry.proxy,
                     parent_ref: *parent_ref,
                     attempt,
                 });
             }
-            if found.is_some() {
-                return Ok(found);
-            }
+            found.extend(latest);
         }
-        Ok(None)
+        Ok(found)
     }
 
     async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError> {

--- a/proofs/proposer/src/alloy.rs
+++ b/proofs/proposer/src/alloy.rs
@@ -3,21 +3,35 @@ use alloy_primitives::{Address, B256, BlockHash, U256};
 use alloy_provider::{Provider, WalletProvider};
 use async_trait::async_trait;
 use world_chain_proofs::{
-    IWorldChainAnchorStateRegistry, IWorldChainProofSystemFactory, IWorldChainProofSystemGame,
-    InvalidationReasonError, ProposalCommitment, ResolutionStatus, RootStateError,
+    IAnchorStateRegistry, IDelayedWETH, IDisputeGameFactory, IMultiProofGame,
+    InvalidationReasonError, MULTI_PROOF_GAME_TYPE, ResolutionStatus, RootStateError,
 };
 use world_chain_prover_service::ProofData;
 
 use crate::{
-    BondManagerClient, ParentRef, Proposal, ProposalSubmission, ProposerClient, ProposerError,
-    types::{CloseGameSubmission, ResolveSubmission, WithdrawSubmission},
+    AnchorRef, BondManagerClient, Proposal, ProposalSubmission, ProposerClient, ProposerError,
+    types::{
+        ClaimSubmission, CloseGameSubmission, PendingWithdrawal, ResolveSubmission, TransitionGame,
+    },
 };
 
-/// Alloy-backed implementation of [`ProofSystemClient`].
+/// Highest retry nonce probed when locating the live game for a transition.
+///
+/// Bounds the attempt walk so a corrupt or adversarial factory state cannot turn a single
+/// canonical-line hop into an unbounded RPC loop.
+const MAX_ATTEMPT_SCAN: u64 = 64;
+
+/// Alloy-backed implementation of the proposer contract clients.
+///
+/// Binds the stock OP Stack `DisputeGameFactory` and `AnchorStateRegistry`; WIP-1006 games are
+/// one game type among several on that factory, so every index-based read filters on
+/// [`MULTI_PROOF_GAME_TYPE`].
 #[derive(Debug, Clone)]
 pub struct AlloyProofSystemClient<P> {
-    factory: IWorldChainProofSystemFactory::IWorldChainProofSystemFactoryInstance<P>,
-    anchor: IWorldChainAnchorStateRegistry::IWorldChainAnchorStateRegistryInstance<P>,
+    factory: IDisputeGameFactory::IDisputeGameFactoryInstance<P>,
+    anchor: IAnchorStateRegistry::IAnchorStateRegistryInstance<P>,
+    /// Domain hash of the registered game implementation, read once at construction.
+    domain_hash: B256,
     provider: P,
 }
 
@@ -25,22 +39,201 @@ impl<P> AlloyProofSystemClient<P>
 where
     P: Provider + Clone,
 {
-    /// Creates a new Alloy-backed contract client.
-    pub fn new(provider: P, factory_address: Address, anchor_address: Address) -> Self {
-        let factory = IWorldChainProofSystemFactory::IWorldChainProofSystemFactoryInstance::new(
+    /// Connects to the deployed proof system and reads the registered implementation's domain.
+    ///
+    /// Fails fast when the WIP-1006 game type has no implementation registered — either the
+    /// factory address is wrong or the kill switch has cleared the implementation, and in both
+    /// cases no proposal can succeed.
+    pub async fn new(
+        provider: P,
+        factory_address: Address,
+        anchor_address: Address,
+    ) -> Result<Self, ProposerError> {
+        let factory = IDisputeGameFactory::IDisputeGameFactoryInstance::new(
             factory_address,
             provider.clone(),
         );
-        let anchor = IWorldChainAnchorStateRegistry::IWorldChainAnchorStateRegistryInstance::new(
+        let anchor = IAnchorStateRegistry::IAnchorStateRegistryInstance::new(
             anchor_address,
             provider.clone(),
         );
 
-        Self {
+        let game_impl = factory
+            .gameImpls(MULTI_PROOF_GAME_TYPE)
+            .call()
+            .await
+            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+        if game_impl == Address::ZERO {
+            return Err(ProposerError::Contract(format!(
+                "dispute-game factory {factory_address} has no implementation for game type {MULTI_PROOF_GAME_TYPE}"
+            )));
+        }
+        let domain_hash =
+            IMultiProofGame::IMultiProofGameInstance::new(game_impl, provider.clone())
+                .domainHash()
+                .call()
+                .await
+                .map_err(|error| ProposerError::Contract(error.to_string()))?;
+
+        Ok(Self {
             factory,
             anchor,
+            domain_hash,
             provider,
+        })
+    }
+
+    /// Returns the domain hash of the registered game implementation.
+    #[must_use]
+    pub const fn domain_hash(&self) -> B256 {
+        self.domain_hash
+    }
+
+    fn game(&self, address: Address) -> IMultiProofGame::IMultiProofGameInstance<P> {
+        IMultiProofGame::IMultiProofGameInstance::new(address, self.provider.clone())
+    }
+
+    /// Resolves the WIP-1006 game at a factory index, skipping other game types.
+    async fn wip_1006_game_at(&self, index: u64) -> Result<Option<Address>, ProposerError> {
+        let entry = self
+            .factory
+            .gameAtIndex(U256::from(index))
+            .call()
+            .await
+            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+
+        Ok((entry.gameType == MULTI_PROOF_GAME_TYPE).then_some(entry.proxy))
+    }
+
+    async fn read_resolution_status(
+        &self,
+        game: Address,
+    ) -> Result<ResolutionStatus, ProposerError> {
+        let result = self
+            .game(game)
+            .resolutionStatus()
+            .call()
+            .await
+            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+        let root_state = result
+            .outcome
+            .try_into()
+            .map_err(|error: RootStateError| ProposerError::Contract(error.to_string()))?;
+        let invalidation_reason = result
+            .reason
+            .try_into()
+            .map_err(|error: InvalidationReasonError| ProposerError::Contract(error.to_string()))?;
+
+        Ok(ResolutionStatus {
+            resolvable: result.resolvable,
+            root_state,
+            invalidation_reason,
+        })
+    }
+
+    async fn read_is_game_finalized(&self, game: Address) -> Result<bool, ProposerError> {
+        self.anchor
+            .isGameFinalized(game)
+            .call()
+            .await
+            .map_err(|error| ProposerError::Contract(error.to_string()))
+    }
+
+    /// Reads the credit `recipient` can unlock from `game`.
+    async fn read_credit(&self, game: Address, recipient: Address) -> Result<U256, ProposerError> {
+        self.game(game)
+            .credit(recipient)
+            .call()
+            .await
+            .map_err(|error| ProposerError::Contract(error.to_string()))
+    }
+
+    /// Reads `recipient`'s pending `DelayedWETH` withdrawal for `game`.
+    async fn read_pending_withdrawal(
+        &self,
+        game: Address,
+        recipient: Address,
+    ) -> Result<PendingWithdrawal, ProposerError> {
+        let weth_address = self
+            .game(game)
+            .weth()
+            .call()
+            .await
+            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+        let weth = IDelayedWETH::IDelayedWETHInstance::new(weth_address, self.provider.clone());
+
+        let (pending, delay) = tokio::try_join!(
+            async {
+                weth.withdrawals(game, recipient)
+                    .call()
+                    .await
+                    .map_err(|error| ProposerError::Contract(error.to_string()))
+            },
+            async {
+                weth.delay()
+                    .call()
+                    .await
+                    .map_err(|error| ProposerError::Contract(error.to_string()))
+            }
+        )?;
+
+        if pending.amount.is_zero() {
+            return Ok(PendingWithdrawal::default());
         }
+        let unlock_at = pending
+            .timestamp
+            .checked_add(delay)
+            .ok_or_else(|| ProposerError::Contract("DelayedWETH unlock time overflows".into()))?;
+
+        Ok(PendingWithdrawal {
+            amount: pending.amount,
+            unlock_at: u256_to_u64(unlock_at, "DelayedWETH unlock time")?,
+        })
+    }
+
+    /// Sends `claimCredit(recipient)` and reports which phase of the two-phase flow ran.
+    async fn send_claim_credit(
+        &self,
+        game: Address,
+        recipient: Address,
+    ) -> Result<ClaimSubmission, ProposerError> {
+        // Read both phases up front so the submission can report what the call moved; the
+        // receipt carries no amount of its own.
+        let credit = self.read_credit(game, recipient).await?;
+        let pending = if credit.is_zero() {
+            self.read_pending_withdrawal(game, recipient).await?
+        } else {
+            PendingWithdrawal::default()
+        };
+
+        let pending_tx = self
+            .game(game)
+            .claimCredit(recipient)
+            .send()
+            .await
+            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+        let tx_hash = *pending_tx.tx_hash();
+        let receipt = pending_tx
+            .get_receipt()
+            .await
+            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+        if !receipt.status() {
+            return Err(ProposerError::Revert(tx_hash));
+        }
+
+        Ok(if credit.is_zero() {
+            ClaimSubmission {
+                tx_hash,
+                amount: pending.amount,
+                withdrawn: true,
+            }
+        } else {
+            ClaimSubmission {
+                tx_hash,
+                amount: credit,
+                withdrawn: false,
+            }
+        })
     }
 }
 
@@ -63,35 +256,37 @@ where
         u256_to_u64(count, "gameCount")
     }
 
-    async fn game_at(&self, index: u64) -> Result<Address, ProposerError> {
-        self.factory
-            .gameAt(U256::from(index))
+    async fn game_at(&self, index: u64) -> Result<Option<Address>, ProposerError> {
+        self.wip_1006_game_at(index).await
+    }
+
+    async fn game_creator(&self, game: Address) -> Result<Address, ProposerError> {
+        self.game(game)
+            .gameCreator()
             .call()
             .await
             .map_err(|error| ProposerError::Contract(error.to_string()))
     }
 
-    async fn game_proposer(&self, game: Address) -> Result<Address, ProposerError> {
-        IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance::new(
-            game,
-            self.provider.clone(),
-        )
-        .proposer()
-        .call()
-        .await
-        .map_err(|error| ProposerError::Contract(error.to_string()))
-    }
-
     async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError> {
-        ProposerClient::resolution_status(self, game).await
+        self.read_resolution_status(game).await
     }
 
-    async fn claimable(&self, game: Address) -> Result<U256, ProposerError> {
-        ProposerClient::claimable(self, game).await
+    async fn is_game_finalized(&self, game: Address) -> Result<bool, ProposerError> {
+        self.read_is_game_finalized(game).await
     }
 
-    async fn withdraw(&self, game: Address) -> Result<WithdrawSubmission, ProposerError> {
-        ProposerClient::withdraw(self, game).await
+    async fn credit(&self, game: Address) -> Result<U256, ProposerError> {
+        self.read_credit(game, self.proposer_address()).await
+    }
+
+    async fn pending_withdrawal(&self, game: Address) -> Result<PendingWithdrawal, ProposerError> {
+        self.read_pending_withdrawal(game, self.proposer_address())
+            .await
+    }
+
+    async fn claim_credit(&self, game: Address) -> Result<ClaimSubmission, ProposerError> {
+        self.send_claim_credit(game, self.proposer_address()).await
     }
 }
 
@@ -100,85 +295,81 @@ impl<P> ProposerClient for AlloyProofSystemClient<P>
 where
     P: Provider + WalletProvider + Clone + Send + Sync + 'static,
 {
-    async fn anchor_parent(&self) -> Result<ParentRef, ProposerError> {
-        let l2_block_number = self
-            .anchor
-            .currentL2BlockNumber()
-            .call()
-            .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))?;
-        let anchor_game = self
-            .anchor
-            .anchorGame()
-            .call()
-            .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+    async fn anchor_parent(&self) -> Result<AnchorRef, ProposerError> {
+        let (anchor_root, anchor_game) = tokio::try_join!(
+            async {
+                self.anchor
+                    .getAnchorRoot()
+                    .call()
+                    .await
+                    .map_err(|error| ProposerError::Contract(error.to_string()))
+            },
+            async {
+                self.anchor
+                    .anchorGame()
+                    .call()
+                    .await
+                    .map_err(|error| ProposerError::Contract(error.to_string()))
+            }
+        )?;
 
-        Ok(ParentRef {
-            address: anchor_parent_address(*self.anchor.address(), anchor_game),
-            l2_block_number: u256_to_u64(l2_block_number, "currentL2BlockNumber")?,
+        Ok(AnchorRef {
+            registry: *self.anchor.address(),
+            anchor_game: (anchor_game != Address::ZERO).then_some(anchor_game),
+            l2_block_number: u256_to_u64(anchor_root.l2SequenceNumber, "getAnchorRoot")?,
         })
     }
 
-    async fn proposal_key(&self, commitment: ProposalCommitment) -> Result<B256, ProposerError> {
-        self.factory
-            .computeProposalKey(
-                commitment.parent_ref,
-                commitment.root_claim,
-                U256::from(commitment.l2_block_number),
-            )
-            .call()
-            .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))
-    }
-
-    async fn game_for_proposal_key(
+    async fn latest_game_for_transition(
         &self,
-        proposal_key: B256,
-    ) -> Result<Option<Address>, ProposerError> {
-        let game = self
-            .factory
-            .games(proposal_key)
-            .call()
-            .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))?;
-
-        Ok((game != Address::ZERO).then_some(game))
+        parent_candidates: &[Address],
+        root_claim: B256,
+        l2_block_number: u64,
+    ) -> Result<Option<TransitionGame>, ProposerError> {
+        for parent_ref in parent_candidates {
+            let mut found: Option<TransitionGame> = None;
+            // Attempts are strictly sequential: attempt N can only be created once attempt N-1
+            // exists, so the walk stops at the first gap.
+            for attempt in 0..MAX_ATTEMPT_SCAN {
+                let commitment = world_chain_proofs::ProposalCommitment {
+                    parent_ref: *parent_ref,
+                    root_claim,
+                    l2_block_number,
+                    attempt,
+                };
+                let entry = self
+                    .factory
+                    .games(
+                        MULTI_PROOF_GAME_TYPE,
+                        root_claim,
+                        commitment.extra_data(self.domain_hash),
+                    )
+                    .call()
+                    .await
+                    .map_err(|error| ProposerError::Contract(error.to_string()))?;
+                if entry.proxy == Address::ZERO {
+                    break;
+                }
+                found = Some(TransitionGame {
+                    address: entry.proxy,
+                    parent_ref: *parent_ref,
+                    attempt,
+                });
+            }
+            if found.is_some() {
+                return Ok(found);
+            }
+        }
+        Ok(None)
     }
 
     async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError> {
-        let game = IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance::new(
-            game,
-            self.provider.clone(),
-        );
-        let resolution_status_result = game
-            .resolutionStatus()
-            .call()
-            .await
-            .map_err(|err| ProposerError::Contract(err.to_string()))?;
-        let resolvable = resolution_status_result.resolvable;
-        let root_state = resolution_status_result
-            .outcome
-            .try_into()
-            .map_err(|err: RootStateError| ProposerError::Contract(err.to_string()))?;
-        let invalidation_reason = resolution_status_result
-            .reason
-            .try_into()
-            .map_err(|err: InvalidationReasonError| ProposerError::Contract(err.to_string()))?;
-        let resolution_status = ResolutionStatus {
-            resolvable,
-            root_state,
-            invalidation_reason,
-        };
-        Ok(resolution_status)
+        self.read_resolution_status(game).await
     }
 
     async fn resolve_game(&self, game: Address) -> Result<ResolveSubmission, ProposerError> {
-        let game = IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance::new(
-            game,
-            self.provider.clone(),
-        );
-        let pending = game
+        let pending = self
+            .game(game)
             .resolve()
             .send()
             .await
@@ -196,12 +387,13 @@ where
         Ok(ResolveSubmission { tx_hash })
     }
 
+    async fn is_game_finalized(&self, game: Address) -> Result<bool, ProposerError> {
+        self.read_is_game_finalized(game).await
+    }
+
     async fn close_game(&self, game: Address) -> Result<CloseGameSubmission, ProposerError> {
-        let game = IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance::new(
-            game,
-            self.provider.clone(),
-        );
-        let pending = game
+        let pending = self
+            .game(game)
             .closeGame()
             .send()
             .await
@@ -219,73 +411,6 @@ where
         Ok(CloseGameSubmission { tx_hash })
     }
 
-    async fn claimable(&self, game: Address) -> Result<U256, ProposerError> {
-        let game = IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance::new(
-            game,
-            self.provider.clone(),
-        );
-        let proposer_address = self.provider.default_signer_address();
-        let amount = game
-            .claimable(proposer_address)
-            .call()
-            .await
-            .map_err(|err| ProposerError::Contract(err.to_string()))?;
-
-        Ok(amount)
-    }
-
-    async fn withdraw(&self, game: Address) -> Result<WithdrawSubmission, ProposerError> {
-        let game = IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance::new(
-            game,
-            self.provider.clone(),
-        );
-        let proposer_address = self.provider.default_signer_address();
-        let pending = game
-            .withdraw(proposer_address)
-            .send()
-            .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))?;
-
-        let tx_hash = *pending.tx_hash();
-        let receipt = pending
-            .get_receipt()
-            .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))?;
-        if !receipt.status() {
-            return Err(ProposerError::Revert(tx_hash));
-        }
-
-        let amount = receipt
-            .logs()
-            .iter()
-            .filter(|log| log.address() == *game.address())
-            .find_map(|log| {
-                log.log_decode_validate::<IWorldChainProofSystemGame::Withdrawn>()
-                    .ok()
-                    .map(|decoded| decoded.inner.data)
-            })
-            .filter(|event| event.recipient == proposer_address)
-            .map(|event| event.amount)
-            .ok_or_else(|| {
-                ProposerError::Contract(format!(
-                    "Withdrawn event missing from withdraw transaction {tx_hash}"
-                ))
-            })?;
-
-        Ok(WithdrawSubmission { tx_hash, amount })
-    }
-
-    async fn proposer_bond(&self) -> Result<U256, ProposerError> {
-        let proposer_bond = self
-            .factory
-            .proposerBond()
-            .call()
-            .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))?;
-
-        Ok(proposer_bond)
-    }
-
     async fn latest_finalized_l1_block(&self) -> Result<BlockHash, ProposerError> {
         let block = self
             .provider
@@ -301,16 +426,21 @@ where
         &self,
         proposal: &Proposal,
         _proof: ProofData,
-        proposer_bond: U256,
     ) -> Result<ProposalSubmission, ProposerError> {
+        // `DisputeGameFactory.create` reverts unless `msg.value` matches the configured init
+        // bond exactly, so it is read per submission rather than cached in configuration.
+        let init_bond = self
+            .factory
+            .initBonds(MULTI_PROOF_GAME_TYPE)
+            .call()
+            .await
+            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+
+        let extra_data = proposal.commitment().extra_data(self.domain_hash);
         let pending = self
             .factory
-            .propose(
-                proposal.parent_ref,
-                proposal.root_claim,
-                U256::from(proposal.l2_block_number),
-            )
-            .value(proposer_bond)
+            .create(MULTI_PROOF_GAME_TYPE, proposal.root_claim, extra_data)
+            .value(init_bond)
             .send()
             .await
             .map_err(|error| ProposerError::Contract(error.to_string()))?;
@@ -329,15 +459,17 @@ where
             .iter()
             .filter(|log| log.address() == *self.factory.address())
             .find_map(|log| {
-                log.log_decode_validate::<IWorldChainProofSystemFactory::GameCreated>()
+                log.log_decode_validate::<IDisputeGameFactory::DisputeGameCreated>()
                     .ok()
                     .map(|decoded| decoded.inner.data)
             })
-            .filter(|event| event.proposalKey == proposal.proposal_key)
-            .map(|event| event.game)
+            .filter(|event| {
+                event.gameType == MULTI_PROOF_GAME_TYPE && event.rootClaim == proposal.root_claim
+            })
+            .map(|event| event.disputeProxy)
             .ok_or_else(|| {
                 ProposerError::Contract(format!(
-                    "GameCreated event missing from proposal transaction {tx_hash}"
+                    "DisputeGameCreated event missing from proposal transaction {tx_hash}"
                 ))
             })?;
 
@@ -354,11 +486,8 @@ where
 {
     /// Reads an L2 block number from a game contract.
     pub async fn game_l2_block_number(&self, game: Address) -> Result<u64, ProposerError> {
-        let game = IWorldChainProofSystemGame::IWorldChainProofSystemGameInstance::new(
-            game,
-            self.provider.clone(),
-        );
-        let l2_block_number = game
+        let l2_block_number = self
+            .game(game)
             .l2BlockNumber()
             .call()
             .await
@@ -372,32 +501,4 @@ fn u256_to_u64(value: U256, field: &'static str) -> Result<u64, ProposerError> {
     value
         .try_into()
         .map_err(|_| ProposerError::Contract(format!("{field} overflows u64")))
-}
-
-fn anchor_parent_address(anchor_address: Address, anchor_game: Address) -> Address {
-    if anchor_game == Address::ZERO {
-        anchor_address
-    } else {
-        anchor_game
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use alloy_primitives::{Address, address};
-
-    use super::anchor_parent_address;
-
-    const ANCHOR: Address = address!("0000000000000000000000000000000000001006");
-    const GAME: Address = address!("0000000000000000000000000000000000000001");
-
-    #[test]
-    fn anchor_parent_address_uses_registry_before_first_game() {
-        assert_eq!(anchor_parent_address(ANCHOR, Address::ZERO), ANCHOR);
-    }
-
-    #[test]
-    fn anchor_parent_address_uses_anchor_game_after_registry_advances() {
-        assert_eq!(anchor_parent_address(ANCHOR, GAME), GAME);
-    }
 }

--- a/proofs/proposer/src/bond_manager.rs
+++ b/proofs/proposer/src/bond_manager.rs
@@ -1,4 +1,7 @@
-use std::collections::HashSet;
+use std::{
+    collections::HashSet,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use alloy_primitives::{Address, U256};
 use tracing::{info, warn};
@@ -63,8 +66,11 @@ where
         let proposer = self.execution_provider.proposer_address();
 
         for index in start..game_count {
-            let game = self.execution_provider.game_at(index).await?;
-            if self.execution_provider.game_proposer(game).await? == proposer {
+            // The dispute-game factory indexes every game type; skip the ones that are not ours.
+            let Some(game) = self.execution_provider.game_at(index).await? else {
+                continue;
+            };
+            if self.execution_provider.game_creator(game).await? == proposer {
                 self.proposed_games.insert(game);
             }
         }
@@ -79,9 +85,14 @@ where
         Ok(())
     }
 
-    /// Withdraws available credits and prunes games that have reached a terminal state.
+    /// Advances the two-phase bond claim on tracked games and prunes fully settled ones.
+    ///
+    /// `MultiProofGame.claimCredit` first unlocks the credit in `DelayedWETH` and only
+    /// transfers it on a second call after the WETH delay, so a game stays tracked until its
+    /// pending withdrawal is drained. Dropping it after the unlock would strand the bond.
     pub async fn withdraw_credits(&mut self) -> Result<(), ProposerError> {
         let proposed_games: Vec<_> = self.proposed_games.iter().copied().collect();
+        let now = unix_now();
 
         for game in proposed_games {
             let result: Result<bool, ProposerError> = async {
@@ -89,18 +100,41 @@ where
                 if !resolution_status.is_resolved() {
                     return Ok(false);
                 }
-
-                let claimable_amount = self.execution_provider.claimable(game).await?;
-                if claimable_amount > U256::ZERO {
-                    let withdraw_submission = self.execution_provider.withdraw(game).await?;
-                    info!(
-                        tx_hash = ?withdraw_submission.tx_hash,
-                        amount = ?withdraw_submission.amount,
-                        game_address = %game,
-                        "withdrew claimable credits"
-                    );
+                // `claimCredit` calls `closeGame`, which reverts until the registry's finality
+                // airgap has elapsed.
+                if !self.execution_provider.is_game_finalized(game).await? {
+                    return Ok(false);
                 }
 
+                let credit = self.execution_provider.credit(game).await?;
+                if credit > U256::ZERO {
+                    let submission = self.execution_provider.claim_credit(game).await?;
+                    info!(
+                        tx_hash = ?submission.tx_hash,
+                        amount = ?submission.amount,
+                        game_address = %game,
+                        "unlocked proposer bond credits in DelayedWETH"
+                    );
+                    // Keep tracking: the unlocked amount still needs the second claim.
+                    return Ok(false);
+                }
+
+                let pending = self.execution_provider.pending_withdrawal(game).await?;
+                if pending.amount.is_zero() {
+                    // Nothing owed on this game; stop tracking it.
+                    return Ok(true);
+                }
+                if now < pending.unlock_at {
+                    return Ok(false);
+                }
+
+                let submission = self.execution_provider.claim_credit(game).await?;
+                info!(
+                    tx_hash = ?submission.tx_hash,
+                    amount = ?submission.amount,
+                    game_address = %game,
+                    "withdrew proposer bond credits"
+                );
                 Ok(true)
             }
             .await;
@@ -139,4 +173,11 @@ where
             }
         }
     }
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time before unix epoch")
+        .as_secs()
 }

--- a/proofs/proposer/src/config.rs
+++ b/proofs/proposer/src/config.rs
@@ -1,7 +1,5 @@
 use std::time::Duration;
 
-use alloy_primitives::U256;
-
 use crate::ProposerError;
 
 /// Default delay between bond-manager scans.
@@ -45,12 +43,14 @@ impl Default for BondManagerConfig {
 }
 
 /// Configuration for the proposer loop.
+///
+/// The proposal bond is deliberately absent: `DisputeGameFactory.create` reverts unless
+/// `msg.value` matches `initBonds(gameType)` exactly, so it is read per submission rather than
+/// captured at startup where an owner update would silently break every proposal.
 #[derive(Debug, Clone)]
 pub struct ProposerConfig {
     /// Number of L2 blocks between proposals.
     pub block_interval: u64,
-    /// Bond sent with `WorldChainProofSystemFactory.propose`.
-    pub proposer_bond: U256,
     /// Delay between periodic proposal attempts.
     pub poll_interval: Duration,
     /// Maximum number of game-resolution transactions submitted per proposer tick.
@@ -82,7 +82,6 @@ impl Default for ProposerConfig {
     fn default() -> Self {
         Self {
             block_interval: 6,
-            proposer_bond: U256::ZERO,
             poll_interval: Duration::from_secs(12),
             max_resolutions_per_tick: 1,
         }

--- a/proofs/proposer/src/lib.rs
+++ b/proofs/proposer/src/lib.rs
@@ -1,7 +1,7 @@
 //! World Chain proposer primitives.
 //!
-//! The proposer watches L2 output roots and creates `WorldChainProofSystemGame`
-//! contracts on L1 through `WorldChainProofSystemFactory`.
+//! The proposer watches L2 output roots and creates WIP-1006 `MultiProofGame`
+//! contracts on L1 through the stock OP Stack `DisputeGameFactory`.
 
 mod alloy;
 mod bond_manager;
@@ -22,8 +22,9 @@ pub use error::ProposerError;
 pub use proposer::WorldChainProposer;
 pub use traits::{BondManagerClient, ProposerClient};
 pub use types::{
-    CanonicalLine, CanonicalScan, CloseGameSubmission, FinalizedGames, NextProposalAction,
-    ParentRef, Proposal, ProposalSubmission, ResolveSubmission, WithdrawSubmission,
+    AnchorRef, CanonicalLine, CanonicalScan, ClaimSubmission, CloseGameSubmission, FinalizedGames,
+    NextProposalAction, ParentRef, PendingWithdrawal, Proposal, ProposalSubmission,
+    ResolveSubmission, TransitionGame,
 };
 
 #[cfg(test)]

--- a/proofs/proposer/src/main.rs
+++ b/proofs/proposer/src/main.rs
@@ -1,5 +1,5 @@
-//! `world-chain-proposer` binary: watches L2 output roots and opens
-//! `WorldChainProofSystemGame` proposals on L1 through the proof-system factory.
+//! `world-chain-proposer` binary: watches L2 output roots and opens WIP-1006
+//! `MultiProofGame` proposals on L1 through the stock OP `DisputeGameFactory`.
 //!
 //! Mirrors the in-process proposer wired by the devnet harness
 //! (`crates/devnet/src/full_stack.rs::start_world_chain_proposer`), reading its
@@ -17,8 +17,7 @@ use tracing::info;
 use url::Url;
 use world_chain_proofs::OptimismConsensusClient;
 use world_chain_proposer::{
-    AlloyProofSystemClient, BondManager, BondManagerConfig, ProposerClient, ProposerConfig,
-    WorldChainProposer,
+    AlloyProofSystemClient, BondManager, BondManagerConfig, ProposerConfig, WorldChainProposer,
 };
 use world_chain_prover_service::RpcProverServiceClient;
 
@@ -40,11 +39,11 @@ struct Cli {
     #[arg(long, env = "PROVER_SERVICE_URL")]
     prover_service_url: String,
 
-    /// `WorldChainProofSystemFactory` address on L1.
+    /// OP Stack `DisputeGameFactory` address on L1.
     #[arg(long, env = "FACTORY_ADDRESS")]
     factory_address: Address,
 
-    /// `WorldChainAnchorStateRegistry` address on L1.
+    /// OP Stack `AnchorStateRegistry` address on L1.
     #[arg(long, env = "ANCHOR_REGISTRY_ADDRESS")]
     anchor_registry_address: Address,
 
@@ -92,7 +91,9 @@ async fn main() -> Result<()> {
         .connect_http(Url::parse(&cli.l1_rpc).context("invalid L1 RPC URL")?);
 
     let contracts =
-        AlloyProofSystemClient::new(provider, cli.factory_address, cli.anchor_registry_address);
+        AlloyProofSystemClient::new(provider, cli.factory_address, cli.anchor_registry_address)
+            .await
+            .context("failed to bind the World Chain proof system")?;
     let bond_manager_config = BondManagerConfig {
         poll_interval: Duration::from_secs(cli.bond_manager_poll_interval_seconds),
         initial_scan_limit: cli.bond_manager_initial_scan_limit,
@@ -101,13 +102,9 @@ async fn main() -> Result<()> {
     let output_roots = OptimismConsensusClient::new(cli.output_root_rpc.clone());
     let proof_requester = RpcProverServiceClient::new(&cli.prover_service_url)
         .with_context(|| format!("failed to connect to {}", cli.prover_service_url))?;
-    let proposer_bond = contracts
-        .proposer_bond()
-        .await
-        .context("failed to read proposer bond")?;
+    let domain_hash = contracts.domain_hash();
     let config = ProposerConfig {
         block_interval: cli.block_interval,
-        proposer_bond,
         poll_interval: Duration::from_secs(cli.poll_interval_seconds),
         max_resolutions_per_tick: cli.max_resolutions_per_tick,
     };
@@ -117,9 +114,10 @@ async fn main() -> Result<()> {
         l1_rpc_url = %cli.l1_rpc,
         output_root_rpc_url = %cli.output_root_rpc,
         prover_service = %cli.prover_service_url,
-        factory = %cli.factory_address,
+        dispute_game_factory = %cli.factory_address,
         anchor = %cli.anchor_registry_address,
         proposer = %proposer_address,
+        domain_hash = %domain_hash,
         block_interval = cli.block_interval,
         max_resolutions_per_tick = cli.max_resolutions_per_tick,
         bond_manager_poll_interval_seconds = cli.bond_manager_poll_interval_seconds,

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -107,14 +107,50 @@ where
                 .output_root_at_block(next_l2_block_number)
                 .await?;
 
-            let Some(existing) = self
+            let existing = self
                 .execution_provider
-                .latest_game_for_transition(&parent_candidates, root_claim, next_l2_block_number)
-                .await?
+                .games_for_transition(&parent_candidates, root_claim, next_l2_block_number)
+                .await?;
+            let mut statuses = Vec::with_capacity(existing.len());
+            for game in &existing {
+                statuses.push(
+                    self.execution_provider
+                        .resolution_status(game.address)
+                        .await?,
+                );
+            }
+
+            // A game that has not been invalidated continues the canonical line, whichever
+            // accepted parent it was created under.
+            if let Some(live) = existing
+                .iter()
+                .zip(&statuses)
+                .find(|(_, status)| status.root_state != RootState::Invalidated)
+                .map(|(game, _)| *game)
+            {
+                let next_game = ParentRef {
+                    address: live.address,
+                    l2_block_number: next_l2_block_number,
+                };
+                canonical_line.push_game(next_game);
+                cursor = next_game;
+                parent_candidates = vec![next_game.address];
+                continue;
+            }
+
+            // Every game at this height is invalidated, so only the one created under the
+            // parent that is still acceptable matters. `MultiProofGame.initialize` rejects a
+            // parent at or below the anchor, so a game whose parent has since been closed into
+            // the anchor can neither be retried under that parent nor chained onto: the
+            // transition rebases onto `cursor.address` at attempt zero instead. This is the
+            // contract's own recovery path for inherited invalidations.
+            let Some((stale, status)) = existing
+                .iter()
+                .zip(&statuses)
+                .find(|(game, _)| game.parent_ref == cursor.address)
             else {
-                // game doesn't exist onchain yet, exit the loop with a
-                // `NextProposalAction::Propose`. The `propose` fn will
-                // later publish this proposal onchain
+                // Nothing occupies this transition under the current parent, either because no
+                // game exists yet or because the only ones that do are stale rebase targets.
                 return Ok(CanonicalScan::new(
                     canonical_line,
                     NextProposalAction::Propose(Proposal {
@@ -126,50 +162,31 @@ where
                 ));
             };
 
-            // game already exists onchain, look at the resolution status now:
-            // - if the root_state becomes `Invalidated`, then immediately return
-            //   because we don't want to keep building on top of an invalid game
-            // - otherwise, add the game to the canonical line and continue the loop
-            let resolution_status = self
-                .execution_provider
-                .resolution_status(existing.address)
-                .await?;
-            if resolution_status.root_state == RootState::Invalidated {
-                let next_action = if resolution_status.resolvable {
-                    NextProposalAction::AwaitNegativeResolution {
-                        game: existing.address,
-                        reason: resolution_status.invalidation_reason,
-                    }
-                } else if resolution_status.invalidation_reason == InvalidationReason::ProofTimeout
-                {
-                    // A retry must reuse the invalidated game's parent reference and root
-                    // claim: `MultiProofGame` only accepts attempt N when attempt N-1 exists
-                    // under the identical `extraData`.
-                    NextProposalAction::RetryTimedOut {
-                        proposal: Proposal {
-                            parent_ref: existing.parent_ref,
-                            root_claim,
-                            l2_block_number: next_l2_block_number,
-                            attempt: existing.attempt.saturating_add(1),
-                        },
-                        invalidated_game: existing.address,
-                    }
-                } else {
-                    NextProposalAction::BlockedByInvalidation {
-                        game: existing.address,
-                        reason: resolution_status.invalidation_reason,
-                    }
-                };
-                return Ok(CanonicalScan::new(canonical_line, next_action));
-            }
-
-            let next_game = ParentRef {
-                address: existing.address,
-                l2_block_number: next_l2_block_number,
+            let next_action = if status.resolvable {
+                NextProposalAction::AwaitNegativeResolution {
+                    game: stale.address,
+                    reason: status.invalidation_reason,
+                }
+            } else if status.invalidation_reason == InvalidationReason::ProofTimeout {
+                // A retry must reuse the invalidated game's parent reference and root claim:
+                // `MultiProofGame` only accepts attempt N when attempt N-1 exists under the
+                // identical `extraData`.
+                NextProposalAction::RetryTimedOut {
+                    proposal: Proposal {
+                        parent_ref: cursor.address,
+                        root_claim,
+                        l2_block_number: next_l2_block_number,
+                        attempt: stale.attempt.saturating_add(1),
+                    },
+                    invalidated_game: stale.address,
+                }
+            } else {
+                NextProposalAction::BlockedByInvalidation {
+                    game: stale.address,
+                    reason: status.invalidation_reason,
+                }
             };
-            canonical_line.push_game(next_game);
-            cursor = next_game;
-            parent_candidates = vec![next_game.address];
+            return Ok(CanonicalScan::new(canonical_line, next_action));
         }
     }
 

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{Address, B256};
+use alloy_primitives::Address;
 use tracing::{info, warn};
 use world_chain_proofs::{ConsensusProvider, InvalidationReason, RootState};
 use world_chain_prover_service::{
@@ -72,10 +72,14 @@ where
     pub async fn anchor_and_canonical_line(&self) -> Result<CanonicalScan, ProposerError> {
         self.config.validate()?;
 
-        let anchor_parent = self.execution_provider.anchor_parent().await?;
-        let mut canonical_line = CanonicalLine::new(anchor_parent);
+        let anchor = self.execution_provider.anchor_parent().await?;
+        let mut cursor = anchor.parent_ref();
+        let mut canonical_line = CanonicalLine::new(cursor);
 
-        let mut cursor = anchor_parent;
+        // Parent references an existing game at the next height may carry. At the anchor tip a
+        // game created before the anchor advanced still points at the anchor game, while new
+        // proposals must point at the registry itself.
+        let mut parent_candidates = anchor.parent_candidates();
         let latest_finalized_l2_block = self.consensus_provider.latest_l2_finalized_block().await?;
 
         // loop to the next canonical game until it reaches the last one
@@ -102,67 +106,70 @@ where
                 .consensus_provider
                 .output_root_at_block(next_l2_block_number)
                 .await?;
-            let mut proposal = Proposal {
-                parent_ref: cursor.address,
-                root_claim,
-                l2_block_number: next_l2_block_number,
-                proposal_key: B256::ZERO,
-            };
-            proposal.proposal_key = self
-                .execution_provider
-                .proposal_key(proposal.commitment())
-                .await?;
 
-            if let Some(next_game_addr) = self
+            let Some(existing) = self
                 .execution_provider
-                .game_for_proposal_key(proposal.proposal_key)
+                .latest_game_for_transition(&parent_candidates, root_claim, next_l2_block_number)
                 .await?
-            {
-                // game already exists onchain, look at the resolution status now:
-                // - if the root_state becomes `Invalidated`, then immediately return
-                //   because we don't want to keep building on top of an invalid game
-                // - otherwise, add the game to the canonical line and continue the loop
-                let resolution_status = self
-                    .execution_provider
-                    .resolution_status(next_game_addr)
-                    .await?;
-                if resolution_status.root_state == RootState::Invalidated {
-                    let next_action = if resolution_status.resolvable {
-                        NextProposalAction::AwaitNegativeResolution {
-                            game: next_game_addr,
-                            reason: resolution_status.invalidation_reason,
-                        }
-                    } else if resolution_status.invalidation_reason
-                        == InvalidationReason::ProofTimeout
-                    {
-                        NextProposalAction::RetryTimedOut {
-                            proposal,
-                            invalidated_game: next_game_addr,
-                        }
-                    } else {
-                        NextProposalAction::BlockedByInvalidation {
-                            game: next_game_addr,
-                            reason: resolution_status.invalidation_reason,
-                        }
-                    };
-                    return Ok(CanonicalScan::new(canonical_line, next_action));
-                }
-
-                let next_game = ParentRef {
-                    address: next_game_addr,
-                    l2_block_number: next_l2_block_number,
-                };
-                canonical_line.push_game(next_game);
-                cursor = next_game;
-            } else {
+            else {
                 // game doesn't exist onchain yet, exit the loop with a
                 // `NextProposalAction::Propose`. The `propose` fn will
                 // later publish this proposal onchain
                 return Ok(CanonicalScan::new(
                     canonical_line,
-                    NextProposalAction::Propose(proposal),
+                    NextProposalAction::Propose(Proposal {
+                        parent_ref: cursor.address,
+                        root_claim,
+                        l2_block_number: next_l2_block_number,
+                        attempt: 0,
+                    }),
                 ));
+            };
+
+            // game already exists onchain, look at the resolution status now:
+            // - if the root_state becomes `Invalidated`, then immediately return
+            //   because we don't want to keep building on top of an invalid game
+            // - otherwise, add the game to the canonical line and continue the loop
+            let resolution_status = self
+                .execution_provider
+                .resolution_status(existing.address)
+                .await?;
+            if resolution_status.root_state == RootState::Invalidated {
+                let next_action = if resolution_status.resolvable {
+                    NextProposalAction::AwaitNegativeResolution {
+                        game: existing.address,
+                        reason: resolution_status.invalidation_reason,
+                    }
+                } else if resolution_status.invalidation_reason == InvalidationReason::ProofTimeout
+                {
+                    // A retry must reuse the invalidated game's parent reference and root
+                    // claim: `MultiProofGame` only accepts attempt N when attempt N-1 exists
+                    // under the identical `extraData`.
+                    NextProposalAction::RetryTimedOut {
+                        proposal: Proposal {
+                            parent_ref: existing.parent_ref,
+                            root_claim,
+                            l2_block_number: next_l2_block_number,
+                            attempt: existing.attempt.saturating_add(1),
+                        },
+                        invalidated_game: existing.address,
+                    }
+                } else {
+                    NextProposalAction::BlockedByInvalidation {
+                        game: existing.address,
+                        reason: resolution_status.invalidation_reason,
+                    }
+                };
+                return Ok(CanonicalScan::new(canonical_line, next_action));
             }
+
+            let next_game = ParentRef {
+                address: existing.address,
+                l2_block_number: next_l2_block_number,
+            };
+            canonical_line.push_game(next_game);
+            cursor = next_game;
+            parent_candidates = vec![next_game.address];
         }
     }
 
@@ -218,6 +225,21 @@ where
         // means taking the one with the highest l2 block number
         let maybe_highest_finalized_game = finalized_games.last();
         if let Some(highest_finalized_game) = maybe_highest_finalized_game {
+            // `closeGame` reverts until the registry's finality airgap has elapsed. Gate on it
+            // so the routine wait is not reported as a failed tick every poll interval.
+            if !self
+                .execution_provider
+                .is_game_finalized(highest_finalized_game.address)
+                .await?
+            {
+                info!(
+                    game_address = %highest_finalized_game.address,
+                    l2_block_number = highest_finalized_game.l2_block_number,
+                    "waiting for dispute-game finality delay before closing game"
+                );
+                return Ok(());
+            }
+
             let close_game_submission = self
                 .execution_provider
                 .close_game(highest_finalized_game.address)
@@ -267,15 +289,15 @@ where
         if self
             .pending_proposal
             .as_ref()
-            .is_some_and(|pending| pending.proposal.proposal_key != proposal.proposal_key)
+            .is_some_and(|pending| pending.proposal != proposal)
         {
             let pending = self
                 .pending_proposal
                 .take()
                 .expect("pending proposal exists");
             warn!(
-                old_proposal_key = ?pending.proposal.proposal_key,
-                new_proposal_key = ?proposal.proposal_key,
+                old_proposal = ?pending.proposal,
+                new_proposal = ?proposal,
                 "canonical proposal changed; discarding stale pending proof"
             );
         }
@@ -330,7 +352,7 @@ where
             ProofStatus::Failed => {
                 warn!(
                     proof_id = %pending.proof_id,
-                    proposal_key = ?pending.proposal.proposal_key,
+                    proposal = ?pending.proposal,
                     "proposal proof failed; retrying the same request next tick"
                 );
                 return Ok(());
@@ -373,14 +395,14 @@ where
 
         let submission = self
             .execution_provider
-            .submit_proposal(&pending.proposal, proof, self.config.proposer_bond)
+            .submit_proposal(&pending.proposal, proof)
             .await?;
         info!(
             tx_hash = ?submission.tx_hash,
             game_address = %submission.game_address,
             l2_block_number = pending.proposal.l2_block_number,
             parent_ref = %pending.proposal.parent_ref,
-            proposal_key = ?pending.proposal.proposal_key,
+            attempt = pending.proposal.attempt,
             retry_of = ?pending.retry_of,
             "submitted World Chain proof-system game"
         );

--- a/proofs/proposer/src/tests.rs
+++ b/proofs/proposer/src/tests.rs
@@ -16,11 +16,12 @@ use world_chain_prover_service::{
 };
 
 use crate::{
-    BondManager, BondManagerClient, BondManagerConfig, CanonicalLine, ParentRef, Proposal,
-    ProposalSubmission, ProposerClient, ProposerConfig, ProposerError, WorldChainProposer,
+    AnchorRef, BondManager, BondManagerClient, BondManagerConfig, CanonicalLine, ParentRef,
+    Proposal, ProposalSubmission, ProposerClient, ProposerConfig, ProposerError,
+    WorldChainProposer,
     types::{
-        CanonicalScan, CloseGameSubmission, NextProposalAction, ResolveSubmission,
-        WithdrawSubmission,
+        CanonicalScan, ClaimSubmission, CloseGameSubmission, NextProposalAction, PendingWithdrawal,
+        ResolveSubmission, TransitionGame,
     },
 };
 
@@ -28,32 +29,61 @@ const DOMAIN_HASH: B256 = b256!("11111111111111111111111111111111111111111111111
 const ANCHOR: Address = address!("0000000000000000000000000000000000001006");
 const GAME_1: Address = address!("0000000000000000000000000000000000000001");
 
+/// Mirrors [`crate::alloy`]'s attempt walk so tests exercise the same lookup shape.
+const MAX_TEST_ATTEMPT: u64 = 4;
+
 #[derive(Debug, Clone)]
 struct MockContracts {
-    anchor: ParentRef,
+    anchor: AnchorRef,
+    /// Games keyed by their `DisputeGameFactory` UUID.
     games: HashMap<B256, Address>,
     submissions: Arc<Mutex<Vec<(Proposal, ProofData)>>>,
     resolution_statuses: Arc<Mutex<HashMap<Address, ResolutionStatus>>>,
     resolutions: Arc<Mutex<Vec<Address>>>,
     closures: Arc<Mutex<Vec<Address>>>,
     submission_failures: Arc<Mutex<usize>>,
+    /// Games whose registry finality airgap has not elapsed yet.
+    unfinalized_games: Arc<Mutex<HashSet<Address>>>,
 }
 
 #[async_trait]
 impl ProposerClient for MockContracts {
-    async fn anchor_parent(&self) -> Result<ParentRef, ProposerError> {
+    async fn anchor_parent(&self) -> Result<AnchorRef, ProposerError> {
         Ok(self.anchor)
     }
 
-    async fn proposal_key(&self, commitment: ProposalCommitment) -> Result<B256, ProposerError> {
-        Ok(commitment.proposal_key(DOMAIN_HASH))
+    async fn latest_game_for_transition(
+        &self,
+        parent_candidates: &[Address],
+        root_claim: B256,
+        l2_block_number: u64,
+    ) -> Result<Option<TransitionGame>, ProposerError> {
+        for parent_ref in parent_candidates {
+            let mut found = None;
+            for attempt in 0..MAX_TEST_ATTEMPT {
+                let uuid = game_uuid(*parent_ref, root_claim, l2_block_number, attempt);
+                let Some(address) = self.games.get(&uuid).copied() else {
+                    break;
+                };
+                found = Some(TransitionGame {
+                    address,
+                    parent_ref: *parent_ref,
+                    attempt,
+                });
+            }
+            if found.is_some() {
+                return Ok(found);
+            }
+        }
+        Ok(None)
     }
 
-    async fn game_for_proposal_key(
-        &self,
-        proposal_key: B256,
-    ) -> Result<Option<Address>, ProposerError> {
-        Ok(self.games.get(&proposal_key).copied())
+    async fn is_game_finalized(&self, game: Address) -> Result<bool, ProposerError> {
+        Ok(!self
+            .unfinalized_games
+            .lock()
+            .expect("not poisoned")
+            .contains(&game))
     }
 
     async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError> {
@@ -83,21 +113,6 @@ impl ProposerClient for MockContracts {
         })
     }
 
-    async fn claimable(&self, _game: Address) -> Result<U256, ProposerError> {
-        Ok(U256::ZERO)
-    }
-
-    async fn withdraw(&self, _game: Address) -> Result<WithdrawSubmission, ProposerError> {
-        Ok(WithdrawSubmission {
-            tx_hash: B256::repeat_byte(0xdd),
-            amount: U256::ZERO,
-        })
-    }
-
-    async fn proposer_bond(&self) -> Result<U256, ProposerError> {
-        Ok(U256::from(1))
-    }
-
     async fn latest_finalized_l1_block(&self) -> Result<B256, ProposerError> {
         Ok(B256::repeat_byte(0xf1))
     }
@@ -106,7 +121,6 @@ impl ProposerClient for MockContracts {
         &self,
         proposal: &Proposal,
         proof: ProofData,
-        _proposer_bond: U256,
     ) -> Result<ProposalSubmission, ProposerError> {
         let mut failures = self.submission_failures.lock().expect("not poisoned");
         if *failures > 0 {
@@ -199,29 +213,48 @@ impl ProofRequester for MockProofRequester {
     }
 }
 
+/// Two-phase bond client mirroring `MultiProofGame.claimCredit`: the first claim moves credit
+/// into a pending `DelayedWETH` withdrawal, the second drains it.
 #[derive(Debug, Clone)]
 struct MockBondClient {
     proposer: Address,
-    games: Arc<Mutex<Vec<(Address, Address)>>>,
+    /// `(game, creator)` pairs in factory index order. `None` marks a foreign game type.
+    games: Arc<Mutex<Vec<(Option<Address>, Address)>>>,
     requested_indices: Arc<Mutex<Vec<u64>>>,
     resolved_games: Arc<Mutex<HashSet<Address>>>,
-    claimable: Arc<Mutex<HashMap<Address, U256>>>,
+    unfinalized_games: Arc<Mutex<HashSet<Address>>>,
+    credit: Arc<Mutex<HashMap<Address, U256>>>,
+    pending: Arc<Mutex<HashMap<Address, PendingWithdrawal>>>,
+    unlocks: Arc<Mutex<Vec<Address>>>,
     withdrawals: Arc<Mutex<Vec<Address>>>,
     fail_game_at_once: Arc<Mutex<Option<u64>>>,
-    fail_withdraw_once: Arc<Mutex<HashSet<Address>>>,
+    fail_claim_once: Arc<Mutex<HashSet<Address>>>,
 }
 
 impl MockBondClient {
     fn new(proposer: Address, games: Vec<(Address, Address)>) -> Self {
+        Self::with_indexed_games(
+            proposer,
+            games
+                .into_iter()
+                .map(|(game, creator)| (Some(game), creator))
+                .collect(),
+        )
+    }
+
+    fn with_indexed_games(proposer: Address, games: Vec<(Option<Address>, Address)>) -> Self {
         Self {
             proposer,
             games: Arc::new(Mutex::new(games)),
             requested_indices: Arc::default(),
             resolved_games: Arc::default(),
-            claimable: Arc::default(),
+            unfinalized_games: Arc::default(),
+            credit: Arc::default(),
+            pending: Arc::default(),
+            unlocks: Arc::default(),
             withdrawals: Arc::default(),
             fail_game_at_once: Arc::default(),
-            fail_withdraw_once: Arc::default(),
+            fail_claim_once: Arc::default(),
         }
     }
 }
@@ -236,7 +269,7 @@ impl BondManagerClient for MockBondClient {
         Ok(self.games.lock().expect("not poisoned").len() as u64)
     }
 
-    async fn game_at(&self, index: u64) -> Result<Address, ProposerError> {
+    async fn game_at(&self, index: u64) -> Result<Option<Address>, ProposerError> {
         self.requested_indices
             .lock()
             .expect("not poisoned")
@@ -254,12 +287,12 @@ impl BondManagerClient for MockBondClient {
             .ok_or_else(|| ProposerError::Contract(format!("missing game at index {index}")))
     }
 
-    async fn game_proposer(&self, game: Address) -> Result<Address, ProposerError> {
+    async fn game_creator(&self, game: Address) -> Result<Address, ProposerError> {
         self.games
             .lock()
             .expect("not poisoned")
             .iter()
-            .find_map(|(candidate, proposer)| (*candidate == game).then_some(*proposer))
+            .find_map(|(candidate, creator)| (*candidate == Some(game)).then_some(*creator))
             .ok_or_else(|| ProposerError::Contract(format!("unknown game {game}")))
     }
 
@@ -280,9 +313,17 @@ impl BondManagerClient for MockBondClient {
         })
     }
 
-    async fn claimable(&self, game: Address) -> Result<U256, ProposerError> {
+    async fn is_game_finalized(&self, game: Address) -> Result<bool, ProposerError> {
+        Ok(!self
+            .unfinalized_games
+            .lock()
+            .expect("not poisoned")
+            .contains(&game))
+    }
+
+    async fn credit(&self, game: Address) -> Result<U256, ProposerError> {
         Ok(self
-            .claimable
+            .credit
             .lock()
             .expect("not poisoned")
             .get(&game)
@@ -290,27 +331,61 @@ impl BondManagerClient for MockBondClient {
             .unwrap_or_default())
     }
 
-    async fn withdraw(&self, game: Address) -> Result<WithdrawSubmission, ProposerError> {
+    async fn pending_withdrawal(&self, game: Address) -> Result<PendingWithdrawal, ProposerError> {
+        Ok(self
+            .pending
+            .lock()
+            .expect("not poisoned")
+            .get(&game)
+            .copied()
+            .unwrap_or_default())
+    }
+
+    async fn claim_credit(&self, game: Address) -> Result<ClaimSubmission, ProposerError> {
         if self
-            .fail_withdraw_once
+            .fail_claim_once
             .lock()
             .expect("not poisoned")
             .remove(&game)
         {
-            return Err(ProposerError::Contract(
-                "injected withdrawal failure".into(),
-            ));
+            return Err(ProposerError::Contract("injected claim failure".into()));
         }
+
+        let credit = self
+            .credit
+            .lock()
+            .expect("not poisoned")
+            .remove(&game)
+            .unwrap_or_default();
+        if credit > U256::ZERO {
+            // Phase 1: unlock in DelayedWETH, immediately withdrawable in tests.
+            self.pending.lock().expect("not poisoned").insert(
+                game,
+                PendingWithdrawal {
+                    amount: credit,
+                    unlock_at: 0,
+                },
+            );
+            self.unlocks.lock().expect("not poisoned").push(game);
+            return Ok(ClaimSubmission {
+                tx_hash: B256::repeat_byte(0xdd),
+                amount: credit,
+                withdrawn: false,
+            });
+        }
+
+        // Phase 2: drain the pending withdrawal.
+        let pending = self
+            .pending
+            .lock()
+            .expect("not poisoned")
+            .remove(&game)
+            .unwrap_or_default();
         self.withdrawals.lock().expect("not poisoned").push(game);
-        Ok(WithdrawSubmission {
-            tx_hash: B256::repeat_byte(0xdd),
-            amount: self
-                .claimable
-                .lock()
-                .expect("not poisoned")
-                .get(&game)
-                .copied()
-                .unwrap_or_default(),
+        Ok(ClaimSubmission {
+            tx_hash: B256::repeat_byte(0xde),
+            amount: pending.amount,
+            withdrawn: true,
         })
     }
 }
@@ -338,7 +413,6 @@ impl ConsensusProvider for MockOutputRoots {
 fn config() -> ProposerConfig {
     ProposerConfig {
         block_interval: 10,
-        proposer_bond: U256::from(1),
         poll_interval: Duration::from_secs(1),
         max_resolutions_per_tick: 1,
     }
@@ -360,13 +434,22 @@ fn positive_ready_status() -> ResolutionStatus {
     }
 }
 
-fn proposal_key(parent_ref: Address, root_claim: B256, l2_block_number: u64) -> B256 {
+fn anchor_at(l2_block_number: u64) -> AnchorRef {
+    AnchorRef {
+        registry: ANCHOR,
+        anchor_game: None,
+        l2_block_number,
+    }
+}
+
+fn game_uuid(parent_ref: Address, root_claim: B256, l2_block_number: u64, attempt: u64) -> B256 {
     ProposalCommitment {
         parent_ref,
         root_claim,
         l2_block_number,
+        attempt,
     }
-    .proposal_key(DOMAIN_HASH)
+    .game_uuid(DOMAIN_HASH)
 }
 
 fn game_address(index: u64) -> Address {
@@ -387,19 +470,17 @@ async fn anchor_and_canonical_line_walks_existing_games_until_gap() {
     let root_10 = B256::repeat_byte(0x10);
     let root_20 = B256::repeat_byte(0x20);
     let mut games = HashMap::new();
-    games.insert(proposal_key(ANCHOR, root_10, 10), GAME_1);
+    games.insert(game_uuid(ANCHOR, root_10, 10, 0), GAME_1);
 
     let contracts = MockContracts {
-        anchor: ParentRef {
-            address: ANCHOR,
-            l2_block_number: 0,
-        },
+        anchor: anchor_at(0),
         games,
         submissions: Arc::default(),
         resolution_statuses: Arc::default(),
         resolutions: Arc::default(),
         closures: Arc::default(),
         submission_failures: Arc::default(),
+        unfinalized_games: Arc::default(),
     };
     let output_roots = MockOutputRoots {
         roots: HashMap::from([(10, root_10), (20, root_20)]),
@@ -427,16 +508,14 @@ async fn anchor_and_canonical_line_walks_existing_games_until_gap() {
 async fn propose_submits_proposal_after_last_canonical_game() {
     let submissions = Arc::default();
     let contracts = MockContracts {
-        anchor: ParentRef {
-            address: ANCHOR,
-            l2_block_number: 0,
-        },
+        anchor: anchor_at(0),
         games: HashMap::new(),
         submissions: Arc::clone(&submissions),
         resolution_statuses: Arc::default(),
         resolutions: Arc::default(),
         closures: Arc::default(),
         submission_failures: Arc::default(),
+        unfinalized_games: Arc::default(),
     };
     let output_roots = MockOutputRoots {
         roots: HashMap::from([(10, B256::repeat_byte(0x10))]),
@@ -458,26 +537,21 @@ async fn propose_submits_proposal_after_last_canonical_game() {
     assert_eq!(proposal.parent_ref, ANCHOR);
     assert_eq!(proposal.root_claim, B256::repeat_byte(0x10));
     assert_eq!(proposal.l2_block_number, 10);
-    assert_eq!(
-        proposal.proposal_key,
-        proposal_key(ANCHOR, B256::repeat_byte(0x10), 10)
-    );
+    assert_eq!(proposal.attempt, 0);
 }
 
 #[tokio::test]
 async fn propose_waits_for_pending_proof_and_reuses_exact_request() {
     let submissions = Arc::default();
     let contracts = MockContracts {
-        anchor: ParentRef {
-            address: ANCHOR,
-            l2_block_number: 0,
-        },
+        anchor: anchor_at(0),
         games: HashMap::new(),
         submissions: Arc::clone(&submissions),
         resolution_statuses: Arc::default(),
         resolutions: Arc::default(),
         closures: Arc::default(),
         submission_failures: Arc::default(),
+        unfinalized_games: Arc::default(),
     };
     let output_roots = MockOutputRoots {
         roots: HashMap::from([(10, B256::repeat_byte(0x10))]),
@@ -512,16 +586,14 @@ async fn propose_waits_for_pending_proof_and_reuses_exact_request() {
 async fn propose_rerequests_failed_proof_without_submitting() {
     let submissions = Arc::default();
     let contracts = MockContracts {
-        anchor: ParentRef {
-            address: ANCHOR,
-            l2_block_number: 0,
-        },
+        anchor: anchor_at(0),
         games: HashMap::new(),
         submissions: Arc::clone(&submissions),
         resolution_statuses: Arc::default(),
         resolutions: Arc::default(),
         closures: Arc::default(),
         submission_failures: Arc::default(),
+        unfinalized_games: Arc::default(),
     };
     let output_roots = MockOutputRoots {
         roots: HashMap::from([(10, B256::repeat_byte(0x10))]),
@@ -549,16 +621,14 @@ async fn propose_rerequests_failed_proof_without_submitting() {
 async fn propose_retains_request_after_transient_status_error() {
     let submissions = Arc::default();
     let contracts = MockContracts {
-        anchor: ParentRef {
-            address: ANCHOR,
-            l2_block_number: 0,
-        },
+        anchor: anchor_at(0),
         games: HashMap::new(),
         submissions: Arc::clone(&submissions),
         resolution_statuses: Arc::default(),
         resolutions: Arc::default(),
         closures: Arc::default(),
         submission_failures: Arc::default(),
+        unfinalized_games: Arc::default(),
     };
     let output_roots = MockOutputRoots {
         roots: HashMap::from([(10, B256::repeat_byte(0x10))]),
@@ -593,16 +663,14 @@ async fn propose_retries_submission_with_same_completed_proof() {
     let submissions = Arc::default();
     let submission_failures = Arc::new(Mutex::new(1));
     let contracts = MockContracts {
-        anchor: ParentRef {
-            address: ANCHOR,
-            l2_block_number: 0,
-        },
+        anchor: anchor_at(0),
         games: HashMap::new(),
         submissions: Arc::clone(&submissions),
         resolution_statuses: Arc::default(),
         resolutions: Arc::default(),
         closures: Arc::default(),
         submission_failures,
+        unfinalized_games: Arc::default(),
     };
     let output_roots = MockOutputRoots {
         roots: HashMap::from([(10, B256::repeat_byte(0x10))]),
@@ -632,16 +700,14 @@ async fn propose_retries_submission_with_same_completed_proof() {
 #[tokio::test]
 async fn propose_replaces_pending_request_when_canonical_candidate_changes() {
     let contracts = MockContracts {
-        anchor: ParentRef {
-            address: ANCHOR,
-            l2_block_number: 0,
-        },
+        anchor: anchor_at(0),
         games: HashMap::new(),
         submissions: Arc::default(),
         resolution_statuses: Arc::default(),
         resolutions: Arc::default(),
         closures: Arc::default(),
         submission_failures: Arc::default(),
+        unfinalized_games: Arc::default(),
     };
     let proof_requester = MockProofRequester::with_status(ProofStatus::Running);
     let mut proposer = WorldChainProposer::new(
@@ -663,7 +729,7 @@ async fn propose_replaces_pending_request_when_canonical_candidate_changes() {
             parent_ref: ANCHOR,
             root_claim: B256::repeat_byte(0x10),
             l2_block_number: 10,
-            proposal_key: B256::repeat_byte(0xa1),
+            attempt: 0,
         }),
     );
     advance_proposal(&mut proposer, &first).await.unwrap();
@@ -677,7 +743,7 @@ async fn propose_replaces_pending_request_when_canonical_candidate_changes() {
             parent_ref: ANCHOR,
             root_claim: B256::repeat_byte(0x20),
             l2_block_number: 10,
-            proposal_key: B256::repeat_byte(0xa2),
+            attempt: 0,
         }),
     );
     advance_proposal(&mut proposer, &second).await.unwrap();
@@ -706,16 +772,14 @@ async fn propose_replaces_pending_request_when_canonical_candidate_changes() {
 #[tokio::test]
 async fn zero_block_interval_is_rejected() {
     let contracts = MockContracts {
-        anchor: ParentRef {
-            address: ANCHOR,
-            l2_block_number: 0,
-        },
+        anchor: anchor_at(0),
         games: HashMap::new(),
         submissions: Arc::default(),
         resolution_statuses: Arc::default(),
         resolutions: Arc::default(),
         closures: Arc::default(),
         submission_failures: Arc::default(),
+        unfinalized_games: Arc::default(),
     };
     let proposer = WorldChainProposer::new(
         ProposerConfig {
@@ -739,16 +803,14 @@ async fn zero_block_interval_is_rejected() {
 #[tokio::test]
 async fn anchor_and_canonical_line_stops_at_finalized_l2_block() {
     let contracts = MockContracts {
-        anchor: ParentRef {
-            address: ANCHOR,
-            l2_block_number: 0,
-        },
+        anchor: anchor_at(0),
         games: HashMap::new(),
         submissions: Arc::default(),
         resolution_statuses: Arc::default(),
         resolutions: Arc::default(),
         closures: Arc::default(),
         submission_failures: Arc::default(),
+        unfinalized_games: Arc::default(),
     };
     let output_roots = MockOutputRoots {
         roots: HashMap::from([(10, B256::repeat_byte(0x10))]),
@@ -780,10 +842,7 @@ async fn resolve_games_caps_submissions_and_keeps_scanning_finalized_games() {
     let resolutions = Arc::default();
     let closures = Arc::default();
     let contracts = MockContracts {
-        anchor: ParentRef {
-            address: ANCHOR,
-            l2_block_number: 0,
-        },
+        anchor: anchor_at(0),
         games: HashMap::new(),
         submissions: Arc::default(),
         resolution_statuses: Arc::new(Mutex::new(HashMap::from([
@@ -801,6 +860,7 @@ async fn resolve_games_caps_submissions_and_keeps_scanning_finalized_games() {
         resolutions: Arc::clone(&resolutions),
         closures: Arc::clone(&closures),
         submission_failures: Arc::default(),
+        unfinalized_games: Arc::default(),
     };
     let proposer = WorldChainProposer::new(
         ProposerConfig {
@@ -854,10 +914,7 @@ async fn finalized_games_do_not_consume_resolution_budget() {
     let game_3 = game_address(3);
     let resolutions = Arc::default();
     let contracts = MockContracts {
-        anchor: ParentRef {
-            address: ANCHOR,
-            l2_block_number: 0,
-        },
+        anchor: anchor_at(0),
         games: HashMap::new(),
         submissions: Arc::default(),
         resolution_statuses: Arc::new(Mutex::new(HashMap::from([
@@ -875,6 +932,7 @@ async fn finalized_games_do_not_consume_resolution_budget() {
         resolutions: Arc::clone(&resolutions),
         closures: Arc::default(),
         submission_failures: Arc::default(),
+        unfinalized_games: Arc::default(),
     };
     let proposer = WorldChainProposer::new(
         config(),
@@ -911,16 +969,14 @@ async fn finalized_games_do_not_consume_resolution_budget() {
 #[tokio::test]
 async fn zero_resolution_budget_is_rejected() {
     let contracts = MockContracts {
-        anchor: ParentRef {
-            address: ANCHOR,
-            l2_block_number: 0,
-        },
+        anchor: anchor_at(0),
         games: HashMap::new(),
         submissions: Arc::default(),
         resolution_statuses: Arc::default(),
         resolutions: Arc::default(),
         closures: Arc::default(),
         submission_failures: Arc::default(),
+        unfinalized_games: Arc::default(),
     };
     let proposer = WorldChainProposer::new(
         ProposerConfig {
@@ -976,7 +1032,7 @@ async fn bond_manager_scans_bounded_initial_window_then_only_new_games() {
         .games
         .lock()
         .expect("not poisoned")
-        .push((game_address(1_006), proposer));
+        .push((Some(game_address(1_006)), proposer));
     client
         .requested_indices
         .lock()
@@ -1020,51 +1076,96 @@ async fn bond_manager_retries_complete_range_after_partial_scan_failure() {
 }
 
 #[tokio::test]
-async fn bond_manager_prunes_resolved_games_and_retries_failed_withdrawals() {
+async fn bond_manager_prunes_resolved_games_and_retries_failed_claims() {
     let proposer = Address::repeat_byte(0xa1);
     let unresolved = game_address(1);
     let zero_credit = game_address(2);
-    let withdrawable = game_address(3);
-    let retry_withdrawal = game_address(4);
+    let claimable = game_address(3);
+    let retry_claim = game_address(4);
+    let awaiting_airgap = game_address(5);
     let games = vec![
         (unresolved, proposer),
         (zero_credit, proposer),
-        (withdrawable, proposer),
-        (retry_withdrawal, proposer),
+        (claimable, proposer),
+        (retry_claim, proposer),
+        (awaiting_airgap, proposer),
     ];
     let client = MockBondClient::new(proposer, games);
     client.resolved_games.lock().expect("not poisoned").extend([
         zero_credit,
-        withdrawable,
-        retry_withdrawal,
-    ]);
-    client.claimable.lock().expect("not poisoned").extend([
-        (withdrawable, U256::from(10)),
-        (retry_withdrawal, U256::from(20)),
+        claimable,
+        retry_claim,
+        awaiting_airgap,
     ]);
     client
-        .fail_withdraw_once
+        .unfinalized_games
         .lock()
         .expect("not poisoned")
-        .insert(retry_withdrawal);
+        .insert(awaiting_airgap);
+    client.credit.lock().expect("not poisoned").extend([
+        (claimable, U256::from(10)),
+        (retry_claim, U256::from(20)),
+        (awaiting_airgap, U256::from(30)),
+    ]);
+    client
+        .fail_claim_once
+        .lock()
+        .expect("not poisoned")
+        .insert(retry_claim);
     let mut manager = BondManager::new(bond_manager_config(100), client.clone());
     manager.scan_games().await.unwrap();
 
+    // Pass 1: only `claimable` advances, and only through the DelayedWETH unlock.
     manager.withdraw_credits().await.unwrap();
 
     assert!(manager.tracks_game(unresolved));
     assert!(!manager.tracks_game(zero_credit));
-    assert!(!manager.tracks_game(withdrawable));
-    assert!(manager.tracks_game(retry_withdrawal));
-    assert_eq!(
-        *client.withdrawals.lock().expect("not poisoned"),
-        vec![withdrawable]
+    assert!(
+        manager.tracks_game(claimable),
+        "unlocked bond must stay tracked"
     );
+    assert!(manager.tracks_game(retry_claim));
+    assert!(
+        manager.tracks_game(awaiting_airgap),
+        "a game inside the finality airgap must stay tracked"
+    );
+    assert_eq!(
+        *client.unlocks.lock().expect("not poisoned"),
+        vec![claimable]
+    );
+    assert!(client.withdrawals.lock().expect("not poisoned").is_empty());
 
+    // Pass 2: `claimable` withdraws and is dropped; the failed claim is retried and unlocks.
     manager.withdraw_credits().await.unwrap();
 
-    assert!(!manager.tracks_game(retry_withdrawal));
+    assert!(!manager.tracks_game(claimable));
+    assert!(manager.tracks_game(retry_claim));
+    assert_eq!(
+        *client.withdrawals.lock().expect("not poisoned"),
+        vec![claimable]
+    );
+
+    // Pass 3: the retried claim withdraws and is dropped.
+    manager.withdraw_credits().await.unwrap();
+
+    assert!(!manager.tracks_game(retry_claim));
     let withdrawals = client.withdrawals.lock().expect("not poisoned");
-    assert!(withdrawals.contains(&withdrawable));
-    assert!(withdrawals.contains(&retry_withdrawal));
+    assert!(withdrawals.contains(&claimable));
+    assert!(withdrawals.contains(&retry_claim));
+}
+
+#[tokio::test]
+async fn bond_manager_skips_foreign_game_types() {
+    let proposer = Address::repeat_byte(0xa1);
+    let ours = game_address(1);
+    let client = MockBondClient::with_indexed_games(
+        proposer,
+        vec![(None, proposer), (Some(ours), proposer), (None, proposer)],
+    );
+    let mut manager = BondManager::new(bond_manager_config(100), client);
+
+    manager.scan_games().await.unwrap();
+
+    assert!(manager.tracks_game(ours));
+    assert_eq!(manager.next_game_index(), Some(3));
 }

--- a/proofs/proposer/src/tests.rs
+++ b/proofs/proposer/src/tests.rs
@@ -52,30 +52,29 @@ impl ProposerClient for MockContracts {
         Ok(self.anchor)
     }
 
-    async fn latest_game_for_transition(
+    async fn games_for_transition(
         &self,
         parent_candidates: &[Address],
         root_claim: B256,
         l2_block_number: u64,
-    ) -> Result<Option<TransitionGame>, ProposerError> {
+    ) -> Result<Vec<TransitionGame>, ProposerError> {
+        let mut found = Vec::with_capacity(parent_candidates.len());
         for parent_ref in parent_candidates {
-            let mut found = None;
+            let mut latest = None;
             for attempt in 0..MAX_TEST_ATTEMPT {
                 let uuid = game_uuid(*parent_ref, root_claim, l2_block_number, attempt);
                 let Some(address) = self.games.get(&uuid).copied() else {
                     break;
                 };
-                found = Some(TransitionGame {
+                latest = Some(TransitionGame {
                     address,
                     parent_ref: *parent_ref,
                     attempt,
                 });
             }
-            if found.is_some() {
-                return Ok(found);
-            }
+            found.extend(latest);
         }
-        Ok(None)
+        Ok(found)
     }
 
     async fn is_game_finalized(&self, game: Address) -> Result<bool, ProposerError> {
@@ -439,6 +438,24 @@ fn anchor_at(l2_block_number: u64) -> AnchorRef {
         registry: ANCHOR,
         anchor_game: None,
         l2_block_number,
+    }
+}
+
+/// The anchor after it has been advanced onto `anchor_game`, which is therefore no longer an
+/// acceptable parent for new proposals.
+fn anchor_advanced_onto(anchor_game: Address, l2_block_number: u64) -> AnchorRef {
+    AnchorRef {
+        registry: ANCHOR,
+        anchor_game: Some(anchor_game),
+        l2_block_number,
+    }
+}
+
+fn timed_out_status() -> ResolutionStatus {
+    ResolutionStatus {
+        resolvable: false,
+        root_state: RootState::Invalidated,
+        invalidation_reason: InvalidationReason::ProofTimeout,
     }
 }
 
@@ -1168,4 +1185,127 @@ async fn bond_manager_skips_foreign_game_types() {
 
     assert!(manager.tracks_game(ours));
     assert_eq!(manager.next_game_index(), Some(3));
+}
+
+#[tokio::test]
+async fn timed_out_game_rebases_onto_registry_after_its_parent_became_the_anchor() {
+    // Anchor advanced onto P, so P is no longer an acceptable parent: `initialize` rejects any
+    // parent at or below the anchor. The timed-out game under P therefore cannot be retried in
+    // place; the transition must start over under the registry sentinel at attempt zero.
+    let parent = game_address(1);
+    let timed_out = game_address(2);
+    let root_20 = B256::repeat_byte(0x20);
+    let contracts = MockContracts {
+        anchor: anchor_advanced_onto(parent, 10),
+        games: HashMap::from([(game_uuid(parent, root_20, 20, 0), timed_out)]),
+        submissions: Arc::default(),
+        resolution_statuses: Arc::new(Mutex::new(HashMap::from([(timed_out, timed_out_status())]))),
+        resolutions: Arc::default(),
+        closures: Arc::default(),
+        submission_failures: Arc::default(),
+        unfinalized_games: Arc::default(),
+    };
+    let proposer = WorldChainProposer::new(
+        config(),
+        contracts,
+        MockOutputRoots {
+            roots: HashMap::from([(20, root_20)]),
+            finalized_l2_block: 20,
+        },
+        MockProofRequester::default(),
+    );
+
+    let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
+
+    assert!(canonical_scan.canonical_line().games().is_empty());
+    assert_eq!(
+        canonical_scan.next_action(),
+        &NextProposalAction::Propose(Proposal {
+            parent_ref: ANCHOR,
+            root_claim: root_20,
+            l2_block_number: 20,
+            attempt: 0,
+        })
+    );
+}
+
+#[tokio::test]
+async fn invalidated_legacy_game_does_not_hide_a_live_registry_parented_rebase() {
+    let parent = game_address(1);
+    let timed_out = game_address(2);
+    let rebased = game_address(3);
+    let root_20 = B256::repeat_byte(0x20);
+    let contracts = MockContracts {
+        anchor: anchor_advanced_onto(parent, 10),
+        games: HashMap::from([
+            (game_uuid(parent, root_20, 20, 0), timed_out),
+            (game_uuid(ANCHOR, root_20, 20, 0), rebased),
+        ]),
+        submissions: Arc::default(),
+        resolution_statuses: Arc::new(Mutex::new(HashMap::from([(timed_out, timed_out_status())]))),
+        resolutions: Arc::default(),
+        closures: Arc::default(),
+        submission_failures: Arc::default(),
+        unfinalized_games: Arc::default(),
+    };
+    let proposer = WorldChainProposer::new(
+        config(),
+        contracts,
+        MockOutputRoots {
+            roots: HashMap::from([(20, root_20)]),
+            finalized_l2_block: 20,
+        },
+        MockProofRequester::default(),
+    );
+
+    let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
+
+    // The live rebase continues the line even though the dead legacy game is scanned first.
+    assert_eq!(
+        canonical_scan.canonical_line().games(),
+        &[ParentRef {
+            address: rebased,
+            l2_block_number: 20,
+        }]
+    );
+}
+
+#[tokio::test]
+async fn timed_out_game_bumps_attempt_while_its_parent_is_still_acceptable() {
+    let timed_out = game_address(2);
+    let root_20 = B256::repeat_byte(0x20);
+    let contracts = MockContracts {
+        anchor: anchor_at(10),
+        games: HashMap::from([(game_uuid(ANCHOR, root_20, 20, 0), timed_out)]),
+        submissions: Arc::default(),
+        resolution_statuses: Arc::new(Mutex::new(HashMap::from([(timed_out, timed_out_status())]))),
+        resolutions: Arc::default(),
+        closures: Arc::default(),
+        submission_failures: Arc::default(),
+        unfinalized_games: Arc::default(),
+    };
+    let proposer = WorldChainProposer::new(
+        config(),
+        contracts,
+        MockOutputRoots {
+            roots: HashMap::from([(20, root_20)]),
+            finalized_l2_block: 20,
+        },
+        MockProofRequester::default(),
+    );
+
+    let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
+
+    assert_eq!(
+        canonical_scan.next_action(),
+        &NextProposalAction::RetryTimedOut {
+            proposal: Proposal {
+                parent_ref: ANCHOR,
+                root_claim: root_20,
+                l2_block_number: 20,
+                attempt: 1,
+            },
+            invalidated_game: timed_out,
+        }
+    );
 }

--- a/proofs/proposer/src/traits.rs
+++ b/proofs/proposer/src/traits.rs
@@ -1,11 +1,13 @@
 use alloy_primitives::{Address, B256, BlockHash, U256};
 use async_trait::async_trait;
-use world_chain_proofs::{ProposalCommitment, ResolutionStatus};
+use world_chain_proofs::ResolutionStatus;
 use world_chain_prover_service::ProofData;
 
 use crate::{
-    ParentRef, Proposal, ProposalSubmission, ProposerError,
-    types::{CloseGameSubmission, ResolveSubmission, WithdrawSubmission},
+    AnchorRef, Proposal, ProposalSubmission, ProposerError,
+    types::{
+        ClaimSubmission, CloseGameSubmission, PendingWithdrawal, ResolveSubmission, TransitionGame,
+    },
 };
 
 /// Contract surface needed by the asynchronous bond manager.
@@ -14,39 +16,49 @@ pub trait BondManagerClient: Send + Sync {
     /// Returns the address whose proposal credits are managed.
     fn proposer_address(&self) -> Address;
 
-    /// Returns the number of games created by the factory.
+    /// Returns the total number of games indexed by the dispute-game factory, across all
+    /// game types.
     async fn game_count(&self) -> Result<u64, ProposerError>;
 
-    /// Returns the game at the provided factory creation index.
-    async fn game_at(&self, index: u64) -> Result<Address, ProposerError>;
+    /// Returns the WIP-1006 game at the provided factory index, or `None` when that index
+    /// holds a game of a different type.
+    async fn game_at(&self, index: u64) -> Result<Option<Address>, ProposerError>;
 
-    /// Returns the proposer that created the provided game.
-    async fn game_proposer(&self, game: Address) -> Result<Address, ProposerError>;
+    /// Returns the account that created the provided game.
+    async fn game_creator(&self, game: Address) -> Result<Address, ProposerError>;
 
     /// Returns the resolution status of the provided game.
     async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError>;
 
-    /// Returns the claimable amount for the managed proposer.
-    async fn claimable(&self, game: Address) -> Result<U256, ProposerError>;
+    /// Returns whether the registry's finality airgap has elapsed for the provided game.
+    ///
+    /// `claimCredit` calls `closeGame`, which reverts until this holds.
+    async fn is_game_finalized(&self, game: Address) -> Result<bool, ProposerError>;
 
-    /// Withdraws credits for the managed proposer.
-    async fn withdraw(&self, game: Address) -> Result<WithdrawSubmission, ProposerError>;
+    /// Returns the credit the managed proposer can unlock from the provided game.
+    async fn credit(&self, game: Address) -> Result<U256, ProposerError>;
+
+    /// Returns the managed proposer's pending `DelayedWETH` withdrawal for the provided game.
+    async fn pending_withdrawal(&self, game: Address) -> Result<PendingWithdrawal, ProposerError>;
+
+    /// Advances the managed proposer's two-phase bond claim on the provided game.
+    async fn claim_credit(&self, game: Address) -> Result<ClaimSubmission, ProposerError>;
 }
 
 /// Minimal contract surface needed by the proposer.
 #[async_trait]
 pub trait ProposerClient: Send + Sync {
-    /// Reads the parent state from the anchor registry.
-    async fn anchor_parent(&self) -> Result<ParentRef, ProposerError>;
+    /// Reads the current anchor checkpoint from the registry.
+    async fn anchor_parent(&self) -> Result<AnchorRef, ProposerError>;
 
-    /// Computes the deterministic proposal key used by the factory lookup.
-    async fn proposal_key(&self, commitment: ProposalCommitment) -> Result<B256, ProposerError>;
-
-    /// Returns an existing game for `proposal_key`, if one exists.
-    async fn game_for_proposal_key(
+    /// Returns the highest-attempt game registered for the given transition under any of
+    /// `parent_candidates`, if one exists.
+    async fn latest_game_for_transition(
         &self,
-        proposal_key: B256,
-    ) -> Result<Option<Address>, ProposerError>;
+        parent_candidates: &[Address],
+        root_claim: B256,
+        l2_block_number: u64,
+    ) -> Result<Option<TransitionGame>, ProposerError>;
 
     /// Returns the resolution status of the provided game, if game exists.
     async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError>;
@@ -54,26 +66,19 @@ pub trait ProposerClient: Send + Sync {
     /// Submits a resolve transaction to the provided game.
     async fn resolve_game(&self, game: Address) -> Result<ResolveSubmission, ProposerError>;
 
+    /// Returns whether the registry's finality airgap has elapsed for the provided game.
+    async fn is_game_finalized(&self, game: Address) -> Result<bool, ProposerError>;
+
     /// Submits a closeGame transaction to the provided game.
     async fn close_game(&self, game: Address) -> Result<CloseGameSubmission, ProposerError>;
-
-    /// Returns the claimable amount the proposer can withdraw from the provided game.
-    async fn claimable(&self, game: Address) -> Result<U256, ProposerError>;
-
-    /// Submits a withdraw transaction to the provided game.
-    async fn withdraw(&self, game: Address) -> Result<WithdrawSubmission, ProposerError>;
-
-    /// Reads the proposer bond from the factory contract.
-    async fn proposer_bond(&self) -> Result<U256, ProposerError>;
 
     /// Gets the latest L1 finalized block hash.
     async fn latest_finalized_l1_block(&self) -> Result<BlockHash, ProposerError>;
 
-    /// Submits a proposal transaction to the factory.
+    /// Creates the proposal's game through the dispute-game factory.
     async fn submit_proposal(
         &self,
         proposal: &Proposal,
         proof: ProofData,
-        proposer_bond: U256,
     ) -> Result<ProposalSubmission, ProposerError>;
 }

--- a/proofs/proposer/src/traits.rs
+++ b/proofs/proposer/src/traits.rs
@@ -51,14 +51,17 @@ pub trait ProposerClient: Send + Sync {
     /// Reads the current anchor checkpoint from the registry.
     async fn anchor_parent(&self) -> Result<AnchorRef, ProposerError>;
 
-    /// Returns the highest-attempt game registered for the given transition under any of
-    /// `parent_candidates`, if one exists.
-    async fn latest_game_for_transition(
+    /// Returns the highest-attempt game registered for the given transition under each of
+    /// `parent_candidates`, in candidate order. Candidates with no game are omitted.
+    ///
+    /// Every candidate is reported rather than just the first hit: an invalidated game under a
+    /// superseded parent must not hide a live one under the parent that is still acceptable.
+    async fn games_for_transition(
         &self,
         parent_candidates: &[Address],
         root_claim: B256,
         l2_block_number: u64,
-    ) -> Result<Option<TransitionGame>, ProposerError>;
+    ) -> Result<Vec<TransitionGame>, ProposerError>;
 
     /// Returns the resolution status of the provided game, if game exists.
     async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError>;

--- a/proofs/proposer/src/types.rs
+++ b/proofs/proposer/src/types.rs
@@ -1,6 +1,64 @@
 use alloy_primitives::{Address, B256, TxHash, U256};
 use world_chain_proofs::{InvalidationReason, ProposalCommitment};
 
+/// The anchor checkpoint the canonical line is rooted at.
+///
+/// `MultiProofGame.initialize` only accepts the registry itself as the parent reference for a
+/// proposal that extends the anchor: once the anchor advances onto a game, that game's L2 block
+/// number is no longer above the anchor and it is rejected as a parent. Games created before the
+/// anchor advanced still reference the anchor game, so both addresses are candidate parents when
+/// looking an existing proposal up.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AnchorRef {
+    /// `AnchorStateRegistry` address, and the parent reference used for new proposals.
+    pub registry: Address,
+    /// Game the registry currently anchors on, if it has advanced past its starting root.
+    pub anchor_game: Option<Address>,
+    /// L2 block number of the anchor output root.
+    pub l2_block_number: u64,
+}
+
+impl AnchorRef {
+    /// Returns the parent reference new proposals extending the anchor must use.
+    #[must_use]
+    pub const fn parent_ref(self) -> ParentRef {
+        ParentRef {
+            address: self.registry,
+            l2_block_number: self.l2_block_number,
+        }
+    }
+
+    /// Returns the parent references an existing proposal at the anchor tip may carry,
+    /// oldest-creation first.
+    #[must_use]
+    pub fn parent_candidates(self) -> Vec<Address> {
+        self.anchor_game
+            .into_iter()
+            .chain(std::iter::once(self.registry))
+            .collect()
+    }
+}
+
+/// A game already registered on the factory for a transition the proposer is scanning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TransitionGame {
+    /// Address of the game clone.
+    pub address: Address,
+    /// Parent reference the game was created with.
+    pub parent_ref: Address,
+    /// Retry nonce the game was created with.
+    pub attempt: u64,
+}
+
+/// A pending `DelayedWETH` withdrawal opened by the first `claimCredit` call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct PendingWithdrawal {
+    /// Amount unlocked in `DelayedWETH` and awaiting the withdrawal delay.
+    pub amount: U256,
+    /// Unix timestamp at which the unlocked amount becomes withdrawable.
+    pub unlock_at: u64,
+}
+
 /// The canonical lineage discovered by the proposer and the action available at its tip.
 #[derive(Debug)]
 pub struct CanonicalScan {
@@ -137,7 +195,7 @@ pub struct ParentRef {
     pub l2_block_number: u64,
 }
 
-/// Candidate proposal data supplied to the proof-system factory.
+/// Candidate proposal data supplied to the dispute-game factory.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Proposal {
     /// Address of the anchor registry or parent game.
@@ -146,18 +204,19 @@ pub struct Proposal {
     pub root_claim: B256,
     /// L2 block number for `root_claim`.
     pub l2_block_number: u64,
-    /// Deterministic factory lookup key, excluding L1 origin.
-    pub proposal_key: B256,
+    /// Retry nonce. Non-zero only when replacing a game invalidated by a proof timeout.
+    pub attempt: u64,
 }
 
 impl Proposal {
-    /// Returns the proposal commitment used to compute the factory lookup key.
+    /// Returns the commitment used to build the factory `extraData` and UUID.
     #[must_use]
     pub const fn commitment(&self) -> ProposalCommitment {
         ProposalCommitment {
             parent_ref: self.parent_ref,
             root_claim: self.root_claim,
             l2_block_number: self.l2_block_number,
+            attempt: self.attempt,
         }
     }
 }
@@ -185,11 +244,16 @@ pub struct CloseGameSubmission {
     pub tx_hash: TxHash,
 }
 
-/// Result of a withdraw transaction.
+/// Result of a `claimCredit` transaction.
+///
+/// Bond payout is two-phase: the first call unlocks the credit in `DelayedWETH`, the second
+/// (after the WETH delay) withdraws and transfers it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct WithdrawSubmission {
-    /// Transaction hash for the withdraw submission.
+pub struct ClaimSubmission {
+    /// Transaction hash for the claim.
     pub tx_hash: TxHash,
-    /// Amount withdrawn from the game.
+    /// Amount moved by this phase.
     pub amount: U256,
+    /// Whether this call finalized the withdrawal and transferred funds.
+    pub withdrawn: bool,
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes L1 dispute-game creation, canonical-line traversal, challenge bonds, and bond settlement across proposer/challenger/defender; mistakes can mis-index games, strand bonds, or post invalid proposals.
> 
> **Overview**
> **Rebinds** the World Chain proof stack from the custom `WorldChainProofSystemFactory` / game contracts to the stock OP **`DisputeGameFactory`**, **`AnchorStateRegistry`**, and WIP-1006 **`MultiProofGame`** (game type 1006). Primitives and Alloy clients now encode proposals as `create(gameType, rootClaim, extraData)`, filter mixed factory indices by game type, and identify games via factory UUID / `attempt` retries instead of proposal keys.
> 
> The **proposer** gains async client setup (domain hash from the registered impl), anchor-aware canonical scanning with `latest_game_for_transition`, proof-timeout retries with incremented `attempt`, per-tx `initBonds`, and anchor close gated on `isGameFinalized`. **Challenger** and **defender** take anchor registry where needed, treat `gameCreator` as the proposer filter, and use bounded forward probes when binary-searching factory cursors past non–WIP-1006 entries.
> 
> **Bond managers** for proposer and challenger drop one-shot `withdraw` / cached factory bonds: challenges read per-game `challengerBond`, payouts go through two-phase **`claimCredit`** and **`DelayedWETH`** pending withdrawals, and games stay tracked until credits are fully drained after registry finality.
> 
> **Devnet** removes the `OP_NATIVE_PROOF_SERVICES_READY` deferral so native proposer/challenger/defender and prover paths run against `DisputeGameFactory.create`, with updated component metadata and logging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fe9d52d7013280f4cbc54ea36e093846e82886b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->