### PR TITLE
feat(proposer): require defined number of confirmations when sending txs onchain

### DIFF
--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -2563,9 +2563,15 @@ async fn start_world_chain_proposer(
         .wallet(EthereumWallet::from(signer))
         .connect_http(Url::parse(l1_rpc_url)?);
 
-    let contracts = AlloyProofSystemClient::new(provider, factory_address, anchor_address)
-        .await
-        .wrap_err("failed to bind the World Chain proof system")?;
+    let required_confirmations = 1;
+    let contracts = AlloyProofSystemClient::new(
+        provider,
+        factory_address,
+        anchor_address,
+        required_confirmations,
+    )
+    .await
+    .wrap_err("failed to bind the World Chain proof system")?;
     let mut bond_manager = BondManager::new(
         BondManagerConfig {
             poll_interval: WORLD_PROPOSER_POLL_INTERVAL,

--- a/proofs/proposer/src/alloy.rs
+++ b/proofs/proposer/src/alloy.rs
@@ -33,6 +33,8 @@ pub struct AlloyProofSystemClient<P> {
     anchor: IAnchorStateRegistry::IAnchorStateRegistryInstance<P>,
     /// Domain hash of the registered game implementation, read once at construction.
     domain_hash: B256,
+    /// Number of confirmations to require after sending a tx onchain.
+    confirmations: u64,
     provider: P,
 }
 
@@ -49,6 +51,7 @@ where
         provider: P,
         factory_address: Address,
         anchor_address: Address,
+        confirmations: u64,
     ) -> Result<Self, ProposerError> {
         let factory = IDisputeGameFactory::IDisputeGameFactoryInstance::new(
             factory_address,
@@ -80,6 +83,7 @@ where
             factory,
             anchor,
             domain_hash,
+            confirmations,
             provider,
         })
     }
@@ -209,6 +213,7 @@ where
             .map_err(|error| ProposerError::Contract(error.to_string()))?;
         let tx_hash = *pending_tx.tx_hash();
         let receipt = pending_tx
+            .with_required_confirmations(self.confirmations)
             .get_receipt()
             .await
             .map_err(|error| ProposerError::Contract(error.to_string()))?;
@@ -372,6 +377,7 @@ where
 
         let tx_hash = *pending.tx_hash();
         let receipt = pending
+            .with_required_confirmations(self.confirmations)
             .get_receipt()
             .await
             .map_err(|error| ProposerError::Contract(error.to_string()))?;
@@ -396,6 +402,7 @@ where
 
         let tx_hash = *pending.tx_hash();
         let receipt = pending
+            .with_required_confirmations(self.confirmations)
             .get_receipt()
             .await
             .map_err(|error| ProposerError::Contract(error.to_string()))?;
@@ -442,6 +449,7 @@ where
 
         let tx_hash = *pending.tx_hash();
         let receipt = pending
+            .with_required_confirmations(self.confirmations)
             .get_receipt()
             .await
             .map_err(|error| ProposerError::Contract(error.to_string()))?;

--- a/proofs/proposer/src/alloy.rs
+++ b/proofs/proposer/src/alloy.rs
@@ -300,22 +300,14 @@ where
     P: Provider + WalletProvider + Clone + Send + Sync + 'static,
 {
     async fn anchor_parent(&self) -> Result<AnchorRef, ProposerError> {
-        let (anchor_root, anchor_game) = tokio::try_join!(
-            async {
-                self.anchor
-                    .getAnchorRoot()
-                    .call()
-                    .await
-                    .map_err(|error| ProposerError::Contract(error.to_string()))
-            },
-            async {
-                self.anchor
-                    .anchorGame()
-                    .call()
-                    .await
-                    .map_err(|error| ProposerError::Contract(error.to_string()))
-            }
-        )?;
+        let (anchor_root, anchor_game) = self
+            .provider
+            .multicall()
+            .add(self.anchor.getAnchorRoot())
+            .add(self.anchor.anchorGame())
+            .aggregate()
+            .await
+            .map_err(|err| ProposerError::Contract(err.to_string()))?;
 
         Ok(AnchorRef {
             registry: *self.anchor.address(),

--- a/proofs/proposer/src/main.rs
+++ b/proofs/proposer/src/main.rs
@@ -74,6 +74,10 @@ struct Cli {
     /// Number of recent factory games scanned when the bond manager starts.
     #[arg(long, env = "BOND_MANAGER_INITIAL_SCAN_LIMIT", default_value_t = 1_000)]
     bond_manager_initial_scan_limit: u64,
+
+    /// Number of confirmations to require after sending a tx onchain.
+    #[arg(long, env = "CONFIRMATIONS", default_value_t = 5)]
+    confirmations: u64,
 }
 
 #[tokio::main]
@@ -90,10 +94,14 @@ async fn main() -> Result<()> {
         .wallet(EthereumWallet::from(cli.proposer_key))
         .connect_http(Url::parse(&cli.l1_rpc).context("invalid L1 RPC URL")?);
 
-    let contracts =
-        AlloyProofSystemClient::new(provider, cli.factory_address, cli.anchor_registry_address)
-            .await
-            .context("failed to bind the World Chain proof system")?;
+    let contracts = AlloyProofSystemClient::new(
+        provider,
+        cli.factory_address,
+        cli.anchor_registry_address,
+        cli.confirmations,
+    )
+    .await
+    .context("failed to bind the World Chain proof system")?;
     let bond_manager_config = BondManagerConfig {
         poll_interval: Duration::from_secs(cli.bond_manager_poll_interval_seconds),
         initial_scan_limit: cli.bond_manager_initial_scan_limit,


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-5004/fix-proposer

### Notes

This PR handles most common L1 reorgs for `world-chain-proposer` by requiring each transaction that it sends onchain to wait for a defined number of blocks before being considered valid (default to 5 l1 blocks --> ~1 minute).

This small fix handles most common L1 reorgs scenario because if the tx sent onchain gets reorged out and not inserted in new blocks, then the operation will fail and the `world-chain-proposer` will simply retry next tick.

The same is true for the reads operation: if some data that is read from L1 gets reorged out, `world-chain-proposer` will just look at the new data in the next tick, since it always starts by fetching the current anchor game (searching through the dispute game factory contract).

If we ever experience a deeper reorg, the `world-chain-proposer` will still work fine and submits the necessary transactions onchain in the next ticks. The only minor problem in a deep reorg is for the bond manager (responsible to claim the bonds). In fact, if the transaction that withdraws the bond from a game gets reorged out by a deep reorg, then the bond manager will skip this game in next ticks, therefore we would need to either restart the proposer (because this triggers a deeper scan) or just manually claim that bond from the contract. I think this issue is minor, therefore not worth a bigger and more complex solution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when L1 writes are considered final for the proposer and bond manager; mis-tuned confirmation counts could slow operations or still leave edge cases on deep reorgs for bond claims.
> 
> **Overview**
> Adds a **configurable L1 confirmation depth** so `world-chain-proposer` does not treat its own transactions as successful until they are buried under enough blocks (default **5**, overridable via `CONFIRMATIONS` / `--confirmations`). This targets shallow L1 reorgs: if a sent tx disappears from the canonical chain, receipt wait fails and the proposer retries on the next tick instead of acting on a reorged-out result.
> 
> `AlloyProofSystemClient` now takes `confirmations` at construction and applies `with_required_confirmations` on receipt polling for **claim credit**, **resolve**, **close game**, and **factory create** (proposals). The devnet in-process proposer passes **1** confirmation for faster local runs.
> 
> `anchor_parent` is switched from parallel RPC calls to a single **multicall** for `getAnchorRoot` and `anchorGame` (read-path only; unchanged reorg semantics per PR notes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc69e8c783197d1024eac8b1f8cc64589da2d33d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->