### PR TITLE
feat: remove l1 head from proof request

### DIFF
--- a/proofs/defender/src/lane.rs
+++ b/proofs/defender/src/lane.rs
@@ -89,7 +89,10 @@ where
             .request_proof(proof_request(metadata, backend))
             .await
         {
-            Ok(id) => LaneState::Requested { id, attempts: 1 },
+            Ok(request_proof_response) => LaneState::Requested {
+                id: request_proof_response.proof_id,
+                attempts: 1,
+            },
             Err(error) => {
                 warn!(%game, ?lane, %error, "proof request failed; retrying next tick");
                 LaneState::Pending
@@ -199,18 +202,18 @@ where
             .request_proof(proof_request(metadata, backend))
             .await
         {
-            Ok(id) => {
+            Ok(request_proof_response) => {
                 let next_attempt = attempts + 1;
                 warn!(
                     %game,
                     ?lane,
-                    %id,
+                    %request_proof_response.proof_id,
                     attempts = next_attempt,
                     max_attempts = self.max_proof_attempts,
                     "proof failed; re-requested proof"
                 );
                 LaneState::Requested {
-                    id,
+                    id: request_proof_response.proof_id,
                     attempts: next_attempt,
                 }
             }

--- a/proofs/defender/src/tests.rs
+++ b/proofs/defender/src/tests.rs
@@ -21,7 +21,7 @@ use world_chain_proofs::{
 };
 use world_chain_prover_service::{
     ProofBackend, ProofData, ProofRequest, ProofRequestError, ProofRequestId, ProofRequester,
-    ProofResponse, ProofStatus, SucceededProofResponse,
+    ProofResponse, ProofStatus, RequestProofResponse, SucceededProofResponse,
 };
 
 const GAME_1: Address = address!("0000000000000000000000000000000000000001");
@@ -332,8 +332,9 @@ impl ProofRequester for MockProver {
     async fn request_proof(
         &self,
         proof_request: ProofRequest,
-    ) -> Result<ProofRequestId, ProofRequestError> {
+    ) -> Result<RequestProofResponse, ProofRequestError> {
         let id = proof_request.id();
+        let l1_head = proof_request.l1_head;
         self.requests
             .lock()
             .expect("not poisoned")
@@ -342,7 +343,10 @@ impl ProofRequester for MockProver {
             .lock()
             .expect("not poisoned")
             .insert(id, proof_request);
-        Ok(id)
+        Ok(RequestProofResponse {
+            proof_id: id,
+            l1_head,
+        })
     }
 
     async fn proof_status(

--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -32,7 +32,7 @@ use world_chain_prover_service::{
     HeartbeatRequest, HeartbeatResponse, ProofBackend, ProofData, ProofJobQueue,
     ProofJobQueueError, ProofRequest, ProofRequestError, ProofRequestId, ProofRequester,
     ProofResponse, ProofStatus, ProverService, ProverServiceConfig, RecordProofSessionRequest,
-    RecordProofSessionResponse, SubmitProofRequest, SubmitProofResponse,
+    RecordProofSessionResponse, RequestProofResponse, SubmitProofRequest, SubmitProofResponse,
 };
 
 pub const BLOCK_INTERVAL: u64 = 10;
@@ -768,7 +768,7 @@ impl ProofRequester for SharedProverService {
     async fn request_proof(
         &self,
         proof_request: ProofRequest,
-    ) -> Result<ProofRequestId, ProofRequestError> {
+    ) -> Result<RequestProofResponse, ProofRequestError> {
         self.service.request_proof(proof_request).await
     }
 

--- a/proofs/integration-tests/tests/orchestration.rs
+++ b/proofs/integration-tests/tests/orchestration.rs
@@ -21,7 +21,7 @@ use world_chain_proposer::{
 };
 use world_chain_prover_service::{
     ProofBackend, ProofData, ProofRequest, ProofRequestError, ProofRequestId, ProofRequester,
-    ProofResponse, ProofStatus, ProverServiceConfig, SucceededProofResponse,
+    ProofResponse, ProofStatus, ProverServiceConfig, RequestProofResponse, SucceededProofResponse,
 };
 
 fn proposer_config() -> ProposerConfig {
@@ -64,8 +64,11 @@ impl ProofRequester for InstantProofRequester {
     async fn request_proof(
         &self,
         request: ProofRequest,
-    ) -> Result<ProofRequestId, ProofRequestError> {
-        Ok(request.id())
+    ) -> Result<RequestProofResponse, ProofRequestError> {
+        Ok(RequestProofResponse {
+            proof_id: request.id(),
+            l1_head: request.l1_head,
+        })
     }
 
     async fn proof_status(

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -304,16 +304,22 @@ where
             .as_ref()
             .expect("pending proposal initialized");
 
-        let returned_id = self
+        let request_proof_response = self
             .proof_requester
             .request_proof(pending.proof_request.clone())
             .await?;
-        if returned_id != pending.proof_id {
+        let request_proof_response_proof_id = request_proof_response.proof_id;
+        if request_proof_response_proof_id != pending.proof_id {
             return Err(ProposerError::InvalidProofResponse(format!(
-                "prover-service returned proof id {returned_id}, expected {}",
+                "prover-service returned proof id {request_proof_response_proof_id}, expected {}",
                 pending.proof_id
             )));
         }
+        self.pending_proposal
+            .as_mut()
+            .expect("pending proposal initialized")
+            .proof_request
+            .l1_head = request_proof_response.l1_head;
         Ok(())
     }
 

--- a/proofs/proposer/src/tests.rs
+++ b/proofs/proposer/src/tests.rs
@@ -12,7 +12,7 @@ use world_chain_proofs::{
 };
 use world_chain_prover_service::{
     ProofBackend, ProofData, ProofRequest, ProofRequestError, ProofRequestId, ProofRequester,
-    ProofResponse, ProofStatus, SucceededProofResponse,
+    ProofResponse, ProofStatus, RequestProofResponse, SucceededProofResponse,
 };
 
 use crate::{
@@ -166,10 +166,14 @@ impl ProofRequester for MockProofRequester {
     async fn request_proof(
         &self,
         request: ProofRequest,
-    ) -> Result<ProofRequestId, ProofRequestError> {
+    ) -> Result<RequestProofResponse, ProofRequestError> {
         let id = request.id();
+        let l1_head = request.l1_head;
         self.requests.lock().expect("not poisoned").push(request);
-        Ok(id)
+        Ok(RequestProofResponse {
+            proof_id: id,
+            l1_head,
+        })
     }
 
     async fn proof_status(

--- a/proofs/prover-cli/src/main.rs
+++ b/proofs/prover-cli/src/main.rs
@@ -193,10 +193,11 @@ async fn run(cli: Cli) -> Result<()> {
     let client = RpcProverServiceClient::new(&cli.prover_service_url)
         .with_context(|| format!("failed to connect to {}", cli.prover_service_url))?;
 
-    let id = client
+    let response = client
         .request_proof(request)
         .await
         .context("submit proof request")?;
+    let id = response.proof_id;
     println!("submitted proof request {id} for L2 block {l2_block_number}");
 
     if !cli.poll {

--- a/proofs/prover-service/src/error.rs
+++ b/proofs/prover-service/src/error.rs
@@ -46,6 +46,8 @@ pub enum ProofRequestError {
     ProofEncoding(#[from] serde_json::Error),
     #[error("The block number {0} exceeds i64 max value.")]
     BlockNumberExceedsI64(BlockNumber),
+    #[error("The provided value has {0} bytes, expected 32.")]
+    MalformedB256(usize),
     #[error("remote prover-service internal error.")]
     RemoteInternal,
     #[error("remote prover-service storage error.")]
@@ -60,6 +62,21 @@ pub enum ProofRequestError {
     RpcServiceDisconnected,
     #[error("RPC client error: {0}.")]
     RpcClient(#[source] JsonRpseeError),
+}
+
+#[derive(Debug)]
+pub struct MalformedB256Error(pub usize);
+
+impl From<MalformedB256Error> for ProofRequestError {
+    fn from(error: MalformedB256Error) -> Self {
+        Self::MalformedB256(error.0)
+    }
+}
+
+impl From<MalformedB256Error> for ProofJobQueueError {
+    fn from(error: MalformedB256Error) -> Self {
+        Self::MalformedB256(error.0)
+    }
 }
 
 /// Data describing a proof request that exceeded retry limits.

--- a/proofs/prover-service/src/error.rs
+++ b/proofs/prover-service/src/error.rs
@@ -34,6 +34,8 @@ pub enum ProofRequestError {
     Sqlx(#[from] sqlx::Error),
     #[error("proof id {0}: proof request row missing after insert conflict. Retry request_proof.")]
     RowMissingAfterConflict(ProofRequestId),
+    #[error("proof id {0}: stored proof request does not match the submitted request.")]
+    RequestMismatch(ProofRequestId),
     #[error("{0}")]
     UnknownProofStatus(String),
     #[error("{0}")]

--- a/proofs/prover-service/src/lib.rs
+++ b/proofs/prover-service/src/lib.rs
@@ -98,8 +98,8 @@ pub use types::{
     GetNextProofResponse, GetProofSessionRequest, GetProofSessionResponse, HeartbeatRequest,
     HeartbeatResponse, LockId, LockedProofRequest, PendingProofResponse, ProofBackend, ProofData,
     ProofJobStatus, ProofRequest, ProofRequestId, ProofResponse, ProofStatus,
-    RecordProofSessionRequest, RecordProofSessionResponse, SessionType, SubmitProofRequest,
-    SubmitProofResponse, SucceededProofResponse,
+    RecordProofSessionRequest, RecordProofSessionResponse, RequestProofResponse, SessionType,
+    SubmitProofRequest, SubmitProofResponse, SucceededProofResponse,
 };
 
 #[cfg(test)]

--- a/proofs/prover-service/src/rpc.rs
+++ b/proofs/prover-service/src/rpc.rs
@@ -110,7 +110,8 @@ impl From<ProofRequestError> for ErrorObjectOwned {
                 ErrorObject::owned(error_code::TOO_MANY_RETRIES, message, Some(data))
             }
             ProofRequestError::Sqlx(_) => ErrorObject::owned(error_code::SQLX, message, None::<()>),
-            ProofRequestError::UnknownProofStatus(_)
+            ProofRequestError::RequestMismatch(_)
+            | ProofRequestError::UnknownProofStatus(_)
             | ProofRequestError::ProofEncoding(_)
             | ProofRequestError::BlockNumberExceedsI64(_)
             | ProofRequestError::RemoteInternal

--- a/proofs/prover-service/src/rpc.rs
+++ b/proofs/prover-service/src/rpc.rs
@@ -9,8 +9,8 @@ use crate::{
     types::{
         GetNextProofRequest, GetNextProofResponse, GetProofSessionRequest, GetProofSessionResponse,
         HeartbeatRequest, HeartbeatResponse, ProofRequest, ProofRequestId, ProofResponse,
-        ProofStatus, RecordProofSessionRequest, RecordProofSessionResponse, SubmitProofRequest,
-        SubmitProofResponse,
+        ProofStatus, RecordProofSessionRequest, RecordProofSessionResponse, RequestProofResponse,
+        SubmitProofRequest, SubmitProofResponse,
     },
 };
 use jsonrpsee::{
@@ -56,9 +56,9 @@ pub mod error_code {
 /// [`ProofRequester`] surface and the worker-facing [`ProofJobQueue`] surface.
 #[rpc(server, client, namespace = "prover")]
 pub trait ProverServiceApi {
-    /// Queue a proof request, returning its deterministic id.
+    /// Queue a proof request, returning its deterministic id and stored L1 head.
     #[method(name = "requestProof")]
-    async fn request_proof(&self, proof_request: ProofRequest) -> RpcResult<ProofRequestId>;
+    async fn request_proof(&self, proof_request: ProofRequest) -> RpcResult<RequestProofResponse>;
 
     /// Get the current status of a proof request.
     #[method(name = "proofStatus")]
@@ -114,6 +114,7 @@ impl From<ProofRequestError> for ErrorObjectOwned {
             | ProofRequestError::UnknownProofStatus(_)
             | ProofRequestError::ProofEncoding(_)
             | ProofRequestError::BlockNumberExceedsI64(_)
+            | ProofRequestError::MalformedB256(_)
             | ProofRequestError::RemoteInternal
             | ProofRequestError::RemoteSqlx
             | ProofRequestError::RpcRequestTimeout
@@ -198,7 +199,7 @@ impl ProverServiceRpc {
 
 #[async_trait]
 impl ProverServiceApiServer for ProverServiceRpc {
-    async fn request_proof(&self, proof_request: ProofRequest) -> RpcResult<ProofRequestId> {
+    async fn request_proof(&self, proof_request: ProofRequest) -> RpcResult<RequestProofResponse> {
         Ok(self.service.request_proof(proof_request).await?)
     }
 
@@ -375,7 +376,7 @@ impl ProofRequester for RpcProverServiceClient {
     async fn request_proof(
         &self,
         proof_request: ProofRequest,
-    ) -> Result<ProofRequestId, ProofRequestError> {
+    ) -> Result<RequestProofResponse, ProofRequestError> {
         let id = proof_request.id();
         ProverServiceApiClient::request_proof(&self.client, proof_request)
             .await

--- a/proofs/prover-service/src/service.rs
+++ b/proofs/prover-service/src/service.rs
@@ -6,8 +6,8 @@ use crate::{
     types::{
         GetNextProofRequest, GetNextProofResponse, GetProofSessionRequest, GetProofSessionResponse,
         HeartbeatRequest, HeartbeatResponse, ProofRequest, ProofRequestId, ProofResponse,
-        ProofStatus, RecordProofSessionRequest, RecordProofSessionResponse, SubmitProofRequest,
-        SubmitProofResponse,
+        ProofStatus, RecordProofSessionRequest, RecordProofSessionResponse, RequestProofResponse,
+        SubmitProofRequest, SubmitProofResponse,
     },
 };
 use async_trait::async_trait;
@@ -63,7 +63,7 @@ impl ProofRequester for ProverService {
     async fn request_proof(
         &self,
         proof_request: ProofRequest,
-    ) -> Result<ProofRequestId, ProofRequestError> {
+    ) -> Result<RequestProofResponse, ProofRequestError> {
         self.store.request_proof(proof_request).await
     }
 

--- a/proofs/prover-service/src/store.rs
+++ b/proofs/prover-service/src/store.rs
@@ -120,7 +120,8 @@ impl ProverServiceStore {
         // conflict path
         let row = sqlx::query(
             r#"
-            SELECT proof_status, retry_count
+            SELECT proof_status, retry_count, backend, game,
+                root_claim, l2_block_number, l1_head
             FROM proof_requests
             WHERE proof_id = $1
             FOR UPDATE
@@ -139,6 +140,11 @@ impl ProverServiceStore {
         let proof_status = ProofStatus::try_from(proof_status_str)
             .map_err(ProofRequestError::UnknownProofStatus)?;
 
+        if !request_matches(&row, &proof_request, proof_status)? {
+            tx.rollback().await?;
+            return Err(ProofRequestError::RequestMismatch(id));
+        }
+
         if proof_status == ProofStatus::Failed {
             // retry the entire proof job if retry_count is less than the max_retry
             let retry_count: i32 = row.get("retry_count");
@@ -156,6 +162,7 @@ impl ProverServiceStore {
                 SET proof_status = $1,
                     job_status = $2,
                     retry_count = retry_count + 1,
+                    l1_head = $3,
                     failure_reason = NULL,
                     proof_data = NULL,
                     finished_at = NULL,
@@ -163,11 +170,12 @@ impl ProverServiceStore {
                     lock_id = NULL,
                     lock_expires_at = NULL,
                     attempt = 0
-                WHERE proof_id = $3
+                WHERE proof_id = $4
                 "#,
             )
             .bind(ProofStatus::Created.as_str())
             .bind(ProofJobStatus::Pending.as_str())
+            .bind(proof_request.l1_head.as_slice())
             .bind(&proof_id)
             .execute(&mut *tx)
             .await?;
@@ -856,6 +864,24 @@ impl ProverServiceStore {
 
 fn proof_id_bytes(id: ProofRequestId) -> Vec<u8> {
     id.0.as_slice().to_vec()
+}
+
+fn request_matches(
+    row: &PgRow,
+    request: &ProofRequest,
+    status: ProofStatus,
+) -> Result<bool, ProofRequestError> {
+    let stored_backend: &str = row.get("backend");
+    let stored_game: &[u8] = row.get("game");
+    let stored_root_claim: &[u8] = row.get("root_claim");
+    let stored_l2_block_number: i64 = row.get("l2_block_number");
+    let stored_l1_head: &[u8] = row.get("l1_head");
+
+    Ok(stored_backend == request.backend.as_str()
+        && stored_game == request.game.as_slice()
+        && stored_root_claim == request.root_claim.as_slice()
+        && stored_l2_block_number == l2_to_i64(request.l2_block_number)?
+        && (status == ProofStatus::Failed || stored_l1_head == request.l1_head.as_slice()))
 }
 
 fn b256_from_bytes(bytes: Vec<u8>) -> Result<B256, ProofJobQueueError> {

--- a/proofs/prover-service/src/store.rs
+++ b/proofs/prover-service/src/store.rs
@@ -144,7 +144,7 @@ impl ProverServiceStore {
         let proof_status = ProofStatus::try_from(proof_status_str)
             .map_err(ProofRequestError::UnknownProofStatus)?;
 
-        if !request_matches(&row, &proof_request, proof_status)? {
+        if !request_matches(&row, &proof_request)? {
             tx.rollback().await?;
             return Err(ProofRequestError::RequestMismatch(id));
         }
@@ -879,22 +879,18 @@ fn proof_id_bytes(id: ProofRequestId) -> Vec<u8> {
     id.0.as_slice().to_vec()
 }
 
-fn request_matches(
-    row: &PgRow,
-    request: &ProofRequest,
-    status: ProofStatus,
-) -> Result<bool, ProofRequestError> {
+/// Returns true if the request matches the stored values with the exception of l1_head
+/// that is not compared because it may change.
+fn request_matches(row: &PgRow, request: &ProofRequest) -> Result<bool, ProofRequestError> {
     let stored_backend: &str = row.get("backend");
     let stored_game: &[u8] = row.get("game");
     let stored_root_claim: &[u8] = row.get("root_claim");
     let stored_l2_block_number: i64 = row.get("l2_block_number");
-    let stored_l1_head: &[u8] = row.get("l1_head");
 
     Ok(stored_backend == request.backend.as_str()
         && stored_game == request.game.as_slice()
         && stored_root_claim == request.root_claim.as_slice()
-        && stored_l2_block_number == l2_to_i64(request.l2_block_number)?
-        && (status == ProofStatus::Failed || stored_l1_head == request.l1_head.as_slice()))
+        && stored_l2_block_number == l2_to_i64(request.l2_block_number)?)
 }
 
 fn b256_from_bytes(bytes: Vec<u8>) -> Result<B256, MalformedB256Error> {

--- a/proofs/prover-service/src/store.rs
+++ b/proofs/prover-service/src/store.rs
@@ -3,16 +3,16 @@ use crate::{
     config::ProverServiceConfig,
     error::{
         BackendMismatchErrorData, BackendSessionAlreadyTerminalErrorData, InvalidConfigError,
-        ProofJobQueueError, ProofJobStatusErrorData, ProofMismatchErrorData, ProofRequestError,
-        ProverServiceInitError, TooManyRetriesErrorData,
+        MalformedB256Error, ProofJobQueueError, ProofJobStatusErrorData, ProofMismatchErrorData,
+        ProofRequestError, ProverServiceInitError, TooManyRetriesErrorData,
     },
     types::{
         BackendSession, BackendSessionStatus, FailedProofResponse, GetNextProofRequest,
         GetNextProofResponse, GetProofSessionRequest, GetProofSessionResponse, HeartbeatRequest,
         HeartbeatResponse, LockId, LockedProofRequest, PendingProofResponse, ProofBackend,
         ProofJobStatus, ProofRequest, ProofRequestId, ProofResponse, ProofStatus,
-        RecordProofSessionRequest, RecordProofSessionResponse, SubmitProofRequest,
-        SubmitProofResponse, SucceededProofResponse,
+        RecordProofSessionRequest, RecordProofSessionResponse, RequestProofResponse,
+        SubmitProofRequest, SubmitProofResponse, SucceededProofResponse,
     },
 };
 use alloy_primitives::{Address, B256};
@@ -80,7 +80,7 @@ impl ProverServiceStore {
     pub(crate) async fn request_proof(
         &self,
         proof_request: ProofRequest,
-    ) -> Result<ProofRequestId, ProofRequestError> {
+    ) -> Result<RequestProofResponse, ProofRequestError> {
         let id = proof_request.id();
         let backend = proof_request.backend;
         let proof_id = proof_id_bytes(id);
@@ -114,7 +114,11 @@ impl ProverServiceStore {
         if insert_result.rows_affected() > 0 {
             // no conflict
             tx.commit().await?;
-            return Ok(id);
+            let request_proof_response = RequestProofResponse {
+                proof_id: id,
+                l1_head: proof_request.l1_head,
+            };
+            return Ok(request_proof_response);
         }
 
         // conflict path
@@ -188,12 +192,21 @@ impl ProverServiceStore {
             );
 
             tx.commit().await?;
-            Ok(id)
+            let request_proof_response = RequestProofResponse {
+                proof_id: id,
+                l1_head: proof_request.l1_head,
+            };
+            Ok(request_proof_response)
         } else {
             // this proof request already exists in the db with a non-failing status.
             // Rollback the db transaction and return the proof id.
             tx.rollback().await?;
-            Ok(id)
+            let stored_l1_head = b256_from_bytes(row.get("l1_head"))?;
+            let request_proof_response = RequestProofResponse {
+                proof_id: id,
+                l1_head: stored_l1_head,
+            };
+            Ok(request_proof_response)
         }
     }
 
@@ -884,9 +897,9 @@ fn request_matches(
         && (status == ProofStatus::Failed || stored_l1_head == request.l1_head.as_slice()))
 }
 
-fn b256_from_bytes(bytes: Vec<u8>) -> Result<B256, ProofJobQueueError> {
+fn b256_from_bytes(bytes: Vec<u8>) -> Result<B256, MalformedB256Error> {
     if bytes.len() != 32 {
-        return Err(ProofJobQueueError::MalformedB256(bytes.len()));
+        return Err(MalformedB256Error(bytes.len()));
     }
     Ok(B256::from_slice(&bytes))
 }

--- a/proofs/prover-service/src/tests.rs
+++ b/proofs/prover-service/src/tests.rs
@@ -163,7 +163,8 @@ async fn full_lifecycle_succeeds() {
     let service = ctx.service;
     let req = request(ProofBackend::Nitro, 1);
 
-    let id = service.request_proof(req.clone()).await.unwrap();
+    let response = service.request_proof(req.clone()).await.unwrap();
+    let id = response.proof_id;
     assert_eq!(
         service.proof_status(id).await.unwrap(),
         ProofStatus::Created
@@ -217,9 +218,9 @@ async fn duplicate_request_is_deduplicated() {
     let first = service.request_proof(req.clone()).await.unwrap();
     let second = service.request_proof(req.clone()).await.unwrap();
     assert_eq!(first, second);
-    assert_eq!(first, req.id());
+    assert_eq!(first.proof_id, req.id());
     assert_eq!(
-        service.proof_status(first).await.unwrap(),
+        service.proof_status(first.proof_id).await.unwrap(),
         ProofStatus::Created
     );
 }
@@ -247,7 +248,7 @@ async fn stale_lock_is_rejected_and_reclaim_succeeds() {
     };
     let service = ctx.service;
     let req = request(ProofBackend::Sp1, 3);
-    let id = service.request_proof(req.clone()).await.unwrap();
+    let id = service.request_proof(req.clone()).await.unwrap().proof_id;
 
     let first = service
         .get_next_proof(get_next_proof_request(ProofBackend::Sp1))
@@ -292,7 +293,7 @@ async fn submit_proof_with_wrong_backend_is_rejected() {
     };
     let service = ctx.service;
     let req = request(ProofBackend::Sp1, 4);
-    let id = service.request_proof(req.clone()).await.unwrap();
+    let id = service.request_proof(req.clone()).await.unwrap().proof_id;
     let locked = service
         .get_next_proof(get_next_proof_request(ProofBackend::Sp1))
         .await
@@ -330,7 +331,7 @@ async fn status_poller_marks_expired_exhausted_jobs_failed() {
     };
     let service = ctx.service;
     let req = request(ProofBackend::Sp1, 5);
-    let id = service.request_proof(req).await.unwrap();
+    let id = service.request_proof(req).await.unwrap().proof_id;
 
     let first = service
         .get_next_proof(get_next_proof_request(ProofBackend::Sp1))
@@ -426,7 +427,7 @@ async fn record_and_get_proof_session_round_trips() {
     };
     let service = ctx.service;
     let req = request(ProofBackend::Sp1, 5);
-    let id = service.request_proof(req.clone()).await.unwrap();
+    let id = service.request_proof(req.clone()).await.unwrap().proof_id;
     let locked = service
         .get_next_proof(get_next_proof_request(ProofBackend::Sp1))
         .await
@@ -477,7 +478,7 @@ async fn rpc_end_to_end() {
     let client = RpcProverServiceClient::new(format!("http://{addr}")).unwrap();
 
     let req = request(ProofBackend::Sp1, 6);
-    let id = client.request_proof(req.clone()).await.unwrap();
+    let id = client.request_proof(req.clone()).await.unwrap().proof_id;
     assert_eq!(client.proof_status(id).await.unwrap(), ProofStatus::Created);
 
     let locked = client

--- a/proofs/prover-service/src/traits.rs
+++ b/proofs/prover-service/src/traits.rs
@@ -3,8 +3,8 @@ use crate::{
     types::{
         GetNextProofRequest, GetNextProofResponse, GetProofSessionRequest, GetProofSessionResponse,
         HeartbeatRequest, HeartbeatResponse, ProofRequest, ProofRequestId, ProofResponse,
-        ProofStatus, RecordProofSessionRequest, RecordProofSessionResponse, SubmitProofRequest,
-        SubmitProofResponse,
+        ProofStatus, RecordProofSessionRequest, RecordProofSessionResponse, RequestProofResponse,
+        SubmitProofRequest, SubmitProofResponse,
     },
 };
 use async_trait::async_trait;
@@ -23,7 +23,7 @@ pub trait ProofRequester {
     async fn request_proof(
         &self,
         proof_request: ProofRequest,
-    ) -> Result<ProofRequestId, ProofRequestError>;
+    ) -> Result<RequestProofResponse, ProofRequestError>;
 
     /// Get the current status of a proof request.
     async fn proof_status(

--- a/proofs/prover-service/src/types.rs
+++ b/proofs/prover-service/src/types.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{Address, B256, BlockNumber, Bytes, keccak256};
+use alloy_primitives::{Address, B256, BlockHash, BlockNumber, Bytes, keccak256};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -65,8 +65,8 @@ pub struct ProofRequest {
 impl ProofRequest {
     /// Compute the deterministic identifier of this request.
     ///
-    /// The id is a commitment to every request field, so requesting the
-    /// same proof twice yields the same id and the duplicate is deduplicated
+    /// The id is a commitment to every request field except for `l1_head`, so requesting
+    /// the same proof twice yields the same id and the duplicate is deduplicated
     /// by the `prover-service`.
     #[must_use]
     pub fn id(&self) -> ProofRequestId {
@@ -75,7 +75,6 @@ impl ProofRequest {
         buf.extend_from_slice(self.game.as_slice());
         buf.extend_from_slice(self.root_claim.as_slice());
         buf.extend_from_slice(&self.l2_block_number.to_be_bytes());
-        buf.extend_from_slice(self.l1_head.as_slice());
         ProofRequestId(keccak256(buf))
     }
 }
@@ -381,6 +380,15 @@ impl TryFrom<&str> for BackendSessionStatus {
             other => Err(format!("Unknown session status: {other}")),
         }
     }
+}
+
+/// Response to the `request_proof` method on the prover-service.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RequestProofResponse {
+    /// The proof request id.
+    pub proof_id: ProofRequestId,
+    /// The l1_head block hash stored in the prover-service.
+    pub l1_head: BlockHash,
 }
 
 /// Request to claim the next queued proof job for a worker.

--- a/proofs/prover-service/src/types.rs
+++ b/proofs/prover-service/src/types.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{Address, B256, BlockHash, BlockNumber, Bytes, keccak256};
+use alloy_primitives::{Address, B256, BlockNumber, Bytes, keccak256};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -388,7 +388,7 @@ pub struct RequestProofResponse {
     /// The proof request id.
     pub proof_id: ProofRequestId,
     /// The l1_head block hash stored in the prover-service.
-    pub l1_head: BlockHash,
+    pub l1_head: B256,
 }
 
 /// Request to claim the next queued proof job for a worker.

--- a/proofs/sp1-worker/tests/e2e_proving.rs
+++ b/proofs/sp1-worker/tests/e2e_proving.rs
@@ -269,10 +269,11 @@ async fn run_worker_proves_real_range_end_to_end_with_prover<P>(
         l2_block_number: claimed_block,
         l1_head,
     };
-    let id = client
+    let response = client
         .request_proof(request)
         .await
         .expect("enqueue proof request");
+    let id = response.proof_id;
     eprintln!(
         "enqueued {id} for block {claimed_block} (interval {block_interval}, {kind} prover); proving may take a while"
     );

--- a/proofs/sp1-worker/tests/rpc_roundtrip.rs
+++ b/proofs/sp1-worker/tests/rpc_roundtrip.rs
@@ -73,11 +73,12 @@ async fn worker_completes_requested_proof_over_rpc() {
         l2_block_number: 1_200,
         l1_head: B256::repeat_byte(0x11),
     };
-    let id = requester
+    let response = requester
         .request_proof(request.clone())
         .await
         .expect("request accepted");
-    assert_eq!(id, request.id());
+    assert_eq!(response.proof_id, request.id());
+    let id = response.proof_id;
 
     let worker = ProofWorker::new(
         queue,


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-5002/make-l1-head-not-part-of-the-proof-request-id

This PR removes the `l1_head` field from the proof request id computation, so that 2 proof requests with all fields equal with the exception of the `l1_head` still generate the same proof request id. This makes it possible for the `world-chain-proposer` to reuse an already generated proof when it gets restarted in the middle of a proof generation before proposing a new game.

The `prover-service` now returns the `l1_head` together with the `proof_id` so that the `world-chain-proposer` can update the `l1_field` and later use it when creating a new game.

### Next Steps

1. There is a slight adjustment to make for sp1 proofs: we could make the `l1_head` invariant explicit by either:
    - allowing l1_head replacement only for `ProofBackend::Nitro` or
    - clearing completed SP1 sessions whenever an SP1 request’s L1 head changes.
    Note that this is not a blocker issue, but still it makes sense to address it in a follow up PR, more info [here](https://linear.app/worldcoin/issue/PROTO-5003/fix-l1-head-for-sp1)
2. Right now the `l1_head` is not used by `world-chain-proposer` when proposing a new game, similarly to the `proof` field. This is because we need to wait for the contract to be upgraded first. Then on a follow up I'll wire it. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes proof id semantics and prover-service dedup/conflict handling across RPC and Postgres; wrong behavior could reuse or reject proofs incorrectly, though scope is mostly orchestration rather than on-chain verification.
> 
> **Overview**
> **Proof request IDs no longer include `l1_head`**, so the same logical job (backend, game, root claim, L2 block) deduplicates even when the L1 head hash differs—e.g. after a proposer restart mid-proof.
> 
> **`request_proof` now returns `RequestProofResponse`** (`proof_id` + **`l1_head` stored in the service**) instead of only an id. JSON-RPC, `ProofRequester`, defender lane driver, CLI, and tests are updated accordingly.
> 
> **Prover-service store behavior on duplicate ids:** conflicts compare all fields **except** `l1_head`; mismatches on the other fields yield **`RequestMismatch`**. On idempotent replay or failed-job retry, the response carries the **canonical stored** `l1_head`; retries also **persist an updated `l1_head`**.
> 
> **`world-chain-proposer`** overwrites pending `proof_request.l1_head` from the response after each `request_proof` (for later game creation; not yet wired on-chain per PR notes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6044f5f0538f896b3e6ca5eabfee0d6762561bbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->