### PR TITLE
feat(proofs): submit proofs after game creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18602,6 +18602,7 @@ dependencies = [
  "alloy-provider",
  "alloy-rpc-types-eth 2.0.5",
  "alloy-signer-local 2.0.5",
+ "alloy-sol-types",
  "anyhow",
  "async-trait",
  "clap",
@@ -18612,6 +18613,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.23",
  "url",
+ "world-chain-proof-core",
  "world-chain-proofs",
  "world-chain-prover-service",
 ]
@@ -18627,6 +18629,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-provider",
  "alloy-signer-local 2.0.5",
+ "alloy-sol-types",
  "anyhow",
  "async-trait",
  "base64 0.22.1",
@@ -18976,6 +18979,7 @@ name = "world-chain-proof-integration-tests"
 version = "2.4.0"
 dependencies = [
  "alloy-primitives",
+ "alloy-sol-types",
  "anyhow",
  "async-trait",
  "testcontainers",
@@ -18984,6 +18988,7 @@ dependencies = [
  "tokio-util",
  "world-chain-challenger",
  "world-chain-defender",
+ "world-chain-proof-core",
  "world-chain-proof-worker",
  "world-chain-proofs",
  "world-chain-proposer",
@@ -19175,7 +19180,6 @@ dependencies = [
  "tracing-subscriber 0.3.23",
  "url",
  "world-chain-proofs",
- "world-chain-prover-service",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18600,7 +18600,6 @@ dependencies = [
  "alloy-network 2.0.5",
  "alloy-primitives",
  "alloy-provider",
- "alloy-rpc-types-eth 2.0.5",
  "alloy-signer-local 2.0.5",
  "alloy-sol-types",
  "anyhow",

--- a/crates/devnet/Cargo.toml
+++ b/crates/devnet/Cargo.toml
@@ -34,6 +34,7 @@ alloy-hardforks.workspace = true
 alloy-network.workspace = true
 alloy-primitives.workspace = true
 alloy-signer-local.workspace = true
+alloy-sol-types.workspace = true
 
 async-trait.workspace = true
 anyhow.workspace = true

--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -2767,12 +2767,7 @@ async fn start_world_chain_defender(
     let output_roots = OptimismConsensusClient::new(output_root_rpc_url.to_string());
     let proof_requester = RpcProverServiceClient::new(prover_service_url)
         .map_err(|error| eyre!("failed to connect defender to prover-service: {error}"))?;
-    let allowed_proposer = DEVNET_PRIVATE_KEY
-        .parse::<PrivateKeySigner>()
-        .wrap_err("invalid allowed World Chain proposer key")?
-        .address();
     let config = DefenderConfig {
-        allowed_proposer,
         poll_interval: WORLD_DEFENDER_POLL_INTERVAL,
         ..DefenderConfig::default()
     };
@@ -2784,7 +2779,6 @@ async fn start_world_chain_defender(
         prover_service = %prover_service_url,
         dispute_game_factory = %deployment.proof_system_factory,
         defender = %defender_address,
-        allowed_proposer = %allowed_proposer,
         "starting native World Chain proof-system defender"
     );
 

--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -14,6 +14,7 @@ use alloy_network::EthereumWallet;
 use alloy_primitives::{Address, B64, hex};
 use alloy_provider::{Provider, ProviderBuilder};
 use alloy_signer_local::PrivateKeySigner;
+use alloy_sol_types::SolValue;
 use async_trait::async_trait;
 use base64::prelude::{BASE64_STANDARD, Engine};
 use eyre::eyre::{Context, Result, bail, eyre};
@@ -51,7 +52,9 @@ use world_chain_defender::{
     AlloyDefenderClient, DEFAULT_L1_TX_CONFIRMATIONS as DEFAULT_DEFENDER_L1_TX_CONFIRMATIONS,
     DefenderConfig, WorldChainDefender,
 };
-use world_chain_proof_core::{hash_world_rollup_config, range::WorldRangeHardforkConfig};
+use world_chain_proof_core::{
+    boot::TransitionPublicValues, hash_world_rollup_config, range::WorldRangeHardforkConfig,
+};
 use world_chain_proof_kona_host_utils::online::OnlineHostConfig;
 use world_chain_proof_succinct_host_utils::{
     Sp1ProverKind, WorldSuccinctProver,
@@ -103,8 +106,7 @@ const PROVER_SERVICE_POSTGRES_PORT: u16 = 5432;
 const PROOF_SYSTEM_BLOCK_INTERVAL: u64 = 10;
 /// Poll interval for the in-process SP1 worker leasing jobs from the prover-service.
 const SP1_WORKER_POLL_INTERVAL: Duration = Duration::from_secs(5);
-/// Env var enabling the in-process defender, prover-service, and SP1 worker. Off by default:
-/// real proving needs the SP1 ELFs. Set a prover backend to turn it on.
+/// Env var enabling the optional SP1 worker used for challenged-game escalation.
 const SP1_WORKER_PROVER_ENV: &str = "DEVNET_SP1_WORKER_PROVER";
 /// SP1 network private key. Required when `DEVNET_SP1_WORKER_PROVER=network`.
 const SP1_PRIVATE_KEY_ENV: &str = "SP1_PRIVATE_KEY";
@@ -364,13 +366,21 @@ impl ClaimedProofJobHandler for DevnetNitroBackend {
     }
 
     async fn handle_claimed_job(&self, job: ProofJob) -> anyhow::Result<ProofData> {
-        // The devnet deploys MockRootIdVerifier lanes. The proposer currently uses this
-        // response only as a readiness gate before stock DGF.create, so deterministic bytes
-        // keep the full queue/worker path exercised without requiring Nitro hardware.
+        let transition = TransitionPublicValues {
+            l1Head: job.request.l1_head,
+            l2PreRoot: Default::default(),
+            l2PreBlockNumber: 0,
+            l2PostRoot: job.request.root_claim,
+            l2PostBlockNumber: job.request.l2_block_number,
+            rollupConfigHash: Default::default(),
+        };
+        // Devnet verifiers accept any ABI-valid payload; deterministic values exercise the
+        // queue, worker, defender encoding, and on-chain submission without Nitro hardware.
         Ok(ProofData::Nitro {
             attestation: job.request.l1_head.as_slice().to_vec().into(),
-            public_values: job.request.root_claim.as_slice().to_vec().into(),
+            public_values: transition.abi_encode().into(),
             signature: job.request.root_claim.as_slice().to_vec().into(),
+            public_key: vec![0x04; 65].into(),
         })
     }
 }
@@ -614,8 +624,7 @@ impl FullStackWorldDevnet {
 
         let proof_services = proof_system.as_ref();
 
-        // The proposer always needs the prover-service for its creation-time Nitro proof.
-        // Defender and SP1 worker startup remains optional below.
+        // Proof workers and the defender share one prover-service.
         let (prover_service, prover_service_url) = if proof_services.is_some() {
             let (service, url) = start_prover_service().await?;
             (Some(service), Some(url))
@@ -629,24 +638,14 @@ impl FullStackWorldDevnet {
             None
         };
 
-        let world_proposer = if let (Some(deployment), Some(prover_service_url)) =
-            (proof_services, prover_service_url.as_deref())
-        {
+        let world_proposer = if let Some(deployment) = proof_services {
             let output_root_rpc = op_nodes
                 .first()
                 .map(|node| node.rpc_url.clone())
                 .ok_or_else(|| {
                     eyre!("full-stack devnet has no op-node for the World Chain proposer")
                 })?;
-            Some(
-                start_world_chain_proposer(
-                    &l1_public_rpc,
-                    &output_root_rpc,
-                    prover_service_url,
-                    deployment,
-                )
-                .await?,
-            )
+            Some(start_world_chain_proposer(&l1_public_rpc, &output_root_rpc, deployment).await?)
         } else {
             None
         };
@@ -663,45 +662,54 @@ impl FullStackWorldDevnet {
             None
         };
 
-        // Optional defender proving loop: an in-process defender and SP1 worker, enabled by
-        // `DEVNET_SP1_WORKER_PROVER`. They share the prover-service started for the proposer.
-        let (sp1_worker, world_defender) = match (
-            proof_services,
-            sp1_worker_prover_kind()?,
-            prover_service_url.as_deref(),
-        ) {
-            (Some(deployment), Some(kind), Some(prover_service_url)) => {
+        // The defender always supplies the initial TEE proof. SP1 proving remains optional
+        // until a challenged game needs a second independent lane.
+        let world_defender = match (proof_services, prover_service_url.as_deref()) {
+            (Some(deployment), Some(prover_service_url)) => {
                 let output_root_rpc = op_nodes
                     .first()
                     .map(|node| node.rpc_url.clone())
                     .ok_or_else(|| {
                         eyre!("full-stack devnet has no op-node for the World Chain defender")
                     })?;
+                Some(
+                    start_world_chain_defender(
+                        &l1_public_rpc,
+                        &output_root_rpc,
+                        prover_service_url,
+                        deployment,
+                    )
+                    .await?,
+                )
+            }
+            _ => None,
+        };
+
+        let sp1_worker = match (
+            proof_services,
+            sp1_worker_prover_kind()?,
+            prover_service_url.as_deref(),
+        ) {
+            (Some(deployment), Some(kind), Some(prover_service_url)) => {
                 let l2_rpc = sequencers
                     .first()
                     .map(|sequencer| sequencer.rpc_url.clone())
                     .ok_or_else(|| {
                         eyre!("full-stack devnet has no sequencer for the SP1 worker")
                     })?;
-                let defender = start_world_chain_defender(
-                    &l1_public_rpc,
-                    &output_root_rpc,
-                    prover_service_url,
-                    deployment,
+                Some(
+                    start_sp1_worker(
+                        &l1_public_rpc,
+                        &l2_rpc,
+                        prover_service_url,
+                        &artifacts.rollup_path,
+                        deployment,
+                        kind,
+                    )
+                    .await?,
                 )
-                .await?;
-                let worker = start_sp1_worker(
-                    &l1_public_rpc,
-                    &l2_rpc,
-                    prover_service_url,
-                    &artifacts.rollup_path,
-                    deployment,
-                    kind,
-                )
-                .await?;
-                (Some(worker), Some(defender))
             }
-            _ => (None, None),
+            _ => None,
         };
 
         let mut metrics_targets = Vec::new();
@@ -2547,7 +2555,6 @@ async fn start_challenger(
 async fn start_world_chain_proposer(
     l1_rpc_url: &str,
     output_root_rpc_url: &str,
-    prover_service_url: &str,
     deployment: &WorldProofSystemDeployment,
 ) -> Result<ProposerTask> {
     let factory_address: Address = deployment
@@ -2584,20 +2591,17 @@ async fn start_world_chain_proposer(
         contracts.clone(),
     );
     let output_roots = OptimismConsensusClient::new(output_root_rpc_url.to_string());
-    let proof_requester = RpcProverServiceClient::new(prover_service_url)
-        .map_err(|error| eyre!("failed to connect proposer to prover-service: {error}"))?;
     let domain_hash = contracts.domain_hash();
     let config = ProposerConfig {
         block_interval: deployment.block_interval,
         poll_interval: WORLD_PROPOSER_POLL_INTERVAL,
         max_resolutions_per_tick: ProposerConfig::default().max_resolutions_per_tick,
     };
-    let mut proposer = WorldChainProposer::new(config, contracts, output_roots, proof_requester);
+    let mut proposer = WorldChainProposer::new(config, contracts, output_roots);
 
     info!(
         l1_rpc_url,
         output_root_rpc_url,
-        prover_service = %prover_service_url,
         dispute_game_factory = %deployment.proof_system_factory,
         anchor = %deployment.anchor_state_registry,
         proposer = %proposer_address,
@@ -2733,9 +2737,9 @@ async fn start_world_chain_challenger(
 /// Spawns the in-process World Chain proof-system defender.
 ///
 /// The defender signs with [`WORLD_DEFENDER_PRIVATE_KEY`], a dedicated dev
-/// account that is funded through the L1 genesis. It watches challenged valid
-/// WIP-1006 games on the `DisputeGameFactory`, requests proofs from the
-/// prover-service, and submits completed proof lanes on L1.
+/// account that is funded through the L1 genesis. It supplies the initial TEE
+/// proof for valid WIP-1006 games, escalates challenged games to the configured
+/// threshold, and resolves negative outcomes.
 async fn start_world_chain_defender(
     l1_rpc_url: &str,
     output_root_rpc_url: &str,
@@ -2799,8 +2803,8 @@ async fn start_world_chain_defender(
     Ok(DefenderTask { handle })
 }
 
-/// Reads the SP1 worker prover backend from [`SP1_WORKER_PROVER_ENV`], or `None` when the
-/// defender proving loop is disabled.
+/// Reads the SP1 worker prover backend from [`SP1_WORKER_PROVER_ENV`], or `None` when
+/// challenged-game SP1 escalation is disabled.
 fn sp1_worker_prover_kind() -> Result<Option<Sp1ProverKind>> {
     match std::env::var(SP1_WORKER_PROVER_ENV) {
         Ok(value) => value.parse().map(Some).map_err(|error| eyre!("{error}")),

--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -2561,11 +2561,6 @@ async fn start_world_chain_proposer(
         .proof_system_factory
         .parse()
         .wrap_err("invalid proof-system factory address")?;
-    let anchor_address: Address = deployment
-        .anchor_state_registry
-        .parse()
-        .wrap_err("invalid anchor-state-registry address")?;
-
     let signer: PrivateKeySigner = DEVNET_PRIVATE_KEY
         .parse()
         .wrap_err("invalid World Chain proposer signing key")?;
@@ -2575,14 +2570,9 @@ async fn start_world_chain_proposer(
         .connect_http(Url::parse(l1_rpc_url)?);
 
     let required_confirmations = 1;
-    let contracts = AlloyProofSystemClient::new(
-        provider,
-        factory_address,
-        anchor_address,
-        required_confirmations,
-    )
-    .await
-    .wrap_err("failed to bind the World Chain proof system")?;
+    let contracts = AlloyProofSystemClient::new(provider, factory_address, required_confirmations)
+        .await
+        .wrap_err("failed to bind the World Chain proof system")?;
     let mut bond_manager = BondManager::new(
         BondManagerConfig {
             poll_interval: WORLD_PROPOSER_POLL_INTERVAL,
@@ -2591,22 +2581,21 @@ async fn start_world_chain_proposer(
         contracts.clone(),
     );
     let output_roots = OptimismConsensusClient::new(output_root_rpc_url.to_string());
-    let domain_hash = contracts.domain_hash();
+    let registered = contracts.registered_lineage_config();
     let config = ProposerConfig {
-        block_interval: deployment.block_interval,
         poll_interval: WORLD_PROPOSER_POLL_INTERVAL,
         max_resolutions_per_tick: ProposerConfig::default().max_resolutions_per_tick,
     };
-    let mut proposer = WorldChainProposer::new(config, contracts, output_roots);
+    let proposer = WorldChainProposer::new(config, contracts, output_roots);
 
     info!(
         l1_rpc_url,
         output_root_rpc_url,
         dispute_game_factory = %deployment.proof_system_factory,
-        anchor = %deployment.anchor_state_registry,
+        anchor = %registered.anchor_registry,
         proposer = %proposer_address,
-        domain_hash = %domain_hash,
-        block_interval = deployment.block_interval,
+        domain_hash = %registered.domain_hash,
+        block_interval = registered.block_interval,
         "starting native World Chain proof-system proposer"
     );
 
@@ -2739,7 +2728,7 @@ async fn start_world_chain_challenger(
 /// The defender signs with [`WORLD_DEFENDER_PRIVATE_KEY`], a dedicated dev
 /// account that is funded through the L1 genesis. It supplies the initial TEE
 /// proof for valid WIP-1006 games, escalates challenged games to the configured
-/// threshold, and resolves negative outcomes.
+/// threshold, and follows the lineage selected from the current anchor.
 async fn start_world_chain_defender(
     l1_rpc_url: &str,
     output_root_rpc_url: &str,
@@ -2763,7 +2752,9 @@ async fn start_world_chain_defender(
         provider,
         factory_address,
         DEFAULT_DEFENDER_L1_TX_CONFIRMATIONS,
-    );
+    )
+    .await
+    .map_err(|error| eyre!("failed to connect defender to proof system: {error}"))?;
     let output_roots = OptimismConsensusClient::new(output_root_rpc_url.to_string());
     let proof_requester = RpcProverServiceClient::new(prover_service_url)
         .map_err(|error| eyre!("failed to connect defender to prover-service: {error}"))?;

--- a/docs/proof/nitro-worker.md
+++ b/docs/proof/nitro-worker.md
@@ -285,7 +285,7 @@ Here is the full journey from "job available" to "proof accepted":
     document with:
     - `user_data` = `keccak256(abi.encode(TransitionPublicValues))`
     - `nonce` = the caller-supplied nonce
-    - `public_key` = the ephemeral secp256k1 public key (33-byte compressed)
+    - `public_key` = the ephemeral secp256k1 public key (65-byte SEC1-uncompressed)
 
 12. **Response returned.** The enclave sends back `TransitionPublicValues`, the raw attestation
     document bytes, and the secp256k1 signature.
@@ -305,7 +305,7 @@ Here is the full journey from "job available" to "proof accepted":
     the job's expected `root_claim`, `l2_block_number`, `l1_head`, and `rollup_config_hash`.
 
 15. **Proof submitted.** The worker posts
-    `ProofData::Nitro { attestation, public_values, signature }`
+    `ProofData::Nitro { attestation, public_values, signature, public_key }`
     back to the `prover-service`.
 
 ---

--- a/e2e-tests/src/it/devnet_withdrawal.rs
+++ b/e2e-tests/src/it/devnet_withdrawal.rs
@@ -162,6 +162,7 @@ async fn op_native_wip_1006_portal_withdrawal_and_bond_claim() -> eyre::Result<(
         anchor.isGameProper(game_address).call().await?,
         "covering WIP-1006 game is not proper"
     );
+    wait_for_initial_proof(l1_provider.clone(), game_address).await?;
 
     let (output_root_proof, withdrawal_proof) =
         build_withdrawal_proof(l2_provider, game_l2_block, withdrawal.hash).await?;
@@ -354,6 +355,29 @@ where
         },
         storage_proof.proof.clone(),
     ))
+}
+
+async fn wait_for_initial_proof<P>(provider: P, game_address: Address) -> eyre::Result<()>
+where
+    P: Provider,
+{
+    let game = IMultiProofGame::IMultiProofGameInstance::new(game_address, provider);
+    let started = Instant::now();
+
+    loop {
+        if game.proofBitmap().call().await? != 0 {
+            return Ok(());
+        }
+        if game.status().call().await? != GAME_IN_PROGRESS {
+            bail!("game {game_address} resolved before receiving its initial proof");
+        }
+        if started.elapsed() >= GAME_WAIT_TIMEOUT {
+            bail!(
+                "timed out waiting for defender to submit an initial proof to game {game_address}"
+            );
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
 }
 
 async fn wait_for_defender_win<P>(provider: P, game_address: Address) -> eyre::Result<()>

--- a/pkg/contracts/scripts/devnet/DeployProofSystem.s.sol
+++ b/pkg/contracts/scripts/devnet/DeployProofSystem.s.sol
@@ -55,6 +55,7 @@ contract DeployProofSystem is Script {
         bytes32 rollupConfigHash;
         uint256 blockInterval;
         uint8 proofThreshold;
+        address proofTimeoutRecipient;
         IDisputeGameFactory disputeGameFactory;
         IAnchorStateRegistry anchorStateRegistry;
         ISystemConfig systemConfig;
@@ -80,9 +81,9 @@ contract DeployProofSystem is Script {
         // 1. Periphery + DelayedWETH + game implementation, from the deployer key.
         vm.startBroadcast(config.privateKey);
         deployment.staking = new MockStakingRegistry();
-        deployment.validityVerifier = new MockRootIdVerifier(false);
-        deployment.teeVerifier = new MockRootIdVerifier(false);
-        deployment.councilVerifier = new MockRootIdVerifier(false);
+        deployment.validityVerifier = new MockRootIdVerifier(true);
+        deployment.teeVerifier = new MockRootIdVerifier(true);
+        deployment.councilVerifier = new MockRootIdVerifier(true);
         deployment.staking.setStaked(vm.addr(config.privateKey), true);
         if (config.challenger != address(0)) {
             deployment.staking.setStaked(config.challenger, true);
@@ -153,6 +154,7 @@ contract DeployProofSystem is Script {
         config.rollupConfigHash = vm.envBytes32("ROLLUP_CONFIG_HASH");
         config.blockInterval = vm.envOr("PROOF_SYSTEM_BLOCK_INTERVAL", uint256(10));
         config.proofThreshold = uint8(vm.envOr("PROOF_THRESHOLD", uint256(ProofLib.PROOF_THRESHOLD)));
+        config.proofTimeoutRecipient = vm.envOr("PROOF_TIMEOUT_RECIPIENT", config.challenger);
         config.disputeGameFactory = IDisputeGameFactory(vm.envAddress("DISPUTE_GAME_FACTORY"));
         config.anchorStateRegistry = IAnchorStateRegistry(vm.envAddress("ANCHOR_STATE_REGISTRY"));
         config.systemConfig = ISystemConfig(vm.envAddress("SYSTEM_CONFIG"));
@@ -176,6 +178,7 @@ contract DeployProofSystem is Script {
         require(config.systemConfig.l2ChainId() == config.l2ChainId, "DeployProofSystem: L2 chain ID mismatch");
         require(config.dgfOwnerKey != 0, "DeployProofSystem: DGF owner key required");
         require(config.proxyAdminOwnerKey != 0, "DeployProofSystem: ProxyAdmin owner key required");
+        require(config.proofTimeoutRecipient != address(0), "DeployProofSystem: proof timeout recipient required");
         if (config.setRespectedGameType) {
             require(config.guardianKey != 0, "DeployProofSystem: guardian key required for cutover");
         }
@@ -197,6 +200,7 @@ contract DeployProofSystem is Script {
             proofPeriod: PROOF_PERIOD,
             proposerBond: PROPOSER_BOND,
             challengerBond: CHALLENGER_BOND,
+            proofTimeoutRecipient: config.proofTimeoutRecipient,
             proofThreshold: config.proofThreshold,
             validityProofVerifier: IWorldChainProofVerifier(address(deployment.validityVerifier)),
             teeVerifier: IWorldChainProofVerifier(address(deployment.teeVerifier)),
@@ -221,6 +225,7 @@ contract DeployProofSystem is Script {
         vm.serializeAddress(root, "teeVerifier", address(deployment.teeVerifier));
         vm.serializeAddress(root, "securityCouncil", address(deployment.councilVerifier));
         vm.serializeAddress(root, "stakingRegistry", address(deployment.staking));
+        vm.serializeAddress(root, "proofTimeoutRecipient", config.proofTimeoutRecipient);
         vm.serializeAddress(root, "gameImplementation", address(deployment.gameImpl));
         vm.serializeAddress(root, "delayedWeth", address(deployment.weth));
         vm.serializeAddress(root, "delayedWethProxyAdmin", address(deployment.wethProxyAdmin));

--- a/pkg/contracts/src/proofs/MultiProofGame.sol
+++ b/pkg/contracts/src/proofs/MultiProofGame.sol
@@ -477,11 +477,10 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
             return (false, state(), ProofLib.InvalidationReason.NONE);
         }
 
-        // TODO: Decide whether reaching PROOF_THRESHOLD should make an unchallenged game
-        // immediately resolvable too. The current WIP guarantees the full challenge window even
-        // with threshold support, while challenged games resolve as soon as they reach the same
-        // threshold; update the WIP together with this branch if threshold support is intended
-        // to provide fast finality in both states.
+        if (ProofLib.hasThreshold(proofBitmap, PROOF_THRESHOLD)) {
+            return (true, ProofLib.RootState.FINALIZED, ProofLib.InvalidationReason.NONE);
+        }
+
         if (challenger == address(0)) {
             if (block.timestamp < challengeDeadline) {
                 return (false, ProofLib.RootState.PROPOSED, ProofLib.InvalidationReason.NONE);
@@ -491,9 +490,6 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
                 : (true, ProofLib.RootState.INVALIDATED, ProofLib.InvalidationReason.PROOF_TIMEOUT);
         }
 
-        if (ProofLib.hasThreshold(proofBitmap, PROOF_THRESHOLD)) {
-            return (true, ProofLib.RootState.FINALIZED, ProofLib.InvalidationReason.NONE);
-        }
         return block.timestamp >= proofDeadline
             ? (true, ProofLib.RootState.INVALIDATED, ProofLib.InvalidationReason.PROOF_TIMEOUT)
             : (false, ProofLib.RootState.CHALLENGED, ProofLib.InvalidationReason.NONE);
@@ -522,6 +518,10 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
         } else if (parentStatus == GameStatus.IN_PROGRESS) {
             // A proposed or challenged parent must resolve before its descendant.
             revert ParentGameNotResolved();
+        } else if (ProofLib.hasThreshold(proofBitmap, PROOF_THRESHOLD)) {
+            // Threshold support provides fast finality whether or not the game was challenged.
+            status = GameStatus.DEFENDER_WINS;
+            normalModeCredit[gameCreator()] = totalBonds;
         } else if (challenger == address(0) && proofBitmap != 0) {
             // Any configured proof lane may support the optimistic path. The offchain defender
             // uses TEE attestations by policy, but the protocol does not privilege a lane.
@@ -534,11 +534,6 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
             status = GameStatus.CHALLENGER_WINS;
             invalidationReason = ProofLib.InvalidationReason.PROOF_TIMEOUT;
             normalModeCredit[proofTimeoutRecipient] = totalBonds;
-        } else if (ProofLib.hasThreshold(proofBitmap, PROOF_THRESHOLD)) {
-            // A challenged game finalizes as soon as enough independent proof lanes support it.
-            // The proposer takes the challenger bond.
-            status = GameStatus.DEFENDER_WINS;
-            normalModeCredit[gameCreator()] = totalBonds;
         } else if (block.timestamp >= proofDeadline) {
             // A challenged game below threshold times out once its proof window expires. The
             // challenger takes the proposer bond.

--- a/pkg/contracts/src/proofs/MultiProofGame.sol
+++ b/pkg/contracts/src/proofs/MultiProofGame.sol
@@ -44,9 +44,10 @@ import {ISemver} from "@optimism-bedrock/interfaces/universal/ISemver.sol";
 /// @title MultiProofGame
 /// @notice A multi-proof dispute game created through the stock Optimism `DisputeGameFactory`
 ///         using the Clone-With-Immutable-Args (CWIA) pattern. Proposals chain parent-to-parent
-///         at a fixed block interval; a challenged proposal finalizes only once enough
-///         independent proof lanes (validity proof, TEE attestation, security council) support
-///         it. Bond custody uses `DelayedWETH` with the two-phase unlock/withdraw claim flow.
+///         at a fixed block interval. An unchallenged proposal requires one valid proof lane;
+///         a challenged proposal requires enough independent lanes (validity proof, TEE
+///         attestation, security council) to reach the configured threshold. Bond custody uses
+///         `DelayedWETH` with the two-phase unlock/withdraw claim flow.
 /// @dev Structure follows `ZKDisputeGame`; challenge/lane semantics are World Chain specific.
 contract MultiProofGame is Clone, ISemver, IMultiProofGame {
     ////////////////////////////////////////////////////////////////
@@ -69,6 +70,7 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
     uint64 public immutable proofPeriod;
     uint256 public immutable proposerBond;
     uint256 public immutable challengerBond;
+    address public immutable proofTimeoutRecipient;
 
     IWorldChainProofVerifier public immutable validityProofVerifier;
     IWorldChainProofVerifier public immutable teeVerifier;
@@ -83,8 +85,8 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
     ////////////////////////////////////////////////////////////////
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0
-    string public constant version = "1.0.0";
+    /// @custom:semver 2.0.0
+    string public constant version = "2.0.0";
 
     Timestamp public createdAt;
     Timestamp public resolvedAt;
@@ -115,10 +117,10 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
             config.challengePeriod == 0 || config.proofPeriod <= config.challengePeriod || config.domain.chainId == 0
                 || config.domain.proofSystemVersion == 0 || config.domain.blockInterval == 0
                 || config.proofThreshold == 0 || config.proofThreshold > ProofLib.PROOF_LANE_COUNT
-                || address(config.disputeGameFactory) == address(0) || address(config.anchorStateRegistry) == address(0)
-                || address(config.weth) == address(0) || address(config.stakingRegistry) == address(0)
-                || address(config.validityProofVerifier) == address(0) || address(config.teeVerifier) == address(0)
-                || address(config.securityCouncil) == address(0)
+                || config.proofTimeoutRecipient == address(0) || address(config.disputeGameFactory) == address(0)
+                || address(config.anchorStateRegistry) == address(0) || address(config.weth) == address(0)
+                || address(config.stakingRegistry) == address(0) || address(config.validityProofVerifier) == address(0)
+                || address(config.teeVerifier) == address(0) || address(config.securityCouncil) == address(0)
         ) {
             revert InvalidActivationParameters();
         }
@@ -139,6 +141,7 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
         proofPeriod = config.proofPeriod;
         proposerBond = config.proposerBond;
         challengerBond = config.challengerBond;
+        proofTimeoutRecipient = config.proofTimeoutRecipient;
         PROOF_THRESHOLD = config.proofThreshold;
         validityProofVerifier = config.validityProofVerifier;
         teeVerifier = config.teeVerifier;
@@ -331,9 +334,9 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
         // Retries: attempt N is only proposable when attempt N-1 for the identical transition
         // timed out on proofs or was created before WIP-1006 became respected. The latter
         // prevents a pre-cutover game from permanently occupying the factory UUID. Inherited
-        // invalidations must rebase onto a replacement parent, which changes `parentRef` and
-        // therefore starts back at attempt zero. Duplicate attempts are impossible: the factory
-        // UUID covers (gameType, rootClaim, extraData).
+        // invalidations rebase onto a replacement parent and therefore restart at attempt zero.
+        // Duplicate attempts are impossible: the factory UUID covers (gameType, rootClaim,
+        // extraData).
         if (attempt() > 0) {
             bytes memory previousExtraData = abi.encode(domainHash, l2SequenceNumber(), parentRef_, attempt() - 1);
             (IDisputeGame previous,) =
@@ -423,11 +426,11 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
 
     /// @inheritdoc IMultiProofGame
     function submitProofLane(uint8 laneId, bytes calldata proof) external {
-        if (status != GameStatus.IN_PROGRESS || challenger == address(0)) {
-            revert ClaimAlreadyResolved();
-        }
-        if (block.timestamp >= proofDeadline) {
-            revert ProofPeriodElapsed(block.timestamp, proofDeadline);
+        if (status != GameStatus.IN_PROGRESS) revert ClaimAlreadyResolved();
+
+        uint64 deadline = challenger == address(0) ? challengeDeadline : proofDeadline;
+        if (block.timestamp >= deadline) {
+            revert ProofPeriodElapsed(block.timestamp, deadline);
         }
         if (laneId >= PROOF_LANE_COUNT) revert InvalidLane(laneId);
 
@@ -474,10 +477,18 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
             return (false, state(), ProofLib.InvalidationReason.NONE);
         }
 
+        // TODO: Decide whether reaching PROOF_THRESHOLD should make an unchallenged game
+        // immediately resolvable too. The current WIP guarantees the full challenge window even
+        // with threshold support, while challenged games resolve as soon as they reach the same
+        // threshold; update the WIP together with this branch if threshold support is intended
+        // to provide fast finality in both states.
         if (challenger == address(0)) {
-            return block.timestamp >= challengeDeadline
+            if (block.timestamp < challengeDeadline) {
+                return (false, ProofLib.RootState.PROPOSED, ProofLib.InvalidationReason.NONE);
+            }
+            return proofBitmap != 0
                 ? (true, ProofLib.RootState.FINALIZED, ProofLib.InvalidationReason.NONE)
-                : (false, ProofLib.RootState.PROPOSED, ProofLib.InvalidationReason.NONE);
+                : (true, ProofLib.RootState.INVALIDATED, ProofLib.InvalidationReason.PROOF_TIMEOUT);
         }
 
         if (ProofLib.hasThreshold(proofBitmap, PROOF_THRESHOLD)) {
@@ -489,9 +500,9 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
     }
 
     /// @notice Resolves the game.
-    ///         `DEFENDER_WINS` when the challenge window expires unchallenged, or when enough
-    ///         proof lanes support a challenged claim. `CHALLENGER_WINS` when the proof window
-    ///         expires below threshold, or when the parent game is invalid.
+    ///         `DEFENDER_WINS` when a proven game expires unchallenged, or when enough proof
+    ///         lanes support a challenged claim. `CHALLENGER_WINS` when an applicable proof
+    ///         window expires below its requirement, or when the parent game is invalid.
     /// @dev Resolution gates on the parent's *status*, never on its claim validity, so the
     ///      anchor registry's finality airgap does not slow the proposal cadence. Bonds are
     ///      credited here and paid out through `claimCredit` after `closeGame`.
@@ -511,12 +522,18 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
         } else if (parentStatus == GameStatus.IN_PROGRESS) {
             // A proposed or challenged parent must resolve before its descendant.
             revert ParentGameNotResolved();
-        } else if (challenger == address(0)) {
-            // An unchallenged proposal finalizes after its challenge window expires. Safety
-            // therefore relies on every incorrect claim being challenged before this deadline.
+        } else if (challenger == address(0) && proofBitmap != 0) {
+            // Any configured proof lane may support the optimistic path. The offchain defender
+            // uses TEE attestations by policy, but the protocol does not privilege a lane.
             if (block.timestamp < challengeDeadline) revert GameNotOver();
             status = GameStatus.DEFENDER_WINS;
             normalModeCredit[gameCreator()] = totalBonds;
+        } else if (challenger == address(0)) {
+            // A proofless proposal cannot win merely because nobody challenged it.
+            if (block.timestamp < challengeDeadline) revert GameNotOver();
+            status = GameStatus.CHALLENGER_WINS;
+            invalidationReason = ProofLib.InvalidationReason.PROOF_TIMEOUT;
+            normalModeCredit[proofTimeoutRecipient] = totalBonds;
         } else if (ProofLib.hasThreshold(proofBitmap, PROOF_THRESHOLD)) {
             // A challenged game finalizes as soon as enough independent proof lanes support it.
             // The proposer takes the challenger bond.

--- a/pkg/contracts/src/proofs/MultiProofGame.sol
+++ b/pkg/contracts/src/proofs/MultiProofGame.sol
@@ -85,8 +85,8 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
     ////////////////////////////////////////////////////////////////
 
     /// @notice Semantic version.
-    /// @custom:semver 2.0.0
-    string public constant version = "2.0.0";
+    /// @custom:semver 1.0.0
+    string public constant version = "1.0.0";
 
     Timestamp public createdAt;
     Timestamp public resolvedAt;

--- a/pkg/contracts/src/proofs/interfaces/IMultiProofGame.sol
+++ b/pkg/contracts/src/proofs/interfaces/IMultiProofGame.sol
@@ -28,6 +28,7 @@ interface IMultiProofGame is IDisputeGame {
         uint64 proofPeriod;
         uint256 proposerBond;
         uint256 challengerBond;
+        address proofTimeoutRecipient;
         uint8 proofThreshold;
         IWorldChainProofVerifier validityProofVerifier;
         IWorldChainProofVerifier teeVerifier;
@@ -104,6 +105,8 @@ interface IMultiProofGame is IDisputeGame {
     /// @notice Hash of the deployment's domain parameters.
     function domainHash() external view returns (bytes32);
 
+    /// @notice Parent reference required for a proposal that directly extends the current anchor.
+
     /// @notice Seconds a proposal may be challenged after creation.
     function challengePeriod() external view returns (uint64);
 
@@ -115,6 +118,9 @@ interface IMultiProofGame is IDisputeGame {
 
     /// @notice Bond required to challenge a proposal.
     function challengerBond() external view returns (uint256);
+
+    /// @notice Recipient of the proposer bond when an unchallenged game expires without proof.
+    function proofTimeoutRecipient() external view returns (address);
 
     /// @notice Verifier backing the validity-proof lane.
     function validityProofVerifier() external view returns (IWorldChainProofVerifier);
@@ -151,7 +157,7 @@ interface IMultiProofGame is IDisputeGame {
     ///         out on proofs or to have been created before this game type became respected.
     function attempt() external view returns (uint256);
 
-    /// @notice Parent game, or the anchor registry when the proposal starts from its current root.
+    /// @notice Parent game, or the anchor registry when no compatible anchor game exists.
     function parentRef() external view returns (address);
 
     /// @notice Output root this proposal starts from.
@@ -217,7 +223,9 @@ interface IMultiProofGame is IDisputeGame {
     ///         exactly `challengerBond`.
     function challenge() external payable;
 
-    /// @notice Submits `proof` for `laneId`. No-ops when the lane already counts.
+    /// @notice Submits `proof` for `laneId`. Before a challenge, any accepted lane satisfies the
+    ///         initial proof requirement; after a challenge, distinct lanes count toward the
+    ///         configured threshold. No-ops when the lane already counts.
     function submitProofLane(uint8 laneId, bytes calldata proof) external;
 
     ////////////////////////////////////////////////////////////////

--- a/pkg/contracts/test/MultiProofGame.t.sol
+++ b/pkg/contracts/test/MultiProofGame.t.sol
@@ -38,6 +38,7 @@ contract MultiProofGameTest is OPStackFixtures {
         assertEq(address(registered), address(game));
         assertTrue(asr.isGameRegistered(IDisputeGame(address(game))));
         assertEq(weth.balanceOf(address(game)), PROPOSER_BOND);
+        assertEq(game.proofBitmap(), 0);
     }
 
     function test_Create_RejectsMalformedExtraData() public {
@@ -157,9 +158,56 @@ contract MultiProofGameTest is OPStackFixtures {
         new MultiProofGame(config);
 
         config = _gameConfig();
+        config.proofTimeoutRecipient = address(0);
+        vm.expectRevert(IMultiProofGame.InvalidActivationParameters.selector);
+        new MultiProofGame(config);
+
+        config = _gameConfig();
         config.domain.chainId = CHAIN_ID + 1;
         vm.expectRevert(IMultiProofGame.InconsistentSystemConfiguration.selector);
         new MultiProofGame(config);
+    }
+
+    function test_UnchallengedFlow_AnyProofLaneCanFinalize() public {
+        for (uint8 lane; lane < ProofLib.PROOF_LANE_COUNT; lane++) {
+            (, uint256 anchorBlock) = asr.getAnchorRoot();
+            uint256 target = anchorBlock + BLOCK_INTERVAL;
+            bytes32 rootClaim = keccak256(abi.encode("lane", lane));
+            MultiProofGame game = _propose(type(uint256).max, rootClaim, target, 0);
+
+            game.submitProofLane(lane, abi.encodePacked(game.rootId()));
+            vm.warp(game.challengeDeadline());
+            game.resolve();
+
+            assertEq(uint8(game.status()), uint8(GameStatus.DEFENDER_WINS));
+            assertEq(game.credit(proposer), PROPOSER_BOND);
+        }
+    }
+
+    function test_UnchallengedFlow_ProoflessProposalLosesBondAndCanRetry() public {
+        MultiProofGame first = _proposeAtAnchor();
+        vm.warp(first.challengeDeadline());
+
+        (bool resolvable, ProofLib.RootState rootState, ProofLib.InvalidationReason reason) = first.resolutionStatus();
+        assertTrue(resolvable);
+        assertEq(uint8(rootState), uint8(ProofLib.RootState.INVALIDATED));
+        assertEq(uint8(reason), uint8(ProofLib.InvalidationReason.PROOF_TIMEOUT));
+
+        first.resolve();
+        assertEq(uint8(first.status()), uint8(GameStatus.CHALLENGER_WINS));
+        assertEq(uint8(first.invalidationReason()), uint8(ProofLib.InvalidationReason.PROOF_TIMEOUT));
+        assertEq(first.credit(proofTimeoutRecipient), PROPOSER_BOND);
+
+        _passAirgap(first);
+        uint256 timeoutRecipientBalance = proofTimeoutRecipient.balance;
+        first.claimCredit(proofTimeoutRecipient);
+        vm.warp(block.timestamp + WETH_DELAY_SECONDS);
+        first.claimCredit(proofTimeoutRecipient);
+        assertEq(proofTimeoutRecipient.balance, timeoutRecipientBalance + PROPOSER_BOND);
+
+        MultiProofGame retry =
+            _propose(type(uint256).max, Claim.unwrap(first.rootClaim()), first.l2SequenceNumber(), first.attempt() + 1);
+        assertEq(retry.attempt(), 1);
     }
 
     function test_UnchallengedFlow_AnchorsAndPaysProposer() public {
@@ -249,6 +297,19 @@ contract MultiProofGameTest is OPStackFixtures {
         assertEq(game.credit(proposer), PROPOSER_BOND + CHALLENGER_BOND);
     }
 
+    function test_Challenge_AfterInitialProofStillRequiresThreshold() public {
+        MultiProofGame game = _proposeAtAnchor();
+        game.submitProofLane(1, abi.encodePacked(game.rootId()));
+        _challenge(game);
+
+        (bool resolvable,,) = game.resolutionStatus();
+        assertFalse(resolvable);
+
+        game.submitProofLane(0, abi.encodePacked(game.rootId()));
+        game.resolve();
+        assertEq(uint8(game.status()), uint8(GameStatus.DEFENDER_WINS));
+    }
+
     function test_ProofLane_RejectsInvalidProofAndExpiredSubmission() public {
         MultiProofGame game = _proposeAtAnchor();
         _challenge(game);
@@ -259,6 +320,16 @@ contract MultiProofGameTest is OPStackFixtures {
         vm.warp(game.proofDeadline());
         bytes memory proof = abi.encodePacked(game.rootId());
         vm.expectRevert();
+        game.submitProofLane(0, proof);
+    }
+
+    function test_ProofLane_RejectsInitialProofAtChallengeDeadline() public {
+        MultiProofGame game = _proposeAtAnchor();
+        uint64 deadline = game.challengeDeadline();
+        bytes memory proof = abi.encodePacked(game.rootId());
+        vm.warp(deadline);
+
+        vm.expectRevert(abi.encodeWithSelector(IMultiProofGame.ProofPeriodElapsed.selector, block.timestamp, deadline));
         game.submitProofLane(0, proof);
     }
 

--- a/pkg/contracts/test/MultiProofGame.t.sol
+++ b/pkg/contracts/test/MultiProofGame.t.sol
@@ -11,6 +11,7 @@ import {
     BadExtraData,
     ClaimAlreadyChallenged,
     GameNotFinalized,
+    GameNotOver,
     GamePaused,
     IncorrectBondAmount,
     InvalidParentGame,
@@ -182,6 +183,29 @@ contract MultiProofGameTest is OPStackFixtures {
             assertEq(uint8(game.status()), uint8(GameStatus.DEFENDER_WINS));
             assertEq(game.credit(proposer), PROPOSER_BOND);
         }
+    }
+
+    function test_UnchallengedFlow_ThresholdProvidesFastFinality() public {
+        MultiProofGame game = _proposeAtAnchor();
+        game.submitProofLane(0, abi.encodePacked(game.rootId()));
+
+        (bool resolvable,,) = game.resolutionStatus();
+        assertFalse(resolvable);
+        vm.expectRevert(GameNotOver.selector);
+        game.resolve();
+
+        game.submitProofLane(1, abi.encodePacked(game.rootId()));
+        ProofLib.RootState rootState;
+        ProofLib.InvalidationReason reason;
+        (resolvable, rootState, reason) = game.resolutionStatus();
+        assertTrue(resolvable);
+        assertEq(uint8(rootState), uint8(ProofLib.RootState.FINALIZED));
+        assertEq(uint8(reason), uint8(ProofLib.InvalidationReason.NONE));
+
+        game.resolve();
+        assertEq(uint8(game.status()), uint8(GameStatus.DEFENDER_WINS));
+        assertEq(game.credit(proposer), PROPOSER_BOND);
+        assertLt(block.timestamp, game.challengeDeadline());
     }
 
     function test_UnchallengedFlow_ProoflessProposalLosesBondAndCanRetry() public {

--- a/pkg/contracts/test/proofs/OPStackFixtures.sol
+++ b/pkg/contracts/test/proofs/OPStackFixtures.sol
@@ -46,6 +46,7 @@ abstract contract OPStackFixtures is Test {
     address internal guardian = makeAddr("guardian");
     address internal proposer = makeAddr("proposer");
     address internal challengerAccount = makeAddr("challenger");
+    address internal proofTimeoutRecipient = makeAddr("proof-timeout-recipient");
 
     MockSystemConfig internal systemConfig;
     IProxyAdmin internal proxyAdmin;
@@ -133,6 +134,7 @@ abstract contract OPStackFixtures is Test {
             proofPeriod: PROOF_PERIOD,
             proposerBond: PROPOSER_BOND,
             challengerBond: CHALLENGER_BOND,
+            proofTimeoutRecipient: proofTimeoutRecipient,
             proofThreshold: PROOF_THRESHOLD,
             validityProofVerifier: IWorldChainProofVerifier(address(validityVerifier)),
             teeVerifier: IWorldChainProofVerifier(address(teeVerifier)),
@@ -193,7 +195,11 @@ abstract contract OPStackFixtures is Test {
     function _proposeAtAnchor() internal returns (MultiProofGame) {
         (, uint256 anchorBlock) = asr.getAnchorRoot();
         uint256 target = anchorBlock + BLOCK_INTERVAL;
-        return _propose(type(uint256).max, _rootClaimFor(target), target, 0);
+        bytes memory extraData = _extraDataForParent(target, gameImpl.canonicalAnchorParent(), 0);
+        vm.prank(proposer);
+        IDisputeGame proxy =
+            dgf.create{value: PROPOSER_BOND}(WC_GAME_TYPE, Claim.wrap(_rootClaimFor(target)), extraData);
+        return MultiProofGame(address(proxy));
     }
 
     /// @dev Creates a child chained onto the game at factory index `parentIndex`.
@@ -218,6 +224,9 @@ abstract contract OPStackFixtures is Test {
 
     /// @dev Warps past the challenge window and resolves (unchallenged path).
     function _resolveUnchallenged(MultiProofGame game) internal {
+        if (game.proofBitmap() == 0) {
+            game.submitProofLane(uint8(ProofLib.ProofLane.TEE_ATTESTATION), abi.encodePacked(game.rootId()));
+        }
         if (block.timestamp < game.challengeDeadline()) {
             vm.warp(game.challengeDeadline());
         }

--- a/pkg/contracts/test/proofs/OPStackFixtures.sol
+++ b/pkg/contracts/test/proofs/OPStackFixtures.sol
@@ -195,7 +195,9 @@ abstract contract OPStackFixtures is Test {
     function _proposeAtAnchor() internal returns (MultiProofGame) {
         (, uint256 anchorBlock) = asr.getAnchorRoot();
         uint256 target = anchorBlock + BLOCK_INTERVAL;
-        bytes memory extraData = _extraDataForParent(target, gameImpl.canonicalAnchorParent(), 0);
+        IDisputeGame anchorGame = asr.anchorGame();
+        address parent = address(anchorGame) == address(0) ? address(asr) : address(anchorGame);
+        bytes memory extraData = _extraDataForParent(target, parent, 0);
         vm.prank(proposer);
         IDisputeGame proxy =
             dgf.create{value: PROPOSER_BOND}(WC_GAME_TYPE, Claim.wrap(_rootClaimFor(target)), extraData);

--- a/proofs/defender/Cargo.toml
+++ b/proofs/defender/Cargo.toml
@@ -24,7 +24,6 @@ world-chain-prover-service.workspace = true
 alloy-network.workspace = true
 alloy-primitives.workspace = true
 alloy-provider = { workspace = true, features = ["reqwest"] }
-alloy-rpc-types-eth.workspace = true
 alloy-signer-local.workspace = true
 alloy-sol-types.workspace = true
 

--- a/proofs/defender/Cargo.toml
+++ b/proofs/defender/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 [dependencies]
 # workspace
 world-chain-proofs.workspace = true
+world-chain-proof-core.workspace = true
 world-chain-prover-service.workspace = true
 
 # alloy
@@ -25,6 +26,7 @@ alloy-primitives.workspace = true
 alloy-provider = { workspace = true, features = ["reqwest"] }
 alloy-rpc-types-eth.workspace = true
 alloy-signer-local.workspace = true
+alloy-sol-types.workspace = true
 
 # misc
 anyhow.workspace = true

--- a/proofs/defender/README.md
+++ b/proofs/defender/README.md
@@ -1,0 +1,15 @@
+# World Chain Defender
+
+The defender reconstructs the same selected game lineage as the proposer from the current
+`AnchorStateRegistry` checkpoint. For each finalized L2 interval it computes the expected output
+root, looks up the highest sequential attempt through the stock `DisputeGameFactory`, and stops at
+the first missing or invalidated transition.
+
+For selected proofless games it submits a TEE proof. If a selected game is challenged, it drives
+the configured independent proof lanes until the contract threshold is reached. The proposer owns
+resolution, retry creation, and anchor advancement.
+
+Only asynchronous proof progress is retained between ticks. Each tick reconstructs the lineage and
+drops proof workflows for games that are no longer selected. A proof-timeout retry therefore moves
+the defender to the replacement attempt; resolving and recovering the abandoned lineage is a manual
+operator responsibility.

--- a/proofs/defender/src/alloy.rs
+++ b/proofs/defender/src/alloy.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::DefenderError,
     traits::DefenderClient,
-    types::{DefenderSubmission, GameMetadata},
+    types::{DefenderSubmission, GameMetadata, ResolveSubmission},
 };
 use alloy_primitives::{Address, Bytes, U256};
 use alloy_provider::Provider;
@@ -94,18 +94,24 @@ where
     async fn game_metadata(&self, address: Address) -> Result<GameMetadata, DefenderError> {
         let game = self.game(address);
         let (
+            domain_hash,
+            parent_ref,
             root_claim,
             l2_block_number,
             l1_origin_hash,
+            l1_origin_number,
             challenge_deadline,
             proof_deadline,
             proof_threshold,
         ) = self
             .provider
             .multicall()
+            .add(game.proposalDomainHash())
+            .add(game.parentRef())
             .add(game.rootClaim())
             .add(game.l2BlockNumber())
             .add(game.l1OriginHash())
+            .add(game.l1OriginNumber())
             .add(game.challengeDeadline())
             .add(game.proofDeadline())
             .add(game.PROOF_THRESHOLD())
@@ -120,9 +126,12 @@ where
 
         Ok(GameMetadata {
             address,
+            domain_hash,
+            parent_ref,
             root_claim,
             l2_block_number: u256_to_u64(l2_block_number, "l2BlockNumber")?,
             l1_origin_hash,
+            l1_origin_number: u256_to_u64(l1_origin_number, "l1OriginNumber")?,
             challenge_deadline,
             proof_deadline,
             proof_threshold,
@@ -152,6 +161,24 @@ where
             .call()
             .await
             .map_err(|error| DefenderError::Contract(error.to_string()))
+    }
+
+    async fn resolve_game(&self, game: Address) -> Result<ResolveSubmission, DefenderError> {
+        let pending = self
+            .game(game)
+            .resolve()
+            .send()
+            .await
+            .map_err(|err| DefenderError::Contract(err.to_string()))?;
+        let tx_hash = *pending.tx_hash();
+        let receipt = pending
+            .get_receipt()
+            .await
+            .map_err(|err| DefenderError::Contract(err.to_string()))?;
+        if !receipt.status() {
+            return Err(DefenderError::Revert(tx_hash));
+        }
+        Ok(ResolveSubmission { tx_hash })
     }
 
     async fn submit_proof(

--- a/proofs/defender/src/alloy.rs
+++ b/proofs/defender/src/alloy.rs
@@ -83,14 +83,6 @@ where
             .map_err(|error| DefenderError::Contract(error.to_string()))
     }
 
-    async fn game_creator(&self, address: Address) -> Result<Address, DefenderError> {
-        self.game(address)
-            .gameCreator()
-            .call()
-            .await
-            .map_err(|error| DefenderError::Contract(error.to_string()))
-    }
-
     async fn game_metadata(&self, address: Address) -> Result<GameMetadata, DefenderError> {
         let game = self.game(address);
         let (

--- a/proofs/defender/src/alloy.rs
+++ b/proofs/defender/src/alloy.rs
@@ -1,23 +1,27 @@
 use crate::{
     error::DefenderError,
     traits::DefenderClient,
-    types::{DefenderSubmission, GameMetadata, ResolveSubmission},
+    types::{DefenderSubmission, GameMetadata},
 };
 use alloy_primitives::{Address, Bytes, U256};
 use alloy_provider::Provider;
-use alloy_rpc_types_eth::BlockId;
 use async_trait::async_trait;
 use world_chain_proofs::{
-    IDisputeGameFactory, IMultiProofGame, MULTI_PROOF_GAME_TYPE, PROOF_LANE_COUNT, ResolutionStatus,
+    IAnchorStateRegistry, IDisputeGameFactory, IMultiProofGame, LineageAnchor, LineageError,
+    LineageGame, LineageProvider, LineageTransition, PROOF_LANE_COUNT, RegisteredLineageConfig,
+    ResolutionStatus, read_game_for_transition, read_lineage_anchor,
+    read_lineage_resolution_status, read_registered_lineage_config,
 };
 
 /// Alloy-backed implementation of [`DefenderClient`].
 ///
-/// Binds the stock OP Stack `DisputeGameFactory`; WIP-1006 games are one game type among
-/// several on that factory, so every index-based read filters on [`MULTI_PROOF_GAME_TYPE`].
+/// Binds the stock OP Stack `DisputeGameFactory` and the anchor registry configured by its
+/// registered WIP-1006 implementation.
 #[derive(Debug, Clone)]
 pub struct AlloyDefenderClient<P> {
     factory: IDisputeGameFactory::IDisputeGameFactoryInstance<P>,
+    anchor: IAnchorStateRegistry::IAnchorStateRegistryInstance<P>,
+    registered: RegisteredLineageConfig,
     confirmations: u64,
     provider: P,
 }
@@ -26,18 +30,29 @@ impl<P> AlloyDefenderClient<P>
 where
     P: Provider + Clone,
 {
-    /// Creates a new Alloy-backed contract client.
-    pub fn new(provider: P, factory_address: Address, confirmations: u64) -> Self {
+    /// Connects to the registered WIP-1006 implementation and its anchor registry.
+    pub async fn new(
+        provider: P,
+        factory_address: Address,
+        confirmations: u64,
+    ) -> Result<Self, DefenderError> {
         let factory = IDisputeGameFactory::IDisputeGameFactoryInstance::new(
             factory_address,
             provider.clone(),
         );
+        let registered = read_registered_lineage_config(&provider, &factory).await?;
+        let anchor = IAnchorStateRegistry::IAnchorStateRegistryInstance::new(
+            registered.anchor_registry,
+            provider.clone(),
+        );
 
-        Self {
+        Ok(Self {
             factory,
+            anchor,
+            registered,
             confirmations,
             provider,
-        }
+        })
     }
 
     fn game(&self, address: Address) -> IMultiProofGame::IMultiProofGameInstance<P> {
@@ -46,43 +61,38 @@ where
 }
 
 #[async_trait]
+impl<P> LineageProvider for AlloyDefenderClient<P>
+where
+    P: Provider + Clone + Send + Sync + 'static,
+{
+    fn lineage_block_interval(&self) -> u64 {
+        self.registered.block_interval
+    }
+
+    async fn lineage_anchor(&self) -> Result<LineageAnchor, LineageError> {
+        read_lineage_anchor(&self.provider, &self.anchor).await
+    }
+
+    async fn game_for_transition(
+        &self,
+        transition: LineageTransition,
+    ) -> Result<Option<LineageGame>, LineageError> {
+        read_game_for_transition(&self.factory, self.registered.domain_hash, transition).await
+    }
+
+    async fn lineage_resolution_status(
+        &self,
+        game: Address,
+    ) -> Result<ResolutionStatus, LineageError> {
+        read_lineage_resolution_status(&self.game(game)).await
+    }
+}
+
+#[async_trait]
 impl<P> DefenderClient for AlloyDefenderClient<P>
 where
     P: Provider + Clone + Send + Sync + 'static,
 {
-    async fn game_count(&self) -> Result<u64, DefenderError> {
-        let count = self
-            .factory
-            .gameCount()
-            .block(BlockId::finalized())
-            .call()
-            .await
-            .map_err(|error| DefenderError::Contract(error.to_string()))?;
-        u256_to_u64(count, "gameCount")
-    }
-
-    async fn game_address_at(&self, index: u64) -> Result<Option<Address>, DefenderError> {
-        let entry = self
-            .factory
-            .gameAtIndex(U256::from(index))
-            .block(BlockId::finalized())
-            .call()
-            .await
-            .map_err(|error| DefenderError::Contract(error.to_string()))?;
-
-        Ok((entry.gameType == MULTI_PROOF_GAME_TYPE).then_some(entry.proxy))
-    }
-
-    async fn game_created_at(&self, index: u64) -> Result<u64, DefenderError> {
-        self.factory
-            .gameAtIndex(U256::from(index))
-            .block(BlockId::finalized())
-            .call()
-            .await
-            .map(|entry| entry.timestamp)
-            .map_err(|error| DefenderError::Contract(error.to_string()))
-    }
-
     async fn game_metadata(&self, address: Address) -> Result<GameMetadata, DefenderError> {
         let game = self.game(address);
         let (
@@ -130,47 +140,12 @@ where
         })
     }
 
-    async fn resolution_status(&self, address: Address) -> Result<ResolutionStatus, DefenderError> {
-        let result = self
-            .game(address)
-            .resolutionStatus()
-            .call()
-            .await
-            .map_err(|error| DefenderError::Contract(error.to_string()))?;
-        let root_state = result.outcome.try_into()?;
-        let invalidation_reason = result.reason.try_into()?;
-
-        Ok(ResolutionStatus {
-            resolvable: result.resolvable,
-            root_state,
-            invalidation_reason,
-        })
-    }
-
     async fn proof_bitmap(&self, address: Address) -> Result<u8, DefenderError> {
         self.game(address)
             .proofBitmap()
             .call()
             .await
             .map_err(|error| DefenderError::Contract(error.to_string()))
-    }
-
-    async fn resolve_game(&self, game: Address) -> Result<ResolveSubmission, DefenderError> {
-        let pending = self
-            .game(game)
-            .resolve()
-            .send()
-            .await
-            .map_err(|err| DefenderError::Contract(err.to_string()))?;
-        let tx_hash = *pending.tx_hash();
-        let receipt = pending
-            .get_receipt()
-            .await
-            .map_err(|err| DefenderError::Contract(err.to_string()))?;
-        if !receipt.status() {
-            return Err(DefenderError::Revert(tx_hash));
-        }
-        Ok(ResolveSubmission { tx_hash })
     }
 
     async fn submit_proof(

--- a/proofs/defender/src/config.rs
+++ b/proofs/defender/src/config.rs
@@ -7,18 +7,6 @@ pub const DEFAULT_MAX_GAME_CONCURRENCY: usize = 10;
 /// Default number of L1 confirmations required for defender transactions.
 pub const DEFAULT_L1_TX_CONFIRMATIONS: u64 = 5;
 
-/// Default maximum number of new factory games discovered per defender tick.
-pub const DEFAULT_MAX_GAMES_PER_TICK: u64 = 100;
-
-/// Default number of previously scanned games reconsidered per defender tick.
-pub const DEFAULT_GAME_SCAN_LOOKBACK: u64 = 100;
-
-/// Default maximum number of game resolutions submitted per defender tick.
-pub const DEFAULT_MAX_RESOLUTIONS_PER_TICK: usize = 10;
-
-/// Default upper bound on the age of a game with an open proof window.
-pub const DEFAULT_MAX_GAME_AGE: Duration = Duration::from_secs(7 * 24 * 60 * 60);
-
 /// Configuration for the defender.
 #[derive(Debug, Clone)]
 pub struct DefenderConfig {
@@ -26,14 +14,6 @@ pub struct DefenderConfig {
     pub poll_interval: Duration,
     /// Maximum number of games to process concurrently.
     pub max_game_concurrency: usize,
-    /// Maximum number of newly created games discovered during one tick.
-    pub max_games_per_tick: u64,
-    /// Number of previously scanned games reconsidered to tolerate mutable-state L1 reorgs.
-    pub game_scan_lookback: u64,
-    /// Maximum number of negatively resolvable games settled during one tick.
-    pub max_resolutions_per_tick: usize,
-    /// Upper bound on the age of any game whose proof window can remain open.
-    pub max_game_age: Duration,
 }
 
 impl DefenderConfig {
@@ -48,21 +28,6 @@ impl DefenderConfig {
                 "max_game_concurrency must be greater than zero",
             ));
         }
-        if self.max_games_per_tick == 0 {
-            return Err(DefenderError::InvalidConfig(
-                "max_games_per_tick must be greater than zero",
-            ));
-        }
-        if self.max_resolutions_per_tick == 0 {
-            return Err(DefenderError::InvalidConfig(
-                "max_resolutions_per_tick must be greater than zero",
-            ));
-        }
-        if self.max_game_age.is_zero() {
-            return Err(DefenderError::InvalidConfig(
-                "max_game_age must be greater than zero",
-            ));
-        }
         Ok(())
     }
 }
@@ -72,10 +37,6 @@ impl Default for DefenderConfig {
         Self {
             poll_interval: Duration::from_mins(1),
             max_game_concurrency: DEFAULT_MAX_GAME_CONCURRENCY,
-            max_games_per_tick: DEFAULT_MAX_GAMES_PER_TICK,
-            game_scan_lookback: DEFAULT_GAME_SCAN_LOOKBACK,
-            max_resolutions_per_tick: DEFAULT_MAX_RESOLUTIONS_PER_TICK,
-            max_game_age: DEFAULT_MAX_GAME_AGE,
         }
     }
 }

--- a/proofs/defender/src/config.rs
+++ b/proofs/defender/src/config.rs
@@ -14,6 +14,9 @@ pub const DEFAULT_MAX_GAMES_PER_TICK: u64 = 100;
 /// Default number of previously scanned games reconsidered per defender tick.
 pub const DEFAULT_GAME_SCAN_LOOKBACK: u64 = 100;
 
+/// Default maximum number of game resolutions submitted per defender tick.
+pub const DEFAULT_MAX_RESOLUTIONS_PER_TICK: usize = 10;
+
 /// Default upper bound on the age of a game with an open proof window.
 pub const DEFAULT_MAX_GAME_AGE: Duration = Duration::from_secs(7 * 24 * 60 * 60);
 
@@ -30,6 +33,8 @@ pub struct DefenderConfig {
     pub max_games_per_tick: u64,
     /// Number of previously scanned games reconsidered to tolerate mutable-state L1 reorgs.
     pub game_scan_lookback: u64,
+    /// Maximum number of negatively resolvable games settled during one tick.
+    pub max_resolutions_per_tick: usize,
     /// Upper bound on the age of any game whose proof window can remain open.
     pub max_game_age: Duration,
 }
@@ -56,6 +61,11 @@ impl DefenderConfig {
                 "max_games_per_tick must be greater than zero",
             ));
         }
+        if self.max_resolutions_per_tick == 0 {
+            return Err(DefenderError::InvalidConfig(
+                "max_resolutions_per_tick must be greater than zero",
+            ));
+        }
         if self.max_game_age.is_zero() {
             return Err(DefenderError::InvalidConfig(
                 "max_game_age must be greater than zero",
@@ -73,6 +83,7 @@ impl Default for DefenderConfig {
             max_game_concurrency: DEFAULT_MAX_GAME_CONCURRENCY,
             max_games_per_tick: DEFAULT_MAX_GAMES_PER_TICK,
             game_scan_lookback: DEFAULT_GAME_SCAN_LOOKBACK,
+            max_resolutions_per_tick: DEFAULT_MAX_RESOLUTIONS_PER_TICK,
             max_game_age: DEFAULT_MAX_GAME_AGE,
         }
     }

--- a/proofs/defender/src/config.rs
+++ b/proofs/defender/src/config.rs
@@ -1,5 +1,4 @@
 use crate::error::DefenderError;
-use alloy_primitives::Address;
 use std::time::Duration;
 
 /// Default number of games processed concurrently.
@@ -23,8 +22,6 @@ pub const DEFAULT_MAX_GAME_AGE: Duration = Duration::from_secs(7 * 24 * 60 * 60)
 /// Configuration for the defender.
 #[derive(Debug, Clone)]
 pub struct DefenderConfig {
-    /// The only proposer whose games this defender is allowed to defend.
-    pub allowed_proposer: Address,
     /// Delay between periodic scan attempts.
     pub poll_interval: Duration,
     /// Maximum number of games to process concurrently.
@@ -41,11 +38,6 @@ pub struct DefenderConfig {
 
 impl DefenderConfig {
     pub(crate) fn validate(&self) -> Result<(), DefenderError> {
-        if self.allowed_proposer.is_zero() {
-            return Err(DefenderError::InvalidConfig(
-                "allowed_proposer must not be the zero address",
-            ));
-        }
         if self.poll_interval.is_zero() {
             return Err(DefenderError::InvalidConfig(
                 "poll_interval must be greater than zero",
@@ -78,7 +70,6 @@ impl DefenderConfig {
 impl Default for DefenderConfig {
     fn default() -> Self {
         Self {
-            allowed_proposer: Address::ZERO,
             poll_interval: Duration::from_mins(1),
             max_game_concurrency: DEFAULT_MAX_GAME_CONCURRENCY,
             max_games_per_tick: DEFAULT_MAX_GAMES_PER_TICK,

--- a/proofs/defender/src/defender.rs
+++ b/proofs/defender/src/defender.rs
@@ -1,22 +1,22 @@
 use crate::{
     config::DefenderConfig,
     error::DefenderError,
-    game::{GameEvaluator, GameObservation, GameOutcome},
+    game::{GameEvaluator, GameObservation},
     lane::{DEFENDED_LANE_COUNT, DEFENDED_LANES, LaneDriver, LaneState},
     traits::DefenderClient,
     types::GameMetadata,
 };
-use alloy_primitives::{Address, BlockNumber};
+use alloy_primitives::Address;
 use futures_util::{StreamExt, stream};
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     time::{SystemTime, UNIX_EPOCH},
 };
 use tracing::{error, info, warn};
-use world_chain_proofs::{ConsensusProvider, InvalidationReason, ProofLane, RootState};
+use world_chain_proofs::{ConsensusProvider, InvalidationReason, ProofLane, select_lineage};
 use world_chain_prover_service::ProofRequester;
 
-/// An active proof-support workflow for a game with a valid root.
+/// An active proof-support workflow for a selected game.
 #[derive(Debug, Clone, Copy)]
 struct ActiveDefense {
     game: GameMetadata,
@@ -36,32 +36,21 @@ impl ActiveDefense {
 /// Result of advancing a single defense for one tick.
 #[derive(Debug, Clone, Copy)]
 enum DefenseProgress {
-    /// The game left the `Challenged` state on-chain.
     Closed,
-    /// The game already has enough proof support to complete the defense.
     Complete,
-    /// The proof deadline elapsed before the defense completed.
     DeadlineElapsed,
-    /// Lane progress after this tick.
     Lanes([LaneState; DEFENDED_LANE_COUNT]),
 }
 
-/// World Chain Defender.
-///
-/// Discovers proof-system games through the factory index and watches them until
-/// resolution. It submits a TEE proof to valid proofless proposals, escalates
-/// challenged games to the configured independent-lane threshold, and resolves
-/// negatively determined games so timed-out proposals can be retried.
+/// Supplies proof support for every valid game on the proposer-selected lineage.
 #[derive(Debug)]
 pub struct WorldChainDefender<E, C, P> {
     config: DefenderConfig,
     execution_provider: E,
     consensus_provider: C,
     proof_requester: P,
-    next_game_index: Option<u64>,
-    watched_games: HashMap<Address, GameMetadata>,
     active_defenses: HashMap<Address, ActiveDefense>,
-    /// Games whose proof retries were exhausted, mapped to their proof deadline.
+    /// Selected games whose prover retries were exhausted, mapped to their proof deadline.
     abandoned_defenses: HashMap<Address, u64>,
 }
 
@@ -78,8 +67,6 @@ impl<E, C, P> WorldChainDefender<E, C, P> {
             execution_provider,
             consensus_provider,
             proof_requester,
-            next_game_index: None,
-            watched_games: HashMap::default(),
             active_defenses: HashMap::default(),
             abandoned_defenses: HashMap::default(),
         }
@@ -89,17 +76,6 @@ impl<E, C, P> WorldChainDefender<E, C, P> {
     #[must_use]
     pub const fn config(&self) -> &DefenderConfig {
         &self.config
-    }
-
-    /// Returns the next factory game index to scan, once initialized.
-    #[must_use]
-    pub const fn next_game_index(&self) -> Option<u64> {
-        self.next_game_index
-    }
-
-    #[cfg(test)]
-    pub(crate) fn watched_games(&self) -> Vec<Address> {
-        self.watched_games.keys().copied().collect()
     }
 
     #[cfg(test)]
@@ -119,122 +95,61 @@ where
     C: ConsensusProvider,
     P: ProofRequester + Sync,
 {
-    /// Binary-searches the factory's monotonic creation timestamps for the first game that
-    /// can still have an open proof window.
-    async fn first_recent_game_index(
-        &self,
-        game_count: u64,
-        cutoff: u64,
-    ) -> Result<u64, DefenderError> {
-        let mut low = 0;
-        let mut high = game_count;
+    /// Reconstructs the valid lineage selected by the same transition rule as the proposer.
+    async fn selected_lineage(&self) -> Result<Vec<GameMetadata>, DefenderError> {
+        let lineage = select_lineage(&self.execution_provider, &self.consensus_provider).await?;
+        let mut games = Vec::with_capacity(lineage.games().len());
 
-        while low < high {
-            let middle = low + (high - low) / 2;
-            if self.execution_provider.game_created_at(middle).await? < cutoff {
-                low = middle + 1;
-            } else {
-                high = middle;
+        for selected in lineage.games() {
+            let metadata = self
+                .execution_provider
+                .game_metadata(selected.game.address)
+                .await?;
+            if metadata.parent_ref != selected.transition.parent_ref
+                || metadata.root_claim != selected.transition.root_claim
+                || metadata.l2_block_number != selected.transition.l2_block_number
+            {
+                return Err(DefenderError::Contract(format!(
+                    "selected game {} does not match its transition commitment",
+                    selected.game.address
+                )));
             }
+            games.push(metadata);
         }
 
-        Ok(low)
+        Ok(games)
     }
 
-    async fn evaluate_discovered_games(
-        &self,
-        games: impl IntoIterator<Item = GameMetadata>,
-        now: u64,
-    ) -> Vec<(GameMetadata, Result<GameOutcome, DefenderError>)> {
-        let evaluator = GameEvaluator::new(&self.execution_provider, &self.consensus_provider);
-        stream::iter(games)
-            .map(move |game| {
-                let evaluator = evaluator;
-                async move {
-                    let result = evaluator.evaluate_discovered(&game, now).await;
-                    (game, result)
-                }
-            })
-            .buffer_unordered(self.config.max_game_concurrency)
-            .collect()
-            .await
-    }
-
-    fn handle_discovered_game_outcomes(
+    async fn sync_defenses_with_selected_lineage(
         &mut self,
-        outcomes: Vec<(GameMetadata, Result<GameOutcome, DefenderError>)>,
-    ) {
-        for (game, outcome) in outcomes {
-            match outcome {
-                Ok(GameOutcome::Track) => {
-                    self.watched_games.insert(game.address, game);
-                }
-                Ok(GameOutcome::Defend) => {
-                    self.watched_games.insert(game.address, game);
-                    self.start_defense(game);
-                }
-                Ok(GameOutcome::Drop) => {}
-                Err(error) => {
-                    warn!(
-                        game = %game.address,
-                        %error,
-                        "game scan failed; retaining for monitoring"
-                    );
-                    self.watched_games.insert(game.address, game);
-                }
-            }
-        }
-    }
-
-    async fn evaluate_tracked_games(
-        &self,
-        latest_finalized_l2_block: BlockNumber,
+        selected: Vec<GameMetadata>,
         now: u64,
-    ) -> Vec<(GameMetadata, Result<GameOutcome, DefenderError>)> {
-        let evaluator = GameEvaluator::new(&self.execution_provider, &self.consensus_provider);
-        stream::iter(self.watched_games.values().copied().collect::<Vec<_>>())
-            .map(move |game| {
-                let evaluator = evaluator;
-                async move {
-                    let result = evaluator
-                        .evaluate_tracked(&game, latest_finalized_l2_block, now)
-                        .await;
-                    (game, result)
-                }
-            })
-            .buffer_unordered(self.config.max_game_concurrency)
-            .collect()
-            .await
-    }
+    ) -> Result<(), DefenderError> {
+        let selected_addresses: HashSet<_> = selected.iter().map(|game| game.address).collect();
+        self.active_defenses.retain(|game, _| {
+            let keep = selected_addresses.contains(game);
+            if !keep {
+                warn!(%game, "stopping proof support because game left the selected lineage");
+            }
+            keep
+        });
+        self.abandoned_defenses
+            .retain(|game, deadline| selected_addresses.contains(game) && now < *deadline);
 
-    fn handle_tracked_game_outcomes(
-        &mut self,
-        outcomes: Vec<(GameMetadata, Result<GameOutcome, DefenderError>)>,
-    ) {
-        for (metadata, outcome) in outcomes {
-            let game = metadata.address;
-            match outcome {
-                Ok(GameOutcome::Defend) => self.start_defense(metadata),
-                Ok(GameOutcome::Drop) => {
-                    self.watched_games.remove(&game);
-                }
-                Ok(GameOutcome::Track) => {}
-                Err(err) => {
-                    warn!(game = %game, error = %err, "game watch failed; retrying next tick");
-                }
+        let evaluator = GameEvaluator::new(&self.execution_provider);
+        for game in selected {
+            if self.active_defenses.contains_key(&game.address)
+                || self.abandoned_defenses.contains_key(&game.address)
+            {
+                continue;
+            }
+            if evaluator.needs_defense(&game, now).await? {
+                info!(game = %game.address, "selected game needs proof support; starting proof workflow");
+                self.active_defenses
+                    .insert(game.address, ActiveDefense::new(game));
             }
         }
-    }
-
-    fn start_defense(&mut self, metadata: GameMetadata) {
-        let game = metadata.address;
-        if self.abandoned_defenses.contains_key(&game) {
-            return;
-        }
-        info!(%game, "game needs proof support and has a valid root; starting proof workflow");
-        self.active_defenses
-            .entry(game)
-            .or_insert_with(|| ActiveDefense::new(metadata));
+        Ok(())
     }
 
     async fn advance_defense(
@@ -243,10 +158,10 @@ where
         now: u64,
     ) -> Result<DefenseProgress, DefenderError> {
         let metadata = &defense.game;
-        let evaluator = GameEvaluator::new(&self.execution_provider, &self.consensus_provider);
-        let (proof_bitmap, deadline, initial_proof) = match evaluator.observe(metadata).await? {
+        let evaluator = GameEvaluator::new(&self.execution_provider);
+        let (proof_bitmap, deadline, tee_only) = match evaluator.observe(metadata).await? {
             GameObservation::Finalized => return Ok(DefenseProgress::Complete),
-            GameObservation::Invalidated { reason, .. } => {
+            GameObservation::Invalidated { reason } => {
                 if reason == InvalidationReason::ProofTimeout {
                     return Ok(DefenseProgress::DeadlineElapsed);
                 }
@@ -279,10 +194,9 @@ where
         let mut lanes = defense.lanes;
         let lane_driver = LaneDriver::new(&self.execution_provider, &self.proof_requester);
         for (slot, (proof_lane, backend)) in DEFENDED_LANES.into_iter().enumerate() {
-            if initial_proof && proof_lane != ProofLane::TeeAttestation {
+            if tee_only && proof_lane != ProofLane::TeeAttestation {
                 continue;
             }
-            // skip lanes already proven on-chain, by us or by anyone else
             if proof_bitmap & proof_lane.mask() != 0 {
                 lanes[slot] = LaneState::Proven;
                 continue;
@@ -352,131 +266,13 @@ where
         }
     }
 
-    async fn advance_active_defenses(&mut self, now: u64) {
-        let defense_results = self.scan_active_defenses(now).await;
-        self.handle_defense_progress(defense_results);
-    }
-
-    async fn resolve_negative_games(&self) {
-        let mut games = self.watched_games.values().copied().collect::<Vec<_>>();
-        games.sort_unstable_by_key(|game| game.l2_block_number);
-
-        let mut submitted = 0;
-        for metadata in games {
-            if submitted >= self.config.max_resolutions_per_tick {
-                break;
-            }
-            let status = match self
-                .execution_provider
-                .resolution_status(metadata.address)
-                .await
-            {
-                Ok(status) => status,
-                Err(error) => {
-                    warn!(
-                        game = %metadata.address,
-                        %error,
-                        "failed to evaluate game for negative resolution"
-                    );
-                    continue;
-                }
-            };
-            if !status.resolvable || status.root_state != RootState::Invalidated {
-                continue;
-            }
-            match self.execution_provider.resolve_game(metadata.address).await {
-                Ok(resolution) => {
-                    info!(
-                        game = %metadata.address,
-                        tx_hash = %resolution.tx_hash,
-                        reason = ?status.invalidation_reason,
-                        "resolved game with negative outcome"
-                    );
-                    submitted += 1;
-                }
-                Err(error) => {
-                    warn!(
-                        game = %metadata.address,
-                        %error,
-                        "negative game resolution failed; retrying next tick"
-                    );
-                }
-            }
-        }
-    }
-
-    async fn discover_games(&mut self, now: u64) -> Result<(), DefenderError> {
-        let game_count = self.execution_provider.game_count().await?;
-        let initialize_cursor = self
-            .next_game_index
-            .is_none_or(|next_game_index| next_game_index > game_count);
-        if initialize_cursor {
-            let cutoff = now.saturating_sub(self.config.max_game_age.as_secs());
-            let first_recent = self.first_recent_game_index(game_count, cutoff).await?;
-            info!(
-                first_recent_game_index = first_recent,
-                game_count, cutoff, "initialized defender game cursor"
-            );
-            self.next_game_index = Some(first_recent);
-        }
-
-        let cursor = self.next_game_index.unwrap_or(game_count);
-        // Factory entries are read at the finalized block, but mutable game state is read at
-        // latest. Reconsider a bounded overlap so a shallow reorg of that state cannot make a
-        // transient Drop outcome permanent. The overlap does not consume the new-game budget.
-        let start = if initialize_cursor {
-            cursor
-        } else {
-            cursor.saturating_sub(self.config.game_scan_lookback)
-        };
-        let end = cursor
-            .saturating_add(self.config.max_games_per_tick)
-            .min(game_count);
-        let mut new_games = Vec::with_capacity((end - start) as usize);
-        for index in start..end {
-            // The dispute-game factory indexes every game type; skip the ones that are not ours.
-            let Some(game) = self.execution_provider.game_address_at(index).await? else {
-                continue;
-            };
-            if self.watched_games.contains_key(&game)
-                || self.active_defenses.contains_key(&game)
-                || self.abandoned_defenses.contains_key(&game)
-            {
-                continue;
-            }
-
-            new_games.push(self.execution_provider.game_metadata(game).await?);
-        }
-
-        let outcomes = self.evaluate_discovered_games(new_games, now).await;
-        self.handle_discovered_game_outcomes(outcomes);
-        self.next_game_index = Some(end);
-        Ok(())
-    }
-
-    async fn advance_tracked_games(&mut self, now: u64) -> Result<(), DefenderError> {
-        if self.watched_games.is_empty() {
-            return Ok(());
-        }
-
-        let latest_finalized_l2_block = self.consensus_provider.latest_l2_finalized_block().await?;
-
-        let outcomes = self
-            .evaluate_tracked_games(latest_finalized_l2_block, now)
-            .await;
-        self.handle_tracked_game_outcomes(outcomes);
-        Ok(())
-    }
-
     pub(crate) async fn tick_at(&mut self, now: u64) -> Result<(), DefenderError> {
         self.config.validate()?;
-        self.abandoned_defenses
-            .retain(|_, proof_deadline| now < *proof_deadline);
-
-        self.resolve_negative_games().await;
-        self.advance_active_defenses(now).await;
-        self.advance_tracked_games(now).await?;
-        self.discover_games(now).await?;
+        let selected = self.selected_lineage().await?;
+        self.sync_defenses_with_selected_lineage(selected, now)
+            .await?;
+        let progress = self.scan_active_defenses(now).await;
+        self.handle_defense_progress(progress);
         Ok(())
     }
 
@@ -493,7 +289,7 @@ where
         loop {
             interval.tick().await;
             if let Err(e) = self.tick().await {
-                warn!(%e, "scan attempt failed");
+                warn!(%e, "defender iteration failed; retrying on next tick");
             }
         }
     }

--- a/proofs/defender/src/defender.rs
+++ b/proofs/defender/src/defender.rs
@@ -48,7 +48,7 @@ enum DefenseProgress {
 
 /// World Chain Defender.
 ///
-/// Discovers allowlisted games through the factory index and watches them until
+/// Discovers proof-system games through the factory index and watches them until
 /// resolution. It submits a TEE proof to valid proofless proposals, escalates
 /// challenged games to the configured independent-lane threshold, and resolves
 /// negatively determined games so timed-out proposals can be retried.
@@ -228,6 +228,9 @@ where
 
     fn start_defense(&mut self, metadata: GameMetadata) {
         let game = metadata.address;
+        if self.abandoned_defenses.contains_key(&game) {
+            return;
+        }
         info!(%game, "game needs proof support and has a valid root; starting proof workflow");
         self.active_defenses
             .entry(game)
@@ -442,15 +445,6 @@ where
                 continue;
             }
 
-            // TODO: The proposer adopts an existing canonical transition regardless of who
-            // created it, so an exact-UUID front-run is followed but currently receives no proof
-            // support here. Reconcile the policies by defending the game selected by the
-            // proposer's canonical-line rules; accepting every foreign game with a valid root
-            // would let parallel branches amplify proof-generation work.
-            let game_creator = self.execution_provider.game_creator(game).await?;
-            if game_creator != self.config.allowed_proposer {
-                continue;
-            }
             new_games.push(self.execution_provider.game_metadata(game).await?);
         }
 

--- a/proofs/defender/src/defender.rs
+++ b/proofs/defender/src/defender.rs
@@ -13,10 +13,10 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 use tracing::{error, info, warn};
-use world_chain_proofs::{ConsensusProvider, InvalidationReason};
+use world_chain_proofs::{ConsensusProvider, InvalidationReason, ProofLane, RootState};
 use world_chain_prover_service::ProofRequester;
 
-/// An active defense of a challenged game with a valid root.
+/// An active proof-support workflow for a game with a valid root.
 #[derive(Debug, Clone, Copy)]
 struct ActiveDefense {
     game: GameMetadata,
@@ -49,10 +49,9 @@ enum DefenseProgress {
 /// World Chain Defender.
 ///
 /// Discovers allowlisted games through the factory index and watches them until
-/// they no longer need defense. When a game is challenged and its root claim
-/// matches the canonical output root, the defender requests one proof per
-/// defended lane from the `prover-service` and submits each completed proof
-/// on-chain via `submitProofLane`.
+/// resolution. It submits a TEE proof to valid proofless proposals, escalates
+/// challenged games to the configured independent-lane threshold, and resolves
+/// negatively determined games so timed-out proposals can be retried.
 #[derive(Debug)]
 pub struct WorldChainDefender<E, C, P> {
     config: DefenderConfig,
@@ -170,7 +169,10 @@ where
                 Ok(GameOutcome::Track) => {
                     self.watched_games.insert(game.address, game);
                 }
-                Ok(GameOutcome::Defend) => self.start_defense(game),
+                Ok(GameOutcome::Defend) => {
+                    self.watched_games.insert(game.address, game);
+                    self.start_defense(game);
+                }
                 Ok(GameOutcome::Drop) => {}
                 Err(error) => {
                     warn!(
@@ -226,10 +228,10 @@ where
 
     fn start_defense(&mut self, metadata: GameMetadata) {
         let game = metadata.address;
-        info!(%game, "challenged game has a valid root; starting defense");
-        self.watched_games.remove(&game);
+        info!(%game, "game needs proof support and has a valid root; starting proof workflow");
         self.active_defenses
-            .insert(game, ActiveDefense::new(metadata));
+            .entry(game)
+            .or_insert_with(|| ActiveDefense::new(metadata));
     }
 
     async fn advance_defense(
@@ -239,13 +241,22 @@ where
     ) -> Result<DefenseProgress, DefenderError> {
         let metadata = &defense.game;
         let evaluator = GameEvaluator::new(&self.execution_provider, &self.consensus_provider);
-        let proof_bitmap = match evaluator.observe(metadata).await? {
+        let (proof_bitmap, deadline, initial_proof) = match evaluator.observe(metadata).await? {
             GameObservation::Finalized => return Ok(DefenseProgress::Complete),
-            GameObservation::Invalidated(reason) => {
+            GameObservation::Invalidated { reason, .. } => {
                 if reason == InvalidationReason::ProofTimeout {
                     return Ok(DefenseProgress::DeadlineElapsed);
                 }
                 return Ok(DefenseProgress::Closed);
+            }
+            GameObservation::Proposed {
+                proof_bitmap,
+                has_initial_support,
+            } => {
+                if has_initial_support {
+                    return Ok(DefenseProgress::Complete);
+                }
+                (proof_bitmap, metadata.challenge_deadline, true)
             }
             GameObservation::Challenged {
                 proof_bitmap,
@@ -254,19 +265,20 @@ where
                 if has_required_support {
                     return Ok(DefenseProgress::Complete);
                 }
-                proof_bitmap
+                (proof_bitmap, metadata.proof_deadline, false)
             }
-            GameObservation::Unset | GameObservation::Proposed => {
-                return Ok(DefenseProgress::Closed);
-            }
+            GameObservation::Unset => return Ok(DefenseProgress::Closed),
         };
-        if now >= metadata.proof_deadline {
+        if now >= deadline {
             return Ok(DefenseProgress::DeadlineElapsed);
         }
 
         let mut lanes = defense.lanes;
         let lane_driver = LaneDriver::new(&self.execution_provider, &self.proof_requester);
         for (slot, (proof_lane, backend)) in DEFENDED_LANES.into_iter().enumerate() {
+            if initial_proof && proof_lane != ProofLane::TeeAttestation {
+                continue;
+            }
             // skip lanes already proven on-chain, by us or by anyone else
             if proof_bitmap & proof_lane.mask() != 0 {
                 lanes[slot] = LaneState::Proven;
@@ -311,8 +323,9 @@ where
                 Ok(DefenseProgress::DeadlineElapsed) => {
                     error!(
                         %game,
+                        challenge_deadline = defense.game.challenge_deadline,
                         proof_deadline = defense.game.proof_deadline,
-                        "challenged game proof deadline elapsed before defense completed"
+                        "game proof deadline elapsed before proof support completed"
                     );
                     self.active_defenses.remove(&game);
                 }
@@ -339,6 +352,54 @@ where
     async fn advance_active_defenses(&mut self, now: u64) {
         let defense_results = self.scan_active_defenses(now).await;
         self.handle_defense_progress(defense_results);
+    }
+
+    async fn resolve_negative_games(&self) {
+        let mut games = self.watched_games.values().copied().collect::<Vec<_>>();
+        games.sort_unstable_by_key(|game| game.l2_block_number);
+
+        let mut submitted = 0;
+        for metadata in games {
+            if submitted >= self.config.max_resolutions_per_tick {
+                break;
+            }
+            let status = match self
+                .execution_provider
+                .resolution_status(metadata.address)
+                .await
+            {
+                Ok(status) => status,
+                Err(error) => {
+                    warn!(
+                        game = %metadata.address,
+                        %error,
+                        "failed to evaluate game for negative resolution"
+                    );
+                    continue;
+                }
+            };
+            if !status.resolvable || status.root_state != RootState::Invalidated {
+                continue;
+            }
+            match self.execution_provider.resolve_game(metadata.address).await {
+                Ok(resolution) => {
+                    info!(
+                        game = %metadata.address,
+                        tx_hash = %resolution.tx_hash,
+                        reason = ?status.invalidation_reason,
+                        "resolved game with negative outcome"
+                    );
+                    submitted += 1;
+                }
+                Err(error) => {
+                    warn!(
+                        game = %metadata.address,
+                        %error,
+                        "negative game resolution failed; retrying next tick"
+                    );
+                }
+            }
+        }
     }
 
     async fn discover_games(&mut self, now: u64) -> Result<(), DefenderError> {
@@ -381,6 +442,11 @@ where
                 continue;
             }
 
+            // TODO: The proposer adopts an existing canonical transition regardless of who
+            // created it, so an exact-UUID front-run is followed but currently receives no proof
+            // support here. Reconcile the policies by defending the game selected by the
+            // proposer's canonical-line rules; accepting every foreign game with a valid root
+            // would let parallel branches amplify proof-generation work.
             let game_creator = self.execution_provider.game_creator(game).await?;
             if game_creator != self.config.allowed_proposer {
                 continue;
@@ -413,6 +479,7 @@ where
         self.abandoned_defenses
             .retain(|_, proof_deadline| now < *proof_deadline);
 
+        self.resolve_negative_games().await;
         self.advance_active_defenses(now).await;
         self.advance_tracked_games(now).await?;
         self.discover_games(now).await?;

--- a/proofs/defender/src/error.rs
+++ b/proofs/defender/src/error.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::TxHash;
 use thiserror::Error;
-use world_chain_proofs::{ConsensusError, InvalidationReasonError, RootStateError};
+use world_chain_proofs::LineageError;
 
 /// Errors returned by the defender.
 #[derive(Debug, Error)]
@@ -15,11 +15,7 @@ pub enum DefenderError {
     #[error("invalid proof payload: {0}")]
     ProofEncoding(String),
     #[error(transparent)]
-    InvalidRootState(#[from] RootStateError),
-    #[error(transparent)]
-    InvalidInvalidationReason(#[from] InvalidationReasonError),
-    #[error(transparent)]
-    OutputRoot(#[from] ConsensusError),
+    Lineage(#[from] LineageError),
     #[error("The submitProofLane transaction didn't execute succesfully: {0}")]
     Revert(TxHash),
 }

--- a/proofs/defender/src/error.rs
+++ b/proofs/defender/src/error.rs
@@ -11,6 +11,9 @@ pub enum DefenderError {
     /// Contract call or transaction failure.
     #[error("contract error: {0}")]
     Contract(String),
+    /// Prover response could not be encoded for its on-chain verifier.
+    #[error("invalid proof payload: {0}")]
+    ProofEncoding(String),
     #[error(transparent)]
     InvalidRootState(#[from] RootStateError),
     #[error(transparent)]

--- a/proofs/defender/src/game.rs
+++ b/proofs/defender/src/game.rs
@@ -243,7 +243,7 @@ where
                 claimed_root = %game.root_claim,
                 canonical_root = %root,
                 challenged,
-                "allowlisted proposer published a non-canonical root; refusing proof support"
+                "game claims a non-canonical root; refusing proof support"
             );
             Ok(GameOutcome::Track)
         }

--- a/proofs/defender/src/game.rs
+++ b/proofs/defender/src/game.rs
@@ -6,21 +6,29 @@ use world_chain_proofs::{ConsensusProvider, InvalidationReason, RootState, proof
 /// On-chain state relevant to the defender for a single game.
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum GameObservation {
-    Proposed,
+    Proposed {
+        proof_bitmap: u8,
+        has_initial_support: bool,
+    },
     Challenged {
         proof_bitmap: u8,
         has_required_support: bool,
     },
     Finalized,
-    Invalidated(InvalidationReason),
+    Invalidated {
+        reason: InvalidationReason,
+        resolvable: bool,
+    },
     Unset,
 }
 
 #[derive(Debug, Clone, Copy)]
 enum GameAssessment {
-    Proposed,
+    Proposed { has_initial_support: bool },
     Challenged,
+    AwaitingResolution,
     Finalized,
+    Invalidatable,
     Closed,
 }
 
@@ -29,7 +37,7 @@ enum GameAssessment {
 pub(crate) enum GameOutcome {
     /// Retain the game for monitoring.
     Track,
-    /// The game was challenged and its root is valid: start a defense.
+    /// The game needs proof support and its root is valid: start a defense.
     Defend,
     /// The game no longer needs watching.
     Drop,
@@ -69,7 +77,13 @@ where
             .resolution_status(game.address)
             .await?;
         Ok(match status.root_state {
-            RootState::Proposed => GameObservation::Proposed,
+            RootState::Proposed => {
+                let proof_bitmap = self.execution_client.proof_bitmap(game.address).await?;
+                GameObservation::Proposed {
+                    proof_bitmap,
+                    has_initial_support: proof_bitmap != 0,
+                }
+            }
             RootState::Challenged => {
                 let proof_bitmap = self.execution_client.proof_bitmap(game.address).await?;
                 GameObservation::Challenged {
@@ -78,18 +92,26 @@ where
                 }
             }
             RootState::Finalized => GameObservation::Finalized,
-            RootState::Invalidated => GameObservation::Invalidated(status.invalidation_reason),
+            RootState::Invalidated => GameObservation::Invalidated {
+                reason: status.invalidation_reason,
+                resolvable: status.resolvable,
+            },
             RootState::None => GameObservation::Unset,
         })
     }
 
     async fn assess(&self, game: &GameMetadata, now: u64) -> Result<GameAssessment, DefenderError> {
         match self.observe(game).await? {
-            GameObservation::Proposed => {
+            GameObservation::Proposed {
+                has_initial_support,
+                ..
+            } => {
                 if now < game.challenge_deadline {
-                    Ok(GameAssessment::Proposed)
+                    Ok(GameAssessment::Proposed {
+                        has_initial_support,
+                    })
                 } else {
-                    Ok(GameAssessment::Closed)
+                    Ok(GameAssessment::AwaitingResolution)
                 }
             }
             GameObservation::Challenged {
@@ -111,17 +133,18 @@ where
                         proof_deadline = game.proof_deadline,
                         "challenged game proof deadline elapsed before defense completed"
                     );
-                    return Ok(GameAssessment::Closed);
+                    return Ok(GameAssessment::AwaitingResolution);
                 }
                 Ok(GameAssessment::Challenged)
             }
             GameObservation::Finalized => Ok(GameAssessment::Finalized),
-            GameObservation::Invalidated(reason) => {
+            GameObservation::Invalidated { reason, resolvable } => {
                 if reason == InvalidationReason::ProofTimeout {
                     error!(
                         game = %game.address,
+                        challenge_deadline = game.challenge_deadline,
                         proof_deadline = game.proof_deadline,
-                        "challenged game proof deadline elapsed before defense completed"
+                        "game proof deadline elapsed before sufficient support was submitted"
                     );
                 } else {
                     warn!(
@@ -130,7 +153,11 @@ where
                         "game is invalidatable without defense"
                     );
                 }
-                Ok(GameAssessment::Closed)
+                Ok(if resolvable {
+                    GameAssessment::Invalidatable
+                } else {
+                    GameAssessment::Closed
+                })
             }
             GameObservation::Unset => {
                 error!(game = %game.address, "factory game has unset root state");
@@ -145,7 +172,10 @@ where
         now: u64,
     ) -> Result<GameOutcome, DefenderError> {
         Ok(match self.assess(game, now).await? {
-            GameAssessment::Proposed | GameAssessment::Challenged => GameOutcome::Track,
+            GameAssessment::Proposed { .. }
+            | GameAssessment::Challenged
+            | GameAssessment::AwaitingResolution
+            | GameAssessment::Invalidatable => GameOutcome::Track,
             GameAssessment::Finalized => {
                 info!(
                     game = %game.address,
@@ -163,30 +193,22 @@ where
         latest_finalized_l2_block: BlockNumber,
         now: u64,
     ) -> Result<GameOutcome, DefenderError> {
-        let address = game.address;
         match self.assess(game, now).await? {
-            GameAssessment::Proposed => Ok(GameOutcome::Track),
-            GameAssessment::Challenged => {
-                // only judge the root against finalized L2 state
-                if game.l2_block_number > latest_finalized_l2_block {
+            GameAssessment::Proposed {
+                has_initial_support,
+            } => {
+                if has_initial_support {
                     return Ok(GameOutcome::Track);
                 }
-                let root = self
-                    .consensus_provider
-                    .output_root_at_block(game.l2_block_number)
-                    .await?;
-                if root == game.root_claim {
-                    Ok(GameOutcome::Defend)
-                } else {
-                    error!(
-                        game = %address,
-                        claimed_root = %game.root_claim,
-                        canonical_root = %root,
-                        "allowlisted proposer published a non-canonical root; refusing to defend"
-                    );
-                    Ok(GameOutcome::Drop)
-                }
+                self.evaluate_root(game, latest_finalized_l2_block, false)
+                    .await
             }
+            GameAssessment::Challenged => {
+                self.evaluate_root(game, latest_finalized_l2_block, true)
+                    .await
+            }
+            GameAssessment::Invalidatable => Ok(GameOutcome::Track),
+            GameAssessment::AwaitingResolution => Ok(GameOutcome::Track),
             GameAssessment::Finalized => {
                 info!(
                     game = %game.address,
@@ -195,6 +217,35 @@ where
                 Ok(GameOutcome::Drop)
             }
             GameAssessment::Closed => Ok(GameOutcome::Drop),
+        }
+    }
+
+    async fn evaluate_root(
+        &self,
+        game: &GameMetadata,
+        latest_finalized_l2_block: BlockNumber,
+        challenged: bool,
+    ) -> Result<GameOutcome, DefenderError> {
+        let address = game.address;
+        // Only support claims checked against finalized L2 state.
+        if game.l2_block_number > latest_finalized_l2_block {
+            return Ok(GameOutcome::Track);
+        }
+        let root = self
+            .consensus_provider
+            .output_root_at_block(game.l2_block_number)
+            .await?;
+        if root == game.root_claim {
+            Ok(GameOutcome::Defend)
+        } else {
+            error!(
+                game = %address,
+                claimed_root = %game.root_claim,
+                canonical_root = %root,
+                challenged,
+                "allowlisted proposer published a non-canonical root; refusing proof support"
+            );
+            Ok(GameOutcome::Track)
         }
     }
 }

--- a/proofs/defender/src/game.rs
+++ b/proofs/defender/src/game.rs
@@ -1,9 +1,7 @@
 use crate::{error::DefenderError, traits::DefenderClient, types::GameMetadata};
-use alloy_primitives::BlockNumber;
-use tracing::{error, info, warn};
-use world_chain_proofs::{ConsensusProvider, InvalidationReason, RootState, proof_count};
+use world_chain_proofs::{InvalidationReason, RootState, proof_count};
 
-/// On-chain state relevant to the defender for a single game.
+/// On-chain state relevant to proof support for one selected game.
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum GameObservation {
     Proposed {
@@ -17,55 +15,20 @@ pub(crate) enum GameObservation {
     Finalized,
     Invalidated {
         reason: InvalidationReason,
-        resolvable: bool,
     },
     Unset,
 }
 
-#[derive(Debug, Clone, Copy)]
-enum GameAssessment {
-    Proposed { has_initial_support: bool },
-    Challenged,
-    AwaitingResolution,
-    Finalized,
-    Invalidatable,
-    Closed,
-}
-
-/// Result of evaluating a game for one tick.
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum GameOutcome {
-    /// Retain the game for monitoring.
-    Track,
-    /// The game needs proof support and its root is valid: start a defense.
-    Defend,
-    /// The game no longer needs watching.
-    Drop,
-}
-
-pub(crate) struct GameEvaluator<'a, E, C> {
+pub(crate) struct GameEvaluator<'a, E> {
     execution_client: &'a E,
-    consensus_provider: &'a C,
 }
 
-impl<'a, E, C> Clone for GameEvaluator<'a, E, C> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<E, C> Copy for GameEvaluator<'_, E, C> {}
-
-impl<'a, E, C> GameEvaluator<'a, E, C>
+impl<'a, E> GameEvaluator<'a, E>
 where
     E: DefenderClient,
-    C: ConsensusProvider,
 {
-    pub(crate) const fn new(execution_client: &'a E, consensus_provider: &'a C) -> Self {
-        Self {
-            execution_client,
-            consensus_provider,
-        }
+    pub(crate) const fn new(execution_client: &'a E) -> Self {
+        Self { execution_client }
     }
 
     pub(crate) async fn observe(
@@ -74,7 +37,7 @@ where
     ) -> Result<GameObservation, DefenderError> {
         let status = self
             .execution_client
-            .resolution_status(game.address)
+            .lineage_resolution_status(game.address)
             .await?;
         Ok(match status.root_state {
             RootState::Proposed => {
@@ -88,168 +51,34 @@ where
                 let proof_bitmap = self.execution_client.proof_bitmap(game.address).await?;
                 GameObservation::Challenged {
                     proof_bitmap,
-                    has_required_support: has_required_proof_support(game, proof_bitmap),
+                    has_required_support: proof_count(proof_bitmap) >= game.proof_threshold,
                 }
             }
             RootState::Finalized => GameObservation::Finalized,
             RootState::Invalidated => GameObservation::Invalidated {
                 reason: status.invalidation_reason,
-                resolvable: status.resolvable,
             },
             RootState::None => GameObservation::Unset,
         })
     }
 
-    async fn assess(&self, game: &GameMetadata, now: u64) -> Result<GameAssessment, DefenderError> {
-        match self.observe(game).await? {
+    pub(crate) async fn needs_defense(
+        &self,
+        game: &GameMetadata,
+        now: u64,
+    ) -> Result<bool, DefenderError> {
+        Ok(match self.observe(game).await? {
             GameObservation::Proposed {
                 has_initial_support,
                 ..
-            } => {
-                if now < game.challenge_deadline {
-                    Ok(GameAssessment::Proposed {
-                        has_initial_support,
-                    })
-                } else {
-                    Ok(GameAssessment::AwaitingResolution)
-                }
-            }
+            } => !has_initial_support && now < game.challenge_deadline,
             GameObservation::Challenged {
-                proof_bitmap,
                 has_required_support,
-            } => {
-                if has_required_support {
-                    info!(
-                        game = %game.address,
-                        proof_bitmap,
-                        proof_threshold = game.proof_threshold,
-                        "challenged game already has sufficient proof support"
-                    );
-                    return Ok(GameAssessment::Closed);
-                }
-                if now >= game.proof_deadline {
-                    error!(
-                        game = %game.address,
-                        proof_deadline = game.proof_deadline,
-                        "challenged game proof deadline elapsed before defense completed"
-                    );
-                    return Ok(GameAssessment::AwaitingResolution);
-                }
-                Ok(GameAssessment::Challenged)
-            }
-            GameObservation::Finalized => Ok(GameAssessment::Finalized),
-            GameObservation::Invalidated { reason, resolvable } => {
-                if reason == InvalidationReason::ProofTimeout {
-                    error!(
-                        game = %game.address,
-                        challenge_deadline = game.challenge_deadline,
-                        proof_deadline = game.proof_deadline,
-                        "game proof deadline elapsed before sufficient support was submitted"
-                    );
-                } else {
-                    warn!(
-                        game = %game.address,
-                        reason = ?reason,
-                        "game is invalidatable without defense"
-                    );
-                }
-                Ok(if resolvable {
-                    GameAssessment::Invalidatable
-                } else {
-                    GameAssessment::Closed
-                })
-            }
-            GameObservation::Unset => {
-                error!(game = %game.address, "factory game has unset root state");
-                Ok(GameAssessment::Closed)
-            }
-        }
-    }
-
-    pub(crate) async fn evaluate_discovered(
-        &self,
-        game: &GameMetadata,
-        now: u64,
-    ) -> Result<GameOutcome, DefenderError> {
-        Ok(match self.assess(game, now).await? {
-            GameAssessment::Proposed { .. }
-            | GameAssessment::Challenged
-            | GameAssessment::AwaitingResolution
-            | GameAssessment::Invalidatable => GameOutcome::Track,
-            GameAssessment::Finalized => {
-                info!(
-                    game = %game.address,
-                    "game already has a positive resolution outcome"
-                );
-                GameOutcome::Drop
-            }
-            GameAssessment::Closed => GameOutcome::Drop,
+                ..
+            } => !has_required_support && now < game.proof_deadline,
+            GameObservation::Finalized
+            | GameObservation::Invalidated { .. }
+            | GameObservation::Unset => false,
         })
     }
-
-    pub(crate) async fn evaluate_tracked(
-        &self,
-        game: &GameMetadata,
-        latest_finalized_l2_block: BlockNumber,
-        now: u64,
-    ) -> Result<GameOutcome, DefenderError> {
-        match self.assess(game, now).await? {
-            GameAssessment::Proposed {
-                has_initial_support,
-            } => {
-                if has_initial_support {
-                    return Ok(GameOutcome::Track);
-                }
-                self.evaluate_root(game, latest_finalized_l2_block, false)
-                    .await
-            }
-            GameAssessment::Challenged => {
-                self.evaluate_root(game, latest_finalized_l2_block, true)
-                    .await
-            }
-            GameAssessment::Invalidatable => Ok(GameOutcome::Track),
-            GameAssessment::AwaitingResolution => Ok(GameOutcome::Track),
-            GameAssessment::Finalized => {
-                info!(
-                    game = %game.address,
-                    "game has a positive resolution outcome"
-                );
-                Ok(GameOutcome::Drop)
-            }
-            GameAssessment::Closed => Ok(GameOutcome::Drop),
-        }
-    }
-
-    async fn evaluate_root(
-        &self,
-        game: &GameMetadata,
-        latest_finalized_l2_block: BlockNumber,
-        challenged: bool,
-    ) -> Result<GameOutcome, DefenderError> {
-        let address = game.address;
-        // Only support claims checked against finalized L2 state.
-        if game.l2_block_number > latest_finalized_l2_block {
-            return Ok(GameOutcome::Track);
-        }
-        let root = self
-            .consensus_provider
-            .output_root_at_block(game.l2_block_number)
-            .await?;
-        if root == game.root_claim {
-            Ok(GameOutcome::Defend)
-        } else {
-            error!(
-                game = %address,
-                claimed_root = %game.root_claim,
-                canonical_root = %root,
-                challenged,
-                "game claims a non-canonical root; refusing proof support"
-            );
-            Ok(GameOutcome::Track)
-        }
-    }
-}
-
-fn has_required_proof_support(game: &GameMetadata, proof_bitmap: u8) -> bool {
-    proof_count(proof_bitmap) >= game.proof_threshold
 }

--- a/proofs/defender/src/lane.rs
+++ b/proofs/defender/src/lane.rs
@@ -1,6 +1,8 @@
-use crate::{traits::DefenderClient, types::GameMetadata};
-use alloy_primitives::Bytes;
+use crate::{error::DefenderError, traits::DefenderClient, types::GameMetadata};
+use alloy_primitives::{Bytes, U256};
+use alloy_sol_types::SolValue;
 use tracing::{error, info, warn};
+use world_chain_proof_core::boot::TransitionPublicValues;
 use world_chain_proofs::ProofLane;
 use world_chain_prover_service::{
     ProofBackend, ProofData, ProofRequest, ProofRequestError, ProofRequestId, ProofRequester,
@@ -159,7 +161,17 @@ where
 
         match self
             .execution_client
-            .submit_proof(game, lane as u8, encode_proof(&response.proof))
+            .submit_proof(
+                game,
+                lane as u8,
+                match encode_proof(metadata, &response.proof) {
+                    Ok(proof) => proof,
+                    Err(error) => {
+                        error!(%game, ?lane, %error, "prover returned an invalid proof payload");
+                        return LaneState::Abandoned;
+                    }
+                },
+            )
             .await
         {
             Ok(submission) => {
@@ -226,30 +238,40 @@ fn proof_request(game: &GameMetadata, backend: ProofBackend) -> ProofRequest {
     }
 }
 
-/// Encode a proof payload into the `bytes` argument of `submitProofLane`.
-///
-/// TODO: encode proofs for their concrete on-chain verifiers. SP1 proofs must
-/// match `SP1ValidityVerifier`'s ABI tuple:
-/// `(domainHash, parentRef, l1OriginNumber, publicValues, proofBytes)`.
-/// That requires proposal context in addition to `ProofData`, so this helper
-/// should move closer to the game/lane submission path before real SP1 lanes
-/// are enabled.
-fn encode_proof(proof: &ProofData) -> Bytes {
+/// Encodes the verifier-specific payload passed to `submitProofLane`.
+fn encode_proof(metadata: &GameMetadata, proof: &ProofData) -> Result<Bytes, DefenderError> {
+    let l1_origin_number = U256::from(metadata.l1_origin_number);
     match proof {
         ProofData::Sp1 {
             proof,
             public_values,
-        } => [public_values.as_ref(), proof.as_ref()].concat().into(),
+        } => Ok((
+            metadata.domain_hash,
+            metadata.parent_ref,
+            l1_origin_number,
+            public_values.clone(),
+            proof.clone(),
+        )
+            .abi_encode()
+            .into()),
         ProofData::Nitro {
-            attestation,
+            attestation: _,
             public_values,
             signature,
-        } => [
-            public_values.as_ref(),
-            attestation.as_ref(),
-            signature.as_ref(),
-        ]
-        .concat()
-        .into(),
+            public_key,
+        } => {
+            let transition = <TransitionPublicValues as SolValue>::abi_decode(public_values)
+                .map_err(|error| DefenderError::ProofEncoding(error.to_string()))?;
+            Ok((
+                metadata.domain_hash,
+                metadata.parent_ref,
+                l1_origin_number,
+                transition,
+                signature.clone(),
+                public_key.clone(),
+            )
+                .abi_encode()
+                .into())
+        }
     }
 }

--- a/proofs/defender/src/lane.rs
+++ b/proofs/defender/src/lane.rs
@@ -260,6 +260,9 @@ fn encode_proof(metadata: &GameMetadata, proof: &ProofData) -> Result<Bytes, Def
             signature,
             public_key,
         } => {
+            // The prover API transports public values as bytes, but NitroProofVerifier embeds
+            // TransitionPublicValues as a static tuple. Encoding the bytes directly would add a
+            // dynamic ABI offset and produce a payload the verifier cannot decode.
             let transition = <TransitionPublicValues as SolValue>::abi_decode(public_values)
                 .map_err(|error| DefenderError::ProofEncoding(error.to_string()))?;
             Ok((

--- a/proofs/defender/src/lib.rs
+++ b/proofs/defender/src/lib.rs
@@ -11,11 +11,11 @@ mod types;
 
 // re-exports
 pub use alloy::AlloyDefenderClient;
-pub use config::{DEFAULT_GAME_SCAN_LOOKBACK, DEFAULT_L1_TX_CONFIRMATIONS, DefenderConfig};
+pub use config::{DEFAULT_L1_TX_CONFIRMATIONS, DefenderConfig};
 pub use defender::WorldChainDefender;
 pub use error::DefenderError;
 pub use traits::DefenderClient;
-pub use types::{DefenderSubmission, GameMetadata, ResolveSubmission};
+pub use types::{DefenderSubmission, GameMetadata};
 
 #[cfg(test)]
 mod tests;

--- a/proofs/defender/src/lib.rs
+++ b/proofs/defender/src/lib.rs
@@ -15,7 +15,7 @@ pub use config::{DEFAULT_GAME_SCAN_LOOKBACK, DEFAULT_L1_TX_CONFIRMATIONS, Defend
 pub use defender::WorldChainDefender;
 pub use error::DefenderError;
 pub use traits::DefenderClient;
-pub use types::{DefenderSubmission, GameMetadata};
+pub use types::{DefenderSubmission, GameMetadata, ResolveSubmission};
 
 #[cfg(test)]
 mod tests;

--- a/proofs/defender/src/main.rs
+++ b/proofs/defender/src/main.rs
@@ -1,5 +1,5 @@
-//! `world-chain-defender` binary: supplies initial proof support for valid WIP-1006 games,
-//! escalates challenged games to the proof threshold, and resolves negative outcomes.
+//! `world-chain-defender` binary: supplies proof support for the valid WIP-1006 games selected
+//! from the current anchor and escalates challenged games to the proof threshold.
 //!
 //! Mirrors the in-process defender wired by the devnet harness
 //! (`crates/devnet/src/full_stack.rs::start_world_chain_defender`), reading its
@@ -16,8 +16,7 @@ use clap::Parser;
 use tracing::info;
 use url::Url;
 use world_chain_defender::{
-    AlloyDefenderClient, DEFAULT_GAME_SCAN_LOOKBACK, DEFAULT_L1_TX_CONFIRMATIONS, DefenderConfig,
-    WorldChainDefender,
+    AlloyDefenderClient, DEFAULT_L1_TX_CONFIRMATIONS, DefenderConfig, WorldChainDefender,
 };
 use world_chain_proofs::OptimismConsensusClient;
 use world_chain_prover_service::RpcProverServiceClient;
@@ -25,7 +24,7 @@ use world_chain_prover_service::RpcProverServiceClient;
 #[derive(Debug, Parser)]
 #[command(
     name = "world-chain-defender",
-    about = "World Chain proof-system defender: proves, escalates, and resolves games"
+    about = "World Chain proof-system defender: proves the lineage selected from the anchor"
 )]
 struct Cli {
     /// Ethereum L1 execution RPC URL.
@@ -48,25 +47,13 @@ struct Cli {
     #[arg(long, env = "DEFENDER_KEY", hide_env_values = true)]
     defender_key: PrivateKeySigner,
 
-    /// Seconds between game-factory polls.
+    /// Seconds between selected-lineage scans.
     #[arg(long, env = "POLL_INTERVAL_SECONDS", default_value_t = 12)]
     poll_interval_seconds: u64,
 
     /// Maximum number of games processed concurrently.
     #[arg(long, env = "MAX_GAME_CONCURRENCY", default_value_t = 10)]
     max_game_concurrency: usize,
-
-    /// Maximum number of newly created games discovered per defender tick.
-    #[arg(long, env = "MAX_GAMES_PER_TICK", default_value_t = 100)]
-    max_games_per_tick: u64,
-
-    /// Number of previously scanned games reconsidered per defender tick.
-    #[arg(
-        long,
-        env = "GAME_SCAN_LOOKBACK",
-        default_value_t = DEFAULT_GAME_SCAN_LOOKBACK
-    )]
-    game_scan_lookback: u64,
 
     /// Number of L1 confirmations required before a proof submission is accepted.
     #[arg(
@@ -76,14 +63,6 @@ struct Cli {
         value_parser = clap::value_parser!(u64).range(1..)
     )]
     l1_tx_confirmations: u64,
-
-    /// Maximum number of negatively resolvable games settled per defender tick.
-    #[arg(long, env = "MAX_RESOLUTIONS_PER_TICK", default_value_t = 10)]
-    max_resolutions_per_tick: usize,
-
-    /// Conservative upper bound on the age of a game with an open proof window.
-    #[arg(long, env = "MAX_GAME_AGE_SECONDS", default_value_t = 604_800)]
-    max_game_age_seconds: u64,
 }
 
 #[tokio::main]
@@ -100,17 +79,15 @@ async fn main() -> Result<()> {
         .wallet(EthereumWallet::from(cli.defender_key))
         .connect_http(Url::parse(&cli.l1_rpc).context("invalid L1 RPC URL")?);
 
-    let client = AlloyDefenderClient::new(provider, cli.factory_address, cli.l1_tx_confirmations);
+    let client = AlloyDefenderClient::new(provider, cli.factory_address, cli.l1_tx_confirmations)
+        .await
+        .context("failed to connect defender to the registered proof system")?;
     let output_roots = OptimismConsensusClient::new(cli.output_root_rpc.clone());
     let proof_requester = RpcProverServiceClient::new(&cli.prover_service_url)
         .with_context(|| format!("failed to connect to {}", cli.prover_service_url))?;
     let config = DefenderConfig {
         poll_interval: Duration::from_secs(cli.poll_interval_seconds),
         max_game_concurrency: cli.max_game_concurrency,
-        max_games_per_tick: cli.max_games_per_tick,
-        game_scan_lookback: cli.game_scan_lookback,
-        max_resolutions_per_tick: cli.max_resolutions_per_tick,
-        max_game_age: Duration::from_secs(cli.max_game_age_seconds),
     };
     let mut defender = WorldChainDefender::new(config, client, output_roots, proof_requester);
 
@@ -120,10 +97,7 @@ async fn main() -> Result<()> {
         prover_service = %cli.prover_service_url,
         dispute_game_factory = %cli.factory_address,
         defender = %defender_address,
-        max_games_per_tick = cli.max_games_per_tick,
-        game_scan_lookback = cli.game_scan_lookback,
         l1_tx_confirmations = cli.l1_tx_confirmations,
-        max_resolutions_per_tick = cli.max_resolutions_per_tick,
         "starting World Chain proof-system defender"
     );
 

--- a/proofs/defender/src/main.rs
+++ b/proofs/defender/src/main.rs
@@ -48,10 +48,6 @@ struct Cli {
     #[arg(long, env = "DEFENDER_KEY", hide_env_values = true)]
     defender_key: PrivateKeySigner,
 
-    /// The only proposer address whose games this defender will defend.
-    #[arg(long, env = "ALLOWED_PROPOSER")]
-    allowed_proposer: Address,
-
     /// Seconds between game-factory polls.
     #[arg(long, env = "POLL_INTERVAL_SECONDS", default_value_t = 12)]
     poll_interval_seconds: u64,
@@ -109,7 +105,6 @@ async fn main() -> Result<()> {
     let proof_requester = RpcProverServiceClient::new(&cli.prover_service_url)
         .with_context(|| format!("failed to connect to {}", cli.prover_service_url))?;
     let config = DefenderConfig {
-        allowed_proposer: cli.allowed_proposer,
         poll_interval: Duration::from_secs(cli.poll_interval_seconds),
         max_game_concurrency: cli.max_game_concurrency,
         max_games_per_tick: cli.max_games_per_tick,
@@ -125,7 +120,6 @@ async fn main() -> Result<()> {
         prover_service = %cli.prover_service_url,
         dispute_game_factory = %cli.factory_address,
         defender = %defender_address,
-        allowed_proposer = %cli.allowed_proposer,
         max_games_per_tick = cli.max_games_per_tick,
         game_scan_lookback = cli.game_scan_lookback,
         l1_tx_confirmations = cli.l1_tx_confirmations,

--- a/proofs/defender/src/main.rs
+++ b/proofs/defender/src/main.rs
@@ -1,6 +1,5 @@
-//! `world-chain-defender` binary: watches challenged valid WIP-1006 games on the OP
-//! `DisputeGameFactory`, requests proofs from the prover-service, and submits completed
-//! proof lanes on L1.
+//! `world-chain-defender` binary: supplies initial proof support for valid WIP-1006 games,
+//! escalates challenged games to the proof threshold, and resolves negative outcomes.
 //!
 //! Mirrors the in-process defender wired by the devnet harness
 //! (`crates/devnet/src/full_stack.rs::start_world_chain_defender`), reading its
@@ -26,7 +25,7 @@ use world_chain_prover_service::RpcProverServiceClient;
 #[derive(Debug, Parser)]
 #[command(
     name = "world-chain-defender",
-    about = "World Chain proof-system defender: proves and submits lanes for challenged games"
+    about = "World Chain proof-system defender: proves, escalates, and resolves games"
 )]
 struct Cli {
     /// Ethereum L1 execution RPC URL.
@@ -82,6 +81,10 @@ struct Cli {
     )]
     l1_tx_confirmations: u64,
 
+    /// Maximum number of negatively resolvable games settled per defender tick.
+    #[arg(long, env = "MAX_RESOLUTIONS_PER_TICK", default_value_t = 10)]
+    max_resolutions_per_tick: usize,
+
     /// Conservative upper bound on the age of a game with an open proof window.
     #[arg(long, env = "MAX_GAME_AGE_SECONDS", default_value_t = 604_800)]
     max_game_age_seconds: u64,
@@ -111,6 +114,7 @@ async fn main() -> Result<()> {
         max_game_concurrency: cli.max_game_concurrency,
         max_games_per_tick: cli.max_games_per_tick,
         game_scan_lookback: cli.game_scan_lookback,
+        max_resolutions_per_tick: cli.max_resolutions_per_tick,
         max_game_age: Duration::from_secs(cli.max_game_age_seconds),
     };
     let mut defender = WorldChainDefender::new(config, client, output_roots, proof_requester);
@@ -125,6 +129,7 @@ async fn main() -> Result<()> {
         max_games_per_tick = cli.max_games_per_tick,
         game_scan_lookback = cli.game_scan_lookback,
         l1_tx_confirmations = cli.l1_tx_confirmations,
+        max_resolutions_per_tick = cli.max_resolutions_per_tick,
         "starting World Chain proof-system defender"
     );
 

--- a/proofs/defender/src/tests.rs
+++ b/proofs/defender/src/tests.rs
@@ -30,8 +30,6 @@ use world_chain_prover_service::{
 const GAME_1: Address = address!("0000000000000000000000000000000000000001");
 const GAME_2: Address = address!("0000000000000000000000000000000000000002");
 const GAME_3: Address = address!("0000000000000000000000000000000000000003");
-const ALLOWED_PROPOSER: Address = address!("00000000000000000000000000000000000000a1");
-const OTHER_PROPOSER: Address = address!("00000000000000000000000000000000000000b2");
 const L2_BLOCK: u64 = 100;
 const L1_ORIGIN_HASH: B256 = B256::repeat_byte(0x42);
 const DOMAIN_HASH: B256 = B256::repeat_byte(0x43);
@@ -50,7 +48,6 @@ const STATE_INVALIDATED: u8 = 4;
 struct MockClient {
     games: Vec<GameMetadata>,
     created_at: Vec<u64>,
-    proposers: HashMap<Address, Address>,
     states: Arc<Mutex<HashMap<Address, u8>>>,
     bitmaps: Arc<Mutex<HashMap<Address, u8>>>,
     parent_unresolved: Arc<Mutex<HashSet<Address>>>,
@@ -77,14 +74,9 @@ impl MockClient {
                 proof_threshold: PROOF_THRESHOLD,
             })
             .collect();
-        let proposers = games
-            .iter()
-            .map(|game| (game.address, ALLOWED_PROPOSER))
-            .collect();
         Self {
             created_at: vec![u64::MAX; games.len()],
             games,
-            proposers,
             states: Arc::new(Mutex::new(states)),
             bitmaps: Arc::default(),
             parent_unresolved: Arc::default(),
@@ -93,10 +85,6 @@ impl MockClient {
             submissions: Arc::default(),
             resolutions: Arc::default(),
         }
-    }
-
-    fn set_proposer(&mut self, game: Address, proposer: Address) {
-        self.proposers.insert(game, proposer);
     }
 
     fn set_created_at(&mut self, game: Address, created_at: u64) {
@@ -218,13 +206,6 @@ impl DefenderClient for MockClient {
             .get(index as usize)
             .copied()
             .ok_or_else(|| DefenderError::Contract(format!("unknown game index {index}")))
-    }
-
-    async fn game_creator(&self, game: Address) -> Result<Address, DefenderError> {
-        self.proposers
-            .get(&game)
-            .copied()
-            .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))
     }
 
     async fn game_metadata(&self, game: Address) -> Result<GameMetadata, DefenderError> {
@@ -500,26 +481,10 @@ impl ProofRequester for MockProver {
 
 fn config() -> DefenderConfig {
     DefenderConfig {
-        allowed_proposer: ALLOWED_PROPOSER,
         poll_interval: Duration::from_secs(1),
         game_scan_lookback: 0,
         ..DefenderConfig::default()
     }
-}
-
-#[tokio::test]
-async fn tick_requires_an_allowed_proposer() {
-    let client = MockClient::new(Vec::new(), HashMap::new());
-    let (output_roots, _finalized_l2_block) = mock_output_roots(HashMap::new(), 0);
-    let mut defender = WorldChainDefender::new(
-        DefenderConfig::default(),
-        client,
-        output_roots,
-        MockProver::default(),
-    );
-
-    let error = defender.tick().await.unwrap_err();
-    assert!(matches!(error, DefenderError::InvalidConfig(_)));
 }
 
 #[tokio::test]
@@ -634,27 +599,6 @@ async fn tick_rechecks_lookback_without_reducing_forward_progress() {
     assert!(watched.contains(&GAME_1));
     assert!(watched.contains(&GAME_2));
     assert!(watched.contains(&GAME_3));
-}
-
-#[tokio::test]
-async fn tick_ignores_games_from_other_proposers() {
-    let canonical_root = B256::repeat_byte(0x20);
-    let mut client = MockClient::new(
-        vec![(GAME_1, canonical_root, L2_BLOCK)],
-        HashMap::from([(GAME_1, STATE_CHALLENGED)]),
-    );
-    client.set_proposer(GAME_1, OTHER_PROPOSER);
-    let (output_roots, _finalized_l2_block) =
-        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
-    let prover = MockProver::default();
-    let mut defender = WorldChainDefender::new(config(), client, output_roots, prover.clone());
-
-    defender.tick().await.unwrap();
-
-    assert_eq!(defender.next_game_index(), Some(1));
-    assert!(prover.requests().is_empty());
-    assert!(defender.watched_games().is_empty());
-    assert!(defender.active_defenses().is_empty());
 }
 
 #[tokio::test]

--- a/proofs/defender/src/tests.rs
+++ b/proofs/defender/src/tests.rs
@@ -3,23 +3,24 @@ use crate::{
     defender::WorldChainDefender,
     error::DefenderError,
     traits::DefenderClient,
-    types::{DefenderSubmission, GameMetadata, ResolveSubmission},
+    types::{DefenderSubmission, GameMetadata},
 };
 use alloy_primitives::{Address, B256, BlockNumber, Bytes, address};
 use alloy_sol_types::SolValue;
 use async_trait::async_trait;
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     sync::{
         Arc, Mutex,
-        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
+        atomic::{AtomicU64, Ordering},
     },
     time::Duration,
 };
 use world_chain_proof_core::boot::TransitionPublicValues;
 use world_chain_proofs::{
-    ConsensusError, ConsensusProvider, InvalidationReason, PROOF_THRESHOLD, ProofLane,
-    ResolutionStatus, RootState, proof_count,
+    ConsensusError, ConsensusProvider, InvalidationReason, LineageAnchor, LineageError,
+    LineageGame, LineageProvider, LineageTransition, MAX_ATTEMPT_SCAN, PROOF_THRESHOLD, ProofLane,
+    ProposalCommitment, ResolutionStatus, RootState, proof_count,
 };
 use world_chain_prover_service::{
     ProofBackend, ProofData, ProofRequest, ProofRequestError, ProofRequestId, ProofRequester,
@@ -27,294 +28,206 @@ use world_chain_prover_service::{
     TooManyRetriesErrorData,
 };
 
+const ANCHOR: Address = address!("00000000000000000000000000000000000000a0");
 const GAME_1: Address = address!("0000000000000000000000000000000000000001");
 const GAME_2: Address = address!("0000000000000000000000000000000000000002");
-const GAME_3: Address = address!("0000000000000000000000000000000000000003");
+const BLOCK_INTERVAL: u64 = 10;
 const L2_BLOCK: u64 = 100;
 const L1_ORIGIN_HASH: B256 = B256::repeat_byte(0x42);
 const DOMAIN_HASH: B256 = B256::repeat_byte(0x43);
-const PARENT_REF: Address = address!("00000000000000000000000000000000000000c3");
 
-/// State discriminant matching [`RootState::Proposed`].
-const STATE_PROPOSED: u8 = 1;
-/// State discriminant matching [`RootState::Challenged`].
-const STATE_CHALLENGED: u8 = 2;
-/// State discriminant matching [`RootState::Finalized`].
-const STATE_FINALIZED: u8 = 3;
-/// State discriminant matching [`RootState::Invalidated`].
-const STATE_INVALIDATED: u8 = 4;
+#[derive(Debug, Clone)]
+struct GameRecord {
+    metadata: GameMetadata,
+    state: RootState,
+    invalidation_reason: InvalidationReason,
+    proof_bitmap: u8,
+}
+
+#[derive(Debug)]
+struct MockState {
+    anchor: LineageAnchor,
+    games_by_uuid: HashMap<B256, Address>,
+    games: HashMap<Address, GameRecord>,
+    submissions: Vec<(Address, u8)>,
+}
 
 #[derive(Debug, Clone)]
 struct MockClient {
-    games: Vec<GameMetadata>,
-    created_at: Vec<u64>,
-    states: Arc<Mutex<HashMap<Address, u8>>>,
-    bitmaps: Arc<Mutex<HashMap<Address, u8>>>,
-    parent_unresolved: Arc<Mutex<HashSet<Address>>>,
-    proof_bitmap_reads: Arc<AtomicUsize>,
-    fail_game_count: Arc<AtomicBool>,
-    submissions: Arc<Mutex<Vec<(Address, u8)>>>,
-    resolutions: Arc<Mutex<Vec<Address>>>,
+    state: Arc<Mutex<MockState>>,
 }
 
 impl MockClient {
-    fn new(games: Vec<(Address, B256, u64)>, states: HashMap<Address, u8>) -> Self {
-        let games: Vec<_> = games
-            .into_iter()
-            .map(|(address, root_claim, l2_block_number)| GameMetadata {
-                address,
-                domain_hash: DOMAIN_HASH,
-                parent_ref: PARENT_REF,
-                root_claim,
-                l2_block_number,
-                l1_origin_hash: L1_ORIGIN_HASH,
-                l1_origin_number: 42,
-                challenge_deadline: u64::MAX,
-                proof_deadline: u64::MAX,
-                proof_threshold: PROOF_THRESHOLD,
-            })
-            .collect();
+    fn new() -> Self {
         Self {
-            created_at: vec![u64::MAX; games.len()],
-            games,
-            states: Arc::new(Mutex::new(states)),
-            bitmaps: Arc::default(),
-            parent_unresolved: Arc::default(),
-            proof_bitmap_reads: Arc::default(),
-            fail_game_count: Arc::default(),
-            submissions: Arc::default(),
-            resolutions: Arc::default(),
+            state: Arc::new(Mutex::new(MockState {
+                anchor: LineageAnchor {
+                    address: ANCHOR,
+                    l2_block_number: L2_BLOCK - BLOCK_INTERVAL,
+                },
+                games_by_uuid: HashMap::new(),
+                games: HashMap::new(),
+                submissions: Vec::new(),
+            })),
         }
     }
 
-    fn set_created_at(&mut self, game: Address, created_at: u64) {
-        let index = self
-            .games
-            .iter()
-            .position(|metadata| metadata.address == game)
-            .expect("game exists");
-        self.created_at[index] = created_at;
+    fn insert_game(
+        &self,
+        address: Address,
+        parent_ref: Address,
+        root_claim: B256,
+        l2_block_number: u64,
+        attempt: u64,
+        state: RootState,
+    ) {
+        let metadata = GameMetadata {
+            address,
+            domain_hash: DOMAIN_HASH,
+            parent_ref,
+            root_claim,
+            l2_block_number,
+            l1_origin_hash: L1_ORIGIN_HASH,
+            l1_origin_number: 42,
+            challenge_deadline: u64::MAX,
+            proof_deadline: u64::MAX,
+            proof_threshold: PROOF_THRESHOLD,
+        };
+        let mut guard = self.state.lock().expect("not poisoned");
+        guard.games_by_uuid.insert(
+            ProposalCommitment {
+                parent_ref,
+                root_claim,
+                l2_block_number,
+                attempt,
+            }
+            .game_uuid(DOMAIN_HASH),
+            address,
+        );
+        guard.games.insert(
+            address,
+            GameRecord {
+                metadata,
+                state,
+                invalidation_reason: InvalidationReason::None,
+                proof_bitmap: 0,
+            },
+        );
     }
 
-    fn set_deadlines(&mut self, game: Address, challenge_deadline: u64, proof_deadline: u64) {
-        let metadata = self
+    fn set_anchor(&self, address: Address, l2_block_number: u64) {
+        self.state.lock().expect("not poisoned").anchor = LineageAnchor {
+            address,
+            l2_block_number,
+        };
+    }
+
+    fn set_state(&self, game: Address, state: RootState, reason: InvalidationReason) {
+        let mut guard = self.state.lock().expect("not poisoned");
+        let record = guard.games.get_mut(&game).expect("game exists");
+        record.state = state;
+        record.invalidation_reason = reason;
+    }
+
+    fn set_bitmap(&self, game: Address, proof_bitmap: u8) {
+        self.state
+            .lock()
+            .expect("not poisoned")
             .games
-            .iter_mut()
-            .find(|metadata| metadata.address == game)
-            .expect("game exists");
+            .get_mut(&game)
+            .expect("game exists")
+            .proof_bitmap = proof_bitmap;
+    }
+
+    fn set_deadlines(&self, game: Address, challenge_deadline: u64, proof_deadline: u64) {
+        let mut guard = self.state.lock().expect("not poisoned");
+        let metadata = &mut guard.games.get_mut(&game).expect("game exists").metadata;
         metadata.challenge_deadline = challenge_deadline;
         metadata.proof_deadline = proof_deadline;
     }
 
-    fn set_proof_threshold(&mut self, game: Address, proof_threshold: u8) {
-        self.games
-            .iter_mut()
-            .find(|metadata| metadata.address == game)
-            .expect("game exists")
-            .proof_threshold = proof_threshold;
-    }
-
-    fn set_state(&self, game: Address, state: u8) {
-        self.states
-            .lock()
-            .expect("not poisoned")
-            .insert(game, state);
-    }
-
-    fn state(&self, game: Address) -> Result<RootState, DefenderError> {
-        let raw = self
-            .states
-            .lock()
-            .expect("not poisoned")
-            .get(&game)
-            .copied()
-            .unwrap_or(STATE_PROPOSED);
-        RootState::try_from(raw).map_err(Into::into)
-    }
-
-    fn set_bitmap(&self, game: Address, bitmap: u8) {
-        self.bitmaps
-            .lock()
-            .expect("not poisoned")
-            .insert(game, bitmap);
-    }
-
-    fn bitmap(&self, game: Address) -> u8 {
-        self.bitmaps
-            .lock()
-            .expect("not poisoned")
-            .get(&game)
-            .copied()
-            .unwrap_or(0)
-    }
-
-    fn set_parent_unresolved(&self, game: Address) {
-        self.parent_unresolved
-            .lock()
-            .expect("not poisoned")
-            .insert(game);
-    }
-
-    fn set_parent_resolved(&self, game: Address) {
-        self.parent_unresolved
-            .lock()
-            .expect("not poisoned")
-            .remove(&game);
-    }
-
-    fn reset_proof_bitmap_reads(&self) {
-        self.proof_bitmap_reads.store(0, Ordering::SeqCst);
-    }
-
-    fn proof_bitmap_reads(&self) -> usize {
-        self.proof_bitmap_reads.load(Ordering::SeqCst)
-    }
-
-    fn set_game_count_failure(&self, fail: bool) {
-        self.fail_game_count.store(fail, Ordering::SeqCst);
-    }
-
     fn submissions(&self) -> Vec<(Address, u8)> {
-        self.submissions.lock().expect("not poisoned").clone()
+        self.state.lock().expect("not poisoned").submissions.clone()
+    }
+}
+
+#[async_trait]
+impl LineageProvider for MockClient {
+    fn lineage_block_interval(&self) -> u64 {
+        BLOCK_INTERVAL
     }
 
-    fn resolutions(&self) -> Vec<Address> {
-        self.resolutions.lock().expect("not poisoned").clone()
+    async fn lineage_anchor(&self) -> Result<LineageAnchor, LineageError> {
+        Ok(self.state.lock().expect("not poisoned").anchor)
+    }
+
+    async fn game_for_transition(
+        &self,
+        transition: LineageTransition,
+    ) -> Result<Option<LineageGame>, LineageError> {
+        let guard = self.state.lock().expect("not poisoned");
+        let mut latest = None;
+        for attempt in 0..MAX_ATTEMPT_SCAN {
+            let uuid = ProposalCommitment {
+                parent_ref: transition.parent_ref,
+                root_claim: transition.root_claim,
+                l2_block_number: transition.l2_block_number,
+                attempt,
+            }
+            .game_uuid(DOMAIN_HASH);
+            let Some(address) = guard.games_by_uuid.get(&uuid).copied() else {
+                break;
+            };
+            latest = Some(LineageGame { address, attempt });
+        }
+        Ok(latest)
+    }
+
+    async fn lineage_resolution_status(
+        &self,
+        game: Address,
+    ) -> Result<ResolutionStatus, LineageError> {
+        let guard = self.state.lock().expect("not poisoned");
+        let record = guard
+            .games
+            .get(&game)
+            .ok_or_else(|| LineageError::Contract(format!("unknown game {game}")))?;
+        let root_state = match record.state {
+            RootState::Proposed | RootState::Challenged
+                if proof_count(record.proof_bitmap) >= record.metadata.proof_threshold =>
+            {
+                RootState::Finalized
+            }
+            state => state,
+        };
+        Ok(ResolutionStatus {
+            resolvable: root_state != record.state,
+            root_state,
+            invalidation_reason: record.invalidation_reason,
+        })
     }
 }
 
 #[async_trait]
 impl DefenderClient for MockClient {
-    async fn game_count(&self) -> Result<u64, DefenderError> {
-        if self.fail_game_count.load(Ordering::SeqCst) {
-            return Err(DefenderError::Contract(
-                "configured game_count failure".into(),
-            ));
-        }
-        Ok(self.games.len() as u64)
-    }
-
-    async fn game_address_at(&self, index: u64) -> Result<Option<Address>, DefenderError> {
-        self.games
-            .get(index as usize)
-            .map(|game| Some(game.address))
-            .ok_or_else(|| DefenderError::Contract(format!("unknown game index {index}")))
-    }
-
-    async fn game_created_at(&self, index: u64) -> Result<u64, DefenderError> {
-        self.created_at
-            .get(index as usize)
-            .copied()
-            .ok_or_else(|| DefenderError::Contract(format!("unknown game index {index}")))
-    }
-
     async fn game_metadata(&self, game: Address) -> Result<GameMetadata, DefenderError> {
-        self.games
-            .iter()
-            .find(|metadata| metadata.address == game)
-            .copied()
+        self.state
+            .lock()
+            .expect("not poisoned")
+            .games
+            .get(&game)
+            .map(|record| record.metadata)
             .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))
     }
 
-    async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, DefenderError> {
-        let state = self.state(game)?;
-        if self
-            .parent_unresolved
+    async fn proof_bitmap(&self, game: Address) -> Result<u8, DefenderError> {
+        self.state
             .lock()
             .expect("not poisoned")
-            .contains(&game)
-        {
-            return Ok(ResolutionStatus {
-                resolvable: false,
-                root_state: state,
-                invalidation_reason: InvalidationReason::None,
-            });
-        }
-        if state == RootState::Challenged {
-            let proof_threshold = self
-                .games
-                .iter()
-                .find(|metadata| metadata.address == game)
-                .expect("game exists")
-                .proof_threshold;
-            if proof_count(self.bitmap(game)) >= proof_threshold {
-                return Ok(ResolutionStatus {
-                    resolvable: true,
-                    root_state: RootState::Finalized,
-                    invalidation_reason: InvalidationReason::None,
-                });
-            }
-            let proof_deadline = self
-                .games
-                .iter()
-                .find(|metadata| metadata.address == game)
-                .expect("game exists")
-                .proof_deadline;
-            if proof_deadline == 0 {
-                return Ok(ResolutionStatus {
-                    resolvable: true,
-                    root_state: RootState::Invalidated,
-                    invalidation_reason: InvalidationReason::ProofTimeout,
-                });
-            }
-        }
-        if state == RootState::Proposed {
-            let metadata = self
-                .games
-                .iter()
-                .find(|metadata| metadata.address == game)
-                .expect("game exists");
-            if metadata.challenge_deadline == 0 {
-                return Ok(ResolutionStatus {
-                    resolvable: true,
-                    root_state: if self.bitmap(game) == 0 {
-                        RootState::Invalidated
-                    } else {
-                        RootState::Finalized
-                    },
-                    invalidation_reason: if self.bitmap(game) == 0 {
-                        InvalidationReason::ProofTimeout
-                    } else {
-                        InvalidationReason::None
-                    },
-                });
-            }
-        }
-        Ok(ResolutionStatus {
-            resolvable: false,
-            root_state: state,
-            invalidation_reason: InvalidationReason::None,
-        })
-    }
-
-    async fn proof_bitmap(&self, game: Address) -> Result<u8, DefenderError> {
-        self.proof_bitmap_reads.fetch_add(1, Ordering::SeqCst);
-        Ok(self.bitmap(game))
-    }
-
-    async fn resolve_game(&self, game: Address) -> Result<ResolveSubmission, DefenderError> {
-        let status = self.resolution_status(game).await?;
-        if !status.resolvable {
-            return Err(DefenderError::Contract(format!(
-                "game {game} is not resolvable"
-            )));
-        }
-        self.set_state(
-            game,
-            match status.root_state {
-                RootState::Finalized => STATE_FINALIZED,
-                RootState::Invalidated => STATE_INVALIDATED,
-                _ => {
-                    return Err(DefenderError::Contract(format!(
-                        "game {game} has no terminal outcome"
-                    )));
-                }
-            },
-        );
-        self.resolutions.lock().expect("not poisoned").push(game);
-        Ok(ResolveSubmission {
-            tx_hash: B256::repeat_byte(0xbb),
-        })
+            .games
+            .get(&game)
+            .map(|record| record.proof_bitmap)
+            .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))
     }
 
     async fn submit_proof(
@@ -323,15 +236,13 @@ impl DefenderClient for MockClient {
         lane: u8,
         _proof: Bytes,
     ) -> Result<DefenderSubmission, DefenderError> {
-        {
-            let mut bitmaps = self.bitmaps.lock().expect("not poisoned");
-            let bitmap = bitmaps.entry(game).or_default();
-            *bitmap |= 1 << lane;
-        }
-        self.submissions
-            .lock()
-            .expect("not poisoned")
-            .push((game, lane));
+        let mut guard = self.state.lock().expect("not poisoned");
+        guard
+            .games
+            .get_mut(&game)
+            .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))?
+            .proof_bitmap |= 1 << lane;
+        guard.submissions.push((game, lane));
         Ok(DefenderSubmission {
             tx_hash: B256::repeat_byte(0xaa),
         })
@@ -358,23 +269,15 @@ impl ConsensusProvider for MockOutputRoots {
     }
 }
 
-fn mock_output_roots(
-    roots: HashMap<u64, B256>,
-    finalized_l2_block: BlockNumber,
-) -> (MockOutputRoots, Arc<AtomicU64>) {
-    let finalized_l2_block = Arc::new(AtomicU64::new(finalized_l2_block));
-    (
-        MockOutputRoots {
-            roots,
-            finalized_l2_block: Arc::clone(&finalized_l2_block),
-        },
-        finalized_l2_block,
-    )
+fn output_roots(entries: &[(u64, B256)], finalized: u64) -> MockOutputRoots {
+    MockOutputRoots {
+        roots: entries.iter().copied().collect(),
+        finalized_l2_block: Arc::new(AtomicU64::new(finalized)),
+    }
 }
 
 #[derive(Debug, Clone, Default)]
 struct MockProver {
-    /// When true, every requested proof reports [`ProofStatus::Failed`].
     fail: bool,
     max_requests_per_proof: Option<u32>,
     requests: Arc<Mutex<Vec<ProofRequest>>>,
@@ -482,637 +385,294 @@ impl ProofRequester for MockProver {
 fn config() -> DefenderConfig {
     DefenderConfig {
         poll_interval: Duration::from_secs(1),
-        game_scan_lookback: 0,
-        ..DefenderConfig::default()
+        max_game_concurrency: 10,
     }
 }
 
 #[tokio::test]
-async fn tick_scans_older_live_game_when_deadlines_are_not_monotonic() {
-    let canonical_root = B256::repeat_byte(0x20);
-    let mut client = MockClient::new(
-        vec![
-            (GAME_1, canonical_root, L2_BLOCK),
-            (GAME_2, canonical_root, L2_BLOCK),
-        ],
-        HashMap::from([(GAME_1, STATE_CHALLENGED), (GAME_2, STATE_CHALLENGED)]),
-    );
-    client.set_deadlines(GAME_2, 0, 0);
-    let (output_roots, _finalized_l2_block) =
-        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
-    let mut defender =
-        WorldChainDefender::new(config(), client, output_roots, MockProver::default());
-
-    defender.tick().await.unwrap();
-    defender.tick().await.unwrap();
-
-    assert_eq!(defender.next_game_index(), Some(2));
-    assert_eq!(defender.active_defenses(), [GAME_1]);
-}
-
-#[tokio::test]
-async fn tick_binary_searches_by_factory_creation_time() {
-    let canonical_root = B256::repeat_byte(0x20);
-    let mut client = MockClient::new(
-        vec![
-            (GAME_1, canonical_root, L2_BLOCK),
-            (GAME_2, canonical_root, L2_BLOCK),
-        ],
-        HashMap::new(),
-    );
-    client.set_created_at(GAME_1, 0);
-    let (output_roots, _finalized_l2_block) =
-        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
-    let mut defender =
-        WorldChainDefender::new(config(), client, output_roots, MockProver::default());
-
-    defender.tick().await.unwrap();
-
-    assert_eq!(defender.next_game_index(), Some(2));
-    assert_eq!(defender.watched_games(), [GAME_2]);
-}
-
-#[tokio::test]
-async fn tick_respects_factory_scan_budget() {
-    let canonical_root = B256::repeat_byte(0x20);
-    let client = MockClient::new(
-        vec![
-            (GAME_1, canonical_root, L2_BLOCK),
-            (GAME_2, canonical_root, L2_BLOCK),
-        ],
-        HashMap::new(),
-    );
-    let (output_roots, _finalized_l2_block) =
-        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
-    let mut limited_config = config();
-    limited_config.max_games_per_tick = 1;
-    let mut defender =
-        WorldChainDefender::new(limited_config, client, output_roots, MockProver::default());
-
-    defender.tick().await.unwrap();
-    assert_eq!(defender.next_game_index(), Some(1));
-    assert_eq!(defender.watched_games(), [GAME_1]);
-
-    defender.tick().await.unwrap();
-    assert_eq!(defender.next_game_index(), Some(2));
-    let watched = defender.watched_games();
-    assert_eq!(watched.len(), 2);
-    assert!(watched.contains(&GAME_1));
-    assert!(watched.contains(&GAME_2));
-}
-
-#[tokio::test]
-async fn tick_rechecks_lookback_without_reducing_forward_progress() {
-    let canonical_root = B256::repeat_byte(0x20);
-    let client = MockClient::new(
-        vec![
-            (GAME_1, canonical_root, L2_BLOCK),
-            (GAME_2, canonical_root, L2_BLOCK),
-            (GAME_3, canonical_root, L2_BLOCK),
-        ],
-        HashMap::from([(GAME_2, STATE_FINALIZED)]),
-    );
-    let (output_roots, _finalized_l2_block) =
-        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
-    let mut defender_config = config();
-    defender_config.max_game_concurrency = 1;
-    defender_config.max_games_per_tick = 2;
-    defender_config.game_scan_lookback = 1;
-    let mut defender = WorldChainDefender::new(
-        defender_config,
-        client.clone(),
-        output_roots,
-        MockProver::default(),
-    );
-
-    defender.tick().await.unwrap();
-    assert_eq!(defender.next_game_index(), Some(2));
-    assert_eq!(defender.watched_games(), [GAME_1]);
-
-    // Simulate a shallow reorg restoring a game that was transiently observed as finalized.
-    client.set_state(GAME_2, STATE_PROPOSED);
-    defender.tick().await.unwrap();
-
-    assert_eq!(defender.next_game_index(), Some(3));
-    let watched = defender.watched_games();
-    assert_eq!(watched.len(), 3);
-    assert!(watched.contains(&GAME_1));
-    assert!(watched.contains(&GAME_2));
-    assert!(watched.contains(&GAME_3));
-}
-
-#[tokio::test]
-async fn tick_discards_invalidated_games() {
-    let canonical_root = B256::repeat_byte(0x20);
-    let client = MockClient::new(
-        vec![(GAME_1, canonical_root, L2_BLOCK)],
-        HashMap::from([(GAME_1, STATE_INVALIDATED)]),
-    );
-    let (output_roots, _finalized_l2_block) =
-        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
+async fn selected_proposed_game_gets_initial_tee_proof() {
+    let root = B256::repeat_byte(0x20);
+    let client = MockClient::new();
+    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, RootState::Proposed);
     let prover = MockProver::default();
-    let mut defender = WorldChainDefender::new(config(), client, output_roots, prover.clone());
-
-    defender.tick().await.unwrap();
-
-    assert!(prover.requests().is_empty());
-    assert!(defender.watched_games().is_empty());
-    assert!(defender.active_defenses().is_empty());
-}
-
-#[tokio::test]
-async fn proposed_game_remains_watched_after_challenge_deadline_until_resolved() {
-    let canonical_root = B256::repeat_byte(0x20);
-    let mut client = MockClient::new(vec![(GAME_1, canonical_root, L2_BLOCK)], HashMap::new());
-    client.set_deadlines(GAME_1, 10, 20);
-    let (output_roots, _finalized_l2_block) =
-        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
-    let mut defender =
-        WorldChainDefender::new(config(), client, output_roots, MockProver::default());
-
-    defender.tick_at(5).await.unwrap();
-    assert_eq!(defender.watched_games(), [GAME_1]);
-
-    defender.tick_at(10).await.unwrap();
-    assert_eq!(defender.watched_games(), [GAME_1]);
-}
-
-#[tokio::test]
-async fn timed_out_game_resolves_after_its_parent_finishes() {
-    let canonical_root = B256::repeat_byte(0x20);
-    let mut client = MockClient::new(vec![(GAME_1, canonical_root, L2_BLOCK)], HashMap::new());
-    client.set_deadlines(GAME_1, 0, 20);
-    client.set_parent_unresolved(GAME_1);
-    let (output_roots, _finalized_l2_block) =
-        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
     let mut defender = WorldChainDefender::new(
         config(),
         client.clone(),
-        output_roots,
-        MockProver::default(),
+        output_roots(&[(L2_BLOCK, root)], L2_BLOCK),
+        prover.clone(),
     );
-
-    defender.tick_at(10).await.unwrap();
-    assert_eq!(defender.watched_games(), [GAME_1]);
-    assert!(client.resolutions().is_empty());
-
-    client.set_parent_resolved(GAME_1);
-    defender.tick_at(11).await.unwrap();
-    assert_eq!(client.resolutions(), [GAME_1]);
-}
-
-#[tokio::test]
-async fn active_defense_is_removed_after_proof_deadline() {
-    let canonical_root = B256::repeat_byte(0x20);
-    let mut client = MockClient::new(
-        vec![(GAME_1, canonical_root, L2_BLOCK)],
-        HashMap::from([(GAME_1, STATE_CHALLENGED)]),
-    );
-    client.set_deadlines(GAME_1, 10, 20);
-    let (output_roots, _finalized_l2_block) =
-        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
-    let prover = MockProver::default();
-    let mut defender = WorldChainDefender::new(config(), client, output_roots, prover.clone());
-
-    defender.tick_at(5).await.unwrap();
-    assert_eq!(defender.watched_games(), [GAME_1]);
-
-    defender.tick_at(6).await.unwrap();
-    assert_eq!(defender.active_defenses(), [GAME_1]);
-    assert!(prover.requests().is_empty());
-
-    defender.tick_at(7).await.unwrap();
-    assert_eq!(prover.requests().len(), 2);
-
-    defender.tick_at(20).await.unwrap();
-    assert!(defender.active_defenses().is_empty());
-    assert_eq!(defender.watched_games(), [GAME_1]);
-
-    // The proof workflow stays closed while the game remains watched for resolution.
-    defender.tick_at(21).await.unwrap();
-    assert!(defender.active_defenses().is_empty());
-    assert_eq!(defender.watched_games(), [GAME_1]);
-}
-
-#[tokio::test]
-async fn active_defense_advances_before_discovery_failure() {
-    let canonical_root = B256::repeat_byte(0x20);
-    let client = MockClient::new(
-        vec![(GAME_1, canonical_root, L2_BLOCK)],
-        HashMap::from([(GAME_1, STATE_CHALLENGED)]),
-    );
-    let (output_roots, _finalized_l2_block) =
-        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
-    let prover = MockProver::default();
-    let mut defender =
-        WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
-
-    // Discovery retains the game for monitoring, then validation promotes it
-    // on the next tick because tracked games run before discovery.
-    defender.tick().await.unwrap();
-    assert_eq!(defender.watched_games(), [GAME_1]);
-    assert!(prover.requests().is_empty());
-
-    defender.tick().await.unwrap();
-    assert_eq!(defender.active_defenses(), [GAME_1]);
-    assert!(prover.requests().is_empty());
-
-    client.set_game_count_failure(true);
-    let error = defender.tick().await.unwrap_err();
-
-    assert!(matches!(error, DefenderError::Contract(_)));
-    assert_eq!(prover.requests().len(), 2);
-    assert_eq!(defender.active_defenses(), [GAME_1]);
-}
-
-#[tokio::test]
-async fn scan_accepts_sufficient_proof_support_hidden_by_an_unresolved_parent() {
-    let canonical_root = B256::repeat_byte(0x20);
-    let mut client = MockClient::new(
-        vec![
-            (GAME_1, canonical_root, L2_BLOCK),
-            (GAME_2, canonical_root, L2_BLOCK),
-        ],
-        HashMap::from([(GAME_2, STATE_CHALLENGED)]),
-    );
-    client.set_deadlines(GAME_1, 20, 20);
-    client.set_deadlines(GAME_2, 20, 20);
-    client.set_proof_threshold(GAME_2, 1);
-    client.set_parent_unresolved(GAME_2);
-    client.set_bitmap(GAME_2, ProofLane::ValidityProof.mask());
-    let (output_roots, _finalized_l2_block) =
-        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
-    let mut limited_config = config();
-    limited_config.max_games_per_tick = 1;
-    let mut defender = WorldChainDefender::new(
-        limited_config,
-        client.clone(),
-        output_roots,
-        MockProver::default(),
-    );
-
-    defender.tick_at(5).await.unwrap();
-    assert_eq!(defender.next_game_index(), Some(1));
-
-    client.reset_proof_bitmap_reads();
-    defender.tick_at(20).await.unwrap();
-
-    assert_eq!(client.proof_bitmap_reads(), 2);
-    assert_eq!(defender.next_game_index(), Some(2));
-    assert_eq!(defender.watched_games(), [GAME_1]);
-    assert!(defender.active_defenses().is_empty());
-}
-
-#[tokio::test]
-async fn watched_game_accepts_sufficient_proof_support_hidden_by_an_unresolved_parent() {
-    let canonical_root = B256::repeat_byte(0x20);
-    let mut client = MockClient::new(vec![(GAME_1, canonical_root, L2_BLOCK)], HashMap::new());
-    client.set_deadlines(GAME_1, 10, 20);
-    client.set_proof_threshold(GAME_1, 1);
-    client.set_parent_unresolved(GAME_1);
-    let (output_roots, _finalized_l2_block) =
-        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
-    let prover = MockProver::default();
-    let mut defender =
-        WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
-
-    defender.tick_at(5).await.unwrap();
-    assert_eq!(defender.watched_games(), [GAME_1]);
-
-    client.set_state(GAME_1, STATE_CHALLENGED);
-    client.set_bitmap(GAME_1, ProofLane::ValidityProof.mask());
-    client.reset_proof_bitmap_reads();
-    defender.tick_at(20).await.unwrap();
-
-    assert_eq!(client.proof_bitmap_reads(), 1);
-    assert!(prover.requests().is_empty());
-    assert!(defender.watched_games().is_empty());
-    assert!(defender.active_defenses().is_empty());
-}
-
-#[tokio::test]
-async fn active_defense_accepts_sufficient_proof_support_hidden_by_an_unresolved_parent() {
-    let canonical_root = B256::repeat_byte(0x20);
-    let mut client = MockClient::new(
-        vec![(GAME_1, canonical_root, L2_BLOCK)],
-        HashMap::from([(GAME_1, STATE_CHALLENGED)]),
-    );
-    client.set_deadlines(GAME_1, 10, 20);
-    client.set_parent_unresolved(GAME_1);
-    let (output_roots, _finalized_l2_block) =
-        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
-    let prover = MockProver::default();
-    let mut defender =
-        WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
-
-    defender.tick_at(5).await.unwrap();
-    assert_eq!(defender.watched_games(), [GAME_1]);
-
-    defender.tick_at(6).await.unwrap();
-    assert_eq!(defender.active_defenses(), [GAME_1]);
-    assert!(prover.requests().is_empty());
-
-    defender.tick_at(7).await.unwrap();
-    assert_eq!(prover.requests().len(), 2);
-
-    client.set_bitmap(
-        GAME_1,
-        ProofLane::ValidityProof.mask() | ProofLane::TeeAttestation.mask(),
-    );
-    client.reset_proof_bitmap_reads();
-    defender.tick_at(20).await.unwrap();
-
-    assert_eq!(client.proof_bitmap_reads(), 2);
-    assert!(client.submissions().is_empty());
-    assert!(defender.watched_games().is_empty());
-    assert!(defender.active_defenses().is_empty());
-}
-
-#[tokio::test]
-async fn tick_defends_challenged_valid_root() {
-    let canonical_root = B256::repeat_byte(0x20);
-
-    let client = MockClient::new(
-        vec![(GAME_1, canonical_root, L2_BLOCK)],
-        HashMap::from([(GAME_1, STATE_CHALLENGED)]),
-    );
-    let (output_roots, _finalized_l2_block) =
-        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
-    let prover = MockProver::default();
-    let mut defender =
-        WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
-
-    // First tick: discovery retains the challenged game for monitoring.
-    defender.tick().await.unwrap();
-    assert_eq!(defender.watched_games(), [GAME_1]);
-    assert!(prover.requests().is_empty());
-
-    // Second tick: validation promotes the challenged game.
-    defender.tick().await.unwrap();
-    assert_eq!(defender.active_defenses(), [GAME_1]);
-    assert!(prover.requests().is_empty());
-
-    // Third tick: both lane proofs are requested.
-    defender.tick().await.unwrap();
-    let requests = prover.requests();
-    assert_eq!(requests.len(), 2);
-    assert_eq!(requests[0].backend, ProofBackend::Sp1);
-    assert_eq!(requests[1].backend, ProofBackend::Nitro);
-    for request in &requests {
-        assert_eq!(request.game, GAME_1);
-        assert_eq!(request.root_claim, canonical_root);
-        assert_eq!(request.l2_block_number, L2_BLOCK);
-        assert_eq!(request.l1_head, L1_ORIGIN_HASH);
-    }
-    assert!(client.submissions().is_empty());
-
-    // Fourth tick: both proofs are completed, fetched and submitted on-chain.
-    defender.tick().await.unwrap();
-
-    assert_eq!(
-        client.submissions(),
-        vec![
-            (GAME_1, ProofLane::ValidityProof as u8),
-            (GAME_1, ProofLane::TeeAttestation as u8),
-        ]
-    );
-    assert!(defender.active_defenses().is_empty());
-    assert!(defender.watched_games().is_empty());
-}
-
-#[tokio::test]
-async fn proposed_valid_game_gets_initial_tee_proof() {
-    let canonical_root = B256::repeat_byte(0x20);
-
-    let client = MockClient::new(vec![(GAME_1, canonical_root, L2_BLOCK)], HashMap::new());
-    let (output_roots, _finalized_l2_block) =
-        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
-    let prover = MockProver::default();
-    let mut defender =
-        WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
-
-    // Discovery and canonical-root validation happen before proving starts.
-    defender.tick().await.unwrap();
-    assert!(prover.requests().is_empty());
-    assert_eq!(defender.watched_games(), [GAME_1]);
-
-    defender.tick().await.unwrap();
-    assert!(prover.requests().is_empty());
-    assert_eq!(defender.active_defenses(), [GAME_1]);
 
     defender.tick().await.unwrap();
     assert_eq!(prover.requests().len(), 1);
     assert_eq!(prover.requests()[0].backend, ProofBackend::Nitro);
 
     defender.tick().await.unwrap();
-    defender.tick().await.unwrap();
-
     assert_eq!(
         client.submissions(),
         vec![(GAME_1, ProofLane::TeeAttestation as u8)]
     );
-    assert_eq!(defender.watched_games(), [GAME_1]);
-    assert!(defender.active_defenses().is_empty());
 }
 
 #[tokio::test]
-async fn challenge_after_initial_tee_proof_requests_only_missing_threshold_lane() {
-    let canonical_root = B256::repeat_byte(0x20);
-    let client = MockClient::new(vec![(GAME_1, canonical_root, L2_BLOCK)], HashMap::new());
-    let (output_roots, _finalized_l2_block) =
-        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
+async fn selected_challenged_game_gets_threshold_lanes() {
+    let root = B256::repeat_byte(0x20);
+    let client = MockClient::new();
+    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, RootState::Challenged);
     let prover = MockProver::default();
-    let mut defender =
-        WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
-
-    for _ in 0..5 {
-        defender.tick().await.unwrap();
-    }
-    client.set_state(GAME_1, STATE_CHALLENGED);
-
-    defender.tick().await.unwrap();
-    defender.tick().await.unwrap();
-    defender.tick().await.unwrap();
-
-    let requests = prover.requests();
-    assert_eq!(requests.len(), 2);
-    assert_eq!(requests[0].backend, ProofBackend::Nitro);
-    assert_eq!(requests[1].backend, ProofBackend::Sp1);
-    assert_eq!(
-        client.submissions(),
-        vec![
-            (GAME_1, ProofLane::TeeAttestation as u8),
-            (GAME_1, ProofLane::ValidityProof as u8),
-        ]
-    );
-}
-
-#[tokio::test]
-async fn proofless_timed_out_game_is_resolved_negatively() {
-    let canonical_root = B256::repeat_byte(0x20);
-    let mut client = MockClient::new(vec![(GAME_1, canonical_root, L2_BLOCK)], HashMap::new());
-    client.set_deadlines(GAME_1, 0, 100);
-    let (output_roots, _finalized_l2_block) =
-        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
     let mut defender = WorldChainDefender::new(
         config(),
         client.clone(),
-        output_roots,
-        MockProver::default(),
-    );
-
-    defender.tick_at(1).await.unwrap();
-    defender.tick_at(1).await.unwrap();
-
-    assert_eq!(client.resolutions(), [GAME_1]);
-    assert_eq!(client.state(GAME_1).unwrap(), RootState::Invalidated);
-    assert!(defender.watched_games().is_empty());
-}
-
-#[tokio::test]
-async fn tick_ignores_challenged_invalid_root() {
-    let proposed_root = B256::repeat_byte(0x10);
-    let canonical_root = B256::repeat_byte(0x20);
-
-    let client = MockClient::new(
-        vec![(GAME_1, proposed_root, L2_BLOCK)],
-        HashMap::from([(GAME_1, STATE_CHALLENGED)]),
-    );
-    let (output_roots, _finalized_l2_block) =
-        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
-    let prover = MockProver::default();
-    let mut defender =
-        WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
-
-    defender.tick().await.unwrap();
-
-    // an invalid root is the challenger's business, not ours
-    assert!(prover.requests().is_empty());
-    assert_eq!(defender.watched_games(), [GAME_1]);
-
-    defender.tick().await.unwrap();
-
-    assert_eq!(defender.watched_games(), [GAME_1]);
-    assert!(defender.active_defenses().is_empty());
-}
-
-#[tokio::test]
-async fn tick_defers_validity_check_until_l2_block_is_finalized() {
-    let canonical_root = B256::repeat_byte(0x20);
-
-    let client = MockClient::new(
-        vec![(GAME_1, canonical_root, L2_BLOCK)],
-        HashMap::from([(GAME_1, STATE_CHALLENGED)]),
-    );
-    let (output_roots, finalized_l2_block) =
-        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK - 1);
-    let prover = MockProver::default();
-    let mut defender =
-        WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
-
-    // the game's L2 block is not finalized yet, so the root cannot be judged
-    defender.tick().await.unwrap();
-    assert!(prover.requests().is_empty());
-    assert_eq!(defender.watched_games(), [GAME_1]);
-
-    finalized_l2_block.store(L2_BLOCK, Ordering::SeqCst);
-    defender.tick().await.unwrap();
-
-    assert!(prover.requests().is_empty());
-    assert_eq!(defender.active_defenses(), [GAME_1]);
-
-    defender.tick().await.unwrap();
-    assert_eq!(prover.requests().len(), 2);
-}
-
-#[tokio::test]
-async fn tick_skips_lane_already_proven() {
-    let canonical_root = B256::repeat_byte(0x20);
-
-    let client = MockClient::new(
-        vec![(GAME_1, canonical_root, L2_BLOCK)],
-        HashMap::from([(GAME_1, STATE_CHALLENGED)]),
-    );
-    client.set_bitmap(GAME_1, ProofLane::ValidityProof.mask());
-    let (output_roots, _finalized_l2_block) =
-        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
-    let prover = MockProver::default();
-    let mut defender =
-        WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
-
-    defender.tick().await.unwrap();
-    defender.tick().await.unwrap();
-    defender.tick().await.unwrap();
-    defender.tick().await.unwrap();
-
-    // the validity lane is already proven on-chain: only the TEE lane runs
-    let requests = prover.requests();
-    assert_eq!(requests.len(), 1);
-    assert_eq!(requests[0].backend, ProofBackend::Nitro);
-    assert_eq!(
-        client.submissions(),
-        vec![(GAME_1, ProofLane::TeeAttestation as u8)]
-    );
-    assert!(defender.active_defenses().is_empty());
-}
-
-#[tokio::test]
-async fn exhausted_prover_retries_are_not_restarted_by_lookback() {
-    let canonical_root = B256::repeat_byte(0x20);
-
-    let client = MockClient::new(
-        vec![(GAME_1, canonical_root, L2_BLOCK)],
-        HashMap::from([(GAME_1, STATE_CHALLENGED)]),
-    );
-    let (output_roots, _finalized_l2_block) =
-        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
-    let prover = MockProver::failing(2);
-    let mut defender_config = config();
-    defender_config.game_scan_lookback = 1;
-    let mut defender = WorldChainDefender::new(
-        defender_config,
-        client.clone(),
-        output_roots,
+        output_roots(&[(L2_BLOCK, root)], L2_BLOCK),
         prover.clone(),
     );
 
-    // Tick 1 discovers the game and tick 2 promotes it. Tick 3 makes the first
-    // request per lane; tick 4 re-requests each failed proof; tick 5 observes
-    // the prover-service retry limit and abandons the defense. Further lookback
-    // scans must not restart it.
+    defender.tick().await.unwrap();
+    let requests = prover.requests();
+    assert_eq!(requests.len(), 2);
+    assert!(
+        requests
+            .iter()
+            .any(|request| request.backend == ProofBackend::Sp1)
+    );
+    assert!(
+        requests
+            .iter()
+            .any(|request| request.backend == ProofBackend::Nitro)
+    );
+
+    defender.tick().await.unwrap();
+    assert_eq!(client.submissions().len(), 2);
+    assert!(defender.active_defenses().is_empty());
+}
+
+#[tokio::test]
+async fn selected_descendant_is_defended_before_parent_resolves() {
+    let root_1 = B256::repeat_byte(0x20);
+    let root_2 = B256::repeat_byte(0x21);
+    let client = MockClient::new();
+    client.insert_game(GAME_1, ANCHOR, root_1, L2_BLOCK, 0, RootState::Proposed);
+    client.set_bitmap(GAME_1, ProofLane::TeeAttestation.mask());
+    client.insert_game(
+        GAME_2,
+        GAME_1,
+        root_2,
+        L2_BLOCK + BLOCK_INTERVAL,
+        0,
+        RootState::Challenged,
+    );
+    let prover = MockProver::default();
+    let mut defender = WorldChainDefender::new(
+        config(),
+        client,
+        output_roots(
+            &[(L2_BLOCK, root_1), (L2_BLOCK + BLOCK_INTERVAL, root_2)],
+            L2_BLOCK + BLOCK_INTERVAL,
+        ),
+        prover.clone(),
+    );
+
+    defender.tick().await.unwrap();
+    assert_eq!(prover.requests().len(), 2);
+    assert!(
+        prover
+            .requests()
+            .iter()
+            .all(|request| request.game == GAME_2)
+    );
+}
+
+#[tokio::test]
+async fn game_for_a_different_root_is_not_selected() {
+    let expected_root = B256::repeat_byte(0x20);
+    let other_root = B256::repeat_byte(0x21);
+    let client = MockClient::new();
+    client.insert_game(
+        GAME_1,
+        ANCHOR,
+        other_root,
+        L2_BLOCK,
+        0,
+        RootState::Challenged,
+    );
+    let prover = MockProver::default();
+    let mut defender = WorldChainDefender::new(
+        config(),
+        client,
+        output_roots(&[(L2_BLOCK, expected_root)], L2_BLOCK),
+        prover.clone(),
+    );
+
+    defender.tick().await.unwrap();
+    assert!(prover.requests().is_empty());
+    assert!(defender.active_defenses().is_empty());
+}
+
+#[tokio::test]
+async fn retry_replaces_active_old_attempt() {
+    let root = B256::repeat_byte(0x20);
+    let client = MockClient::new();
+    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, RootState::Challenged);
+    let prover = MockProver::default();
+    let mut defender = WorldChainDefender::new(
+        config(),
+        client.clone(),
+        output_roots(&[(L2_BLOCK, root)], L2_BLOCK),
+        prover,
+    );
+
+    defender.tick().await.unwrap();
+    assert_eq!(defender.active_defenses(), [GAME_1]);
+
+    client.set_state(
+        GAME_1,
+        RootState::Invalidated,
+        InvalidationReason::ProofTimeout,
+    );
+    client.insert_game(GAME_2, ANCHOR, root, L2_BLOCK, 1, RootState::Proposed);
+    defender.tick().await.unwrap();
+
+    assert_eq!(defender.active_defenses(), [GAME_2]);
+    assert!(client.submissions().iter().all(|(game, _)| *game != GAME_1));
+}
+
+#[tokio::test]
+async fn anchor_advance_drops_the_old_prefix() {
+    let root_1 = B256::repeat_byte(0x20);
+    let root_2 = B256::repeat_byte(0x21);
+    let client = MockClient::new();
+    client.insert_game(GAME_1, ANCHOR, root_1, L2_BLOCK, 0, RootState::Challenged);
+    client.insert_game(
+        GAME_2,
+        GAME_1,
+        root_2,
+        L2_BLOCK + BLOCK_INTERVAL,
+        0,
+        RootState::Proposed,
+    );
+    let mut defender = WorldChainDefender::new(
+        config(),
+        client.clone(),
+        output_roots(
+            &[(L2_BLOCK, root_1), (L2_BLOCK + BLOCK_INTERVAL, root_2)],
+            L2_BLOCK + BLOCK_INTERVAL,
+        ),
+        MockProver::default(),
+    );
+
+    defender.tick().await.unwrap();
+    assert!(defender.active_defenses().contains(&GAME_1));
+
+    client.set_anchor(GAME_1, L2_BLOCK);
+    defender.tick().await.unwrap();
+    assert!(!defender.active_defenses().contains(&GAME_1));
+    assert!(defender.active_defenses().contains(&GAME_2));
+}
+
+#[tokio::test]
+async fn invalidated_selected_attempt_is_left_for_the_proposer() {
+    let root = B256::repeat_byte(0x20);
+    let client = MockClient::new();
+    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, RootState::Invalidated);
+    client.set_state(
+        GAME_1,
+        RootState::Invalidated,
+        InvalidationReason::ProofTimeout,
+    );
+    let prover = MockProver::default();
+    let mut defender = WorldChainDefender::new(
+        config(),
+        client,
+        output_roots(&[(L2_BLOCK, root)], L2_BLOCK),
+        prover.clone(),
+    );
+
+    defender.tick().await.unwrap();
+    assert!(prover.requests().is_empty());
+    assert!(defender.active_defenses().is_empty());
+}
+
+#[tokio::test]
+async fn unfinalized_transition_is_not_selected_yet() {
+    let root = B256::repeat_byte(0x20);
+    let client = MockClient::new();
+    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, RootState::Challenged);
+    let prover = MockProver::default();
+    let mut defender = WorldChainDefender::new(
+        config(),
+        client,
+        output_roots(&[(L2_BLOCK, root)], L2_BLOCK - 1),
+        prover.clone(),
+    );
+
+    defender.tick().await.unwrap();
+    assert!(prover.requests().is_empty());
+}
+
+#[tokio::test]
+async fn existing_lane_is_not_requested_again() {
+    let root = B256::repeat_byte(0x20);
+    let client = MockClient::new();
+    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, RootState::Challenged);
+    client.set_bitmap(GAME_1, ProofLane::ValidityProof.mask());
+    let prover = MockProver::default();
+    let mut defender = WorldChainDefender::new(
+        config(),
+        client,
+        output_roots(&[(L2_BLOCK, root)], L2_BLOCK),
+        prover.clone(),
+    );
+
+    defender.tick().await.unwrap();
+    assert_eq!(prover.requests().len(), 1);
+    assert_eq!(prover.requests()[0].backend, ProofBackend::Nitro);
+}
+
+#[tokio::test]
+async fn exhausted_challenged_proofs_are_not_restarted() {
+    let root = B256::repeat_byte(0x20);
+    let client = MockClient::new();
+    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, RootState::Challenged);
+    let prover = MockProver::failing(2);
+    let mut defender = WorldChainDefender::new(
+        config(),
+        client,
+        output_roots(&[(L2_BLOCK, root)], L2_BLOCK),
+        prover.clone(),
+    );
+
     for _ in 0..8 {
         defender.tick().await.unwrap();
     }
 
     assert_eq!(prover.requests().len(), 6);
-    assert!(client.submissions().is_empty());
     assert!(defender.active_defenses().is_empty());
     assert_eq!(defender.abandoned_defenses(), [GAME_1]);
 }
 
 #[tokio::test]
-async fn defense_closes_when_game_leaves_challenged_state() {
-    let canonical_root = B256::repeat_byte(0x20);
-
-    let client = MockClient::new(
-        vec![(GAME_1, canonical_root, L2_BLOCK)],
-        HashMap::from([(GAME_1, STATE_CHALLENGED)]),
-    );
-    let (output_roots, _finalized_l2_block) =
-        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
+async fn selected_game_deadline_stops_proof_work() {
+    let root = B256::repeat_byte(0x20);
+    let client = MockClient::new();
+    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, RootState::Proposed);
+    client.set_deadlines(GAME_1, 10, 20);
     let prover = MockProver::default();
-    let mut defender =
-        WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
+    let mut defender = WorldChainDefender::new(
+        config(),
+        client,
+        output_roots(&[(L2_BLOCK, root)], L2_BLOCK),
+        prover.clone(),
+    );
 
-    defender.tick().await.unwrap();
-    assert_eq!(defender.watched_games(), [GAME_1]);
-
-    defender.tick().await.unwrap();
-    assert_eq!(defender.active_defenses(), [GAME_1]);
-
-    client.set_state(GAME_1, STATE_FINALIZED);
-    defender.tick().await.unwrap();
-
-    assert!(client.submissions().is_empty());
+    defender.tick_at(10).await.unwrap();
+    assert!(prover.requests().is_empty());
     assert!(defender.active_defenses().is_empty());
+}
+
+#[test]
+fn config_rejects_zero_concurrency() {
+    let config = DefenderConfig {
+        poll_interval: Duration::from_secs(1),
+        max_game_concurrency: 0,
+    };
+    assert!(config.validate().is_err());
 }

--- a/proofs/defender/src/tests.rs
+++ b/proofs/defender/src/tests.rs
@@ -3,9 +3,10 @@ use crate::{
     defender::WorldChainDefender,
     error::DefenderError,
     traits::DefenderClient,
-    types::{DefenderSubmission, GameMetadata},
+    types::{DefenderSubmission, GameMetadata, ResolveSubmission},
 };
 use alloy_primitives::{Address, B256, BlockNumber, Bytes, address};
+use alloy_sol_types::SolValue;
 use async_trait::async_trait;
 use std::{
     collections::{HashMap, HashSet},
@@ -15,6 +16,7 @@ use std::{
     },
     time::Duration,
 };
+use world_chain_proof_core::boot::TransitionPublicValues;
 use world_chain_proofs::{
     ConsensusError, ConsensusProvider, InvalidationReason, PROOF_THRESHOLD, ProofLane,
     ResolutionStatus, RootState, proof_count,
@@ -32,6 +34,8 @@ const ALLOWED_PROPOSER: Address = address!("000000000000000000000000000000000000
 const OTHER_PROPOSER: Address = address!("00000000000000000000000000000000000000b2");
 const L2_BLOCK: u64 = 100;
 const L1_ORIGIN_HASH: B256 = B256::repeat_byte(0x42);
+const DOMAIN_HASH: B256 = B256::repeat_byte(0x43);
+const PARENT_REF: Address = address!("00000000000000000000000000000000000000c3");
 
 /// State discriminant matching [`RootState::Proposed`].
 const STATE_PROPOSED: u8 = 1;
@@ -53,6 +57,7 @@ struct MockClient {
     proof_bitmap_reads: Arc<AtomicUsize>,
     fail_game_count: Arc<AtomicBool>,
     submissions: Arc<Mutex<Vec<(Address, u8)>>>,
+    resolutions: Arc<Mutex<Vec<Address>>>,
 }
 
 impl MockClient {
@@ -61,9 +66,12 @@ impl MockClient {
             .into_iter()
             .map(|(address, root_claim, l2_block_number)| GameMetadata {
                 address,
+                domain_hash: DOMAIN_HASH,
+                parent_ref: PARENT_REF,
                 root_claim,
                 l2_block_number,
                 l1_origin_hash: L1_ORIGIN_HASH,
+                l1_origin_number: 42,
                 challenge_deadline: u64::MAX,
                 proof_deadline: u64::MAX,
                 proof_threshold: PROOF_THRESHOLD,
@@ -83,6 +91,7 @@ impl MockClient {
             proof_bitmap_reads: Arc::default(),
             fail_game_count: Arc::default(),
             submissions: Arc::default(),
+            resolutions: Arc::default(),
         }
     }
 
@@ -158,6 +167,13 @@ impl MockClient {
             .insert(game);
     }
 
+    fn set_parent_resolved(&self, game: Address) {
+        self.parent_unresolved
+            .lock()
+            .expect("not poisoned")
+            .remove(&game);
+    }
+
     fn reset_proof_bitmap_reads(&self) {
         self.proof_bitmap_reads.store(0, Ordering::SeqCst);
     }
@@ -172,6 +188,10 @@ impl MockClient {
 
     fn submissions(&self) -> Vec<(Address, u8)> {
         self.submissions.lock().expect("not poisoned").clone()
+    }
+
+    fn resolutions(&self) -> Vec<Address> {
+        self.resolutions.lock().expect("not poisoned").clone()
     }
 }
 
@@ -257,6 +277,28 @@ impl DefenderClient for MockClient {
                 });
             }
         }
+        if state == RootState::Proposed {
+            let metadata = self
+                .games
+                .iter()
+                .find(|metadata| metadata.address == game)
+                .expect("game exists");
+            if metadata.challenge_deadline == 0 {
+                return Ok(ResolutionStatus {
+                    resolvable: true,
+                    root_state: if self.bitmap(game) == 0 {
+                        RootState::Invalidated
+                    } else {
+                        RootState::Finalized
+                    },
+                    invalidation_reason: if self.bitmap(game) == 0 {
+                        InvalidationReason::ProofTimeout
+                    } else {
+                        InvalidationReason::None
+                    },
+                });
+            }
+        }
         Ok(ResolutionStatus {
             resolvable: false,
             root_state: state,
@@ -267,6 +309,31 @@ impl DefenderClient for MockClient {
     async fn proof_bitmap(&self, game: Address) -> Result<u8, DefenderError> {
         self.proof_bitmap_reads.fetch_add(1, Ordering::SeqCst);
         Ok(self.bitmap(game))
+    }
+
+    async fn resolve_game(&self, game: Address) -> Result<ResolveSubmission, DefenderError> {
+        let status = self.resolution_status(game).await?;
+        if !status.resolvable {
+            return Err(DefenderError::Contract(format!(
+                "game {game} is not resolvable"
+            )));
+        }
+        self.set_state(
+            game,
+            match status.root_state {
+                RootState::Finalized => STATE_FINALIZED,
+                RootState::Invalidated => STATE_INVALIDATED,
+                _ => {
+                    return Err(DefenderError::Contract(format!(
+                        "game {game} has no terminal outcome"
+                    )));
+                }
+            },
+        );
+        self.resolutions.lock().expect("not poisoned").push(game);
+        Ok(ResolveSubmission {
+            tx_hash: B256::repeat_byte(0xbb),
+        })
     }
 
     async fn submit_proof(
@@ -410,8 +477,18 @@ impl ProofRequester for MockProver {
             },
             ProofBackend::Nitro => ProofData::Nitro {
                 attestation: Bytes::from_static(b"attestation"),
-                public_values: Bytes::from_static(b"public values"),
+                public_values: TransitionPublicValues {
+                    l1Head: request.l1_head,
+                    l2PreRoot: B256::ZERO,
+                    l2PreBlockNumber: 0,
+                    l2PostRoot: request.root_claim,
+                    l2PostBlockNumber: request.l2_block_number,
+                    rollupConfigHash: B256::ZERO,
+                }
+                .abi_encode()
+                .into(),
                 signature: Bytes::from_static(b"signature"),
+                public_key: Bytes::from_static(b"public key"),
             },
         };
         Ok(ProofResponse::Succeeded(SucceededProofResponse {
@@ -600,7 +677,7 @@ async fn tick_discards_invalidated_games() {
 }
 
 #[tokio::test]
-async fn proposed_game_is_removed_after_challenge_deadline() {
+async fn proposed_game_remains_watched_after_challenge_deadline_until_resolved() {
     let canonical_root = B256::repeat_byte(0x20);
     let mut client = MockClient::new(vec![(GAME_1, canonical_root, L2_BLOCK)], HashMap::new());
     client.set_deadlines(GAME_1, 10, 20);
@@ -613,7 +690,31 @@ async fn proposed_game_is_removed_after_challenge_deadline() {
     assert_eq!(defender.watched_games(), [GAME_1]);
 
     defender.tick_at(10).await.unwrap();
-    assert!(defender.watched_games().is_empty());
+    assert_eq!(defender.watched_games(), [GAME_1]);
+}
+
+#[tokio::test]
+async fn timed_out_game_resolves_after_its_parent_finishes() {
+    let canonical_root = B256::repeat_byte(0x20);
+    let mut client = MockClient::new(vec![(GAME_1, canonical_root, L2_BLOCK)], HashMap::new());
+    client.set_deadlines(GAME_1, 0, 20);
+    client.set_parent_unresolved(GAME_1);
+    let (output_roots, _finalized_l2_block) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
+    let mut defender = WorldChainDefender::new(
+        config(),
+        client.clone(),
+        output_roots,
+        MockProver::default(),
+    );
+
+    defender.tick_at(10).await.unwrap();
+    assert_eq!(defender.watched_games(), [GAME_1]);
+    assert!(client.resolutions().is_empty());
+
+    client.set_parent_resolved(GAME_1);
+    defender.tick_at(11).await.unwrap();
+    assert_eq!(client.resolutions(), [GAME_1]);
 }
 
 #[tokio::test]
@@ -641,11 +742,12 @@ async fn active_defense_is_removed_after_proof_deadline() {
 
     defender.tick_at(20).await.unwrap();
     assert!(defender.active_defenses().is_empty());
-    assert!(defender.watched_games().is_empty());
+    assert_eq!(defender.watched_games(), [GAME_1]);
 
-    // Removal makes the critical deadline condition one-shot.
+    // The proof workflow stays closed while the game remains watched for resolution.
     defender.tick_at(21).await.unwrap();
     assert!(defender.active_defenses().is_empty());
+    assert_eq!(defender.watched_games(), [GAME_1]);
 }
 
 #[tokio::test]
@@ -711,9 +813,9 @@ async fn scan_accepts_sufficient_proof_support_hidden_by_an_unresolved_parent() 
     client.reset_proof_bitmap_reads();
     defender.tick_at(20).await.unwrap();
 
-    assert_eq!(client.proof_bitmap_reads(), 1);
+    assert_eq!(client.proof_bitmap_reads(), 2);
     assert_eq!(defender.next_game_index(), Some(2));
-    assert!(defender.watched_games().is_empty());
+    assert_eq!(defender.watched_games(), [GAME_1]);
     assert!(defender.active_defenses().is_empty());
 }
 
@@ -776,7 +878,7 @@ async fn active_defense_accepts_sufficient_proof_support_hidden_by_an_unresolved
     client.reset_proof_bitmap_reads();
     defender.tick_at(20).await.unwrap();
 
-    assert_eq!(client.proof_bitmap_reads(), 1);
+    assert_eq!(client.proof_bitmap_reads(), 2);
     assert!(client.submissions().is_empty());
     assert!(defender.watched_games().is_empty());
     assert!(defender.active_defenses().is_empty());
@@ -835,7 +937,7 @@ async fn tick_defends_challenged_valid_root() {
 }
 
 #[tokio::test]
-async fn tick_waits_for_proposed_game_to_be_challenged() {
+async fn proposed_valid_game_gets_initial_tee_proof() {
     let canonical_root = B256::repeat_byte(0x20);
 
     let client = MockClient::new(vec![(GAME_1, canonical_root, L2_BLOCK)], HashMap::new());
@@ -845,19 +947,82 @@ async fn tick_waits_for_proposed_game_to_be_challenged() {
     let mut defender =
         WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
 
-    // the game is only proposed: keep watching, no proof requests
+    // Discovery and canonical-root validation happen before proving starts.
     defender.tick().await.unwrap();
     assert!(prover.requests().is_empty());
     assert_eq!(defender.watched_games(), [GAME_1]);
 
-    client.set_state(GAME_1, STATE_CHALLENGED);
     defender.tick().await.unwrap();
-
     assert!(prover.requests().is_empty());
     assert_eq!(defender.active_defenses(), [GAME_1]);
 
     defender.tick().await.unwrap();
-    assert_eq!(prover.requests().len(), 2);
+    assert_eq!(prover.requests().len(), 1);
+    assert_eq!(prover.requests()[0].backend, ProofBackend::Nitro);
+
+    defender.tick().await.unwrap();
+    defender.tick().await.unwrap();
+
+    assert_eq!(
+        client.submissions(),
+        vec![(GAME_1, ProofLane::TeeAttestation as u8)]
+    );
+    assert_eq!(defender.watched_games(), [GAME_1]);
+    assert!(defender.active_defenses().is_empty());
+}
+
+#[tokio::test]
+async fn challenge_after_initial_tee_proof_requests_only_missing_threshold_lane() {
+    let canonical_root = B256::repeat_byte(0x20);
+    let client = MockClient::new(vec![(GAME_1, canonical_root, L2_BLOCK)], HashMap::new());
+    let (output_roots, _finalized_l2_block) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
+    let prover = MockProver::default();
+    let mut defender =
+        WorldChainDefender::new(config(), client.clone(), output_roots, prover.clone());
+
+    for _ in 0..5 {
+        defender.tick().await.unwrap();
+    }
+    client.set_state(GAME_1, STATE_CHALLENGED);
+
+    defender.tick().await.unwrap();
+    defender.tick().await.unwrap();
+    defender.tick().await.unwrap();
+
+    let requests = prover.requests();
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[0].backend, ProofBackend::Nitro);
+    assert_eq!(requests[1].backend, ProofBackend::Sp1);
+    assert_eq!(
+        client.submissions(),
+        vec![
+            (GAME_1, ProofLane::TeeAttestation as u8),
+            (GAME_1, ProofLane::ValidityProof as u8),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn proofless_timed_out_game_is_resolved_negatively() {
+    let canonical_root = B256::repeat_byte(0x20);
+    let mut client = MockClient::new(vec![(GAME_1, canonical_root, L2_BLOCK)], HashMap::new());
+    client.set_deadlines(GAME_1, 0, 100);
+    let (output_roots, _finalized_l2_block) =
+        mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
+    let mut defender = WorldChainDefender::new(
+        config(),
+        client.clone(),
+        output_roots,
+        MockProver::default(),
+    );
+
+    defender.tick_at(1).await.unwrap();
+    defender.tick_at(1).await.unwrap();
+
+    assert_eq!(client.resolutions(), [GAME_1]);
+    assert_eq!(client.state(GAME_1).unwrap(), RootState::Invalidated);
+    assert!(defender.watched_games().is_empty());
 }
 
 #[tokio::test]
@@ -883,7 +1048,7 @@ async fn tick_ignores_challenged_invalid_root() {
 
     defender.tick().await.unwrap();
 
-    assert!(defender.watched_games().is_empty());
+    assert_eq!(defender.watched_games(), [GAME_1]);
     assert!(defender.active_defenses().is_empty());
 }
 

--- a/proofs/defender/src/traits.rs
+++ b/proofs/defender/src/traits.rs
@@ -16,8 +16,6 @@ pub trait DefenderClient: Send + Sync {
     async fn game_address_at(&self, index: u64) -> Result<Option<Address>, DefenderError>;
     /// Returns the creation timestamp of any game at the provided factory index.
     async fn game_created_at(&self, index: u64) -> Result<u64, DefenderError>;
-    /// Reads the account that created the provided game.
-    async fn game_creator(&self, game: Address) -> Result<Address, DefenderError>;
     /// Reads the immutable game data needed to monitor and defend its root claim.
     async fn game_metadata(&self, game: Address) -> Result<GameMetadata, DefenderError>;
     /// Returns the current resolution evaluation for the provided game.

--- a/proofs/defender/src/traits.rs
+++ b/proofs/defender/src/traits.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::DefenderError,
-    types::{DefenderSubmission, GameMetadata},
+    types::{DefenderSubmission, GameMetadata, ResolveSubmission},
 };
 use alloy_primitives::{Address, Bytes};
 use async_trait::async_trait;
@@ -24,7 +24,9 @@ pub trait DefenderClient: Send + Sync {
     async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, DefenderError>;
     /// Get the bitmap of proof lanes already proven for the provided game.
     async fn proof_bitmap(&self, game: Address) -> Result<u8, DefenderError>;
-    /// Submit a proof to support a challenged game.
+    /// Resolves a game whose outcome is already determined.
+    async fn resolve_game(&self, game: Address) -> Result<ResolveSubmission, DefenderError>;
+    /// Submits a proof to support a proposed or challenged game.
     async fn submit_proof(
         &self,
         game: Address,

--- a/proofs/defender/src/traits.rs
+++ b/proofs/defender/src/traits.rs
@@ -1,29 +1,17 @@
 use crate::{
     error::DefenderError,
-    types::{DefenderSubmission, GameMetadata, ResolveSubmission},
+    types::{DefenderSubmission, GameMetadata},
 };
 use alloy_primitives::{Address, Bytes};
 use async_trait::async_trait;
-use world_chain_proofs::ResolutionStatus;
+use world_chain_proofs::LineageProvider;
 
 #[async_trait]
-pub trait DefenderClient: Send + Sync {
-    /// Returns the total number of games indexed by the dispute-game factory, across all
-    /// game types.
-    async fn game_count(&self) -> Result<u64, DefenderError>;
-    /// Returns the WIP-1006 game at the provided factory index, or `None` when that index
-    /// holds a game of a different type.
-    async fn game_address_at(&self, index: u64) -> Result<Option<Address>, DefenderError>;
-    /// Returns the creation timestamp of any game at the provided factory index.
-    async fn game_created_at(&self, index: u64) -> Result<u64, DefenderError>;
+pub trait DefenderClient: LineageProvider {
     /// Reads the immutable game data needed to monitor and defend its root claim.
     async fn game_metadata(&self, game: Address) -> Result<GameMetadata, DefenderError>;
-    /// Returns the current resolution evaluation for the provided game.
-    async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, DefenderError>;
     /// Get the bitmap of proof lanes already proven for the provided game.
     async fn proof_bitmap(&self, game: Address) -> Result<u8, DefenderError>;
-    /// Resolves a game whose outcome is already determined.
-    async fn resolve_game(&self, game: Address) -> Result<ResolveSubmission, DefenderError>;
     /// Submits a proof to support a proposed or challenged game.
     async fn submit_proof(
         &self,

--- a/proofs/defender/src/types.rs
+++ b/proofs/defender/src/types.rs
@@ -21,9 +21,3 @@ pub struct DefenderSubmission {
     /// Transaction hash for the proof submission.
     pub tx_hash: TxHash,
 }
-
-/// Result of a submitted `resolve` transaction.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ResolveSubmission {
-    pub tx_hash: TxHash,
-}

--- a/proofs/defender/src/types.rs
+++ b/proofs/defender/src/types.rs
@@ -4,9 +4,12 @@ use alloy_primitives::{Address, B256, TxHash};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GameMetadata {
     pub address: Address,
+    pub domain_hash: B256,
+    pub parent_ref: Address,
     pub root_claim: B256,
     pub l2_block_number: u64,
     pub l1_origin_hash: B256,
+    pub l1_origin_number: u64,
     pub challenge_deadline: u64,
     pub proof_deadline: u64,
     pub proof_threshold: u8,
@@ -15,6 +18,12 @@ pub struct GameMetadata {
 /// Result of a submitted `submitProofLane` transaction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DefenderSubmission {
-    /// Transaction hash for the challenge submission.
+    /// Transaction hash for the proof submission.
+    pub tx_hash: TxHash,
+}
+
+/// Result of a submitted `resolve` transaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResolveSubmission {
     pub tx_hash: TxHash,
 }

--- a/proofs/integration-tests/Cargo.toml
+++ b/proofs/integration-tests/Cargo.toml
@@ -14,12 +14,14 @@ workspace = true
 [dependencies]
 world-chain-challenger.workspace = true
 world-chain-defender.workspace = true
+world-chain-proof-core.workspace = true
 world-chain-proof-worker.workspace = true
 world-chain-proofs.workspace = true
 world-chain-proposer.workspace = true
 world-chain-prover-service.workspace = true
 
 alloy-primitives.workspace = true
+alloy-sol-types.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 

--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -6,6 +6,7 @@
 //! depending on a live chain or expensive proof generation.
 
 use alloy_primitives::{Address, B256, BlockNumber, Bytes, U256, address};
+use alloy_sol_types::SolValue;
 use async_trait::async_trait;
 use std::{
     collections::HashMap,
@@ -16,7 +17,9 @@ use world_chain_challenger::{
 };
 use world_chain_defender::{
     DefenderClient, DefenderError, DefenderSubmission, GameMetadata as DefenderGameMetadata,
+    ResolveSubmission as DefenderResolveSubmission,
 };
+use world_chain_proof_core::boot::TransitionPublicValues;
 use world_chain_proof_worker::{ClaimedProofJobHandler, ProofJob};
 use world_chain_proofs::{
     ConsensusError, ConsensusProvider, InvalidationReason, PROOF_SYSTEM_VERSION, PROOF_THRESHOLD,
@@ -44,6 +47,7 @@ const STATE_NONE: u8 = 0;
 const STATE_PROPOSED: u8 = 1;
 const STATE_CHALLENGED: u8 = 2;
 const STATE_FINALIZED: u8 = 3;
+const STATE_INVALIDATED: u8 = 4;
 
 /// Domain used by the fake proof-system factory.
 #[must_use]
@@ -161,8 +165,7 @@ impl FakeExecution {
             state: Arc::new(Mutex::new(FakeExecutionState {
                 domain_hash: test_domain().hash(),
                 anchor: AnchorRef {
-                    registry: ANCHOR,
-                    anchor_game: None,
+                    address: ANCHOR,
                     l2_block_number: 0,
                 },
                 finalized_l1_block: 10_000,
@@ -313,36 +316,28 @@ impl ProposerClient for FakeExecution {
             .anchor)
     }
 
-    async fn games_for_transition(
+    async fn game_for_transition(
         &self,
-        parent_candidates: &[Address],
+        parent_ref: Address,
         root_claim: B256,
         l2_block_number: u64,
-    ) -> Result<Vec<TransitionGame>, ProposerError> {
+    ) -> Result<Option<TransitionGame>, ProposerError> {
         let state = self.state.lock().expect("fake execution mutex poisoned");
-        let mut found = Vec::with_capacity(parent_candidates.len());
-        for parent_ref in parent_candidates {
-            let mut latest = None;
-            for attempt in 0..MAX_ATTEMPT_SCAN {
-                let uuid = ProposalCommitment {
-                    parent_ref: *parent_ref,
-                    root_claim,
-                    l2_block_number,
-                    attempt,
-                }
-                .game_uuid(state.domain_hash);
-                let Some(address) = state.games_by_key.get(&uuid).copied() else {
-                    break;
-                };
-                latest = Some(TransitionGame {
-                    address,
-                    parent_ref: *parent_ref,
-                    attempt,
-                });
+        let mut latest = None;
+        for attempt in 0..MAX_ATTEMPT_SCAN {
+            let uuid = ProposalCommitment {
+                parent_ref,
+                root_claim,
+                l2_block_number,
+                attempt,
             }
-            found.extend(latest);
+            .game_uuid(state.domain_hash);
+            let Some(address) = state.games_by_key.get(&uuid).copied() else {
+                break;
+            };
+            latest = Some(TransitionGame { address, attempt });
         }
-        Ok(found)
+        Ok(latest)
     }
 
     /// The fake has no registry finality airgap: a resolved game is immediately closeable.
@@ -429,8 +424,7 @@ impl ProposerClient for FakeExecution {
         }
         let l2_block_number = record.event.l2_block_number;
         state.anchor = AnchorRef {
-            registry: ANCHOR,
-            anchor_game: Some(game),
+            address: game,
             l2_block_number,
         };
         Ok(CloseGameSubmission {
@@ -438,14 +432,9 @@ impl ProposerClient for FakeExecution {
         })
     }
 
-    async fn latest_finalized_l1_block(&self) -> Result<B256, ProposerError> {
-        Ok(B256::repeat_byte(0xf1))
-    }
-
     async fn submit_proposal(
         &self,
         proposal: &Proposal,
-        _proof: ProofData,
     ) -> Result<ProposalSubmission, ProposerError> {
         let mut state = self.state.lock().expect("fake execution mutex poisoned");
         let uuid = proposal.commitment().game_uuid(state.domain_hash);
@@ -592,16 +581,18 @@ impl DefenderClient for FakeExecution {
     }
 
     async fn game_metadata(&self, game: Address) -> Result<DefenderGameMetadata, DefenderError> {
-        self.state
-            .lock()
-            .expect("fake execution mutex poisoned")
+        let state = self.state.lock().expect("fake execution mutex poisoned");
+        state
             .games_by_address
             .get(&game)
             .map(|record| DefenderGameMetadata {
                 address: game,
+                domain_hash: state.domain_hash,
+                parent_ref: record.event.parent_ref,
                 root_claim: record.event.root_claim,
                 l2_block_number: record.event.l2_block_number,
                 l1_origin_hash: record.event.l1_origin_hash,
+                l1_origin_number: record.event.l1_origin_number,
                 challenge_deadline: record.challenge_deadline,
                 proof_deadline: record.proof_deadline,
                 proof_threshold: PROOF_THRESHOLD,
@@ -645,6 +636,21 @@ impl DefenderClient for FakeExecution {
                 invalidation_reason: InvalidationReason::ProofTimeout,
             });
         }
+        if current_state == RootState::Proposed && record.challenge_deadline == 0 {
+            return Ok(ResolutionStatus {
+                resolvable: true,
+                root_state: if record.proof_bitmap == 0 {
+                    RootState::Invalidated
+                } else {
+                    RootState::Finalized
+                },
+                invalidation_reason: if record.proof_bitmap == 0 {
+                    InvalidationReason::ProofTimeout
+                } else {
+                    InvalidationReason::None
+                },
+            });
+        }
 
         Ok(ResolutionStatus {
             resolvable: false,
@@ -661,6 +667,35 @@ impl DefenderClient for FakeExecution {
             .get(&game)
             .map(|record| record.proof_bitmap)
             .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))
+    }
+
+    async fn resolve_game(
+        &self,
+        game: Address,
+    ) -> Result<DefenderResolveSubmission, DefenderError> {
+        let status = DefenderClient::resolution_status(self, game).await?;
+        if !status.resolvable {
+            return Err(DefenderError::Contract(format!(
+                "game {game} is not resolvable"
+            )));
+        }
+        let mut state = self.state.lock().expect("fake execution mutex poisoned");
+        let record = state
+            .games_by_address
+            .get_mut(&game)
+            .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))?;
+        record.state = match status.root_state {
+            RootState::Finalized => STATE_FINALIZED,
+            RootState::Invalidated => STATE_INVALIDATED,
+            _ => {
+                return Err(DefenderError::Contract(format!(
+                    "game {game} has no terminal outcome"
+                )));
+            }
+        };
+        Ok(DefenderResolveSubmission {
+            tx_hash: B256::with_last_byte(game.as_slice()[19]),
+        })
     }
 
     async fn submit_proof(
@@ -680,9 +715,9 @@ impl DefenderClient for FakeExecution {
             .games_by_address
             .get_mut(&game)
             .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))?;
-        if record.state != STATE_CHALLENGED {
+        if record.state != STATE_PROPOSED && record.state != STATE_CHALLENGED {
             return Err(DefenderError::Contract(format!(
-                "game {game} is not challenged"
+                "game {game} is not open for proofs"
             )));
         }
 
@@ -751,8 +786,18 @@ impl ClaimedProofJobHandler for FakeProofBackend {
             },
             ProofBackend::Nitro => ProofData::Nitro {
                 attestation: request.l1_head.as_slice().to_vec().into(),
-                public_values: request.root_claim.as_slice().to_vec().into(),
+                public_values: TransitionPublicValues {
+                    l1Head: request.l1_head,
+                    l2PreRoot: B256::ZERO,
+                    l2PreBlockNumber: 0,
+                    l2PostRoot: request.root_claim,
+                    l2PostBlockNumber: request.l2_block_number,
+                    rollupConfigHash: B256::ZERO,
+                }
+                .abi_encode()
+                .into(),
                 signature: vec![0x7e, request.l2_block_number as u8].into(), // mock signature
+                public_key: Bytes::from_static(b"public key"),
             },
         })
     }

--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -368,7 +368,9 @@ impl ProposerClient for FakeExecution {
                 invalidation_reason: InvalidationReason::None,
             });
         }
-        if record.state == STATE_CHALLENGED && has_threshold(record.proof_bitmap) {
+        if matches!(record.state, STATE_PROPOSED | STATE_CHALLENGED)
+            && has_threshold(record.proof_bitmap)
+        {
             return Ok(ResolutionStatus {
                 resolvable: true,
                 root_state: RootState::Finalized,
@@ -397,7 +399,7 @@ impl ProposerClient for FakeExecution {
             .get_mut(&game)
             .ok_or_else(|| ProposerError::Contract(format!("unknown game {game}")))?;
         if parent_unresolved
-            || record.state != STATE_CHALLENGED
+            || !matches!(record.state, STATE_PROPOSED | STATE_CHALLENGED)
             || !has_threshold(record.proof_bitmap)
         {
             return Err(ProposerError::Contract(format!(
@@ -622,7 +624,9 @@ impl DefenderClient for FakeExecution {
                 invalidation_reason: InvalidationReason::None,
             });
         }
-        if current_state == RootState::Challenged && has_threshold(record.proof_bitmap) {
+        if matches!(current_state, RootState::Proposed | RootState::Challenged)
+            && has_threshold(record.proof_bitmap)
+        {
             return Ok(ResolutionStatus {
                 resolvable: true,
                 root_state: RootState::Finalized,

--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -17,18 +17,18 @@ use world_chain_challenger::{
 };
 use world_chain_defender::{
     DefenderClient, DefenderError, DefenderSubmission, GameMetadata as DefenderGameMetadata,
-    ResolveSubmission as DefenderResolveSubmission,
 };
 use world_chain_proof_core::boot::TransitionPublicValues;
 use world_chain_proof_worker::{ClaimedProofJobHandler, ProofJob};
 use world_chain_proofs::{
-    ConsensusError, ConsensusProvider, InvalidationReason, PROOF_SYSTEM_VERSION, PROOF_THRESHOLD,
-    ProofDomain, ProofLane, ProposalCommitment, ResolutionStatus, RootCommitment, RootState,
-    WorldChainGameCreated, has_threshold,
+    ConsensusError, ConsensusProvider, InvalidationReason, LineageAnchor, LineageError,
+    LineageGame, LineageProvider, LineageTransition, MAX_ATTEMPT_SCAN, PROOF_SYSTEM_VERSION,
+    PROOF_THRESHOLD, ProofDomain, ProofLane, ProposalCommitment, ResolutionStatus, RootCommitment,
+    RootState, WorldChainGameCreated, has_threshold,
 };
 use world_chain_proposer::{
-    AnchorRef, CloseGameSubmission, Proposal, ProposalSubmission, ProposerClient, ProposerError,
-    ResolveSubmission, TransitionGame,
+    CloseGameSubmission, Proposal, ProposalSubmission, ProposerClient, ProposerError,
+    ResolveSubmission,
 };
 use world_chain_prover_service::{
     GetNextProofRequest, GetNextProofResponse, GetProofSessionRequest, GetProofSessionResponse,
@@ -133,7 +133,7 @@ pub struct FakeExecution {
 #[derive(Debug)]
 struct FakeExecutionState {
     domain_hash: B256,
-    anchor: AnchorRef,
+    anchor: LineageAnchor,
     finalized_l1_block: BlockNumber,
     next_game_nonce: u8,
     games_by_key: HashMap<B256, Address>,
@@ -164,7 +164,7 @@ impl FakeExecution {
         Self {
             state: Arc::new(Mutex::new(FakeExecutionState {
                 domain_hash: test_domain().hash(),
-                anchor: AnchorRef {
+                anchor: LineageAnchor {
                     address: ANCHOR,
                     l2_block_number: 0,
                 },
@@ -293,9 +293,6 @@ fn proof_lane(lane: u8) -> Option<ProofLane> {
     }
 }
 
-/// Mirrors the attempt walk in the real Alloy clients.
-const MAX_ATTEMPT_SCAN: u64 = 4;
-
 fn parent_is_unresolved(state: &FakeExecutionState, record: &GameRecord) -> bool {
     if record.event.parent_ref == ANCHOR {
         return false;
@@ -307,8 +304,12 @@ fn parent_is_unresolved(state: &FakeExecutionState, record: &GameRecord) -> bool
 }
 
 #[async_trait]
-impl ProposerClient for FakeExecution {
-    async fn anchor_parent(&self) -> Result<AnchorRef, ProposerError> {
+impl LineageProvider for FakeExecution {
+    fn lineage_block_interval(&self) -> u64 {
+        BLOCK_INTERVAL
+    }
+
+    async fn lineage_anchor(&self) -> Result<LineageAnchor, LineageError> {
         Ok(self
             .state
             .lock()
@@ -318,42 +319,37 @@ impl ProposerClient for FakeExecution {
 
     async fn game_for_transition(
         &self,
-        parent_ref: Address,
-        root_claim: B256,
-        l2_block_number: u64,
-    ) -> Result<Option<TransitionGame>, ProposerError> {
+        transition: LineageTransition,
+    ) -> Result<Option<LineageGame>, LineageError> {
         let state = self.state.lock().expect("fake execution mutex poisoned");
         let mut latest = None;
         for attempt in 0..MAX_ATTEMPT_SCAN {
             let uuid = ProposalCommitment {
-                parent_ref,
-                root_claim,
-                l2_block_number,
+                parent_ref: transition.parent_ref,
+                root_claim: transition.root_claim,
+                l2_block_number: transition.l2_block_number,
                 attempt,
             }
             .game_uuid(state.domain_hash);
             let Some(address) = state.games_by_key.get(&uuid).copied() else {
                 break;
             };
-            latest = Some(TransitionGame { address, attempt });
+            latest = Some(LineageGame { address, attempt });
         }
         Ok(latest)
     }
 
-    /// The fake has no registry finality airgap: a resolved game is immediately closeable.
-    async fn is_game_finalized(&self, _game: Address) -> Result<bool, ProposerError> {
-        Ok(true)
-    }
-
-    async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError> {
+    async fn lineage_resolution_status(
+        &self,
+        game: Address,
+    ) -> Result<ResolutionStatus, LineageError> {
         let state = self.state.lock().expect("fake execution mutex poisoned");
         let record = state
             .games_by_address
             .get(&game)
-            .ok_or_else(|| ProposerError::Contract(format!("unknown game {game}")))?;
+            .ok_or_else(|| LineageError::Contract(format!("unknown game {game}")))?;
 
-        let root_state = RootState::try_from(record.state)
-            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+        let root_state = RootState::try_from(record.state)?;
         if root_state == RootState::Finalized {
             return Ok(ResolutionStatus {
                 resolvable: false,
@@ -377,6 +373,28 @@ impl ProposerClient for FakeExecution {
                 invalidation_reason: InvalidationReason::None,
             });
         }
+        if root_state == RootState::Challenged && record.proof_deadline == 0 {
+            return Ok(ResolutionStatus {
+                resolvable: true,
+                root_state: RootState::Invalidated,
+                invalidation_reason: InvalidationReason::ProofTimeout,
+            });
+        }
+        if root_state == RootState::Proposed && record.challenge_deadline == 0 {
+            return Ok(ResolutionStatus {
+                resolvable: true,
+                root_state: if record.proof_bitmap == 0 {
+                    RootState::Invalidated
+                } else {
+                    RootState::Finalized
+                },
+                invalidation_reason: if record.proof_bitmap == 0 {
+                    InvalidationReason::ProofTimeout
+                } else {
+                    InvalidationReason::None
+                },
+            });
+        }
 
         Ok(ResolutionStatus {
             resolvable: false,
@@ -384,29 +402,36 @@ impl ProposerClient for FakeExecution {
             invalidation_reason: InvalidationReason::None,
         })
     }
+}
+
+#[async_trait]
+impl ProposerClient for FakeExecution {
+    /// The fake has no registry finality airgap: a resolved game is immediately closeable.
+    async fn is_game_finalized(&self, _game: Address) -> Result<bool, ProposerError> {
+        Ok(true)
+    }
 
     async fn resolve_game(&self, game: Address) -> Result<ResolveSubmission, ProposerError> {
+        let status = self.lineage_resolution_status(game).await?;
+        if !status.resolvable {
+            return Err(ProposerError::Contract(format!(
+                "game {game} is not resolvable"
+            )));
+        }
         let mut state = self.state.lock().expect("fake execution mutex poisoned");
-        let parent_unresolved = {
-            let record = state
-                .games_by_address
-                .get(&game)
-                .ok_or_else(|| ProposerError::Contract(format!("unknown game {game}")))?;
-            parent_is_unresolved(&state, record)
-        };
         let record = state
             .games_by_address
             .get_mut(&game)
             .ok_or_else(|| ProposerError::Contract(format!("unknown game {game}")))?;
-        if parent_unresolved
-            || !matches!(record.state, STATE_PROPOSED | STATE_CHALLENGED)
-            || !has_threshold(record.proof_bitmap)
-        {
-            return Err(ProposerError::Contract(format!(
-                "game {game} is not positively resolvable"
-            )));
-        }
-        record.state = STATE_FINALIZED;
+        record.state = match status.root_state {
+            RootState::Finalized => STATE_FINALIZED,
+            RootState::Invalidated => STATE_INVALIDATED,
+            _ => {
+                return Err(ProposerError::Contract(format!(
+                    "game {game} has no terminal outcome"
+                )));
+            }
+        };
 
         Ok(ResolveSubmission {
             tx_hash: B256::with_last_byte(game.as_slice()[19]),
@@ -425,7 +450,7 @@ impl ProposerClient for FakeExecution {
             )));
         }
         let l2_block_number = record.event.l2_block_number;
-        state.anchor = AnchorRef {
+        state.anchor = LineageAnchor {
             address: game,
             l2_block_number,
         };
@@ -542,36 +567,6 @@ impl ChallengerClient for FakeExecution {
 
 #[async_trait]
 impl DefenderClient for FakeExecution {
-    async fn game_count(&self) -> Result<u64, DefenderError> {
-        Ok(self
-            .state
-            .lock()
-            .expect("fake execution mutex poisoned")
-            .game_order
-            .len() as u64)
-    }
-
-    async fn game_address_at(&self, index: u64) -> Result<Option<Address>, DefenderError> {
-        self.state
-            .lock()
-            .expect("fake execution mutex poisoned")
-            .game_order
-            .get(index as usize)
-            .copied()
-            .map(Some)
-            .ok_or_else(|| DefenderError::Contract(format!("unknown game index {index}")))
-    }
-
-    async fn game_created_at(&self, index: u64) -> Result<u64, DefenderError> {
-        self.state
-            .lock()
-            .expect("fake execution mutex poisoned")
-            .game_order
-            .get(index as usize)
-            .map(|_| u64::MAX)
-            .ok_or_else(|| DefenderError::Contract(format!("unknown game index {index}")))
-    }
-
     async fn game_metadata(&self, game: Address) -> Result<DefenderGameMetadata, DefenderError> {
         let state = self.state.lock().expect("fake execution mutex poisoned");
         state
@@ -592,67 +587,6 @@ impl DefenderClient for FakeExecution {
             .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))
     }
 
-    async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, DefenderError> {
-        let state = self.state.lock().expect("fake execution mutex poisoned");
-        let record = state
-            .games_by_address
-            .get(&game)
-            .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))?;
-        let current_state = RootState::try_from(record.state)?;
-
-        if current_state == RootState::Finalized {
-            return Ok(ResolutionStatus {
-                resolvable: false,
-                root_state: current_state,
-                invalidation_reason: InvalidationReason::None,
-            });
-        }
-        if parent_is_unresolved(&state, record) {
-            return Ok(ResolutionStatus {
-                resolvable: false,
-                root_state: current_state,
-                invalidation_reason: InvalidationReason::None,
-            });
-        }
-        if matches!(current_state, RootState::Proposed | RootState::Challenged)
-            && has_threshold(record.proof_bitmap)
-        {
-            return Ok(ResolutionStatus {
-                resolvable: true,
-                root_state: RootState::Finalized,
-                invalidation_reason: InvalidationReason::None,
-            });
-        }
-        if current_state == RootState::Challenged && record.proof_deadline == 0 {
-            return Ok(ResolutionStatus {
-                resolvable: true,
-                root_state: RootState::Invalidated,
-                invalidation_reason: InvalidationReason::ProofTimeout,
-            });
-        }
-        if current_state == RootState::Proposed && record.challenge_deadline == 0 {
-            return Ok(ResolutionStatus {
-                resolvable: true,
-                root_state: if record.proof_bitmap == 0 {
-                    RootState::Invalidated
-                } else {
-                    RootState::Finalized
-                },
-                invalidation_reason: if record.proof_bitmap == 0 {
-                    InvalidationReason::ProofTimeout
-                } else {
-                    InvalidationReason::None
-                },
-            });
-        }
-
-        Ok(ResolutionStatus {
-            resolvable: false,
-            root_state: current_state,
-            invalidation_reason: InvalidationReason::None,
-        })
-    }
-
     async fn proof_bitmap(&self, game: Address) -> Result<u8, DefenderError> {
         self.state
             .lock()
@@ -661,35 +595,6 @@ impl DefenderClient for FakeExecution {
             .get(&game)
             .map(|record| record.proof_bitmap)
             .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))
-    }
-
-    async fn resolve_game(
-        &self,
-        game: Address,
-    ) -> Result<DefenderResolveSubmission, DefenderError> {
-        let status = DefenderClient::resolution_status(self, game).await?;
-        if !status.resolvable {
-            return Err(DefenderError::Contract(format!(
-                "game {game} is not resolvable"
-            )));
-        }
-        let mut state = self.state.lock().expect("fake execution mutex poisoned");
-        let record = state
-            .games_by_address
-            .get_mut(&game)
-            .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))?;
-        record.state = match status.root_state {
-            RootState::Finalized => STATE_FINALIZED,
-            RootState::Invalidated => STATE_INVALIDATED,
-            _ => {
-                return Err(DefenderError::Contract(format!(
-                    "game {game} has no terminal outcome"
-                )));
-            }
-        };
-        Ok(DefenderResolveSubmission {
-            tx_hash: B256::with_last_byte(game.as_slice()[19]),
-        })
     }
 
     async fn submit_proof(

--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -572,16 +572,6 @@ impl DefenderClient for FakeExecution {
             .ok_or_else(|| DefenderError::Contract(format!("unknown game index {index}")))
     }
 
-    async fn game_creator(&self, game: Address) -> Result<Address, DefenderError> {
-        self.state
-            .lock()
-            .expect("fake execution mutex poisoned")
-            .games_by_address
-            .get(&game)
-            .map(|record| record.event.game_creator)
-            .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))
-    }
-
     async fn game_metadata(&self, game: Address) -> Result<DefenderGameMetadata, DefenderError> {
         let state = self.state.lock().expect("fake execution mutex poisoned");
         state

--- a/proofs/integration-tests/tests/orchestration.rs
+++ b/proofs/integration-tests/tests/orchestration.rs
@@ -8,8 +8,7 @@ use tokio_util::sync::CancellationToken;
 use world_chain_challenger::{ChallengerConfig, WorldChainChallenger};
 use world_chain_defender::{DefenderClient, DefenderConfig, WorldChainDefender};
 use world_chain_proof_integration_tests::{
-    BLOCK_INTERVAL, FAKE_PROPOSER, FakeConsensus, FakeExecution, FakeProofBackend,
-    SharedProverService,
+    BLOCK_INTERVAL, FakeConsensus, FakeExecution, FakeProofBackend, SharedProverService,
 };
 use world_chain_proof_worker::{
     ProofWorker, ProofWorkerConfig, RetryConfig, WorkerHeartbeatConfig,
@@ -37,7 +36,6 @@ fn challenger_config() -> ChallengerConfig {
 
 fn defender_config() -> DefenderConfig {
     DefenderConfig {
-        allowed_proposer: FAKE_PROPOSER,
         poll_interval: Duration::from_secs(1),
         ..DefenderConfig::default()
     }

--- a/proofs/integration-tests/tests/orchestration.rs
+++ b/proofs/integration-tests/tests/orchestration.rs
@@ -13,15 +13,14 @@ use world_chain_proof_integration_tests::{
 use world_chain_proof_worker::{
     ProofWorker, ProofWorkerConfig, RetryConfig, WorkerHeartbeatConfig,
 };
-use world_chain_proofs::{ProofLane, RootState, has_threshold};
+use world_chain_proofs::{LineageProvider, ProofLane, RootState, has_threshold};
 use world_chain_proposer::{
-    CanonicalScan, ProposerClient, ProposerConfig, ProposerError, WorldChainProposer,
+    ProposerClient, ProposerConfig, ProposerError, ProposerScan, WorldChainProposer,
 };
 use world_chain_prover_service::{ProofBackend, ProverServiceConfig};
 
 fn proposer_config() -> ProposerConfig {
     ProposerConfig {
-        block_interval: BLOCK_INTERVAL,
         poll_interval: Duration::from_secs(1),
         max_resolutions_per_tick: 1,
     }
@@ -48,23 +47,23 @@ fn assert_defense_lanes(lanes: Vec<ProofLane>) {
 }
 
 async fn settle_with_proposer(proposer: &WorldChainProposer<FakeExecution, FakeConsensus>) {
-    let canonical_scan = proposer
-        .anchor_and_canonical_line()
+    let scan = proposer
+        .scan_selected_lineage()
         .await
-        .expect("canonical line reconstructed");
-    let finalized_games = proposer
-        .resolve_games(canonical_scan.canonical_line())
+        .expect("selected lineage reconstructed");
+    let highest_finalized_game = proposer
+        .resolve_games(scan.lineage().games())
         .await
         .expect("canonical games resolved");
     proposer
-        .advance_anchor(finalized_games)
+        .advance_anchor(highest_finalized_game)
         .await
         .expect("anchor advanced");
 }
 
 async fn post_proposal(
     proposer: &WorldChainProposer<FakeExecution, FakeConsensus>,
-    scan: &CanonicalScan,
+    scan: &ProposerScan,
 ) -> Result<(), ProposerError> {
     proposer.submit_next_proposal(scan).await
 }
@@ -76,11 +75,11 @@ async fn fake_resolution_matches_contract_transition_semantics() {
     let consensus = FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
     let proposer = WorldChainProposer::new(proposer_config(), chain.clone(), consensus);
 
-    let canonical_scan = proposer
-        .anchor_and_canonical_line()
+    let scan = proposer
+        .scan_selected_lineage()
         .await
-        .expect("canonical line reconstructed");
-    post_proposal(&proposer, &canonical_scan)
+        .expect("selected lineage reconstructed");
+    post_proposal(&proposer, &scan)
         .await
         .expect("proposal posted");
     let game = chain.latest_game().expect("game created").game;
@@ -103,7 +102,7 @@ async fn fake_resolution_matches_contract_transition_semantics() {
         .await
         .expect("TEE proof submitted");
 
-    let ready = ProposerClient::resolution_status(&chain, game)
+    let ready = LineageProvider::lineage_resolution_status(&chain, game)
         .await
         .expect("resolution status available");
     assert!(ready.resolvable);
@@ -112,7 +111,7 @@ async fn fake_resolution_matches_contract_transition_semantics() {
 
     settle_with_proposer(&proposer).await;
 
-    let finalized = ProposerClient::resolution_status(&chain, game)
+    let finalized = LineageProvider::lineage_resolution_status(&chain, game)
         .await
         .expect("resolution status available");
     assert!(!finalized.resolvable);
@@ -227,11 +226,11 @@ async fn invalid_root_is_challenged_by_real_challenger() {
 
     let proposer =
         WorldChainProposer::new(proposer_config(), chain.clone(), bad_proposer_consensus);
-    let canonical_scan = proposer
-        .anchor_and_canonical_line()
+    let scan = proposer
+        .scan_selected_lineage()
         .await
-        .expect("canonical line reconstructed");
-    post_proposal(&proposer, &canonical_scan)
+        .expect("selected lineage reconstructed");
+    post_proposal(&proposer, &scan)
         .await
         .expect("bad proposal posted");
     let game = chain.latest_game().expect("game created").game;
@@ -253,11 +252,11 @@ async fn valid_proposal_receives_initial_tee_proof_through_worker() {
     let canonical_root = B256::repeat_byte(0x20);
     let consensus = FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
     let proposer = WorldChainProposer::new(proposer_config(), chain.clone(), consensus.clone());
-    let canonical_scan = proposer
-        .anchor_and_canonical_line()
+    let scan = proposer
+        .scan_selected_lineage()
         .await
-        .expect("canonical line reconstructed");
-    post_proposal(&proposer, &canonical_scan)
+        .expect("selected lineage reconstructed");
+    post_proposal(&proposer, &scan)
         .await
         .expect("proposal posted");
     let game = chain.latest_game().expect("game created").game;
@@ -293,11 +292,11 @@ async fn valid_challenged_root_is_defended_through_workers() {
     let consensus = FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
 
     let proposer = WorldChainProposer::new(proposer_config(), chain.clone(), consensus.clone());
-    let canonical_scan = proposer
-        .anchor_and_canonical_line()
+    let scan = proposer
+        .scan_selected_lineage()
         .await
-        .expect("canonical line reconstructed");
-    post_proposal(&proposer, &canonical_scan)
+        .expect("selected lineage reconstructed");
+    post_proposal(&proposer, &scan)
         .await
         .expect("proposal posted");
     let game = chain.latest_game().expect("game created").game;
@@ -338,11 +337,11 @@ async fn valid_challenged_root_survives_transient_proof_failure() {
     let consensus = FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
 
     let proposer = WorldChainProposer::new(proposer_config(), chain.clone(), consensus.clone());
-    let canonical_scan = proposer
-        .anchor_and_canonical_line()
+    let scan = proposer
+        .scan_selected_lineage()
         .await
-        .expect("canonical line reconstructed");
-    post_proposal(&proposer, &canonical_scan)
+        .expect("selected lineage reconstructed");
+    post_proposal(&proposer, &scan)
         .await
         .expect("proposal posted");
     let game = chain.latest_game().expect("game created").game;
@@ -393,11 +392,11 @@ async fn defender_ignores_challenged_invalid_root() {
 
     let proposer =
         WorldChainProposer::new(proposer_config(), chain.clone(), bad_proposer_consensus);
-    let canonical_scan = proposer
-        .anchor_and_canonical_line()
+    let scan = proposer
+        .scan_selected_lineage()
         .await
-        .expect("canonical line reconstructed");
-    post_proposal(&proposer, &canonical_scan)
+        .expect("selected lineage reconstructed");
+    post_proposal(&proposer, &scan)
         .await
         .expect("bad proposal posted");
     let game = chain.latest_game().expect("game created").game;

--- a/proofs/integration-tests/tests/orchestration.rs
+++ b/proofs/integration-tests/tests/orchestration.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 
 use alloy_primitives::{B256, Bytes};
-use async_trait::async_trait;
 use testcontainers::{ContainerAsync, runners::AsyncRunner};
 use testcontainers_modules::postgres;
 use tokio::task::JoinHandle;
@@ -19,10 +18,7 @@ use world_chain_proofs::{ProofLane, RootState, has_threshold};
 use world_chain_proposer::{
     CanonicalScan, ProposerClient, ProposerConfig, ProposerError, WorldChainProposer,
 };
-use world_chain_prover_service::{
-    ProofBackend, ProofData, ProofRequest, ProofRequestError, ProofRequestId, ProofRequester,
-    ProofResponse, ProofStatus, ProverServiceConfig, RequestProofResponse, SucceededProofResponse,
-};
+use world_chain_prover_service::{ProofBackend, ProverServiceConfig};
 
 fn proposer_config() -> ProposerConfig {
     ProposerConfig {
@@ -53,47 +49,7 @@ fn assert_defense_lanes(lanes: Vec<ProofLane>) {
     assert!(lanes.contains(&ProofLane::TeeAttestation));
 }
 
-#[derive(Debug, Clone, Copy)]
-struct InstantProofRequester;
-
-#[async_trait]
-impl ProofRequester for InstantProofRequester {
-    async fn request_proof(
-        &self,
-        request: ProofRequest,
-    ) -> Result<RequestProofResponse, ProofRequestError> {
-        Ok(RequestProofResponse {
-            proof_id: request.id(),
-            l1_head: request.l1_head,
-        })
-    }
-
-    async fn proof_status(
-        &self,
-        _proof_id: ProofRequestId,
-    ) -> Result<ProofStatus, ProofRequestError> {
-        Ok(ProofStatus::Succeeded)
-    }
-
-    async fn get_proof(
-        &self,
-        proof_id: ProofRequestId,
-    ) -> Result<ProofResponse, ProofRequestError> {
-        Ok(ProofResponse::Succeeded(SucceededProofResponse {
-            id: proof_id,
-            proof: ProofData::Nitro {
-                attestation: Bytes::from_static(&[1]),
-                public_values: Bytes::from_static(&[2]),
-                signature: Bytes::from_static(&[3]),
-            },
-        }))
-    }
-}
-
-async fn settle_with_proposer<P>(proposer: &WorldChainProposer<FakeExecution, FakeConsensus, P>)
-where
-    P: ProofRequester,
-{
+async fn settle_with_proposer(proposer: &WorldChainProposer<FakeExecution, FakeConsensus>) {
     let canonical_scan = proposer
         .anchor_and_canonical_line()
         .await
@@ -108,15 +64,11 @@ where
         .expect("anchor advanced");
 }
 
-async fn post_proposal<P>(
-    proposer: &mut WorldChainProposer<FakeExecution, FakeConsensus, P>,
+async fn post_proposal(
+    proposer: &WorldChainProposer<FakeExecution, FakeConsensus>,
     scan: &CanonicalScan,
-) -> Result<(), ProposerError>
-where
-    P: ProofRequester,
-{
-    proposer.request_proof(scan).await?;
-    proposer.poll_and_submit().await
+) -> Result<(), ProposerError> {
+    proposer.submit_next_proposal(scan).await
 }
 
 #[tokio::test]
@@ -124,18 +76,13 @@ async fn fake_resolution_matches_contract_transition_semantics() {
     let chain = FakeExecution::new();
     let canonical_root = B256::repeat_byte(0x20);
     let consensus = FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
-    let mut proposer = WorldChainProposer::new(
-        proposer_config(),
-        chain.clone(),
-        consensus,
-        InstantProofRequester,
-    );
+    let proposer = WorldChainProposer::new(proposer_config(), chain.clone(), consensus);
 
     let canonical_scan = proposer
         .anchor_and_canonical_line()
         .await
         .expect("canonical line reconstructed");
-    post_proposal(&mut proposer, &canonical_scan)
+    post_proposal(&proposer, &canonical_scan)
         .await
         .expect("proposal posted");
     let game = chain.latest_game().expect("game created").game;
@@ -172,7 +119,7 @@ async fn fake_resolution_matches_contract_transition_semantics() {
         .expect("resolution status available");
     assert!(!finalized.resolvable);
     assert_eq!(finalized.root_state, RootState::Finalized);
-    assert!(chain.resolve_game(game).await.is_err());
+    assert!(ProposerClient::resolve_game(&chain, game).await.is_err());
 }
 
 struct ProofStack {
@@ -280,17 +227,13 @@ async fn invalid_root_is_challenged_by_real_challenger() {
     let honest_consensus =
         FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
 
-    let mut proposer = WorldChainProposer::new(
-        proposer_config(),
-        chain.clone(),
-        bad_proposer_consensus,
-        InstantProofRequester,
-    );
+    let proposer =
+        WorldChainProposer::new(proposer_config(), chain.clone(), bad_proposer_consensus);
     let canonical_scan = proposer
         .anchor_and_canonical_line()
         .await
         .expect("canonical line reconstructed");
-    post_proposal(&mut proposer, &canonical_scan)
+    post_proposal(&proposer, &canonical_scan)
         .await
         .expect("bad proposal posted");
     let game = chain.latest_game().expect("game created").game;
@@ -307,22 +250,56 @@ async fn invalid_root_is_challenged_by_real_challenger() {
 }
 
 #[tokio::test]
+async fn valid_proposal_receives_initial_tee_proof_through_worker() {
+    let chain = FakeExecution::new();
+    let canonical_root = B256::repeat_byte(0x20);
+    let consensus = FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
+    let proposer = WorldChainProposer::new(proposer_config(), chain.clone(), consensus.clone());
+    let canonical_scan = proposer
+        .anchor_and_canonical_line()
+        .await
+        .expect("canonical line reconstructed");
+    post_proposal(&proposer, &canonical_scan)
+        .await
+        .expect("proposal posted");
+    let game = chain.latest_game().expect("game created").game;
+
+    let Some(stack) = start_proof_stack().await else {
+        return;
+    };
+    let mut defender = WorldChainDefender::new(
+        defender_config(),
+        chain.clone(),
+        consensus,
+        stack.service.clone(),
+    );
+
+    for _ in 0..200 {
+        defender.tick().await.expect("defender scan succeeds");
+        if chain.proof_bitmap(game) != 0 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    assert_eq!(chain.game_state(game), RootState::Proposed);
+    assert_eq!(chain.submitted_lanes(game), [ProofLane::TeeAttestation]);
+
+    stop_proof_stack(stack).await;
+}
+
+#[tokio::test]
 async fn valid_challenged_root_is_defended_through_workers() {
     let chain = FakeExecution::new();
     let canonical_root = B256::repeat_byte(0x20);
     let consensus = FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
 
-    let mut proposer = WorldChainProposer::new(
-        proposer_config(),
-        chain.clone(),
-        consensus.clone(),
-        InstantProofRequester,
-    );
+    let proposer = WorldChainProposer::new(proposer_config(), chain.clone(), consensus.clone());
     let canonical_scan = proposer
         .anchor_and_canonical_line()
         .await
         .expect("canonical line reconstructed");
-    post_proposal(&mut proposer, &canonical_scan)
+    post_proposal(&proposer, &canonical_scan)
         .await
         .expect("proposal posted");
     let game = chain.latest_game().expect("game created").game;
@@ -362,17 +339,12 @@ async fn valid_challenged_root_survives_transient_proof_failure() {
     let canonical_root = B256::repeat_byte(0x20);
     let consensus = FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
 
-    let mut proposer = WorldChainProposer::new(
-        proposer_config(),
-        chain.clone(),
-        consensus.clone(),
-        InstantProofRequester,
-    );
+    let proposer = WorldChainProposer::new(proposer_config(), chain.clone(), consensus.clone());
     let canonical_scan = proposer
         .anchor_and_canonical_line()
         .await
         .expect("canonical line reconstructed");
-    post_proposal(&mut proposer, &canonical_scan)
+    post_proposal(&proposer, &canonical_scan)
         .await
         .expect("proposal posted");
     let game = chain.latest_game().expect("game created").game;
@@ -421,17 +393,13 @@ async fn defender_ignores_challenged_invalid_root() {
     let honest_consensus =
         FakeConsensus::new(BLOCK_INTERVAL).with_root(BLOCK_INTERVAL, canonical_root);
 
-    let mut proposer = WorldChainProposer::new(
-        proposer_config(),
-        chain.clone(),
-        bad_proposer_consensus,
-        InstantProofRequester,
-    );
+    let proposer =
+        WorldChainProposer::new(proposer_config(), chain.clone(), bad_proposer_consensus);
     let canonical_scan = proposer
         .anchor_and_canonical_line()
         .await
         .expect("canonical line reconstructed");
-    post_proposal(&mut proposer, &canonical_scan)
+    post_proposal(&proposer, &canonical_scan)
         .await
         .expect("bad proposal posted");
     let game = chain.latest_game().expect("game created").game;

--- a/proofs/nitro/worker/src/lib.rs
+++ b/proofs/nitro/worker/src/lib.rs
@@ -16,7 +16,7 @@
 //!  │  NitroProver::prove_range  ────────────► Nitro Enclave                              │
 //!  │       │                                  (vsock / PCR-pinned)                       │
 //!  │       ▼                                                                              │
-//!  │  prover_submitProof(Nitro { attestation, public_values, signature })                │
+//!  │  prover_submitProof(Nitro { attestation, public_values, signature, public_key })    │
 //!  └──────────────────────────────────────────────────────────────────────────────────────┘
 //! ```
 
@@ -168,6 +168,10 @@ impl ClaimedProofJobHandler for NitroBackend {
         );
 
         Ok(ProofData::Nitro {
+            public_key: world_chain_proof_nitro::attestation::extract_nsm_public_key(
+                &artifact.attestation_doc,
+            )?
+            .into(),
             attestation: Bytes::from(artifact.attestation_doc),
             public_values: artifact.transition_public_values.abi_encode().into(),
             signature: Bytes::from(artifact.signature),

--- a/proofs/primitives/src/bindings.rs
+++ b/proofs/primitives/src/bindings.rs
@@ -1,6 +1,13 @@
 use alloy_sol_types::sol;
 
 sol! {
+    struct ProofDomainData {
+        uint256 chainId;
+        uint256 proofSystemVersion;
+        bytes32 rollupConfigHash;
+        uint256 blockInterval;
+    }
+
     /// Stock OP Stack `DisputeGameFactory`. WIP-1006 games are created and indexed here
     /// alongside every other game type registered on the chain, so every index-based read
     /// must filter on `MULTI_PROOF_GAME_TYPE`.
@@ -53,6 +60,7 @@ sol! {
         // Deployment parameters (immutables on the implementation).
         function PROOF_THRESHOLD() external view returns (uint8);
         function PROOF_LANE_COUNT() external view returns (uint8);
+        function domain() external view returns (ProofDomainData memory);
         function domainHash() external view returns (bytes32);
         function challengePeriod() external view returns (uint64);
         function proofPeriod() external view returns (uint64);

--- a/proofs/primitives/src/bindings.rs
+++ b/proofs/primitives/src/bindings.rs
@@ -54,10 +54,12 @@ sol! {
         function PROOF_THRESHOLD() external view returns (uint8);
         function PROOF_LANE_COUNT() external view returns (uint8);
         function domainHash() external view returns (bytes32);
+        function canonicalAnchorParent() external view returns (address);
         function challengePeriod() external view returns (uint64);
         function proofPeriod() external view returns (uint64);
         function proposerBond() external view returns (uint256);
         function challengerBond() external view returns (uint256);
+        function proofTimeoutRecipient() external view returns (address);
         function disputeGameFactory() external view returns (address);
         function anchorStateRegistry() external view returns (address);
         function weth() external view returns (address);

--- a/proofs/primitives/src/bindings.rs
+++ b/proofs/primitives/src/bindings.rs
@@ -54,7 +54,6 @@ sol! {
         function PROOF_THRESHOLD() external view returns (uint8);
         function PROOF_LANE_COUNT() external view returns (uint8);
         function domainHash() external view returns (bytes32);
-        function canonicalAnchorParent() external view returns (address);
         function challengePeriod() external view returns (uint64);
         function proofPeriod() external view returns (uint64);
         function proposerBond() external view returns (uint256);

--- a/proofs/primitives/src/lib.rs
+++ b/proofs/primitives/src/lib.rs
@@ -6,14 +6,21 @@
 
 mod bindings;
 mod consensus_provider;
+mod lineage;
 mod types;
 
 // re-exports
 pub use bindings::{IAnchorStateRegistry, IDelayedWETH, IDisputeGameFactory, IMultiProofGame};
 pub use consensus_provider::{ConsensusError, ConsensusProvider, OptimismConsensusClient};
+pub use lineage::{
+    LineageAnchor, LineageError, LineageGame, LineageProvider, LineageStop, LineageTransition,
+    RegisteredLineageConfig, SelectedLineage, SelectedLineageGame, read_game_for_transition,
+    read_lineage_anchor, read_lineage_resolution_status, read_registered_lineage_config,
+    select_lineage,
+};
 pub use types::{
-    InvalidationReason, InvalidationReasonError, MULTI_PROOF_GAME_TYPE, PROOF_LANE_COUNT,
-    PROOF_SYSTEM_VERSION, PROOF_THRESHOLD, ProofDomain, ProofLane, ProposalCommitment,
-    ResolutionStatus, RootCommitment, RootState, RootStateError, WorldChainGameCreated,
-    has_threshold, proof_count,
+    InvalidationReason, InvalidationReasonError, MAX_ATTEMPT_SCAN, MULTI_PROOF_GAME_TYPE,
+    PROOF_LANE_COUNT, PROOF_SYSTEM_VERSION, PROOF_THRESHOLD, ProofDomain, ProofLane,
+    ProposalCommitment, ResolutionStatus, RootCommitment, RootState, RootStateError,
+    WorldChainGameCreated, has_threshold, proof_count,
 };

--- a/proofs/primitives/src/lineage.rs
+++ b/proofs/primitives/src/lineage.rs
@@ -1,0 +1,352 @@
+use crate::{
+    ConsensusError, ConsensusProvider, IAnchorStateRegistry, IDisputeGameFactory, IMultiProofGame,
+    InvalidationReasonError, MAX_ATTEMPT_SCAN, MULTI_PROOF_GAME_TYPE, ProposalCommitment,
+    ResolutionStatus, RootState, RootStateError,
+};
+use alloy_primitives::{Address, B256};
+use alloy_provider::Provider;
+use async_trait::async_trait;
+use thiserror::Error;
+
+/// Anchor checkpoint from which the selected proposal lineage extends.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LineageAnchor {
+    /// Current anchor game, or the registry sentinel before the first game is anchored.
+    pub address: Address,
+    /// L2 block number committed by the anchor.
+    pub l2_block_number: u64,
+}
+
+/// Expected state transition at one proposal interval.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LineageTransition {
+    /// Registry sentinel or game that the transition extends.
+    pub parent_ref: Address,
+    /// Canonical output root at `l2_block_number`.
+    pub root_claim: B256,
+    /// L2 block claimed by this transition.
+    pub l2_block_number: u64,
+}
+
+/// Highest existing retry attempt for a transition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LineageGame {
+    /// Address of the game clone.
+    pub address: Address,
+    /// Retry nonce encoded in the game's factory key.
+    pub attempt: u64,
+}
+
+/// Existing game selected for an expected state transition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SelectedLineageGame {
+    /// Canonical transition used to select the game.
+    pub transition: LineageTransition,
+    /// Highest existing attempt for the transition.
+    pub game: LineageGame,
+}
+
+/// Immutable lineage configuration exposed by the registered WIP-1006 implementation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RegisteredLineageConfig {
+    /// Hash of the proof domain encoded into every game factory key.
+    pub domain_hash: B256,
+    /// Number of L2 blocks covered by each proposal transition.
+    pub block_interval: u64,
+    /// Registry that owns the selected anchor checkpoint.
+    pub anchor_registry: Address,
+}
+
+/// Reason selected-lineage traversal stopped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LineageStop {
+    /// The next proposal interval exceeds the consensus client's finalized L2 head.
+    CaughtUp {
+        target_block: u64,
+        finalized_block: u64,
+    },
+    /// No game exists for the next expected transition.
+    Missing(LineageTransition),
+    /// The highest attempt for the next transition is invalidated.
+    Invalidated {
+        transition: LineageTransition,
+        game: LineageGame,
+        status: ResolutionStatus,
+    },
+}
+
+/// Selected games extending the current anchor and the condition at their tip.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SelectedLineage {
+    anchor: LineageAnchor,
+    games: Vec<SelectedLineageGame>,
+    stop: LineageStop,
+}
+
+impl SelectedLineage {
+    #[must_use]
+    pub const fn anchor(&self) -> LineageAnchor {
+        self.anchor
+    }
+
+    #[must_use]
+    pub fn games(&self) -> &[SelectedLineageGame] {
+        &self.games
+    }
+
+    #[must_use]
+    pub const fn stop(&self) -> LineageStop {
+        self.stop
+    }
+}
+
+/// Failure while reading or reconstructing the selected proposal lineage.
+#[derive(Debug, Error)]
+pub enum LineageError {
+    #[error("contract error: {0}")]
+    Contract(String),
+    #[error("l2 block number overflow: parent {parent_block} + interval {block_interval}")]
+    BlockNumberOverflow {
+        parent_block: u64,
+        block_interval: u64,
+    },
+    #[error("lineage block interval must be greater than zero")]
+    ZeroBlockInterval,
+    #[error("selected game {0} has unset root state")]
+    UnsetGame(Address),
+    #[error(transparent)]
+    Consensus(#[from] ConsensusError),
+    #[error(transparent)]
+    InvalidRootState(#[from] RootStateError),
+    #[error(transparent)]
+    InvalidInvalidationReason(#[from] InvalidationReasonError),
+}
+
+/// Contract reads required to select a proposal lineage.
+#[async_trait]
+pub trait LineageProvider: Send + Sync {
+    /// Proposal interval committed by the registered proof domain.
+    fn lineage_block_interval(&self) -> u64;
+
+    async fn lineage_anchor(&self) -> Result<LineageAnchor, LineageError>;
+
+    async fn game_for_transition(
+        &self,
+        transition: LineageTransition,
+    ) -> Result<Option<LineageGame>, LineageError>;
+
+    async fn lineage_resolution_status(
+        &self,
+        game: Address,
+    ) -> Result<ResolutionStatus, LineageError>;
+}
+
+/// Reconstructs the unique valid lineage selected by canonical output roots.
+pub async fn select_lineage<E, C>(
+    execution: &E,
+    consensus: &C,
+) -> Result<SelectedLineage, LineageError>
+where
+    E: LineageProvider,
+    C: ConsensusProvider,
+{
+    let block_interval = execution.lineage_block_interval();
+    if block_interval == 0 {
+        return Err(LineageError::ZeroBlockInterval);
+    }
+
+    let anchor = execution.lineage_anchor().await?;
+    let finalized_block = consensus.latest_l2_finalized_block().await?;
+    let mut parent = anchor;
+    let mut games = Vec::new();
+
+    loop {
+        let l2_block_number = parent.l2_block_number.checked_add(block_interval).ok_or(
+            LineageError::BlockNumberOverflow {
+                parent_block: parent.l2_block_number,
+                block_interval,
+            },
+        )?;
+        if l2_block_number > finalized_block {
+            return Ok(SelectedLineage {
+                anchor,
+                games,
+                stop: LineageStop::CaughtUp {
+                    target_block: l2_block_number,
+                    finalized_block,
+                },
+            });
+        }
+
+        let transition = LineageTransition {
+            parent_ref: parent.address,
+            root_claim: consensus.output_root_at_block(l2_block_number).await?,
+            l2_block_number,
+        };
+        let Some(game) = execution.game_for_transition(transition).await? else {
+            return Ok(SelectedLineage {
+                anchor,
+                games,
+                stop: LineageStop::Missing(transition),
+            });
+        };
+        let status = execution.lineage_resolution_status(game.address).await?;
+        if status.root_state == RootState::Invalidated {
+            return Ok(SelectedLineage {
+                anchor,
+                games,
+                stop: LineageStop::Invalidated {
+                    transition,
+                    game,
+                    status,
+                },
+            });
+        }
+        if status.root_state == RootState::None {
+            return Err(LineageError::UnsetGame(game.address));
+        }
+
+        games.push(SelectedLineageGame { transition, game });
+        parent = LineageAnchor {
+            address: game.address,
+            l2_block_number,
+        };
+    }
+}
+
+/// Reads the current game-or-registry anchor sentinel.
+pub async fn read_lineage_anchor<P>(
+    provider: &P,
+    anchor: &IAnchorStateRegistry::IAnchorStateRegistryInstance<P>,
+) -> Result<LineageAnchor, LineageError>
+where
+    P: Provider + Clone,
+{
+    let (anchor_root, anchor_game) = provider
+        .multicall()
+        .add(anchor.getAnchorRoot())
+        .add(anchor.anchorGame())
+        .aggregate()
+        .await
+        .map_err(|error| LineageError::Contract(error.to_string()))?;
+    let l2_block_number = anchor_root
+        .l2SequenceNumber
+        .try_into()
+        .map_err(|_| LineageError::Contract("getAnchorRoot overflows u64".into()))?;
+
+    Ok(LineageAnchor {
+        address: if anchor_game == Address::ZERO {
+            *anchor.address()
+        } else {
+            anchor_game
+        },
+        l2_block_number,
+    })
+}
+
+/// Discovers the lineage configuration from the factory's registered WIP-1006 implementation.
+pub async fn read_registered_lineage_config<P>(
+    provider: &P,
+    factory: &IDisputeGameFactory::IDisputeGameFactoryInstance<P>,
+) -> Result<RegisteredLineageConfig, LineageError>
+where
+    P: Provider + Clone,
+{
+    let implementation_address = factory
+        .gameImpls(MULTI_PROOF_GAME_TYPE)
+        .call()
+        .await
+        .map_err(|error| LineageError::Contract(error.to_string()))?;
+    if implementation_address == Address::ZERO {
+        return Err(LineageError::Contract(format!(
+            "dispute-game factory {} has no implementation for game type {MULTI_PROOF_GAME_TYPE}",
+            factory.address()
+        )));
+    }
+
+    let implementation =
+        IMultiProofGame::IMultiProofGameInstance::new(implementation_address, provider.clone());
+    let (domain_hash, anchor_registry, domain) = provider
+        .multicall()
+        .add(implementation.domainHash())
+        .add(implementation.anchorStateRegistry())
+        .add(implementation.domain())
+        .aggregate()
+        .await
+        .map_err(|error| LineageError::Contract(error.to_string()))?;
+    if anchor_registry == Address::ZERO {
+        return Err(LineageError::Contract(
+            "registered game implementation has no anchor registry".into(),
+        ));
+    }
+    let block_interval = domain
+        .blockInterval
+        .try_into()
+        .map_err(|_| LineageError::Contract("domain.blockInterval overflows u64".into()))?;
+    if block_interval == 0 {
+        return Err(LineageError::ZeroBlockInterval);
+    }
+
+    Ok(RegisteredLineageConfig {
+        domain_hash,
+        block_interval,
+        anchor_registry,
+    })
+}
+
+/// Looks up the highest sequential retry attempt for a transition.
+pub async fn read_game_for_transition<P>(
+    factory: &IDisputeGameFactory::IDisputeGameFactoryInstance<P>,
+    domain_hash: B256,
+    transition: LineageTransition,
+) -> Result<Option<LineageGame>, LineageError>
+where
+    P: Provider + Clone,
+{
+    let mut latest = None;
+    for attempt in 0..MAX_ATTEMPT_SCAN {
+        let commitment = ProposalCommitment {
+            parent_ref: transition.parent_ref,
+            root_claim: transition.root_claim,
+            l2_block_number: transition.l2_block_number,
+            attempt,
+        };
+        let entry = factory
+            .games(
+                MULTI_PROOF_GAME_TYPE,
+                transition.root_claim,
+                commitment.extra_data(domain_hash),
+            )
+            .call()
+            .await
+            .map_err(|error| LineageError::Contract(error.to_string()))?;
+        if entry.proxy == Address::ZERO {
+            break;
+        }
+        latest = Some(LineageGame {
+            address: entry.proxy,
+            attempt,
+        });
+    }
+    Ok(latest)
+}
+
+/// Reads and decodes a game's current resolution evaluation.
+pub async fn read_lineage_resolution_status<P>(
+    game: &IMultiProofGame::IMultiProofGameInstance<P>,
+) -> Result<ResolutionStatus, LineageError>
+where
+    P: Provider + Clone,
+{
+    let result = game
+        .resolutionStatus()
+        .call()
+        .await
+        .map_err(|error| LineageError::Contract(error.to_string()))?;
+
+    Ok(ResolutionStatus {
+        resolvable: result.resolvable,
+        root_state: result.outcome.try_into()?,
+        invalidation_reason: result.reason.try_into()?,
+    })
+}

--- a/proofs/primitives/src/types.rs
+++ b/proofs/primitives/src/types.rs
@@ -18,6 +18,9 @@ pub const PROOF_SYSTEM_VERSION: u64 = 1;
 /// index-based read must filter on this value.
 pub const MULTI_PROOF_GAME_TYPE: u32 = 1006;
 
+/// Maximum number of sequential retry attempts probed for one transition.
+pub const MAX_ATTEMPT_SCAN: u64 = 64;
+
 /// The `MultiProofGame.WorldChainGameCreated` event.
 #[derive(Debug, Clone, Copy)]
 pub struct WorldChainGameCreated {

--- a/proofs/proposer/Cargo.toml
+++ b/proofs/proposer/Cargo.toml
@@ -17,7 +17,6 @@ workspace = true
 [dependencies]
 # workspace
 world-chain-proofs.workspace = true
-world-chain-prover-service.workspace = true
 
 # alloy
 alloy-consensus.workspace = true

--- a/proofs/proposer/README.md
+++ b/proofs/proposer/README.md
@@ -13,9 +13,8 @@ Stack `DisputeGameFactory.create(gameType, rootClaim, extraData)`.
 
 ## Items needed to propose a new L2 output root
 
-- `parent_ref`: address of the canonical parent selected by the registered game implementation.
-  This is normally the current compatible anchor game or a descendant game. The
-  `AnchorStateRegistry` address is used as a sentinel when no compatible anchor game exists.
+- `parent_ref`: address of the current anchor game or a descendant game. The
+  `AnchorStateRegistry` address is used only before the first game is anchored.
 - `root_claim`: OP stack output root.
 - `l2_block_number`: L2 block number for the root claim.
 - `attempt`: retry nonce, non-zero only when replacing a game invalidated by a proof timeout.
@@ -28,14 +27,11 @@ parentRef, attempt)` and the game's factory UUID is
 
 ### `parent_ref`
 
-- read `canonicalAnchorParent()` from the registered `MultiProofGame` implementation. It returns
-  the current anchor game when that game remains an eligible WIP-1006 parent in the same proof
-  domain. It returns the `AnchorStateRegistry` sentinel for the initial anchor, an incompatible
-  proof domain or game type, or an ineligible anchor game.
+- read the current anchor game from `AnchorStateRegistry`. Use it as `parent_ref` when present;
+  otherwise use the registry address as the initial sentinel.
 - compute L2 output root for block equal to `parent_ref`'s `l2_block_number` + `BLOCK_INTERVAL`
 - look the game up with `DisputeGameFactory.games(gameType, rootClaim, extraData)`, walking
-  `attempt` upward until the first gap. There is exactly one canonical parent to query: anchor
-  advancement does not change the parent reference or factory UUID of an existing transition.
+  `attempt` upward until the first gap.
 - if a game exists, it becomes the `parent_ref` and we continue this loop
 - if it doesn't exist - i.e. the address is `0x00..00`, then the current `parent_ref` is returned
 

--- a/proofs/proposer/README.md
+++ b/proofs/proposer/README.md
@@ -13,8 +13,9 @@ Stack `DisputeGameFactory.create(gameType, rootClaim, extraData)`.
 
 ## Items needed to propose a new L2 output root
 
-- `parent_ref`: address of the parent game, or the `AnchorStateRegistry` contract address when the
-  proposal extends the current anchor.
+- `parent_ref`: address of the canonical parent selected by the registered game implementation.
+  This is normally the current compatible anchor game or a descendant game. The
+  `AnchorStateRegistry` address is used as a sentinel when no compatible anchor game exists.
 - `root_claim`: OP stack output root.
 - `l2_block_number`: L2 block number for the root claim.
 - `attempt`: retry nonce, non-zero only when replacing a game invalidated by a proof timeout.
@@ -27,14 +28,14 @@ parentRef, attempt)` and the game's factory UUID is
 
 ### `parent_ref`
 
-- start with `parent_ref` equal to the `AnchorStateRegistry` address. Once the anchor advances onto
-  a game, that game is no longer a valid parent — `MultiProofGame.initialize` rejects a parent at or
-  below the anchor — so new proposals extending the anchor always point at the registry.
+- read `canonicalAnchorParent()` from the registered `MultiProofGame` implementation. It returns
+  the current anchor game when that game remains an eligible WIP-1006 parent in the same proof
+  domain. It returns the `AnchorStateRegistry` sentinel for the initial anchor, an incompatible
+  proof domain or game type, or an ineligible anchor game.
 - compute L2 output root for block equal to `parent_ref`'s `l2_block_number` + `BLOCK_INTERVAL`
 - look the game up with `DisputeGameFactory.games(gameType, rootClaim, extraData)`, walking
-  `attempt` upward until the first gap. At the anchor tip both the registry and the current anchor
-  game are candidate parents, because a game created before the anchor advanced still references
-  the anchor game.
+  `attempt` upward until the first gap. There is exactly one canonical parent to query: anchor
+  advancement does not change the parent reference or factory UUID of an existing transition.
 - if a game exists, it becomes the `parent_ref` and we continue this loop
 - if it doesn't exist - i.e. the address is `0x00..00`, then the current `parent_ref` is returned
 

--- a/proofs/proposer/README.md
+++ b/proofs/proposer/README.md
@@ -29,11 +29,24 @@ parentRef, attempt)` and the game's factory UUID is
 
 - read the current anchor game from `AnchorStateRegistry`. Use it as `parent_ref` when present;
   otherwise use the registry address as the initial sentinel.
-- compute L2 output root for block equal to `parent_ref`'s `l2_block_number` + `BLOCK_INTERVAL`
+- read the block interval from the registered game's proof domain and compute the L2 output root
+  for `parent_ref`'s `l2_block_number` plus that interval
 - look the game up with `DisputeGameFactory.games(gameType, rootClaim, extraData)`, walking
   `attempt` upward until the first gap.
 - if a game exists, it becomes the `parent_ref` and we continue this loop
 - if it doesn't exist - i.e. the address is `0x00..00`, then the current `parent_ref` is returned
+
+The proposer resolves every determined game on this selected lineage. A positive resolution may
+advance the anchor after the registry finality delay; a proof-timeout resolution permits the next
+attempt to be created.
+
+## Retry operations
+
+The automated services assume proof-timeout retries are exceptional. The proposer creates the next
+attempt and the defender follows that replacement, but games descending from the abandoned attempt
+are not automatically recovered. Operators must resolve that stale lineage parent-first and claim
+any resulting bond credits. Retry creation is logged at error level so it can trigger an incident
+response; a follow-up can include the complete stale lineage in that alert.
 
 ### `root_claim`
 
@@ -41,7 +54,7 @@ parentRef, attempt)` and the game's factory UUID is
 
 ### `l2_block_number`
 
-- `parent_ref`'s `l2_block_number` field + `BLOCK_INTERVAL`
+- `parent_ref`'s `l2_block_number` plus the registered proof domain's block interval
 
 ## Bond settlement
 

--- a/proofs/proposer/src/alloy.rs
+++ b/proofs/proposer/src/alloy.rs
@@ -1,13 +1,12 @@
 use alloy_consensus::BlockHeader;
-use alloy_eips::{BlockId, BlockNumberOrTag};
-use alloy_primitives::{Address, B256, BlockHash, U256};
+use alloy_eips::BlockNumberOrTag;
+use alloy_primitives::{Address, B256, U256};
 use alloy_provider::{Provider, WalletProvider};
 use async_trait::async_trait;
 use world_chain_proofs::{
     IAnchorStateRegistry, IDelayedWETH, IDisputeGameFactory, IMultiProofGame,
     InvalidationReasonError, MULTI_PROOF_GAME_TYPE, ResolutionStatus, RootStateError,
 };
-use world_chain_prover_service::ProofData;
 
 use crate::{
     AnchorRef, BondManagerClient, Proposal, ProposalSubmission, ProposerClient, ProposerError,
@@ -31,6 +30,7 @@ const MAX_ATTEMPT_SCAN: u64 = 64;
 pub struct AlloyProofSystemClient<P> {
     factory: IDisputeGameFactory::IDisputeGameFactoryInstance<P>,
     anchor: IAnchorStateRegistry::IAnchorStateRegistryInstance<P>,
+    game_implementation: IMultiProofGame::IMultiProofGameInstance<P>,
     /// Domain hash of the registered game implementation, read once at construction.
     domain_hash: B256,
     /// Number of confirmations to require after sending a tx onchain.
@@ -72,16 +72,18 @@ where
                 "dispute-game factory {factory_address} has no implementation for game type {MULTI_PROOF_GAME_TYPE}"
             )));
         }
-        let domain_hash =
-            IMultiProofGame::IMultiProofGameInstance::new(game_impl, provider.clone())
-                .domainHash()
-                .call()
-                .await
-                .map_err(|error| ProposerError::Contract(error.to_string()))?;
+        let game_implementation =
+            IMultiProofGame::IMultiProofGameInstance::new(game_impl, provider.clone());
+        let domain_hash = game_implementation
+            .domainHash()
+            .call()
+            .await
+            .map_err(|error| ProposerError::Contract(error.to_string()))?;
 
         Ok(Self {
             factory,
             anchor,
+            game_implementation,
             domain_hash,
             confirmations,
             provider,
@@ -305,62 +307,56 @@ where
     P: Provider + WalletProvider + Clone + Send + Sync + 'static,
 {
     async fn anchor_parent(&self) -> Result<AnchorRef, ProposerError> {
-        let (anchor_root, anchor_game) = self
+        let (anchor_root, canonical_parent) = self
             .provider
             .multicall()
             .add(self.anchor.getAnchorRoot())
-            .add(self.anchor.anchorGame())
+            .add(self.game_implementation.canonicalAnchorParent())
             .aggregate()
             .await
             .map_err(|err| ProposerError::Contract(err.to_string()))?;
 
         Ok(AnchorRef {
-            registry: *self.anchor.address(),
-            anchor_game: (anchor_game != Address::ZERO).then_some(anchor_game),
+            address: canonical_parent,
             l2_block_number: u256_to_u64(anchor_root.l2SequenceNumber, "getAnchorRoot")?,
         })
     }
 
-    async fn games_for_transition(
+    async fn game_for_transition(
         &self,
-        parent_candidates: &[Address],
+        parent_ref: Address,
         root_claim: B256,
         l2_block_number: u64,
-    ) -> Result<Vec<TransitionGame>, ProposerError> {
-        let mut found = Vec::with_capacity(parent_candidates.len());
-        for parent_ref in parent_candidates {
-            let mut latest: Option<TransitionGame> = None;
-            // Attempts are strictly sequential: attempt N can only be created once attempt N-1
-            // exists, so the walk stops at the first gap.
-            for attempt in 0..MAX_ATTEMPT_SCAN {
-                let commitment = world_chain_proofs::ProposalCommitment {
-                    parent_ref: *parent_ref,
+    ) -> Result<Option<TransitionGame>, ProposerError> {
+        let mut latest: Option<TransitionGame> = None;
+        // Attempts are strictly sequential: attempt N can only be created once attempt N-1
+        // exists, so the walk stops at the first gap.
+        for attempt in 0..MAX_ATTEMPT_SCAN {
+            let commitment = world_chain_proofs::ProposalCommitment {
+                parent_ref,
+                root_claim,
+                l2_block_number,
+                attempt,
+            };
+            let entry = self
+                .factory
+                .games(
+                    MULTI_PROOF_GAME_TYPE,
                     root_claim,
-                    l2_block_number,
-                    attempt,
-                };
-                let entry = self
-                    .factory
-                    .games(
-                        MULTI_PROOF_GAME_TYPE,
-                        root_claim,
-                        commitment.extra_data(self.domain_hash),
-                    )
-                    .call()
-                    .await
-                    .map_err(|error| ProposerError::Contract(error.to_string()))?;
-                if entry.proxy == Address::ZERO {
-                    break;
-                }
-                latest = Some(TransitionGame {
-                    address: entry.proxy,
-                    parent_ref: *parent_ref,
-                    attempt,
-                });
+                    commitment.extra_data(self.domain_hash),
+                )
+                .call()
+                .await
+                .map_err(|error| ProposerError::Contract(error.to_string()))?;
+            if entry.proxy == Address::ZERO {
+                break;
             }
-            found.extend(latest);
+            latest = Some(TransitionGame {
+                address: entry.proxy,
+                attempt,
+            });
         }
-        Ok(found)
+        Ok(latest)
     }
 
     async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError> {
@@ -413,21 +409,9 @@ where
         Ok(CloseGameSubmission { tx_hash })
     }
 
-    async fn latest_finalized_l1_block(&self) -> Result<BlockHash, ProposerError> {
-        let block = self
-            .provider
-            .get_block(BlockId::finalized())
-            .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))?;
-        let block = block.ok_or_else(|| ProposerError::FinalizedBlockNotFound)?;
-        let hash = block.hash();
-        Ok(hash)
-    }
-
     async fn submit_proposal(
         &self,
         proposal: &Proposal,
-        _proof: ProofData,
     ) -> Result<ProposalSubmission, ProposerError> {
         // `DisputeGameFactory.create` reverts unless `msg.value` matches the configured init
         // bond exactly, so it is read per submission rather than cached in configuration.

--- a/proofs/proposer/src/alloy.rs
+++ b/proofs/proposer/src/alloy.rs
@@ -1,25 +1,19 @@
 use alloy_consensus::BlockHeader;
 use alloy_eips::BlockNumberOrTag;
-use alloy_primitives::{Address, B256, U256};
+use alloy_primitives::{Address, U256};
 use alloy_provider::{Provider, WalletProvider};
 use async_trait::async_trait;
 use world_chain_proofs::{
-    IAnchorStateRegistry, IDelayedWETH, IDisputeGameFactory, IMultiProofGame,
-    InvalidationReasonError, MULTI_PROOF_GAME_TYPE, ResolutionStatus, RootStateError,
+    IAnchorStateRegistry, IDelayedWETH, IDisputeGameFactory, IMultiProofGame, LineageAnchor,
+    LineageError, LineageGame, LineageProvider, LineageTransition, MULTI_PROOF_GAME_TYPE,
+    RegisteredLineageConfig, ResolutionStatus, read_game_for_transition, read_lineage_anchor,
+    read_lineage_resolution_status, read_registered_lineage_config,
 };
 
 use crate::{
-    AnchorRef, BondManagerClient, Proposal, ProposalSubmission, ProposerClient, ProposerError,
-    types::{
-        ClaimSubmission, CloseGameSubmission, PendingWithdrawal, ResolveSubmission, TransitionGame,
-    },
+    BondManagerClient, Proposal, ProposalSubmission, ProposerClient, ProposerError,
+    types::{ClaimSubmission, CloseGameSubmission, PendingWithdrawal, ResolveSubmission},
 };
-
-/// Highest retry nonce probed when locating the live game for a transition.
-///
-/// Bounds the attempt walk so a corrupt or adversarial factory state cannot turn a single
-/// canonical-line hop into an unbounded RPC loop.
-const MAX_ATTEMPT_SCAN: u64 = 64;
 
 /// Alloy-backed implementation of the proposer contract clients.
 ///
@@ -30,8 +24,7 @@ const MAX_ATTEMPT_SCAN: u64 = 64;
 pub struct AlloyProofSystemClient<P> {
     factory: IDisputeGameFactory::IDisputeGameFactoryInstance<P>,
     anchor: IAnchorStateRegistry::IAnchorStateRegistryInstance<P>,
-    /// Domain hash of the registered game implementation, read once at construction.
-    domain_hash: B256,
+    registered: RegisteredLineageConfig,
     /// Number of confirmations to require after sending a tx onchain.
     confirmations: u64,
     provider: P,
@@ -49,49 +42,31 @@ where
     pub async fn new(
         provider: P,
         factory_address: Address,
-        anchor_address: Address,
         confirmations: u64,
     ) -> Result<Self, ProposerError> {
         let factory = IDisputeGameFactory::IDisputeGameFactoryInstance::new(
             factory_address,
             provider.clone(),
         );
+        let registered = read_registered_lineage_config(&provider, &factory).await?;
         let anchor = IAnchorStateRegistry::IAnchorStateRegistryInstance::new(
-            anchor_address,
+            registered.anchor_registry,
             provider.clone(),
         );
-
-        let game_impl = factory
-            .gameImpls(MULTI_PROOF_GAME_TYPE)
-            .call()
-            .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))?;
-        if game_impl == Address::ZERO {
-            return Err(ProposerError::Contract(format!(
-                "dispute-game factory {factory_address} has no implementation for game type {MULTI_PROOF_GAME_TYPE}"
-            )));
-        }
-        let game_implementation =
-            IMultiProofGame::IMultiProofGameInstance::new(game_impl, provider.clone());
-        let domain_hash = game_implementation
-            .domainHash()
-            .call()
-            .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))?;
 
         Ok(Self {
             factory,
             anchor,
-            domain_hash,
+            registered,
             confirmations,
             provider,
         })
     }
 
-    /// Returns the domain hash of the registered game implementation.
+    /// Returns the immutable configuration of the registered game implementation.
     #[must_use]
-    pub const fn domain_hash(&self) -> B256 {
-        self.domain_hash
+    pub const fn registered_lineage_config(&self) -> RegisteredLineageConfig {
+        self.registered
     }
 
     fn game(&self, address: Address) -> IMultiProofGame::IMultiProofGameInstance<P> {
@@ -114,26 +89,9 @@ where
         &self,
         game: Address,
     ) -> Result<ResolutionStatus, ProposerError> {
-        let result = self
-            .game(game)
-            .resolutionStatus()
-            .call()
+        read_lineage_resolution_status(&self.game(game))
             .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))?;
-        let root_state = result
-            .outcome
-            .try_into()
-            .map_err(|error: RootStateError| ProposerError::Contract(error.to_string()))?;
-        let invalidation_reason = result
-            .reason
-            .try_into()
-            .map_err(|error: InvalidationReasonError| ProposerError::Contract(error.to_string()))?;
-
-        Ok(ResolutionStatus {
-            resolvable: result.resolvable,
-            root_state,
-            invalidation_reason,
-        })
+            .map_err(Into::into)
     }
 
     async fn read_is_game_finalized(&self, game: Address) -> Result<bool, ProposerError> {
@@ -300,71 +258,38 @@ where
 }
 
 #[async_trait]
-impl<P> ProposerClient for AlloyProofSystemClient<P>
+impl<P> LineageProvider for AlloyProofSystemClient<P>
 where
     P: Provider + WalletProvider + Clone + Send + Sync + 'static,
 {
-    async fn anchor_parent(&self) -> Result<AnchorRef, ProposerError> {
-        let (anchor_root, anchor_game) = self
-            .provider
-            .multicall()
-            .add(self.anchor.getAnchorRoot())
-            .add(self.anchor.anchorGame())
-            .aggregate()
-            .await
-            .map_err(|err| ProposerError::Contract(err.to_string()))?;
+    fn lineage_block_interval(&self) -> u64 {
+        self.registered.block_interval
+    }
 
-        Ok(AnchorRef {
-            address: if anchor_game == Address::ZERO {
-                *self.anchor.address()
-            } else {
-                anchor_game
-            },
-            l2_block_number: u256_to_u64(anchor_root.l2SequenceNumber, "getAnchorRoot")?,
-        })
+    async fn lineage_anchor(&self) -> Result<LineageAnchor, LineageError> {
+        read_lineage_anchor(&self.provider, &self.anchor).await
     }
 
     async fn game_for_transition(
         &self,
-        parent_ref: Address,
-        root_claim: B256,
-        l2_block_number: u64,
-    ) -> Result<Option<TransitionGame>, ProposerError> {
-        let mut latest: Option<TransitionGame> = None;
-        // Attempts are strictly sequential: attempt N can only be created once attempt N-1
-        // exists, so the walk stops at the first gap.
-        for attempt in 0..MAX_ATTEMPT_SCAN {
-            let commitment = world_chain_proofs::ProposalCommitment {
-                parent_ref,
-                root_claim,
-                l2_block_number,
-                attempt,
-            };
-            let entry = self
-                .factory
-                .games(
-                    MULTI_PROOF_GAME_TYPE,
-                    root_claim,
-                    commitment.extra_data(self.domain_hash),
-                )
-                .call()
-                .await
-                .map_err(|error| ProposerError::Contract(error.to_string()))?;
-            if entry.proxy == Address::ZERO {
-                break;
-            }
-            latest = Some(TransitionGame {
-                address: entry.proxy,
-                attempt,
-            });
-        }
-        Ok(latest)
+        transition: LineageTransition,
+    ) -> Result<Option<LineageGame>, LineageError> {
+        read_game_for_transition(&self.factory, self.registered.domain_hash, transition).await
     }
 
-    async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError> {
-        self.read_resolution_status(game).await
+    async fn lineage_resolution_status(
+        &self,
+        game: Address,
+    ) -> Result<ResolutionStatus, LineageError> {
+        read_lineage_resolution_status(&self.game(game)).await
     }
+}
 
+#[async_trait]
+impl<P> ProposerClient for AlloyProofSystemClient<P>
+where
+    P: Provider + WalletProvider + Clone + Send + Sync + 'static,
+{
     async fn resolve_game(&self, game: Address) -> Result<ResolveSubmission, ProposerError> {
         let pending = self
             .game(game)
@@ -424,7 +349,9 @@ where
             .await
             .map_err(|error| ProposerError::Contract(error.to_string()))?;
 
-        let extra_data = proposal.commitment().extra_data(self.domain_hash);
+        let extra_data = proposal
+            .commitment()
+            .extra_data(self.registered.domain_hash);
         let pending = self
             .factory
             .create(MULTI_PROOF_GAME_TYPE, proposal.root_claim, extra_data)

--- a/proofs/proposer/src/alloy.rs
+++ b/proofs/proposer/src/alloy.rs
@@ -30,7 +30,6 @@ const MAX_ATTEMPT_SCAN: u64 = 64;
 pub struct AlloyProofSystemClient<P> {
     factory: IDisputeGameFactory::IDisputeGameFactoryInstance<P>,
     anchor: IAnchorStateRegistry::IAnchorStateRegistryInstance<P>,
-    game_implementation: IMultiProofGame::IMultiProofGameInstance<P>,
     /// Domain hash of the registered game implementation, read once at construction.
     domain_hash: B256,
     /// Number of confirmations to require after sending a tx onchain.
@@ -83,7 +82,6 @@ where
         Ok(Self {
             factory,
             anchor,
-            game_implementation,
             domain_hash,
             confirmations,
             provider,
@@ -307,17 +305,21 @@ where
     P: Provider + WalletProvider + Clone + Send + Sync + 'static,
 {
     async fn anchor_parent(&self) -> Result<AnchorRef, ProposerError> {
-        let (anchor_root, canonical_parent) = self
+        let (anchor_root, anchor_game) = self
             .provider
             .multicall()
             .add(self.anchor.getAnchorRoot())
-            .add(self.game_implementation.canonicalAnchorParent())
+            .add(self.anchor.anchorGame())
             .aggregate()
             .await
             .map_err(|err| ProposerError::Contract(err.to_string()))?;
 
         Ok(AnchorRef {
-            address: canonical_parent,
+            address: if anchor_game == Address::ZERO {
+                *self.anchor.address()
+            } else {
+                anchor_game
+            },
             l2_block_number: u256_to_u64(anchor_root.l2SequenceNumber, "getAnchorRoot")?,
         })
     }

--- a/proofs/proposer/src/config.rs
+++ b/proofs/proposer/src/config.rs
@@ -49,8 +49,6 @@ impl Default for BondManagerConfig {
 /// captured at startup where an owner update would silently break every proposal.
 #[derive(Debug, Clone)]
 pub struct ProposerConfig {
-    /// Number of L2 blocks between proposals.
-    pub block_interval: u64,
     /// Delay between periodic proposal attempts.
     pub poll_interval: Duration,
     /// Maximum number of game-resolution transactions submitted per proposer tick.
@@ -59,11 +57,6 @@ pub struct ProposerConfig {
 
 impl ProposerConfig {
     pub(crate) fn validate(&self) -> Result<(), ProposerError> {
-        if self.block_interval == 0 {
-            return Err(ProposerError::InvalidConfig(
-                "block_interval must be greater than zero",
-            ));
-        }
         if self.poll_interval.is_zero() {
             return Err(ProposerError::InvalidConfig(
                 "poll_interval must be greater than zero",
@@ -81,7 +74,6 @@ impl ProposerConfig {
 impl Default for ProposerConfig {
     fn default() -> Self {
         Self {
-            block_interval: 6,
             poll_interval: Duration::from_secs(12),
             max_resolutions_per_tick: 1,
         }

--- a/proofs/proposer/src/error.rs
+++ b/proofs/proposer/src/error.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::TxHash;
 use thiserror::Error;
-use world_chain_proofs::ConsensusError;
+use world_chain_proofs::LineageError;
 
 /// Errors returned by the proposer.
 #[derive(Debug, Error)]
@@ -8,19 +8,11 @@ pub enum ProposerError {
     /// Invalid proposer configuration.
     #[error("invalid proposer config: {0}")]
     InvalidConfig(&'static str),
-    /// Adding `block_interval` overflowed `u64`.
-    #[error("l2 block number overflow: parent {parent_block} + interval {block_interval}")]
-    BlockNumberOverflow {
-        /// Parent L2 block number.
-        parent_block: u64,
-        /// Configured block interval.
-        block_interval: u64,
-    },
     /// Contract call or transaction failure.
     #[error("contract error: {0}")]
     Contract(String),
     #[error(transparent)]
-    OutputRoot(#[from] ConsensusError),
+    Lineage(#[from] LineageError),
     #[error("The proposal transaction didn't execute succesfully: {0}")]
     Revert(TxHash),
 }

--- a/proofs/proposer/src/error.rs
+++ b/proofs/proposer/src/error.rs
@@ -1,7 +1,6 @@
 use alloy_primitives::TxHash;
 use thiserror::Error;
 use world_chain_proofs::ConsensusError;
-use world_chain_prover_service::ProofRequestError;
 
 /// Errors returned by the proposer.
 #[derive(Debug, Error)]
@@ -20,14 +19,6 @@ pub enum ProposerError {
     /// Contract call or transaction failure.
     #[error("contract error: {0}")]
     Contract(String),
-    #[error("L1 finalized block not found")]
-    FinalizedBlockNotFound,
-    /// Prover-service request failure.
-    #[error(transparent)]
-    ProofRequest(#[from] ProofRequestError),
-    /// Prover-service returned data inconsistent with the requested proof.
-    #[error("invalid proof response: {0}")]
-    InvalidProofResponse(String),
     #[error(transparent)]
     OutputRoot(#[from] ConsensusError),
     #[error("The proposal transaction didn't execute succesfully: {0}")]

--- a/proofs/proposer/src/lib.rs
+++ b/proofs/proposer/src/lib.rs
@@ -22,9 +22,8 @@ pub use error::ProposerError;
 pub use proposer::WorldChainProposer;
 pub use traits::{BondManagerClient, ProposerClient};
 pub use types::{
-    AnchorRef, CanonicalLine, CanonicalScan, ClaimSubmission, CloseGameSubmission, FinalizedGames,
-    NextProposalAction, ParentRef, PendingWithdrawal, Proposal, ProposalSubmission,
-    ResolveSubmission, TransitionGame,
+    ClaimSubmission, CloseGameSubmission, NextProposalAction, PendingWithdrawal, Proposal,
+    ProposalSubmission, ProposerScan, ResolveSubmission,
 };
 
 #[cfg(test)]

--- a/proofs/proposer/src/main.rs
+++ b/proofs/proposer/src/main.rs
@@ -19,7 +19,6 @@ use world_chain_proofs::OptimismConsensusClient;
 use world_chain_proposer::{
     AlloyProofSystemClient, BondManager, BondManagerConfig, ProposerConfig, WorldChainProposer,
 };
-use world_chain_prover_service::RpcProverServiceClient;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -34,10 +33,6 @@ struct Cli {
     /// op-node rollup RPC URL used to read canonical L2 output roots.
     #[arg(long, env = "OUTPUT_ROOT_RPC_URL")]
     output_root_rpc: String,
-
-    /// prover-service JSON-RPC URL.
-    #[arg(long, env = "PROVER_SERVICE_URL")]
-    prover_service_url: String,
 
     /// OP Stack `DisputeGameFactory` address on L1.
     #[arg(long, env = "FACTORY_ADDRESS")]
@@ -108,20 +103,17 @@ async fn main() -> Result<()> {
     };
     let mut bond_manager = BondManager::new(bond_manager_config, contracts.clone());
     let output_roots = OptimismConsensusClient::new(cli.output_root_rpc.clone());
-    let proof_requester = RpcProverServiceClient::new(&cli.prover_service_url)
-        .with_context(|| format!("failed to connect to {}", cli.prover_service_url))?;
     let domain_hash = contracts.domain_hash();
     let config = ProposerConfig {
         block_interval: cli.block_interval,
         poll_interval: Duration::from_secs(cli.poll_interval_seconds),
         max_resolutions_per_tick: cli.max_resolutions_per_tick,
     };
-    let mut proposer = WorldChainProposer::new(config, contracts, output_roots, proof_requester);
+    let mut proposer = WorldChainProposer::new(config, contracts, output_roots);
 
     info!(
         l1_rpc_url = %cli.l1_rpc,
         output_root_rpc_url = %cli.output_root_rpc,
-        prover_service = %cli.prover_service_url,
         dispute_game_factory = %cli.factory_address,
         anchor = %cli.anchor_registry_address,
         proposer = %proposer_address,

--- a/proofs/proposer/src/main.rs
+++ b/proofs/proposer/src/main.rs
@@ -38,17 +38,9 @@ struct Cli {
     #[arg(long, env = "FACTORY_ADDRESS")]
     factory_address: Address,
 
-    /// OP Stack `AnchorStateRegistry` address on L1.
-    #[arg(long, env = "ANCHOR_REGISTRY_ADDRESS")]
-    anchor_registry_address: Address,
-
     /// Hex-encoded private key the proposer signs L1 transactions with.
     #[arg(long, env = "PROPOSER_KEY", hide_env_values = true)]
     proposer_key: PrivateKeySigner,
-
-    /// L2 blocks between a proposal's parent and its claimed block.
-    #[arg(long, env = "BLOCK_INTERVAL")]
-    block_interval: u64,
 
     /// Seconds between output-root polls.
     #[arg(long, env = "POLL_INTERVAL_SECONDS", default_value_t = 12)]
@@ -89,36 +81,30 @@ async fn main() -> Result<()> {
         .wallet(EthereumWallet::from(cli.proposer_key))
         .connect_http(Url::parse(&cli.l1_rpc).context("invalid L1 RPC URL")?);
 
-    let contracts = AlloyProofSystemClient::new(
-        provider,
-        cli.factory_address,
-        cli.anchor_registry_address,
-        cli.confirmations,
-    )
-    .await
-    .context("failed to bind the World Chain proof system")?;
+    let contracts = AlloyProofSystemClient::new(provider, cli.factory_address, cli.confirmations)
+        .await
+        .context("failed to bind the World Chain proof system")?;
     let bond_manager_config = BondManagerConfig {
         poll_interval: Duration::from_secs(cli.bond_manager_poll_interval_seconds),
         initial_scan_limit: cli.bond_manager_initial_scan_limit,
     };
     let mut bond_manager = BondManager::new(bond_manager_config, contracts.clone());
     let output_roots = OptimismConsensusClient::new(cli.output_root_rpc.clone());
-    let domain_hash = contracts.domain_hash();
+    let registered = contracts.registered_lineage_config();
     let config = ProposerConfig {
-        block_interval: cli.block_interval,
         poll_interval: Duration::from_secs(cli.poll_interval_seconds),
         max_resolutions_per_tick: cli.max_resolutions_per_tick,
     };
-    let mut proposer = WorldChainProposer::new(config, contracts, output_roots);
+    let proposer = WorldChainProposer::new(config, contracts, output_roots);
 
     info!(
         l1_rpc_url = %cli.l1_rpc,
         output_root_rpc_url = %cli.output_root_rpc,
         dispute_game_factory = %cli.factory_address,
-        anchor = %cli.anchor_registry_address,
+        anchor = %registered.anchor_registry,
         proposer = %proposer_address,
-        domain_hash = %domain_hash,
-        block_interval = cli.block_interval,
+        domain_hash = %registered.domain_hash,
+        block_interval = registered.block_interval,
         max_resolutions_per_tick = cli.max_resolutions_per_tick,
         bond_manager_poll_interval_seconds = cli.bond_manager_poll_interval_seconds,
         bond_manager_initial_scan_limit = cli.bond_manager_initial_scan_limit,

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -1,9 +1,12 @@
-use tracing::{info, warn};
-use world_chain_proofs::{ConsensusProvider, InvalidationReason, RootState};
+use tracing::{error, info, warn};
+use world_chain_proofs::{
+    ConsensusProvider, InvalidationReason, LineageStop, RootState, SelectedLineageGame,
+    select_lineage,
+};
 
 use crate::{
-    ParentRef, Proposal, ProposerClient, ProposerConfig, ProposerError,
-    types::{CanonicalLine, CanonicalScan, FinalizedGames, NextProposalAction},
+    Proposal, ProposerClient, ProposerConfig, ProposerError,
+    types::{NextProposalAction, ProposerScan},
 };
 
 /// World Chain Proposer.
@@ -40,162 +43,118 @@ where
     ///
     /// A game is considered canonical if it's built on top of a valid game and its root_claim
     /// is correct - i.e. it matches the one computed by the proposer itself.
-    pub async fn anchor_and_canonical_line(&self) -> Result<CanonicalScan, ProposerError> {
+    pub async fn scan_selected_lineage(&self) -> Result<ProposerScan, ProposerError> {
         self.config.validate()?;
 
-        let anchor = self.execution_provider.anchor_parent().await?;
-        let mut cursor = anchor.parent_ref();
-        let mut canonical_line = CanonicalLine::new(cursor);
-
-        let latest_finalized_l2_block = self.consensus_provider.latest_l2_finalized_block().await?;
-
-        // loop to the next canonical game until it reaches the last one
-        loop {
-            let next_l2_block_number = cursor
-                .l2_block_number
-                .checked_add(self.config.block_interval)
-                .ok_or(ProposerError::BlockNumberOverflow {
-                    parent_block: cursor.l2_block_number,
-                    block_interval: self.config.block_interval,
-                })?;
-
-            if next_l2_block_number > latest_finalized_l2_block {
-                return Ok(CanonicalScan::new(
-                    canonical_line,
-                    NextProposalAction::CaughtUp {
-                        target_block: next_l2_block_number,
-                        finalized_block: latest_finalized_l2_block,
-                    },
-                ));
+        let lineage = select_lineage(&self.execution_provider, &self.consensus_provider).await?;
+        let next_action = match lineage.stop() {
+            LineageStop::CaughtUp {
+                target_block,
+                finalized_block,
+            } => NextProposalAction::CaughtUp {
+                target_block,
+                finalized_block,
+            },
+            LineageStop::Missing(transition) => NextProposalAction::Propose(Proposal {
+                parent_ref: transition.parent_ref,
+                root_claim: transition.root_claim,
+                l2_block_number: transition.l2_block_number,
+                attempt: 0,
+            }),
+            LineageStop::Invalidated {
+                transition,
+                game,
+                status,
+            } => {
+                if status.resolvable {
+                    NextProposalAction::ResolveNegative {
+                        game: game.address,
+                        reason: status.invalidation_reason,
+                    }
+                } else if status.invalidation_reason == InvalidationReason::ProofTimeout {
+                    // A retry must reuse the invalidated game's transition commitment.
+                    NextProposalAction::RetryTimedOut {
+                        proposal: Proposal {
+                            parent_ref: transition.parent_ref,
+                            root_claim: transition.root_claim,
+                            l2_block_number: transition.l2_block_number,
+                            attempt: game.attempt.checked_add(1).ok_or_else(|| {
+                                ProposerError::Contract("proposal attempt overflows u64".into())
+                            })?,
+                        },
+                        invalidated_game: game.address,
+                    }
+                } else {
+                    NextProposalAction::BlockedByInvalidation {
+                        game: game.address,
+                        reason: status.invalidation_reason,
+                    }
+                }
             }
+        };
 
-            let root_claim = self
-                .consensus_provider
-                .output_root_at_block(next_l2_block_number)
-                .await?;
-
-            let existing = self
-                .execution_provider
-                .game_for_transition(cursor.address, root_claim, next_l2_block_number)
-                .await?;
-            let Some(game) = existing else {
-                return Ok(CanonicalScan::new(
-                    canonical_line,
-                    NextProposalAction::Propose(Proposal {
-                        parent_ref: cursor.address,
-                        root_claim,
-                        l2_block_number: next_l2_block_number,
-                        attempt: 0,
-                    }),
-                ));
-            };
-            let status = self
-                .execution_provider
-                .resolution_status(game.address)
-                .await?;
-
-            if status.root_state != RootState::Invalidated {
-                let next_game = ParentRef {
-                    address: game.address,
-                    l2_block_number: next_l2_block_number,
-                };
-                canonical_line.push_game(next_game);
-                cursor = next_game;
-                continue;
-            }
-
-            let next_action = if status.resolvable {
-                NextProposalAction::AwaitNegativeResolution {
-                    game: game.address,
-                    reason: status.invalidation_reason,
-                }
-            } else if status.invalidation_reason == InvalidationReason::ProofTimeout {
-                // A retry must reuse the invalidated game's parent reference and root claim:
-                // `MultiProofGame` only accepts attempt N when attempt N-1 exists under the
-                // identical `extraData`.
-                NextProposalAction::RetryTimedOut {
-                    proposal: Proposal {
-                        parent_ref: cursor.address,
-                        root_claim,
-                        l2_block_number: next_l2_block_number,
-                        attempt: game.attempt.checked_add(1).ok_or_else(|| {
-                            ProposerError::Contract("proposal attempt overflows u64".into())
-                        })?,
-                    },
-                    invalidated_game: game.address,
-                }
-            } else {
-                NextProposalAction::BlockedByInvalidation {
-                    game: game.address,
-                    reason: status.invalidation_reason,
-                }
-            };
-            return Ok(CanonicalScan::new(canonical_line, next_action));
-        }
+        Ok(ProposerScan::new(lineage, next_action))
     }
 
-    /// Resolves positively resolvable games parent-first and returns all finalized games.
+    /// Resolves positively resolvable games parent-first and returns the highest finalized game.
     ///
     /// Games finalized by an earlier iteration or another keeper are included so anchor
     /// advancement can be retried.
     pub async fn resolve_games(
         &self,
-        canonical_line: &CanonicalLine,
-    ) -> Result<FinalizedGames, ProposerError> {
-        let mut finalized_games = FinalizedGames::default();
+        games: &[SelectedLineageGame],
+    ) -> Result<Option<SelectedLineageGame>, ProposerError> {
+        let mut highest_finalized_game = None;
         let mut resolutions_submitted = 0;
-        for game in canonical_line.games() {
+        for selected in games {
+            let game = selected.game;
             let resolution_status = self
                 .execution_provider
-                .resolution_status(game.address)
+                .lineage_resolution_status(game.address)
                 .await?;
             if resolution_status.positive_resolvable() {
                 if resolutions_submitted >= self.config.max_resolutions_per_tick {
                     info!(
                         game_address = %game.address,
-                        l2_block_number = game.l2_block_number,
+                        l2_block_number = selected.transition.l2_block_number,
                         max_resolutions_per_tick = self.config.max_resolutions_per_tick,
                         "skipping game resolution because proposer tick budget is exhausted"
                     );
                     continue;
                 }
-                // resolve the game
                 let resolve_submission = self.execution_provider.resolve_game(game.address).await?;
                 info!(
                     game_address = %game.address,
-                    l2_block_number = game.l2_block_number,
+                    l2_block_number = selected.transition.l2_block_number,
                     tx_hash = ?resolve_submission.tx_hash,
                     "resolved World Chain proof-system game"
                 );
-                finalized_games.push(*game);
+                highest_finalized_game = Some(*selected);
                 resolutions_submitted += 1;
             } else if resolution_status.root_state == RootState::Finalized {
                 // the game was finalized in an earlier iteration or by another keeper
-                finalized_games.push(*game);
+                highest_finalized_game = Some(*selected);
             }
         }
-        Ok(finalized_games)
+        Ok(highest_finalized_game)
     }
 
     /// Advances the anchor to the highest finalized game, if one is available.
     pub async fn advance_anchor(
         &self,
-        finalized_games: FinalizedGames,
+        highest_finalized_game: Option<SelectedLineageGame>,
     ) -> Result<(), ProposerError> {
-        // games are ordered by l2 block number, therefore taking the last one
-        // means taking the one with the highest l2 block number
-        let maybe_highest_finalized_game = finalized_games.last();
-        if let Some(highest_finalized_game) = maybe_highest_finalized_game {
+        if let Some(highest_finalized_game) = highest_finalized_game {
             // `closeGame` reverts until the registry's finality airgap has elapsed. Gate on it
             // so the routine wait is not reported as a failed tick every poll interval.
             if !self
                 .execution_provider
-                .is_game_finalized(highest_finalized_game.address)
+                .is_game_finalized(highest_finalized_game.game.address)
                 .await?
             {
                 info!(
-                    game_address = %highest_finalized_game.address,
-                    l2_block_number = highest_finalized_game.l2_block_number,
+                    game_address = %highest_finalized_game.game.address,
+                    l2_block_number = highest_finalized_game.transition.l2_block_number,
                     "waiting for dispute-game finality delay before closing game"
                 );
                 return Ok(());
@@ -203,11 +162,11 @@ where
 
             let close_game_submission = self
                 .execution_provider
-                .close_game(highest_finalized_game.address)
+                .close_game(highest_finalized_game.game.address)
                 .await?;
             info!(
-                game_address = %highest_finalized_game.address,
-                l2_block_number = highest_finalized_game.l2_block_number,
+                game_address = %highest_finalized_game.game.address,
+                l2_block_number = highest_finalized_game.transition.l2_block_number,
                 tx_hash = ?close_game_submission.tx_hash,
                 "closed World Chain proof-system game"
             );
@@ -215,19 +174,31 @@ where
         Ok(())
     }
 
-    /// Creates the next canonical game, or waits while its predecessor is unresolved.
-    pub async fn submit_next_proposal(&self, scan: &CanonicalScan) -> Result<(), ProposerError> {
+    /// Resolves a negative tip or creates the next selected game or retry.
+    pub async fn submit_next_proposal(&self, scan: &ProposerScan) -> Result<(), ProposerError> {
         let (proposal, retry_of) = match scan.next_action() {
             NextProposalAction::Propose(proposal) => (*proposal, None),
             NextProposalAction::RetryTimedOut {
                 proposal,
                 invalidated_game,
-            } => (*proposal, Some(*invalidated_game)),
-            NextProposalAction::AwaitNegativeResolution { game, reason } => {
-                warn!(
+            } => {
+                error!(
+                    invalidated_game = %invalidated_game,
+                    parent_ref = %proposal.parent_ref,
+                    root_claim = %proposal.root_claim,
+                    l2_block_number = proposal.l2_block_number,
+                    attempt = proposal.attempt,
+                    "creating a retry; the abandoned lineage requires manual resolution and bond recovery"
+                );
+                (*proposal, Some(*invalidated_game))
+            }
+            NextProposalAction::ResolveNegative { game, reason } => {
+                let submission = self.execution_provider.resolve_game(*game).await?;
+                info!(
                     game_address = %game,
                     invalidation_reason = ?reason,
-                    "waiting for game to be resolved with its negative outcome"
+                    tx_hash = ?submission.tx_hash,
+                    "resolved selected game with its negative outcome"
                 );
                 return Ok(());
             }
@@ -256,7 +227,7 @@ where
     }
 
     /// Runs the proposer forever, logging transient failures and retrying on each tick.
-    pub async fn run_forever(&mut self) -> Result<(), ProposerError> {
+    pub async fn run_forever(&self) -> Result<(), ProposerError> {
         self.config.validate()?;
 
         let mut interval = tokio::time::interval(self.config.poll_interval);
@@ -264,13 +235,13 @@ where
             interval.tick().await;
             let iteration: Result<(), ProposerError> = async {
                 // 1. refresh the anchor and canonical line
-                let canonical_scan = self.anchor_and_canonical_line().await?;
+                let scan = self.scan_selected_lineage().await?;
                 // 2. resolve positive-ready games parent-first
-                let finalized_games = self.resolve_games(canonical_scan.canonical_line()).await?;
+                let highest_finalized_game = self.resolve_games(scan.lineage().games()).await?;
                 // 3. advance the anchor to the highest finalized canonical game
-                self.advance_anchor(finalized_games).await?;
-                // 4. submit a new canonical proposal or retry
-                self.submit_next_proposal(&canonical_scan).await?;
+                self.advance_anchor(highest_finalized_game).await?;
+                // 4. resolve a negative tip, or submit a new proposal or retry
+                self.submit_next_proposal(&scan).await?;
                 Ok(())
             }
             .await;

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -1,48 +1,26 @@
-use alloy_primitives::Address;
 use tracing::{info, warn};
 use world_chain_proofs::{ConsensusProvider, InvalidationReason, RootState};
-use world_chain_prover_service::{
-    ProofBackend, ProofRequest, ProofRequestId, ProofRequester, ProofResponse, ProofStatus,
-};
 
 use crate::{
     ParentRef, Proposal, ProposerClient, ProposerConfig, ProposerError,
     types::{CanonicalLine, CanonicalScan, FinalizedGames, NextProposalAction},
 };
 
-/// Proposal and exact Nitro request retained while proof generation is in flight.
-#[derive(Debug, Clone)]
-struct PendingProposal {
-    proposal: Proposal,
-    retry_of: Option<Address>,
-    proof_request: ProofRequest,
-    proof_id: ProofRequestId,
-}
-
 /// World Chain Proposer.
 #[derive(Debug)]
-pub struct WorldChainProposer<E, C, P> {
+pub struct WorldChainProposer<E, C> {
     config: ProposerConfig,
     execution_provider: E,
     consensus_provider: C,
-    proof_requester: P,
-    pending_proposal: Option<PendingProposal>,
 }
 
-impl<E, C, P> WorldChainProposer<E, C, P> {
-    /// Creates a proposer from execution, consensus, and proof-requester providers.
-    pub fn new(
-        config: ProposerConfig,
-        execution_provider: E,
-        consensus_provider: C,
-        proof_requester: P,
-    ) -> Self {
+impl<E, C> WorldChainProposer<E, C> {
+    /// Creates a proposer from execution and consensus providers.
+    pub const fn new(config: ProposerConfig, execution_provider: E, consensus_provider: C) -> Self {
         Self {
             config,
             execution_provider,
             consensus_provider,
-            proof_requester,
-            pending_proposal: None,
         }
     }
 
@@ -51,19 +29,12 @@ impl<E, C, P> WorldChainProposer<E, C, P> {
     pub const fn config(&self) -> &ProposerConfig {
         &self.config
     }
-
-    /// Returns whether a proposal is waiting for its Nitro proof or L1 submission.
-    #[must_use]
-    pub const fn has_pending_proposal(&self) -> bool {
-        self.pending_proposal.is_some()
-    }
 }
 
-impl<E, C, P> WorldChainProposer<E, C, P>
+impl<E, C> WorldChainProposer<E, C>
 where
     E: ProposerClient,
     C: ConsensusProvider,
-    P: ProofRequester,
 {
     /// Fetches the anchor, reconstructs its canonical descendants, and determines the next action.
     ///
@@ -76,10 +47,6 @@ where
         let mut cursor = anchor.parent_ref();
         let mut canonical_line = CanonicalLine::new(cursor);
 
-        // A game created before the registry advanced onto its parent still references that
-        // now-anchored game. The same transition created after the advance must reference the
-        // registry sentinel because game parents at or below the anchor are rejected.
-        let mut parent_candidates = anchor.parent_candidates();
         let latest_finalized_l2_block = self.consensus_provider.latest_l2_finalized_block().await?;
 
         // loop to the next canonical game until it reaches the last one
@@ -109,48 +76,9 @@ where
 
             let existing = self
                 .execution_provider
-                .games_for_transition(&parent_candidates, root_claim, next_l2_block_number)
+                .game_for_transition(cursor.address, root_claim, next_l2_block_number)
                 .await?;
-            let mut statuses = Vec::with_capacity(existing.len());
-            for game in &existing {
-                statuses.push(
-                    self.execution_provider
-                        .resolution_status(game.address)
-                        .await?,
-                );
-            }
-
-            // A game that has not been invalidated continues the canonical line, whichever
-            // accepted parent it was created under.
-            if let Some(live) = existing
-                .iter()
-                .zip(&statuses)
-                .find(|(_, status)| status.root_state != RootState::Invalidated)
-                .map(|(game, _)| *game)
-            {
-                let next_game = ParentRef {
-                    address: live.address,
-                    l2_block_number: next_l2_block_number,
-                };
-                canonical_line.push_game(next_game);
-                cursor = next_game;
-                parent_candidates = vec![next_game.address];
-                continue;
-            }
-
-            // Every game at this height is invalidated, so only the one created under the
-            // parent that is still acceptable matters. `MultiProofGame.initialize` rejects a
-            // parent at or below the anchor, so a game whose parent has since been closed into
-            // the anchor can neither be retried under that parent nor chained onto: the
-            // transition rebases onto `cursor.address` at attempt zero instead. This is the
-            // contract's own recovery path for inherited invalidations.
-            let Some((stale, status)) = existing
-                .iter()
-                .zip(&statuses)
-                .find(|(game, _)| game.parent_ref == cursor.address)
-            else {
-                // Nothing occupies this transition under the current parent, either because no
-                // game exists yet or because the only ones that do are stale rebase targets.
+            let Some(game) = existing else {
                 return Ok(CanonicalScan::new(
                     canonical_line,
                     NextProposalAction::Propose(Proposal {
@@ -161,10 +89,24 @@ where
                     }),
                 ));
             };
+            let status = self
+                .execution_provider
+                .resolution_status(game.address)
+                .await?;
+
+            if status.root_state != RootState::Invalidated {
+                let next_game = ParentRef {
+                    address: game.address,
+                    l2_block_number: next_l2_block_number,
+                };
+                canonical_line.push_game(next_game);
+                cursor = next_game;
+                continue;
+            }
 
             let next_action = if status.resolvable {
                 NextProposalAction::AwaitNegativeResolution {
-                    game: stale.address,
+                    game: game.address,
                     reason: status.invalidation_reason,
                 }
             } else if status.invalidation_reason == InvalidationReason::ProofTimeout {
@@ -176,13 +118,15 @@ where
                         parent_ref: cursor.address,
                         root_claim,
                         l2_block_number: next_l2_block_number,
-                        attempt: stale.attempt.saturating_add(1),
+                        attempt: game.attempt.checked_add(1).ok_or_else(|| {
+                            ProposerError::Contract("proposal attempt overflows u64".into())
+                        })?,
                     },
-                    invalidated_game: stale.address,
+                    invalidated_game: game.address,
                 }
             } else {
                 NextProposalAction::BlockedByInvalidation {
-                    game: stale.address,
+                    game: game.address,
                     reason: status.invalidation_reason,
                 }
             };
@@ -271,8 +215,8 @@ where
         Ok(())
     }
 
-    /// Reconciles and requests the proof for the next canonical proposal action.
-    pub async fn request_proof(&mut self, scan: &CanonicalScan) -> Result<(), ProposerError> {
+    /// Creates the next canonical game, or waits while its predecessor is unresolved.
+    pub async fn submit_next_proposal(&self, scan: &CanonicalScan) -> Result<(), ProposerError> {
         let (proposal, retry_of) = match scan.next_action() {
             NextProposalAction::Propose(proposal) => (*proposal, None),
             NextProposalAction::RetryTimedOut {
@@ -283,9 +227,8 @@ where
                 warn!(
                     game_address = %game,
                     invalidation_reason = ?reason,
-                    "waiting for challenger to resolve game with negative outcome"
+                    "waiting for game to be resolved with its negative outcome"
                 );
-                self.pending_proposal = None;
                 return Ok(());
             }
             NextProposalAction::BlockedByInvalidation { game, reason } => {
@@ -294,142 +237,21 @@ where
                     invalidation_reason = ?reason,
                     "invalidated transition is not automatically retryable; governance intervention required"
                 );
-                self.pending_proposal = None;
                 return Ok(());
             }
-            NextProposalAction::CaughtUp { .. } => {
-                self.pending_proposal = None;
-                return Ok(());
-            }
+            NextProposalAction::CaughtUp { .. } => return Ok(()),
         };
 
-        if self
-            .pending_proposal
-            .as_ref()
-            .is_some_and(|pending| pending.proposal != proposal)
-        {
-            let pending = self
-                .pending_proposal
-                .take()
-                .expect("pending proposal exists");
-            warn!(
-                old_proposal = ?pending.proposal,
-                new_proposal = ?proposal,
-                "canonical proposal changed; discarding stale pending proof"
-            );
-        }
-
-        if self.pending_proposal.is_none() {
-            let latest_finalized_l1 = self.execution_provider.latest_finalized_l1_block().await?;
-            let proof_request = ProofRequest {
-                backend: ProofBackend::Nitro,
-                // No game exists until the proof-backed proposal transaction is submitted.
-                game: Address::ZERO,
-                root_claim: proposal.root_claim,
-                l2_block_number: proposal.l2_block_number,
-                l1_head: latest_finalized_l1,
-            };
-            let proof_id = proof_request.id();
-            self.pending_proposal = Some(PendingProposal {
-                proposal,
-                retry_of,
-                proof_request,
-                proof_id,
-            });
-        }
-
-        let pending = self
-            .pending_proposal
-            .as_ref()
-            .expect("pending proposal initialized");
-
-        let request_proof_response = self
-            .proof_requester
-            .request_proof(pending.proof_request.clone())
-            .await?;
-        let request_proof_response_proof_id = request_proof_response.proof_id;
-        if request_proof_response_proof_id != pending.proof_id {
-            return Err(ProposerError::InvalidProofResponse(format!(
-                "prover-service returned proof id {request_proof_response_proof_id}, expected {}",
-                pending.proof_id
-            )));
-        }
-        self.pending_proposal
-            .as_mut()
-            .expect("pending proposal initialized")
-            .proof_request
-            .l1_head = request_proof_response.l1_head;
-        Ok(())
-    }
-
-    /// Polls the pending Nitro proof and submits its proposal once the proof is ready.
-    ///
-    /// Pending and failed proofs remain queued for a later tick. Proof retrieval and proposal
-    /// submission errors retain the pending state so the same completed proof can be retried.
-    pub async fn poll_and_submit(&mut self) -> Result<(), ProposerError> {
-        let Some(pending) = self.pending_proposal.as_ref() else {
-            return Ok(());
-        };
-        match self.proof_requester.proof_status(pending.proof_id).await? {
-            ProofStatus::Created | ProofStatus::Running => return Ok(()),
-            ProofStatus::Failed => {
-                warn!(
-                    proof_id = %pending.proof_id,
-                    proposal = ?pending.proposal,
-                    "proposal proof failed; retrying the same request next tick"
-                );
-                return Ok(());
-            }
-            ProofStatus::Succeeded => {}
-        }
-
-        let proof = match self.proof_requester.get_proof(pending.proof_id).await? {
-            ProofResponse::Succeeded(response) if response.id == pending.proof_id => response.proof,
-            ProofResponse::Succeeded(response) => {
-                return Err(ProposerError::InvalidProofResponse(format!(
-                    "proof response id {} does not match requested id {}",
-                    response.id, pending.proof_id
-                )));
-            }
-            ProofResponse::Pending(response) => {
-                warn!(
-                    proof_id = %pending.proof_id,
-                    status = %response.status,
-                    "proof status succeeded but proof response is pending; retrying next tick"
-                );
-                return Ok(());
-            }
-            ProofResponse::Failed(response) => {
-                warn!(
-                    proof_id = %pending.proof_id,
-                    reason = %response.reason,
-                    "proof status succeeded but proof response failed; retrying next tick"
-                );
-                return Ok(());
-            }
-        };
-        if proof.backend() != ProofBackend::Nitro {
-            return Err(ProposerError::InvalidProofResponse(format!(
-                "proof {} was produced by {}, expected nitro",
-                pending.proof_id,
-                proof.backend()
-            )));
-        }
-
-        let submission = self
-            .execution_provider
-            .submit_proposal(&pending.proposal, proof)
-            .await?;
+        let submission = self.execution_provider.submit_proposal(&proposal).await?;
         info!(
             tx_hash = ?submission.tx_hash,
             game_address = %submission.game_address,
-            l2_block_number = pending.proposal.l2_block_number,
-            parent_ref = %pending.proposal.parent_ref,
-            attempt = pending.proposal.attempt,
-            retry_of = ?pending.retry_of,
+            l2_block_number = proposal.l2_block_number,
+            parent_ref = %proposal.parent_ref,
+            attempt = proposal.attempt,
+            retry_of = ?retry_of,
             "submitted World Chain proof-system game"
         );
-        self.pending_proposal = None;
         Ok(())
     }
 
@@ -447,10 +269,8 @@ where
                 let finalized_games = self.resolve_games(canonical_scan.canonical_line()).await?;
                 // 3. advance the anchor to the highest finalized canonical game
                 self.advance_anchor(finalized_games).await?;
-                // 4. request the proof for a new canonical proposal or retry
-                self.request_proof(&canonical_scan).await?;
-                // 5. submit the proposal once its proof is ready
-                self.poll_and_submit().await?;
+                // 4. submit a new canonical proposal or retry
+                self.submit_next_proposal(&canonical_scan).await?;
                 Ok(())
             }
             .await;

--- a/proofs/proposer/src/tests.rs
+++ b/proofs/proposer/src/tests.rs
@@ -7,15 +7,11 @@ use std::{
     time::Duration,
 };
 
-use alloy_primitives::{Address, B256, BlockNumber, Bytes, U256, address, b256};
+use alloy_primitives::{Address, B256, BlockNumber, U256, address, b256};
 use async_trait::async_trait;
 use world_chain_proofs::{
     ConsensusError, ConsensusProvider, InvalidationReason, ProposalCommitment, ResolutionStatus,
     RootState,
-};
-use world_chain_prover_service::{
-    ProofBackend, ProofData, ProofRequest, ProofRequestError, ProofRequestId, ProofRequester,
-    ProofResponse, ProofStatus, RequestProofResponse, SucceededProofResponse,
 };
 
 use crate::{
@@ -40,7 +36,7 @@ struct MockContracts {
     anchor: AnchorRef,
     /// Games keyed by their `DisputeGameFactory` UUID.
     games: HashMap<B256, Address>,
-    submissions: Arc<Mutex<Vec<(Proposal, ProofData)>>>,
+    submissions: Arc<Mutex<Vec<Proposal>>>,
     resolution_statuses: Arc<Mutex<HashMap<Address, ResolutionStatus>>>,
     resolutions: Arc<Mutex<Vec<Address>>>,
     closures: Arc<Mutex<Vec<Address>>>,
@@ -55,29 +51,21 @@ impl ProposerClient for MockContracts {
         Ok(self.anchor)
     }
 
-    async fn games_for_transition(
+    async fn game_for_transition(
         &self,
-        parent_candidates: &[Address],
+        parent_ref: Address,
         root_claim: B256,
         l2_block_number: u64,
-    ) -> Result<Vec<TransitionGame>, ProposerError> {
-        let mut found = Vec::with_capacity(parent_candidates.len());
-        for parent_ref in parent_candidates {
-            let mut latest = None;
-            for attempt in 0..MAX_TEST_ATTEMPT {
-                let uuid = game_uuid(*parent_ref, root_claim, l2_block_number, attempt);
-                let Some(address) = self.games.get(&uuid).copied() else {
-                    break;
-                };
-                latest = Some(TransitionGame {
-                    address,
-                    parent_ref: *parent_ref,
-                    attempt,
-                });
-            }
-            found.extend(latest);
+    ) -> Result<Option<TransitionGame>, ProposerError> {
+        let mut latest = None;
+        for attempt in 0..MAX_TEST_ATTEMPT {
+            let uuid = game_uuid(parent_ref, root_claim, l2_block_number, attempt);
+            let Some(address) = self.games.get(&uuid).copied() else {
+                break;
+            };
+            latest = Some(TransitionGame { address, attempt });
         }
-        Ok(found)
+        Ok(latest)
     }
 
     async fn is_game_finalized(&self, game: Address) -> Result<bool, ProposerError> {
@@ -115,14 +103,9 @@ impl ProposerClient for MockContracts {
         })
     }
 
-    async fn latest_finalized_l1_block(&self) -> Result<B256, ProposerError> {
-        Ok(B256::repeat_byte(0xf1))
-    }
-
     async fn submit_proposal(
         &self,
         proposal: &Proposal,
-        proof: ProofData,
     ) -> Result<ProposalSubmission, ProposerError> {
         let mut failures = self.submission_failures.lock().expect("not poisoned");
         if *failures > 0 {
@@ -135,87 +118,11 @@ impl ProposerClient for MockContracts {
         self.submissions
             .lock()
             .expect("not poisoned")
-            .push((*proposal, proof));
+            .push(*proposal);
         Ok(ProposalSubmission {
             tx_hash: B256::repeat_byte(0xaa),
             game_address: Address::repeat_byte(0xaa),
         })
-    }
-}
-
-#[derive(Debug, Clone)]
-struct MockProofRequester {
-    requests: Arc<Mutex<Vec<ProofRequest>>>,
-    status: Arc<Mutex<ProofStatus>>,
-    fail_status_once: Arc<Mutex<bool>>,
-}
-
-impl Default for MockProofRequester {
-    fn default() -> Self {
-        Self {
-            requests: Arc::default(),
-            status: Arc::new(Mutex::new(ProofStatus::Succeeded)),
-            fail_status_once: Arc::default(),
-        }
-    }
-}
-
-impl MockProofRequester {
-    fn with_status(status: ProofStatus) -> Self {
-        Self {
-            status: Arc::new(Mutex::new(status)),
-            ..Self::default()
-        }
-    }
-
-    fn set_status(&self, status: ProofStatus) {
-        *self.status.lock().expect("not poisoned") = status;
-    }
-
-    fn fail_next_status(&self) {
-        *self.fail_status_once.lock().expect("not poisoned") = true;
-    }
-}
-
-#[async_trait]
-impl ProofRequester for MockProofRequester {
-    async fn request_proof(
-        &self,
-        request: ProofRequest,
-    ) -> Result<RequestProofResponse, ProofRequestError> {
-        let id = request.id();
-        let l1_head = request.l1_head;
-        self.requests.lock().expect("not poisoned").push(request);
-        Ok(RequestProofResponse {
-            proof_id: id,
-            l1_head,
-        })
-    }
-
-    async fn proof_status(
-        &self,
-        _proof_id: ProofRequestId,
-    ) -> Result<ProofStatus, ProofRequestError> {
-        let mut fail_once = self.fail_status_once.lock().expect("not poisoned");
-        if *fail_once {
-            *fail_once = false;
-            return Err(ProofRequestError::RemoteInternal);
-        }
-        Ok(*self.status.lock().expect("not poisoned"))
-    }
-
-    async fn get_proof(
-        &self,
-        proof_id: ProofRequestId,
-    ) -> Result<ProofResponse, ProofRequestError> {
-        Ok(ProofResponse::Succeeded(SucceededProofResponse {
-            id: proof_id,
-            proof: ProofData::Nitro {
-                attestation: Bytes::from_static(&[1]),
-                public_values: Bytes::from_static(&[2]),
-                signature: Bytes::from_static(&[3]),
-            },
-        }))
     }
 }
 
@@ -431,11 +338,10 @@ fn config() -> ProposerConfig {
 }
 
 async fn advance_proposal(
-    proposer: &mut WorldChainProposer<MockContracts, MockOutputRoots, MockProofRequester>,
+    proposer: &WorldChainProposer<MockContracts, MockOutputRoots>,
     scan: &CanonicalScan,
 ) -> Result<(), ProposerError> {
-    proposer.request_proof(scan).await?;
-    proposer.poll_and_submit().await
+    proposer.submit_next_proposal(scan).await
 }
 
 fn positive_ready_status() -> ResolutionStatus {
@@ -448,18 +354,14 @@ fn positive_ready_status() -> ResolutionStatus {
 
 fn anchor_at(l2_block_number: u64) -> AnchorRef {
     AnchorRef {
-        registry: ANCHOR,
-        anchor_game: None,
+        address: ANCHOR,
         l2_block_number,
     }
 }
 
-/// The anchor after it has been advanced onto `anchor_game`, which is therefore no longer an
-/// acceptable parent for new proposals.
 fn anchor_advanced_onto(anchor_game: Address, l2_block_number: u64) -> AnchorRef {
     AnchorRef {
-        registry: ANCHOR,
-        anchor_game: Some(anchor_game),
+        address: anchor_game,
         l2_block_number,
     }
 }
@@ -516,12 +418,7 @@ async fn anchor_and_canonical_line_walks_existing_games_until_gap() {
         roots: HashMap::from([(10, root_10), (20, root_20)]),
         finalized_l2_block: 20,
     };
-    let proposer = WorldChainProposer::new(
-        config(),
-        contracts,
-        output_roots,
-        MockProofRequester::default(),
-    );
+    let proposer = WorldChainProposer::new(config(), contracts, output_roots);
 
     let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
 
@@ -551,19 +448,12 @@ async fn propose_submits_proposal_after_last_canonical_game() {
         roots: HashMap::from([(10, B256::repeat_byte(0x10))]),
         finalized_l2_block: 10,
     };
-    let mut proposer = WorldChainProposer::new(
-        config(),
-        contracts,
-        output_roots,
-        MockProofRequester::default(),
-    );
+    let proposer = WorldChainProposer::new(config(), contracts, output_roots);
     let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
 
-    advance_proposal(&mut proposer, &canonical_scan)
-        .await
-        .unwrap();
+    advance_proposal(&proposer, &canonical_scan).await.unwrap();
 
-    let proposal = submissions.lock().expect("not poisoned")[0].0;
+    let proposal = submissions.lock().expect("not poisoned")[0];
     assert_eq!(proposal.parent_ref, ANCHOR);
     assert_eq!(proposal.root_claim, B256::repeat_byte(0x10));
     assert_eq!(proposal.l2_block_number, 10);
@@ -571,125 +461,7 @@ async fn propose_submits_proposal_after_last_canonical_game() {
 }
 
 #[tokio::test]
-async fn propose_waits_for_pending_proof_and_reuses_exact_request() {
-    let submissions = Arc::default();
-    let contracts = MockContracts {
-        anchor: anchor_at(0),
-        games: HashMap::new(),
-        submissions: Arc::clone(&submissions),
-        resolution_statuses: Arc::default(),
-        resolutions: Arc::default(),
-        closures: Arc::default(),
-        submission_failures: Arc::default(),
-        unfinalized_games: Arc::default(),
-    };
-    let output_roots = MockOutputRoots {
-        roots: HashMap::from([(10, B256::repeat_byte(0x10))]),
-        finalized_l2_block: 10,
-    };
-    let proof_requester = MockProofRequester::with_status(ProofStatus::Running);
-    let mut proposer =
-        WorldChainProposer::new(config(), contracts, output_roots, proof_requester.clone());
-    let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
-
-    advance_proposal(&mut proposer, &canonical_scan)
-        .await
-        .unwrap();
-
-    assert!(submissions.lock().expect("not poisoned").is_empty());
-    let first_request = proof_requester.requests.lock().expect("not poisoned")[0].clone();
-    assert_eq!(first_request.backend, ProofBackend::Nitro);
-    assert_eq!(first_request.game, Address::ZERO);
-    assert_eq!(first_request.l1_head, B256::repeat_byte(0xf1));
-
-    proof_requester.set_status(ProofStatus::Succeeded);
-    advance_proposal(&mut proposer, &canonical_scan)
-        .await
-        .unwrap();
-
-    let requests = proof_requester.requests.lock().expect("not poisoned");
-    assert_eq!(requests.as_slice(), &[first_request.clone(), first_request]);
-    assert_eq!(submissions.lock().expect("not poisoned").len(), 1);
-}
-
-#[tokio::test]
-async fn propose_rerequests_failed_proof_without_submitting() {
-    let submissions = Arc::default();
-    let contracts = MockContracts {
-        anchor: anchor_at(0),
-        games: HashMap::new(),
-        submissions: Arc::clone(&submissions),
-        resolution_statuses: Arc::default(),
-        resolutions: Arc::default(),
-        closures: Arc::default(),
-        submission_failures: Arc::default(),
-        unfinalized_games: Arc::default(),
-    };
-    let output_roots = MockOutputRoots {
-        roots: HashMap::from([(10, B256::repeat_byte(0x10))]),
-        finalized_l2_block: 10,
-    };
-    let proof_requester = MockProofRequester::with_status(ProofStatus::Failed);
-    let mut proposer =
-        WorldChainProposer::new(config(), contracts, output_roots, proof_requester.clone());
-    let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
-
-    advance_proposal(&mut proposer, &canonical_scan)
-        .await
-        .unwrap();
-    advance_proposal(&mut proposer, &canonical_scan)
-        .await
-        .unwrap();
-
-    let requests = proof_requester.requests.lock().expect("not poisoned");
-    assert_eq!(requests.len(), 2);
-    assert_eq!(requests[0], requests[1]);
-    assert!(submissions.lock().expect("not poisoned").is_empty());
-}
-
-#[tokio::test]
-async fn propose_retains_request_after_transient_status_error() {
-    let submissions = Arc::default();
-    let contracts = MockContracts {
-        anchor: anchor_at(0),
-        games: HashMap::new(),
-        submissions: Arc::clone(&submissions),
-        resolution_statuses: Arc::default(),
-        resolutions: Arc::default(),
-        closures: Arc::default(),
-        submission_failures: Arc::default(),
-        unfinalized_games: Arc::default(),
-    };
-    let output_roots = MockOutputRoots {
-        roots: HashMap::from([(10, B256::repeat_byte(0x10))]),
-        finalized_l2_block: 10,
-    };
-    let proof_requester = MockProofRequester::default();
-    proof_requester.fail_next_status();
-    let mut proposer =
-        WorldChainProposer::new(config(), contracts, output_roots, proof_requester.clone());
-    let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
-
-    assert!(matches!(
-        advance_proposal(&mut proposer, &canonical_scan).await,
-        Err(ProposerError::ProofRequest(
-            ProofRequestError::RemoteInternal
-        ))
-    ));
-    assert!(submissions.lock().expect("not poisoned").is_empty());
-
-    advance_proposal(&mut proposer, &canonical_scan)
-        .await
-        .unwrap();
-
-    let requests = proof_requester.requests.lock().expect("not poisoned");
-    assert_eq!(requests.len(), 2);
-    assert_eq!(requests[0], requests[1]);
-    assert_eq!(submissions.lock().expect("not poisoned").len(), 1);
-}
-
-#[tokio::test]
-async fn propose_retries_submission_with_same_completed_proof() {
+async fn propose_can_retry_a_failed_submission() {
     let submissions = Arc::default();
     let submission_failures = Arc::new(Mutex::new(1));
     let contracts = MockContracts {
@@ -706,97 +478,18 @@ async fn propose_retries_submission_with_same_completed_proof() {
         roots: HashMap::from([(10, B256::repeat_byte(0x10))]),
         finalized_l2_block: 10,
     };
-    let proof_requester = MockProofRequester::default();
-    let mut proposer =
-        WorldChainProposer::new(config(), contracts, output_roots, proof_requester.clone());
+    let proposer = WorldChainProposer::new(config(), contracts, output_roots);
     let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
 
     assert!(matches!(
-        advance_proposal(&mut proposer, &canonical_scan).await,
+        advance_proposal(&proposer, &canonical_scan).await,
         Err(ProposerError::Contract(_))
     ));
     assert!(submissions.lock().expect("not poisoned").is_empty());
 
-    advance_proposal(&mut proposer, &canonical_scan)
-        .await
-        .unwrap();
+    advance_proposal(&proposer, &canonical_scan).await.unwrap();
 
-    let requests = proof_requester.requests.lock().expect("not poisoned");
-    assert_eq!(requests.len(), 2);
-    assert_eq!(requests[0], requests[1]);
     assert_eq!(submissions.lock().expect("not poisoned").len(), 1);
-}
-
-#[tokio::test]
-async fn propose_replaces_pending_request_when_canonical_candidate_changes() {
-    let contracts = MockContracts {
-        anchor: anchor_at(0),
-        games: HashMap::new(),
-        submissions: Arc::default(),
-        resolution_statuses: Arc::default(),
-        resolutions: Arc::default(),
-        closures: Arc::default(),
-        submission_failures: Arc::default(),
-        unfinalized_games: Arc::default(),
-    };
-    let proof_requester = MockProofRequester::with_status(ProofStatus::Running);
-    let mut proposer = WorldChainProposer::new(
-        config(),
-        contracts,
-        MockOutputRoots {
-            roots: HashMap::new(),
-            finalized_l2_block: 0,
-        },
-        proof_requester.clone(),
-    );
-    let canonical_line = CanonicalLine::new(ParentRef {
-        address: ANCHOR,
-        l2_block_number: 0,
-    });
-    let first = CanonicalScan::new(
-        canonical_line,
-        NextProposalAction::Propose(Proposal {
-            parent_ref: ANCHOR,
-            root_claim: B256::repeat_byte(0x10),
-            l2_block_number: 10,
-            attempt: 0,
-        }),
-    );
-    advance_proposal(&mut proposer, &first).await.unwrap();
-
-    let second = CanonicalScan::new(
-        CanonicalLine::new(ParentRef {
-            address: ANCHOR,
-            l2_block_number: 0,
-        }),
-        NextProposalAction::Propose(Proposal {
-            parent_ref: ANCHOR,
-            root_claim: B256::repeat_byte(0x20),
-            l2_block_number: 10,
-            attempt: 0,
-        }),
-    );
-    advance_proposal(&mut proposer, &second).await.unwrap();
-
-    {
-        let requests = proof_requester.requests.lock().expect("not poisoned");
-        assert_eq!(requests.len(), 2);
-        assert_eq!(requests[0].root_claim, B256::repeat_byte(0x10));
-        assert_eq!(requests[1].root_claim, B256::repeat_byte(0x20));
-    }
-
-    let caught_up = CanonicalScan::new(
-        CanonicalLine::new(ParentRef {
-            address: ANCHOR,
-            l2_block_number: 10,
-        }),
-        NextProposalAction::CaughtUp {
-            target_block: 20,
-            finalized_block: 10,
-        },
-    );
-    advance_proposal(&mut proposer, &caught_up).await.unwrap();
-    assert!(!proposer.has_pending_proposal());
 }
 
 #[tokio::test]
@@ -821,7 +514,6 @@ async fn zero_block_interval_is_rejected() {
             roots: HashMap::new(),
             finalized_l2_block: 0,
         },
-        MockProofRequester::default(),
     );
 
     assert!(matches!(
@@ -846,12 +538,7 @@ async fn anchor_and_canonical_line_stops_at_finalized_l2_block() {
         roots: HashMap::from([(10, B256::repeat_byte(0x10))]),
         finalized_l2_block: 9,
     };
-    let proposer = WorldChainProposer::new(
-        config(),
-        contracts,
-        output_roots,
-        MockProofRequester::default(),
-    );
+    let proposer = WorldChainProposer::new(config(), contracts, output_roots);
 
     let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
 
@@ -902,7 +589,6 @@ async fn resolve_games_caps_submissions_and_keeps_scanning_finalized_games() {
             roots: HashMap::new(),
             finalized_l2_block: 0,
         },
-        MockProofRequester::default(),
     );
     let mut canonical_line = CanonicalLine::new(ParentRef {
         address: ANCHOR,
@@ -971,7 +657,6 @@ async fn finalized_games_do_not_consume_resolution_budget() {
             roots: HashMap::new(),
             finalized_l2_block: 0,
         },
-        MockProofRequester::default(),
     );
     let mut canonical_line = CanonicalLine::new(ParentRef {
         address: ANCHOR,
@@ -1018,7 +703,6 @@ async fn zero_resolution_budget_is_rejected() {
             roots: HashMap::new(),
             finalized_l2_block: 0,
         },
-        MockProofRequester::default(),
     );
 
     assert!(matches!(
@@ -1235,10 +919,7 @@ async fn bond_manager_uses_l1_timestamp_for_delayed_withdrawal() {
 }
 
 #[tokio::test]
-async fn timed_out_game_rebases_onto_registry_after_its_parent_became_the_anchor() {
-    // Anchor advanced onto P, so P is no longer an acceptable parent: `initialize` rejects any
-    // parent at or below the anchor. The timed-out game under P therefore cannot be retried in
-    // place; the transition must start over under the registry sentinel at attempt zero.
+async fn timed_out_game_retries_after_its_parent_becomes_the_anchor() {
     let parent = game_address(1);
     let timed_out = game_address(2);
     let root_20 = B256::repeat_byte(0x20);
@@ -1259,7 +940,6 @@ async fn timed_out_game_rebases_onto_registry_after_its_parent_became_the_anchor
             roots: HashMap::from([(20, root_20)]),
             finalized_l2_block: 20,
         },
-        MockProofRequester::default(),
     );
 
     let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
@@ -1267,53 +947,15 @@ async fn timed_out_game_rebases_onto_registry_after_its_parent_became_the_anchor
     assert!(canonical_scan.canonical_line().games().is_empty());
     assert_eq!(
         canonical_scan.next_action(),
-        &NextProposalAction::Propose(Proposal {
-            parent_ref: ANCHOR,
-            root_claim: root_20,
-            l2_block_number: 20,
-            attempt: 0,
-        })
-    );
-}
-
-#[tokio::test]
-async fn invalidated_legacy_game_does_not_hide_a_live_registry_parented_rebase() {
-    let parent = game_address(1);
-    let timed_out = game_address(2);
-    let rebased = game_address(3);
-    let root_20 = B256::repeat_byte(0x20);
-    let contracts = MockContracts {
-        anchor: anchor_advanced_onto(parent, 10),
-        games: HashMap::from([
-            (game_uuid(parent, root_20, 20, 0), timed_out),
-            (game_uuid(ANCHOR, root_20, 20, 0), rebased),
-        ]),
-        submissions: Arc::default(),
-        resolution_statuses: Arc::new(Mutex::new(HashMap::from([(timed_out, timed_out_status())]))),
-        resolutions: Arc::default(),
-        closures: Arc::default(),
-        submission_failures: Arc::default(),
-        unfinalized_games: Arc::default(),
-    };
-    let proposer = WorldChainProposer::new(
-        config(),
-        contracts,
-        MockOutputRoots {
-            roots: HashMap::from([(20, root_20)]),
-            finalized_l2_block: 20,
-        },
-        MockProofRequester::default(),
-    );
-
-    let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
-
-    // The live rebase continues the line even though the dead legacy game is scanned first.
-    assert_eq!(
-        canonical_scan.canonical_line().games(),
-        &[ParentRef {
-            address: rebased,
-            l2_block_number: 20,
-        }]
+        &NextProposalAction::RetryTimedOut {
+            proposal: Proposal {
+                parent_ref: parent,
+                root_claim: root_20,
+                l2_block_number: 20,
+                attempt: 1,
+            },
+            invalidated_game: timed_out,
+        }
     );
 }
 
@@ -1338,7 +980,6 @@ async fn timed_out_game_bumps_attempt_while_its_parent_is_still_acceptable() {
             roots: HashMap::from([(20, root_20)]),
             finalized_l2_block: 20,
         },
-        MockProofRequester::default(),
     );
 
     let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();

--- a/proofs/proposer/src/tests.rs
+++ b/proofs/proposer/src/tests.rs
@@ -10,17 +10,17 @@ use std::{
 use alloy_primitives::{Address, B256, BlockNumber, U256, address, b256};
 use async_trait::async_trait;
 use world_chain_proofs::{
-    ConsensusError, ConsensusProvider, InvalidationReason, ProposalCommitment, ResolutionStatus,
-    RootState,
+    ConsensusError, ConsensusProvider, InvalidationReason, LineageAnchor, LineageError,
+    LineageGame, LineageProvider, LineageTransition, ProposalCommitment, ResolutionStatus,
+    RootState, SelectedLineageGame,
 };
 
 use crate::{
-    AnchorRef, BondManager, BondManagerClient, BondManagerConfig, CanonicalLine, ParentRef,
-    Proposal, ProposalSubmission, ProposerClient, ProposerConfig, ProposerError,
-    WorldChainProposer,
+    BondManager, BondManagerClient, BondManagerConfig, Proposal, ProposalSubmission,
+    ProposerClient, ProposerConfig, ProposerError, ProposerScan, WorldChainProposer,
     types::{
-        CanonicalScan, ClaimSubmission, CloseGameSubmission, NextProposalAction, PendingWithdrawal,
-        ResolveSubmission, TransitionGame,
+        ClaimSubmission, CloseGameSubmission, NextProposalAction, PendingWithdrawal,
+        ResolveSubmission,
     },
 };
 
@@ -33,7 +33,7 @@ const MAX_TEST_ATTEMPT: u64 = 4;
 
 #[derive(Debug, Clone)]
 struct MockContracts {
-    anchor: AnchorRef,
+    anchor: LineageAnchor,
     /// Games keyed by their `DisputeGameFactory` UUID.
     games: HashMap<B256, Address>,
     submissions: Arc<Mutex<Vec<Proposal>>>,
@@ -46,37 +46,39 @@ struct MockContracts {
 }
 
 #[async_trait]
-impl ProposerClient for MockContracts {
-    async fn anchor_parent(&self) -> Result<AnchorRef, ProposerError> {
+impl LineageProvider for MockContracts {
+    fn lineage_block_interval(&self) -> u64 {
+        10
+    }
+
+    async fn lineage_anchor(&self) -> Result<LineageAnchor, LineageError> {
         Ok(self.anchor)
     }
 
     async fn game_for_transition(
         &self,
-        parent_ref: Address,
-        root_claim: B256,
-        l2_block_number: u64,
-    ) -> Result<Option<TransitionGame>, ProposerError> {
+        transition: LineageTransition,
+    ) -> Result<Option<LineageGame>, LineageError> {
         let mut latest = None;
         for attempt in 0..MAX_TEST_ATTEMPT {
-            let uuid = game_uuid(parent_ref, root_claim, l2_block_number, attempt);
+            let uuid = game_uuid(
+                transition.parent_ref,
+                transition.root_claim,
+                transition.l2_block_number,
+                attempt,
+            );
             let Some(address) = self.games.get(&uuid).copied() else {
                 break;
             };
-            latest = Some(TransitionGame { address, attempt });
+            latest = Some(LineageGame { address, attempt });
         }
         Ok(latest)
     }
 
-    async fn is_game_finalized(&self, game: Address) -> Result<bool, ProposerError> {
-        Ok(!self
-            .unfinalized_games
-            .lock()
-            .expect("not poisoned")
-            .contains(&game))
-    }
-
-    async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError> {
+    async fn lineage_resolution_status(
+        &self,
+        game: Address,
+    ) -> Result<ResolutionStatus, LineageError> {
         Ok(self
             .resolution_statuses
             .lock()
@@ -87,6 +89,17 @@ impl ProposerClient for MockContracts {
                 root_state: RootState::Proposed,
                 invalidation_reason: InvalidationReason::None,
             }))
+    }
+}
+
+#[async_trait]
+impl ProposerClient for MockContracts {
+    async fn is_game_finalized(&self, game: Address) -> Result<bool, ProposerError> {
+        Ok(!self
+            .unfinalized_games
+            .lock()
+            .expect("not poisoned")
+            .contains(&game))
     }
 
     async fn resolve_game(&self, game: Address) -> Result<ResolveSubmission, ProposerError> {
@@ -331,7 +344,6 @@ impl ConsensusProvider for MockOutputRoots {
 
 fn config() -> ProposerConfig {
     ProposerConfig {
-        block_interval: 10,
         poll_interval: Duration::from_secs(1),
         max_resolutions_per_tick: 1,
     }
@@ -339,7 +351,7 @@ fn config() -> ProposerConfig {
 
 async fn advance_proposal(
     proposer: &WorldChainProposer<MockContracts, MockOutputRoots>,
-    scan: &CanonicalScan,
+    scan: &ProposerScan,
 ) -> Result<(), ProposerError> {
     proposer.submit_next_proposal(scan).await
 }
@@ -352,15 +364,15 @@ fn positive_ready_status() -> ResolutionStatus {
     }
 }
 
-fn anchor_at(l2_block_number: u64) -> AnchorRef {
-    AnchorRef {
+fn anchor_at(l2_block_number: u64) -> LineageAnchor {
+    LineageAnchor {
         address: ANCHOR,
         l2_block_number,
     }
 }
 
-fn anchor_advanced_onto(anchor_game: Address, l2_block_number: u64) -> AnchorRef {
-    AnchorRef {
+fn anchor_advanced_onto(anchor_game: Address, l2_block_number: u64) -> LineageAnchor {
+    LineageAnchor {
         address: anchor_game,
         l2_block_number,
     }
@@ -369,6 +381,14 @@ fn anchor_advanced_onto(anchor_game: Address, l2_block_number: u64) -> AnchorRef
 fn timed_out_status() -> ResolutionStatus {
     ResolutionStatus {
         resolvable: false,
+        root_state: RootState::Invalidated,
+        invalidation_reason: InvalidationReason::ProofTimeout,
+    }
+}
+
+fn negatively_resolvable_timeout() -> ResolutionStatus {
+    ResolutionStatus {
+        resolvable: true,
         root_state: RootState::Invalidated,
         invalidation_reason: InvalidationReason::ProofTimeout,
     }
@@ -390,6 +410,20 @@ fn game_address(index: u64) -> Address {
     Address::from(bytes)
 }
 
+fn selected_game(address: Address, l2_block_number: u64) -> SelectedLineageGame {
+    SelectedLineageGame {
+        transition: LineageTransition {
+            parent_ref: ANCHOR,
+            root_claim: B256::ZERO,
+            l2_block_number,
+        },
+        game: LineageGame {
+            address,
+            attempt: 0,
+        },
+    }
+}
+
 fn bond_manager_config(initial_scan_limit: u64) -> BondManagerConfig {
     BondManagerConfig {
         poll_interval: Duration::from_secs(1),
@@ -398,7 +432,7 @@ fn bond_manager_config(initial_scan_limit: u64) -> BondManagerConfig {
 }
 
 #[tokio::test]
-async fn anchor_and_canonical_line_walks_existing_games_until_gap() {
+async fn scan_selected_lineage_walks_existing_games_until_gap() {
     let root_10 = B256::repeat_byte(0x10);
     let root_20 = B256::repeat_byte(0x20);
     let mut games = HashMap::new();
@@ -420,15 +454,11 @@ async fn anchor_and_canonical_line_walks_existing_games_until_gap() {
     };
     let proposer = WorldChainProposer::new(config(), contracts, output_roots);
 
-    let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
+    let scan = proposer.scan_selected_lineage().await.unwrap();
 
-    assert_eq!(
-        canonical_scan.canonical_line().games(),
-        &[ParentRef {
-            address: GAME_1,
-            l2_block_number: 10,
-        }]
-    );
+    assert_eq!(scan.lineage().games().len(), 1);
+    assert_eq!(scan.lineage().games()[0].game.address, GAME_1);
+    assert_eq!(scan.lineage().games()[0].transition.l2_block_number, 10);
 }
 
 #[tokio::test]
@@ -449,9 +479,9 @@ async fn propose_submits_proposal_after_last_canonical_game() {
         finalized_l2_block: 10,
     };
     let proposer = WorldChainProposer::new(config(), contracts, output_roots);
-    let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
+    let scan = proposer.scan_selected_lineage().await.unwrap();
 
-    advance_proposal(&proposer, &canonical_scan).await.unwrap();
+    advance_proposal(&proposer, &scan).await.unwrap();
 
     let proposal = submissions.lock().expect("not poisoned")[0];
     assert_eq!(proposal.parent_ref, ANCHOR);
@@ -479,51 +509,60 @@ async fn propose_can_retry_a_failed_submission() {
         finalized_l2_block: 10,
     };
     let proposer = WorldChainProposer::new(config(), contracts, output_roots);
-    let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
+    let scan = proposer.scan_selected_lineage().await.unwrap();
 
     assert!(matches!(
-        advance_proposal(&proposer, &canonical_scan).await,
+        advance_proposal(&proposer, &scan).await,
         Err(ProposerError::Contract(_))
     ));
     assert!(submissions.lock().expect("not poisoned").is_empty());
 
-    advance_proposal(&proposer, &canonical_scan).await.unwrap();
+    advance_proposal(&proposer, &scan).await.unwrap();
 
     assert_eq!(submissions.lock().expect("not poisoned").len(), 1);
 }
 
 #[tokio::test]
-async fn zero_block_interval_is_rejected() {
+async fn proposer_resolves_the_selected_negative_game() {
+    let root = B256::repeat_byte(0x10);
+    let resolutions = Arc::default();
     let contracts = MockContracts {
         anchor: anchor_at(0),
-        games: HashMap::new(),
+        games: HashMap::from([(game_uuid(ANCHOR, root, 10, 0), GAME_1)]),
         submissions: Arc::default(),
-        resolution_statuses: Arc::default(),
-        resolutions: Arc::default(),
+        resolution_statuses: Arc::new(Mutex::new(HashMap::from([(
+            GAME_1,
+            negatively_resolvable_timeout(),
+        )]))),
+        resolutions: Arc::clone(&resolutions),
         closures: Arc::default(),
         submission_failures: Arc::default(),
         unfinalized_games: Arc::default(),
     };
     let proposer = WorldChainProposer::new(
-        ProposerConfig {
-            block_interval: 0,
-            ..config()
-        },
+        config(),
         contracts,
         MockOutputRoots {
-            roots: HashMap::new(),
-            finalized_l2_block: 0,
+            roots: HashMap::from([(10, root)]),
+            finalized_l2_block: 10,
         },
     );
 
-    assert!(matches!(
-        proposer.anchor_and_canonical_line().await,
-        Err(ProposerError::InvalidConfig(_))
-    ));
+    let scan = proposer.scan_selected_lineage().await.unwrap();
+    assert_eq!(
+        scan.next_action(),
+        &NextProposalAction::ResolveNegative {
+            game: GAME_1,
+            reason: InvalidationReason::ProofTimeout,
+        }
+    );
+
+    proposer.submit_next_proposal(&scan).await.unwrap();
+    assert_eq!(*resolutions.lock().expect("not poisoned"), vec![GAME_1]);
 }
 
 #[tokio::test]
-async fn anchor_and_canonical_line_stops_at_finalized_l2_block() {
+async fn scan_selected_lineage_stops_at_finalized_l2_block() {
     let contracts = MockContracts {
         anchor: anchor_at(0),
         games: HashMap::new(),
@@ -540,16 +579,10 @@ async fn anchor_and_canonical_line_stops_at_finalized_l2_block() {
     };
     let proposer = WorldChainProposer::new(config(), contracts, output_roots);
 
-    let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
+    let scan = proposer.scan_selected_lineage().await.unwrap();
 
-    assert!(canonical_scan.canonical_line().games().is_empty());
-    assert_eq!(
-        canonical_scan.canonical_line().anchor(),
-        ParentRef {
-            address: ANCHOR,
-            l2_block_number: 0,
-        }
-    );
+    assert!(scan.lineage().games().is_empty());
+    assert_eq!(scan.lineage().anchor(), anchor_at(0));
 }
 
 #[tokio::test]
@@ -590,37 +623,23 @@ async fn resolve_games_caps_submissions_and_keeps_scanning_finalized_games() {
             finalized_l2_block: 0,
         },
     );
-    let mut canonical_line = CanonicalLine::new(ParentRef {
-        address: ANCHOR,
-        l2_block_number: 0,
-    });
-    canonical_line.push_game(ParentRef {
-        address: GAME_1,
-        l2_block_number: 10,
-    });
-    canonical_line.push_game(ParentRef {
-        address: game_2,
-        l2_block_number: 20,
-    });
-    canonical_line.push_game(ParentRef {
-        address: game_3,
-        l2_block_number: 30,
-    });
+    let games = [
+        selected_game(GAME_1, 10),
+        selected_game(game_2, 20),
+        selected_game(game_3, 30),
+    ];
 
-    let finalized_games = proposer.resolve_games(&canonical_line).await.unwrap();
+    let highest_finalized_game = proposer.resolve_games(&games).await.unwrap();
     assert_eq!(
         *resolutions.lock().expect("not poisoned"),
         vec![GAME_1, game_2]
     );
-    assert_eq!(
-        finalized_games.last(),
-        Some(ParentRef {
-            address: game_3,
-            l2_block_number: 30,
-        })
-    );
+    assert_eq!(highest_finalized_game, Some(selected_game(game_3, 30)));
 
-    proposer.advance_anchor(finalized_games).await.unwrap();
+    proposer
+        .advance_anchor(highest_finalized_game)
+        .await
+        .unwrap();
     assert_eq!(*closures.lock().expect("not poisoned"), vec![game_3]);
 }
 
@@ -658,27 +677,16 @@ async fn finalized_games_do_not_consume_resolution_budget() {
             finalized_l2_block: 0,
         },
     );
-    let mut canonical_line = CanonicalLine::new(ParentRef {
-        address: ANCHOR,
-        l2_block_number: 0,
-    });
-    for (address, l2_block_number) in [(GAME_1, 10), (game_2, 20), (game_3, 30)] {
-        canonical_line.push_game(ParentRef {
-            address,
-            l2_block_number,
-        });
-    }
+    let games = [
+        selected_game(GAME_1, 10),
+        selected_game(game_2, 20),
+        selected_game(game_3, 30),
+    ];
 
-    let finalized_games = proposer.resolve_games(&canonical_line).await.unwrap();
+    let highest_finalized_game = proposer.resolve_games(&games).await.unwrap();
 
     assert_eq!(*resolutions.lock().expect("not poisoned"), vec![game_2]);
-    assert_eq!(
-        finalized_games.last(),
-        Some(ParentRef {
-            address: game_2,
-            l2_block_number: 20,
-        })
-    );
+    assert_eq!(highest_finalized_game, Some(selected_game(game_2, 20)));
 }
 
 #[tokio::test]
@@ -706,7 +714,7 @@ async fn zero_resolution_budget_is_rejected() {
     );
 
     assert!(matches!(
-        proposer.anchor_and_canonical_line().await,
+        proposer.scan_selected_lineage().await,
         Err(ProposerError::InvalidConfig(_))
     ));
 }
@@ -942,11 +950,11 @@ async fn timed_out_game_retries_after_its_parent_becomes_the_anchor() {
         },
     );
 
-    let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
+    let scan = proposer.scan_selected_lineage().await.unwrap();
 
-    assert!(canonical_scan.canonical_line().games().is_empty());
+    assert!(scan.lineage().games().is_empty());
     assert_eq!(
-        canonical_scan.next_action(),
+        scan.next_action(),
         &NextProposalAction::RetryTimedOut {
             proposal: Proposal {
                 parent_ref: parent,
@@ -982,10 +990,10 @@ async fn timed_out_game_bumps_attempt_while_its_parent_is_still_acceptable() {
         },
     );
 
-    let canonical_scan = proposer.anchor_and_canonical_line().await.unwrap();
+    let scan = proposer.scan_selected_lineage().await.unwrap();
 
     assert_eq!(
-        canonical_scan.next_action(),
+        scan.next_action(),
         &NextProposalAction::RetryTimedOut {
             proposal: Proposal {
                 parent_ref: ANCHOR,

--- a/proofs/proposer/src/traits.rs
+++ b/proofs/proposer/src/traits.rs
@@ -1,7 +1,6 @@
-use alloy_primitives::{Address, B256, BlockHash, U256};
+use alloy_primitives::{Address, B256, U256};
 use async_trait::async_trait;
 use world_chain_proofs::ResolutionStatus;
-use world_chain_prover_service::ProofData;
 
 use crate::{
     AnchorRef, Proposal, ProposalSubmission, ProposerError,
@@ -54,17 +53,13 @@ pub trait ProposerClient: Send + Sync {
     /// Reads the current anchor checkpoint from the registry.
     async fn anchor_parent(&self) -> Result<AnchorRef, ProposerError>;
 
-    /// Returns the highest-attempt game registered for the given transition under each of
-    /// `parent_candidates`, in candidate order. Candidates with no game are omitted.
-    ///
-    /// Every candidate is reported rather than just the first hit: an invalidated game under a
-    /// superseded parent must not hide a live one under the parent that is still acceptable.
-    async fn games_for_transition(
+    /// Returns the highest-attempt game registered for the transition under `parent_ref`.
+    async fn game_for_transition(
         &self,
-        parent_candidates: &[Address],
+        parent_ref: Address,
         root_claim: B256,
         l2_block_number: u64,
-    ) -> Result<Vec<TransitionGame>, ProposerError>;
+    ) -> Result<Option<TransitionGame>, ProposerError>;
 
     /// Returns the resolution status of the provided game, if game exists.
     async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError>;
@@ -78,13 +73,9 @@ pub trait ProposerClient: Send + Sync {
     /// Submits a closeGame transaction to the provided game.
     async fn close_game(&self, game: Address) -> Result<CloseGameSubmission, ProposerError>;
 
-    /// Gets the latest L1 finalized block hash.
-    async fn latest_finalized_l1_block(&self) -> Result<BlockHash, ProposerError>;
-
     /// Creates the proposal's game through the dispute-game factory.
     async fn submit_proposal(
         &self,
         proposal: &Proposal,
-        proof: ProofData,
     ) -> Result<ProposalSubmission, ProposerError>;
 }

--- a/proofs/proposer/src/traits.rs
+++ b/proofs/proposer/src/traits.rs
@@ -1,12 +1,10 @@
-use alloy_primitives::{Address, B256, U256};
+use alloy_primitives::{Address, U256};
 use async_trait::async_trait;
-use world_chain_proofs::ResolutionStatus;
+use world_chain_proofs::{LineageProvider, ResolutionStatus};
 
 use crate::{
-    AnchorRef, Proposal, ProposalSubmission, ProposerError,
-    types::{
-        ClaimSubmission, CloseGameSubmission, PendingWithdrawal, ResolveSubmission, TransitionGame,
-    },
+    Proposal, ProposalSubmission, ProposerError,
+    types::{ClaimSubmission, CloseGameSubmission, PendingWithdrawal, ResolveSubmission},
 };
 
 /// Contract surface needed by the asynchronous bond manager.
@@ -49,21 +47,7 @@ pub trait BondManagerClient: Send + Sync {
 
 /// Minimal contract surface needed by the proposer.
 #[async_trait]
-pub trait ProposerClient: Send + Sync {
-    /// Reads the current anchor checkpoint from the registry.
-    async fn anchor_parent(&self) -> Result<AnchorRef, ProposerError>;
-
-    /// Returns the highest-attempt game registered for the transition under `parent_ref`.
-    async fn game_for_transition(
-        &self,
-        parent_ref: Address,
-        root_claim: B256,
-        l2_block_number: u64,
-    ) -> Result<Option<TransitionGame>, ProposerError>;
-
-    /// Returns the resolution status of the provided game, if game exists.
-    async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError>;
-
+pub trait ProposerClient: LineageProvider {
     /// Submits a resolve transaction to the provided game.
     async fn resolve_game(&self, game: Address) -> Result<ResolveSubmission, ProposerError>;
 

--- a/proofs/proposer/src/types.rs
+++ b/proofs/proposer/src/types.rs
@@ -1,34 +1,5 @@
 use alloy_primitives::{Address, B256, TxHash, U256};
-use world_chain_proofs::{InvalidationReason, ProposalCommitment};
-
-/// The parent checkpoint selected from the anchor registry.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct AnchorRef {
-    /// Current anchor game, or the registry sentinel before the first game is anchored.
-    pub address: Address,
-    /// L2 block number of the anchor output root.
-    pub l2_block_number: u64,
-}
-
-impl AnchorRef {
-    /// Returns the parent reference new proposals extending the anchor must use.
-    #[must_use]
-    pub const fn parent_ref(self) -> ParentRef {
-        ParentRef {
-            address: self.address,
-            l2_block_number: self.l2_block_number,
-        }
-    }
-}
-
-/// A game already registered on the factory for a transition the proposer is scanning.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct TransitionGame {
-    /// Address of the game clone.
-    pub address: Address,
-    /// Retry nonce the game was created with.
-    pub attempt: u64,
-}
+use world_chain_proofs::{InvalidationReason, ProposalCommitment, SelectedLineage};
 
 /// A pending `DelayedWETH` withdrawal opened by the first `claimCredit` call.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -39,28 +10,25 @@ pub struct PendingWithdrawal {
     pub unlock_at: u64,
 }
 
-/// The canonical lineage discovered by the proposer and the action available at its tip.
+/// The selected lineage discovered by the proposer and the action available at its tip.
 #[derive(Debug)]
-pub struct CanonicalScan {
-    canonical_line: CanonicalLine,
+pub struct ProposerScan {
+    lineage: SelectedLineage,
     next_action: NextProposalAction,
 }
 
-impl CanonicalScan {
-    pub(crate) const fn new(
-        canonical_line: CanonicalLine,
-        next_action: NextProposalAction,
-    ) -> Self {
+impl ProposerScan {
+    pub(crate) const fn new(lineage: SelectedLineage, next_action: NextProposalAction) -> Self {
         Self {
-            canonical_line,
+            lineage,
             next_action,
         }
     }
 
-    /// Returns the valid canonical lineage found by the scan.
+    /// Returns the valid selected lineage found by the scan.
     #[must_use]
-    pub const fn canonical_line(&self) -> &CanonicalLine {
-        &self.canonical_line
+    pub const fn lineage(&self) -> &SelectedLineage {
+        &self.lineage
     }
 
     /// Returns the action available at the tip of the canonical lineage.
@@ -82,8 +50,8 @@ pub enum NextProposalAction {
         /// Invalidated game that this proposal replaces.
         invalidated_game: Address,
     },
-    /// Wait for the challenger to resolve a game whose outcome is negative.
-    AwaitNegativeResolution {
+    /// Resolve the selected game with its determined negative outcome.
+    ResolveNegative {
         /// Game that is ready to resolve negatively.
         game: Address,
         /// Negative outcome reported by the game.
@@ -103,76 +71,6 @@ pub enum NextProposalAction {
         /// Current finalized L2 block reported by the consensus client.
         finalized_block: u64,
     },
-}
-
-/// The current anchor checkpoint and the canonical games built on top of it.
-#[derive(Debug)]
-pub struct CanonicalLine {
-    anchor: ParentRef,
-    games: Vec<ParentRef>,
-}
-
-impl CanonicalLine {
-    /// Creates an empty canonical line rooted at `anchor`.
-    #[must_use]
-    pub const fn new(anchor: ParentRef) -> Self {
-        Self {
-            anchor,
-            games: Vec::new(),
-        }
-    }
-
-    /// Returns the checkpoint this canonical line is rooted at.
-    #[must_use]
-    pub const fn anchor(&self) -> ParentRef {
-        self.anchor
-    }
-
-    /// Appends a canonical game built on the current tip.
-    pub fn push_game(&mut self, game: ParentRef) {
-        self.games.push(game);
-    }
-
-    /// Returns the canonical games built on top of the anchor.
-    #[must_use]
-    pub fn games(&self) -> &[ParentRef] {
-        &self.games
-    }
-
-    /// Returns the last canonical game, or the anchor when no game exists yet.
-    #[must_use]
-    pub fn tip(&self) -> ParentRef {
-        self.games.last().copied().unwrap_or(self.anchor)
-    }
-}
-
-/// Canonical games that have reached the finalized state and may advance the anchor.
-#[derive(Debug, Default)]
-pub struct FinalizedGames {
-    /// Finalized games ordered by increasing L2 block number.
-    pub games: Vec<ParentRef>,
-}
-
-impl FinalizedGames {
-    /// Appends a finalized game to the ordered collection.
-    pub fn push(&mut self, game: ParentRef) {
-        self.games.push(game);
-    }
-
-    /// Returns the finalized game with the highest L2 block number, if any.
-    #[must_use]
-    pub fn last(&self) -> Option<ParentRef> {
-        self.games.last().copied()
-    }
-}
-
-/// A parent reference that the next proposal should build on.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ParentRef {
-    /// Address of the anchor registry or parent game.
-    pub address: Address,
-    /// L2 block number of the parent output root.
-    pub l2_block_number: u64,
 }
 
 /// Candidate proposal data supplied to the dispute-game factory.

--- a/proofs/proposer/src/types.rs
+++ b/proofs/proposer/src/types.rs
@@ -1,10 +1,10 @@
 use alloy_primitives::{Address, B256, TxHash, U256};
 use world_chain_proofs::{InvalidationReason, ProposalCommitment};
 
-/// The canonical parent checkpoint selected by the registered game implementation.
+/// The parent checkpoint selected from the anchor registry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AnchorRef {
-    /// Compatible anchor game, or the registry sentinel for an initial or incompatible anchor.
+    /// Current anchor game, or the registry sentinel before the first game is anchored.
     pub address: Address,
     /// L2 block number of the anchor output root.
     pub l2_block_number: u64,

--- a/proofs/proposer/src/types.rs
+++ b/proofs/proposer/src/types.rs
@@ -1,21 +1,11 @@
 use alloy_primitives::{Address, B256, TxHash, U256};
 use world_chain_proofs::{InvalidationReason, ProposalCommitment};
 
-/// The anchor checkpoint the canonical line is rooted at.
-///
-/// `MultiProofGame.initialize` only accepts the registry itself as the parent reference for a
-/// proposal that extends the anchor: once the anchor advances onto a game, that game's L2 block
-/// number is no longer above the anchor and it is rejected as a parent. Games created before the
-/// anchor advanced still reference the anchor game, so both addresses are candidate parents when
-/// looking an existing proposal up.
+/// The canonical parent checkpoint selected by the registered game implementation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AnchorRef {
-    /// `AnchorStateRegistry` address. New proposals extending the current anchor use this
-    /// sentinel as `parentRef`, not the game currently represented by the anchor.
-    pub registry: Address,
-    /// Game currently represented by the anchor, used only to find proposals created before
-    /// the registry advanced onto it.
-    pub anchor_game: Option<Address>,
+    /// Compatible anchor game, or the registry sentinel for an initial or incompatible anchor.
+    pub address: Address,
     /// L2 block number of the anchor output root.
     pub l2_block_number: u64,
 }
@@ -25,19 +15,9 @@ impl AnchorRef {
     #[must_use]
     pub const fn parent_ref(self) -> ParentRef {
         ParentRef {
-            address: self.registry,
+            address: self.address,
             l2_block_number: self.l2_block_number,
         }
-    }
-
-    /// Returns the parent references an existing proposal at the anchor tip may carry,
-    /// oldest-creation first.
-    #[must_use]
-    pub fn parent_candidates(self) -> Vec<Address> {
-        self.anchor_game
-            .into_iter()
-            .chain(std::iter::once(self.registry))
-            .collect()
     }
 }
 
@@ -46,8 +26,6 @@ impl AnchorRef {
 pub struct TransitionGame {
     /// Address of the game clone.
     pub address: Address,
-    /// Parent reference the game was created with.
-    pub parent_ref: Address,
     /// Retry nonce the game was created with.
     pub attempt: u64,
 }

--- a/proofs/prover-service/src/store.rs
+++ b/proofs/prover-service/src/store.rs
@@ -881,24 +881,19 @@ fn proof_id_bytes(id: ProofRequestId) -> Vec<u8> {
 
 /// Returns true if the request matches the stored values.
 ///
-/// Nitro requests may replace their L1 head after a failed attempt because the proposer
-/// deliberately retries against a newer finalized head. SP1 requests are pinned to the L1
-/// origin in immutable game metadata, so accepting a different head could make a completed
-/// backend session from the previous attempt unusable while still eligible for resumption.
+/// The L1 head is immutable game metadata. A mismatch must create a different request rather
+/// than resuming a backend session whose proof cannot satisfy the game verifier.
 fn request_matches(row: &PgRow, request: &ProofRequest) -> Result<bool, ProofRequestError> {
     let stored_backend: &str = row.get("backend");
     let stored_game: &[u8] = row.get("game");
     let stored_root_claim: &[u8] = row.get("root_claim");
     let stored_l2_block_number: i64 = row.get("l2_block_number");
     let stored_l1_head = b256_from_bytes(row.get("l1_head"))?;
-    let l1_head_matches =
-        request.backend == ProofBackend::Nitro || stored_l1_head == request.l1_head;
-
     Ok(stored_backend == request.backend.as_str()
         && stored_game == request.game.as_slice()
         && stored_root_claim == request.root_claim.as_slice()
         && stored_l2_block_number == l2_to_i64(request.l2_block_number)?
-        && l1_head_matches)
+        && stored_l1_head == request.l1_head)
 }
 
 fn b256_from_bytes(bytes: Vec<u8>) -> Result<B256, MalformedB256Error> {

--- a/proofs/prover-service/src/tests.rs
+++ b/proofs/prover-service/src/tests.rs
@@ -87,6 +87,7 @@ fn proof_for(req: &ProofRequest) -> SucceededProofResponse {
             attestation: Bytes::from(vec![0xcc]),
             public_values: Bytes::from(vec![0xee]),
             signature: Bytes::from(vec![0xdd]),
+            public_key: Bytes::from(vec![0xff]),
         },
     };
     SucceededProofResponse {
@@ -153,6 +154,10 @@ fn request_id_is_deterministic() {
     assert_eq!(sp1.id(), request(ProofBackend::Sp1, 1).id());
     assert_ne!(sp1.id(), request(ProofBackend::Nitro, 1).id());
     assert_ne!(sp1.id(), request(ProofBackend::Sp1, 2).id());
+
+    let mut different_l1_head = sp1.clone();
+    different_l1_head.l1_head = B256::with_last_byte(0xff);
+    assert_ne!(sp1.id(), different_l1_head.id());
 }
 
 #[tokio::test]
@@ -307,6 +312,7 @@ async fn submit_proof_with_wrong_backend_is_rejected() {
             attestation: Bytes::from(vec![0xcc]),
             public_values: Bytes::from(vec![0xee]),
             signature: Bytes::from(vec![0xdd]),
+            public_key: Bytes::from(vec![0xff]),
         },
     };
     assert!(matches!(

--- a/proofs/prover-service/src/types.rs
+++ b/proofs/prover-service/src/types.rs
@@ -65,9 +65,8 @@ pub struct ProofRequest {
 impl ProofRequest {
     /// Compute the deterministic identifier of this request.
     ///
-    /// The id is a commitment to every request field except for `l1_head`, so requesting
-    /// the same proof twice yields the same id and the duplicate is deduplicated
-    /// by the `prover-service`.
+    /// The id commits to every request field, so exact duplicates are deduplicated without
+    /// allowing a proof pinned to a different L1 head to satisfy this request.
     #[must_use]
     pub fn id(&self) -> ProofRequestId {
         let mut buf = Vec::with_capacity(1 + 20 + 32 + 8 + 32);
@@ -75,6 +74,7 @@ impl ProofRequest {
         buf.extend_from_slice(self.game.as_slice());
         buf.extend_from_slice(self.root_claim.as_slice());
         buf.extend_from_slice(&self.l2_block_number.to_be_bytes());
+        buf.extend_from_slice(self.l1_head.as_slice());
         ProofRequestId(keccak256(buf))
     }
 }
@@ -200,6 +200,8 @@ pub enum ProofData {
         public_values: Bytes,
         /// Enclave signature over the proven outputs.
         signature: Bytes,
+        /// SEC1-uncompressed public key certified by the attestation document.
+        public_key: Bytes,
     },
 }
 

--- a/wips/wip-1006.md
+++ b/wips/wip-1006.md
@@ -319,7 +319,7 @@ The proposal data remains aligned with the OP Stack:
 - factory identity uses the canonical `(gameType, rootClaim, extraData)` UUID;
 - `domainHash`, `l2BlockNumber`, `parentRef`, and `attempt` are encoded in `extraData`.
 
-Offchain proposers, challengers, and defenders MUST use the stock factory indexing and creation APIs plus the WIP-1006 game extensions. They do not require a custom factory or anchor registry. A deployment MAY have its defender submit the TEE lane as the initial operational policy, but challenged games MUST still be escalated with an independent lane.
+Offchain services MUST use the stock factory creation and lookup APIs plus the WIP-1006 game extensions. They do not require a custom factory or anchor registry. Proposers and defenders MAY reconstruct a selected lineage by looking up the expected transition from the current anchor; challengers use the factory index to inspect all games. A deployment MAY have its defender submit the TEE lane as the initial operational policy, but challenged games MUST still be escalated with an independent lane.
 
 ## Test Cases
 

--- a/wips/wip-1006.md
+++ b/wips/wip-1006.md
@@ -1,7 +1,7 @@
 ---
 wip: 1006
 title: Proof System Architecture
-description: OP Stack dispute game with a one-day optimistic challenge period and a 2-of-3 proof-lane defense for challenged World Chain output roots.
+description: OP Stack dispute game requiring one proof within a one-day challenge period and a 2-of-3 proof-lane defense when challenged.
 author: 0xOsiris (@0xOsiris), Phillip Kemper, Alessandro Mazza, Piotr Heilman (@piohei)
 status: Draft
 type: Standards Track
@@ -11,7 +11,7 @@ created: 2026-05-27
 
 ## Abstract
 
-We outline an OP Stack dispute game in which a proposer posts an output root optimistically without a proof. If no staked participant challenges the root within one day, the game may resolve in favor of the proposer. A challenge submits no proof of invalidity; it shifts the burden to the proposer, who has seven days from game creation to assemble a threshold of independent validity signals. Failure to reach the threshold resolves the game in favor of the challenger. The stock `DisputeGameFactory`, `AnchorStateRegistry`, `OptimismPortal2`, and `DelayedWETH` remain responsible for game creation, claim validity, withdrawals, and bond custody.
+We outline an OP Stack dispute game in which a proposer posts an output root without embedding proof material in the factory identity. At least one configured proof lane must support the root during the initial one-day challenge window. If nobody challenges and a proof was submitted, the game may resolve in favor of the proposer; without a proof it resolves against the proposer. A challenge may be submitted whether or not the initial proof already exists and raises the requirement to two independent proof lanes by seven days from game creation. The stock `DisputeGameFactory`, `AnchorStateRegistry`, `OptimismPortal2`, and `DelayedWETH` remain responsible for game creation, claim validity, withdrawals, and bond custody.
 
 ## Motivation
 
@@ -19,7 +19,8 @@ The vanilla OP Stack fault-proof system inherits a multi-day challenge window fo
 
 World Chain targets two properties that neither model provides together:
 
-- **A cheap common path.** No proof is paid for or produced when no staked participant objects to a root.
+- **A stable factory identity.** Proof bytes are submitted to the created game rather than included in `extraData`, so the stock factory UUID remains predictable from the transition.
+- **A cheap common path.** Only one configured proof lane is required when no staked participant objects to a root.
 - **A diversified disputed path.** When a root is challenged, the proposer must defend it, and no single prover, TEE vendor, or council action can finalize that defense. At least two independent lanes must agree.
 
 The result is fast finality in the common case and `n / m` threshold security in the dispute case.
@@ -43,10 +44,11 @@ Activation parameters are set at hardfork activation and held as immutable value
 
 | Name | Initial Value | Meaning |
 | --- | --- | --- |
-| `CHALLENGE_PERIOD` | `1 day` | Duration after proposal creation during which a staked participant MAY challenge a root without submitting proof material. Per-proposal `challengeDeadline = createdAt + CHALLENGE_PERIOD`. |
+| `CHALLENGE_PERIOD` | `1 day` | Duration after proposal creation during which a staked participant MAY challenge a root and any party MAY submit the initial proof. Per-proposal `challengeDeadline = createdAt + CHALLENGE_PERIOD`. |
 | `PROOF_PERIOD` | `7 days` | Duration after proposal creation during which the proposer MAY defend a challenged root by accumulating lane submissions toward `PROOF_THRESHOLD`. Per-proposal `proofDeadline = createdAt + PROOF_PERIOD`. `PROOF_PERIOD` MUST be greater than `CHALLENGE_PERIOD`. A challenged root that the proposer has not defended to `PROOF_THRESHOLD` by `proofDeadline` MUST be invalidated. |
-| `PROPOSER_BOND` | TBD | ETH bond supplied to `DisputeGameFactory.create` and held as `DelayedWETH` credit by the game. Paid to the proposer after `DEFENDER_WINS`, to the challenger after proof timeout, or refunded if the registry invalidates the game. |
+| `PROPOSER_BOND` | TBD | ETH bond supplied to `DisputeGameFactory.create` and held as `DelayedWETH` credit by the game. Paid to the proposer after `DEFENDER_WINS`, to the challenger after a challenged proof timeout, to the configured protocol recipient after an unchallenged proof timeout, or refunded if the registry invalidates the game. |
 | `CHALLENGER_BOND` | TBD | ETH bond supplied by the challenger and held as `DelayedWETH` credit by the game. Paid to the proposer after a successful defense, to the challenger after proof timeout, or refunded if the registry invalidates the game. |
+| `PROOF_TIMEOUT_RECIPIENT` | TBD | Nonzero protocol-controlled recipient credited with the proposer bond when an unchallenged proposal expires without any valid proof lane. |
 
 ### Proof Lanes
 
@@ -71,7 +73,7 @@ The data bound by every proof and attestation is split into immutable domain con
 | `rootClaim` | Proposer | Claimed L2 output root, computed as in the [OP Stack output-root V1 encoding][op-output-root]. |
 | `domainHash` | Proposer | Hash of the implementation's immutable domain. The game MUST reject a value that differs from its configured `domainHash`. |
 | `l2BlockNumber` | Proposer | L2 block number for `rootClaim`, matching the [`l2BlockNumber` field of an OP Stack L2 output proposal][op-proposals]. |
-| `parentRef` | Proposer | Address of the parent — the `AnchorStateRegistry` for the first proposal, otherwise the parent proposal. Same convention as the OP Stack [Fault Dispute Game `extraData` parent reference][op-dgi] and the parent reference encoded in Base Azul's `AggregateVerifier` extra-data layout (see [Base Azul proof system][base-azul]). The parent's `rootClaim` and `l2BlockNumber` are read from this reference rather than re-supplied. |
+| `parentRef` | Proposer | Address of the canonical parent. A proposal extending the current anchor uses `AnchorStateRegistry.anchorGame()` when that game remains an eligible parent with the same game type and domain; otherwise it uses the `AnchorStateRegistry` sentinel. Further descendants use their concrete parent game. The parent's `rootClaim` and `l2BlockNumber` are read from this reference rather than re-supplied. |
 | `attempt` | Proposer | Retry nonce for the same transition. Attempt zero is the initial game; later attempts are permitted only after an eligible predecessor fails or is made obsolete by activation. |
 | `l1OriginHash` | Factory | L1 origin hash captured at proposal creation. The proposer does not pass it as calldata; it is read via `blockhash()` or [EIP-2935][eip-2935] history and pinned by the factory, mirroring the OP Stack [`l1Head` snapshot at clone creation][op-dgi] that Base Azul inherits. |
 | `l1OriginNumber` | Game | L1 block number paired with the factory-captured `l1OriginHash`. |
@@ -151,7 +153,8 @@ The OP Stack lifecycle uses `GameStatus` for externally consumed resolution. The
 ```mermaid
 stateDiagram-v2
     [*] --> PROPOSED: factory.create(root)
-    PROPOSED --> FINALIZED: resolve after unchallenged deadline
+    PROPOSED --> FINALIZED: one proof + unchallenged deadline
+    PROPOSED --> INVALIDATED: no proof at unchallenged deadline
     PROPOSED --> CHALLENGED: staked challenge before challenge deadline
     CHALLENGED --> FINALIZED: resolve after PROOF_THRESHOLD lanes
     CHALLENGED --> INVALIDATED: resolve after proof timeout
@@ -173,13 +176,15 @@ A root enters the system in the `PROPOSED` state.
 4. The game records `createdAt = block.timestamp`, `challengeDeadline = createdAt + CHALLENGE_PERIOD`, and `proofDeadline = createdAt + PROOF_PERIOD`.
 5. The proposer bond is deposited into `DelayedWETH`, and the root remains open to challenge until `challengeDeadline`.
 
-The proposer MUST NOT be required or permitted to submit proof-lane material before a challenge.
+The canonical parent for a direct extension of the current anchor is the anchor game itself when it remains an eligible WIP-1006 parent in the same proof domain. The registry address is accepted as a sentinel only when there is no compatible anchor game, including initial deployment, retirement or blacklisting of the stored anchor game, and a proof-domain upgrade. This rule keeps the factory UUID stable when a concrete parent later becomes the anchor: descendants and retries continue to reference the same game rather than acquiring a second registry-parented identity.
 
-An initial `attempt = 0` identifies the first game for a transition. A later attempt MUST identify its exact predecessor and MUST be accepted only for a protocol-defined recovery case, such as a proof timeout or a game created before WIP-1006 became respected.
+Proof material MUST NOT be part of factory creation or `extraData`. After the game exists, any party MAY submit a valid configured proof lane before `challengeDeadline`. Offchain services MAY choose a preferred operational lane, but the onchain protocol MUST NOT privilege one lane for the initial proof.
+
+An initial `attempt = 0` identifies the first game for a transition. A later attempt keeps the same `parentRef`, increments `attempt`, and MUST be accepted only after the preceding attempt enters a protocol-defined recovery case, such as a proof timeout or a game created before WIP-1006 became respected.
 
 ### Challenge Lifecycle
 
-Any staked participant MAY challenge a proposed root before `challengeDeadline`. A challenge goes through optimistically: the challenger is not asked to prove that the root is invalid, and the challenge succeeds by default unless the proposer defends the root. The challenge merely shifts the burden of proof onto the proposer, who must then establish the root's validity per [Proposer Defense and Challenged Finality](#proposer-defense-and-challenged-finality).
+Any staked participant MAY challenge a proposed root before `challengeDeadline`, regardless of whether an initial proof lane already supports it. A challenge goes through optimistically: the challenger is not asked to prove that the root is invalid, and the challenge succeeds by default unless the proposer defends the root. The challenge raises the required support from one lane to `PROOF_THRESHOLD`.
 
 The challenge transaction:
 
@@ -201,10 +206,13 @@ The game MUST resolve with `DEFENDER_WINS` when all of the following hold:
 
 - the root is still `PROPOSED`;
 - `block.timestamp >= challengeDeadline`;
+- at least one configured proof lane supports `rootId`;
 - the parent is the anchor sentinel or has resolved with `DEFENDER_WINS`; and
 - the parent is not blacklisted.
 
-An unchallenged game resolves without proof-lane submissions. A self-blacklisted, retired, unrespected, or otherwise improper game may still have `DEFENDER_WINS` status, but the registry MUST reject its claim and the game MUST use refund-mode bond settlement.
+If no proof lane supports the root at `challengeDeadline`, the game MUST instead resolve with `CHALLENGER_WINS`, record proof timeout, and credit the proposer bond to the configured protocol recipient. This outcome MUST remain retryable even when no challenger exists.
+
+A self-blacklisted, retired, unrespected, or otherwise improper game may still have `DEFENDER_WINS` status, but the registry MUST reject its claim and the game MUST use refund-mode bond settlement.
 
 ### Proposer Defense and Challenged Finality
 
@@ -216,14 +224,14 @@ Each root tracks a per-lane support set (the **proof bitmap**) with one bit per 
 
 For each lane submission, the contract MUST:
 
-1. Verify that the root is in `CHALLENGED`.
-2. Verify that `block.timestamp < proofDeadline`.
+1. Verify that the game is still in progress.
+2. Verify that `block.timestamp < challengeDeadline` when unchallenged, or `block.timestamp < proofDeadline` when challenged.
 3. Verify that the proof or attestation binds to `rootId`.
 4. Verify the proof or attestation according to the lane-specific verifier.
 5. Set the lane's bit in the root's proof bitmap.
 6. Emit a threshold-reached signal when the bitmap first contains at least `PROOF_THRESHOLD` distinct lanes.
 
-A lane submission at or after `proofDeadline` MUST revert. Once threshold is met, anyone MAY call `resolve()`, which MUST resolve the game with `DEFENDER_WINS`.
+A lane submission at or after its applicable deadline MUST revert. Once threshold is met, anyone MAY call `resolve()`, which MUST resolve the challenged game with `DEFENDER_WINS`.
 
 If `block.timestamp >= proofDeadline` and the proof bitmap contains fewer than `PROOF_THRESHOLD` distinct lanes, anyone MAY call `resolve()`. The game MUST resolve with `CHALLENGER_WINS`, record proof timeout as the invalidation reason, and credit both bonds to the challenger.
 
@@ -307,22 +315,27 @@ The proposal data remains aligned with the OP Stack:
 
 - `rootClaim` follows the [OP Stack output-root V1 encoding](https://specs.optimism.io/protocol/proposals.html#l2-output-commitment-construction).
 - `l2BlockNumber` matches the [`l2BlockNumber` field of an L2 output proposal](https://specs.optimism.io/protocol/proposals.html).
-- `parentRef` follows the [Fault Dispute Game `extraData` parent reference convention](https://specs.optimism.io/fault-proof/stage-one/dispute-game-interface.html) — the `AnchorStateRegistry` for the first proposal, otherwise the parent proposal address.
+- `parentRef` follows the [Fault Dispute Game `extraData` parent reference convention](https://specs.optimism.io/fault-proof/stage-one/dispute-game-interface.html). Direct anchor extensions use the compatible anchor game when one exists and the `AnchorStateRegistry` sentinel at initial deployment or across an incompatible domain boundary.
 - `l1OriginHash` is factory-captured at proposal creation, matching the L1 head snapshot taken by `DisputeGameFactory` at clone creation.
 - factory identity uses the canonical `(gameType, rootClaim, extraData)` UUID;
 - `domainHash`, `l2BlockNumber`, `parentRef`, and `attempt` are encoded in `extraData`.
 
-Offchain proposers, challengers, and defenders MUST use the stock factory indexing and creation APIs plus the WIP-1006 game extensions. They do not require a custom factory or anchor registry.
+Offchain proposers, challengers, and defenders MUST use the stock factory indexing and creation APIs plus the WIP-1006 game extensions. They do not require a custom factory or anchor registry. A deployment MAY have its defender submit the TEE lane as the initial operational policy, but challenged games MUST still be escalated with an independent lane.
 
 ## Test Cases
 
 Before this WIP can move beyond Draft, implementations SHOULD cover at least:
 
-- an unchallenged root finalizes after exactly `CHALLENGE_PERIOD`;
+- a newly created game has no proof support and a factory UUID independent of later proof bytes;
+- an unchallenged root with any one valid configured lane finalizes after exactly `CHALLENGE_PERIOD`;
+- an unchallenged proofless root invalidates after exactly `CHALLENGE_PERIOD`, forfeits its proposer bond to the configured protocol recipient, and can be retried;
 - factory creation rejects an incorrect domain hash or malformed `extraData`;
+- once a compatible game becomes the anchor, a direct child MUST reference that game and creation with the registry sentinel MUST fail;
+- after switching to an implementation with a different domain, a direct child MUST use the registry sentinel;
 - factory UUID lookup and `findLatestGames` preserve the complete WIP-1006 `extraData`;
 - an unstaked account cannot challenge;
 - a staked account can challenge without proof before the deadline;
+- a staked account can challenge after an initial proof, and the game then requires `PROOF_THRESHOLD` lanes;
 - a challenge at or after the deadline reverts;
 - a configuration where `proofDeadline <= challengeDeadline` is rejected;
 - a challenged root with one supporting lane does not finalize;
@@ -339,11 +352,11 @@ Before this WIP can move beyond Draft, implementations SHOULD cover at least:
 
 ## Security Considerations
 
-**Unchallenged-path liveness depends on honest watchers.** Safety in the common case relies on at least one honest staked participant challenging an invalid root within `CHALLENGE_PERIOD`. The architecture does not protect against a root that no one watches.
+**Unchallenged-path safety relies on one proof lane.** Any single configured lane may support the common path. An invalid root can therefore finalize if one lane is compromised and no honest staked participant challenges it before `challengeDeadline`. A timely challenge escalates the game to the independent-lane threshold.
 
 **Disputed-path safety depends on lane independence.** A false challenged finality requires two lanes to accept the same invalid root. Implementations MUST avoid shared signing keys, shared verifier keys, shared operator control, and shared offchain infrastructure across lanes, because any such sharing collapses the effective threshold below two.
 
-**TEE trust assumptions live in one lane.** The TEE lane rests on the hardware vendor, the enclave image measurement, the registrar that admits signers, and the revocation process. Each of these is a potential single point of failure for that lane. The TEE lane is therefore counted exactly once in the threshold and MUST NOT be used as the sole finality mechanism. A compromised registrar, stale signer set, or weakened image-measurement policy can turn this lane unsafe without affecting the other two.
+**TEE trust assumptions live in one lane.** The TEE lane rests on the hardware vendor, the enclave image measurement, the registrar that admits signers, and the revocation process. Each of these is a potential single point of failure for that lane. The TEE lane is counted exactly once. Deployments MAY use it as their preferred initial proof, but a challenge MUST require an additional independent lane. A compromised registrar, stale signer set, or weakened image-measurement policy can turn this lane unsafe without affecting the other two.
 
 **Security Council is a safety valve, not a finality mechanism.** Council signing keys, quorum rules, and action domains MUST be isolated from unrelated governance actions. A council attestation alone MUST NOT finalize a challenged root.
 

--- a/wips/wip-1006.md
+++ b/wips/wip-1006.md
@@ -73,7 +73,7 @@ The data bound by every proof and attestation is split into immutable domain con
 | `rootClaim` | Proposer | Claimed L2 output root, computed as in the [OP Stack output-root V1 encoding][op-output-root]. |
 | `domainHash` | Proposer | Hash of the implementation's immutable domain. The game MUST reject a value that differs from its configured `domainHash`. |
 | `l2BlockNumber` | Proposer | L2 block number for `rootClaim`, matching the [`l2BlockNumber` field of an OP Stack L2 output proposal][op-proposals]. |
-| `parentRef` | Proposer | Address of the canonical parent. A proposal extending the current anchor uses `AnchorStateRegistry.anchorGame()` when that game remains an eligible parent with the same game type and domain; otherwise it uses the `AnchorStateRegistry` sentinel. Further descendants use their concrete parent game. The parent's `rootClaim` and `l2BlockNumber` are read from this reference rather than re-supplied. |
+| `parentRef` | Proposer | Address of the parent — the `AnchorStateRegistry` for the first proposal, otherwise the parent proposal. Same convention as the OP Stack [Fault Dispute Game `extraData` parent reference][op-dgi] and the parent reference encoded in Base Azul's `AggregateVerifier` extra-data layout (see [Base Azul proof system][base-azul]). The parent's `rootClaim` and `l2BlockNumber` are read from this reference rather than re-supplied. |
 | `attempt` | Proposer | Retry nonce for the same transition. Attempt zero is the initial game; later attempts are permitted only after an eligible predecessor fails or is made obsolete by activation. |
 | `l1OriginHash` | Factory | L1 origin hash captured at proposal creation. The proposer does not pass it as calldata; it is read via `blockhash()` or [EIP-2935][eip-2935] history and pinned by the factory, mirroring the OP Stack [`l1Head` snapshot at clone creation][op-dgi] that Base Azul inherits. |
 | `l1OriginNumber` | Game | L1 block number paired with the factory-captured `l1OriginHash`. |
@@ -176,8 +176,6 @@ A root enters the system in the `PROPOSED` state.
 3. The game validates the domain, parent registration and eligibility, exact L2 block interval, retry predecessor, and bond.
 4. The game records `createdAt = block.timestamp`, `challengeDeadline = createdAt + CHALLENGE_PERIOD`, and `proofDeadline = createdAt + PROOF_PERIOD`.
 5. The proposer bond is deposited into `DelayedWETH`, and the root remains open to challenge until `challengeDeadline`.
-
-The canonical parent for a direct extension of the current anchor is the anchor game itself when it remains an eligible WIP-1006 parent in the same proof domain. The registry address is accepted as a sentinel only when there is no compatible anchor game, including initial deployment, retirement or blacklisting of the stored anchor game, and a proof-domain upgrade. This rule keeps the factory UUID stable when a concrete parent later becomes the anchor: descendants and retries continue to reference the same game rather than acquiring a second registry-parented identity.
 
 Proof material MUST NOT be part of factory creation or `extraData`. After the game exists, any party MAY submit a valid configured proof lane before `challengeDeadline`. Offchain services MAY choose a preferred operational lane, but the onchain protocol MUST NOT privilege one lane for the initial proof.
 
@@ -316,7 +314,7 @@ The proposal data remains aligned with the OP Stack:
 
 - `rootClaim` follows the [OP Stack output-root V1 encoding](https://specs.optimism.io/protocol/proposals.html#l2-output-commitment-construction).
 - `l2BlockNumber` matches the [`l2BlockNumber` field of an L2 output proposal](https://specs.optimism.io/protocol/proposals.html).
-- `parentRef` follows the [Fault Dispute Game `extraData` parent reference convention](https://specs.optimism.io/fault-proof/stage-one/dispute-game-interface.html). Direct anchor extensions use the compatible anchor game when one exists and the `AnchorStateRegistry` sentinel at initial deployment or across an incompatible domain boundary.
+- `parentRef` follows the [Fault Dispute Game `extraData` parent reference convention](https://specs.optimism.io/fault-proof/stage-one/dispute-game-interface.html) — the `AnchorStateRegistry` for the first proposal, otherwise the parent proposal address.
 - `l1OriginHash` is factory-captured at proposal creation, matching the L1 head snapshot taken by `DisputeGameFactory` at clone creation.
 - factory identity uses the canonical `(gameType, rootClaim, extraData)` UUID;
 - `domainHash`, `l2BlockNumber`, `parentRef`, and `attempt` are encoded in `extraData`.
@@ -332,8 +330,6 @@ Before this WIP can move beyond Draft, implementations SHOULD cover at least:
 - an unchallenged root with `PROOF_THRESHOLD` distinct lanes finalizes before `CHALLENGE_PERIOD`;
 - an unchallenged proofless root invalidates after exactly `CHALLENGE_PERIOD`, forfeits its proposer bond to the configured protocol recipient, and can be retried;
 - factory creation rejects an incorrect domain hash or malformed `extraData`;
-- once a compatible game becomes the anchor, a direct child MUST reference that game and creation with the registry sentinel MUST fail;
-- after switching to an implementation with a different domain, a direct child MUST use the registry sentinel;
 - factory UUID lookup and `findLatestGames` preserve the complete WIP-1006 `extraData`;
 - an unstaked account cannot challenge;
 - a staked account can challenge without proof before the deadline;

--- a/wips/wip-1006.md
+++ b/wips/wip-1006.md
@@ -153,6 +153,7 @@ The OP Stack lifecycle uses `GameStatus` for externally consumed resolution. The
 ```mermaid
 stateDiagram-v2
     [*] --> PROPOSED: factory.create(root)
+    PROPOSED --> FINALIZED: PROOF_THRESHOLD lanes
     PROPOSED --> FINALIZED: one proof + unchallenged deadline
     PROPOSED --> INVALIDATED: no proof at unchallenged deadline
     PROPOSED --> CHALLENGED: staked challenge before challenge deadline
@@ -200,15 +201,15 @@ A challenge submitted at or after `challengeDeadline` MUST revert.
 
 ### Unchallenged Finality
 
-If no valid challenge has been submitted by `challengeDeadline`, anyone MAY call `resolve()`.
-
-The game MUST resolve with `DEFENDER_WINS` when all of the following hold:
+An unchallenged root that reaches `PROOF_THRESHOLD` MAY resolve immediately with `DEFENDER_WINS`.
+Otherwise, if no valid challenge has been submitted by `challengeDeadline`, anyone MAY call
+`resolve()`. The game MUST resolve with `DEFENDER_WINS` when all of the following hold:
 
 - the root is still `PROPOSED`;
-- `block.timestamp >= challengeDeadline`;
-- at least one configured proof lane supports `rootId`;
 - the parent is the anchor sentinel or has resolved with `DEFENDER_WINS`; and
-- the parent is not blacklisted.
+- the parent is not blacklisted; and
+- either at least `PROOF_THRESHOLD` configured lanes support `rootId`, or
+  `block.timestamp >= challengeDeadline` and at least one configured lane supports `rootId`.
 
 If no proof lane supports the root at `challengeDeadline`, the game MUST instead resolve with `CHALLENGER_WINS`, record proof timeout, and credit the proposer bond to the configured protocol recipient. This outcome MUST remain retryable even when no challenger exists.
 
@@ -231,7 +232,7 @@ For each lane submission, the contract MUST:
 5. Set the lane's bit in the root's proof bitmap.
 6. Emit a threshold-reached signal when the bitmap first contains at least `PROOF_THRESHOLD` distinct lanes.
 
-A lane submission at or after its applicable deadline MUST revert. Once threshold is met, anyone MAY call `resolve()`, which MUST resolve the challenged game with `DEFENDER_WINS`.
+A lane submission at or after its applicable deadline MUST revert. Once threshold is met, anyone MAY call `resolve()`, which MUST resolve the game with `DEFENDER_WINS` whether or not it was challenged.
 
 If `block.timestamp >= proofDeadline` and the proof bitmap contains fewer than `PROOF_THRESHOLD` distinct lanes, anyone MAY call `resolve()`. The game MUST resolve with `CHALLENGER_WINS`, record proof timeout as the invalidation reason, and credit both bonds to the challenger.
 
@@ -328,6 +329,7 @@ Before this WIP can move beyond Draft, implementations SHOULD cover at least:
 
 - a newly created game has no proof support and a factory UUID independent of later proof bytes;
 - an unchallenged root with any one valid configured lane finalizes after exactly `CHALLENGE_PERIOD`;
+- an unchallenged root with `PROOF_THRESHOLD` distinct lanes finalizes before `CHALLENGE_PERIOD`;
 - an unchallenged proofless root invalidates after exactly `CHALLENGE_PERIOD`, forfeits its proposer bond to the configured protocol recipient, and can be retried;
 - factory creation rejects an incorrect domain hash or malformed `extraData`;
 - once a compatible game becomes the anchor, a direct child MUST reference that game and creation with the registry sentinel MUST fail;


### PR DESCRIPTION
- move initial proof generation from proposer to defender
- require proof support for unchallenged success
- make canonical parent unique -> only allow ASR anchor if no compatible anchor of current game type exists
- let defender negatively resolve to enable propser to re-propose


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes L1 dispute-game resolution, bond routing, and parent/canonical rules in MultiProofGame v2.0.0, plus coordinated proposer/defender/prover behavior; mistakes affect withdrawals, anchoring, and fund custody.
> 
> **Overview**
> Moves **proof submission to after** `DisputeGameFactory.create`: the proposer only opens games; the defender (and workers) supply proofs on-chain afterward.
> 
> **`MultiProofGame` v2.0.0** tightens resolution: an unchallenged proposal needs **at least one valid proof lane** before the challenge window can end in a defender win; a proposal with **no proof** times out and forfeits the proposer bond to **`proofTimeoutRecipient`**. Challenged games still need the configured multi-lane threshold. Adds **`canonicalAnchorParent()`** and stricter parent checks (**`NonCanonicalAnchorParent`**) so proposals chain off the right anchor parent across domain upgrades and retired games. **`submitProofLane`** is allowed while still *proposed* (deadline = challenge deadline) and after challenge (proof deadline).
> 
> **Offchain services** align with that model: **`world-chain-proposer`** drops prover-service / pre-create Nitro proofing and posts proposals directly; canonical scanning uses a single parent from **`canonicalAnchorParent()`**. **`world-chain-defender`** submits an initial **TEE** lane for valid proofless games, requests **SP1 + Nitro** only when challenged, ABI-encodes lane payloads (including **`public_key`** on Nitro), and **`resolve()`** negatively resolvable games (e.g. proof timeouts) so retries can proceed.
> 
> **Devnet / deploy / e2e**: defender always runs when the proof stack is enabled; SP1 worker is optional for escalation; mock Nitro proofs use **`TransitionPublicValues`**; withdrawal test waits for **`proofBitmap != 0`**; deploy script sets mock verifiers to accept proofs and configures proof timeout recipient.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbd9e5d6bfeb4d7628b2cb681b64b82345e00f4c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->