### PR TITLE
fix(pool): prevent PBH bundle validation amplification

### DIFF
--- a/crates/pool/src/root.rs
+++ b/crates/pool/src/root.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 
 use alloy_consensus::{BlockHeader, Sealable};
 use alloy_primitives::{Address, U256};
@@ -27,12 +27,10 @@ where
     world_id: Address,
     /// The client used to aquire account state from the database.
     client: Client,
-    /// A map of valid roots indexed by block timestamp.
-    valid_roots: BTreeMap<u64, Field>,
+    /// A map of valid roots to the timestamp when they were last observed.
+    valid_roots: HashMap<Field, u64>,
     /// The timestamp of the latest valid root.
     latest_valid_timestamp: u64,
-    /// The latest root
-    latest_root: Field,
 }
 
 /// TODO: Think through reorg scenarios
@@ -49,9 +47,8 @@ where
         let mut this = Self {
             client,
             world_id,
-            valid_roots: BTreeMap::new(),
+            valid_roots: HashMap::new(),
             latest_valid_timestamp: 0,
-            latest_root: Field::ZERO,
         };
 
         // If we have a state provider, we can try to load the latest root from the state.
@@ -61,9 +58,9 @@ where
                 && let Ok(state) = this.client.state_by_block_hash(block.header().hash_slow())
                 && let Ok(Some(latest_root)) = state.storage(this.world_id, LATEST_ROOT_SLOT.into())
             {
-                this.latest_root = latest_root;
-                this.valid_roots
-                    .insert(block.header().timestamp(), latest_root);
+                let timestamp = block.header().timestamp();
+                this.latest_valid_timestamp = timestamp;
+                this.valid_roots.insert(latest_root, timestamp);
             }
         }
         Ok(this)
@@ -90,7 +87,7 @@ where
             .map_err(WorldChainTransactionPoolError::Provider)?;
         self.latest_valid_timestamp = block.timestamp();
         if let Some(root) = root {
-            self.valid_roots.insert(block.timestamp(), root);
+            self.valid_roots.insert(root, block.timestamp());
         }
 
         self.prune_invalid();
@@ -101,10 +98,9 @@ where
     /// Prunes all roots from the cache that are not within the expiration window.
     fn prune_invalid(&mut self) {
         if self.latest_valid_timestamp > ROOT_EXPIRATION_WINDOW {
-            self.valid_roots.retain(|timestamp, root| {
-                *timestamp >= self.latest_valid_timestamp - ROOT_EXPIRATION_WINDOW
-                    || *root == self.latest_root // Always keep the latest root
-            });
+            let oldest_valid_timestamp = self.latest_valid_timestamp - ROOT_EXPIRATION_WINDOW;
+            self.valid_roots
+                .retain(|_, last_observed| *last_observed >= oldest_valid_timestamp);
         };
     }
 
@@ -113,9 +109,13 @@ where
     /// # Returns
     ///
     /// A `Vec<Field>` containing all valid roots.
-    // TODO: can this be a slice instead?
     fn roots(&self) -> Vec<Field> {
-        self.valid_roots.values().cloned().collect()
+        self.valid_roots.keys().copied().collect()
+    }
+
+    /// Returns whether a root is currently valid.
+    fn contains(&self, root: &Field) -> bool {
+        self.valid_roots.contains_key(root)
     }
 }
 
@@ -156,7 +156,7 @@ where
     ///
     /// A boolean indicating whether the root is valid.
     pub fn validate_root(&self, root: Field) -> bool {
-        self.cache.read().roots().contains(&root)
+        self.cache.read().contains(&root)
     }
 
     /// Commits a new block to the validator.
@@ -239,6 +239,31 @@ mod tests {
         assert!(validator.validate_root(root_3));
         assert!(validator.validate_root(root_2));
         assert!(!validator.validate_root(root_1));
+        Ok(())
+    }
+
+    #[test]
+    fn test_repeated_root_is_stored_once_and_refreshes_expiration() -> eyre::Result<()> {
+        let validator = world_chain_root_validator()?;
+        let root_1 = Field::from(1u64);
+        let root_2 = Field::from(2u64);
+        let timestamp = 1000000000;
+
+        add_block_with_root_with_timestamp(&validator, timestamp, root_1);
+        add_block_with_root_with_timestamp(&validator, timestamp + ROOT_EXPIRATION_WINDOW, root_1);
+
+        assert_eq!(validator.roots().len(), 1);
+
+        add_block_with_root_with_timestamp(
+            &validator,
+            timestamp + ROOT_EXPIRATION_WINDOW + 1,
+            root_2,
+        );
+
+        assert!(validator.validate_root(root_1));
+        assert!(validator.validate_root(root_2));
+        assert_eq!(validator.roots().len(), 2);
+
         Ok(())
     }
 

--- a/crates/pool/src/validator.rs
+++ b/crates/pool/src/validator.rs
@@ -139,8 +139,13 @@ where
                 .to_outcome(tx);
         };
 
-        // Reject empty aggregator arrays - they bypass all validation
-        if calldata._0.is_empty() {
+        // Reject empty aggregator arrays and groups - they bypass proof validation.
+        if calldata._0.is_empty()
+            || calldata
+                ._0
+                .iter()
+                .any(|aggregated_ops| aggregated_ops.userOps.is_empty())
+        {
             return WorldChainPoolTransactionError::from(PBHValidationError::MissingPbhPayload)
                 .to_outcome(tx);
         }
@@ -155,6 +160,9 @@ where
             )
             .to_outcome(tx);
         }
+
+        // Take one root snapshot for the entire transaction so every group shares it.
+        let valid_roots = self.root_validator.roots();
 
         // Validate all proofs associated with each UserOp
         let mut aggregated_payloads = vec![];
@@ -176,8 +184,6 @@ where
                 return WorldChainPoolTransactionError::from(PBHValidationError::MissingPbhPayload)
                     .to_outcome(tx);
             }
-
-            let valid_roots = self.root_validator.roots();
 
             let payloads: Vec<PbhPayload> = match pbh_payloads
                 .into_par_iter()
@@ -491,6 +497,59 @@ pub mod tests {
         pool.add_external_transaction(tx.clone().into())
             .await
             .expect("Failed to add transaction");
+    }
+
+    #[tokio::test]
+    async fn validate_pbh_bundle_with_multiple_non_empty_groups() {
+        const BUNDLER_ACCOUNT: u32 = 9;
+
+        let pool = setup().await;
+        let external_nullifier =
+            ExternalNullifier::with_date_marker(DateMarker::from(chrono::Utc::now()), 0);
+        let (user_op_1, proof_1) = user_op()
+            .acc(0)
+            .external_nullifier(external_nullifier)
+            .call();
+        let (user_op_2, proof_2) = user_op()
+            .acc(1)
+            .external_nullifier(external_nullifier)
+            .call();
+        let mut bundle = pbh_bundle(vec![user_op_1], vec![proof_1.into()]);
+        let second_group = pbh_bundle(vec![user_op_2], vec![proof_2.into()])
+            ._0
+            .pop()
+            .unwrap();
+        bundle._0.push(second_group);
+
+        let tx = eip1559()
+            .to(PBH_DEV_ENTRYPOINT)
+            .input(bundle.abi_encode())
+            .call();
+        let tx = eth_tx(BUNDLER_ACCOUNT, tx).await;
+
+        pool.add_external_transaction(tx.into())
+            .await
+            .expect("Failed to add multi-group PBH transaction");
+    }
+
+    #[tokio::test]
+    async fn reject_pbh_bundle_with_empty_group() {
+        const BUNDLER_ACCOUNT: u32 = 9;
+
+        let pool = setup().await;
+        let bundle = pbh_bundle(vec![], vec![]);
+        let tx = eip1559()
+            .to(PBH_DEV_ENTRYPOINT)
+            .input(bundle.abi_encode())
+            .call();
+        let tx = eth_tx(BUNDLER_ACCOUNT, tx).await;
+
+        let err = pool
+            .add_external_transaction(tx.into())
+            .await
+            .expect_err("Empty aggregator groups must be rejected");
+
+        assert!(err.to_string().contains("Missing PBH Payload"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
This PR fixes a bug discovered through hackerone.

### Problem

PBH bundle validation copied the entire World ID root cache for every aggregator group. Attackers could submit many empty groups to trigger excessive memory copying, while the cache stored duplicate root entries for every block.

### Solution

Reject empty aggregator groups, take one root snapshot per transaction, and store each distinct root with its last-observed timestamp. Add regression tests covering empty groups, multi-group bundles, and root deduplication.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transaction-pool PBH proof validation and root expiry semantics; behavior change is intentional for a security fix but could affect edge cases around root retention.
> 
> **Overview**
> Fixes a **DoS / resource amplification** issue in PBH bundle validation where attackers could force repeated copies of the World ID root cache.
> 
> **PBH validator** now rejects aggregator groups with empty `userOps` (not only an empty top-level array), takes **one** `valid_roots` snapshot per transaction for all groups, and adds pool tests for multi-group acceptance and empty-group rejection.
> 
> **Root cache** is keyed by root with **last-observed block timestamp** instead of one entry per block timestamp, so duplicate roots are stored once and pruning drops roots outside the expiration window by refreshing that timestamp on re-seen roots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1914ec7f7562ee23815788d57d417faa0eafc07c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->