### PR TITLE
feat: flashblock sentry node selection

### DIFF
--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -25,9 +25,9 @@ pub use builder::*;
 pub use p2p::*;
 pub use pbh::*;
 
-pub const DEFAULT_FLASHBLOCKS_BOOTNODES: &str = "enode://78ca7daeb63956cbc3985853d5699a6404d976a2612575563f46876968fdca2383a195ee7db40de348757b2256195996933708f351169ca3f3fe93ab2a774608@16.62.98.53:30303,enode://c96dcadf4cdea4c39ec3fd775637d9e67d455b856b1514cfcf55b72f873a34b96d69e47ccea9fc797a446d4e6948aa80f6b9d479a1727ca166758a900b08f422@16.63.14.166:30303,enode://15688a7b281c32a4da633252dcc5019d60f037ee9eb46d05093dd3023bdd688b9b207d10a39e054a5ed87db666b2cb75696f6537de74d1e1f8dcabc53dc8d2ab@16.63.123.160:30303";
+pub const DEFAULT_FLASHBLOCKS_SENTRIES: &str = "enode://78ca7daeb63956cbc3985853d5699a6404d976a2612575563f46876968fdca2383a195ee7db40de348757b2256195996933708f351169ca3f3fe93ab2a774608@16.62.98.53:30303,enode://c96dcadf4cdea4c39ec3fd775637d9e67d455b856b1514cfcf55b72f873a34b96d69e47ccea9fc797a446d4e6948aa80f6b9d479a1727ca166758a900b08f422@16.63.14.166:30303,enode://15688a7b281c32a4da633252dcc5019d60f037ee9eb46d05093dd3023bdd688b9b207d10a39e054a5ed87db666b2cb75696f6537de74d1e1f8dcabc53dc8d2ab@16.63.123.160:30303";
 
-pub const DEFAULT_FLASHBLOCKS_BOOTNODES_SEPOLIA: &str = "enode://08f6bec85b85908cc0bf09fb26fba7e5c53c4e924aae795784aa002a18afd7d1e0be5f9bb8c71fbad9b86c00b27fd45b654e234ef4b7eff2432acd6cddc256d3@51.34.157.154:30303,enode://444a4af7a46f668f8f1abf3863caa72cbe773e6830083a493cc43e9996b4e3017013605bfddb779b2494a3f9cf75961b70ad35a347bc055969a3744e1738de6d@16.18.61.93:30303,enode://ae8e652ad611d0276427ecc751c5effacdb6a9dcf8080b9380f24db7a0770ff657ded924d45805fb3eef21159f7294316b0e6dc51101f92b86c955509a3e8cc0@51.96.83.177:30303";
+pub const DEFAULT_FLASHBLOCKS_SENTRIES_SEPOLIA: &str = "enode://08f6bec85b85908cc0bf09fb26fba7e5c53c4e924aae795784aa002a18afd7d1e0be5f9bb8c71fbad9b86c00b27fd45b654e234ef4b7eff2432acd6cddc256d3@51.34.157.154:30303,enode://444a4af7a46f668f8f1abf3863caa72cbe773e6830083a493cc43e9996b4e3017013605bfddb779b2494a3f9cf75961b70ad35a347bc055969a3744e1738de6d@16.18.61.93:30303,enode://ae8e652ad611d0276427ecc751c5effacdb6a9dcf8080b9380f24db7a0770ff657ded924d45805fb3eef21159f7294316b0e6dc51101f92b86c955509a3e8cc0@51.96.83.177:30303";
 
 use crate::config::WorldChainNodeConfig;
 
@@ -186,7 +186,7 @@ pub struct WorldChainArgs {
     #[arg(long = "tx-peers", value_delimiter = ',', value_name = "PEER_ID")]
     pub tx_peers: Option<Vec<PeerId>>,
 
-    /// Disable the default World Chain bootnodes.
+    /// Disable the default World Chain flashblocks sentries.
     #[arg(
         long = "worldchain.disable-bootnodes",
         value_name = "WORLDCHAIN_DISABLE_BOOTNODES",
@@ -252,11 +252,16 @@ impl WorldChainArgs {
                     )?);
                 }
 
-                if self.flashblocks.is_some() && !self.disable_bootnodes {
-                    let bootnodes = parse_trusted_peer(DEFAULT_FLASHBLOCKS_BOOTNODES)?;
-                    debug!(target: "world_chain::network", ?bootnodes, "Setting default flashblocks bootnodes");
-                    // dedup happens later
-                    config.network.trusted_peers.extend(bootnodes);
+                if let Some(flashblocks) = &mut self.flashblocks
+                    && flashblocks.sentry_peers.is_empty()
+                    && !self.disable_bootnodes
+                {
+                    flashblocks.sentry_peers = parse_trusted_peer(DEFAULT_FLASHBLOCKS_SENTRIES)?;
+                    debug!(
+                        target: "world_chain::network",
+                        sentries = ?flashblocks.sentry_peers,
+                        "Setting default flashblocks sentries"
+                    );
                 }
 
                 if self.pbh.entrypoint == Address::default() {
@@ -291,11 +296,17 @@ impl WorldChainArgs {
                     )?);
                 }
 
-                if self.flashblocks.is_some() && !self.disable_bootnodes {
-                    let bootnodes = parse_trusted_peer(DEFAULT_FLASHBLOCKS_BOOTNODES_SEPOLIA)?;
-                    debug!(target: "world_chain::network", ?bootnodes, "Setting default flashblocks bootnodes");
-                    // dedup happens later
-                    config.network.trusted_peers.extend(bootnodes);
+                if let Some(flashblocks) = &mut self.flashblocks
+                    && flashblocks.sentry_peers.is_empty()
+                    && !self.disable_bootnodes
+                {
+                    flashblocks.sentry_peers =
+                        parse_trusted_peer(DEFAULT_FLASHBLOCKS_SENTRIES_SEPOLIA)?;
+                    debug!(
+                        target: "world_chain::network",
+                        sentries = ?flashblocks.sentry_peers,
+                        "Setting default flashblocks sentry pool"
+                    );
                 }
 
                 if self.pbh.entrypoint == Address::default() {
@@ -337,6 +348,15 @@ impl WorldChainArgs {
                 }
                 if self.pbh.signature_aggregator == Address::default() {
                     warn!("missing `--builder.signature_aggregator`, using default")
+                }
+            }
+        }
+
+        if let Some(flashblocks) = &self.flashblocks {
+            let bootnodes = config.network.bootnodes.get_or_insert_default();
+            for sentry in &flashblocks.sentry_peers {
+                if !bootnodes.iter().any(|bootnode| bootnode.id == sentry.id) {
+                    bootnodes.push(sentry.clone());
                 }
             }
         }
@@ -521,6 +541,34 @@ mod tests {
         assert!(
             args.flashblocks.expect("just asserted").enabled,
             "expected parsed flashblocks args to have enabled=true"
+        );
+    }
+
+    #[test]
+    fn flashblocks_uses_default_mainnet_sentry_limit() {
+        let args = CommandParser::parse_from(["bin", "--flashblocks.enabled"]).world;
+        let mut node_config = NodeConfig::new(WorldChainSpec::mainnet());
+
+        let config = args.into_config(&mut node_config).unwrap();
+        let flashblocks = config.args.flashblocks.expect("flashblocks enabled");
+
+        assert_eq!(
+            flashblocks.max_sentry_connections,
+            DEFAULT_MAX_SENTRY_CONNECTIONS
+        );
+        assert_eq!(flashblocks.sentry_peers.len(), 3);
+        assert_eq!(
+            node_config
+                .network
+                .bootnodes
+                .as_ref()
+                .expect("sentries are discovery bootnodes")
+                .len(),
+            3
+        );
+        assert!(
+            node_config.network.trusted_peers.is_empty(),
+            "sentry selection must happen after the local PeerId is known"
         );
     }
 

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -352,15 +352,6 @@ impl WorldChainArgs {
             }
         }
 
-        if let Some(flashblocks) = &self.flashblocks {
-            let bootnodes = config.network.bootnodes.get_or_insert_default();
-            for sentry in &flashblocks.sentry_peers {
-                if !bootnodes.iter().any(|bootnode| bootnode.id == sentry.id) {
-                    bootnodes.push(sentry.clone());
-                }
-            }
-        }
-
         let bal_enabled = self.flashblocks.as_ref().is_some_and(|fb| fb.access_list);
 
         info!(
@@ -557,14 +548,9 @@ mod tests {
             DEFAULT_MAX_SENTRY_CONNECTIONS
         );
         assert_eq!(flashblocks.sentry_peers.len(), 3);
-        assert_eq!(
-            node_config
-                .network
-                .bootnodes
-                .as_ref()
-                .expect("sentries are discovery bootnodes")
-                .len(),
-            3
+        assert!(
+            node_config.network.bootnodes.is_none(),
+            "preserve the chain-specific bootnode fallback until network configuration is resolved"
         );
         assert!(
             node_config.network.trusted_peers.is_empty(),

--- a/crates/cli/src/cli/builder.rs
+++ b/crates/cli/src/cli/builder.rs
@@ -8,6 +8,9 @@ use std::path::PathBuf;
 use crate::cli::p2p::FanoutArgs;
 
 /// Default number of flashblocks sentries a client maintains as trusted RLPx peers.
+///
+/// In non critical scenarios, relying on a single sentry to supply flashblocks
+/// should be adequate. Users running critical infrastructure may want 2.
 pub const DEFAULT_MAX_SENTRY_CONNECTIONS: usize = 1;
 
 /// Parameters for pbh builder configuration

--- a/crates/cli/src/cli/builder.rs
+++ b/crates/cli/src/cli/builder.rs
@@ -7,6 +7,9 @@ use std::path::PathBuf;
 
 use crate::cli::p2p::FanoutArgs;
 
+/// Default number of flashblocks sentries a client maintains as trusted RLPx peers.
+pub const DEFAULT_MAX_SENTRY_CONNECTIONS: usize = 1;
+
 /// Parameters for pbh builder configuration
 #[derive(Debug, Clone, PartialEq, clap::Args)]
 #[command(next_help_heading = "Block Builder")]
@@ -160,6 +163,33 @@ pub struct FlashblocksArgs {
     )]
     pub store_path: Option<PathBuf>,
 
+    /// Candidate flashblocks sentries and discovery bootnodes.
+    ///
+    /// By default, clients deterministically select
+    /// `--flashblocks.max-sentry-connections` peers from this pool. The selection is stable for a
+    /// persisted P2P identity and evenly distributes clients across the pool. Every candidate is
+    /// retained as a UDP discovery bootnode, including sentries that are not selected for RLPx.
+    #[arg(
+        long = "flashblocks.sentry-peers",
+        alias = "flashblocks.sentry_peers",
+        env = "FLASHBLOCKS_SENTRY_PEERS",
+        value_delimiter = ',',
+        value_name = "ENODE",
+        required = false
+    )]
+    pub sentry_peers: Vec<TrustedPeer>,
+
+    /// Maximum number of candidate flashblocks sentries maintained as trusted RLPx peers.
+    ///
+    /// Set this to at least the sentry pool size for builders that must connect to every sentry.
+    #[arg(
+        long = "flashblocks.max-sentry-connections",
+        alias = "flashblocks.max_sentry_connections",
+        env = "FLASHBLOCKS_MAX_SENTRY_CONNECTIONS",
+        default_value_t = DEFAULT_MAX_SENTRY_CONNECTIONS
+    )]
+    pub max_sentry_connections: usize,
+
     #[command(flatten)]
     pub fanout: FanoutArgs,
 }
@@ -178,7 +208,7 @@ pub fn parse_trusted_peer(s: &str) -> eyre::Result<Vec<TrustedPeer>> {
     s.split(',')
         .map(|enode| {
             enode.parse().map_err(|err| {
-                eyre::Report::msg(format!("invalid flashblocks bootnode '{}': {}", enode, err))
+                eyre::Report::msg(format!("invalid flashblocks sentry '{}': {}", enode, err))
             })
         })
         .collect()
@@ -208,6 +238,8 @@ mod tests {
             access_list: true,
             store: false,
             store_path: None,
+            sentry_peers: Vec::new(),
+            max_sentry_connections: DEFAULT_MAX_SENTRY_CONNECTIONS,
             fanout: FanoutArgs::default(),
         };
 
@@ -241,6 +273,8 @@ mod tests {
             access_list: false,
             store: false,
             store_path: None,
+            sentry_peers: Vec::new(),
+            max_sentry_connections: DEFAULT_MAX_SENTRY_CONNECTIONS,
             fanout: FanoutArgs::default(),
         };
 
@@ -274,5 +308,17 @@ mod tests {
     #[test]
     fn flashblocks_store_requires_flashblocks_enabled() {
         CommandParser::try_parse_from(["bin", "--flashblocks.store"]).unwrap_err();
+    }
+
+    #[test]
+    fn flashblocks_sentry_connection_policy() {
+        let args = CommandParser::parse_from([
+            "bin",
+            "--flashblocks.enabled",
+            "--flashblocks.max-sentry-connections",
+            "4",
+        ]);
+
+        assert_eq!(args.flashblocks.max_sentry_connections, 4);
     }
 }

--- a/crates/node/src/context.rs
+++ b/crates/node/src/context.rs
@@ -1,6 +1,6 @@
 // Module defining World Chain Node Preset contexts for components & add-ons.
 
-use std::time::Duration;
+use std::{collections::HashSet, sync::Arc, time::Duration};
 
 use crate::{
     add_ons::WorldChainAddOns,
@@ -13,6 +13,7 @@ use crate::{
     payload_service::FlashblocksPayloadServiceBuilder,
     pool::WorldChainPoolBuilder,
 };
+use alloy_primitives::keccak256;
 use ed25519_dalek::VerifyingKey;
 use hex::ToHex;
 use reth_network::protocol::IntoRlpxSubProtocol;
@@ -40,10 +41,8 @@ use world_chain_p2p::{
 use world_chain_primitives::p2p::Authorization;
 use world_chain_rpc::eth::FlashblocksEthApiBuilder;
 
-use std::sync::Arc;
-
 use crossbeam_channel::{Receiver, Sender};
-use tracing::info;
+use tracing::{debug, info};
 use world_chain_builder::WorldChainPayloadBuilderCtxBuilder;
 use world_chain_evm::{
     BlockExecutionWitness, ExecutionWitnessHandle, WitnessCache, WorldChainEvmConfig,
@@ -54,7 +53,7 @@ use world_chain_validator::coordinator::FlashblocksExecutionCoordinator;
 
 use crate::tx_propagation::WorldChainTransactionPropagationPolicy;
 use reth_network::PeersInfo;
-use reth_network_peers::PeerId;
+use reth_network_peers::{PeerId, TrustedPeer};
 use reth_node_builder::{BuilderContext, components::NetworkBuilder};
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
 
@@ -69,6 +68,8 @@ pub struct WorldChainNetworkBuilder {
     op_network_builder: OpNetworkBuilder,
     tx_peers: Option<Vec<PeerId>>,
     p2p_handle: Option<FlashblocksHandle>,
+    flashblock_sentries: Vec<TrustedPeer>,
+    max_sentry_connections: usize,
 }
 
 impl WorldChainNetworkBuilder {
@@ -87,8 +88,110 @@ impl WorldChainNetworkBuilder {
             op_network_builder,
             tx_peers,
             p2p_handle,
+            flashblock_sentries: Vec::new(),
+            max_sentry_connections: 0,
         }
     }
+
+    /// Configures the candidate flashblocks sentry pool and the number of sentries this node
+    /// should maintain as trusted RLPx peers.
+    pub fn with_flashblock_sentries(
+        mut self,
+        sentries: Vec<TrustedPeer>,
+        max_connections: usize,
+    ) -> Self {
+        self.flashblock_sentries = sentries;
+        self.max_sentry_connections = max_connections;
+        self
+    }
+}
+
+const FLASHBLOCKS_SENTRY_SELECTION_DOMAIN: &[u8] = b"worldchain-flashblocks-sentry-v1";
+
+/// Ranks sentries using highest-random-weight (rendezvous) hashing.
+///
+/// A persisted local P2P identity produces a stable selection. Adding or removing a sentry only
+/// remaps clients whose highest-ranked set changes.
+fn rank_flashblock_sentries(local_peer_id: PeerId, sentries: &[TrustedPeer]) -> Vec<PeerId> {
+    let mut ranked = sentries
+        .iter()
+        .filter(|sentry| sentry.id != local_peer_id)
+        .map(|sentry| {
+            let mut input = Vec::with_capacity(
+                FLASHBLOCKS_SENTRY_SELECTION_DOMAIN.len() + local_peer_id.len() + sentry.id.len(),
+            );
+            input.extend_from_slice(FLASHBLOCKS_SENTRY_SELECTION_DOMAIN);
+            input.extend_from_slice(local_peer_id.as_slice());
+            input.extend_from_slice(sentry.id.as_slice());
+            (keccak256(input), sentry.id)
+        })
+        .collect::<Vec<_>>();
+
+    ranked.sort_unstable_by(|(left_score, left_id), (right_score, right_id)| {
+        right_score
+            .cmp(left_score)
+            .then_with(|| left_id.cmp(right_id))
+    });
+    ranked.dedup_by_key(|(_, peer_id)| *peer_id);
+    ranked.into_iter().map(|(_, peer_id)| peer_id).collect()
+}
+
+/// Adds only the selected sentries to the trusted set and prevents RLPx connections to the rest.
+///
+/// The peer-manager ban list is intentionally separate from the discovery ban lists, so an
+/// excluded combined bootnode/sentry can still be used for UDP discovery.
+fn apply_flashblock_sentry_policy(
+    peers_config: &mut reth_network::PeersConfig,
+    local_peer_id: PeerId,
+    sentries: &[TrustedPeer],
+    max_connections: usize,
+) -> Vec<PeerId> {
+    let ranked = rank_flashblock_sentries(local_peer_id, sentries);
+    let selected = ranked
+        .iter()
+        .copied()
+        .take(max_connections)
+        .collect::<Vec<_>>();
+    let selected_set = selected.iter().copied().collect::<HashSet<_>>();
+    let all_sentry_ids = sentries
+        .iter()
+        .map(|sentry| sentry.id)
+        .collect::<HashSet<_>>();
+
+    // Preserve unrelated operator-supplied trusted peers, while enforcing the selection for every
+    // peer that belongs to the configured sentry pool.
+    peers_config
+        .trusted_nodes
+        .retain(|peer| !all_sentry_ids.contains(&peer.id) || selected_set.contains(&peer.id));
+
+    // A sentry may have been restored from the persisted peers file or supplied as a basic node.
+    // Remove every candidate from those sets so selected sentries are re-added only as trusted
+    // peers and excluded sentries cannot bypass the peer-manager ban during outbound slot refill.
+    peers_config
+        .basic_nodes
+        .retain(|peer| !all_sentry_ids.contains(&peer.id));
+    peers_config
+        .persisted_peers
+        .retain(|peer| !all_sentry_ids.contains(&peer.record.id));
+
+    let mut trusted_ids = peers_config
+        .trusted_nodes
+        .iter()
+        .map(|peer| peer.id)
+        .collect::<HashSet<_>>();
+    for sentry in sentries {
+        if selected_set.contains(&sentry.id) && trusted_ids.insert(sentry.id) {
+            peers_config.trusted_nodes.push(sentry.clone());
+        }
+    }
+
+    for peer_id in all_sentry_ids.difference(&selected_set) {
+        if *peer_id != local_peer_id {
+            peers_config.ban_list.ban_peer(*peer_id);
+        }
+    }
+
+    selected
 }
 
 impl<Node, Pool> NetworkBuilder<Node, Pool> for WorldChainNetworkBuilder
@@ -109,6 +212,8 @@ where
             op_network_builder,
             tx_peers,
             p2p_handle,
+            flashblock_sentries,
+            max_sentry_connections,
         } = self;
 
         let mut network_config = op_network_builder.network_config(ctx)?;
@@ -118,13 +223,28 @@ where
             .trusted_nodes
             .retain(|peer| peer.id != local_peer_id);
 
-        let mut trusted_peer_ids: Vec<_> = network_config
+        let selected_sentries = apply_flashblock_sentry_policy(
+            &mut network_config.peers_config,
+            local_peer_id,
+            &flashblock_sentries,
+            max_sentry_connections,
+        );
+        if !flashblock_sentries.is_empty() {
+            debug!(
+                target: "world_chain::network",
+                sentries = ?selected_sentries,
+                "connecting to flashblocks sentries"
+            );
+        }
+
+        let trusted_peer_ids: Vec<_> = network_config
             .peers_config
             .trusted_nodes
             .iter()
             .map(|peer| peer.id)
+            .collect::<HashSet<_>>()
+            .into_iter()
             .collect();
-        trusted_peer_ids.dedup();
 
         let mut network = reth_network::NetworkManager::builder(network_config).await?;
 
@@ -237,6 +357,7 @@ where
                             rollup,
                             builder,
                             pbh,
+                            flashblocks,
                             tx_peers,
                             ..
                         },
@@ -254,7 +375,7 @@ where
             ..
         } = rollup;
 
-        let wc_network_builder = WorldChainNetworkBuilder::new(
+        let mut wc_network_builder = WorldChainNetworkBuilder::new(
             disable_txpool_gossip,
             !discovery_v4,
             tx_peers,
@@ -264,6 +385,12 @@ where
                     flashblocks_components_ctx.flashblocks_handle.clone()
                 }),
         );
+        if let Some(flashblocks) = flashblocks {
+            wc_network_builder = wc_network_builder.with_flashblock_sentries(
+                flashblocks.sentry_peers,
+                flashblocks.max_sentry_connections,
+            );
+        }
 
         let (
             flashblocks_interval,
@@ -484,6 +611,98 @@ impl From<WorldChainNodeConfig> for FlashblocksComponentsContext {
             flashblocks_handle,
             to_jobs_generator,
             authorizer_vk,
+        }
+    }
+}
+
+#[cfg(test)]
+mod sentry_policy_tests {
+    use super::*;
+    use world_chain_cli::cli::DEFAULT_FLASHBLOCKS_SENTRIES;
+
+    fn sentries() -> Vec<TrustedPeer> {
+        DEFAULT_FLASHBLOCKS_SENTRIES
+            .split(',')
+            .map(|sentry| sentry.parse().expect("valid default sentry"))
+            .collect()
+    }
+
+    #[test]
+    fn rendezvous_selection_is_stable_and_order_independent() {
+        let local_peer_id = PeerId::random();
+        let sentries = sentries();
+        let selected = rank_flashblock_sentries(local_peer_id, &sentries);
+
+        let mut reversed = sentries.clone();
+        reversed.reverse();
+
+        assert_eq!(selected, rank_flashblock_sentries(local_peer_id, &reversed));
+        assert_eq!(selected.len(), sentries.len());
+    }
+
+    #[test]
+    fn policy_trusts_two_and_bans_other_sentries() {
+        let local_peer_id = PeerId::random();
+        let sentries = sentries();
+        let mut unrelated_peer = sentries[0].clone();
+        unrelated_peer.id = PeerId::random();
+        let mut peers_config = reth_network::PeersConfig::default();
+        peers_config.trusted_nodes.push(unrelated_peer.clone());
+
+        for sentry in &sentries {
+            let record = sentry.resolve_blocking().expect("resolvable sentry");
+            peers_config.basic_nodes.insert(record);
+            peers_config.persisted_peers.push(
+                reth_network::types::PersistedPeerInfo::from_node_record(record),
+            );
+        }
+
+        let selected =
+            apply_flashblock_sentry_policy(&mut peers_config, local_peer_id, &sentries, 2);
+        let selected_set = selected.iter().copied().collect::<HashSet<_>>();
+
+        assert_eq!(selected.len(), 2);
+        assert!(peers_config.trusted_nodes.contains(&unrelated_peer));
+        assert!(peers_config.basic_nodes.is_empty());
+        assert!(peers_config.persisted_peers.is_empty());
+        assert_eq!(
+            peers_config
+                .trusted_nodes
+                .iter()
+                .filter(|peer| selected_set.contains(&peer.id))
+                .count(),
+            2
+        );
+
+        let excluded = sentries
+            .iter()
+            .find(|sentry| !selected_set.contains(&sentry.id))
+            .expect("one sentry should be excluded");
+        assert!(peers_config.ban_list.is_banned_peer(&excluded.id));
+    }
+
+    #[test]
+    fn max_at_least_pool_size_trusts_every_sentry() {
+        let local_peer_id = PeerId::random();
+        let sentries = sentries();
+        let mut peers_config = reth_network::PeersConfig::default();
+
+        let selected = apply_flashblock_sentry_policy(
+            &mut peers_config,
+            local_peer_id,
+            &sentries,
+            sentries.len(),
+        );
+
+        assert_eq!(selected.len(), sentries.len());
+        for sentry in sentries {
+            assert!(
+                peers_config
+                    .trusted_nodes
+                    .iter()
+                    .any(|trusted| trusted.id == sentry.id)
+            );
+            assert!(!peers_config.ban_list.is_banned_peer(&sentry.id));
         }
     }
 }

--- a/crates/node/src/context.rs
+++ b/crates/node/src/context.rs
@@ -136,6 +136,15 @@ fn rank_flashblock_sentries(local_peer_id: PeerId, sentries: &[TrustedPeer]) -> 
     ranked.into_iter().map(|(_, peer_id)| peer_id).collect()
 }
 
+/// Adds flashblocks sentries to the already-resolved discovery bootnodes.
+fn add_flashblock_sentry_bootnodes(bootnodes: &mut HashSet<TrustedPeer>, sentries: &[TrustedPeer]) {
+    for sentry in sentries {
+        if !bootnodes.iter().any(|bootnode| bootnode.id == sentry.id) {
+            bootnodes.insert(sentry.clone());
+        }
+    }
+}
+
 /// Adds only the selected sentries to the trusted set and prevents RLPx connections to the rest.
 ///
 /// The peer-manager ban list is intentionally separate from the discovery ban lists, so an
@@ -217,6 +226,7 @@ where
         } = self;
 
         let mut network_config = op_network_builder.network_config(ctx)?;
+        add_flashblock_sentry_bootnodes(&mut network_config.boot_nodes, &flashblock_sentries);
         let local_peer_id = network_config.hello_message.id;
         network_config
             .peers_config
@@ -638,6 +648,22 @@ mod sentry_policy_tests {
 
         assert_eq!(selected, rank_flashblock_sentries(local_peer_id, &reversed));
         assert_eq!(selected.len(), sentries.len());
+    }
+
+    #[test]
+    fn sentries_are_added_without_replacing_chain_bootnodes() {
+        let sentries = sentries();
+        let mut chain_bootnode = sentries[0].clone();
+        chain_bootnode.id = PeerId::random();
+        let mut bootnodes = HashSet::from([chain_bootnode.clone()]);
+
+        add_flashblock_sentry_bootnodes(&mut bootnodes, &sentries);
+
+        assert!(bootnodes.contains(&chain_bootnode));
+        assert_eq!(bootnodes.len(), sentries.len() + 1);
+        for sentry in sentries {
+            assert!(bootnodes.contains(&sentry));
+        }
     }
 
     #[test]

--- a/crates/test-utils/src/node.rs
+++ b/crates/test-utils/src/node.rs
@@ -106,6 +106,8 @@ pub fn test_config_with_peers_and_gossip(
             access_list,
             store: false,
             store_path: None,
+            sentry_peers: Vec::new(),
+            max_sentry_connections: world_chain_cli::cli::builder::DEFAULT_MAX_SENTRY_CONNECTIONS,
             fanout: FanoutArgs::default(),
         })
     } else {

--- a/e2e-tests/src/it/testsuite.rs
+++ b/e2e-tests/src/it/testsuite.rs
@@ -2900,6 +2900,8 @@ fn test_flashblocks_args(authorizer_sk: &SigningKey, builder_sk: &SigningKey) ->
         access_list: true,
         store: false,
         store_path: None,
+        sentry_peers: Vec::new(),
+        max_sentry_connections: world_chain_cli::cli::builder::DEFAULT_MAX_SENTRY_CONNECTIONS,
         fanout: Default::default(),
     }
 }

--- a/specs/cli/reference.md
+++ b/specs/cli/reference.md
@@ -200,6 +200,21 @@ Flashblocks:
           
           [env: FLASHBLOCKS_STORE_PATH=]
 
+      --flashblocks.sentry-peers <ENODE>
+          Candidate flashblocks sentries and discovery bootnodes.
+          
+          By default, clients deterministically select `--flashblocks.max-sentry-connections` peers from this pool. The selection is stable for a persisted P2P identity and evenly distributes clients across the pool. Every candidate is retained as a UDP discovery bootnode, including sentries that are not selected for RLPx.
+          
+          [env: FLASHBLOCKS_SENTRY_PEERS=]
+
+      --flashblocks.max-sentry-connections <MAX_SENTRY_CONNECTIONS>
+          Maximum number of candidate flashblocks sentries maintained as trusted RLPx peers.
+          
+          Set this to at least the sentry pool size for builders that must connect to every sentry.
+          
+          [env: FLASHBLOCKS_MAX_SENTRY_CONNECTIONS=]
+          [default: 1]
+
       --flashblocks.max-send-peers <MAX_SEND_PEERS>
           Override the flashblocks send-set size
           
@@ -243,6 +258,6 @@ Flashblocks:
           Comma-separated list of peer IDs to which transactions should be propagated
 
       --worldchain.disable-bootnodes
-          Disable the default World Chain bootnodes
+          Disable the default World Chain flashblocks sentries
 
 ```


### PR DESCRIPTION
Feature to reduce the number of connections to available sentry nodes. This should minimize required bandwidth to serve flashblocks.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default P2P trust and ban behavior for flashblocks nodes; misconfiguration or selection bugs could reduce flashblock connectivity, though policy is covered by new tests.
> 
> **Overview**
> Flashblocks clients no longer trust every default flashblocks bootnode for RLPx. Defaults are loaded into a **sentry pool** (`flashblocks.sentry_peers`, renamed from bootnode constants), and the network layer picks up to **`--flashblocks.max-sentry-connections`** peers (default **1**) per node.
> 
> **Selection** uses rendezvous hashing on the persisted local `PeerId`, so choice is stable and spreads load across the pool. **All** pool members stay UDP discovery bootnodes; only the chosen sentries are added as trusted RLPx peers. Non-selected sentries are peer-manager banned for RLPx so they cannot be dialed via persisted/basic peers, while discovery can still use them.
> 
> Chain defaults for World mainnet/Sepolia populate `sentry_peers` at config time instead of extending `network.trusted_peers` immediately—sentry policy runs when the network is built and the local identity is known. Builders can raise `max-sentry-connections` to connect to every sentry. CLI reference and unit/e2e test fixtures were updated for the new flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b984eff7347e9c0c7e0534361a9b9709cfc16e7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->