### PR TITLE
fix: ci test profile

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,6 +1,11 @@
 [profile.default]
 failure-output = "immediate-final"
 success-output = "never"
+slow-timeout = { period = "120s", terminate-after = 3 }
+
+[[profile.default.overrides]]
+filter = 'package(world-chain-tests)'
+threads-required = 4
 
 [profile.default.junit]
 path = "target/nextest/junit.xml"
@@ -10,3 +15,7 @@ store-success-output = false
 [profile.ci]
 fail-fast = false
 failure-output = "immediate-final"
+
+[[profile.ci.overrides]]
+filter = 'package(world-chain-tests)'
+retries = { backoff = "exponential", count = 2, delay = "2s", jitter = true }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -7,6 +7,10 @@ slow-timeout = { period = "120s", terminate-after = 3 }
 filter = 'package(world-chain-tests)'
 threads-required = 4
 
+[[profile.default.overrides]]
+filter = 'test(/acceptance_tests::/)'
+slow-timeout = { period = "300s", terminate-after = 6 }
+
 [profile.default.junit]
 path = "target/nextest/junit.xml"
 store-failure-output = true
@@ -17,5 +21,5 @@ fail-fast = false
 failure-output = "immediate-final"
 
 [[profile.ci.overrides]]
-filter = 'package(world-chain-tests)'
+filter = 'package(world-chain-tests) - test(/acceptance_tests::/)'
 retries = { backoff = "exponential", count = 2, delay = "2s", jitter = true }

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -76,7 +76,7 @@ jobs:
           restore-keys: cargo-test-
       - uses: taiki-e/install-action@nextest
       - name: tests
-        run: just test
+        run: just test --profile ci
 
   cargo-clippy:
     runs-on: arc-public-8xlarge-amd64-runner

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,9 @@ exclude = ["proofs/succinct/programs"]
 
 default-members = ["bin/world-chain"]
 
+[profile.dev.package."*"]
+opt-level = 2
+
 [profile.maxperf]
 codegen-units = 1
 inherits = "release"
@@ -66,9 +69,6 @@ inherits = "dev"
 
 
 [workspace.lints.rust]
-# eyre 0.6's `bail!` macro ends with a trailing semicolon, which nightly Rust
-# now warns about when the macro is used in expression position (match arms, etc.).
-# This is a known upstream issue; suppress until eyre is updated or we migrate.
 semicolon_in_expressions_from_macros = "allow"
 
 

--- a/e2e-tests/src/it/acceptance_tests/mod.rs
+++ b/e2e-tests/src/it/acceptance_tests/mod.rs
@@ -21,7 +21,7 @@ async fn run_acceptance_tests() -> eyre::Result<()> {
     erc4337::sponsored_user_operations(&env).await
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_network() -> eyre::Result<()> {
     run_acceptance_tests().await
 }

--- a/e2e-tests/src/it/admin_tracing.rs
+++ b/e2e-tests/src/it/admin_tracing.rs
@@ -18,7 +18,7 @@ use tracing::level_filters::LevelFilter;
 use world_chain_node::context::WorldChainDefaultContext;
 use world_chain_test_utils::e2e_harness::setup::WorldChainTestBuilder;
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_admin_tracing_directives_apply_and_revert() -> eyre::Result<()> {
     // Install a reloadable tracing subscriber and register the reload handle,
     // exactly as `reth_tracing` does when the CLI enables reload. Each nextest

--- a/e2e-tests/src/it/devnet_smoke.rs
+++ b/e2e-tests/src/it/devnet_smoke.rs
@@ -10,7 +10,7 @@ use world_chain_devnet::{
 use world_chain_test_utils::DEV_CHAIN_ID;
 
 #[ignore = "Does not run in CI"]
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn direct_sequencer_devnet_smoke() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
@@ -139,7 +139,7 @@ async fn wait_for_safe_head_progress(
 }
 
 #[ignore = "Does not run in CI"]
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn devnet_run_until_shutdown_uses_continuous_block_driver() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 

--- a/e2e-tests/src/it/devnet_withdrawal.rs
+++ b/e2e-tests/src/it/devnet_withdrawal.rs
@@ -81,7 +81,7 @@ struct InitiatedWithdrawal {
 }
 
 #[ignore = "requires Docker, Foundry, and the full local OP Stack"]
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn op_native_wip_1006_portal_withdrawal_and_bond_claim() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 

--- a/e2e-tests/src/it/testsuite.rs
+++ b/e2e-tests/src/it/testsuite.rs
@@ -96,7 +96,7 @@ async fn create_priority_transaction(
     Ok((signed.encoded_2718().into(), *signed.tx_hash()))
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_can_build_pbh_payload() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
     let (signers, mut nodes, _tasks, _, _) = WorldChainTestBuilder::builder()
@@ -130,7 +130,7 @@ async fn test_can_build_pbh_payload() -> eyre::Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_transaction_pool_ordering() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
@@ -182,7 +182,7 @@ async fn test_transaction_pool_ordering() -> eyre::Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_enforces_block_uncompressed_size_limit() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
@@ -279,7 +279,7 @@ async fn test_enforces_block_uncompressed_size_limit() -> eyre::Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_without_block_uncompressed_size_limit_includes_all_transactions() -> eyre::Result<()>
 {
     reth_tracing::init_test_tracing();
@@ -386,7 +386,7 @@ async fn signed_gas_burner(
 /// 3. **The gate actually engaged** – the load spills across multiple blocks and at least one block
 ///    fills close to the limit, proving the overflow path was exercised rather than trivially fitting.
 /// 4. **No transaction is wrongly dropped** – deferred transactions drain over subsequent blocks.
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_payload_builder_fuzzed_gas_limits_flashblocks() -> eyre::Result<()> {
     use std::sync::Mutex;
 
@@ -568,7 +568,7 @@ async fn test_payload_builder_fuzzed_gas_limits_flashblocks() -> eyre::Result<()
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_invalidate_dup_tx_and_nullifier() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
     let (_signers, mut nodes, _tasks, _, _) = WorldChainTestBuilder::builder()
@@ -586,7 +586,7 @@ async fn test_invalidate_dup_tx_and_nullifier() -> eyre::Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_dup_pbh_nonce() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
@@ -617,7 +617,7 @@ async fn test_dup_pbh_nonce() -> eyre::Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_flashblocks() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
@@ -746,7 +746,7 @@ async fn test_flashblocks() -> eyre::Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_eth_api_receipt() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
@@ -842,7 +842,7 @@ async fn test_eth_api_receipt() -> eyre::Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_eth_api_call() -> eyre::Result<()> {
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
@@ -925,7 +925,7 @@ async fn test_eth_api_call() -> eyre::Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_op_api_supported_capabilities_call() -> eyre::Result<()> {
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
@@ -949,7 +949,7 @@ async fn test_op_api_supported_capabilities_call() -> eyre::Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_eth_block_by_hash_pending() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -1041,7 +1041,7 @@ async fn test_eth_block_by_hash_pending() -> eyre::Result<()> {
 ///
 /// Verifies that without tx_peers configuration, transactions propagate to ALL connected peers
 /// using Reth's default TransactionPropagationKind::All policy.
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_default_propagation_policy() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
@@ -1120,7 +1120,7 @@ async fn test_default_propagation_policy() -> eyre::Result<()> {
 /// Test Part 2:
 /// - Inject tx into Node 2 -> should propagate to both Node 0 and Node 1
 /// - Verifies multi-peer whitelist works correctly
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_selective_propagation_policy() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
@@ -1284,7 +1284,7 @@ async fn test_selective_propagation_policy() -> eyre::Result<()> {
 /// - Inject tx into Node 0 -> should NOT propagate to any node
 /// - Inject tx into Node 1 -> should NOT propagate to any node (even though Node 0 is whitelisted)
 /// - Verifies that disable_txpool_gossip takes precedence over tx_peers
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_gossip_disabled_no_propagation() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
@@ -1357,7 +1357,7 @@ async fn test_gossip_disabled_no_propagation() -> eyre::Result<()> {
 /// 3. Flashblock indices are monotonically increasing within an epoch
 /// 4. The P2P state's flushed cursor tracks the latest yielded flashblock
 /// 5. Stale flashblocks (from old epochs) are never yielded
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_event_stream_invariants() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
@@ -1523,7 +1523,7 @@ async fn test_event_stream_invariants() -> eyre::Result<()> {
 /// End-to-end test: uses [`EngineDriver`] to build multiple blocks while
 /// querying the pending block, logs, transactions, and receipts via the
 /// Eth JSON-RPC API at each block boundary.
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_engine_driver_pending_block_queries() -> eyre::Result<()> {
     use alloy_eips::BlockNumberOrTag;
     use reth_rpc_api::EthApiClient;
@@ -1724,7 +1724,7 @@ async fn test_engine_driver_pending_block_queries() -> eyre::Result<()> {
 /// Large block production loop using [`EngineDriver`] that sanity-checks
 /// all helper macros in the `on_block` hook: `provider!`, `fetch_block!`,
 /// `fetch_tx!`, `fetch_receipt!`, `eth_call!`, `fetch_logs!`.
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_eth_api_assertions() -> eyre::Result<()> {
     use alloy_provider::Provider;
     use alloy_rpc_types::Filter;
@@ -1963,7 +1963,7 @@ async fn test_eth_api_assertions() -> eyre::Result<()> {
 /// - For each block, expect: Canon(N), then Pending(0, is_base=true), then
 ///   at least one more Pending with increasing indices
 /// - After all blocks, verify all assertions passed
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_assertion_driven_event_stream() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
     tokio::time::sleep(Duration::from_millis(100)).await;
@@ -3150,7 +3150,7 @@ async fn p2p_wait_for_pending_block(
 /// 2. Follower processes flashblocks through the coordinator (`validate_flashblock_with_state`)
 /// 3. After mining, the builder's `get_payload_v4` result and the follower's coordinator
 ///    pending block should agree on block_hash, state_root, receipts_root, and gas_used.
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_coordinator_payload_matches_builder() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes affect test/CI configuration and dev compile settings only; no production runtime or security-sensitive logic is modified.
> 
> **Overview**
> Hardens **CI and local test runs** for the heavy `world-chain-tests` (`e2e-tests`) package and speeds up dev builds of test dependencies.
> 
> **Nextest / CI:** `.config/nextest.toml` adds a **120s slow-timeout** (terminate after 3 periods), reserves **4 threads** for `package(world-chain-tests)` under the default profile, and under **`profile.ci`** applies **exponential retries** (2 retries, 2s delay, jitter) for that package. Rust CI now runs `just test --profile ci` instead of the default profile.
> 
> **Build:** Workspace `Cargo.toml` sets **`[profile.dev.package."*"] opt-level = 2`** so dependency crates compile with more optimization during `dev`/`test` builds. The long comment above `semicolon_in_expressions_from_macros = "allow"` is removed (the lint allow remains).
> 
> **E2e Tokio:** Multi-thread integration tests across acceptance, admin tracing, devnet, and `testsuite` now use **`worker_threads = 4`**, aligning runtime threading with nextest’s `threads-required` for the same package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11a9362baf355b17e9e479bc03ac7ef2b11bfb70. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->