### PR TITLE
refactor(nitro): register signer addresses

### DIFF
--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -380,7 +380,6 @@ impl ClaimedProofJobHandler for DevnetNitroBackend {
             attestation: job.request.l1_head.as_slice().to_vec().into(),
             public_values: transition.abi_encode().into(),
             signature: job.request.root_claim.as_slice().to_vec().into(),
-            public_key: vec![0x04; 65].into(),
         })
     }
 }

--- a/docs/proof/nitro-worker.md
+++ b/docs/proof/nitro-worker.md
@@ -305,7 +305,7 @@ Here is the full journey from "job available" to "proof accepted":
     the job's expected `root_claim`, `l2_block_number`, `l1_head`, and `rollup_config_hash`.
 
 15. **Proof submitted.** The worker posts
-    `ProofData::Nitro { attestation, public_values, signature, public_key }`
+    `ProofData::Nitro { attestation, public_values, signature }`
     back to the `prover-service`.
 
 ---
@@ -349,9 +349,9 @@ The two layers are linked through the **key registration** step:
    secp256k1 key belongs to which enclave (with specific PCRs).
 2. `NitroAttestationVerifier` verifies the full attestation (P-384 sig, cert chain,
    PCRs) and extracts the public key.
-3. `NitroEnclaveKeyRegistry` stores the key as `Active`.
+3. `NitroEnclaveKeyRegistry` derives the Ethereum signer address and stores it as `Active`.
 4. During proof verification, `NitroProofVerifier` uses `ecrecover` on the secp256k1
-   signature and checks that the recovered key is registered.
+   signature and checks that the recovered signer address is registered.
 
 This design separates the **expensive operation** (P-384 attestation verification +
 cert chain validation, done once at key registration) from the **cheap operation**

--- a/docs/proof/nitro-worker.md
+++ b/docs/proof/nitro-worker.md
@@ -66,11 +66,11 @@ The `nitro-worker` Kubernetes pod contains two containers:
 
 ```
 NitroProofVerifier           ← World Chain addition: dispute game lane hook
-  │  ecrecover signature → check key is registered
+  │  ecrecover signature → check signer is registered
   ▼
-NitroEnclaveKeyRegistry      ← World Chain addition: 3-state key lifecycle
-  │  registerKey() / revokeKey() / isKeyRegistered()
-  │  key lifecycle: Unknown → Active → Revoked
+NitroEnclaveKeyRegistry      ← World Chain addition: 3-state signer lifecycle
+  │  registerKey() / revokeSigner() / isSignerRegistered()
+  │  signer lifecycle: Unknown → Active → Revoked
   ▼
 NitroAttestationVerifier     ← World Chain addition: PCR triple allowlist + timestamps
   │  parse COSE_Sign1, verify P-384 sig, check PCR0+PCR1+PCR2
@@ -449,7 +449,7 @@ NitroAttestationVerifier.verifyAttestation(attestationTbs, signature)
         └─ 6. Extract and return the secp256k1 public key from public_key field
                     │
                     ▼
-        NitroEnclaveKeyRegistry stores keccak256(publicKey) as Active
+        NitroEnclaveKeyRegistry derives and stores the signer address as Active
 ```
 
 ### Proof Verification (Every Proof)
@@ -462,26 +462,23 @@ NitroProofVerifier
         │
         ├─ 1. ABI-decode proof:
         │      (domainHash, parentRef, l1OriginNumber,
-        │       transitionPublicValues, signature, expectedPublicKey)
+        │       transitionPublicValues, signature)
         │
         ├─ 2. Reconstruct rootId from proof fields
         │      └─ Assert reconstructed == supplied rootId
         │
         ├─ 3. Check l2PreRoot matches parentRef's root claim
         │
-        ├─ 4. Check expectedPublicKey is registered in NitroEnclaveKeyRegistry
-        │      └─ isKeyRegistered(expectedPublicKey) must return true
-        │
-        ├─ 5. Compute signing commitment:
+        ├─ 4. Compute signing commitment:
         │      keccak256(abi.encode(transitionPublicValues))
         │
-        ├─ 6. ecrecover(commitment, signature) → recovered address
+        ├─ 5. ecrecover(commitment, signature) → recovered signer
         │      └─ EIP-2 low-s check: reject if s > secp256k1n/2
         │
-        ├─ 7. Compare recovered address with keccak256(expectedPublicKey[1:65])[12:]
-        │      └─ Must match
+        ├─ 6. Check recovered signer in NitroEnclaveKeyRegistry
+        │      └─ isSignerRegistered(recovered) must return true
         │
-        └─ 8. Return true (or false on any failure — never reverts)
+        └─ 7. Return true (or false on any failure — never reverts)
 ```
 
 > **Base comparison:** Base's `SystemConfigGlobal.registerSigner()` performs the same
@@ -492,10 +489,9 @@ NitroProofVerifier
 > enclaveAddress = address(uint160(publicKeyHash))
 > validSigners[enclaveAddress] = true
 > ```
-> World Chain takes the same approach but stores `keccak256(fullPublicKey)` →
-> `KeyStatus` in `NitroEnclaveKeyRegistry` instead of `address → bool` in a flat map,
-> enabling the 3-state lifecycle and making the full uncompressed key available for
-> verification. The on-chain `ecrecover` check is identical in both systems.
+> World Chain also stores lifecycle state by signer address, but uses a three-state
+> `SignerStatus` rather than a boolean so revocation remains permanent. The on-chain
+> `ecrecover` check is identical in both systems.
 
 ---
 
@@ -540,7 +536,8 @@ ephemeral public key in the `public_key` field.
 The operator calls `NitroEnclaveKeyRegistry.registerKey(attestationTbs, signature)`:
 - `NitroAttestationVerifier` verifies the attestation (P-384 sig, cert chain, PCRs)
 - Extracts the secp256k1 public key
-- Key state transitions from `Unknown` → `Active`
+- Derives its Ethereum signer address as `keccak256(publicKey[1:65])[12:]`
+- Signer state transitions from `Unknown` → `Active`
 
 ### 6. Prove
 
@@ -549,17 +546,17 @@ by `NitroProofVerifier`, because the signing key is registered.
 
 ### 7. Revoke (If Needed)
 
-The owner can call `NitroEnclaveKeyRegistry.revokeKey(publicKey)`:
-- Key state transitions from `Active` → `Revoked`
-- **Revocation is permanent** — the same key cannot be re-registered
+The owner can call `NitroEnclaveKeyRegistry.revokeSigner(signer)`:
+- Signer state transitions from `Active` → `Revoked`
+- **Revocation is permanent** — the same signer cannot be re-registered
 - Subsequent proofs signed by this key will fail verification
 
 Revocation is necessary when an enclave is decommissioned or compromised.
 
 > **Base comparison:** Base's `SystemConfigGlobal` uses a simple `mapping(address =>
 > bool) validSigners`. Deregistration is `delete validSigners[addr]` — the address
-> can be re-added later with a new attestation. World Chain's `KeyStatus.Revoked` is
-> permanent; a revoked key hash can never be reactivated. This closes the replay
+> can be re-added later with a new attestation. World Chain's `SignerStatus.Revoked` is
+> permanent; a revoked signer can never be reactivated. This closes the replay
 > attack window (a captured attestation could re-register a deleted Base key, but not
 > a World Chain `Revoked` one).
 
@@ -796,12 +793,12 @@ via `approvePCRSet` / `revokePCRSet`. No PCRs are baked into the contract constr
 This allows the owner to approve new enclave images and retire old ones without
 redeploying the verifier contract.
 
-### Q: Why store revoked keys in `NitroEnclaveKeyRegistry` instead of just deleting them?
+### Q: Why store revoked signers in `NitroEnclaveKeyRegistry` instead of just deleting them?
 
 **A:** To prevent replay attacks. If a key were simply deleted on revocation, an
 attacker who captured that key's original attestation document could re-submit it to
-`registerKey` and restore the key. The `Revoked` state is permanent — once revoked, a
-key can never be re-registered regardless of whether a valid attestation document for
+`registerKey` and restore the signer. The `Revoked` state is permanent — once revoked, a
+signer can never be re-registered regardless of whether a valid attestation document for
 it is available. The lifecycle is strictly `Unknown → Active → Revoked` with no path
 back.
 
@@ -817,11 +814,11 @@ to a 2-value one — both fit in a single storage slot byte.
 
 **A:** This was explicitly considered and decided against. Revoking a PCR set is a
 **forward-looking** operation — it prevents *new* keys from registering under that
-image. Existing registered keys were individually verified at registration time and are
-tracked separately. Mass-revoking all keys on PCR revocation would require either an
-on-chain `PCR → [keys]` mapping (which conflicts with multi-instance support) or an
-O(n) loop over all keys. The security posture is: if you need to revoke all keys from
-a compromised image, call `revokeKey` for each individually. This is noted as a
+image. Existing registered signers were individually verified at registration time and are
+tracked separately. Mass-revoking all signers on PCR revocation would require either an
+on-chain `PCR → [signers]` mapping (which conflicts with multi-instance support) or an
+O(n) loop over all signers. The security posture is: if you need to revoke all signers from
+a compromised image, call `revokeSigner` for each individually. This is noted as a
 security consideration in the contract's NatSpec.
 
 ### Q: Can you build an EIF on a regular machine, or do you need a Nitro-capable EC2 host?

--- a/pkg/contracts/scripts/devnet/DeployNitro.s.sol
+++ b/pkg/contracts/scripts/devnet/DeployNitro.s.sol
@@ -61,8 +61,8 @@ import {NitroProofVerifier} from "../../src/proofs/nitro/NitroProofVerifier.sol"
 ///           accepts both old- and new-image attestations during overlap.
 ///        4. After migration, `verifier.revokePCRSet(oldPcr0, oldPcr1,
 ///           oldPcr2)` to stop accepting new registrations for the retired
-///           image. Already-registered keys remain in the registry until
-///           individually revoked via `registry.revokeKey(pubkey)`.
+///           image. Already-registered signers remain in the registry until
+///           individually revoked via `registry.revokeSigner(signer)`.
 contract DeployNitro is Script {
     function run() external {
         address owner = vm.envAddress("OWNER");

--- a/pkg/contracts/src/proofs/nitro/NitroAttestationVerifier.sol
+++ b/pkg/contracts/src/proofs/nitro/NitroAttestationVerifier.sol
@@ -202,9 +202,9 @@ contract NitroAttestationVerifier is NitroValidator, INitroAttestationVerifier, 
     ///
     ///      ## Important: revocation is NOT retroactive
     ///      Revoking a PCR triple only blocks **new** key registrations for
-    ///      that image. Keys that were already registered from this image
-    ///      remain `NitroEnclaveKeyRegistry.KeyStatus.Active` until they are
-    ///      individually revoked via `NitroEnclaveKeyRegistry.revokeKey`.
+    ///      that image. Signers that were already registered from this image
+    ///      remain `NitroEnclaveKeyRegistry.SignerStatus.Active` until they are
+    ///      individually revoked via `NitroEnclaveKeyRegistry.revokeSigner`.
     ///
     ///      This is intentional. Nitro enclave signing keys are ephemeral:
     ///      they are generated in-memory at enclave startup, never persisted,
@@ -215,8 +215,8 @@ contract NitroAttestationVerifier is NitroValidator, INitroAttestationVerifier, 
     ///           can re-register.
     ///      Operators who want belt-and-suspenders may listen for
     ///      `PCRSetRevoked` events off-chain and call
-    ///      `NitroEnclaveKeyRegistry.revokeKey` for each affected key (the
-    ///      `KeyRegistered` event carries the bound PCR triple). See
+    ///      `NitroEnclaveKeyRegistry.revokeSigner` for each affected signer (the
+    ///      `SignerRegistered` event carries the bound PCR triple). See
     ///      `NitroEnclaveKeyRegistry` for the full rationale on why an
     ///      on-chain cascade is deliberately not implemented.
     function revokePCRSet(bytes32 pcr0, bytes32 pcr1, bytes32 pcr2) external onlyOwner {

--- a/pkg/contracts/src/proofs/nitro/NitroEnclaveKeyRegistry.sol
+++ b/pkg/contracts/src/proofs/nitro/NitroEnclaveKeyRegistry.sol
@@ -6,7 +6,7 @@ import {INitroAttestationVerifier} from "./INitroAttestationVerifier.sol";
 
 /// @title NitroEnclaveKeyRegistry
 /// @author Worldcoin
-/// @notice Registry of attested AWS Nitro enclave secp256k1 public keys.
+/// @notice Registry of attested AWS Nitro enclave secp256k1 signers.
 /// @dev Registration goes through a fully on-chain `INitroAttestationVerifier`
 ///      which:
 ///        - validates the COSE_Sign1 P-384 signature;
@@ -17,35 +17,33 @@ import {INitroAttestationVerifier} from "./INitroAttestationVerifier.sol";
 ///        - returns the embedded SEC1-uncompressed secp256k1 public key together
 ///          with the PCR triple it was bound to.
 ///
-///      The registry records the returned key in a per-key `keccak256(publicKey)`
-///      flag and emits `KeyRegistered` with the bound PCR triple, which is the
-///      authoritative off-chain index from PCRs to keys. The registry
+///      The registry derives the key's Ethereum address and records lifecycle
+///      state by signer. `SignerRegistered` is the authoritative off-chain
+///      index from PCRs to signers. The registry
 ///      deliberately does NOT maintain an on-chain `PCRs → key` lookup:
 ///      multiple validator instances run the same enclave image simultaneously,
 ///      so the relationship is one-to-many and any 1:1 map would silently
 ///      overwrite peers' entries.
 ///
-///      The registry owner can revoke any key at any time (e.g. on enclave
-///      compromise); revocation is permanent — a revoked key cannot be
+///      The registry owner can revoke any signer at any time (e.g. on enclave
+///      compromise); revocation is permanent — a revoked signer cannot be
 ///      re-registered even if a valid attestation document for it is replayed.
 contract NitroEnclaveKeyRegistry is Ownable {
     /*//////////////////////////////////////////////////////////////
                                  ERRORS
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Thrown when `revokeKey` is called for a key that is not
-    ///         currently registered as `KeyStatus.Active`.
-    error KeyNotRegistered();
+    /// @notice Thrown when `revokeSigner` is called for an address that is not active.
+    error SignerNotRegistered();
 
-    /// @notice Thrown when `registerKey` is called for a key that is already
-    ///         `KeyStatus.Active`.
-    error KeyAlreadyRegistered();
+    /// @notice Thrown when `registerKey` derives a signer that is already active.
+    error SignerAlreadyRegistered();
 
     /// @notice Thrown when `registerKey` is called for a key that was
     ///         previously revoked. Revocation is permanent — a compromised
     ///         enclave key must not be silently restored by re-submitting
     ///         its attestation document.
-    error KeyRevokedPermanently();
+    error SignerRevokedPermanently();
 
     /// @notice Thrown when the verifier returns a malformed public key.
     error InvalidPublicKey();
@@ -54,21 +52,21 @@ contract NitroEnclaveKeyRegistry is Ownable {
                                  EVENTS
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Emitted when an enclave public key is registered against a PCR triple.
-    event KeyRegistered(bytes publicKey, bytes32 pcr0, bytes32 pcr1, bytes32 pcr2);
+    /// @notice Emitted when an enclave signer is registered against a PCR triple.
+    event SignerRegistered(address indexed signer, bytes32 pcr0, bytes32 pcr1, bytes32 pcr2);
 
-    /// @notice Emitted when a previously registered key is revoked by the owner.
-    event KeyRevoked(bytes publicKey);
+    /// @notice Emitted when a previously registered signer is revoked by the owner.
+    event SignerRevoked(address indexed signer);
 
     /*//////////////////////////////////////////////////////////////
                                   TYPES
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Lifecycle state of a registered key.
-    /// @dev The default zero value (`Unknown`) denotes a key that has never
+    /// @notice Lifecycle state of a registered signer.
+    /// @dev The default zero value (`Unknown`) denotes a signer that has never
     ///      been registered. Transitions are strictly
     ///      `Unknown → Active → Revoked`; there is no path back.
-    enum KeyStatus {
+    enum SignerStatus {
         Unknown,
         Active,
         Revoked
@@ -81,8 +79,8 @@ contract NitroEnclaveKeyRegistry is Ownable {
     /// @notice On-chain Nitro attestation verifier.
     INitroAttestationVerifier public immutable verifier;
 
-    /// @notice `keccak256(publicKey) → lifecycle status`.
-    mapping(bytes32 keyHash => KeyStatus status) private _keyStatus;
+    /// @notice Enclave signer address to lifecycle status.
+    mapping(address signer => SignerStatus status) private _signerStatus;
 
     /*//////////////////////////////////////////////////////////////
                               CONSTRUCTOR
@@ -117,34 +115,36 @@ contract NitroEnclaveKeyRegistry is Ownable {
     ///                       `tools/p384_hints.js attestation ...`.
     function registerKey(bytes calldata attestationTbs, bytes calldata signature, bytes calldata attestationSigHints)
         external
-        returns (bytes memory publicKey, bytes32 pcr0, bytes32 pcr1, bytes32 pcr2)
+        returns (address signer, bytes32 pcr0, bytes32 pcr1, bytes32 pcr2)
     {
+        bytes memory publicKey;
         (publicKey, pcr0, pcr1, pcr2) = verifier.verifyAttestation(attestationTbs, signature, attestationSigHints);
         if (publicKey.length != 65 || publicKey[0] != 0x04) revert InvalidPublicKey();
 
-        bytes32 keyHash = keccak256(publicKey);
-        KeyStatus status = _keyStatus[keyHash];
-        if (status == KeyStatus.Revoked) revert KeyRevokedPermanently();
-        if (status == KeyStatus.Active) revert KeyAlreadyRegistered();
-        _keyStatus[keyHash] = KeyStatus.Active;
+        signer = _signerAddress(publicKey);
+        if (signer == address(0)) revert InvalidPublicKey();
+        SignerStatus status = _signerStatus[signer];
+        if (status == SignerStatus.Revoked) revert SignerRevokedPermanently();
+        if (status == SignerStatus.Active) revert SignerAlreadyRegistered();
+        _signerStatus[signer] = SignerStatus.Active;
 
-        emit KeyRegistered(publicKey, pcr0, pcr1, pcr2);
+        emit SignerRegistered(signer, pcr0, pcr1, pcr2);
     }
 
     /*//////////////////////////////////////////////////////////////
                                REVOCATION
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Revoke a previously registered enclave key.
+    /// @notice Revoke a previously registered enclave signer.
     /// @dev Only callable by the owner. Revocation is permanent — see
-    ///      `isKeyRevoked` — so a compromised key cannot be silently restored
+    ///      `isSignerRevoked` — so a compromised signer cannot be silently restored
     ///      by replaying its attestation document.
     ///
     ///      ## Relationship to `NitroAttestationVerifier.revokePCRSet`
     ///      Revoking a PCR set on the verifier (i.e. retiring an enclave
-    ///      image) does **not** automatically transition the keys that were
-    ///      registered under that image to `KeyStatus.Revoked` here. Each key
-    ///      remains `KeyStatus.Active` until `revokeKey` is called for it
+    ///      image) does **not** automatically transition signers registered
+    ///      under that image to `SignerStatus.Revoked` here. Each signer
+    ///      remains `SignerStatus.Active` until `revokeSigner` is called
     ///      individually.
     ///
     ///      This is intentional. Nitro enclave signing keys are ephemeral:
@@ -160,42 +160,50 @@ contract NitroEnclaveKeyRegistry is Ownable {
     ///
     ///      Belt-and-suspenders operators can still observe
     ///      `NitroAttestationVerifier.PCRSetRevoked` events off-chain and
-    ///      call `revokeKey` for every affected key. The `KeyRegistered`
+    ///      call `revokeSigner` for every affected signer. The `SignerRegistered`
     ///      event carries the bound PCR triple specifically to make this
     ///      easy.
     ///
     ///      ## Why no on-chain cascade?
     ///      An automatic on-chain cascade was considered and rejected:
-    ///        - Storing `pcrSetHash → keyHash[]` to enumerate affected keys
+    ///        - Storing `pcrSetHash → signer[]` to enumerate affected signers
     ///          requires an unbounded array per image, with O(N) gas on
     ///          `registerKey` and on the cascade itself.
-    ///        - Doing the lookup lazily in `isKeyRegistered` would add an
+    ///        - Doing the lookup lazily in `isSignerRegistered` would add an
     ///          extra SLOAD on every proof-verification call (the hot path),
     ///          for no security gain given Nitro's hardware key-destruction
     ///          guarantee.
-    function revokeKey(bytes calldata publicKey) external onlyOwner {
-        bytes32 keyHash = keccak256(publicKey);
-        if (_keyStatus[keyHash] != KeyStatus.Active) revert KeyNotRegistered();
-        _keyStatus[keyHash] = KeyStatus.Revoked;
-        emit KeyRevoked(publicKey);
+    function revokeSigner(address signer) external onlyOwner {
+        if (_signerStatus[signer] != SignerStatus.Active) revert SignerNotRegistered();
+        _signerStatus[signer] = SignerStatus.Revoked;
+        emit SignerRevoked(signer);
     }
 
     /*//////////////////////////////////////////////////////////////
                                  VIEWS
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Returns the lifecycle status of `publicKey`.
-    function keyStatus(bytes calldata publicKey) external view returns (KeyStatus) {
-        return _keyStatus[keccak256(publicKey)];
+    /// @notice Returns the lifecycle status of `signer`.
+    function signerStatus(address signer) external view returns (SignerStatus) {
+        return _signerStatus[signer];
     }
 
-    /// @notice Returns whether `publicKey` is currently registered (and not revoked).
-    function isKeyRegistered(bytes calldata publicKey) external view returns (bool) {
-        return _keyStatus[keccak256(publicKey)] == KeyStatus.Active;
+    /// @notice Returns whether `signer` is currently registered and not revoked.
+    function isSignerRegistered(address signer) external view returns (bool) {
+        return _signerStatus[signer] == SignerStatus.Active;
     }
 
-    /// @notice Returns whether `publicKey` has been permanently revoked.
-    function isKeyRevoked(bytes calldata publicKey) external view returns (bool) {
-        return _keyStatus[keccak256(publicKey)] == KeyStatus.Revoked;
+    /// @notice Returns whether `signer` has been permanently revoked.
+    function isSignerRevoked(address signer) external view returns (bool) {
+        return _signerStatus[signer] == SignerStatus.Revoked;
+    }
+
+    /// @dev Ethereum addresses hash the 64-byte X/Y coordinates, excluding the 0x04 SEC1 prefix.
+    function _signerAddress(bytes memory publicKey) internal pure returns (address signer) {
+        bytes32 keyHash;
+        assembly ("memory-safe") {
+            keyHash := keccak256(add(publicKey, 33), 64)
+        }
+        signer = address(uint160(uint256(keyHash)));
     }
 }

--- a/pkg/contracts/src/proofs/nitro/NitroProofVerifier.sol
+++ b/pkg/contracts/src/proofs/nitro/NitroProofVerifier.sol
@@ -21,11 +21,9 @@ import {NitroEnclaveKeyRegistry} from "./NitroEnclaveKeyRegistry.sol";
 ///           equals the `rootId` the game is asking about. This binds the
 ///           Nitro signature to the *specific* proposal under dispute.
 ///        2. Binds the proposal transition fields to the calling game's immutable snapshot.
-///        3. Checks that `expectedPublicKey` is currently registered in
+///        3. Recomputes the signing commitment from all transition public values.
+///        4. Recovers the signer via `ecrecover` and checks that address against
 ///           `NitroEnclaveKeyRegistry`.
-///        4. Recomputes the signing commitment from all transition public values.
-///        5. Recovers the signer via `ecrecover` and matches it against the
-///           Ethereum address derived from `expectedPublicKey`.
 ///
 ///      Any decode or verification failure is surfaced as `false` (never
 ///      a revert) to honour the boolean-predicate contract of
@@ -38,11 +36,6 @@ contract NitroProofVerifier is IWorldChainProofVerifier {
     /// @dev Thrown when the proof's signature bytes are not exactly 65 bytes.
     ///      Surfaced as `false` via `verify`'s try/catch.
     error InvalidSignatureLength();
-
-    /// @dev Thrown when the proof's expected public key is not a 65-byte
-    ///      SEC1-uncompressed secp256k1 key (`0x04 || X || Y`). The World
-    ///      Nitro enclave always emits this form.
-    error InvalidPublicKey();
 
     /*//////////////////////////////////////////////////////////////
                                 STORAGE
@@ -72,8 +65,7 @@ contract NitroProofVerifier is IWorldChainProofVerifier {
     ///            address parentRef,
     ///            uint256 l1OriginNumber,
     ///            TransitionPublicValues transitionPublicValues,
-    ///            bytes   signature,
-    ///            bytes   expectedPublicKey
+    ///            bytes   signature
     ///        )
     ///
     ///      Decoding plus `_verifyDecoded` live behind an external `this.`
@@ -98,9 +90,8 @@ contract NitroProofVerifier is IWorldChainProofVerifier {
             address parentRef,
             uint256 l1OriginNumber,
             ProofLib.TransitionPublicValues memory transition,
-            bytes memory signature,
-            bytes memory expectedPublicKey
-        ) = abi.decode(proof, (bytes32, address, uint256, ProofLib.TransitionPublicValues, bytes, bytes));
+            bytes memory signature
+        ) = abi.decode(proof, (bytes32, address, uint256, ProofLib.TransitionPublicValues, bytes));
 
         // 1. Bind the proof identity and transition fields to the calling game's immutable snapshot.
         bool matchesGame =
@@ -109,7 +100,7 @@ contract NitroProofVerifier is IWorldChainProofVerifier {
 
         // 2. Verify the enclave signature over all transition public values.
         bytes32 commitment = _signingCommitment(transition);
-        return _verifyEnclaveSignature(commitment, signature, expectedPublicKey);
+        return _verifyEnclaveSignature(commitment, signature);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -124,21 +115,11 @@ contract NitroProofVerifier is IWorldChainProofVerifier {
         return keccak256(abi.encode(transition));
     }
 
-    /// @dev Checks that `signature` over `commitment` recovers to the address
-    ///      derived from `expectedPublicKey`, and that the key is registered.
-    ///      Returns `false` on logical mismatch (unregistered key, wrong
-    ///      signer, malleable s, etc.); reverts on structural errors
-    ///      (`InvalidSignatureLength`, `InvalidPublicKey`) which `verify`
-    ///      catches and turns into `false`.
-    function _verifyEnclaveSignature(bytes32 commitment, bytes memory signature, bytes memory expectedPublicKey)
-        internal
-        view
-        returns (bool)
-    {
-        if (expectedPublicKey.length != 65 || expectedPublicKey[0] != 0x04) revert InvalidPublicKey();
-
-        if (!_isKeyRegistered(expectedPublicKey)) return false;
-
+    /// @dev Checks that `signature` over `commitment` recovers to a registered signer.
+    ///      Returns `false` on logical mismatch (unregistered signer, malleable s,
+    ///      etc.); reverts on a structurally invalid signature length, which
+    ///      `verify` catches and turns into `false`.
+    function _verifyEnclaveSignature(bytes32 commitment, bytes memory signature) internal view returns (bool) {
         if (signature.length != 65) revert InvalidSignatureLength();
 
         bytes32 r;
@@ -159,26 +140,8 @@ contract NitroProofVerifier is IWorldChainProofVerifier {
         if (v != 27 && v != 28) return false;
 
         address recovered = ecrecover(commitment, v, r, s);
-        // ecrecover returns address(0) for malformed (r, s, v) tuples that
-        // it cannot decode. Reject explicitly: matching against an
-        // expectedPublicKey that derives to address(0) is cryptographically
-        // impossible, but a defensive check here keeps the failure mode
-        // explicit and audit-friendly.
+        // ecrecover returns address(0) for malformed (r, s, v) tuples.
         if (recovered == address(0)) return false;
-
-        // Ethereum address = last 20 bytes of keccak256(X || Y), i.e. of the
-        // 64-byte tail after the `0x04` prefix.
-        bytes32 keyHash;
-        assembly ("memory-safe") {
-            // expectedPublicKey[1:65] is 64 bytes starting at +33 (length word + prefix).
-            keyHash := keccak256(add(expectedPublicKey, 33), 64)
-        }
-        return recovered == address(uint160(uint256(keyHash)));
-    }
-
-    /// @dev Memory-bytes wrapper around the calldata-only `isKeyRegistered`
-    ///      view on the registry.
-    function _isKeyRegistered(bytes memory publicKey) internal view returns (bool) {
-        return registry.isKeyRegistered(publicKey);
+        return registry.isSignerRegistered(recovered);
     }
 }

--- a/pkg/contracts/test/nitro/NitroEnclaveKeyRegistry.t.sol
+++ b/pkg/contracts/test/nitro/NitroEnclaveKeyRegistry.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import {Test} from "forge-std/Test.sol";
+import {Test, Vm} from "forge-std/Test.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {NitroEnclaveKeyRegistry} from "../../src/proofs/nitro/NitroEnclaveKeyRegistry.sol";
 import {MockNitroAttestationVerifier} from "./mocks/MockNitroAttestationVerifier.sol";
@@ -22,6 +22,8 @@ contract NitroEnclaveKeyRegistryTest is Test {
 
     bytes pubKey;
     bytes otherKey;
+    address signer;
+    address otherSigner;
 
     function setUp() public {
         attestationVerifier = new MockNitroAttestationVerifier();
@@ -29,6 +31,8 @@ contract NitroEnclaveKeyRegistryTest is Test {
 
         pubKey = _key(0x01);
         otherKey = _key(0xAB);
+        signer = _signer(pubKey);
+        otherSigner = _signer(otherKey);
         attestationVerifier.setExpectation(TBS, SIG, pubKey, PCR0, PCR1, PCR2);
     }
 
@@ -40,12 +44,23 @@ contract NitroEnclaveKeyRegistryTest is Test {
         }
     }
 
-    function test_RegisterKey_StoresKeyAndEmits() public {
-        vm.expectEmit(false, false, false, true);
-        emit NitroEnclaveKeyRegistry.KeyRegistered(pubKey, PCR0, PCR1, PCR2);
+    function _signer(bytes memory key) internal pure returns (address) {
+        return address(uint160(uint256(keccak256(_slice64(key)))));
+    }
+
+    function _slice64(bytes memory key) internal pure returns (bytes memory coordinates) {
+        coordinates = new bytes(64);
+        for (uint256 i; i < 64; i++) {
+            coordinates[i] = key[i + 1];
+        }
+    }
+
+    function test_RegisterKey_StoresSignerAndEmits() public {
+        vm.expectEmit(true, false, false, true);
+        emit NitroEnclaveKeyRegistry.SignerRegistered(signer, PCR0, PCR1, PCR2);
         registry.registerKey(TBS, SIG, "");
 
-        assertTrue(registry.isKeyRegistered(pubKey));
+        assertTrue(registry.isSignerRegistered(signer));
     }
 
     function test_RegisterKey_RevertsWhenVerifierRejects() public {
@@ -61,36 +76,36 @@ contract NitroEnclaveKeyRegistryTest is Test {
         registry.registerKey(hex"badf00", SIG, "");
     }
 
-    function test_IsKeyRegistered_FalseForUnknown() public view {
-        assertFalse(registry.isKeyRegistered(otherKey));
+    function test_IsSignerRegistered_FalseForUnknown() public view {
+        assertFalse(registry.isSignerRegistered(otherSigner));
     }
 
-    function test_RevokeKey_OnlyOwner() public {
+    function test_RevokeSigner_OnlyOwner() public {
         registry.registerKey(TBS, SIG, "");
 
         vm.prank(attacker);
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, attacker));
-        registry.revokeKey(pubKey);
+        registry.revokeSigner(signer);
 
         vm.prank(owner);
-        vm.expectEmit(false, false, false, true);
-        emit NitroEnclaveKeyRegistry.KeyRevoked(pubKey);
-        registry.revokeKey(pubKey);
+        vm.expectEmit(true, false, false, true);
+        emit NitroEnclaveKeyRegistry.SignerRevoked(signer);
+        registry.revokeSigner(signer);
 
-        assertFalse(registry.isKeyRegistered(pubKey));
+        assertFalse(registry.isSignerRegistered(signer));
     }
 
-    function test_RevokeKey_RevertsForUnregistered() public {
+    function test_RevokeSigner_RevertsForUnregistered() public {
         vm.prank(owner);
-        vm.expectRevert(NitroEnclaveKeyRegistry.KeyNotRegistered.selector);
-        registry.revokeKey(pubKey);
+        vm.expectRevert(NitroEnclaveKeyRegistry.SignerNotRegistered.selector);
+        registry.revokeSigner(signer);
     }
 
     function test_MultipleInstancesSameImage() public {
         // Two validator instances run the same enclave image → same PCR triple,
         // but each has its own ephemeral key. Both must register successfully
-        // and both must be queryable via isKeyRegistered. (No on-chain
-        // PCRs → key index exists; the KeyRegistered events are the off-chain
+        // and both must be queryable via isSignerRegistered. (No on-chain
+        // PCRs → signer index exists; the SignerRegistered events are the off-chain
         // source of truth.)
         registry.registerKey(TBS, SIG, "");
 
@@ -98,8 +113,8 @@ contract NitroEnclaveKeyRegistryTest is Test {
         attestationVerifier.setExpectation(tbs2, SIG, otherKey, PCR0, PCR1, PCR2);
         registry.registerKey(tbs2, SIG, "");
 
-        assertTrue(registry.isKeyRegistered(pubKey));
-        assertTrue(registry.isKeyRegistered(otherKey));
+        assertTrue(registry.isSignerRegistered(signer));
+        assertTrue(registry.isSignerRegistered(otherSigner));
     }
 
     function test_Constructor_SetsOwnerAndVerifier() public view {
@@ -112,14 +127,26 @@ contract NitroEnclaveKeyRegistryTest is Test {
         new NitroEnclaveKeyRegistry(attestationVerifier, address(0));
     }
 
-    function test_RegisterKey_ReturnsKeyAndPCRs() public {
-        // The function's return values must be forwarded verbatim from the
-        // verifier so off-chain consumers can rely on them.
-        (bytes memory key, bytes32 p0, bytes32 p1, bytes32 p2) = registry.registerKey(TBS, SIG, "");
-        assertEq(key, pubKey);
+    function test_RegisterKey_ReturnsSignerAndPCRs() public {
+        // PCRs are forwarded from the verifier while the public key is reduced
+        // to the same signer identity that ecrecover returns for proofs.
+        (address registeredSigner, bytes32 p0, bytes32 p1, bytes32 p2) = registry.registerKey(TBS, SIG, "");
+        assertEq(registeredSigner, signer);
         assertEq(p0, PCR0);
         assertEq(p1, PCR1);
         assertEq(p2, PCR2);
+    }
+
+    function test_RegisterKey_DerivesEthereumAddressFromAttestedKey() public {
+        Vm.Wallet memory wallet = vm.createWallet("attested-enclave");
+        bytes memory walletKey = abi.encodePacked(bytes1(0x04), wallet.publicKeyX, wallet.publicKeyY);
+        bytes memory walletTbs = hex"0a11ce";
+        attestationVerifier.setExpectation(walletTbs, SIG, walletKey, PCR0, PCR1, PCR2);
+
+        (address registeredSigner,,,) = registry.registerKey(walletTbs, SIG, "");
+
+        assertEq(registeredSigner, wallet.addr);
+        assertTrue(registry.isSignerRegistered(wallet.addr));
     }
 
     function test_RegisterKey_RejectsValidLengthKeyWithWrongPrefix() public {
@@ -155,37 +182,37 @@ contract NitroEnclaveKeyRegistryTest is Test {
         registry.registerKey(hex"6666", SIG, "");
     }
 
-    function test_RevokeKey_AlreadyRevokedRevertsKeyNotRegistered() public {
+    function test_RevokeSigner_AlreadyRevokedRevertsSignerNotRegistered() public {
         registry.registerKey(TBS, SIG, "");
         vm.prank(owner);
-        registry.revokeKey(pubKey);
+        registry.revokeSigner(signer);
         // A second revoke for the same (now Revoked) key must surface
-        // `KeyNotRegistered`, NOT silently succeed and re-emit the event.
+        // `SignerNotRegistered`, NOT silently succeed and re-emit the event.
         vm.prank(owner);
-        vm.expectRevert(NitroEnclaveKeyRegistry.KeyNotRegistered.selector);
-        registry.revokeKey(pubKey);
+        vm.expectRevert(NitroEnclaveKeyRegistry.SignerNotRegistered.selector);
+        registry.revokeSigner(signer);
     }
 
-    function test_RevokeKey_RevertsForUnknownKey() public {
-        // Revoking a never-seen key must surface `KeyNotRegistered`.
+    function test_RevokeSigner_RevertsForUnknownSigner() public {
+        // Revoking a never-seen signer must surface `SignerNotRegistered`.
         vm.prank(owner);
-        vm.expectRevert(NitroEnclaveKeyRegistry.KeyNotRegistered.selector);
-        registry.revokeKey(otherKey);
+        vm.expectRevert(NitroEnclaveKeyRegistry.SignerNotRegistered.selector);
+        registry.revokeSigner(otherSigner);
     }
 
-    function test_RegisterKey_EmitsKeyRegisteredWithExactPCRs() public {
+    function test_RegisterKey_EmitsSignerRegisteredWithExactPCRs() public {
         // Stronger assertion: emits the exact event including all PCRs.
-        vm.expectEmit(false, false, false, true);
-        emit NitroEnclaveKeyRegistry.KeyRegistered(pubKey, PCR0, PCR1, PCR2);
+        vm.expectEmit(true, false, false, true);
+        emit NitroEnclaveKeyRegistry.SignerRegistered(signer, PCR0, PCR1, PCR2);
         registry.registerKey(TBS, SIG, "");
     }
 
-    function test_KeyStatus_ForUnknownKeyIsZero() public view {
-        // The default `KeyStatus.Unknown == 0` invariant: any never-seen key
-        // must report Unknown, isKeyRegistered=false, isKeyRevoked=false.
-        assertEq(uint8(registry.keyStatus(otherKey)), uint8(NitroEnclaveKeyRegistry.KeyStatus.Unknown));
-        assertFalse(registry.isKeyRegistered(otherKey));
-        assertFalse(registry.isKeyRevoked(otherKey));
+    function test_SignerStatus_ForUnknownSignerIsZero() public view {
+        // The default `SignerStatus.Unknown == 0` invariant: any never-seen signer
+        // must report Unknown, isSignerRegistered=false, isSignerRevoked=false.
+        assertEq(uint8(registry.signerStatus(otherSigner)), uint8(NitroEnclaveKeyRegistry.SignerStatus.Unknown));
+        assertFalse(registry.isSignerRegistered(otherSigner));
+        assertFalse(registry.isSignerRevoked(otherSigner));
     }
 
     function test_RegisterKey_PropagatesVerifierRevertVerbatim() public {
@@ -198,58 +225,58 @@ contract NitroEnclaveKeyRegistryTest is Test {
         registry.registerKey(hex"deadbeef", hex"00", "");
     }
 
-    function test_RevokeKey_PreventsReregistration() public {
+    function test_RevokeSigner_PreventsReregistration() public {
         registry.registerKey(TBS, SIG, "");
 
         vm.prank(owner);
-        registry.revokeKey(pubKey);
-        assertFalse(registry.isKeyRegistered(pubKey));
-        assertTrue(registry.isKeyRevoked(pubKey));
+        registry.revokeSigner(signer);
+        assertFalse(registry.isSignerRegistered(signer));
+        assertTrue(registry.isSignerRevoked(signer));
 
         // Anyone re-submitting the same attestation must fail.
-        vm.expectRevert(NitroEnclaveKeyRegistry.KeyRevokedPermanently.selector);
+        vm.expectRevert(NitroEnclaveKeyRegistry.SignerRevokedPermanently.selector);
         registry.registerKey(TBS, SIG, "");
 
-        assertFalse(registry.isKeyRegistered(pubKey));
+        assertFalse(registry.isSignerRegistered(signer));
     }
 
-    function test_RevokeKey_AlsoBlocksRegistrationUnderDifferentPCRs() public {
+    function test_RevokeSigner_AlsoBlocksRegistrationUnderDifferentPCRs() public {
         registry.registerKey(TBS, SIG, "");
 
         vm.prank(owner);
-        registry.revokeKey(pubKey);
+        registry.revokeSigner(signer);
 
         // Even if a doc later asserted the same key under different PCRs, the
-        // revoke must be sticky on the key itself.
+        // revoke must be sticky on the derived signer.
         bytes32 otherPcr0 = bytes32(uint256(0xff));
         attestationVerifier.setExpectation(hex"1234", SIG, pubKey, otherPcr0, PCR1, PCR2);
-        vm.expectRevert(NitroEnclaveKeyRegistry.KeyRevokedPermanently.selector);
+        vm.expectRevert(NitroEnclaveKeyRegistry.SignerRevokedPermanently.selector);
         registry.registerKey(hex"1234", SIG, "");
     }
 
-    function test_IsKeyRevoked_FalseBeforeRevoke() public {
+    function test_IsSignerRevoked_FalseBeforeRevoke() public {
         registry.registerKey(TBS, SIG, "");
-        assertFalse(registry.isKeyRevoked(pubKey));
+        assertFalse(registry.isSignerRevoked(signer));
     }
 
     function test_RegisterKey_RevertsIfAlreadyActive() public {
         registry.registerKey(TBS, SIG, "");
-        vm.expectRevert(NitroEnclaveKeyRegistry.KeyAlreadyRegistered.selector);
+        vm.expectRevert(NitroEnclaveKeyRegistry.SignerAlreadyRegistered.selector);
         registry.registerKey(TBS, SIG, "");
     }
 
-    function test_KeyStatus_LifecycleTransitions() public {
+    function test_SignerStatus_LifecycleTransitions() public {
         // Unknown
-        assertEq(uint8(registry.keyStatus(pubKey)), uint8(NitroEnclaveKeyRegistry.KeyStatus.Unknown));
+        assertEq(uint8(registry.signerStatus(signer)), uint8(NitroEnclaveKeyRegistry.SignerStatus.Unknown));
 
         // Active
         registry.registerKey(TBS, SIG, "");
-        assertEq(uint8(registry.keyStatus(pubKey)), uint8(NitroEnclaveKeyRegistry.KeyStatus.Active));
+        assertEq(uint8(registry.signerStatus(signer)), uint8(NitroEnclaveKeyRegistry.SignerStatus.Active));
 
         // Revoked
         vm.prank(owner);
-        registry.revokeKey(pubKey);
-        assertEq(uint8(registry.keyStatus(pubKey)), uint8(NitroEnclaveKeyRegistry.KeyStatus.Revoked));
+        registry.revokeSigner(signer);
+        assertEq(uint8(registry.signerStatus(signer)), uint8(NitroEnclaveKeyRegistry.SignerStatus.Revoked));
     }
 
     function test_MultiImageCoexistence() public {
@@ -265,7 +292,7 @@ contract NitroEnclaveKeyRegistryTest is Test {
         registry.registerKey(tbsB, SIG, "");
 
         // Both keys are registered.
-        assertTrue(registry.isKeyRegistered(pubKey));
-        assertTrue(registry.isKeyRegistered(otherKey));
+        assertTrue(registry.isSignerRegistered(signer));
+        assertTrue(registry.isSignerRegistered(otherSigner));
     }
 }

--- a/pkg/contracts/test/nitro/NitroEndToEnd.t.sol
+++ b/pkg/contracts/test/nitro/NitroEndToEnd.t.sol
@@ -133,20 +133,16 @@ contract NitroEndToEndTest is Test {
         return _signCommitment(w, _transition(postRoot, blk, cfg));
     }
 
-    function _proof(bytes memory sig, bytes memory pub, ProofLib.TransitionPublicValues memory transition)
+    function _proof(bytes memory sig, ProofLib.TransitionPublicValues memory transition)
         internal
         view
         returns (bytes memory)
     {
-        return abi.encode(domainHash, address(parent), L1N, transition, sig, pub);
+        return abi.encode(domainHash, address(parent), L1N, transition, sig);
     }
 
-    function _proof(bytes memory sig, bytes memory pub, bytes32 postRoot, uint64 blk, bytes32 cfg)
-        internal
-        view
-        returns (bytes memory)
-    {
-        return _proof(sig, pub, _transition(postRoot, blk, cfg));
+    function _proof(bytes memory sig, bytes32 postRoot, uint64 blk, bytes32 cfg) internal view returns (bytes memory) {
+        return _proof(sig, _transition(postRoot, blk, cfg));
     }
 
     function _rootId(bytes32 postRoot, uint64 blk) internal view returns (bytes32) {
@@ -167,39 +163,39 @@ contract NitroEndToEndTest is Test {
         //    See NitroAttestationVerifierTest for the real-fixture coverage.
         //
         // 2. Anyone calls registry.registerKey(tbs, sig). The verifier
-        //    surfaces the enclave key + PCRs; the registry stores them.
-        vm.expectEmit(false, false, false, true);
-        emit NitroEnclaveKeyRegistry.KeyRegistered(enclavePubKey, PCR0, PCR1, PCR2);
+        //    surfaces the enclave key + PCRs; the registry stores its signer address.
+        vm.expectEmit(true, false, false, true);
+        emit NitroEnclaveKeyRegistry.SignerRegistered(enclaveWallet.addr, PCR0, PCR1, PCR2);
         registry.registerKey(TBS, SIG, "");
-        assertTrue(registry.isKeyRegistered(enclavePubKey));
-        assertEq(uint8(registry.keyStatus(enclavePubKey)), uint8(NitroEnclaveKeyRegistry.KeyStatus.Active));
+        assertTrue(registry.isSignerRegistered(enclaveWallet.addr));
+        assertEq(uint8(registry.signerStatus(enclaveWallet.addr)), uint8(NitroEnclaveKeyRegistry.SignerStatus.Active));
 
         // 3. The (live) enclave signs a signing-commitment for some rollup
         //    boot-info. The proposer wraps it up into a NitroProofVerifier
         //    proof tuple and submits it to dispute-game resolution.
         bytes memory sig = _signCommitment(enclaveWallet, POST, BLK, CFG);
-        assertTrue(_verify(_rootId(POST, BLK), _proof(sig, enclavePubKey, POST, BLK, CFG)));
+        assertTrue(_verify(_rootId(POST, BLK), _proof(sig, POST, BLK, CFG)));
     }
 
-    function test_E2E_RevokeKeyInvalidatesFutureProofs() public {
+    function test_E2E_RevokeSignerInvalidatesFutureProofs() public {
         registry.registerKey(TBS, SIG, "");
         bytes memory sig = _signCommitment(enclaveWallet, POST, BLK, CFG);
 
         // Pre-revoke: proof is valid.
-        assertTrue(_verify(_rootId(POST, BLK), _proof(sig, enclavePubKey, POST, BLK, CFG)));
+        assertTrue(_verify(_rootId(POST, BLK), _proof(sig, POST, BLK, CFG)));
 
         // Owner revokes the key (e.g. on compromise).
         vm.prank(owner);
-        registry.revokeKey(enclavePubKey);
-        assertTrue(registry.isKeyRevoked(enclavePubKey));
+        registry.revokeSigner(enclaveWallet.addr);
+        assertTrue(registry.isSignerRevoked(enclaveWallet.addr));
 
         // Same (previously valid) proof MUST now be rejected — the proof
         // verifier consults the registry on every call.
-        assertFalse(_verify(_rootId(POST, BLK), _proof(sig, enclavePubKey, POST, BLK, CFG)));
+        assertFalse(_verify(_rootId(POST, BLK), _proof(sig, POST, BLK, CFG)));
 
         // And the registry must permanently refuse to re-register the key,
         // even via a fresh attestation.
-        vm.expectRevert(NitroEnclaveKeyRegistry.KeyRevokedPermanently.selector);
+        vm.expectRevert(NitroEnclaveKeyRegistry.SignerRevokedPermanently.selector);
         registry.registerKey(TBS, SIG, "");
     }
 
@@ -218,8 +214,8 @@ contract NitroEndToEndTest is Test {
         bytes memory sigA = _signCommitment(enclaveWallet, POST, BLK, CFG);
         bytes memory sigB = _signCommitment(secondWallet, POST, BLK, CFG);
 
-        assertTrue(_verify(_rootId(POST, BLK), _proof(sigA, enclavePubKey, POST, BLK, CFG)));
-        assertTrue(_verify(_rootId(POST, BLK), _proof(sigB, secondPubKey, POST, BLK, CFG)));
+        assertTrue(_verify(_rootId(POST, BLK), _proof(sigA, POST, BLK, CFG)));
+        assertTrue(_verify(_rootId(POST, BLK), _proof(sigB, POST, BLK, CFG)));
     }
 
     function test_E2E_RevokeOneEnclaveDoesNotAffectPeer() public {
@@ -234,19 +230,19 @@ contract NitroEndToEndTest is Test {
         registry.registerKey(tbs2, SIG, "");
 
         vm.prank(owner);
-        registry.revokeKey(enclavePubKey);
+        registry.revokeSigner(enclaveWallet.addr);
 
         bytes memory sigA = _signCommitment(enclaveWallet, POST, BLK, CFG);
         bytes memory sigB = _signCommitment(secondWallet, POST, BLK, CFG);
-        assertFalse(_verify(_rootId(POST, BLK), _proof(sigA, enclavePubKey, POST, BLK, CFG)));
-        assertTrue(_verify(_rootId(POST, BLK), _proof(sigB, secondPubKey, POST, BLK, CFG)));
+        assertFalse(_verify(_rootId(POST, BLK), _proof(sigA, POST, BLK, CFG)));
+        assertTrue(_verify(_rootId(POST, BLK), _proof(sigB, POST, BLK, CFG)));
     }
 
-    function test_E2E_UnregisteredKeyFails() public {
+    function test_E2E_UnregisteredSignerFails() public {
         // Skip registration; the proof verifier MUST refuse even a
         // cryptographically-valid signature from an unknown key.
         bytes memory sig = _signCommitment(enclaveWallet, POST, BLK, CFG);
-        assertFalse(_verify(_rootId(POST, BLK), _proof(sig, enclavePubKey, POST, BLK, CFG)));
+        assertFalse(_verify(_rootId(POST, BLK), _proof(sig, POST, BLK, CFG)));
     }
 
     function test_E2E_ProofMustBindToRequestedRootId() public {
@@ -254,6 +250,6 @@ contract NitroEndToEndTest is Test {
         bytes memory sig = _signCommitment(enclaveWallet, POST, BLK, CFG);
 
         // Honest proof but the dispute game asks about a different rootId.
-        assertFalse(_verify(bytes32(uint256(0xdead)), _proof(sig, enclavePubKey, POST, BLK, CFG)));
+        assertFalse(_verify(bytes32(uint256(0xdead)), _proof(sig, POST, BLK, CFG)));
     }
 }

--- a/pkg/contracts/test/nitro/NitroProofVerifier.t.sol
+++ b/pkg/contracts/test/nitro/NitroProofVerifier.t.sol
@@ -112,8 +112,8 @@ contract NitroProofVerifierTest is Test {
             );
     }
 
-    function _proofBytes(bytes memory sig, bytes memory pub) internal view returns (bytes memory) {
-        return abi.encode(domainHash, address(parent), L1_ORIGIN_NUMBER, _transition(), sig, pub);
+    function _proofBytes(bytes memory sig) internal view returns (bytes memory) {
+        return abi.encode(domainHash, address(parent), L1_ORIGIN_NUMBER, _transition(), sig);
     }
 
     function _setGameContext(ProofLib.TransitionPublicValues memory transition) internal {
@@ -152,7 +152,7 @@ contract NitroProofVerifierTest is Test {
 
     function test_Verify_HappyPath() public {
         bytes memory sig = _sign(_commitment());
-        assertTrue(_verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
+        assertTrue(_verify(_expectedRootId(), _proofBytes(sig)));
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -163,7 +163,7 @@ contract NitroProofVerifierTest is Test {
         // Honest signature + transition public values, but the game asks about a different
         // rootId — the verifier must NOT validate.
         bytes memory sig = _sign(_commitment());
-        assertFalse(_verify(bytes32(uint256(0xdead)), _proofBytes(sig, enclavePubKey)));
+        assertFalse(_verify(bytes32(uint256(0xdead)), _proofBytes(sig)));
     }
 
     function test_Verify_FalseForWrongBootInfo() public {
@@ -178,8 +178,7 @@ contract NitroProofVerifierTest is Test {
             L1_ORIGIN_HASH,
             L1_ORIGIN_NUMBER
         );
-        bytes memory proof =
-            abi.encode(domainHash, address(parent), L1_ORIGIN_NUMBER, wrongTransition, sig, enclavePubKey);
+        bytes memory proof = abi.encode(domainHash, address(parent), L1_ORIGIN_NUMBER, wrongTransition, sig);
         assertFalse(_verify(wrongRootId, proof));
     }
 
@@ -187,8 +186,7 @@ contract NitroProofVerifierTest is Test {
         ProofLib.TransitionPublicValues memory wrongTransition = _transition();
         wrongTransition.l2PreRoot = keccak256("wrong-pre-root");
         bytes memory sig = _sign(keccak256(abi.encode(wrongTransition)));
-        bytes memory proof =
-            abi.encode(domainHash, address(parent), L1_ORIGIN_NUMBER, wrongTransition, sig, enclavePubKey);
+        bytes memory proof = abi.encode(domainHash, address(parent), L1_ORIGIN_NUMBER, wrongTransition, sig);
         assertFalse(_verify(_expectedRootId(), proof));
     }
 
@@ -196,8 +194,7 @@ contract NitroProofVerifierTest is Test {
         ProofLib.TransitionPublicValues memory wrongTransition = _transition();
         wrongTransition.l2PreBlockNumber += 1;
         bytes memory sig = _sign(keccak256(abi.encode(wrongTransition)));
-        bytes memory proof =
-            abi.encode(domainHash, address(parent), L1_ORIGIN_NUMBER, wrongTransition, sig, enclavePubKey);
+        bytes memory proof = abi.encode(domainHash, address(parent), L1_ORIGIN_NUMBER, wrongTransition, sig);
 
         assertFalse(_verify(_expectedRootId(), proof));
     }
@@ -206,20 +203,19 @@ contract NitroProofVerifierTest is Test {
                             REGISTRY GATES
     //////////////////////////////////////////////////////////////*/
 
-    function test_Verify_FalseForUnregisteredKey() public {
+    function test_Verify_FalseForUnregisteredSigner() public {
         Vm.Wallet memory rogue = vm.createWallet("rogue");
-        bytes memory roguePub = _uncompressedKey(rogue.publicKeyX, rogue.publicKeyY);
         bytes memory sig = _sign(rogue, _commitment());
-        assertFalse(_verify(_expectedRootId(), _proofBytes(sig, roguePub)));
+        assertFalse(_verify(_expectedRootId(), _proofBytes(sig)));
     }
 
-    function test_Verify_FalseForRevokedKey() public {
+    function test_Verify_FalseForRevokedSigner() public {
         bytes memory sig = _sign(_commitment());
 
         vm.prank(owner);
-        registry.revokeKey(enclavePubKey);
+        registry.revokeSigner(enclaveWallet.addr);
 
-        assertFalse(_verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
+        assertFalse(_verify(_expectedRootId(), _proofBytes(sig)));
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -227,27 +223,26 @@ contract NitroProofVerifierTest is Test {
     //////////////////////////////////////////////////////////////*/
 
     function test_Verify_FalseForDifferentSigner() public {
-        // Sign with a different key while passing the registered enclave key.
         Vm.Wallet memory rogue = vm.createWallet("rogue");
         bytes memory sig = _sign(rogue, _commitment());
-        assertFalse(_verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
+        assertFalse(_verify(_expectedRootId(), _proofBytes(sig)));
     }
 
-    function test_Verify_FalseForBadSignatureLength() public {
+    function test_Verify_FalseForBadSignatureLength() public view {
         bytes memory sig = hex"1234";
-        assertFalse(_verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
+        assertFalse(_verify(_expectedRootId(), _proofBytes(sig)));
     }
 
-    function test_Verify_FalseForSignatureLength64() public {
+    function test_Verify_FalseForSignatureLength64() public view {
         // EIP-2098 "compact" 64-byte signatures are NOT accepted; the
         // contract is strict about 65-byte (r || s || v) tuples.
         bytes memory sig = new bytes(64);
-        assertFalse(_verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
+        assertFalse(_verify(_expectedRootId(), _proofBytes(sig)));
     }
 
-    function test_Verify_FalseForEmptySignature() public {
+    function test_Verify_FalseForEmptySignature() public view {
         bytes memory sig = "";
-        assertFalse(_verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
+        assertFalse(_verify(_expectedRootId(), _proofBytes(sig)));
     }
 
     function test_Verify_FalseForHighSSignature() public {
@@ -269,9 +264,9 @@ contract NitroProofVerifierTest is Test {
         uint8 vFlipped = v == 27 ? 28 : 27;
         bytes memory malleable = abi.encodePacked(r, sHigh, vFlipped);
         // Original signature still validates...
-        assertTrue(_verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
+        assertTrue(_verify(_expectedRootId(), _proofBytes(sig)));
         // ...but the malleable high-s twin must NOT.
-        assertFalse(_verify(_expectedRootId(), _proofBytes(malleable, enclavePubKey)));
+        assertFalse(_verify(_expectedRootId(), _proofBytes(malleable)));
     }
 
     function test_Verify_FalseForInvalidV() public {
@@ -281,57 +276,24 @@ contract NitroProofVerifierTest is Test {
         assembly {
             mstore8(add(add(sig, 32), 64), 29)
         }
-        assertFalse(_verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
+        assertFalse(_verify(_expectedRootId(), _proofBytes(sig)));
         // Also v = 0 (legacy unsigned).
         assembly {
             mstore8(add(add(sig, 32), 64), 0)
         }
-        assertFalse(_verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
+        assertFalse(_verify(_expectedRootId(), _proofBytes(sig)));
         // Also v = 26.
         assembly {
             mstore8(add(add(sig, 32), 64), 26)
         }
-        assertFalse(_verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
+        assertFalse(_verify(_expectedRootId(), _proofBytes(sig)));
     }
 
-    function test_Verify_FalseForAllZeroSignature() public {
+    function test_Verify_FalseForAllZeroSignature() public view {
         // r = s = 0, v = 27. ecrecover returns address(0) → false.
         bytes memory sig = new bytes(65);
         sig[64] = bytes1(uint8(27));
-        assertFalse(_verify(_expectedRootId(), _proofBytes(sig, enclavePubKey)));
-    }
-
-    /*//////////////////////////////////////////////////////////////
-                              KEY GATES
-    //////////////////////////////////////////////////////////////*/
-
-    function test_Verify_FalseForCompressedKey() public {
-        bytes memory compressed = new bytes(33);
-        compressed[0] = 0x02;
-        bytes memory sig = _sign(_commitment());
-        assertFalse(_verify(_expectedRootId(), _proofBytes(sig, compressed)));
-    }
-
-    function test_Verify_FalseForBadKey() public view {
-        // 7-byte key cannot be SEC1-decoded → _verifyEnclaveSignature
-        // reverts with InvalidPublicKey → verify() catches and returns false.
-        bytes memory badKey = hex"01020304050607";
-        assertFalse(_verify(_expectedRootId(), _proofBytes(hex"00", badKey)));
-    }
-
-    function test_Verify_FalseForEmptyPublicKey() public view {
-        bytes memory emptyKey = "";
-        assertFalse(_verify(_expectedRootId(), _proofBytes(hex"00", emptyKey)));
-    }
-
-    function test_Verify_FalseForKeyWithLength65AndWrongPrefix() public {
-        // 65-byte length passes the length gate but the prefix check
-        // (`publicKey[0] != 0x04`) must still reject it.
-        bytes memory key = new bytes(65);
-        key[0] = 0x03;
-        // Use a real signature so we fail on the prefix check, not earlier.
-        bytes memory sig = _sign(_commitment());
-        assertFalse(_verify(_expectedRootId(), _proofBytes(sig, key)));
+        assertFalse(_verify(_expectedRootId(), _proofBytes(sig)));
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -362,7 +324,7 @@ contract NitroProofVerifierTest is Test {
         bytes32 rootId = ProofLib.rootId(domainHash, address(parent), L2_POST_ROOT, 0, L1_ORIGIN_HASH, L1_ORIGIN_NUMBER);
         bytes32 commitment = keccak256(abi.encode(transition));
         bytes memory sig = _sign(commitment);
-        bytes memory proof = abi.encode(domainHash, address(parent), L1_ORIGIN_NUMBER, transition, sig, enclavePubKey);
+        bytes memory proof = abi.encode(domainHash, address(parent), L1_ORIGIN_NUMBER, transition, sig);
         _setGameContext(transition);
         assertTrue(_verify(rootId, proof));
     }
@@ -375,8 +337,7 @@ contract NitroProofVerifierTest is Test {
         wrongTransition.rollupConfigHash = wrongCfg;
         bytes32 commitment = keccak256(abi.encode(wrongTransition));
         bytes memory sig = _sign(commitment);
-        bytes memory proof =
-            abi.encode(domainHash, address(parent), L1_ORIGIN_NUMBER, wrongTransition, sig, enclavePubKey);
+        bytes memory proof = abi.encode(domainHash, address(parent), L1_ORIGIN_NUMBER, wrongTransition, sig);
         assertFalse(_verify(_expectedRootId(), proof));
     }
 
@@ -384,7 +345,7 @@ contract NitroProofVerifierTest is Test {
         // verify() is view: calling it twice must return the same result
         // and not record any state change.
         bytes memory sig = _sign(_commitment());
-        bytes memory proof = _proofBytes(sig, enclavePubKey);
+        bytes memory proof = _proofBytes(sig);
         bytes32 root = _expectedRootId();
         assertTrue(_verify(root, proof));
         assertTrue(_verify(root, proof));

--- a/proofs/defender/src/lane.rs
+++ b/proofs/defender/src/lane.rs
@@ -258,7 +258,6 @@ fn encode_proof(metadata: &GameMetadata, proof: &ProofData) -> Result<Bytes, Def
             attestation: _,
             public_values,
             signature,
-            public_key,
         } => {
             // The prover API transports public values as bytes, but NitroProofVerifier embeds
             // TransitionPublicValues as a static tuple. Encoding the bytes directly would add a
@@ -271,10 +270,57 @@ fn encode_proof(metadata: &GameMetadata, proof: &ProofData) -> Result<Bytes, Def
                 l1_origin_number,
                 transition,
                 signature.clone(),
-                public_key.clone(),
             )
                 .abi_encode()
                 .into())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{Address, B256};
+
+    #[test]
+    fn nitro_encoding_matches_verifier_payload() {
+        let transition = TransitionPublicValues {
+            l1Head: B256::repeat_byte(0x11),
+            l2PreRoot: B256::repeat_byte(0x22),
+            l2PreBlockNumber: 10,
+            l2PostRoot: B256::repeat_byte(0x33),
+            l2PostBlockNumber: 20,
+            rollupConfigHash: B256::repeat_byte(0x44),
+        };
+        let metadata = GameMetadata {
+            address: Address::repeat_byte(0x55),
+            domain_hash: B256::repeat_byte(0x66),
+            parent_ref: Address::repeat_byte(0x77),
+            root_claim: transition.l2PostRoot,
+            l2_block_number: transition.l2PostBlockNumber,
+            l1_origin_hash: transition.l1Head,
+            l1_origin_number: 42,
+            challenge_deadline: 100,
+            proof_deadline: 200,
+            proof_threshold: 2,
+        };
+        let signature = Bytes::from(vec![0x88; 65]);
+        let proof = ProofData::Nitro {
+            attestation: Bytes::from_static(b"attestation"),
+            public_values: transition.abi_encode().into(),
+            signature: signature.clone(),
+        };
+
+        let encoded = encode_proof(&metadata, &proof).expect("valid Nitro proof payload");
+        let expected = (
+            metadata.domain_hash,
+            metadata.parent_ref,
+            U256::from(metadata.l1_origin_number),
+            transition,
+            signature,
+        )
+            .abi_encode();
+
+        assert_eq!(encoded.as_ref(), expected);
     }
 }

--- a/proofs/defender/src/tests.rs
+++ b/proofs/defender/src/tests.rs
@@ -372,7 +372,6 @@ impl ProofRequester for MockProver {
                 .abi_encode()
                 .into(),
                 signature: Bytes::from_static(b"signature"),
-                public_key: Bytes::from_static(b"public key"),
             },
         };
         Ok(ProofResponse::Succeeded(SucceededProofResponse {

--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -696,7 +696,6 @@ impl ClaimedProofJobHandler for FakeProofBackend {
                 .abi_encode()
                 .into(),
                 signature: vec![0x7e, request.l2_block_number as u8].into(), // mock signature
-                public_key: Bytes::from_static(b"public key"),
             },
         })
     }

--- a/proofs/nitro/worker/src/lib.rs
+++ b/proofs/nitro/worker/src/lib.rs
@@ -16,7 +16,7 @@
 //!  │  NitroProver::prove_range  ────────────► Nitro Enclave                              │
 //!  │       │                                  (vsock / PCR-pinned)                       │
 //!  │       ▼                                                                              │
-//!  │  prover_submitProof(Nitro { attestation, public_values, signature, public_key })    │
+//!  │  prover_submitProof(Nitro { attestation, public_values, signature })                │
 //!  └──────────────────────────────────────────────────────────────────────────────────────┘
 //! ```
 
@@ -168,10 +168,6 @@ impl ClaimedProofJobHandler for NitroBackend {
         );
 
         Ok(ProofData::Nitro {
-            public_key: world_chain_proof_nitro::attestation::extract_nsm_public_key(
-                &artifact.attestation_doc,
-            )?
-            .into(),
             attestation: Bytes::from(artifact.attestation_doc),
             public_values: artifact.transition_public_values.abi_encode().into(),
             signature: Bytes::from(artifact.signature),

--- a/proofs/proposer/README.md
+++ b/proofs/proposer/README.md
@@ -45,7 +45,7 @@ attempt to be created.
 The automated services assume proof-timeout retries are exceptional. The proposer creates the next
 attempt and the defender follows that replacement, but games descending from the abandoned attempt
 are not automatically recovered. Operators must resolve that stale lineage parent-first and claim
-any resulting bond credits. Retry creation is logged at error level so it can trigger an incident
+any resulting bond credits. Retry creation is logged at warn level so it can trigger an incident
 response; a follow-up can include the complete stale lineage in that alert.
 
 ### `root_claim`

--- a/proofs/prover-service/src/tests.rs
+++ b/proofs/prover-service/src/tests.rs
@@ -87,7 +87,6 @@ fn proof_for(req: &ProofRequest) -> SucceededProofResponse {
             attestation: Bytes::from(vec![0xcc]),
             public_values: Bytes::from(vec![0xee]),
             signature: Bytes::from(vec![0xdd]),
-            public_key: Bytes::from(vec![0xff]),
         },
     };
     SucceededProofResponse {
@@ -312,7 +311,6 @@ async fn submit_proof_with_wrong_backend_is_rejected() {
             attestation: Bytes::from(vec![0xcc]),
             public_values: Bytes::from(vec![0xee]),
             signature: Bytes::from(vec![0xdd]),
-            public_key: Bytes::from(vec![0xff]),
         },
     };
     assert!(matches!(

--- a/proofs/prover-service/src/types.rs
+++ b/proofs/prover-service/src/types.rs
@@ -200,8 +200,6 @@ pub enum ProofData {
         public_values: Bytes,
         /// Enclave signature over the proven outputs.
         signature: Bytes,
-        /// SEC1-uncompressed public key certified by the attestation document.
-        public_key: Bytes,
     },
 }
 

--- a/wips/wip-1006.md
+++ b/wips/wip-1006.md
@@ -250,7 +250,7 @@ The validity proof lane verifies that the transition from `parentRoot` at `paren
 
 #### TEE Attestation
 
-The TEE lane accepts an attestation from a registered TEE signer over `rootId`. The verifier MUST check that the signer is registered, that the signer is valid for the active TEE image or measurement, that the attestation binds to `rootId`, and that the attestation has not expired or been revoked.
+The TEE lane accepts a signature from a registered TEE signer over transition data bound to `rootId`. Signer admission MUST verify the hardware attestation, approved image measurements, and attestation freshness before deriving and activating the signer's identity. For each proof, the lane verifier MUST check the transition binding, recover the signer from the signature, and require that signer to remain active in the registry. Revocation MUST prevent all subsequent proofs from that signer.
 
 #### Security Council Attestation
 


### PR DESCRIPTION
closes https://linear.app/worldcoin/issue/PROTO-5011/remove-the-nitro-public-key-from-every-proof-payload

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 8724b994ea379e539094640e1b5337f254f234a7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->