### PR TITLE
fix: restrict request_matches to ensure only nitro can change l1_head

### DIFF
--- a/proofs/prover-service/src/store.rs
+++ b/proofs/prover-service/src/store.rs
@@ -879,18 +879,26 @@ fn proof_id_bytes(id: ProofRequestId) -> Vec<u8> {
     id.0.as_slice().to_vec()
 }
 
-/// Returns true if the request matches the stored values with the exception of l1_head
-/// that is not compared because it may change.
+/// Returns true if the request matches the stored values.
+///
+/// Nitro requests may replace their L1 head after a failed attempt because the proposer
+/// deliberately retries against a newer finalized head. SP1 requests are pinned to the L1
+/// origin in immutable game metadata, so accepting a different head could make a completed
+/// backend session from the previous attempt unusable while still eligible for resumption.
 fn request_matches(row: &PgRow, request: &ProofRequest) -> Result<bool, ProofRequestError> {
     let stored_backend: &str = row.get("backend");
     let stored_game: &[u8] = row.get("game");
     let stored_root_claim: &[u8] = row.get("root_claim");
     let stored_l2_block_number: i64 = row.get("l2_block_number");
+    let stored_l1_head = b256_from_bytes(row.get("l1_head"))?;
+    let l1_head_matches =
+        request.backend == ProofBackend::Nitro || stored_l1_head == request.l1_head;
 
     Ok(stored_backend == request.backend.as_str()
         && stored_game == request.game.as_slice()
         && stored_root_claim == request.root_claim.as_slice()
-        && stored_l2_block_number == l2_to_i64(request.l2_block_number)?)
+        && stored_l2_block_number == l2_to_i64(request.l2_block_number)?
+        && l1_head_matches)
 }
 
 fn b256_from_bytes(bytes: Vec<u8>) -> Result<B256, MalformedB256Error> {


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-5003/fix-l1-head-for-sp1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes proof job deduplication semantics for SP1 and could reject previously accepted conflicting re-requests; scope is limited to the conflict path in `request_proof`.
> 
> **Overview**
> Tightens duplicate proof-request validation in `request_matches` so **`l1_head` is compared for non-Nitro backends (including SP1)** instead of being ignored.
> 
> **Nitro** may still resubmit with a different `l1_head` after a failed attempt (newer finalized head). **SP1** must match the stored head because the L1 origin is fixed in game metadata; allowing a different head on conflict could treat the request as the same job while invalidating a prior backend session that could still be resumed.
> 
> Docs on `request_matches` are updated to explain this backend-specific behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ce44f4850b97f1139857b5047f10a024f2ddf8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->