### PR TITLE
feat: resolve invalid parent bonds

### DIFF
--- a/proofs/defender/README.md
+++ b/proofs/defender/README.md
@@ -11,5 +11,5 @@ resolution, retry creation, and anchor advancement.
 
 Only asynchronous proof progress is retained between ticks. Each tick reconstructs the lineage and
 drops proof workflows for games that are no longer selected. A proof-timeout retry therefore moves
-the defender to the replacement attempt; resolving and recovering the abandoned lineage is a manual
-operator responsibility.
+the defender to the replacement attempt. Descendants of the invalidated attempt need no further
+proof support: the proposer bond manager resolves them as `INVALID_PARENT` and claims their refunds.

--- a/proofs/defender/src/defender.rs
+++ b/proofs/defender/src/defender.rs
@@ -105,15 +105,6 @@ where
                 .execution_provider
                 .game_metadata(selected.game.address)
                 .await?;
-            if metadata.parent_ref != selected.transition.parent_ref
-                || metadata.root_claim != selected.transition.root_claim
-                || metadata.l2_block_number != selected.transition.l2_block_number
-            {
-                return Err(DefenderError::Contract(format!(
-                    "selected game {} does not match its transition commitment",
-                    selected.game.address
-                )));
-            }
             games.push(metadata);
         }
 

--- a/proofs/primitives/src/types.rs
+++ b/proofs/primitives/src/types.rs
@@ -258,6 +258,13 @@ impl ResolutionStatus {
         self.resolvable && self.root_state == RootState::Finalized
     }
 
+    /// Returns whether the game can be resolved as invalid because its parent is invalid.
+    pub fn invalid_parent_resolvable(&self) -> bool {
+        self.resolvable
+            && self.root_state == RootState::Invalidated
+            && self.invalidation_reason == InvalidationReason::InvalidParent
+    }
+
     /// Returns whether the game has already reached a terminal state.
     ///
     /// The root state may describe the expected outcome of a game that is currently resolvable,

--- a/proofs/proposer/README.md
+++ b/proofs/proposer/README.md
@@ -46,7 +46,7 @@ The automated services assume proof-timeout retries are exceptional. The propose
 attempt and the defender follows that replacement. Games descending from the abandoned attempt
 become resolvable as `INVALID_PARENT`; the bond manager keeps proposer-owned games tracked, resolves
 those descendants as their parents settle, and claims the refunded bonds. Retry creation remains
-logged at error level for operator visibility.
+logged at warn level for operator visibility.
 
 ### `root_claim`
 

--- a/proofs/proposer/README.md
+++ b/proofs/proposer/README.md
@@ -43,10 +43,10 @@ attempt to be created.
 ## Retry operations
 
 The automated services assume proof-timeout retries are exceptional. The proposer creates the next
-attempt and the defender follows that replacement, but games descending from the abandoned attempt
-are not automatically recovered. Operators must resolve that stale lineage parent-first and claim
-any resulting bond credits. Retry creation is logged at error level so it can trigger an incident
-response; a follow-up can include the complete stale lineage in that alert.
+attempt and the defender follows that replacement. Games descending from the abandoned attempt
+become resolvable as `INVALID_PARENT`; the bond manager keeps proposer-owned games tracked, resolves
+those descendants as their parents settle, and claims the refunded bonds. Retry creation remains
+logged at error level for operator visibility.
 
 ### `root_claim`
 
@@ -61,5 +61,5 @@ response; a follow-up can include the complete stale lineage in that alert.
 Bonds are custodied in `DelayedWETH` and paid out in two phases. The first `claimCredit(recipient)`
 call unlocks the credit; the second, after the WETH delay, withdraws and transfers it. Both are
 gated on `AnchorStateRegistry.isGameFinalized`, since `claimCredit` calls `closeGame`, which reverts
-until the registry's finality airgap has elapsed. The bond manager keeps a game tracked until its
-pending withdrawal is drained.
+until the registry's finality airgap has elapsed. The bond manager keeps every discovered
+proposer-owned game tracked until it is resolved and its pending withdrawal is drained.

--- a/proofs/proposer/src/alloy.rs
+++ b/proofs/proposer/src/alloy.rs
@@ -102,6 +102,27 @@ where
             .map_err(|error| ProposerError::Contract(error.to_string()))
     }
 
+    async fn send_resolve_game(&self, game: Address) -> Result<ResolveSubmission, ProposerError> {
+        let pending = self
+            .game(game)
+            .resolve()
+            .send()
+            .await
+            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+
+        let tx_hash = *pending.tx_hash();
+        let receipt = pending
+            .with_required_confirmations(self.confirmations)
+            .get_receipt()
+            .await
+            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+        if !receipt.status() {
+            return Err(ProposerError::Revert(tx_hash));
+        }
+
+        Ok(ResolveSubmission { tx_hash })
+    }
+
     /// Reads the credit `recipient` can unlock from `game`.
     async fn read_credit(&self, game: Address, recipient: Address) -> Result<U256, ProposerError> {
         self.game(game)
@@ -230,6 +251,10 @@ where
         self.read_resolution_status(game).await
     }
 
+    async fn resolve_game(&self, game: Address) -> Result<ResolveSubmission, ProposerError> {
+        self.send_resolve_game(game).await
+    }
+
     async fn is_game_finalized(&self, game: Address) -> Result<bool, ProposerError> {
         self.read_is_game_finalized(game).await
     }
@@ -291,24 +316,7 @@ where
     P: Provider + WalletProvider + Clone + Send + Sync + 'static,
 {
     async fn resolve_game(&self, game: Address) -> Result<ResolveSubmission, ProposerError> {
-        let pending = self
-            .game(game)
-            .resolve()
-            .send()
-            .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))?;
-
-        let tx_hash = *pending.tx_hash();
-        let receipt = pending
-            .with_required_confirmations(self.confirmations)
-            .get_receipt()
-            .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))?;
-        if !receipt.status() {
-            return Err(ProposerError::Revert(tx_hash));
-        }
-
-        Ok(ResolveSubmission { tx_hash })
+        self.send_resolve_game(game).await
     }
 
     async fn is_game_finalized(&self, game: Address) -> Result<bool, ProposerError> {

--- a/proofs/proposer/src/bond_manager.rs
+++ b/proofs/proposer/src/bond_manager.rs
@@ -96,6 +96,9 @@ where
             let result: Result<bool, ProposerError> = async {
                 let resolution_status = self.execution_provider.resolution_status(game).await?;
                 if !resolution_status.is_resolved() {
+                    // Retried lineages no longer expose their stale descendants to the canonical
+                    // proposer loop, so the bond manager resolves those descendants for recovery.
+                    // Leave direct proof timeouts to the proposer to avoid racing retry creation.
                     if resolution_status.resolvable
                         && resolution_status.root_state == RootState::Invalidated
                         && resolution_status.invalidation_reason

--- a/proofs/proposer/src/bond_manager.rs
+++ b/proofs/proposer/src/bond_manager.rs
@@ -2,10 +2,11 @@ use std::collections::HashSet;
 
 use alloy_primitives::{Address, U256};
 use tracing::{info, warn};
+use world_chain_proofs::{InvalidationReason, RootState};
 
 use crate::{BondManagerClient, BondManagerConfig, ProposerError};
 
-/// Discovers games created by the proposer and asynchronously withdraws resolved bond credits.
+/// Discovers proposer-owned games, resolves invalid-parent descendants, and recovers bond credits.
 #[derive(Debug)]
 pub struct BondManager<E> {
     config: BondManagerConfig,
@@ -82,12 +83,12 @@ where
         Ok(())
     }
 
-    /// Advances the two-phase bond claim on tracked games and prunes fully settled ones.
+    /// Resolves invalid-parent games, advances bond claims, and prunes fully settled games.
     ///
     /// `MultiProofGame.claimCredit` first unlocks the credit in `DelayedWETH` and only
     /// transfers it on a second call after the WETH delay, so a game stays tracked until its
     /// pending withdrawal is drained. Dropping it after the unlock would strand the bond.
-    pub async fn withdraw_credits(&mut self) -> Result<(), ProposerError> {
+    pub async fn settle_games(&mut self) -> Result<(), ProposerError> {
         let proposed_games: Vec<_> = self.proposed_games.iter().copied().collect();
         let now = self.execution_provider.latest_l1_timestamp().await?;
 
@@ -95,6 +96,18 @@ where
             let result: Result<bool, ProposerError> = async {
                 let resolution_status = self.execution_provider.resolution_status(game).await?;
                 if !resolution_status.is_resolved() {
+                    if resolution_status.resolvable
+                        && resolution_status.root_state == RootState::Invalidated
+                        && resolution_status.invalidation_reason
+                            == InvalidationReason::InvalidParent
+                    {
+                        let submission = self.execution_provider.resolve_game(game).await?;
+                        info!(
+                            tx_hash = ?submission.tx_hash,
+                            game_address = %game,
+                            "resolved proposer-owned game invalidated by its parent"
+                        );
+                    }
                     return Ok(false);
                 }
                 // `claimCredit` calls `closeGame`, which reverts until the registry's finality
@@ -154,7 +167,7 @@ where
         Ok(())
     }
 
-    /// Runs game discovery and withdrawals forever on an interval independent of proposals.
+    /// Runs game discovery and bond settlement forever on an interval independent of proposals.
     pub async fn run_forever(&mut self) -> Result<(), ProposerError> {
         self.config.validate()?;
 
@@ -165,8 +178,8 @@ where
             if let Err(error) = self.scan_games().await {
                 warn!(%error, "bond-manager game scan failed; retrying on next tick");
             }
-            if let Err(error) = self.withdraw_credits().await {
-                warn!(%error, "bond-manager withdrawal pass failed; retrying on next tick");
+            if let Err(error) = self.settle_games().await {
+                warn!(%error, "bond-manager settlement pass failed; retrying on next tick");
             }
         }
     }

--- a/proofs/proposer/src/bond_manager.rs
+++ b/proofs/proposer/src/bond_manager.rs
@@ -2,7 +2,6 @@ use std::collections::HashSet;
 
 use alloy_primitives::{Address, U256};
 use tracing::{info, warn};
-use world_chain_proofs::{InvalidationReason, RootState};
 
 use crate::{BondManagerClient, BondManagerConfig, ProposerError};
 
@@ -99,11 +98,7 @@ where
                     // Retried lineages no longer expose their stale descendants to the canonical
                     // proposer loop, so the bond manager resolves those descendants for recovery.
                     // Leave direct proof timeouts to the proposer to avoid racing retry creation.
-                    if resolution_status.resolvable
-                        && resolution_status.root_state == RootState::Invalidated
-                        && resolution_status.invalidation_reason
-                            == InvalidationReason::InvalidParent
-                    {
+                    if resolution_status.invalid_parent_resolvable() {
                         let submission = self.execution_provider.resolve_game(game).await?;
                         info!(
                             tx_hash = ?submission.tx_hash,

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -188,7 +188,7 @@ where
                     root_claim = %proposal.root_claim,
                     l2_block_number = proposal.l2_block_number,
                     attempt = proposal.attempt,
-                    "creating a retry; the abandoned lineage requires manual resolution and bond recovery"
+                    "creating a retry; bond manager will recover proposer-owned descendants invalidated by the old attempt"
                 );
                 (*proposal, Some(*invalidated_game))
             }

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -1,4 +1,4 @@
-use tracing::{error, info, warn};
+use tracing::{info, warn};
 use world_chain_proofs::{
     ConsensusProvider, InvalidationReason, LineageStop, RootState, SelectedLineageGame,
     select_lineage,
@@ -182,7 +182,7 @@ where
                 proposal,
                 invalidated_game,
             } => {
-                error!(
+                warn!(
                     invalidated_game = %invalidated_game,
                     parent_ref = %proposal.parent_ref,
                     root_claim = %proposal.root_claim,

--- a/proofs/proposer/src/tests.rs
+++ b/proofs/proposer/src/tests.rs
@@ -148,6 +148,8 @@ struct MockBondClient {
     games: Arc<Mutex<Vec<(Option<Address>, Address)>>>,
     requested_indices: Arc<Mutex<Vec<u64>>>,
     resolved_games: Arc<Mutex<HashSet<Address>>>,
+    resolution_statuses: Arc<Mutex<HashMap<Address, ResolutionStatus>>>,
+    resolutions: Arc<Mutex<Vec<Address>>>,
     unfinalized_games: Arc<Mutex<HashSet<Address>>>,
     credit: Arc<Mutex<HashMap<Address, U256>>>,
     pending: Arc<Mutex<HashMap<Address, PendingWithdrawal>>>,
@@ -175,6 +177,8 @@ impl MockBondClient {
             games: Arc::new(Mutex::new(games)),
             requested_indices: Arc::default(),
             resolved_games: Arc::default(),
+            resolution_statuses: Arc::default(),
+            resolutions: Arc::default(),
             unfinalized_games: Arc::default(),
             credit: Arc::default(),
             pending: Arc::default(),
@@ -225,6 +229,15 @@ impl BondManagerClient for MockBondClient {
     }
 
     async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError> {
+        if let Some(status) = self
+            .resolution_statuses
+            .lock()
+            .expect("not poisoned")
+            .get(&game)
+            .copied()
+        {
+            return Ok(status);
+        }
         let resolved = self
             .resolved_games
             .lock()
@@ -238,6 +251,23 @@ impl BondManagerClient for MockBondClient {
                 RootState::Proposed
             },
             invalidation_reason: InvalidationReason::None,
+        })
+    }
+
+    async fn resolve_game(&self, game: Address) -> Result<ResolveSubmission, ProposerError> {
+        let mut statuses = self.resolution_statuses.lock().expect("not poisoned");
+        let status = statuses
+            .get_mut(&game)
+            .ok_or_else(|| ProposerError::Contract(format!("game {game} is not resolvable")))?;
+        if !status.resolvable {
+            return Err(ProposerError::Contract(format!(
+                "game {game} is not resolvable"
+            )));
+        }
+        status.resolvable = false;
+        self.resolutions.lock().expect("not poisoned").push(game);
+        Ok(ResolveSubmission {
+            tx_hash: B256::repeat_byte(0xbb),
         })
     }
 
@@ -838,7 +868,7 @@ async fn bond_manager_prunes_resolved_games_and_retries_failed_claims() {
     manager.scan_games().await.unwrap();
 
     // Pass 1: only `claimable` advances, and only through the DelayedWETH unlock.
-    manager.withdraw_credits().await.unwrap();
+    manager.settle_games().await.unwrap();
 
     assert!(manager.tracks_game(unresolved));
     assert!(!manager.tracks_game(zero_credit));
@@ -858,7 +888,7 @@ async fn bond_manager_prunes_resolved_games_and_retries_failed_claims() {
     assert!(client.withdrawals.lock().expect("not poisoned").is_empty());
 
     // Pass 2: `claimable` withdraws and is dropped; the failed claim is retried and unlocks.
-    manager.withdraw_credits().await.unwrap();
+    manager.settle_games().await.unwrap();
 
     assert!(!manager.tracks_game(claimable));
     assert!(manager.tracks_game(retry_claim));
@@ -868,12 +898,83 @@ async fn bond_manager_prunes_resolved_games_and_retries_failed_claims() {
     );
 
     // Pass 3: the retried claim withdraws and is dropped.
-    manager.withdraw_credits().await.unwrap();
+    manager.settle_games().await.unwrap();
 
     assert!(!manager.tracks_game(retry_claim));
     let withdrawals = client.withdrawals.lock().expect("not poisoned");
     assert!(withdrawals.contains(&claimable));
     assert!(withdrawals.contains(&retry_claim));
+}
+
+#[tokio::test]
+async fn bond_manager_resolves_invalid_parent_before_claiming_refund() {
+    let proposer = Address::repeat_byte(0xa1);
+    let game = game_address(1);
+    let client = MockBondClient::new(proposer, vec![(game, proposer)]);
+    client
+        .resolution_statuses
+        .lock()
+        .expect("not poisoned")
+        .insert(
+            game,
+            ResolutionStatus {
+                resolvable: true,
+                root_state: RootState::Invalidated,
+                invalidation_reason: InvalidationReason::InvalidParent,
+            },
+        );
+    client
+        .credit
+        .lock()
+        .expect("not poisoned")
+        .insert(game, U256::from(10));
+    let mut manager = BondManager::new(bond_manager_config(100), client.clone());
+    manager.scan_games().await.unwrap();
+
+    manager.settle_games().await.unwrap();
+    assert_eq!(
+        *client.resolutions.lock().expect("not poisoned"),
+        vec![game]
+    );
+    assert!(client.unlocks.lock().expect("not poisoned").is_empty());
+    assert!(manager.tracks_game(game));
+
+    manager.settle_games().await.unwrap();
+    assert_eq!(*client.unlocks.lock().expect("not poisoned"), vec![game]);
+    assert!(manager.tracks_game(game));
+
+    manager.settle_games().await.unwrap();
+    assert_eq!(
+        *client.withdrawals.lock().expect("not poisoned"),
+        vec![game]
+    );
+    assert!(!manager.tracks_game(game));
+}
+
+#[tokio::test]
+async fn bond_manager_leaves_direct_proof_timeout_to_lineage_proposer() {
+    let proposer = Address::repeat_byte(0xa1);
+    let game = game_address(1);
+    let client = MockBondClient::new(proposer, vec![(game, proposer)]);
+    client
+        .resolution_statuses
+        .lock()
+        .expect("not poisoned")
+        .insert(
+            game,
+            ResolutionStatus {
+                resolvable: true,
+                root_state: RootState::Invalidated,
+                invalidation_reason: InvalidationReason::ProofTimeout,
+            },
+        );
+    let mut manager = BondManager::new(bond_manager_config(100), client.clone());
+    manager.scan_games().await.unwrap();
+
+    manager.settle_games().await.unwrap();
+
+    assert!(client.resolutions.lock().expect("not poisoned").is_empty());
+    assert!(manager.tracks_game(game));
 }
 
 #[tokio::test]
@@ -913,12 +1014,12 @@ async fn bond_manager_uses_l1_timestamp_for_delayed_withdrawal() {
 
     let mut manager = BondManager::new(bond_manager_config(100), client.clone());
     manager.scan_games().await.unwrap();
-    manager.withdraw_credits().await.unwrap();
+    manager.settle_games().await.unwrap();
     assert!(manager.tracks_game(game));
     assert!(client.withdrawals.lock().expect("not poisoned").is_empty());
 
     client.latest_l1_timestamp.store(100, Ordering::SeqCst);
-    manager.withdraw_credits().await.unwrap();
+    manager.settle_games().await.unwrap();
     assert!(!manager.tracks_game(game));
     assert_eq!(
         *client.withdrawals.lock().expect("not poisoned"),

--- a/proofs/proposer/src/traits.rs
+++ b/proofs/proposer/src/traits.rs
@@ -27,6 +27,9 @@ pub trait BondManagerClient: Send + Sync {
     /// Returns the resolution status of the provided game.
     async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError>;
 
+    /// Resolves a proposer-owned game invalidated by its parent.
+    async fn resolve_game(&self, game: Address) -> Result<ResolveSubmission, ProposerError>;
+
     /// Returns whether the registry's finality airgap has elapsed for the provided game.
     ///
     /// `claimCredit` calls `closeGame`, which reverts until this holds.


### PR DESCRIPTION
iff we retry a game due to proof timeout - the old lineage should still get resolved to collect proposer bounds, this is taken care of in the bond manager by 

we intentionally do NOT resolve positively resolve games in the bond manager as this is part of the other proposer tassk and we want to avoid race conditions.