### PR TITLE
Revert "feat(proofs): require proof-backed game creation"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18627,7 +18627,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-provider",
  "alloy-signer-local 2.0.5",
- "alloy-sol-types",
  "anyhow",
  "async-trait",
  "base64 0.22.1",
@@ -19163,7 +19162,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-provider",
  "alloy-signer-local 2.0.5",
- "alloy-sol-types",
  "anyhow",
  "async-trait",
  "clap",
@@ -19176,7 +19174,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.23",
  "url",
- "world-chain-proof-core",
  "world-chain-proofs",
  "world-chain-prover-service",
 ]

--- a/crates/devnet/Cargo.toml
+++ b/crates/devnet/Cargo.toml
@@ -28,7 +28,6 @@ world-chain-sp1-worker = { workspace = true, default-features = false }
 world-chain-test-utils.workspace = true
 
 alloy-provider.workspace = true
-alloy-sol-types.workspace = true
 alloy-eips.workspace = true
 alloy-genesis.workspace = true
 alloy-hardforks.workspace = true

--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -11,10 +11,9 @@ use std::{
 use alloy_eips::{BlockNumberOrTag, eip1559::BaseFeeParams};
 use alloy_genesis::Genesis;
 use alloy_network::EthereumWallet;
-use alloy_primitives::{Address, B64, B256, hex};
+use alloy_primitives::{Address, B64, hex};
 use alloy_provider::{Provider, ProviderBuilder};
 use alloy_signer_local::PrivateKeySigner;
-use alloy_sol_types::SolValue;
 use async_trait::async_trait;
 use base64::prelude::{BASE64_STANDARD, Engine};
 use eyre::eyre::{Context, Result, bail, eyre};
@@ -49,9 +48,7 @@ use world_chain_challenger::{
     WorldChainChallenger,
 };
 use world_chain_defender::{AlloyDefenderClient, DefenderConfig, WorldChainDefender};
-use world_chain_proof_core::{
-    boot::TransitionPublicValues, hash_world_rollup_config, range::WorldRangeHardforkConfig,
-};
+use world_chain_proof_core::{hash_world_rollup_config, range::WorldRangeHardforkConfig};
 use world_chain_proof_kona_host_utils::online::OnlineHostConfig;
 use world_chain_proof_succinct_host_utils::{
     Sp1ProverKind, WorldSuccinctProver,
@@ -364,21 +361,13 @@ impl ClaimedProofJobHandler for DevnetNitroBackend {
     }
 
     async fn handle_claimed_job(&self, job: ProofJob) -> anyhow::Result<ProofData> {
-        let public_values = TransitionPublicValues {
-            l1Head: job.request.l1_head,
-            l2PreRoot: B256::ZERO,
-            l2PreBlockNumber: job.request.l2_block_number.saturating_sub(1),
-            l2PostRoot: job.request.root_claim,
-            l2PostBlockNumber: job.request.l2_block_number,
-            rollupConfigHash: B256::ZERO,
-        };
-        let mut public_key = vec![0; 65];
-        public_key[0] = 0x04;
+        // The devnet deploys MockRootIdVerifier lanes. The proposer currently uses this
+        // response only as a readiness gate before stock DGF.create, so deterministic bytes
+        // keep the full queue/worker path exercised without requiring Nitro hardware.
         Ok(ProofData::Nitro {
             attestation: job.request.l1_head.as_slice().to_vec().into(),
-            public_values: public_values.abi_encode().into(),
+            public_values: job.request.root_claim.as_slice().to_vec().into(),
             signature: job.request.root_claim.as_slice().to_vec().into(),
-            public_key: public_key.into(),
         })
     }
 }

--- a/crates/devnet/src/l1.rs
+++ b/crates/devnet/src/l1.rs
@@ -79,9 +79,6 @@ impl L1DevChain {
             config.chain_id.to_string(),
             "--block-time".to_string(),
             config.block_time_secs.to_string(),
-            // Proof-system services consume finalized L2 blocks, so keep Anvil finality fast.
-            "--slots-in-an-epoch".to_string(),
-            "1".to_string(),
         ];
 
         if let Some(genesis_file) = &config.genesis_file {

--- a/e2e-tests/src/it/devnet_withdrawal.rs
+++ b/e2e-tests/src/it/devnet_withdrawal.rs
@@ -14,14 +14,12 @@ use world_chain_devnet::{
     is_docker_unavailable,
 };
 use world_chain_proofs::{
-    IAnchorStateRegistry, IDelayedWETH, IDisputeGameFactory, IMultiProofGame,
-    MULTI_PROOF_GAME_TYPE, ProofLane,
+    IAnchorStateRegistry, IDelayedWETH, IDisputeGameFactory, IMultiProofGame, MULTI_PROOF_GAME_TYPE,
 };
 
 const DEVNET_SIGNER_KEY: &str =
     "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a";
 const L2_TO_L1_MESSAGE_PASSER: Address = address!("4200000000000000000000000000000000000016");
-const HISTORY_STORAGE: Address = address!("0000F90827F1C53a10cb7A02335B175320002935");
 const GAME_WAIT_TIMEOUT: Duration = Duration::from_secs(300);
 const GAME_IN_PROGRESS: u8 = 0;
 const GAME_DEFENDER_WINS: u8 = 2;
@@ -151,10 +149,6 @@ async fn op_native_wip_1006_portal_withdrawal_and_bond_claim() -> eyre::Result<(
         anchor.respectedGameType().call().await? == MULTI_PROOF_GAME_TYPE,
         "WIP-1006 is not the AnchorStateRegistry's respected game type"
     );
-    ensure!(
-        !l1_provider.get_code_at(HISTORY_STORAGE).await?.is_empty(),
-        "L1 devnet is missing the EIP-2935 history contract"
-    );
 
     let withdrawal = initiate_withdrawal(l2_provider.clone(), withdrawal_sender).await?;
     let (game_index, game_address, game_l2_block) =
@@ -168,35 +162,9 @@ async fn op_native_wip_1006_portal_withdrawal_and_bond_claim() -> eyre::Result<(
         anchor.isGameProper(game_address).call().await?,
         "covering WIP-1006 game is not proper"
     );
-    ensure!(
-        !game.creationProof().call().await?.is_empty(),
-        "covering WIP-1006 game has no creation proof"
-    );
-    ensure!(
-        game.creationProofLane().call().await? == ProofLane::TeeAttestation as u8,
-        "covering WIP-1006 game was not created with a TEE proof"
-    );
-    ensure!(
-        game.proofCount().call().await? == 1,
-        "creation proof did not seed exactly one proof lane"
-    );
-    let l1_origin_number: u64 = game.l1OriginNumber().call().await?.try_into()?;
-    let selected_l1_origin = l1_provider
-        .get_block_by_number(BlockNumberOrTag::Number(l1_origin_number))
-        .await?
-        .ok_or_eyre("selected WIP-1006 L1 origin is unavailable")?;
-    ensure!(
-        game.l1Head().call().await? == selected_l1_origin.header.hash,
-        "game L1 head does not match the proposer-selected L1 block"
-    );
 
     let (output_root_proof, withdrawal_proof) =
         build_withdrawal_proof(l2_provider, game_l2_block, withdrawal.hash).await?;
-    let game_created_at = game.createdAt().call().await?;
-    let current_timestamp = latest_timestamp(&l1_provider).await?;
-    if current_timestamp <= game_created_at {
-        advance_to_timestamp(&l1_provider, game_created_at.saturating_add(1)).await?;
-    }
     ensure!(
         portal
             .proveWithdrawalTransaction(

--- a/pkg/contracts/scripts/devnet/DeployProofSystem.s.sol
+++ b/pkg/contracts/scripts/devnet/DeployProofSystem.s.sol
@@ -81,7 +81,7 @@ contract DeployProofSystem is Script {
         vm.startBroadcast(config.privateKey);
         deployment.staking = new MockStakingRegistry();
         deployment.validityVerifier = new MockRootIdVerifier(false);
-        deployment.teeVerifier = new MockRootIdVerifier(true);
+        deployment.teeVerifier = new MockRootIdVerifier(false);
         deployment.councilVerifier = new MockRootIdVerifier(false);
         deployment.staking.setStaked(vm.addr(config.privateKey), true);
         if (config.challenger != address(0)) {

--- a/pkg/contracts/src/proofs/MultiProofGame.sol
+++ b/pkg/contracts/src/proofs/MultiProofGame.sol
@@ -31,7 +31,8 @@ import {
     InvalidParentGame,
     NoCreditToClaim,
     ParentGameNotResolved,
-    UnexpectedGameType
+    UnexpectedGameType,
+    UnexpectedRootClaim
 } from "@optimism-bedrock/src/dispute/lib/Errors.sol";
 import {IDisputeGame} from "@optimism-bedrock/interfaces/dispute/IDisputeGame.sol";
 import {IDisputeGameFactory} from "@optimism-bedrock/interfaces/dispute/IDisputeGameFactory.sol";
@@ -47,9 +48,6 @@ import {ISemver} from "@optimism-bedrock/interfaces/universal/ISemver.sol";
 ///         it. Bond custody uses `DelayedWETH` with the two-phase unlock/withdraw claim flow.
 /// @dev Structure follows `ZKDisputeGame`; challenge/lane semantics are World Chain specific.
 contract MultiProofGame is Clone, ISemver, IMultiProofGame {
-    /// @dev EIP-2935 history contract, retaining the latest 8,191 block hashes.
-    address internal constant HISTORY_STORAGE = 0x0000F90827F1C53a10cb7A02335B175320002935;
-
     ////////////////////////////////////////////////////////////////
     //                       Immutables                           //
     ////////////////////////////////////////////////////////////////
@@ -154,22 +152,11 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
     //                       CWIA getters                         //
     ////////////////////////////////////////////////////////////////
 
-    // CWIA layout appended by `DisputeGameFactory.create` (no implementation args).
-    // Addresses in ABI words are right-aligned:
-    //   [0x000, 0x014) creator address                    (factory prefix)
-    //   [0x014, 0x034) root claim                         (factory prefix)
-    //   [0x034, 0x054) factory-captured parent block hash (unused by this game)
-    //   [0x054, 0x074) domainHash                         (extraData word 0)
-    //   [0x074, 0x094) l2BlockNumber                      (extraData word 1)
-    //   [0x094, 0x0B4) parentRef                          (extraData word 2)
-    //   [0x0B4, 0x0D4) attempt                            (extraData word 3)
-    //   [0x0D4, 0x0F4) retryOf                            (extraData word 4)
-    //   [0x0F4, 0x114) l1OriginHash                       (extraData word 5)
-    //   [0x114, 0x134) l1OriginNumber                     (extraData word 6)
-    //   [0x134, 0x154) creationProofLane                   (extraData word 7)
-    //   [0x154, 0x174) creationProof offset (= 0x120)     (extraData word 8)
-    //   [0x174, 0x194) creationProof length               (dynamic tail)
-    //   [0x194, ...) creationProof bytes, padded to 32 bytes
+    // CWIA layout appended by `DisputeGameFactory.create` (no implementation args):
+    //   [0x00, 0x14) creator address
+    //   [0x14, 0x34) root claim
+    //   [0x34, 0x54) l1 head (parent block hash at creation)
+    //   [0x54, 0xD4) extraData = abi.encode(domainHash, l2BlockNumber, parentRef, attempt)
 
     function gameCreator() public pure returns (address creator_) {
         creator_ = _getArgAddress(0x00);
@@ -180,7 +167,7 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
     }
 
     function l1Head() public pure returns (Hash l1Head_) {
-        l1Head_ = Hash.wrap(_getArgBytes32(0xF4));
+        l1Head_ = Hash.wrap(_getArgBytes32(0x34));
     }
 
     /// @inheritdoc IMultiProofGame
@@ -207,36 +194,8 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
         attempt_ = _getArgUint256(0xB4);
     }
 
-    /// @inheritdoc IMultiProofGame
-    function retryOf() public pure returns (address retryOf_) {
-        uint256 rawRetryOf = _getArgUint256(0xD4);
-        if (rawRetryOf > type(uint160).max) revert BadExtraData();
-        // forge-lint: disable-next-line(unsafe-typecast)
-        retryOf_ = address(uint160(rawRetryOf));
-    }
-
-    /// @inheritdoc IMultiProofGame
-    function creationProof() public pure returns (bytes memory proof_) {
-        bytes memory data = extraData();
-        (,,,,,,,, proof_) =
-            abi.decode(data, (bytes32, uint256, address, uint256, address, bytes32, uint256, uint8, bytes));
-    }
-
-    /// @inheritdoc IMultiProofGame
-    function creationProofLane() public pure returns (ProofLib.ProofLane lane_) {
-        bytes memory data = extraData();
-        (,,,,,,, uint8 laneId,) =
-            abi.decode(data, (bytes32, uint256, address, uint256, address, bytes32, uint256, uint8, bytes));
-        if (laneId >= PROOF_LANE_COUNT) revert InvalidLane(laneId);
-        lane_ = ProofLib.ProofLane(laneId);
-    }
-
-    /// @notice Returns the ABI-encoded proposal data supplied to `DisputeGameFactory.create`.
-    /// @dev Excludes the 0x54-byte CWIA prefix containing the creator, root claim, and factory-captured L1 block hash.
     function extraData() public pure returns (bytes memory extraData_) {
-        bytes memory args = _getArgBytes();
-        if (args.length < 0x54) revert BadExtraData();
-        extraData_ = _getArgBytes(0x54, args.length - 0x54);
+        extraData_ = _getArgBytes(0x54, 0x80);
     }
 
     ////////////////////////////////////////////////////////////////
@@ -320,6 +279,19 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
     function initialize() external payable {
         if (initialized) revert AlreadyInitialized();
 
+        // Reject any calldata whose length differs from the exact CWIA payload. This prevents
+        // extraData padding games that would mint distinct factory UUIDs for the same proposal,
+        // and blocks direct `initialize` calls on clones with malformed payloads.
+        //
+        // Expected length: 0xDA
+        // - 0x04 selector
+        // - 0x14 creator address
+        // - 0x20 root claim
+        // - 0x20 l1 head
+        // - 0x80 extraData (domainHash, l2BlockNumber, parentRef, attempt)
+        // - 0x02 CWIA length suffix
+        if (msg.data.length != 0xDA) revert BadExtraData();
+
         // Only the configured factory may initialize; this also rules out direct initialization
         // of the implementation contract itself.
         if (msg.sender != address(disputeGameFactory)) revert NotDisputeGameFactory(msg.sender);
@@ -327,45 +299,12 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
         // Defense-in-depth against `setInitBond` drifting from the configured proposer bond.
         if (msg.value != proposerBond) revert IncorrectBondAmount();
 
-        bytes memory proposalExtraData = extraData();
-        if (proposalExtraData.length < 0x160) revert BadExtraData();
-        (
-            bytes32 proposalDomainHash_,
-            uint256 l2BlockNumber_,
-            address parentRef_,
-            uint256 attempt_,
-            address retryOf_,
-            bytes32 l1OriginHash_,
-            uint256 l1OriginNumber_,
-            uint8 creationProofLaneId_,
-            bytes memory creationProof_
-        ) = abi.decode(proposalExtraData, (bytes32, uint256, address, uint256, address, bytes32, uint256, uint8, bytes));
-        if (
-            creationProof_.length == 0
-                || keccak256(proposalExtraData)
-                    != keccak256(
-                        abi.encode(
-                            proposalDomainHash_,
-                            l2BlockNumber_,
-                            parentRef_,
-                            attempt_,
-                            retryOf_,
-                            l1OriginHash_,
-                            l1OriginNumber_,
-                            creationProofLaneId_,
-                            creationProof_
-                        )
-                    )
-        ) {
-            revert BadExtraData();
-        }
-        if (creationProofLaneId_ >= PROOF_LANE_COUNT) revert InvalidLane(creationProofLaneId_);
-
         // Preserves the former propose-time registry pause gate.
         if (anchorStateRegistry.paused()) revert GamePaused();
-        if (proposalDomainHash_ != domainHash) revert InvalidDomainHash(domainHash, proposalDomainHash_);
+        if (proposalDomainHash() != domainHash) revert InvalidDomainHash(domainHash, proposalDomainHash());
 
         (Hash anchorRoot, uint256 anchorL2BlockNumber) = anchorStateRegistry.getAnchorRoot();
+        address parentRef_ = parentRef();
 
         if (parentRef_ == address(anchorStateRegistry)) {
             // The proposal extends the accepted anchor; the registry acts as the parent sentinel.
@@ -398,49 +337,46 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
         }
 
         uint256 expectedL2BlockNumber = startingL2BlockNumber + DOMAIN_BLOCK_INTERVAL;
-        if (l2BlockNumber_ != expectedL2BlockNumber) {
-            revert InvalidL2BlockNumber(expectedL2BlockNumber, l2BlockNumber_);
+        if (l2SequenceNumber() != expectedL2BlockNumber) {
+            revert InvalidL2BlockNumber(expectedL2BlockNumber, l2SequenceNumber());
         }
+        // Per spec, the sequence number must fit within a uint64.
+        if (l2SequenceNumber() > type(uint64).max) revert UnexpectedRootClaim(rootClaim());
 
-        // Retries explicitly reference the previous concrete game because its selected L1 head
-        // and creation proof make its factory UUID impossible to reconstruct from the transition.
-        if ((attempt_ == 0) != (retryOf_ == address(0))) {
-            revert InvalidRetryReference(attempt_, retryOf_);
-        }
-        if (attempt_ != 0) {
-            if (retryOf_.code.length == 0) revert GameNotRetryable(keccak256(abi.encode(retryOf_)));
-            IMultiProofGame previous = IMultiProofGame(retryOf_);
-            (GameType previousType, Claim previousClaim, bytes memory previousExtraData) = previous.gameData();
-            (IDisputeGame registeredPrevious,) =
-                disputeGameFactory.games(previousType, previousClaim, previousExtraData);
+        // Retries: attempt N is only proposable when attempt N-1 for the identical transition
+        // timed out on proofs or was created before WIP-1006 became respected. The latter
+        // prevents a pre-cutover game from permanently occupying the factory UUID. Inherited
+        // invalidations must rebase onto a replacement parent, which changes `parentRef` and
+        // therefore starts back at attempt zero. Duplicate attempts are impossible: the factory
+        // UUID covers (gameType, rootClaim, extraData).
+        if (attempt() > 0) {
+            bytes memory previousExtraData = abi.encode(domainHash, l2SequenceNumber(), parentRef_, attempt() - 1);
+            (IDisputeGame previous,) =
+                disputeGameFactory.games(GameTypes.MULTI_PROOF_GAME_TYPE, rootClaim(), previousExtraData);
             if (
-                address(registeredPrevious) != retryOf_ || previousType.raw() != GameTypes.MULTI_PROOF_GAME_TYPE.raw()
-                    || previous.proposalDomainHash() != domainHash || previous.parentRef() != parentRef_
-                    || Claim.unwrap(previousClaim) != Claim.unwrap(rootClaim())
-                    || previous.l2SequenceNumber() != l2BlockNumber_ || previous.attempt() != attempt_ - 1
+                address(previous) == address(0)
                     || (previous.wasRespectedGameTypeWhenCreated()
                         && (previous.status() != GameStatus.CHALLENGER_WINS
-                            || previous.invalidationReason() != ProofLib.InvalidationReason.PROOF_TIMEOUT))
+                            || IMultiProofGame(address(previous)).invalidationReason()
+                                != ProofLib.InvalidationReason.PROOF_TIMEOUT))
             ) {
-                revert GameNotRetryable(keccak256(abi.encode(retryOf_)));
+                revert GameNotRetryable(keccak256(
+                        abi.encode(GameTypes.MULTI_PROOF_GAME_TYPE, rootClaim(), previousExtraData)
+                    ));
             }
         }
 
-        if (
-            l1OriginNumber_ > type(uint64).max || l1OriginHash_ == bytes32(0)
-                || _historicalBlockHash(l1OriginNumber_) != l1OriginHash_
-        ) {
-            revert InvalidL1Head(l1OriginHash_, l1OriginNumber_);
-        }
-        _l1OriginNumber = uint64(l1OriginNumber_);
+        // `initialize` runs in the same transaction as `DisputeGameFactory.create`, which set
+        // `l1Head = blockhash(block.number - 1)`.
+        _l1OriginNumber = uint64(block.number - 1);
         rootId = ProofLib.rootId(
-            domainHash, parentRef_, Claim.unwrap(rootClaim()), l2BlockNumber_, l1OriginHash_, _l1OriginNumber
+            domainHash,
+            parentRef_,
+            Claim.unwrap(rootClaim()),
+            l2SequenceNumber(),
+            Hash.unwrap(l1Head()),
+            _l1OriginNumber
         );
-        ProofLib.ProofLane creationProofLane_ = creationProofLane();
-        if (!_verifierFor(creationProofLane_).verify(rootId, creationProof_)) {
-            revert InvalidProof(creationProofLane_, rootId);
-        }
-        proofBitmap = ProofLib.laneMask(creationProofLane_);
 
         challengeDeadline = uint64(block.timestamp + challengePeriod);
         proofDeadline = uint64(block.timestamp + proofPeriod);
@@ -455,22 +391,9 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
         wasRespectedGameTypeWhenCreated =
             anchorStateRegistry.respectedGameType().raw() == GameTypes.MULTI_PROOF_GAME_TYPE.raw();
 
-        _emitCreationEvents(creationProofLane_);
-    }
-
-    /// @dev `BLOCKHASH` retains 256 blocks; EIP-2935 extends contract access to 8,191.
-    function _historicalBlockHash(uint256 blockNumber_) internal view returns (bytes32 hash_) {
-        if (blockNumber_ >= block.number) revert InvalidBlockNumber(blockNumber_);
-        if (block.number - blockNumber_ <= 256) return blockhash(blockNumber_);
-
-        (bool success, bytes memory result) = HISTORY_STORAGE.staticcall(abi.encode(blockNumber_));
-        if (success && result.length == 32) hash_ = abi.decode(result, (bytes32));
-    }
-
-    function _emitCreationEvents(ProofLib.ProofLane creationProofLane_) internal {
         emit WorldChainGameCreated(
             rootId,
-            parentRef(),
+            parentRef_,
             Claim.unwrap(rootClaim()),
             l2SequenceNumber(),
             Hash.unwrap(l1Head()),
@@ -478,10 +401,6 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
             attempt(),
             gameCreator()
         );
-        emit ProofLaneSupported(creationProofLane_, rootId, proofBitmap);
-        if (ProofLib.hasThreshold(proofBitmap, PROOF_THRESHOLD)) {
-            emit ProofThresholdReached(rootId, proofBitmap);
-        }
     }
 
     ////////////////////////////////////////////////////////////////

--- a/pkg/contracts/src/proofs/interfaces/IMultiProofGame.sol
+++ b/pkg/contracts/src/proofs/interfaces/IMultiProofGame.sol
@@ -53,9 +53,6 @@ interface IMultiProofGame is IDisputeGame {
     error InvalidLane(uint8 lane);
     error InvalidProof(ProofLib.ProofLane lane, bytes32 rootId);
     error InvalidDomainHash(bytes32 expected, bytes32 actual);
-    error InvalidL1Head(bytes32 l1OriginHash, uint256 l1OriginNumber);
-    error InvalidBlockNumber(uint256 blockNumber);
-    error InvalidRetryReference(uint256 attempt, address retryOf);
     error InconsistentSystemConfiguration();
 
     ////////////////////////////////////////////////////////////////
@@ -153,15 +150,6 @@ interface IMultiProofGame is IDisputeGame {
     /// @notice Retry nonce for this transition. Attempt N requires attempt N-1 to have timed
     ///         out on proofs or to have been created before this game type became respected.
     function attempt() external view returns (uint256);
-
-    /// @notice Previous attempt for this transition, or the zero address for attempt zero.
-    function retryOf() external view returns (address);
-
-    /// @notice Proof verified when the proposal was created.
-    function creationProof() external view returns (bytes memory);
-
-    /// @notice Lane through which `creationProof` was verified.
-    function creationProofLane() external view returns (ProofLib.ProofLane);
 
     /// @notice Parent game, or the anchor registry when the proposal starts from its current root.
     function parentRef() external view returns (address);

--- a/pkg/contracts/src/proofs/nitro/NitroProofVerifier.sol
+++ b/pkg/contracts/src/proofs/nitro/NitroProofVerifier.sol
@@ -102,18 +102,6 @@ contract NitroProofVerifier is IWorldChainProofVerifier {
             bytes memory expectedPublicKey
         ) = abi.decode(proof, (bytes32, address, uint256, ProofLib.TransitionPublicValues, bytes, bytes));
 
-        // `abi.decode` accepts trailing bytes. Reject non-canonical encodings so one decoded
-        // creation proof cannot produce multiple DisputeGameFactory UUIDs by changing bytes
-        // that the verifier would otherwise ignore.
-        if (
-            keccak256(proof)
-                != keccak256(
-                    abi.encode(domainHash, parentRef, l1OriginNumber, transition, signature, expectedPublicKey)
-                )
-        ) {
-            return false;
-        }
-
         // 1. Bind the proof identity and transition fields to the calling game's immutable snapshot.
         bool matchesGame =
             ProofVerificationLib.matchesGame(gameAddress, rootId, domainHash, parentRef, l1OriginNumber, transition);

--- a/pkg/contracts/test/MultiProofGame.t.sol
+++ b/pkg/contracts/test/MultiProofGame.t.sol
@@ -17,7 +17,6 @@ import {
     ParentGameNotResolved
 } from "@optimism-bedrock/src/dispute/lib/Errors.sol";
 import {IDisputeGame} from "@optimism-bedrock/interfaces/dispute/IDisputeGame.sol";
-import {Preinstalls} from "@optimism-bedrock/src/libraries/Preinstalls.sol";
 
 contract MultiProofGameTest is OPStackFixtures {
     function test_Create_RegistersCanonicalGame() public {
@@ -31,12 +30,6 @@ contract MultiProofGameTest is OPStackFixtures {
         assertEq(game.startingRootClaim(), STARTING_ANCHOR_ROOT);
         assertEq(game.startingL2BlockNumber(), STARTING_ANCHOR_BLOCK);
         assertEq(game.attempt(), 0);
-        assertEq(game.retryOf(), address(0));
-        assertEq(Hash.unwrap(game.l1Head()), L1_ORIGIN_HASH);
-        assertEq(game.l1OriginNumber(), L1_ORIGIN_NUMBER);
-        assertEq(uint8(game.creationProofLane()), uint8(ProofLib.ProofLane.TEE_ATTESTATION));
-        assertEq(game.creationProof(), hex"01");
-        assertEq(game.proofBitmap(), ProofLib.laneMask(ProofLib.ProofLane.TEE_ATTESTATION));
         assertEq(GameType.unwrap(game.gameType()), GameType.unwrap(WC_GAME_TYPE));
         assertTrue(game.wasRespectedGameTypeWhenCreated());
 
@@ -57,159 +50,9 @@ contract MultiProofGameTest is OPStackFixtures {
         );
 
         uint256 malformedParent = uint256(uint160(address(asr))) | (uint256(1) << 160);
-        bytes memory extraData = _extraData(target, type(uint256).max, 0);
-        assembly ("memory-safe") {
-            mstore(add(extraData, 0x60), malformedParent)
-        }
-        vm.prank(proposer);
-        vm.expectRevert();
-        dgf.create{value: PROPOSER_BOND}(WC_GAME_TYPE, Claim.wrap(_rootClaimFor(target)), extraData);
-
-        bytes memory paddedExtraData = bytes.concat(_extraData(target, type(uint256).max, 0), bytes32(0));
+        bytes memory extraData = abi.encode(ProofLib.domainHash(_domain()), target, malformedParent, uint256(0));
         vm.prank(proposer);
         vm.expectRevert(BadExtraData.selector);
-        dgf.create{value: PROPOSER_BOND}(WC_GAME_TYPE, Claim.wrap(_rootClaimFor(target)), paddedExtraData);
-    }
-
-    function test_Create_RequiresValidCreationProofAndL1Head() public {
-        uint256 target = STARTING_ANCHOR_BLOCK + BLOCK_INTERVAL;
-        bytes32 rootClaim = _rootClaimFor(target);
-
-        teeVerifier.setAcceptAny(false);
-        vm.prank(proposer);
-        bytes32 rootId =
-            ProofLib.rootId(gameImpl.domainHash(), address(asr), rootClaim, target, L1_ORIGIN_HASH, L1_ORIGIN_NUMBER);
-        vm.expectRevert(
-            abi.encodeWithSelector(IMultiProofGame.InvalidProof.selector, ProofLib.ProofLane.TEE_ATTESTATION, rootId)
-        );
-        dgf.create{value: PROPOSER_BOND}(WC_GAME_TYPE, Claim.wrap(rootClaim), _extraData(target, type(uint256).max, 0));
-        teeVerifier.setAcceptAny(true);
-
-        bytes memory emptyProofExtraData = abi.encode(
-            gameImpl.domainHash(),
-            target,
-            address(asr),
-            uint256(0),
-            address(0),
-            L1_ORIGIN_HASH,
-            L1_ORIGIN_NUMBER,
-            uint8(ProofLib.ProofLane.TEE_ATTESTATION),
-            bytes("")
-        );
-        vm.prank(proposer);
-        vm.expectRevert(BadExtraData.selector);
-        dgf.create{value: PROPOSER_BOND}(WC_GAME_TYPE, Claim.wrap(rootClaim), emptyProofExtraData);
-
-        bytes memory wrongL1HeadExtraData = _extraData(target, type(uint256).max, 0);
-        bytes32 wrongL1Head = keccak256("wrong-l1-head");
-        assembly ("memory-safe") {
-            mstore(add(wrongL1HeadExtraData, 0xC0), wrongL1Head)
-        }
-        vm.prank(proposer);
-        vm.expectRevert(
-            abi.encodeWithSelector(IMultiProofGame.InvalidL1Head.selector, wrongL1Head, uint256(L1_ORIGIN_NUMBER))
-        );
-        dgf.create{value: PROPOSER_BOND}(WC_GAME_TYPE, Claim.wrap(rootClaim), wrongL1HeadExtraData);
-
-        uint256 invalidBlockNumber = block.number;
-        bytes memory futureL1HeadExtraData = abi.encode(
-            gameImpl.domainHash(),
-            target,
-            address(asr),
-            uint256(0),
-            address(0),
-            keccak256("future-l1-head"),
-            invalidBlockNumber,
-            uint8(ProofLib.ProofLane.TEE_ATTESTATION),
-            hex"01"
-        );
-        vm.prank(proposer);
-        vm.expectRevert(abi.encodeWithSelector(IMultiProofGame.InvalidBlockNumber.selector, invalidBlockNumber));
-        dgf.create{value: PROPOSER_BOND}(WC_GAME_TYPE, Claim.wrap(rootClaim), futureL1HeadExtraData);
-    }
-
-    function test_Create_RejectsInconsistentRetryReference() public {
-        uint256 target = STARTING_ANCHOR_BLOCK + BLOCK_INTERVAL;
-        bytes32 rootClaim = _rootClaimFor(target);
-        address unexpectedRetry = makeAddr("unexpected-retry");
-        bytes memory unexpectedRetryExtraData = abi.encode(
-            gameImpl.domainHash(),
-            target,
-            address(asr),
-            uint256(0),
-            unexpectedRetry,
-            L1_ORIGIN_HASH,
-            L1_ORIGIN_NUMBER,
-            uint8(ProofLib.ProofLane.TEE_ATTESTATION),
-            hex"01"
-        );
-
-        vm.prank(proposer);
-        vm.expectRevert(
-            abi.encodeWithSelector(IMultiProofGame.InvalidRetryReference.selector, uint256(0), unexpectedRetry)
-        );
-        dgf.create{value: PROPOSER_BOND}(WC_GAME_TYPE, Claim.wrap(rootClaim), unexpectedRetryExtraData);
-
-        bytes memory missingRetryExtraData = abi.encode(
-            gameImpl.domainHash(),
-            target,
-            address(asr),
-            uint256(1),
-            address(0),
-            L1_ORIGIN_HASH,
-            L1_ORIGIN_NUMBER,
-            uint8(ProofLib.ProofLane.TEE_ATTESTATION),
-            hex"01"
-        );
-
-        vm.prank(proposer);
-        vm.expectRevert(abi.encodeWithSelector(IMultiProofGame.InvalidRetryReference.selector, uint256(1), address(0)));
-        dgf.create{value: PROPOSER_BOND}(WC_GAME_TYPE, Claim.wrap(rootClaim), missingRetryExtraData);
-    }
-
-    function test_Create_AcceptsL1HeadFromEIP2935History() public {
-        vm.etch(Preinstalls.HistoryStorage, Preinstalls.HistoryStorageCode);
-        vm.store(Preinstalls.HistoryStorage, bytes32(uint256(L1_ORIGIN_NUMBER % 8191)), L1_ORIGIN_HASH);
-        vm.roll(L1_ORIGIN_NUMBER + 300);
-
-        MultiProofGame game = _proposeAtAnchor();
-
-        assertEq(Hash.unwrap(game.l1Head()), L1_ORIGIN_HASH);
-        assertEq(game.l1OriginNumber(), L1_ORIGIN_NUMBER);
-    }
-
-    function test_Create_AcceptsAnyConfiguredProofLane() public {
-        uint256 target = STARTING_ANCHOR_BLOCK + BLOCK_INTERVAL;
-        bytes32 rootClaim = _rootClaimFor(target);
-
-        teeVerifier.setAcceptAny(false);
-        for (uint8 laneId; laneId < gameImpl.PROOF_LANE_COUNT(); laneId++) {
-            if (laneId == uint8(ProofLib.ProofLane.VALIDITY_PROOF)) validityVerifier.setAcceptAny(true);
-            if (laneId == uint8(ProofLib.ProofLane.TEE_ATTESTATION)) teeVerifier.setAcceptAny(true);
-            if (laneId == uint8(ProofLib.ProofLane.SECURITY_COUNCIL)) councilVerifier.setAcceptAny(true);
-
-            bytes memory extraData = _extraDataForParentWithLane(target, address(asr), 0, laneId);
-            vm.prank(proposer);
-            MultiProofGame game = MultiProofGame(
-                address(dgf.create{value: PROPOSER_BOND}(WC_GAME_TYPE, Claim.wrap(rootClaim), extraData))
-            );
-
-            assertEq(uint8(game.creationProofLane()), laneId);
-            assertEq(game.proofBitmap(), uint8(1) << laneId);
-
-            validityVerifier.setAcceptAny(false);
-            teeVerifier.setAcceptAny(false);
-            councilVerifier.setAcceptAny(false);
-        }
-    }
-
-    function test_Create_RejectsInvalidCreationProofLane() public {
-        uint256 target = STARTING_ANCHOR_BLOCK + BLOCK_INTERVAL;
-        uint8 invalidLane = gameImpl.PROOF_LANE_COUNT();
-        bytes memory extraData = _extraDataForParentWithLane(target, address(asr), 0, invalidLane);
-
-        vm.prank(proposer);
-        vm.expectRevert(abi.encodeWithSelector(IMultiProofGame.InvalidLane.selector, invalidLane));
         dgf.create{value: PROPOSER_BOND}(WC_GAME_TYPE, Claim.wrap(_rootClaimFor(target)), extraData);
     }
 
@@ -217,15 +60,13 @@ contract MultiProofGameTest is OPStackFixtures {
         uint256 target = STARTING_ANCHOR_BLOCK + BLOCK_INTERVAL;
         bytes32 wrongDomain = keccak256("wrong-domain");
 
-        bytes memory wrongDomainExtraData = _extraData(target, type(uint256).max, 0);
-        assembly ("memory-safe") {
-            mstore(add(wrongDomainExtraData, 0x20), wrongDomain)
-        }
         vm.prank(proposer);
         vm.expectRevert(
             abi.encodeWithSelector(IMultiProofGame.InvalidDomainHash.selector, gameImpl.domainHash(), wrongDomain)
         );
-        dgf.create{value: PROPOSER_BOND}(WC_GAME_TYPE, Claim.wrap(_rootClaimFor(target)), wrongDomainExtraData);
+        dgf.create{value: PROPOSER_BOND}(
+            WC_GAME_TYPE, Claim.wrap(_rootClaimFor(target)), abi.encode(wrongDomain, target, address(asr), uint256(0))
+        );
 
         uint256 wrongTarget = target + 1;
         vm.prank(proposer);
@@ -386,7 +227,7 @@ contract MultiProofGameTest is OPStackFixtures {
 
         game.submitProofLane(0, abi.encodePacked(game.rootId()));
         game.submitProofLane(0, abi.encodePacked(game.rootId()));
-        assertEq(game.proofCount(), 2);
+        assertEq(game.proofCount(), 1);
 
         game.submitProofLane(1, abi.encodePacked(game.rootId()));
         game.resolve();
@@ -419,7 +260,6 @@ contract MultiProofGameTest is OPStackFixtures {
 
         MultiProofGame retry = _propose(type(uint256).max, Claim.unwrap(first.rootClaim()), first.l2SequenceNumber(), 1);
         assertEq(retry.attempt(), 1);
-        assertEq(retry.retryOf(), address(first));
         assertEq(retry.startingRootClaim(), first.startingRootClaim());
     }
 

--- a/pkg/contracts/test/nitro/NitroProofVerifier.t.sol
+++ b/pkg/contracts/test/nitro/NitroProofVerifier.t.sol
@@ -353,13 +353,6 @@ contract NitroProofVerifierTest is Test {
         assertFalse(_verify(_expectedRootId(), hex"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"));
     }
 
-    function test_Verify_FalseForTrailingBytes() public {
-        bytes memory sig = _sign(_commitment());
-        bytes memory proof = bytes.concat(_proofBytes(sig, enclavePubKey), hex"01");
-
-        assertFalse(_verify(_expectedRootId(), proof));
-    }
-
     function test_Verify_AcceptsZeroL2BlockNumber() public {
         // Boundary: l2BlockNumber = 0 must work, since the rootId is
         // recomputed deterministically and the commitment is signed over

--- a/pkg/contracts/test/proofs/OPStackFixtures.sol
+++ b/pkg/contracts/test/proofs/OPStackFixtures.sol
@@ -42,8 +42,6 @@ abstract contract OPStackFixtures is Test {
 
     bytes32 internal constant STARTING_ANCHOR_ROOT = keccak256("starting-anchor-root");
     uint256 internal constant STARTING_ANCHOR_BLOCK = 1_000;
-    bytes32 internal constant L1_ORIGIN_HASH = keccak256("finalized-l1-origin");
-    uint256 internal constant L1_ORIGIN_NUMBER = 999;
 
     address internal guardian = makeAddr("guardian");
     address internal proposer = makeAddr("proposer");
@@ -104,15 +102,12 @@ abstract contract OPStackFixtures is Test {
         stakingRegistry = new MockStakingRegistry();
         stakingRegistry.setStaked(challengerAccount, true);
         validityVerifier = new MockRootIdVerifier(false);
-        teeVerifier = new MockRootIdVerifier(true);
+        teeVerifier = new MockRootIdVerifier(false);
         councilVerifier = new MockRootIdVerifier(false);
 
         gameImpl = new MultiProofGame(_gameConfig());
         dgf.setImplementation(WC_GAME_TYPE, IDisputeGame(address(gameImpl)), hex"");
         dgf.setInitBond(WC_GAME_TYPE, PROPOSER_BOND);
-
-        vm.roll(L1_ORIGIN_NUMBER + 1);
-        vm.setBlockhash(L1_ORIGIN_NUMBER, L1_ORIGIN_HASH);
 
         // The registry retires every game created at or before its initialization timestamp.
         vm.warp(block.timestamp + 1);
@@ -173,37 +168,10 @@ abstract contract OPStackFixtures is Test {
 
     function _extraDataForParent(uint256 l2BlockNumber, address parent, uint256 attempt)
         internal
-        view
+        pure
         returns (bytes memory)
     {
-        return _extraDataForParentWithLane(l2BlockNumber, parent, attempt, uint8(ProofLib.ProofLane.TEE_ATTESTATION));
-    }
-
-    function _extraDataForParentWithLane(
-        uint256 l2BlockNumber,
-        address parent,
-        uint256 attempt,
-        uint8 creationProofLane
-    ) internal view returns (bytes memory) {
-        address retryOf;
-        if (attempt > 0) {
-            uint256 gameCount = dgf.gameCount();
-            if (gameCount > 0) {
-                (,, IDisputeGame previous) = dgf.gameAtIndex(gameCount - 1);
-                retryOf = address(previous);
-            }
-        }
-        return abi.encode(
-            ProofLib.domainHash(_domain()),
-            l2BlockNumber,
-            parent,
-            attempt,
-            retryOf,
-            L1_ORIGIN_HASH,
-            L1_ORIGIN_NUMBER,
-            creationProofLane,
-            hex"01"
-        );
+        return abi.encode(ProofLib.domainHash(_domain()), l2BlockNumber, parent, attempt);
     }
 
     function _rootClaimFor(uint256 l2BlockNumber) internal pure returns (bytes32) {

--- a/proofs/defender/src/lane.rs
+++ b/proofs/defender/src/lane.rs
@@ -256,7 +256,6 @@ fn encode_proof(proof: &ProofData) -> Bytes {
             attestation,
             public_values,
             signature,
-            public_key: _,
         } => [
             public_values.as_ref(),
             attestation.as_ref(),

--- a/proofs/defender/src/tests.rs
+++ b/proofs/defender/src/tests.rs
@@ -396,7 +396,6 @@ impl ProofRequester for MockProver {
                 attestation: Bytes::from_static(b"attestation"),
                 public_values: Bytes::from_static(b"public values"),
                 signature: Bytes::from_static(b"signature"),
-                public_key: Bytes::from_static(b"public key"),
             },
         };
         Ok(ProofResponse::Succeeded(SucceededProofResponse {

--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -132,7 +132,7 @@ struct FakeExecutionState {
     anchor: AnchorRef,
     finalized_l1_block: BlockNumber,
     next_game_nonce: u8,
-    games_by_key: HashMap<ProposalCommitment, Address>,
+    games_by_key: HashMap<B256, Address>,
     games_by_address: HashMap<Address, GameRecord>,
     game_order: Vec<Address>,
 }
@@ -254,7 +254,9 @@ impl FakeExecution {
             attempt: proposal.attempt,
         };
 
-        state.games_by_key.insert(proposal.commitment(), game);
+        state
+            .games_by_key
+            .insert(proposal.commitment().game_uuid(state.domain_hash), game);
         state.game_order.push(game);
         state.games_by_address.insert(
             game,
@@ -313,7 +315,6 @@ impl ProposerClient for FakeExecution {
 
     async fn games_for_transition(
         &self,
-        _anchor_game: Option<Address>,
         parent_candidates: &[Address],
         root_claim: B256,
         l2_block_number: u64,
@@ -323,13 +324,14 @@ impl ProposerClient for FakeExecution {
         for parent_ref in parent_candidates {
             let mut latest = None;
             for attempt in 0..MAX_ATTEMPT_SCAN {
-                let key = ProposalCommitment {
+                let uuid = ProposalCommitment {
                     parent_ref: *parent_ref,
                     root_claim,
                     l2_block_number,
                     attempt,
-                };
-                let Some(address) = state.games_by_key.get(&key).copied() else {
+                }
+                .game_uuid(state.domain_hash);
+                let Some(address) = state.games_by_key.get(&uuid).copied() else {
                     break;
                 };
                 latest = Some(TransitionGame {
@@ -443,14 +445,13 @@ impl ProposerClient for FakeExecution {
     async fn submit_proposal(
         &self,
         proposal: &Proposal,
-        _retry_of: Option<Address>,
         _proof: ProofData,
     ) -> Result<ProposalSubmission, ProposerError> {
         let mut state = self.state.lock().expect("fake execution mutex poisoned");
-        let key = proposal.commitment();
-        if let Some(existing) = state.games_by_key.get(&key) {
+        let uuid = proposal.commitment().game_uuid(state.domain_hash);
+        if let Some(existing) = state.games_by_key.get(&uuid) {
             return Err(ProposerError::Contract(format!(
-                "game already exists for proposal {key:?} at {existing}"
+                "game already exists for factory uuid {uuid} at {existing}"
             )));
         }
         let event = Self::create_game(&mut state, proposal);
@@ -752,7 +753,6 @@ impl ClaimedProofJobHandler for FakeProofBackend {
                 attestation: request.l1_head.as_slice().to_vec().into(),
                 public_values: request.root_claim.as_slice().to_vec().into(),
                 signature: vec![0x7e, request.l2_block_number as u8].into(), // mock signature
-                public_key: vec![0x04; 65].into(),
             },
         })
     }

--- a/proofs/integration-tests/tests/orchestration.rs
+++ b/proofs/integration-tests/tests/orchestration.rs
@@ -86,7 +86,6 @@ impl ProofRequester for InstantProofRequester {
                 attestation: Bytes::from_static(&[1]),
                 public_values: Bytes::from_static(&[2]),
                 signature: Bytes::from_static(&[3]),
-                public_key: Bytes::from_static(&[4]),
             },
         }))
     }

--- a/proofs/nitro/worker/src/lib.rs
+++ b/proofs/nitro/worker/src/lib.rs
@@ -16,7 +16,7 @@
 //!  │  NitroProver::prove_range  ────────────► Nitro Enclave                              │
 //!  │       │                                  (vsock / PCR-pinned)                       │
 //!  │       ▼                                                                              │
-//!  │  prover_submitProof(Nitro { attestation, public_values, signature, public_key })    │
+//!  │  prover_submitProof(Nitro { attestation, public_values, signature })                │
 //!  └──────────────────────────────────────────────────────────────────────────────────────┘
 //! ```
 
@@ -168,10 +168,6 @@ impl ClaimedProofJobHandler for NitroBackend {
         );
 
         Ok(ProofData::Nitro {
-            public_key: world_chain_proof_nitro::attestation::extract_nsm_public_key(
-                &artifact.attestation_doc,
-            )?
-            .into(),
             attestation: Bytes::from(artifact.attestation_doc),
             public_values: artifact.transition_public_values.abi_encode().into(),
             signature: Bytes::from(artifact.signature),

--- a/proofs/primitives/src/bindings.rs
+++ b/proofs/primitives/src/bindings.rs
@@ -6,14 +6,6 @@ sol! {
     /// must filter on `MULTI_PROOF_GAME_TYPE`.
     #[sol(rpc)]
     interface IDisputeGameFactory {
-        struct GameSearchResult {
-            uint256 index;
-            bytes32 metadata;
-            uint64 timestamp;
-            bytes32 rootClaim;
-            bytes extraData;
-        }
-
         event DisputeGameCreated(address indexed disputeProxy, uint32 indexed gameType, bytes32 indexed rootClaim);
 
         function create(uint32 gameType, bytes32 rootClaim, bytes calldata extraData)
@@ -29,10 +21,6 @@ sol! {
             view
             returns (uint32 gameType, uint64 timestamp, address proxy);
         function gameCount() external view returns (uint256 gameCount);
-        function findLatestGames(uint32 gameType, uint256 start, uint256 count)
-            external
-            view
-            returns (GameSearchResult[] memory games);
         function gameImpls(uint32 gameType) external view returns (address impl);
         function initBonds(uint32 gameType) external view returns (uint256 bond);
         function getGameUUID(uint32 gameType, bytes32 rootClaim, bytes calldata extraData)
@@ -78,15 +66,11 @@ sol! {
         function rootId() external view returns (bytes32);
         function proposalDomainHash() external view returns (bytes32);
         function attempt() external view returns (uint256);
-        function retryOf() external view returns (address);
-        function creationProofLane() external view returns (uint8);
-        function creationProof() external view returns (bytes memory);
         function parentRef() external view returns (address);
         function startingRootClaim() external view returns (bytes32);
         function startingL2BlockNumber() external view returns (uint256);
         function l2BlockNumber() external view returns (uint256);
         function l2SequenceNumber() external view returns (uint256);
-        function l1Head() external view returns (bytes32);
         function l1OriginHash() external view returns (bytes32);
         function l1OriginNumber() external view returns (uint256);
         function rootClaim() external view returns (bytes32);

--- a/proofs/primitives/src/lib.rs
+++ b/proofs/primitives/src/lib.rs
@@ -14,6 +14,6 @@ pub use consensus_provider::{ConsensusError, ConsensusProvider, OptimismConsensu
 pub use types::{
     InvalidationReason, InvalidationReasonError, MULTI_PROOF_GAME_TYPE, PROOF_LANE_COUNT,
     PROOF_SYSTEM_VERSION, PROOF_THRESHOLD, ProofDomain, ProofLane, ProposalCommitment,
-    ProposalExtraData, ResolutionStatus, RootCommitment, RootState, RootStateError,
-    WorldChainGameCreated, has_threshold, proof_count,
+    ResolutionStatus, RootCommitment, RootState, RootStateError, WorldChainGameCreated,
+    has_threshold, proof_count,
 };

--- a/proofs/primitives/src/types.rs
+++ b/proofs/primitives/src/types.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::{Address, B256, BlockNumber, Bytes, U256, keccak256};
-use alloy_sol_types::{SolValue, sol};
+use alloy_sol_types::SolValue;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -17,20 +17,6 @@ pub const PROOF_SYSTEM_VERSION: u64 = 1;
 /// The stock `DisputeGameFactory` indexes every game type in one array, so every
 /// index-based read must filter on this value.
 pub const MULTI_PROOF_GAME_TYPE: u32 = 1006;
-
-sol! {
-    struct ProposalExtraDataWire {
-        bytes32 domainHash;
-        uint256 l2BlockNumber;
-        address parentRef;
-        uint256 attempt;
-        address retryOf;
-        bytes32 l1OriginHash;
-        uint256 l1OriginNumber;
-        uint8 creationProofLane;
-        bytes creationProof;
-    }
-}
 
 /// The `MultiProofGame.WorldChainGameCreated` event.
 #[derive(Debug, Clone, Copy)]
@@ -106,7 +92,7 @@ impl ProofDomain {
 }
 
 /// Per-proposal commitment fields used to compute a canonical root id.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProposalCommitment {
     /// Parent `AnchorStateRegistry` or parent game address.
     pub parent_ref: Address,
@@ -122,78 +108,33 @@ pub struct ProposalCommitment {
 impl ProposalCommitment {
     /// ABI-encodes the CWIA payload `MultiProofGame` reads from its clone arguments.
     ///
-    /// Must match the dynamic `extraData` consumed by `MultiProofGame`.
+    /// Must match `abi.encode(domainHash, l2BlockNumber, parentRef, attempt)` as consumed by
+    /// `MultiProofGame`'s CWIA getters.
     #[must_use]
-    pub fn extra_data(
-        self,
-        domain_hash: B256,
-        retry_of: Address,
-        l1_origin_hash: B256,
-        l1_origin_number: u64,
-        creation_proof_lane: ProofLane,
-        creation_proof: Bytes,
-    ) -> Bytes {
-        ProposalExtraDataWire {
-            domainHash: domain_hash,
-            l2BlockNumber: U256::from(self.l2_block_number),
-            parentRef: self.parent_ref,
-            attempt: U256::from(self.attempt),
-            retryOf: retry_of,
-            l1OriginHash: l1_origin_hash,
-            l1OriginNumber: U256::from(l1_origin_number),
-            creationProofLane: creation_proof_lane as u8,
-            creationProof: creation_proof,
-        }
-        .abi_encode_params()
-        .into()
+    pub fn extra_data(self, domain_hash: B256) -> Bytes {
+        (
+            domain_hash,
+            U256::from(self.l2_block_number),
+            self.parent_ref,
+            U256::from(self.attempt),
+        )
+            .abi_encode_params()
+            .into()
     }
-}
 
-/// Proposal fields decoded from a WIP-1006 game's factory `extraData`.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ProposalExtraData {
-    pub domain_hash: B256,
-    pub l2_block_number: u64,
-    pub parent_ref: Address,
-    pub attempt: u64,
-    pub retry_of: Address,
-    pub l1_origin_hash: B256,
-    pub l1_origin_number: u64,
-    pub creation_proof_lane: ProofLane,
-    pub creation_proof: Bytes,
-}
-
-impl ProposalExtraData {
-    /// Decodes the canonical proof-backed proposal payload.
-    pub fn decode(data: &[u8]) -> Result<Self, String> {
-        let decoded =
-            ProposalExtraDataWire::abi_decode_params(data).map_err(|error| error.to_string())?;
-        let canonical = decoded.clone().abi_encode_params();
-        if canonical != data {
-            return Err("non-canonical proposal extraData".to_string());
-        }
-        Ok(Self {
-            domain_hash: decoded.domainHash,
-            l2_block_number: decoded
-                .l2BlockNumber
-                .try_into()
-                .map_err(|_| "l2 block number exceeds u64".to_string())?,
-            parent_ref: decoded.parentRef,
-            attempt: decoded
-                .attempt
-                .try_into()
-                .map_err(|_| "attempt exceeds u64".to_string())?,
-            retry_of: decoded.retryOf,
-            l1_origin_hash: decoded.l1OriginHash,
-            l1_origin_number: decoded
-                .l1OriginNumber
-                .try_into()
-                .map_err(|_| "l1 origin number exceeds u64".to_string())?,
-            creation_proof_lane: ProofLane::from_u8(decoded.creationProofLane).ok_or_else(
-                || format!("invalid creation proof lane {}", decoded.creationProofLane),
-            )?,
-            creation_proof: decoded.creationProof,
-        })
+    /// Computes the `DisputeGameFactory` UUID that identifies this proposal's game.
+    ///
+    /// Mirrors `DisputeGameFactory.getGameUUID`, so the proposer can look a game up without
+    /// an extra round trip.
+    #[must_use]
+    pub fn game_uuid(self, domain_hash: B256) -> B256 {
+        let encoded = (
+            MULTI_PROOF_GAME_TYPE,
+            self.root_claim,
+            self.extra_data(domain_hash),
+        )
+            .abi_encode_params();
+        keccak256(encoded)
     }
 }
 
@@ -202,13 +143,19 @@ impl ProposalExtraData {
 pub struct RootCommitment {
     /// Proposal fields supplied by the proposer.
     pub proposal: ProposalCommitment,
-    /// Proposer-selected L1 origin hash verified by the game at creation.
+    /// L1 origin hash pinned by the proposal factory.
     pub l1_origin_hash: B256,
     /// L1 origin block number paired with `l1_origin_hash`.
     pub l1_origin_number: u64,
 }
 
 impl RootCommitment {
+    /// Compute the `DisputeGameFactory` UUID for this proposal.
+    #[must_use]
+    pub fn game_uuid(self, domain_hash: B256) -> B256 {
+        self.proposal.game_uuid(domain_hash)
+    }
+
     /// Compute the Solidity-compatible root id for this proposal.
     #[must_use]
     pub fn root_id(self, domain_hash: B256) -> B256 {
@@ -238,17 +185,6 @@ pub enum ProofLane {
 }
 
 impl ProofLane {
-    /// Returns the proof lane represented by its protocol identifier.
-    #[must_use]
-    pub const fn from_u8(value: u8) -> Option<Self> {
-        match value {
-            0 => Some(Self::ValidityProof),
-            1 => Some(Self::TeeAttestation),
-            2 => Some(Self::SecurityCouncil),
-            _ => None,
-        }
-    }
-
     /// Bit assigned to this lane in the per-root proof bitmap.
     #[must_use]
     pub const fn mask(self) -> u8 {
@@ -380,6 +316,7 @@ mod tests {
             b256!("6cccba67d43368ae81da6cf22798e228b82b953c51c1bbce76959b166b888dd3")
         );
 
+        assert_ne!(B256::ZERO, proposal.game_uuid(domain.hash()));
         let changed = ProofDomain {
             chain_id: 4802,
             ..domain
@@ -389,7 +326,7 @@ mod tests {
     }
 
     #[test]
-    fn proposal_extra_data_round_trips() {
+    fn game_uuid_matches_dispute_game_factory_encoding() {
         let domain_hash = b256!("1111111111111111111111111111111111111111111111111111111111111111");
         let proposal = ProposalCommitment {
             parent_ref: address!("0000000000000000000000000000000000001006"),
@@ -398,30 +335,31 @@ mod tests {
             attempt: 0,
         };
 
-        let l1_origin_hash =
-            b256!("3333333333333333333333333333333333333333333333333333333333333333");
-        let proof = Bytes::from_static(&hex!("deadbeef"));
-        let encoded = proposal.extra_data(
-            domain_hash,
-            Address::ZERO,
-            l1_origin_hash,
-            42,
-            ProofLane::TeeAttestation,
-            proof.clone(),
+        // Reference values from `cast abi-encode` / `cast keccak`, pinning this encoding to the
+        // CWIA payload `MultiProofGame` reads at offsets 0x54/0x74/0x94/0xB4 and to
+        // `DisputeGameFactory.getGameUUID(GameType,Claim,bytes)`.
+        assert_eq!(
+            proposal.extra_data(domain_hash),
+            Bytes::from_static(&hex!(
+                "1111111111111111111111111111111111111111111111111111111111111111"
+                "0000000000000000000000000000000000000000000000000000000000000064"
+                "0000000000000000000000000000000000000000000000000000000000001006"
+                "0000000000000000000000000000000000000000000000000000000000000000"
+            ))
         );
         assert_eq!(
-            ProposalExtraData::decode(&encoded).unwrap(),
-            ProposalExtraData {
-                domain_hash,
-                l2_block_number: proposal.l2_block_number,
-                parent_ref: proposal.parent_ref,
-                attempt: proposal.attempt,
-                retry_of: Address::ZERO,
-                l1_origin_hash,
-                l1_origin_number: 42,
-                creation_proof_lane: ProofLane::TeeAttestation,
-                creation_proof: proof,
-            }
+            proposal.game_uuid(domain_hash),
+            b256!("97c09945ea02810652360265a6c8f070ce4d6fb10651f7f76126130d6209ee33")
+        );
+
+        // Retries occupy a distinct factory UUID.
+        let retry = ProposalCommitment {
+            attempt: 1,
+            ..proposal
+        };
+        assert_ne!(
+            proposal.game_uuid(domain_hash),
+            retry.game_uuid(domain_hash)
         );
     }
 }

--- a/proofs/proposer/Cargo.toml
+++ b/proofs/proposer/Cargo.toml
@@ -18,7 +18,6 @@ workspace = true
 # workspace
 world-chain-proofs.workspace = true
 world-chain-prover-service.workspace = true
-world-chain-proof-core.workspace = true
 
 # alloy
 alloy-consensus.workspace = true
@@ -26,7 +25,6 @@ alloy-network.workspace = true
 alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-provider = { workspace = true, features = ["reqwest"] }
-alloy-sol-types.workspace = true
 alloy-signer-local.workspace = true
 
 # misc

--- a/proofs/proposer/README.md
+++ b/proofs/proposer/README.md
@@ -18,14 +18,10 @@ Stack `DisputeGameFactory.create(gameType, rootClaim, extraData)`.
 - `root_claim`: OP stack output root.
 - `l2_block_number`: L2 block number for the root claim.
 - `attempt`: retry nonce, non-zero only when replacing a game invalidated by a proof timeout.
-- `retry_of`: concrete previous game for a non-zero attempt.
-- `l1_origin_hash` and `l1_origin_number`: recent L1 block selected by the proposer.
-- `creation_proof_lane`: lane used to verify the creation proof. The proposer uses `TEE_ATTESTATION`.
-- `creation_proof`: proof verified by the selected lane during creation.
 
-These fields determine the factory call:
-`extraData = abi.encode(domainHash, l2BlockNumber, parentRef, attempt, retryOf, l1OriginHash,
-l1OriginNumber, creationProofLane, creationProof)`.
+These four fields determine the factory call: `extraData = abi.encode(domainHash, l2BlockNumber,
+parentRef, attempt)` and the game's factory UUID is
+`keccak256(abi.encode(gameType, rootClaim, extraData))`.
 
 ## How to get these items
 
@@ -35,30 +31,12 @@ l1OriginNumber, creationProofLane, creationProof)`.
   a game, that game is no longer a valid parent — `MultiProofGame.initialize` rejects a parent at or
   below the anchor — so new proposals extending the anchor always point at the registry.
 - compute L2 output root for block equal to `parent_ref`'s `l2_block_number` + `BLOCK_INTERVAL`
-- take one paginated `DisputeGameFactory.findLatestGames` snapshot back to the current anchor game
-  and cache it for the observed `(anchor_game, game_count)`;
-- ignore games from re-registered implementations with another domain or `extraData` layout;
-- for each interval, filter that in-memory snapshot by the expected parent, output root, and L2
-  block number, then retain the leaf of every explicit `retry_of` lineage;
-- follow the earliest non-invalidated leaf and repeat with that concrete game as the only parent;
-- if no matching game exists, propose the expected transition under the current parent.
-
-At the anchor tip both the registry and the current anchor game are candidate parents. A game
-created before the anchor advanced still references the anchor game, whereas one created after the
-advance must reference the registry sentinel.
-
-### Parallel games and retries
-
-The factory UUID identifies one exact `(gameType, rootClaim, extraData)` payload. Since `extraData`
-contains the creation proof, selected L1 origin, and `retry_of`, multiple bonded games can represent
-the same logical `(parent_ref, root_claim, l2_block_number, attempt)` with different UUIDs.
-`attempt` is consequently local to the lineage linked by `retry_of`, rather than a globally unique
-transition nonce.
-
-The proposer removes games referenced as retry predecessors and considers the remaining lineage
-tips in factory-index order. It follows the first non-invalidated matching tip and then searches
-only for children of that concrete game address. Other correct sibling games do not block this
-lineage; their permissionless resolution and bond settlement remain independent.
+- look the game up with `DisputeGameFactory.games(gameType, rootClaim, extraData)`, walking
+  `attempt` upward until the first gap. At the anchor tip both the registry and the current anchor
+  game are candidate parents, because a game created before the anchor advanced still references
+  the anchor game.
+- if a game exists, it becomes the `parent_ref` and we continue this loop
+- if it doesn't exist - i.e. the address is `0x00..00`, then the current `parent_ref` is returned
 
 ### `root_claim`
 
@@ -67,20 +45,6 @@ lineage; their permissionless resolution and bond settlement remain independent.
 ### `l2_block_number`
 
 - `parent_ref`'s `l2_block_number` field + `BLOCK_INTERVAL`
-
-### Creation proof and L1 origin
-
-- request a Nitro proof against a finalized L1 head;
-- encode its transition values, signature, and registered enclave public key in `creation_proof`;
-- reject and re-request a proof once its L1 origin is more than 8,000 blocks old, leaving
-  transaction-inclusion headroom inside EIP-2935's 8,191-block history window.
-
-## Devnet coverage
-
-The ignored full-stack E2E covers proof-backed game creation, the stock Portal prove/finalize
-withdrawal flow, anchor advancement, and both DelayedWETH bond-claim phases. The devnet uses a
-`MockRootIdVerifier` for the creation lane, so production Nitro key registration and verification
-remain separate integration coverage.
 
 ## Bond settlement
 

--- a/proofs/proposer/src/alloy.rs
+++ b/proofs/proposer/src/alloy.rs
@@ -1,19 +1,11 @@
-use std::{
-    collections::HashSet,
-    sync::{Arc, Mutex},
-};
-
 use alloy_consensus::BlockHeader;
 use alloy_eips::{BlockId, BlockNumberOrTag};
-use alloy_primitives::{Address, B256, BlockHash, Bytes, U256};
+use alloy_primitives::{Address, B256, BlockHash, U256};
 use alloy_provider::{Provider, WalletProvider};
-use alloy_sol_types::SolValue;
 use async_trait::async_trait;
-use world_chain_proof_core::boot::TransitionPublicValues;
 use world_chain_proofs::{
     IAnchorStateRegistry, IDelayedWETH, IDisputeGameFactory, IMultiProofGame,
-    InvalidationReasonError, MULTI_PROOF_GAME_TYPE, ProofLane, ProposalExtraData, ResolutionStatus,
-    RootStateError,
+    InvalidationReasonError, MULTI_PROOF_GAME_TYPE, ResolutionStatus, RootStateError,
 };
 use world_chain_prover_service::ProofData;
 
@@ -24,57 +16,11 @@ use crate::{
     },
 };
 
-/// Number of WIP-1006 games requested per reverse factory scan.
-const GAME_SCAN_PAGE_SIZE: u64 = 64;
-
-/// Leaves 191 blocks of transaction-inclusion headroom inside EIP-2935's 8,191-block window.
-const MAX_CREATION_PROOF_AGE: u64 = 8_000;
-
-#[derive(Debug, Clone)]
-struct ScannedTransitionGame {
-    factory_index: u64,
-    address: Address,
-    root_claim: B256,
-    data: ProposalExtraData,
-}
-
-#[derive(Debug, Clone)]
-struct GameScanCache {
-    anchor_game: Option<Address>,
-    game_count: u64,
-    games: Arc<Vec<ScannedTransitionGame>>,
-}
-
-/// Returns the leaf of every explicit `retryOf` lineage in deterministic factory order.
+/// Highest retry nonce probed when locating the live game for a transition.
 ///
-/// Proof-backed `extraData` permits several UUIDs for the same logical attempt, so parallel
-/// lineages are retained for the proposer to evaluate rather than collapsed by attempt number.
-fn select_transition_tips(
-    mut candidates: Vec<ScannedTransitionGame>,
-    parent_candidates: &[Address],
-) -> Vec<TransitionGame> {
-    candidates.sort_by_key(|game| game.factory_index);
-    let referenced: HashSet<_> = candidates
-        .iter()
-        .filter_map(|game| (game.data.retry_of != Address::ZERO).then_some(game.data.retry_of))
-        .collect();
-    let mut found = Vec::new();
-    for parent_ref in parent_candidates {
-        found.extend(
-            candidates
-                .iter()
-                .filter(|game| {
-                    game.data.parent_ref == *parent_ref && !referenced.contains(&game.address)
-                })
-                .map(|game| TransitionGame {
-                    address: game.address,
-                    parent_ref: *parent_ref,
-                    attempt: game.data.attempt,
-                }),
-        );
-    }
-    found
-}
+/// Bounds the attempt walk so a corrupt or adversarial factory state cannot turn a single
+/// canonical-line hop into an unbounded RPC loop.
+const MAX_ATTEMPT_SCAN: u64 = 64;
 
 /// Alloy-backed implementation of the proposer contract clients.
 ///
@@ -87,8 +33,6 @@ pub struct AlloyProofSystemClient<P> {
     anchor: IAnchorStateRegistry::IAnchorStateRegistryInstance<P>,
     /// Domain hash of the registered game implementation, read once at construction.
     domain_hash: B256,
-    /// Snapshot shared by every transition lookup during canonical-line reconstruction.
-    game_scan_cache: Arc<Mutex<Option<GameScanCache>>>,
     /// Number of confirmations to require after sending a tx onchain.
     confirmations: u64,
     provider: P,
@@ -139,7 +83,6 @@ where
             factory,
             anchor,
             domain_hash,
-            game_scan_cache: Arc::new(Mutex::new(None)),
             confirmations,
             provider,
         })
@@ -153,114 +96,6 @@ where
 
     fn game(&self, address: Address) -> IMultiProofGame::IMultiProofGameInstance<P> {
         IMultiProofGame::IMultiProofGameInstance::new(address, self.provider.clone())
-    }
-
-    /// Builds the candidate set used to reconstruct descendants of the current anchor.
-    ///
-    /// A logical transition no longer has one derivable factory UUID because its `extraData`
-    /// contains the selected L1 origin and creation proof. We therefore page backwards through
-    /// WIP-1006 games, stopping once entries predate the anchor game, and retain only games whose
-    /// layout and domain belong to the currently registered implementation.
-    async fn scan_transition_games(
-        &self,
-        anchor_game: Option<Address>,
-        game_count: u64,
-    ) -> Result<Vec<ScannedTransitionGame>, ProposerError> {
-        let anchor_created_at = if let Some(anchor_game) = anchor_game {
-            Some(
-                self.game(anchor_game)
-                    .createdAt()
-                    .call()
-                    .await
-                    .map_err(|error| ProposerError::Contract(error.to_string()))?,
-            )
-        } else {
-            None
-        };
-        let mut start = game_count - 1;
-        let mut games = Vec::new();
-        loop {
-            let page = self
-                .factory
-                .findLatestGames(
-                    MULTI_PROOF_GAME_TYPE,
-                    U256::from(start),
-                    U256::from(GAME_SCAN_PAGE_SIZE),
-                )
-                .call()
-                .await
-                .map_err(|error| ProposerError::Contract(error.to_string()))?;
-            if page.is_empty() {
-                break;
-            }
-
-            let mut oldest_index = start;
-            let mut crossed_anchor = false;
-            for entry in page {
-                let index = u256_to_u64(entry.index, "findLatestGames index")?;
-                oldest_index = oldest_index.min(index);
-                if anchor_created_at.is_some_and(|created_at| entry.timestamp < created_at) {
-                    crossed_anchor = true;
-                    break;
-                }
-                let Ok(data) = ProposalExtraData::decode(&entry.extraData) else {
-                    // A re-registered game type may have older implementations with another
-                    // extraData layout. They cannot belong to this implementation's domain.
-                    continue;
-                };
-                if data.domain_hash != self.domain_hash {
-                    continue;
-                }
-                games.push(ScannedTransitionGame {
-                    factory_index: index,
-                    address: Address::from_slice(&entry.metadata.as_slice()[12..]),
-                    root_claim: entry.rootClaim,
-                    data,
-                });
-            }
-
-            if crossed_anchor || oldest_index == 0 {
-                break;
-            }
-            start = oldest_index - 1;
-        }
-        Ok(games)
-    }
-
-    /// Reuses one factory scan across every height inspected while rebuilding the canonical line.
-    ///
-    /// An anchor change moves the scan boundary, while a factory-count change may introduce a
-    /// sibling, retry, or descendant, so either change invalidates the snapshot.
-    async fn transition_game_snapshot(
-        &self,
-        anchor_game: Option<Address>,
-        game_count: u64,
-    ) -> Result<Arc<Vec<ScannedTransitionGame>>, ProposerError> {
-        let cached = self
-            .game_scan_cache
-            .lock()
-            .map_err(|_| ProposerError::Contract("game scan cache lock poisoned".into()))?
-            .clone();
-        if let Some(cached) = cached
-            && cached.anchor_game == anchor_game
-            && cached.game_count == game_count
-        {
-            return Ok(cached.games);
-        }
-
-        // TODO: If full rebuilds become a bottleneck, extend an unchanged anchor's snapshot
-        // from its cached factory index. Incremental reuse must also invalidate on L1 reorgs.
-        let games = Arc::new(self.scan_transition_games(anchor_game, game_count).await?);
-        *self
-            .game_scan_cache
-            .lock()
-            .map_err(|_| ProposerError::Contract("game scan cache lock poisoned".into()))? =
-            Some(GameScanCache {
-                anchor_game,
-                game_count,
-                games: Arc::clone(&games),
-            });
-        Ok(games)
     }
 
     /// Resolves the WIP-1006 game at a factory index, skipping other game types.
@@ -488,39 +323,44 @@ where
 
     async fn games_for_transition(
         &self,
-        anchor_game: Option<Address>,
         parent_candidates: &[Address],
         root_claim: B256,
         l2_block_number: u64,
     ) -> Result<Vec<TransitionGame>, ProposerError> {
-        let game_count = self
-            .factory
-            .gameCount()
-            .call()
-            .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))?;
-        let game_count = u256_to_u64(game_count, "gameCount")?;
-        if game_count == 0 {
-            return Ok(Vec::new());
+        let mut found = Vec::with_capacity(parent_candidates.len());
+        for parent_ref in parent_candidates {
+            let mut latest: Option<TransitionGame> = None;
+            // Attempts are strictly sequential: attempt N can only be created once attempt N-1
+            // exists, so the walk stops at the first gap.
+            for attempt in 0..MAX_ATTEMPT_SCAN {
+                let commitment = world_chain_proofs::ProposalCommitment {
+                    parent_ref: *parent_ref,
+                    root_claim,
+                    l2_block_number,
+                    attempt,
+                };
+                let entry = self
+                    .factory
+                    .games(
+                        MULTI_PROOF_GAME_TYPE,
+                        root_claim,
+                        commitment.extra_data(self.domain_hash),
+                    )
+                    .call()
+                    .await
+                    .map_err(|error| ProposerError::Contract(error.to_string()))?;
+                if entry.proxy == Address::ZERO {
+                    break;
+                }
+                latest = Some(TransitionGame {
+                    address: entry.proxy,
+                    parent_ref: *parent_ref,
+                    attempt,
+                });
+            }
+            found.extend(latest);
         }
-
-        // The snapshot contains all current-domain games since the anchor. Narrow it to the
-        // logical transition requested by the canonical-line walker, then return only the leaf
-        // of each explicit retry lineage. Factory-index ordering is preserved so the walker can
-        // choose the earliest non-invalidated sibling deterministically.
-        let candidates = self
-            .transition_game_snapshot(anchor_game, game_count)
-            .await?
-            .iter()
-            .filter(|game| {
-                game.root_claim == root_claim
-                    && game.data.l2_block_number == l2_block_number
-                    && parent_candidates.contains(&game.data.parent_ref)
-            })
-            .cloned()
-            .collect();
-
-        Ok(select_transition_tips(candidates, parent_candidates))
+        Ok(found)
     }
 
     async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError> {
@@ -587,8 +427,7 @@ where
     async fn submit_proposal(
         &self,
         proposal: &Proposal,
-        retry_of: Option<Address>,
-        proof: ProofData,
+        _proof: ProofData,
     ) -> Result<ProposalSubmission, ProposerError> {
         // `DisputeGameFactory.create` reverts unless `msg.value` matches the configured init
         // bond exactly, so it is read per submission rather than cached in configuration.
@@ -599,61 +438,7 @@ where
             .await
             .map_err(|error| ProposerError::Contract(error.to_string()))?;
 
-        let ProofData::Nitro {
-            public_values,
-            signature,
-            public_key,
-            ..
-        } = proof
-        else {
-            return Err(ProposerError::InvalidProofResponse(
-                "proposal creation requires a Nitro proof".into(),
-            ));
-        };
-        let transition = TransitionPublicValues::abi_decode(&public_values)
-            .map_err(|error| ProposerError::InvalidProofResponse(error.to_string()))?;
-        let l1_origin_hash = transition.l1Head;
-        let l1_origin = self
-            .provider
-            .get_block_by_hash(l1_origin_hash)
-            .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))?
-            .ok_or_else(|| {
-                ProposerError::InvalidProofResponse(format!(
-                    "proof L1 head {} is unavailable",
-                    l1_origin_hash
-                ))
-            })?;
-        let l1_origin_number = l1_origin.header.number();
-        let latest_l1_block = self
-            .provider
-            .get_block_number()
-            .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))?;
-        if latest_l1_block.saturating_sub(l1_origin_number) > MAX_CREATION_PROOF_AGE {
-            return Err(ProposerError::StaleCreationProof {
-                l1_origin_number,
-                latest_l1_block,
-            });
-        }
-        let creation_proof: Bytes = (
-            self.domain_hash,
-            proposal.parent_ref,
-            U256::from(l1_origin_number),
-            transition,
-            signature,
-            public_key,
-        )
-            .abi_encode_params()
-            .into();
-        let extra_data = proposal.commitment().extra_data(
-            self.domain_hash,
-            retry_of.unwrap_or(Address::ZERO),
-            l1_origin_hash,
-            l1_origin_number,
-            ProofLane::TeeAttestation,
-            creation_proof,
-        );
+        let extra_data = proposal.commitment().extra_data(self.domain_hash);
         let pending = self
             .factory
             .create(MULTI_PROOF_GAME_TYPE, proposal.root_claim, extra_data)
@@ -719,69 +504,4 @@ fn u256_to_u64(value: U256, field: &'static str) -> Result<u64, ProposerError> {
     value
         .try_into()
         .map_err(|_| ProposerError::Contract(format!("{field} overflows u64")))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn candidate(
-        index: u64,
-        address: Address,
-        parent_ref: Address,
-        attempt: u64,
-        retry_of: Address,
-    ) -> ScannedTransitionGame {
-        ScannedTransitionGame {
-            factory_index: index,
-            address,
-            root_claim: B256::ZERO,
-            data: ProposalExtraData {
-                domain_hash: B256::ZERO,
-                l2_block_number: 1,
-                parent_ref,
-                attempt,
-                retry_of,
-                l1_origin_hash: B256::ZERO,
-                l1_origin_number: 0,
-                creation_proof_lane: ProofLane::TeeAttestation,
-                creation_proof: Bytes::from_static(&[1]),
-            },
-        }
-    }
-
-    #[test]
-    fn selects_every_explicit_retry_lineage_tip() {
-        let parent = Address::with_last_byte(1);
-        let first = Address::with_last_byte(2);
-        let parallel = Address::with_last_byte(3);
-        let retry = Address::with_last_byte(4);
-        let parallel_retry = Address::with_last_byte(5);
-
-        let found = select_transition_tips(
-            vec![
-                candidate(14, parallel_retry, parent, 1, parallel),
-                candidate(11, parallel, parent, 0, Address::ZERO),
-                candidate(13, retry, parent, 1, first),
-                candidate(10, first, parent, 0, Address::ZERO),
-            ],
-            &[parent],
-        );
-
-        assert_eq!(
-            found,
-            vec![
-                TransitionGame {
-                    address: retry,
-                    parent_ref: parent,
-                    attempt: 1,
-                },
-                TransitionGame {
-                    address: parallel_retry,
-                    parent_ref: parent,
-                    attempt: 1,
-                },
-            ]
-        );
-    }
 }

--- a/proofs/proposer/src/bond_manager.rs
+++ b/proofs/proposer/src/bond_manager.rs
@@ -94,9 +94,6 @@ where
         for game in proposed_games {
             let result: Result<bool, ProposerError> = async {
                 let resolution_status = self.execution_provider.resolution_status(game).await?;
-                // TODO: Resolve proposer-owned games here when they are resolvable. The
-                // canonical-line resolver never visits abandoned siblings or descendants,
-                // which otherwise leaves their proposer bonds locked.
                 if !resolution_status.is_resolved() {
                     return Ok(false);
                 }

--- a/proofs/proposer/src/error.rs
+++ b/proofs/proposer/src/error.rs
@@ -28,14 +28,6 @@ pub enum ProposerError {
     /// Prover-service returned data inconsistent with the requested proof.
     #[error("invalid proof response: {0}")]
     InvalidProofResponse(String),
-    /// The proof's L1 origin is too old for reliable EIP-2935 inclusion.
-    #[error(
-        "creation proof L1 origin {l1_origin_number} is stale at latest L1 block {latest_l1_block}"
-    )]
-    StaleCreationProof {
-        l1_origin_number: u64,
-        latest_l1_block: u64,
-    },
     #[error(transparent)]
     OutputRoot(#[from] ConsensusError),
     #[error("The proposal transaction didn't execute succesfully: {0}")]

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -109,12 +109,7 @@ where
 
             let existing = self
                 .execution_provider
-                .games_for_transition(
-                    anchor.anchor_game,
-                    &parent_candidates,
-                    root_claim,
-                    next_l2_block_number,
-                )
+                .games_for_transition(&parent_candidates, root_claim, next_l2_block_number)
                 .await?;
             let mut statuses = Vec::with_capacity(existing.len());
             for game in &existing {
@@ -125,10 +120,8 @@ where
                 );
             }
 
-            // `games_for_transition` returns lineage tips in factory-index order. Following the
-            // first non-invalidated tip gives every proposer restart the same deterministic
-            // branch. Descendants of later siblings are intentionally outside that branch and
-            // may need to be proposed again under the selected concrete parent.
+            // A game that has not been invalidated continues the canonical line, whichever
+            // accepted parent it was created under.
             if let Some(live) = existing
                 .iter()
                 .zip(&statuses)
@@ -151,12 +144,11 @@ where
             // the anchor can neither be retried under that parent nor chained onto: the
             // transition rebases onto `cursor.address` at attempt zero instead. This is the
             // contract's own recovery path for inherited invalidations.
-            let current_parent_games: Vec<_> = existing
+            let Some((stale, status)) = existing
                 .iter()
                 .zip(&statuses)
-                .filter(|(game, _)| game.parent_ref == cursor.address)
-                .collect();
-            if current_parent_games.is_empty() {
+                .find(|(game, _)| game.parent_ref == cursor.address)
+            else {
                 // Nothing occupies this transition under the current parent, either because no
                 // game exists yet or because the only ones that do are stale rebase targets.
                 return Ok(CanonicalScan::new(
@@ -168,35 +160,27 @@ where
                         attempt: 0,
                     }),
                 ));
-            }
+            };
 
-            let next_action = if let Some((stale, _)) =
-                current_parent_games.iter().copied().find(|(_, status)| {
-                    !status.resolvable
-                        && status.invalidation_reason == InvalidationReason::ProofTimeout
-                }) {
+            let next_action = if status.resolvable {
+                NextProposalAction::AwaitNegativeResolution {
+                    game: stale.address,
+                    reason: status.invalidation_reason,
+                }
+            } else if status.invalidation_reason == InvalidationReason::ProofTimeout {
+                // A retry must reuse the invalidated game's parent reference and root claim:
+                // `MultiProofGame` only accepts attempt N when attempt N-1 exists under the
+                // identical `extraData`.
                 NextProposalAction::RetryTimedOut {
                     proposal: Proposal {
                         parent_ref: cursor.address,
                         root_claim,
                         l2_block_number: next_l2_block_number,
-                        attempt: stale.attempt.checked_add(1).ok_or_else(|| {
-                            ProposerError::Contract("proposal attempt overflows u64".into())
-                        })?,
+                        attempt: stale.attempt.saturating_add(1),
                     },
                     invalidated_game: stale.address,
                 }
-            } else if let Some((stale, status)) = current_parent_games
-                .iter()
-                .copied()
-                .find(|(_, status)| status.resolvable)
-            {
-                NextProposalAction::AwaitNegativeResolution {
-                    game: stale.address,
-                    reason: status.invalidation_reason,
-                }
             } else {
-                let (stale, status) = current_parent_games[0];
                 NextProposalAction::BlockedByInvalidation {
                     game: stale.address,
                     reason: status.invalidation_reason,
@@ -432,29 +416,10 @@ where
             )));
         }
 
-        let submission = match self
+        let submission = self
             .execution_provider
-            .submit_proposal(&pending.proposal, pending.retry_of, proof)
-            .await
-        {
-            Ok(submission) => submission,
-            Err(
-                error @ ProposerError::StaleCreationProof {
-                    l1_origin_number,
-                    latest_l1_block,
-                },
-            ) => {
-                warn!(
-                    %error,
-                    l1_origin_number,
-                    latest_l1_block,
-                    "discarding stale creation proof"
-                );
-                self.pending_proposal = None;
-                return Ok(());
-            }
-            Err(error) => return Err(error),
-        };
+            .submit_proposal(&pending.proposal, proof)
+            .await?;
         info!(
             tx_hash = ?submission.tx_hash,
             game_address = %submission.game_address,

--- a/proofs/proposer/src/tests.rs
+++ b/proofs/proposer/src/tests.rs
@@ -7,11 +7,11 @@ use std::{
     time::Duration,
 };
 
-use alloy_primitives::{Address, B256, BlockNumber, Bytes, U256, address, b256, keccak256};
-use alloy_sol_types::SolValue;
+use alloy_primitives::{Address, B256, BlockNumber, Bytes, U256, address, b256};
 use async_trait::async_trait;
 use world_chain_proofs::{
-    ConsensusError, ConsensusProvider, InvalidationReason, ResolutionStatus, RootState,
+    ConsensusError, ConsensusProvider, InvalidationReason, ProposalCommitment, ResolutionStatus,
+    RootState,
 };
 use world_chain_prover_service::{
     ProofBackend, ProofData, ProofRequest, ProofRequestError, ProofRequestId, ProofRequester,
@@ -39,7 +39,7 @@ const MAX_TEST_ATTEMPT: u64 = 4;
 struct MockContracts {
     anchor: AnchorRef,
     /// Games keyed by their `DisputeGameFactory` UUID.
-    games: HashMap<B256, Vec<Address>>,
+    games: HashMap<B256, Address>,
     submissions: Arc<Mutex<Vec<(Proposal, ProofData)>>>,
     resolution_statuses: Arc<Mutex<HashMap<Address, ResolutionStatus>>>,
     resolutions: Arc<Mutex<Vec<Address>>>,
@@ -57,27 +57,23 @@ impl ProposerClient for MockContracts {
 
     async fn games_for_transition(
         &self,
-        _anchor_game: Option<Address>,
         parent_candidates: &[Address],
         root_claim: B256,
         l2_block_number: u64,
     ) -> Result<Vec<TransitionGame>, ProposerError> {
         let mut found = Vec::with_capacity(parent_candidates.len());
         for parent_ref in parent_candidates {
-            let mut latest = Vec::new();
+            let mut latest = None;
             for attempt in 0..MAX_TEST_ATTEMPT {
-                let uuid = transition_key(*parent_ref, root_claim, l2_block_number, attempt);
-                let Some(addresses) = self.games.get(&uuid) else {
+                let uuid = game_uuid(*parent_ref, root_claim, l2_block_number, attempt);
+                let Some(address) = self.games.get(&uuid).copied() else {
                     break;
                 };
-                latest = addresses
-                    .iter()
-                    .map(|address| TransitionGame {
-                        address: *address,
-                        parent_ref: *parent_ref,
-                        attempt,
-                    })
-                    .collect();
+                latest = Some(TransitionGame {
+                    address,
+                    parent_ref: *parent_ref,
+                    attempt,
+                });
             }
             found.extend(latest);
         }
@@ -126,17 +122,9 @@ impl ProposerClient for MockContracts {
     async fn submit_proposal(
         &self,
         proposal: &Proposal,
-        _retry_of: Option<Address>,
         proof: ProofData,
     ) -> Result<ProposalSubmission, ProposerError> {
         let mut failures = self.submission_failures.lock().expect("not poisoned");
-        if *failures == usize::MAX {
-            *failures = 0;
-            return Err(ProposerError::StaleCreationProof {
-                l1_origin_number: 1,
-                latest_l1_block: 8_002,
-            });
-        }
         if *failures > 0 {
             *failures -= 1;
             return Err(ProposerError::Contract(
@@ -226,7 +214,6 @@ impl ProofRequester for MockProofRequester {
                 attestation: Bytes::from_static(&[1]),
                 public_values: Bytes::from_static(&[2]),
                 signature: Bytes::from_static(&[3]),
-                public_key: Bytes::from_static(&[4]),
             },
         }))
     }
@@ -485,22 +472,14 @@ fn timed_out_status() -> ResolutionStatus {
     }
 }
 
-fn transition_key(
-    parent_ref: Address,
-    root_claim: B256,
-    l2_block_number: u64,
-    attempt: u64,
-) -> B256 {
-    keccak256(
-        (
-            DOMAIN_HASH,
-            parent_ref,
-            root_claim,
-            U256::from(l2_block_number),
-            U256::from(attempt),
-        )
-            .abi_encode_params(),
-    )
+fn game_uuid(parent_ref: Address, root_claim: B256, l2_block_number: u64, attempt: u64) -> B256 {
+    ProposalCommitment {
+        parent_ref,
+        root_claim,
+        l2_block_number,
+        attempt,
+    }
+    .game_uuid(DOMAIN_HASH)
 }
 
 fn game_address(index: u64) -> Address {
@@ -521,7 +500,7 @@ async fn anchor_and_canonical_line_walks_existing_games_until_gap() {
     let root_10 = B256::repeat_byte(0x10);
     let root_20 = B256::repeat_byte(0x20);
     let mut games = HashMap::new();
-    games.insert(transition_key(ANCHOR, root_10, 10, 0), vec![GAME_1]);
+    games.insert(game_uuid(ANCHOR, root_10, 10, 0), GAME_1);
 
     let contracts = MockContracts {
         anchor: anchor_at(0),
@@ -745,45 +724,6 @@ async fn propose_retries_submission_with_same_completed_proof() {
     let requests = proof_requester.requests.lock().expect("not poisoned");
     assert_eq!(requests.len(), 2);
     assert_eq!(requests[0], requests[1]);
-    assert_eq!(submissions.lock().expect("not poisoned").len(), 1);
-}
-
-#[tokio::test]
-async fn propose_discards_stale_creation_proof_before_retrying() {
-    let submissions = Arc::default();
-    let contracts = MockContracts {
-        anchor: anchor_at(0),
-        games: HashMap::new(),
-        submissions: Arc::clone(&submissions),
-        resolution_statuses: Arc::default(),
-        resolutions: Arc::default(),
-        closures: Arc::default(),
-        submission_failures: Arc::new(Mutex::new(usize::MAX)),
-        unfinalized_games: Arc::default(),
-    };
-    let output_roots = MockOutputRoots {
-        roots: HashMap::from([(10, B256::repeat_byte(0x10))]),
-        finalized_l2_block: 10,
-    };
-    let proof_requester = MockProofRequester::default();
-    let mut proposer =
-        WorldChainProposer::new(config(), contracts, output_roots, proof_requester.clone());
-    let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
-
-    advance_proposal(&mut proposer, &canonical_scan)
-        .await
-        .unwrap();
-    assert!(!proposer.has_pending_proposal());
-    assert!(submissions.lock().expect("not poisoned").is_empty());
-
-    advance_proposal(&mut proposer, &canonical_scan)
-        .await
-        .unwrap();
-
-    assert_eq!(
-        proof_requester.requests.lock().expect("not poisoned").len(),
-        2
-    );
     assert_eq!(submissions.lock().expect("not poisoned").len(), 1);
 }
 
@@ -1304,7 +1244,7 @@ async fn timed_out_game_rebases_onto_registry_after_its_parent_became_the_anchor
     let root_20 = B256::repeat_byte(0x20);
     let contracts = MockContracts {
         anchor: anchor_advanced_onto(parent, 10),
-        games: HashMap::from([(transition_key(parent, root_20, 20, 0), vec![timed_out])]),
+        games: HashMap::from([(game_uuid(parent, root_20, 20, 0), timed_out)]),
         submissions: Arc::default(),
         resolution_statuses: Arc::new(Mutex::new(HashMap::from([(timed_out, timed_out_status())]))),
         resolutions: Arc::default(),
@@ -1337,7 +1277,7 @@ async fn timed_out_game_rebases_onto_registry_after_its_parent_became_the_anchor
 }
 
 #[tokio::test]
-async fn invalidated_stale_parent_game_does_not_hide_a_live_registry_parented_rebase() {
+async fn invalidated_legacy_game_does_not_hide_a_live_registry_parented_rebase() {
     let parent = game_address(1);
     let timed_out = game_address(2);
     let rebased = game_address(3);
@@ -1345,8 +1285,8 @@ async fn invalidated_stale_parent_game_does_not_hide_a_live_registry_parented_re
     let contracts = MockContracts {
         anchor: anchor_advanced_onto(parent, 10),
         games: HashMap::from([
-            (transition_key(parent, root_20, 20, 0), vec![timed_out]),
-            (transition_key(ANCHOR, root_20, 20, 0), vec![rebased]),
+            (game_uuid(parent, root_20, 20, 0), timed_out),
+            (game_uuid(ANCHOR, root_20, 20, 0), rebased),
         ]),
         submissions: Arc::default(),
         resolution_statuses: Arc::new(Mutex::new(HashMap::from([(timed_out, timed_out_status())]))),
@@ -1367,7 +1307,7 @@ async fn invalidated_stale_parent_game_does_not_hide_a_live_registry_parented_re
 
     let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
 
-    // The live rebase continues the line even though the dead stale-parent game is scanned first.
+    // The live rebase continues the line even though the dead legacy game is scanned first.
     assert_eq!(
         canonical_scan.canonical_line().games(),
         &[ParentRef {
@@ -1383,7 +1323,7 @@ async fn timed_out_game_bumps_attempt_while_its_parent_is_still_acceptable() {
     let root_20 = B256::repeat_byte(0x20);
     let contracts = MockContracts {
         anchor: anchor_at(10),
-        games: HashMap::from([(transition_key(ANCHOR, root_20, 20, 0), vec![timed_out])]),
+        games: HashMap::from([(game_uuid(ANCHOR, root_20, 20, 0), timed_out)]),
         submissions: Arc::default(),
         resolution_statuses: Arc::new(Mutex::new(HashMap::from([(timed_out, timed_out_status())]))),
         resolutions: Arc::default(),
@@ -1414,44 +1354,5 @@ async fn timed_out_game_bumps_attempt_while_its_parent_is_still_acceptable() {
             },
             invalidated_game: timed_out,
         }
-    );
-}
-
-#[tokio::test]
-async fn timed_out_lineage_does_not_hide_a_parallel_live_game() {
-    let timed_out = game_address(2);
-    let live = game_address(3);
-    let root_20 = B256::repeat_byte(0x20);
-    let contracts = MockContracts {
-        anchor: anchor_at(10),
-        games: HashMap::from([(
-            transition_key(ANCHOR, root_20, 20, 0),
-            vec![timed_out, live],
-        )]),
-        submissions: Arc::default(),
-        resolution_statuses: Arc::new(Mutex::new(HashMap::from([(timed_out, timed_out_status())]))),
-        resolutions: Arc::default(),
-        closures: Arc::default(),
-        submission_failures: Arc::default(),
-        unfinalized_games: Arc::default(),
-    };
-    let proposer = WorldChainProposer::new(
-        config(),
-        contracts,
-        MockOutputRoots {
-            roots: HashMap::from([(20, root_20)]),
-            finalized_l2_block: 20,
-        },
-        MockProofRequester::default(),
-    );
-
-    let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
-
-    assert_eq!(
-        canonical_scan.canonical_line().games(),
-        &[ParentRef {
-            address: live,
-            l2_block_number: 20,
-        }]
     );
 }

--- a/proofs/proposer/src/traits.rs
+++ b/proofs/proposer/src/traits.rs
@@ -61,7 +61,6 @@ pub trait ProposerClient: Send + Sync {
     /// superseded parent must not hide a live one under the parent that is still acceptable.
     async fn games_for_transition(
         &self,
-        anchor_game: Option<Address>,
         parent_candidates: &[Address],
         root_claim: B256,
         l2_block_number: u64,
@@ -86,7 +85,6 @@ pub trait ProposerClient: Send + Sync {
     async fn submit_proposal(
         &self,
         proposal: &Proposal,
-        retry_of: Option<Address>,
         proof: ProofData,
     ) -> Result<ProposalSubmission, ProposerError>;
 }

--- a/proofs/prover-service/src/tests.rs
+++ b/proofs/prover-service/src/tests.rs
@@ -87,7 +87,6 @@ fn proof_for(req: &ProofRequest) -> SucceededProofResponse {
             attestation: Bytes::from(vec![0xcc]),
             public_values: Bytes::from(vec![0xee]),
             signature: Bytes::from(vec![0xdd]),
-            public_key: Bytes::from(vec![0x04]),
         },
     };
     SucceededProofResponse {
@@ -308,7 +307,6 @@ async fn submit_proof_with_wrong_backend_is_rejected() {
             attestation: Bytes::from(vec![0xcc]),
             public_values: Bytes::from(vec![0xee]),
             signature: Bytes::from(vec![0xdd]),
-            public_key: Bytes::from(vec![0x04]),
         },
     };
     assert!(matches!(

--- a/proofs/prover-service/src/types.rs
+++ b/proofs/prover-service/src/types.rs
@@ -200,8 +200,6 @@ pub enum ProofData {
         public_values: Bytes,
         /// Enclave signature over the proven outputs.
         signature: Bytes,
-        /// SEC1-uncompressed public key certified by the attestation document.
-        public_key: Bytes,
     },
 }
 

--- a/wips/wip-1006.md
+++ b/wips/wip-1006.md
@@ -11,18 +11,18 @@ created: 2026-05-27
 
 ## Abstract
 
-We outline an OP Stack dispute game in which every proposed output root carries a TEE proof at creation. The proof counts as one lane but does not finalize the root: if no staked participant challenges it within one day, the game may resolve in favor of the proposer; if challenged, the proposer has seven days from game creation to add an independent lane and reach the 2-of-3 threshold. A challenge submits no proof of invalidity. Failure to reach the threshold resolves the game in favor of the challenger. The stock `DisputeGameFactory`, `AnchorStateRegistry`, `OptimismPortal2`, and `DelayedWETH` remain responsible for game creation, claim validity, withdrawals, and bond custody.
+We outline an OP Stack dispute game in which a proposer posts an output root optimistically without a proof. If no staked participant challenges the root within one day, the game may resolve in favor of the proposer. A challenge submits no proof of invalidity; it shifts the burden to the proposer, who has seven days from game creation to assemble a threshold of independent validity signals. Failure to reach the threshold resolves the game in favor of the challenger. The stock `DisputeGameFactory`, `AnchorStateRegistry`, `OptimismPortal2`, and `DelayedWETH` remain responsible for game creation, claim validity, withdrawals, and bond custody.
 
 ## Motivation
 
-The vanilla OP Stack fault-proof system inherits a multi-day challenge window for every proposal and routes every dispute through a single interactive fault-proof lane. Base's Azul proof system reduces that window when two heterogeneous proofs agree, but final resolution still rests on at most two lanes.
+The vanilla OP Stack fault-proof system inherits a multi-day challenge window for every proposal and routes every dispute through a single interactive fault-proof lane. Base's Azul proof system reduces that window when two heterogeneous proofs (TEE and ZK) agree, but still requires a proof on the common path and still rests final resolution on at most two lanes.
 
 World Chain targets two properties that neither model provides together:
 
-- **A proof-backed optimistic path.** Every proposal starts with one TEE-attested transition, remains challengeable, and can finalize after the challenge window without producing another proof.
-- **A diversified disputed path.** When a root is challenged, its creation-time TEE lane is insufficient: the proposer must add an independent validity or council lane before the deadline.
+- **A cheap common path.** No proof is paid for or produced when no staked participant objects to a root.
+- **A diversified disputed path.** When a root is challenged, the proposer must defend it, and no single prover, TEE vendor, or council action can finalize that defense. At least two independent lanes must agree.
 
-The result is one-lane assurance plus watcher oversight in the common case and 2-of-3 threshold security in the disputed case.
+The result is fast finality in the common case and `n / m` threshold security in the dispute case.
 
 ## Specification
 
@@ -73,26 +73,13 @@ The data bound by every proof and attestation is split into immutable domain con
 | `l2BlockNumber` | Proposer | L2 block number for `rootClaim`, matching the [`l2BlockNumber` field of an OP Stack L2 output proposal][op-proposals]. |
 | `parentRef` | Proposer | Address of the parent — the `AnchorStateRegistry` for the first proposal, otherwise the parent proposal. Same convention as the OP Stack [Fault Dispute Game `extraData` parent reference][op-dgi] and the parent reference encoded in Base Azul's `AggregateVerifier` extra-data layout (see [Base Azul proof system][base-azul]). The parent's `rootClaim` and `l2BlockNumber` are read from this reference rather than re-supplied. |
 | `attempt` | Proposer | Retry nonce for the same transition. Attempt zero is the initial game; later attempts are permitted only after an eligible predecessor fails or is made obsolete by activation. |
-| `retryOf` | Proposer | Previous concrete game for a non-zero attempt. It MUST represent the same transition and be eligible for retry. |
-| `l1OriginHash` | Proposer | Recent L1 block selected by the proposer and verified against `blockhash(l1OriginNumber)` or [EIP-2935][eip-2935] history during creation. |
-| `l1OriginNumber` | Proposer | L1 block number paired with `l1OriginHash`. |
-| `creationProofLane` | Proposer | Proof lane used to verify `creationProof`. |
-| `creationProof` | Proposer | Proof verified during game initialization and counted as the initial `creationProofLane`. |
+| `l1OriginHash` | Factory | L1 origin hash captured at proposal creation. The proposer does not pass it as calldata; it is read via `blockhash()` or [EIP-2935][eip-2935] history and pinned by the factory, mirroring the OP Stack [`l1Head` snapshot at clone creation][op-dgi] that Base Azul inherits. |
+| `l1OriginNumber` | Game | L1 block number paired with the factory-captured `l1OriginHash`. |
 
 The proposer calls `DisputeGameFactory.create(gameType, rootClaim, extraData)`, where:
 
 ```text
-extraData = abi.encode(
-    domainHash,
-    l2BlockNumber,
-    parentRef,
-    attempt,
-    retryOf,
-    l1OriginHash,
-    l1OriginNumber,
-    creationProofLane,
-    creationProof
-)
+extraData = abi.encode(domainHash, l2BlockNumber, parentRef, attempt)
 ```
 
 [op-output-root]: https://specs.optimism.io/protocol/proposals.html#l2-output-commitment-construction
@@ -119,8 +106,8 @@ These values are set once on the game implementation (analogous to Base's `CONFI
 
 The contracts use two related identifiers:
 
-- `gameUUID` is the stock `DisputeGameFactory` lookup key. It commits to `gameType`, `rootClaim`, and the complete proof-backed `extraData`.
-- `rootId` is the proof-bound transition commitment. It includes the proposer-selected L1 origin and is the value every proof lane MUST bind to.
+- `gameUUID` is the stock `DisputeGameFactory` lookup key. It commits to `gameType`, `rootClaim`, and the complete `extraData`, but excludes the factory-captured L1 origin.
+- `rootId` is the proof-bound commitment. It includes the factory-captured L1 origin and is the value every proof lane MUST bind to.
 
 The contract computes:
 
@@ -136,15 +123,10 @@ extraData = abi.encode(
     domainHash,
     l2BlockNumber,
     parentRef,
-    attempt,
-    retryOf,
-    l1OriginHash,
-    l1OriginNumber,
-    creationProofLane,
-    creationProof
+    attempt
 )
 
-gameUUID = keccak256(abi.encode(
+gameUUID = keccak256(abi.encodePacked(
     gameType,
     rootClaim,
     extraData
@@ -160,17 +142,7 @@ rootId = keccak256(abi.encode(
 ))
 ```
 
-The factory MUST reject duplicate games with the same `gameUUID`. This guarantees uniqueness only
-for one exact creation payload. Because the creation proof, selected L1 origin, and retry
-predecessor are part of `extraData`, multiple bonded games MAY have different `gameUUID` values
-while sharing the same `(domainHash, parentRef, rootClaim, l2BlockNumber, attempt)`. Attempts are
-therefore local to the explicit lineage formed by `retryOf`, not a global nonce for the logical
-transition. Offchain participants MUST tolerate parallel lineages: challengers evaluate every game
-independently, while proposers MAY deterministically follow one non-invalidated lineage. An
-unselected game does not block another lineage or anchor advancement and remains independently
-resolvable and closable through the permissionless game lifecycle.
-
-All proofs and attestations MUST bind to `rootId`. A proof or attestation that binds to a different domain, parent, root, block range, or L1 origin MUST NOT be accepted for `rootId`.
+The factory MUST reject duplicate games with the same `gameUUID`. All proofs and attestations MUST bind to `rootId`. A proof or attestation that binds to a different domain, parent, root, block range, or L1 origin MUST NOT be accepted for `rootId`.
 
 ### State Machine
 
@@ -196,20 +168,14 @@ stateDiagram-v2
 A root enters the system in the `PROPOSED` state.
 
 1. The proposer calls the stock `DisputeGameFactory.create` with the WIP-1006 game type, `rootClaim`, and canonical `extraData`, supplying the configured initialization bond.
-2. The factory creates a clone of the registered WIP-1006 implementation and calls `initialize`.
-3. The game validates the domain, parent registration and eligibility, exact L2 block interval, retry predecessor, selected L1 head, creation proof, and bond.
+2. The factory creates a clone of the registered WIP-1006 implementation, captures the creator and L1 head, and calls `initialize`.
+3. The game validates the domain, parent registration and eligibility, exact L2 block interval, retry predecessor, and bond.
 4. The game records `createdAt = block.timestamp`, `challengeDeadline = createdAt + CHALLENGE_PERIOD`, and `proofDeadline = createdAt + PROOF_PERIOD`.
-5. The game records the creation proof as support from the `TEE_ATTESTATION` lane.
-6. The proposer bond is deposited into `DelayedWETH`, and the root remains open to challenge until `challengeDeadline`.
+5. The proposer bond is deposited into `DelayedWETH`, and the root remains open to challenge until `challengeDeadline`.
 
-The proposer MUST attach a valid TEE proof at creation. Additional proof-lane material is submitted
-only after a challenge.
+The proposer MUST NOT be required or permitted to submit proof-lane material before a challenge.
 
-An initial `attempt = 0` identifies the first game in a retry lineage. A later attempt MUST identify
-its exact predecessor and MUST be accepted only for a protocol-defined recovery case, such as a
-proof timeout or a game created before WIP-1006 became respected. Another game MAY start a parallel
-lineage at the same attempt when its complete proof-backed creation payload produces a distinct
-`gameUUID`.
+An initial `attempt = 0` identifies the first game for a transition. A later attempt MUST identify its exact predecessor and MUST be accepted only for a protocol-defined recovery case, such as a proof timeout or a game created before WIP-1006 became respected.
 
 ### Challenge Lifecycle
 
@@ -238,7 +204,7 @@ The game MUST resolve with `DEFENDER_WINS` when all of the following hold:
 - the parent is the anchor sentinel or has resolved with `DEFENDER_WINS`; and
 - the parent is not blacklisted.
 
-An unchallenged game resolves without additional proof-lane submissions. A self-blacklisted, retired, unrespected, or otherwise improper game may still have `DEFENDER_WINS` status, but the registry MUST reject its claim and the game MUST use refund-mode bond settlement.
+An unchallenged game resolves without proof-lane submissions. A self-blacklisted, retired, unrespected, or otherwise improper game may still have `DEFENDER_WINS` status, but the registry MUST reject its claim and the game MUST use refund-mode bond settlement.
 
 ### Proposer Defense and Challenged Finality
 
@@ -315,7 +281,7 @@ WIP-1006 is implemented as a new game type on the stock OP Stack dispute infrast
 
 | Interface | Role | Reference |
 | --- | --- | --- |
-| `IDisputeGameFactory` | Stock OP factory; registers the WIP-1006 implementation, creates clones, and indexes games by UUID and list index. | [`DisputeGameFactory`][base-factory] |
+| `IDisputeGameFactory` | Stock OP factory; registers the WIP-1006 implementation, creates clones, indexes games by UUID and list index, and captures `l1Head`. | [`DisputeGameFactory`][base-factory] |
 | `IDisputeGame` / `IMultiProofGame` | Per-proposal game; exposes the Portal-facing lifecycle and World Chain proof-lane extensions. | [`AggregateVerifier`][base-aggregate] |
 | `IAnchorStateRegistry` | Stock OP registry; evaluates registration, respect, blacklist, retirement, finality, claim validity, and the current anchor. | [`AnchorStateRegistry`][base-anchor] |
 | `IDelayedWETH` | Holds proposer and challenger bonds and enforces delayed two-phase credit withdrawal. | OP Stack `DelayedWETH`. |
@@ -342,9 +308,9 @@ The proposal data remains aligned with the OP Stack:
 - `rootClaim` follows the [OP Stack output-root V1 encoding](https://specs.optimism.io/protocol/proposals.html#l2-output-commitment-construction).
 - `l2BlockNumber` matches the [`l2BlockNumber` field of an L2 output proposal](https://specs.optimism.io/protocol/proposals.html).
 - `parentRef` follows the [Fault Dispute Game `extraData` parent reference convention](https://specs.optimism.io/fault-proof/stage-one/dispute-game-interface.html) — the `AnchorStateRegistry` for the first proposal, otherwise the parent proposal address.
-- `l1OriginHash` is selected by the proposer and checked against recent L1 block history at creation.
+- `l1OriginHash` is factory-captured at proposal creation, matching the L1 head snapshot taken by `DisputeGameFactory` at clone creation.
 - factory identity uses the canonical `(gameType, rootClaim, extraData)` UUID;
-- all per-proposal context, including the creation proof, is encoded canonically in `extraData`.
+- `domainHash`, `l2BlockNumber`, `parentRef`, and `attempt` are encoded in `extraData`.
 
 Offchain proposers, challengers, and defenders MUST use the stock factory indexing and creation APIs plus the WIP-1006 game extensions. They do not require a custom factory or anchor registry.
 
@@ -354,7 +320,6 @@ Before this WIP can move beyond Draft, implementations SHOULD cover at least:
 
 - an unchallenged root finalizes after exactly `CHALLENGE_PERIOD`;
 - factory creation rejects an incorrect domain hash or malformed `extraData`;
-- factory creation rejects an invalid proof or mismatched L1 origin;
 - factory UUID lookup and `findLatestGames` preserve the complete WIP-1006 `extraData`;
 - an unstaked account cannot challenge;
 - a staked account can challenge without proof before the deadline;
@@ -374,7 +339,7 @@ Before this WIP can move beyond Draft, implementations SHOULD cover at least:
 
 ## Security Considerations
 
-**Unchallenged-path safety combines the TEE lane and honest watchers.** Every root has a verified TEE lane at creation, but an invalid root can still finalize if that lane is compromised and no honest staked participant challenges it within `CHALLENGE_PERIOD`. Watchers therefore remain an independent safety backstop on the common path.
+**Unchallenged-path liveness depends on honest watchers.** Safety in the common case relies on at least one honest staked participant challenging an invalid root within `CHALLENGE_PERIOD`. The architecture does not protect against a root that no one watches.
 
 **Disputed-path safety depends on lane independence.** A false challenged finality requires two lanes to accept the same invalid root. Implementations MUST avoid shared signing keys, shared verifier keys, shared operator control, and shared offchain infrastructure across lanes, because any such sharing collapses the effective threshold below two.
 
@@ -384,9 +349,7 @@ Before this WIP can move beyond Draft, implementations SHOULD cover at least:
 
 **`rootId` domain separation is critical.** Every lane MUST bind to the same `rootId`, and `rootId` itself MUST commit to `chainId`, `proofSystemVersion`, `rollupConfigHash`, and the parent/child block range. Missing domain separation allows replay across chains, hardfork schedules, game types, proof-system versions, or block ranges.
 
-**`gameUUID` is not a proof target.** It exists for duplicate prevention of one concrete
-proof-backed game. Proofs and attestations MUST bind to `rootId`, while offchain discovery groups
-the proof-specific UUIDs by their decoded transition fields.
+**`gameUUID` is not a proof target.** It exists for factory duplicate prevention and discovery. Proofs and attestations MUST bind to `rootId`, because the factory UUID does not include the L1 origin captured at game creation.
 
 **Bond and stake calibration are security-critical.** If `CHALLENGER_BOND` is too cheap, attackers can grief honest roots into the slow path. If `CHALLENGER_BOND` is too expensive, honest watchers may fail to challenge invalid roots. If `PROPOSER_BOND` is too cheap, invalid-proposal spam is cheap and forces honest watchers to lock capital per challenge; if `PROPOSER_BOND` is too expensive, only well-capitalized actors can propose, which centralizes the role. Exact economic parameters are out of scope for this WIP but MUST be tuned before mainnet deployment.
 


### PR DESCRIPTION
Reverts worldcoin/world-chain#928

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large contract and proposer behavior change to dispute-game creation, identity, and retries; incorrect CWIA/extraData or UUID logic could break game registration, canonical-line walking, or withdrawals.
> 
> **Overview**
> **Reverts proof-backed game creation** so WIP-1006 proposals go through stock `DisputeGameFactory.create` with **no creation-time proof** and **minimal `extraData`**: `abi.encode(domainHash, l2BlockNumber, parentRef, attempt)` only.
> 
> **On-chain (`MultiProofGame`)** drops creation-proof fields and verification at `initialize`, removes EIP-2935 / proposer-selected L1 origin from the CWIA payload, pins **`l1Head` at the factory offset** and **`l1OriginNumber` from `block.number - 1`**, tightens **`msg.data.length == 0xDA`**, and rewrites **retry** logic to look up attempt `N-1` via the factory UUID instead of `retryOf`. Post-challenge lane behavior is adjusted (e.g. duplicate lane submissions no longer inflate `proofCount`).
> 
> **Rust proposer stack** stops encoding Nitro creation proofs into `extraData`, removes **`findLatestGames` scan / parallel lineage** handling, and resolves transitions with **`DisputeGameFactory.games` + attempt walk** and **`ProposalCommitment::game_uuid`**. **`ProofData::Nitro`** no longer carries **`public_key`**; devnet Nitro mocks use deterministic bytes as a readiness gate only.
> 
> **WIP-1006.md** is aligned with **optimistic propose, proof only after challenge**, and factory-captured L1 origin. E2E/devnet/deploy tests shed creation-proof and history-contract assertions; deploy uses **`MockRootIdVerifier(false)`** for the TEE lane.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd4da1fbc920e2255c4678366dc37ff3c0e2cf2d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->