### PR TITLE
feat(defender): make it l1 reorg aware

### DIFF
--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -46,7 +46,10 @@ use world_chain_challenger::{
     BondManagerConfig as ChallengerBondManagerConfig, ChallengerConfig, OwnedGames,
     ResolutionManager, ResolutionManagerConfig, WorldChainChallenger,
 };
-use world_chain_defender::{AlloyDefenderClient, DefenderConfig, WorldChainDefender};
+use world_chain_defender::{
+    AlloyDefenderClient, DEFAULT_L1_TX_CONFIRMATIONS as DEFAULT_DEFENDER_L1_TX_CONFIRMATIONS,
+    DefenderConfig, WorldChainDefender,
+};
 use world_chain_proof_core::{hash_world_rollup_config, range::WorldRangeHardforkConfig};
 use world_chain_proof_kona_host_utils::online::OnlineHostConfig;
 use world_chain_proof_succinct_host_utils::{
@@ -2746,7 +2749,11 @@ async fn start_world_chain_defender(
         .wallet(EthereumWallet::from(signer))
         .connect_http(Url::parse(l1_rpc_url)?);
 
-    let client = AlloyDefenderClient::new(provider, factory_address);
+    let client = AlloyDefenderClient::new(
+        provider,
+        factory_address,
+        DEFAULT_DEFENDER_L1_TX_CONFIRMATIONS,
+    );
     let output_roots = OptimismConsensusClient::new(output_root_rpc_url.to_string());
     let proof_requester = RpcProverServiceClient::new(prover_service_url)
         .map_err(|error| eyre!("failed to connect defender to prover-service: {error}"))?;

--- a/proofs/defender/src/alloy.rs
+++ b/proofs/defender/src/alloy.rs
@@ -18,6 +18,7 @@ use world_chain_proofs::{
 #[derive(Debug, Clone)]
 pub struct AlloyDefenderClient<P> {
     factory: IDisputeGameFactory::IDisputeGameFactoryInstance<P>,
+    confirmations: u64,
     provider: P,
 }
 
@@ -26,13 +27,17 @@ where
     P: Provider + Clone,
 {
     /// Creates a new Alloy-backed contract client.
-    pub fn new(provider: P, factory_address: Address) -> Self {
+    pub fn new(provider: P, factory_address: Address, confirmations: u64) -> Self {
         let factory = IDisputeGameFactory::IDisputeGameFactoryInstance::new(
             factory_address,
             provider.clone(),
         );
 
-        Self { factory, provider }
+        Self {
+            factory,
+            confirmations,
+            provider,
+        }
     }
 
     fn game(&self, address: Address) -> IMultiProofGame::IMultiProofGameInstance<P> {
@@ -163,6 +168,7 @@ where
             .map_err(|err| DefenderError::Contract(err.to_string()))?;
         let tx_hash = *pending.tx_hash();
         let receipt = pending
+            .with_required_confirmations(self.confirmations)
             .get_receipt()
             .await
             .map_err(|err| DefenderError::Contract(err.to_string()))?;

--- a/proofs/defender/src/config.rs
+++ b/proofs/defender/src/config.rs
@@ -5,8 +5,14 @@ use std::time::Duration;
 /// Default number of games processed concurrently.
 pub const DEFAULT_MAX_GAME_CONCURRENCY: usize = 10;
 
+/// Default number of L1 confirmations required for defender transactions.
+pub const DEFAULT_L1_TX_CONFIRMATIONS: u64 = 5;
+
 /// Default maximum number of new factory games discovered per defender tick.
 pub const DEFAULT_MAX_GAMES_PER_TICK: u64 = 100;
+
+/// Default number of previously scanned games reconsidered per defender tick.
+pub const DEFAULT_GAME_SCAN_LOOKBACK: u64 = 100;
 
 /// Default upper bound on the age of a game with an open proof window.
 pub const DEFAULT_MAX_GAME_AGE: Duration = Duration::from_secs(7 * 24 * 60 * 60);
@@ -25,6 +31,8 @@ pub struct DefenderConfig {
     pub max_game_concurrency: usize,
     /// Maximum number of newly created games discovered during one tick.
     pub max_games_per_tick: u64,
+    /// Number of previously scanned games reconsidered to tolerate mutable-state L1 reorgs.
+    pub game_scan_lookback: u64,
     /// Upper bound on the age of any game whose proof window can remain open.
     pub max_game_age: Duration,
     /// Maximum number of proving attempts per lane before abandoning it.
@@ -74,6 +82,7 @@ impl Default for DefenderConfig {
             poll_interval: Duration::from_mins(1),
             max_game_concurrency: DEFAULT_MAX_GAME_CONCURRENCY,
             max_games_per_tick: DEFAULT_MAX_GAMES_PER_TICK,
+            game_scan_lookback: DEFAULT_GAME_SCAN_LOOKBACK,
             max_game_age: DEFAULT_MAX_GAME_AGE,
             max_proof_attempts: DEFAULT_MAX_PROOF_ATTEMPTS,
         }

--- a/proofs/defender/src/config.rs
+++ b/proofs/defender/src/config.rs
@@ -17,9 +17,6 @@ pub const DEFAULT_GAME_SCAN_LOOKBACK: u64 = 100;
 /// Default upper bound on the age of a game with an open proof window.
 pub const DEFAULT_MAX_GAME_AGE: Duration = Duration::from_secs(7 * 24 * 60 * 60);
 
-/// Default number of proving attempts per lane before abandoning it.
-pub const DEFAULT_MAX_PROOF_ATTEMPTS: u32 = 3;
-
 /// Configuration for the defender.
 #[derive(Debug, Clone)]
 pub struct DefenderConfig {
@@ -35,8 +32,6 @@ pub struct DefenderConfig {
     pub game_scan_lookback: u64,
     /// Upper bound on the age of any game whose proof window can remain open.
     pub max_game_age: Duration,
-    /// Maximum number of proving attempts per lane before abandoning it.
-    pub max_proof_attempts: u32,
 }
 
 impl DefenderConfig {
@@ -66,11 +61,6 @@ impl DefenderConfig {
                 "max_game_age must be greater than zero",
             ));
         }
-        if self.max_proof_attempts == 0 {
-            return Err(DefenderError::InvalidConfig(
-                "max_proof_attempts must be greater than zero",
-            ));
-        }
         Ok(())
     }
 }
@@ -84,7 +74,6 @@ impl Default for DefenderConfig {
             max_games_per_tick: DEFAULT_MAX_GAMES_PER_TICK,
             game_scan_lookback: DEFAULT_GAME_SCAN_LOOKBACK,
             max_game_age: DEFAULT_MAX_GAME_AGE,
-            max_proof_attempts: DEFAULT_MAX_PROOF_ATTEMPTS,
         }
     }
 }

--- a/proofs/defender/src/defender.rs
+++ b/proofs/defender/src/defender.rs
@@ -337,10 +337,10 @@ where
 
     async fn discover_games(&mut self, now: u64) -> Result<(), DefenderError> {
         let game_count = self.execution_provider.game_count().await?;
-        if self
+        let initialize_cursor = self
             .next_game_index
-            .is_none_or(|next_game_index| next_game_index > game_count)
-        {
+            .is_none_or(|next_game_index| next_game_index > game_count);
+        if initialize_cursor {
             let cutoff = now.saturating_sub(self.config.max_game_age.as_secs());
             let first_recent = self.first_recent_game_index(game_count, cutoff).await?;
             info!(
@@ -350,8 +350,16 @@ where
             self.next_game_index = Some(first_recent);
         }
 
-        let start = self.next_game_index.unwrap_or(game_count);
-        let end = start
+        let cursor = self.next_game_index.unwrap_or(game_count);
+        // Factory entries are read at the finalized block, but mutable game state is read at
+        // latest. Reconsider a bounded overlap so a shallow reorg of that state cannot make a
+        // transient Drop outcome permanent. The overlap does not consume the new-game budget.
+        let start = if initialize_cursor {
+            cursor
+        } else {
+            cursor.saturating_sub(self.config.game_scan_lookback)
+        };
+        let end = cursor
             .saturating_add(self.config.max_games_per_tick)
             .min(game_count);
         let mut new_games = Vec::with_capacity((end - start) as usize);

--- a/proofs/defender/src/defender.rs
+++ b/proofs/defender/src/defender.rs
@@ -62,6 +62,8 @@ pub struct WorldChainDefender<E, C, P> {
     next_game_index: Option<u64>,
     watched_games: HashMap<Address, GameMetadata>,
     active_defenses: HashMap<Address, ActiveDefense>,
+    /// Games whose proof retries were exhausted, mapped to their proof deadline.
+    abandoned_defenses: HashMap<Address, u64>,
 }
 
 impl<E, C, P> WorldChainDefender<E, C, P> {
@@ -80,6 +82,7 @@ impl<E, C, P> WorldChainDefender<E, C, P> {
             next_game_index: None,
             watched_games: HashMap::default(),
             active_defenses: HashMap::default(),
+            abandoned_defenses: HashMap::default(),
         }
     }
 
@@ -103,6 +106,11 @@ impl<E, C, P> WorldChainDefender<E, C, P> {
     #[cfg(test)]
     pub(crate) fn active_defenses(&self) -> Vec<Address> {
         self.active_defenses.keys().copied().collect()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn abandoned_defenses(&self) -> Vec<Address> {
+        self.abandoned_defenses.keys().copied().collect()
     }
 }
 
@@ -257,11 +265,7 @@ where
         }
 
         let mut lanes = defense.lanes;
-        let lane_driver = LaneDriver::new(
-            &self.execution_provider,
-            &self.proof_requester,
-            self.config.max_proof_attempts,
-        );
+        let lane_driver = LaneDriver::new(&self.execution_provider, &self.proof_requester);
         for (slot, (proof_lane, backend)) in DEFENDED_LANES.into_iter().enumerate() {
             // skip lanes already proven on-chain, by us or by anyone else
             if proof_bitmap & proof_lane.mask() != 0 {
@@ -318,6 +322,8 @@ where
                         self.active_defenses.remove(&game);
                     } else if lanes.iter().all(|lane| lane.is_terminal()) {
                         error!(%game, "defense abandoned without proving all lanes");
+                        self.abandoned_defenses
+                            .insert(game, defense.game.proof_deadline);
                         self.active_defenses.remove(&game);
                     } else if let Some(defense) = self.active_defenses.get_mut(&game) {
                         defense.lanes = lanes;
@@ -368,7 +374,10 @@ where
             let Some(game) = self.execution_provider.game_address_at(index).await? else {
                 continue;
             };
-            if self.watched_games.contains_key(&game) || self.active_defenses.contains_key(&game) {
+            if self.watched_games.contains_key(&game)
+                || self.active_defenses.contains_key(&game)
+                || self.abandoned_defenses.contains_key(&game)
+            {
                 continue;
             }
 
@@ -401,6 +410,8 @@ where
 
     pub(crate) async fn tick_at(&mut self, now: u64) -> Result<(), DefenderError> {
         self.config.validate()?;
+        self.abandoned_defenses
+            .retain(|_, proof_deadline| now < *proof_deadline);
 
         self.advance_active_defenses(now).await;
         self.advance_tracked_games(now).await?;

--- a/proofs/defender/src/lane.rs
+++ b/proofs/defender/src/lane.rs
@@ -3,8 +3,8 @@ use alloy_primitives::Bytes;
 use tracing::{error, info, warn};
 use world_chain_proofs::ProofLane;
 use world_chain_prover_service::{
-    ProofBackend, ProofData, ProofRequest, ProofRequestId, ProofRequester, ProofResponse,
-    ProofStatus,
+    ProofBackend, ProofData, ProofRequest, ProofRequestError, ProofRequestId, ProofRequester,
+    ProofResponse, ProofStatus,
 };
 
 /// Number of proof lanes the defender drives.
@@ -23,7 +23,7 @@ pub(crate) enum LaneState {
     /// The proof has not been requested yet.
     Pending,
     /// The proof was requested from the prover-service.
-    Requested { id: ProofRequestId, attempts: u32 },
+    Requested { id: ProofRequestId },
     /// The lane is proven on-chain.
     Proven,
     /// Proving permanently failed after exhausting all attempts.
@@ -40,7 +40,6 @@ impl LaneState {
 pub(crate) struct LaneDriver<'a, E, P> {
     execution_client: &'a E,
     proof_requester: &'a P,
-    max_proof_attempts: u32,
 }
 
 impl<'a, E, P> LaneDriver<'a, E, P>
@@ -48,15 +47,10 @@ where
     E: DefenderClient,
     P: ProofRequester + Sync,
 {
-    pub(crate) const fn new(
-        execution_client: &'a E,
-        proof_requester: &'a P,
-        max_proof_attempts: u32,
-    ) -> Self {
+    pub(crate) const fn new(execution_client: &'a E, proof_requester: &'a P) -> Self {
         Self {
             execution_client,
             proof_requester,
-            max_proof_attempts,
         }
     }
 
@@ -70,8 +64,8 @@ where
         match state {
             LaneState::Proven | LaneState::Abandoned => state,
             LaneState::Pending => self.request_pending_lane(metadata, lane, backend).await,
-            LaneState::Requested { id, attempts } => {
-                self.advance_requested_lane(metadata, lane, backend, id, attempts)
+            LaneState::Requested { id } => {
+                self.advance_requested_lane(metadata, lane, backend, id)
                     .await
             }
         }
@@ -91,8 +85,11 @@ where
         {
             Ok(request_proof_response) => LaneState::Requested {
                 id: request_proof_response.proof_id,
-                attempts: 1,
             },
+            Err(ProofRequestError::TooManyRetries(error)) => {
+                error!(%game, ?lane, %error, "prover-service exhausted retries; abandoning lane");
+                LaneState::Abandoned
+            }
             Err(error) => {
                 warn!(%game, ?lane, %error, "proof request failed; retrying next tick");
                 LaneState::Pending
@@ -106,10 +103,9 @@ where
         lane: ProofLane,
         backend: ProofBackend,
         id: ProofRequestId,
-        attempts: u32,
     ) -> LaneState {
         let game = metadata.address;
-        let state = LaneState::Requested { id, attempts };
+        let state = LaneState::Requested { id };
         let status = match self.proof_requester.proof_status(id).await {
             Ok(status) => status,
             Err(error) => {
@@ -121,10 +117,7 @@ where
         match status {
             ProofStatus::Created | ProofStatus::Running => state,
             ProofStatus::Succeeded => self.submit_succeeded_lane(metadata, lane, id, state).await,
-            ProofStatus::Failed => {
-                self.retry_failed_lane(metadata, lane, backend, attempts, state)
-                    .await
-            }
+            ProofStatus::Failed => self.retry_failed_lane(metadata, lane, backend, state).await,
         }
     }
 
@@ -187,35 +180,30 @@ where
         metadata: &GameMetadata,
         lane: ProofLane,
         backend: ProofBackend,
-        attempts: u32,
         state: LaneState,
     ) -> LaneState {
         let game = metadata.address;
-        if attempts >= self.max_proof_attempts {
-            error!(%game, ?lane, attempts, "proving permanently failed; abandoning lane");
-            return LaneState::Abandoned;
-        }
-
-        // re-requesting a failed proof re-queues it
+        // Re-requesting a failed proof re-queues the same deterministic proof id. The
+        // prover-service owns the durable retry counter and rejects exhausted requests.
         match self
             .proof_requester
             .request_proof(proof_request(metadata, backend))
             .await
         {
             Ok(request_proof_response) => {
-                let next_attempt = attempts + 1;
                 warn!(
                     %game,
                     ?lane,
                     %request_proof_response.proof_id,
-                    attempts = next_attempt,
-                    max_attempts = self.max_proof_attempts,
                     "proof failed; re-requested proof"
                 );
                 LaneState::Requested {
                     id: request_proof_response.proof_id,
-                    attempts: next_attempt,
                 }
+            }
+            Err(ProofRequestError::TooManyRetries(error)) => {
+                error!(%game, ?lane, %error, "prover-service exhausted retries; abandoning lane");
+                LaneState::Abandoned
             }
             Err(error) => {
                 warn!(%game, ?lane, %error, "proof re-request failed; retrying next tick");

--- a/proofs/defender/src/lib.rs
+++ b/proofs/defender/src/lib.rs
@@ -11,7 +11,7 @@ mod types;
 
 // re-exports
 pub use alloy::AlloyDefenderClient;
-pub use config::DefenderConfig;
+pub use config::{DEFAULT_GAME_SCAN_LOOKBACK, DEFAULT_L1_TX_CONFIRMATIONS, DefenderConfig};
 pub use defender::WorldChainDefender;
 pub use error::DefenderError;
 pub use traits::DefenderClient;

--- a/proofs/defender/src/main.rs
+++ b/proofs/defender/src/main.rs
@@ -16,7 +16,10 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use tracing::info;
 use url::Url;
-use world_chain_defender::{AlloyDefenderClient, DefenderConfig, WorldChainDefender};
+use world_chain_defender::{
+    AlloyDefenderClient, DEFAULT_GAME_SCAN_LOOKBACK, DEFAULT_L1_TX_CONFIRMATIONS, DefenderConfig,
+    WorldChainDefender,
+};
 use world_chain_proofs::OptimismConsensusClient;
 use world_chain_prover_service::RpcProverServiceClient;
 
@@ -62,6 +65,23 @@ struct Cli {
     #[arg(long, env = "MAX_GAMES_PER_TICK", default_value_t = 100)]
     max_games_per_tick: u64,
 
+    /// Number of previously scanned games reconsidered per defender tick.
+    #[arg(
+        long,
+        env = "GAME_SCAN_LOOKBACK",
+        default_value_t = DEFAULT_GAME_SCAN_LOOKBACK
+    )]
+    game_scan_lookback: u64,
+
+    /// Number of L1 confirmations required before a proof submission is accepted.
+    #[arg(
+        long,
+        env = "L1_TX_CONFIRMATIONS",
+        default_value_t = DEFAULT_L1_TX_CONFIRMATIONS,
+        value_parser = clap::value_parser!(u64).range(1..)
+    )]
+    l1_tx_confirmations: u64,
+
     /// Conservative upper bound on the age of a game with an open proof window.
     #[arg(long, env = "MAX_GAME_AGE_SECONDS", default_value_t = 604_800)]
     max_game_age_seconds: u64,
@@ -85,7 +105,7 @@ async fn main() -> Result<()> {
         .wallet(EthereumWallet::from(cli.defender_key))
         .connect_http(Url::parse(&cli.l1_rpc).context("invalid L1 RPC URL")?);
 
-    let client = AlloyDefenderClient::new(provider, cli.factory_address);
+    let client = AlloyDefenderClient::new(provider, cli.factory_address, cli.l1_tx_confirmations);
     let output_roots = OptimismConsensusClient::new(cli.output_root_rpc.clone());
     let proof_requester = RpcProverServiceClient::new(&cli.prover_service_url)
         .with_context(|| format!("failed to connect to {}", cli.prover_service_url))?;
@@ -94,6 +114,7 @@ async fn main() -> Result<()> {
         poll_interval: Duration::from_secs(cli.poll_interval_seconds),
         max_game_concurrency: cli.max_game_concurrency,
         max_games_per_tick: cli.max_games_per_tick,
+        game_scan_lookback: cli.game_scan_lookback,
         max_game_age: Duration::from_secs(cli.max_game_age_seconds),
         max_proof_attempts: cli.max_proof_attempts,
     };
@@ -107,6 +128,8 @@ async fn main() -> Result<()> {
         defender = %defender_address,
         allowed_proposer = %cli.allowed_proposer,
         max_games_per_tick = cli.max_games_per_tick,
+        game_scan_lookback = cli.game_scan_lookback,
+        l1_tx_confirmations = cli.l1_tx_confirmations,
         "starting World Chain proof-system defender"
     );
 

--- a/proofs/defender/src/main.rs
+++ b/proofs/defender/src/main.rs
@@ -85,10 +85,6 @@ struct Cli {
     /// Conservative upper bound on the age of a game with an open proof window.
     #[arg(long, env = "MAX_GAME_AGE_SECONDS", default_value_t = 604_800)]
     max_game_age_seconds: u64,
-
-    /// Maximum proof attempts per lane before giving up.
-    #[arg(long, env = "MAX_PROOF_ATTEMPTS", default_value_t = 3)]
-    max_proof_attempts: u32,
 }
 
 #[tokio::main]
@@ -116,7 +112,6 @@ async fn main() -> Result<()> {
         max_games_per_tick: cli.max_games_per_tick,
         game_scan_lookback: cli.game_scan_lookback,
         max_game_age: Duration::from_secs(cli.max_game_age_seconds),
-        max_proof_attempts: cli.max_proof_attempts,
     };
     let mut defender = WorldChainDefender::new(config, client, output_roots, proof_requester);
 

--- a/proofs/defender/src/tests.rs
+++ b/proofs/defender/src/tests.rs
@@ -26,6 +26,7 @@ use world_chain_prover_service::{
 
 const GAME_1: Address = address!("0000000000000000000000000000000000000001");
 const GAME_2: Address = address!("0000000000000000000000000000000000000002");
+const GAME_3: Address = address!("0000000000000000000000000000000000000003");
 const ALLOWED_PROPOSER: Address = address!("00000000000000000000000000000000000000a1");
 const OTHER_PROPOSER: Address = address!("00000000000000000000000000000000000000b2");
 const L2_BLOCK: u64 = 100;
@@ -409,6 +410,7 @@ fn config() -> DefenderConfig {
     DefenderConfig {
         allowed_proposer: ALLOWED_PROPOSER,
         poll_interval: Duration::from_secs(1),
+        game_scan_lookback: 0,
         ..DefenderConfig::default()
     }
 }
@@ -500,6 +502,46 @@ async fn tick_respects_factory_scan_budget() {
     assert_eq!(watched.len(), 2);
     assert!(watched.contains(&GAME_1));
     assert!(watched.contains(&GAME_2));
+}
+
+#[tokio::test]
+async fn tick_rechecks_lookback_without_reducing_forward_progress() {
+    let canonical_root = B256::repeat_byte(0x20);
+    let client = MockClient::new(
+        vec![
+            (GAME_1, canonical_root, L2_BLOCK),
+            (GAME_2, canonical_root, L2_BLOCK),
+            (GAME_3, canonical_root, L2_BLOCK),
+        ],
+        HashMap::from([(GAME_2, STATE_FINALIZED)]),
+    );
+    let (output_roots, _finalized_l2_block) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
+    let mut defender_config = config();
+    defender_config.max_game_concurrency = 1;
+    defender_config.max_games_per_tick = 2;
+    defender_config.game_scan_lookback = 1;
+    let mut defender = WorldChainDefender::new(
+        defender_config,
+        client.clone(),
+        output_roots,
+        MockProver::default(),
+    );
+
+    defender.tick().await.unwrap();
+    assert_eq!(defender.next_game_index(), Some(2));
+    assert_eq!(defender.watched_games(), [GAME_1]);
+
+    // Simulate a shallow reorg restoring a game that was transiently observed as finalized.
+    client.set_state(GAME_2, STATE_PROPOSED);
+    defender.tick().await.unwrap();
+
+    assert_eq!(defender.next_game_index(), Some(3));
+    let watched = defender.watched_games();
+    assert_eq!(watched.len(), 3);
+    assert!(watched.contains(&GAME_1));
+    assert!(watched.contains(&GAME_2));
+    assert!(watched.contains(&GAME_3));
 }
 
 #[tokio::test]

--- a/proofs/defender/src/tests.rs
+++ b/proofs/defender/src/tests.rs
@@ -22,6 +22,7 @@ use world_chain_proofs::{
 use world_chain_prover_service::{
     ProofBackend, ProofData, ProofRequest, ProofRequestError, ProofRequestId, ProofRequester,
     ProofResponse, ProofStatus, RequestProofResponse, SucceededProofResponse,
+    TooManyRetriesErrorData,
 };
 
 const GAME_1: Address = address!("0000000000000000000000000000000000000001");
@@ -327,14 +328,17 @@ fn mock_output_roots(
 struct MockProver {
     /// When true, every requested proof reports [`ProofStatus::Failed`].
     fail: bool,
+    max_requests_per_proof: Option<u32>,
     requests: Arc<Mutex<Vec<ProofRequest>>>,
+    request_counts: Arc<Mutex<HashMap<ProofRequestId, u32>>>,
     by_id: Arc<Mutex<HashMap<ProofRequestId, ProofRequest>>>,
 }
 
 impl MockProver {
-    fn failing() -> Self {
+    fn failing(max_requests_per_proof: u32) -> Self {
         Self {
             fail: true,
+            max_requests_per_proof: Some(max_requests_per_proof),
             ..Self::default()
         }
     }
@@ -356,6 +360,17 @@ impl ProofRequester for MockProver {
             .lock()
             .expect("not poisoned")
             .push(proof_request.clone());
+        if let Some(max_requests_per_proof) = self.max_requests_per_proof {
+            let mut request_counts = self.request_counts.lock().expect("not poisoned");
+            let request_count = request_counts.entry(id).or_default();
+            if *request_count >= max_requests_per_proof {
+                return Err(ProofRequestError::TooManyRetries(TooManyRetriesErrorData {
+                    proof_id: id,
+                    max_retries: max_requests_per_proof.saturating_sub(1),
+                }));
+            }
+            *request_count += 1;
+        }
         self.by_id
             .lock()
             .expect("not poisoned")
@@ -933,7 +948,7 @@ async fn tick_skips_lane_already_proven() {
 }
 
 #[tokio::test]
-async fn failed_proofs_are_rerequested_up_to_the_attempt_bound() {
+async fn exhausted_prover_retries_are_not_restarted_by_lookback() {
     let canonical_root = B256::repeat_byte(0x20);
 
     let client = MockClient::new(
@@ -942,29 +957,28 @@ async fn failed_proofs_are_rerequested_up_to_the_attempt_bound() {
     );
     let (output_roots, _finalized_l2_block) =
         mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
-    let prover = MockProver::failing();
+    let prover = MockProver::failing(2);
+    let mut defender_config = config();
+    defender_config.game_scan_lookback = 1;
     let mut defender = WorldChainDefender::new(
-        DefenderConfig {
-            max_proof_attempts: 2,
-            ..config()
-        },
+        defender_config,
         client.clone(),
         output_roots,
         prover.clone(),
     );
 
     // Tick 1 discovers the game and tick 2 promotes it. Tick 3 makes the first
-    // request per lane; tick 4 re-requests each failed proof; tick 5 exhausts
-    // the attempts.
-    defender.tick().await.unwrap();
-    defender.tick().await.unwrap();
-    defender.tick().await.unwrap();
-    defender.tick().await.unwrap();
-    defender.tick().await.unwrap();
+    // request per lane; tick 4 re-requests each failed proof; tick 5 observes
+    // the prover-service retry limit and abandons the defense. Further lookback
+    // scans must not restart it.
+    for _ in 0..8 {
+        defender.tick().await.unwrap();
+    }
 
-    assert_eq!(prover.requests().len(), 4);
+    assert_eq!(prover.requests().len(), 6);
     assert!(client.submissions().is_empty());
     assert!(defender.active_defenses().is_empty());
+    assert_eq!(defender.abandoned_defenses(), [GAME_1]);
 }
 
 #[tokio::test]

--- a/proofs/integration-tests/tests/orchestration.rs
+++ b/proofs/integration-tests/tests/orchestration.rs
@@ -43,7 +43,6 @@ fn defender_config() -> DefenderConfig {
     DefenderConfig {
         allowed_proposer: FAKE_PROPOSER,
         poll_interval: Duration::from_secs(1),
-        max_proof_attempts: 2,
         ..DefenderConfig::default()
     }
 }


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-5006/fix-defender

Same approach as of https://github.com/worldcoin/world-chain/pull/935

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dispute-game defense timing (lookback, abandoned-game gating) and L1 tx confirmation behavior on proof submission; misconfiguration could delay submissions or miss games, but scope is the defender service rather than core chain consensus.
> 
> **Overview**
> **L1 reorg resilience:** Game discovery now re-scans a bounded window of previously seen factory indices (`game_scan_lookback`, default 100) each tick so shallow reorgs of mutable game state (read at latest) cannot permanently drop a game that was transiently finalized. Games with exhausted proof retries are tracked in `abandoned_defenses` until their proof deadline so lookback does not restart hopeless defenses.
> 
> **L1 submission safety:** `AlloyDefenderClient` waits for a configurable number of L1 confirmations (default 5, `L1_TX_CONFIRMATIONS`) before treating `submitProofLane` receipts as successful; devnet and the CLI wire this through.
> 
> **Proof retry ownership:** Defender-local `max_proof_attempts` is removed. Lane proving retries are owned by the prover-service (`ProofRequestError::TooManyRetries`); lane state no longer tracks attempt counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f318fd5557d775bb31ccdd9765c220ac9f63b327. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->