### PR TITLE
fix(game): ensure `parentRef` uniqueness

### DIFF
--- a/pkg/contracts/src/proofs/MultiProofGame.sol
+++ b/pkg/contracts/src/proofs/MultiProofGame.sol
@@ -14,7 +14,8 @@ import {
     GameStatus,
     GameType,
     Hash,
-    Timestamp
+    Timestamp,
+    Proposal
 } from "@optimism-bedrock/src/dispute/lib/Types.sol";
 import {
     AlreadyInitialized,
@@ -303,37 +304,21 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
         if (anchorStateRegistry.paused()) revert GamePaused();
         if (proposalDomainHash() != domainHash) revert InvalidDomainHash(domainHash, proposalDomainHash());
 
-        (Hash anchorRoot, uint256 anchorL2BlockNumber) = anchorStateRegistry.getAnchorRoot();
         address parentRef_ = parentRef();
 
         if (parentRef_ == address(anchorStateRegistry)) {
-            // The proposal extends the accepted anchor; the registry acts as the parent sentinel.
-            if (Hash.unwrap(anchorRoot) == bytes32(0)) revert AnchorRootNotFound();
-            startingRootClaim = Hash.unwrap(anchorRoot);
-            startingL2BlockNumber = anchorL2BlockNumber;
+            Proposal memory startingOutputRoot = anchorStateRegistry.getStartingAnchorRoot();
+            startingRootClaim = startingOutputRoot.root.raw();
+            startingL2BlockNumber = startingOutputRoot.l2SequenceNumber;
         } else {
-            if (parentRef_.code.length == 0) revert InvalidParentGame();
             IDisputeGame parent = IDisputeGame(parentRef_);
-            (GameType parentType, Claim parentClaim, bytes memory parentExtraData) = parent.gameData();
-            (IDisputeGame registeredParent,) = disputeGameFactory.games(parentType, parentClaim, parentExtraData);
 
-            if (address(registeredParent) != parentRef_) revert InvalidParentGame();
-            if (parentType.raw() != GameTypes.MULTI_PROOF_GAME_TYPE.raw()) revert UnexpectedGameType();
-            if (parent.status() == GameStatus.CHALLENGER_WINS) revert InvalidParentGame();
-            if (anchorStateRegistry.isGameBlacklisted(parent) || anchorStateRegistry.isGameRetired(parent)) {
+            if (!_isValidGame(parent)) {
                 revert InvalidParentGame();
             }
-            if (!parent.wasRespectedGameTypeWhenCreated()) revert InvalidParentGame();
-            // Guards against chaining onto games from an older implementation with a different
-            // domain (e.g. after a proof-system version bump reusing the same game type).
-            if (IMultiProofGame(address(parent)).domainHash() != domainHash) revert InvalidParentGame();
 
             startingRootClaim = Claim.unwrap(parent.rootClaim());
             startingL2BlockNumber = parent.l2SequenceNumber();
-
-            // A parent at or below the anchor is stale: proposals extending the anchor state
-            // must use the anchor sentinel instead so their starting root is registry-attested.
-            if (startingL2BlockNumber <= anchorL2BlockNumber) revert InvalidParentGame();
         }
 
         uint256 expectedL2BlockNumber = startingL2BlockNumber + DOMAIN_BLOCK_INTERVAL;
@@ -401,6 +386,14 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
             attempt(),
             gameCreator()
         );
+    }
+
+    /// @notice Checks if the game is registered, respected, not blacklisted, not retired, and not challenged.
+    /// @param game The game to check.
+    function _isValidGame(IDisputeGame game) internal view returns (bool) {
+        return anchorStateRegistry.isGameRegistered(game) && anchorStateRegistry.isGameRespected(game)
+            && !anchorStateRegistry.isGameBlacklisted(game) && !anchorStateRegistry.isGameRetired(game)
+            && (game.status() != GameStatus.CHALLENGER_WINS);
     }
 
     ////////////////////////////////////////////////////////////////

--- a/pkg/contracts/test/MultiProofGame.t.sol
+++ b/pkg/contracts/test/MultiProofGame.t.sol
@@ -79,7 +79,7 @@ contract MultiProofGameTest is OPStackFixtures {
     function test_Create_RejectsUnregisteredAndBlacklistedParents() public {
         uint256 target = STARTING_ANCHOR_BLOCK + BLOCK_INTERVAL;
         vm.prank(proposer);
-        vm.expectRevert(InvalidParentGame.selector);
+        vm.expectRevert();
         dgf.create{value: PROPOSER_BOND}(
             WC_GAME_TYPE, Claim.wrap(_rootClaimFor(target)), _extraDataForParent(target, makeAddr("unknown-parent"), 0)
         );
@@ -114,21 +114,35 @@ contract MultiProofGameTest is OPStackFixtures {
         dgf.create{value: PROPOSER_BOND}(WC_GAME_TYPE, Claim.wrap(_rootClaimFor(childTarget)), childExtraData);
     }
 
-    function test_Create_UsesAnchorSentinelAfterAnchorAdvances() public {
+    function test_Create_UsesPreviousAnchorGameAfterAnchorAdvances() public {
         MultiProofGame parent = _proposeAtAnchor();
         _resolveUnchallenged(parent);
         _passAirgap(parent);
         parent.closeGame();
 
         uint256 target = parent.l2SequenceNumber() + BLOCK_INTERVAL;
-        bytes memory staleParentExtraData = _extraData(target, 0, 0);
         vm.prank(proposer);
-        vm.expectRevert(InvalidParentGame.selector);
-        dgf.create{value: PROPOSER_BOND}(WC_GAME_TYPE, Claim.wrap(_rootClaimFor(target)), staleParentExtraData);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IMultiProofGame.InvalidL2BlockNumber.selector, STARTING_ANCHOR_BLOCK + BLOCK_INTERVAL, target
+            )
+        );
+        dgf.create{value: PROPOSER_BOND}(
+            WC_GAME_TYPE, Claim.wrap(_rootClaimFor(target)), _extraData(target, type(uint256).max, 0)
+        );
 
-        MultiProofGame child = _proposeAtAnchor();
-        assertEq(child.startingRootClaim(), Claim.unwrap(parent.rootClaim()));
-        assertEq(child.startingL2BlockNumber(), parent.l2SequenceNumber());
+        bytes memory previousAnchorParentExtraData = _extraData(target, 0, 0);
+        vm.prank(proposer);
+        MultiProofGame previousAnchorChild = MultiProofGame(
+            address(
+                dgf.create{value: PROPOSER_BOND}(
+                    WC_GAME_TYPE, Claim.wrap(_rootClaimFor(target)), previousAnchorParentExtraData
+                )
+            )
+        );
+        assertEq(previousAnchorChild.parentRef(), address(parent));
+        assertEq(previousAnchorChild.startingRootClaim(), Claim.unwrap(parent.rootClaim()));
+        assertEq(previousAnchorChild.startingL2BlockNumber(), parent.l2SequenceNumber());
     }
 
     function test_Constructor_RejectsInvalidConfiguration() public {


### PR DESCRIPTION
This PR solves the problem of restricting the `parentRef` to be unique per transition. It solves it by making sure that the `parentRef` is equal to `ASR` only in the first game (or multiple if competing for the same l2 block number), essentially when there is no parent game, then it must always equal the exact parent game.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes dispute-game initialization and parent/anchor semantics on a security-critical proposal chain; mis-validation could allow invalid parents or wrong starting roots.
> 
> **Overview**
> **Parent validation at proposal time** is centralized in `_isValidGame`, which requires the parent to be registry-registered and respected, not blacklisted or retired, and not `CHALLENGER_WINS`. The old inline checks (factory UUID match, fixed game type, `wasRespectedGameTypeWhenCreated`, matching `domainHash` on the parent contract) are removed in favor of those registry gates.
> 
> **Anchor-sentinel proposals** no longer call `getAnchorRoot()`; they use `anchorStateRegistry.getStartingAnchorRoot()` for the starting claim and L2 sequence. The **“parent at or below current anchor is stale—force anchor sentinel”** revert is removed, so a child can point at a finalized prior anchor game via `parentRef` even after the registry anchor advances.
> 
> **Tests** expect generic reverts for bad/unregistered parents, assert that re-proposing with the anchor sentinel after anchor advance fails on **L2 interval** (not `InvalidParentGame`), and show the valid path chains off the previous anchor game with the expected starting root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4906b9aa2203c83a074bdb714d6216b292dffe5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->