### PR TITLE
feat(proofs): charge protocol fee on challenges

### DIFF
--- a/pkg/contracts/README.md
+++ b/pkg/contracts/README.md
@@ -14,6 +14,8 @@ This repository contains smart contracts for World Chain, including PBH (Priorit
 
 `credit(recipient)` returns the amount assigned to `recipient`. `claimCredit(recipient)` is permissionless and always pays `recipient`: its first call unlocks the credit in `DelayedWETH`, and a call after the withdrawal delay transfers the funds. Automation must retain resolved games until both phases complete.
 
+Every accepted challenge deducts the implementation's immutable `challengeFee` from the challenger bond and credits it to the immutable `protocolFeeRecipient`. The fee remains charged in both normal and refund settlement modes, preventing a proposer and challenger under common control from recycling the full bond while forcing an additional proof. The proposer bond must exceed the challenge fee, making a successful challenge gross-profitable before transaction costs.
+
 ## OP Stack Withdrawal Boundary
 
 The compatibility target is `OptimismPortal2` 5.6.1 shipped by the devnet's version-tagged `op-deployer:v0.7.1` image. Solidity imports are pinned separately to [`op-contracts/v7.0.0` at `a7c88c8`](https://github.com/ethereum-optimism/optimism/tree/a7c88c8d636ceb9944ea0edaf7d033da258778ab/packages/contracts-bedrock), which exposes the same Portal version and the stock dispute interfaces compiled by this repository. `MultiProofGame` implements the Portal-facing `IDisputeGame` ABI and adds the WIP-1006 proof-lane API. The withdrawal E2E runs these compiled game contracts against the Portal, factory, and registry deployed from the pinned `op-deployer` image.

--- a/pkg/contracts/scripts/devnet/DeployProofSystem.s.sol
+++ b/pkg/contracts/scripts/devnet/DeployProofSystem.s.sol
@@ -55,7 +55,8 @@ contract DeployProofSystem is Script {
         bytes32 rollupConfigHash;
         uint256 blockInterval;
         uint8 proofThreshold;
-        address proofTimeoutRecipient;
+        address protocolFeeRecipient;
+        uint256 challengeFee;
         IDisputeGameFactory disputeGameFactory;
         IAnchorStateRegistry anchorStateRegistry;
         ISystemConfig systemConfig;
@@ -71,6 +72,7 @@ contract DeployProofSystem is Script {
     uint64 internal constant PROOF_PERIOD = 7 days;
     uint256 internal constant PROPOSER_BOND = 1 ether;
     uint256 internal constant CHALLENGER_BOND = 0.1 ether;
+    uint256 internal constant DEFAULT_CHALLENGE_FEE = 0.01 ether;
 
     function run() external returns (Deployment memory deployment) {
         Config memory config = _readConfig();
@@ -154,7 +156,8 @@ contract DeployProofSystem is Script {
         config.rollupConfigHash = vm.envBytes32("ROLLUP_CONFIG_HASH");
         config.blockInterval = vm.envOr("PROOF_SYSTEM_BLOCK_INTERVAL", uint256(10));
         config.proofThreshold = uint8(vm.envOr("PROOF_THRESHOLD", uint256(ProofLib.PROOF_THRESHOLD)));
-        config.proofTimeoutRecipient = vm.envOr("PROOF_TIMEOUT_RECIPIENT", config.challenger);
+        config.protocolFeeRecipient = vm.envOr("PROTOCOL_FEE_RECIPIENT", config.challenger);
+        config.challengeFee = vm.envOr("CHALLENGE_FEE", DEFAULT_CHALLENGE_FEE);
         config.disputeGameFactory = IDisputeGameFactory(vm.envAddress("DISPUTE_GAME_FACTORY"));
         config.anchorStateRegistry = IAnchorStateRegistry(vm.envAddress("ANCHOR_STATE_REGISTRY"));
         config.systemConfig = ISystemConfig(vm.envAddress("SYSTEM_CONFIG"));
@@ -178,7 +181,10 @@ contract DeployProofSystem is Script {
         require(config.systemConfig.l2ChainId() == config.l2ChainId, "DeployProofSystem: L2 chain ID mismatch");
         require(config.dgfOwnerKey != 0, "DeployProofSystem: DGF owner key required");
         require(config.proxyAdminOwnerKey != 0, "DeployProofSystem: ProxyAdmin owner key required");
-        require(config.proofTimeoutRecipient != address(0), "DeployProofSystem: proof timeout recipient required");
+        require(config.protocolFeeRecipient != address(0), "DeployProofSystem: protocol fee recipient required");
+        require(config.challengeFee > 0, "DeployProofSystem: challenge fee required");
+        require(config.challengeFee <= CHALLENGER_BOND, "DeployProofSystem: challenge fee exceeds bond");
+        require(config.challengeFee < PROPOSER_BOND, "DeployProofSystem: proposer bond must exceed challenge fee");
         if (config.setRespectedGameType) {
             require(config.guardianKey != 0, "DeployProofSystem: guardian key required for cutover");
         }
@@ -200,7 +206,8 @@ contract DeployProofSystem is Script {
             proofPeriod: PROOF_PERIOD,
             proposerBond: PROPOSER_BOND,
             challengerBond: CHALLENGER_BOND,
-            proofTimeoutRecipient: config.proofTimeoutRecipient,
+            protocolFeeRecipient: config.protocolFeeRecipient,
+            challengeFee: config.challengeFee,
             proofThreshold: config.proofThreshold,
             validityProofVerifier: IWorldChainProofVerifier(address(deployment.validityVerifier)),
             teeVerifier: IWorldChainProofVerifier(address(deployment.teeVerifier)),
@@ -225,7 +232,7 @@ contract DeployProofSystem is Script {
         vm.serializeAddress(root, "teeVerifier", address(deployment.teeVerifier));
         vm.serializeAddress(root, "securityCouncil", address(deployment.councilVerifier));
         vm.serializeAddress(root, "stakingRegistry", address(deployment.staking));
-        vm.serializeAddress(root, "proofTimeoutRecipient", config.proofTimeoutRecipient);
+        vm.serializeAddress(root, "protocolFeeRecipient", config.protocolFeeRecipient);
         vm.serializeAddress(root, "gameImplementation", address(deployment.gameImpl));
         vm.serializeAddress(root, "delayedWeth", address(deployment.weth));
         vm.serializeAddress(root, "delayedWethProxyAdmin", address(deployment.wethProxyAdmin));
@@ -234,6 +241,7 @@ contract DeployProofSystem is Script {
         vm.serializeUint(root, "l2ChainId", config.l2ChainId);
         vm.serializeUint(root, "proofSystemVersion", 1);
         vm.serializeUint(root, "blockInterval", config.blockInterval);
+        vm.serializeUint(root, "challengeFee", config.challengeFee);
         string memory json = vm.serializeUint(root, "proofThreshold", config.proofThreshold);
         vm.writeJson(json, out);
     }

--- a/pkg/contracts/src/proofs/MultiProofGame.sol
+++ b/pkg/contracts/src/proofs/MultiProofGame.sol
@@ -70,7 +70,8 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
     uint64 public immutable proofPeriod;
     uint256 public immutable proposerBond;
     uint256 public immutable challengerBond;
-    address public immutable proofTimeoutRecipient;
+    address public immutable protocolFeeRecipient;
+    uint256 public immutable challengeFee;
 
     IWorldChainProofVerifier public immutable validityProofVerifier;
     IWorldChainProofVerifier public immutable teeVerifier;
@@ -117,10 +118,12 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
             config.challengePeriod == 0 || config.proofPeriod <= config.challengePeriod || config.domain.chainId == 0
                 || config.domain.proofSystemVersion == 0 || config.domain.blockInterval == 0
                 || config.proofThreshold == 0 || config.proofThreshold > ProofLib.PROOF_LANE_COUNT
-                || config.proofTimeoutRecipient == address(0) || address(config.disputeGameFactory) == address(0)
-                || address(config.anchorStateRegistry) == address(0) || address(config.weth) == address(0)
-                || address(config.stakingRegistry) == address(0) || address(config.validityProofVerifier) == address(0)
-                || address(config.teeVerifier) == address(0) || address(config.securityCouncil) == address(0)
+                || config.protocolFeeRecipient == address(0) || address(config.disputeGameFactory) == address(0)
+                || config.challengeFee == 0 || config.challengeFee > config.challengerBond
+                || config.challengeFee >= config.proposerBond || address(config.anchorStateRegistry) == address(0)
+                || address(config.weth) == address(0) || address(config.stakingRegistry) == address(0)
+                || address(config.validityProofVerifier) == address(0) || address(config.teeVerifier) == address(0)
+                || address(config.securityCouncil) == address(0)
         ) {
             revert InvalidActivationParameters();
         }
@@ -141,7 +144,8 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
         proofPeriod = config.proofPeriod;
         proposerBond = config.proposerBond;
         challengerBond = config.challengerBond;
-        proofTimeoutRecipient = config.proofTimeoutRecipient;
+        protocolFeeRecipient = config.protocolFeeRecipient;
+        challengeFee = config.challengeFee;
         PROOF_THRESHOLD = config.proofThreshold;
         validityProofVerifier = config.validityProofVerifier;
         teeVerifier = config.teeVerifier;
@@ -416,11 +420,14 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
         challenger = payable(msg.sender);
         challengedAt = uint64(block.timestamp);
 
-        // Custody the challenger bond in DelayedWETH and track the refund-mode credit.
-        refundModeCredit[msg.sender] += msg.value;
+        // The fee is credited in both settlement modes so no later outcome can recycle it.
+        normalModeCredit[protocolFeeRecipient] += challengeFee;
+        refundModeCredit[protocolFeeRecipient] += challengeFee;
+        refundModeCredit[msg.sender] += msg.value - challengeFee;
         totalBonds += msg.value;
         weth.deposit{value: msg.value}();
 
+        emit ChallengeFeeCharged(protocolFeeRecipient, challengeFee);
         emit Challenged(msg.sender, proofDeadline);
     }
 
@@ -509,37 +516,37 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
 
         if (parentBlacklisted || parentStatus == GameStatus.CHALLENGER_WINS) {
             // An invalid parent invalidates this game regardless of its own proof state. Unlike
-            // ZKDisputeGame (which awards the challenger), both bonds are refunded: neither
-            // party is at fault for an ancestor's failure.
+            // ZKDisputeGame (which awards the challenger), participant funds are refunded
+            // because neither party caused the ancestor failure; the protocol fee remains charged.
             status = GameStatus.CHALLENGER_WINS;
             invalidationReason = ProofLib.InvalidationReason.INVALID_PARENT;
             normalModeCredit[gameCreator()] += proposerBond;
-            if (challenger != address(0)) normalModeCredit[challenger] += challengerBond;
+            if (challenger != address(0)) normalModeCredit[challenger] += challengerBond - challengeFee;
         } else if (parentStatus == GameStatus.IN_PROGRESS) {
             // A proposed or challenged parent must resolve before its descendant.
             revert ParentGameNotResolved();
         } else if (ProofLib.hasThreshold(proofBitmap, PROOF_THRESHOLD)) {
             // Threshold support provides fast finality whether or not the game was challenged.
             status = GameStatus.DEFENDER_WINS;
-            normalModeCredit[gameCreator()] = totalBonds;
+            normalModeCredit[gameCreator()] += _distributableBonds();
         } else if (challenger == address(0) && proofBitmap != 0) {
             // Any configured proof lane may support the optimistic path. The offchain defender
             // uses TEE attestations by policy, but the protocol does not privilege a lane.
             if (block.timestamp < challengeDeadline) revert GameNotOver();
             status = GameStatus.DEFENDER_WINS;
-            normalModeCredit[gameCreator()] = totalBonds;
+            normalModeCredit[gameCreator()] += totalBonds;
         } else if (challenger == address(0)) {
             // A proofless proposal cannot win merely because nobody challenged it.
             if (block.timestamp < challengeDeadline) revert GameNotOver();
             status = GameStatus.CHALLENGER_WINS;
             invalidationReason = ProofLib.InvalidationReason.PROOF_TIMEOUT;
-            normalModeCredit[proofTimeoutRecipient] = totalBonds;
+            normalModeCredit[protocolFeeRecipient] += totalBonds;
         } else if (block.timestamp >= proofDeadline) {
             // A challenged game below threshold times out once its proof window expires. The
             // challenger takes the proposer bond.
             status = GameStatus.CHALLENGER_WINS;
             invalidationReason = ProofLib.InvalidationReason.PROOF_TIMEOUT;
-            normalModeCredit[challenger] = totalBonds;
+            normalModeCredit[challenger] += _distributableBonds();
         } else {
             revert GameNotOver();
         }
@@ -548,6 +555,10 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
         emit Resolved(status);
 
         return status;
+    }
+
+    function _distributableBonds() internal view returns (uint256) {
+        return challenger == address(0) ? totalBonds : totalBonds - challengeFee;
     }
 
     /// @notice Returns the parent's resolution inputs.

--- a/pkg/contracts/src/proofs/interfaces/IMultiProofGame.sol
+++ b/pkg/contracts/src/proofs/interfaces/IMultiProofGame.sol
@@ -28,7 +28,8 @@ interface IMultiProofGame is IDisputeGame {
         uint64 proofPeriod;
         uint256 proposerBond;
         uint256 challengerBond;
-        address proofTimeoutRecipient;
+        address protocolFeeRecipient;
+        uint256 challengeFee;
         uint8 proofThreshold;
         IWorldChainProofVerifier validityProofVerifier;
         IWorldChainProofVerifier teeVerifier;
@@ -77,6 +78,9 @@ interface IMultiProofGame is IDisputeGame {
     /// @notice Emitted when a staked challenger disputes the proposal.
     event Challenged(address indexed challenger, uint64 proofDeadline);
 
+    /// @notice Emitted when a challenge assigns its non-refundable fee to the protocol.
+    event ChallengeFeeCharged(address indexed recipient, uint256 amount);
+
     /// @notice Emitted when a proof lane is accepted for the first time.
     event ProofLaneSupported(ProofLib.ProofLane indexed lane, bytes32 indexed rootId, uint8 proofBitmap);
 
@@ -119,8 +123,11 @@ interface IMultiProofGame is IDisputeGame {
     /// @notice Bond required to challenge a proposal.
     function challengerBond() external view returns (uint256);
 
-    /// @notice Recipient of the proposer bond when an unchallenged game expires without proof.
-    function proofTimeoutRecipient() external view returns (address);
+    /// @notice Protocol-controlled recipient of proof-timeout forfeitures and challenge fees.
+    function protocolFeeRecipient() external view returns (address);
+
+    /// @notice Non-refundable portion of the challenger bond charged whenever a game is challenged.
+    function challengeFee() external view returns (uint256);
 
     /// @notice Verifier backing the validity-proof lane.
     function validityProofVerifier() external view returns (IWorldChainProofVerifier);

--- a/pkg/contracts/test/MultiProofGame.t.sol
+++ b/pkg/contracts/test/MultiProofGame.t.sol
@@ -159,7 +159,22 @@ contract MultiProofGameTest is OPStackFixtures {
         new MultiProofGame(config);
 
         config = _gameConfig();
-        config.proofTimeoutRecipient = address(0);
+        config.protocolFeeRecipient = address(0);
+        vm.expectRevert(IMultiProofGame.InvalidActivationParameters.selector);
+        new MultiProofGame(config);
+
+        config = _gameConfig();
+        config.challengeFee = 0;
+        vm.expectRevert(IMultiProofGame.InvalidActivationParameters.selector);
+        new MultiProofGame(config);
+
+        config = _gameConfig();
+        config.challengeFee = CHALLENGER_BOND + 1;
+        vm.expectRevert(IMultiProofGame.InvalidActivationParameters.selector);
+        new MultiProofGame(config);
+
+        config = _gameConfig();
+        config.proposerBond = CHALLENGE_FEE;
         vm.expectRevert(IMultiProofGame.InvalidActivationParameters.selector);
         new MultiProofGame(config);
 
@@ -220,14 +235,14 @@ contract MultiProofGameTest is OPStackFixtures {
         first.resolve();
         assertEq(uint8(first.status()), uint8(GameStatus.CHALLENGER_WINS));
         assertEq(uint8(first.invalidationReason()), uint8(ProofLib.InvalidationReason.PROOF_TIMEOUT));
-        assertEq(first.credit(proofTimeoutRecipient), PROPOSER_BOND);
+        assertEq(first.credit(protocolFeeRecipient), PROPOSER_BOND);
 
         _passAirgap(first);
-        uint256 timeoutRecipientBalance = proofTimeoutRecipient.balance;
-        first.claimCredit(proofTimeoutRecipient);
+        uint256 timeoutRecipientBalance = protocolFeeRecipient.balance;
+        first.claimCredit(protocolFeeRecipient);
         vm.warp(block.timestamp + WETH_DELAY_SECONDS);
-        first.claimCredit(proofTimeoutRecipient);
-        assertEq(proofTimeoutRecipient.balance, timeoutRecipientBalance + PROPOSER_BOND);
+        first.claimCredit(protocolFeeRecipient);
+        assertEq(protocolFeeRecipient.balance, timeoutRecipientBalance + PROPOSER_BOND);
 
         MultiProofGame retry =
             _propose(type(uint256).max, Claim.unwrap(first.rootClaim()), first.l2SequenceNumber(), first.attempt() + 1);
@@ -291,6 +306,11 @@ contract MultiProofGameTest is OPStackFixtures {
         game.challenge{value: CHALLENGER_BOND - 1}();
 
         _challenge(game);
+        assertEq(game.refundModeCredit(challengerAccount), CHALLENGER_BOND - CHALLENGE_FEE);
+        assertEq(game.refundModeCredit(protocolFeeRecipient), CHALLENGE_FEE);
+        assertEq(game.normalModeCredit(protocolFeeRecipient), CHALLENGE_FEE);
+        assertEq(weth.balanceOf(address(game)), PROPOSER_BOND + CHALLENGER_BOND);
+
         vm.prank(challengerAccount);
         vm.expectRevert(ClaimAlreadyChallenged.selector);
         game.challenge{value: CHALLENGER_BOND}();
@@ -318,7 +338,50 @@ contract MultiProofGameTest is OPStackFixtures {
         game.submitProofLane(1, abi.encodePacked(game.rootId()));
         game.resolve();
         assertEq(uint8(game.status()), uint8(GameStatus.DEFENDER_WINS));
-        assertEq(game.credit(proposer), PROPOSER_BOND + CHALLENGER_BOND);
+        assertEq(game.credit(proposer), PROPOSER_BOND + CHALLENGER_BOND - CHALLENGE_FEE);
+        assertEq(game.credit(protocolFeeRecipient), CHALLENGE_FEE);
+    }
+
+    function test_SelfChallenge_CannotRecycleChallengeFee() public {
+        stakingRegistry.setStaked(proposer, true);
+        MultiProofGame game = _proposeAtAnchor();
+
+        vm.prank(proposer);
+        game.challenge{value: CHALLENGER_BOND}();
+        _submitLanes(game, 2);
+        game.resolve();
+
+        assertEq(game.credit(proposer), PROPOSER_BOND + CHALLENGER_BOND - CHALLENGE_FEE);
+        assertEq(game.credit(protocolFeeRecipient), CHALLENGE_FEE);
+        assertEq(game.credit(proposer) + game.credit(protocolFeeRecipient), game.totalBonds());
+    }
+
+    function test_ProtocolFeeRecipientOverlapWithProposer_PreservesAllCredit() public {
+        IMultiProofGame.GameConfig memory config = _gameConfig();
+        config.protocolFeeRecipient = proposer;
+        MultiProofGame overlappingImpl = new MultiProofGame(config);
+        dgf.setImplementation(WC_GAME_TYPE, IDisputeGame(address(overlappingImpl)), hex"");
+
+        MultiProofGame game = _proposeAtAnchor();
+        _challenge(game);
+        _submitLanes(game, 2);
+        game.resolve();
+
+        assertEq(game.credit(proposer), game.totalBonds());
+    }
+
+    function test_ProtocolFeeRecipientOverlapWithChallenger_PreservesAllCredit() public {
+        IMultiProofGame.GameConfig memory config = _gameConfig();
+        config.protocolFeeRecipient = challengerAccount;
+        MultiProofGame overlappingImpl = new MultiProofGame(config);
+        dgf.setImplementation(WC_GAME_TYPE, IDisputeGame(address(overlappingImpl)), hex"");
+
+        MultiProofGame game = _proposeAtAnchor();
+        _challenge(game);
+        vm.warp(game.proofDeadline());
+        game.resolve();
+
+        assertEq(game.credit(challengerAccount), game.totalBonds());
     }
 
     function test_Challenge_AfterInitialProofStillRequiresThreshold() public {
@@ -365,7 +428,8 @@ contract MultiProofGameTest is OPStackFixtures {
 
         assertEq(uint8(first.status()), uint8(GameStatus.CHALLENGER_WINS));
         assertEq(uint8(first.invalidationReason()), uint8(ProofLib.InvalidationReason.PROOF_TIMEOUT));
-        assertEq(first.credit(challengerAccount), PROPOSER_BOND + CHALLENGER_BOND);
+        assertEq(first.credit(challengerAccount), PROPOSER_BOND + CHALLENGER_BOND - CHALLENGE_FEE);
+        assertEq(first.credit(protocolFeeRecipient), CHALLENGE_FEE);
 
         MultiProofGame retry = _propose(type(uint256).max, Claim.unwrap(first.rootClaim()), first.l2SequenceNumber(), 1);
         assertEq(retry.attempt(), 1);
@@ -409,7 +473,8 @@ contract MultiProofGameTest is OPStackFixtures {
         assertEq(uint8(child.status()), uint8(GameStatus.CHALLENGER_WINS));
         assertEq(uint8(child.invalidationReason()), uint8(ProofLib.InvalidationReason.INVALID_PARENT));
         assertEq(child.credit(proposer), PROPOSER_BOND);
-        assertEq(child.credit(challengerAccount), CHALLENGER_BOND);
+        assertEq(child.credit(challengerAccount), CHALLENGER_BOND - CHALLENGE_FEE);
+        assertEq(child.credit(protocolFeeRecipient), CHALLENGE_FEE);
     }
 
     function test_BlacklistedParent_CascadesBeforeParentResolution() public {
@@ -456,7 +521,8 @@ contract MultiProofGameTest is OPStackFixtures {
 
         assertEq(uint8(game.bondDistributionMode()), uint8(BondDistributionMode.REFUND));
         assertEq(game.credit(proposer), PROPOSER_BOND);
-        assertEq(game.credit(challengerAccount), CHALLENGER_BOND);
+        assertEq(game.credit(challengerAccount), CHALLENGER_BOND - CHALLENGE_FEE);
+        assertEq(game.credit(protocolFeeRecipient), CHALLENGE_FEE);
         (, uint256 anchorBlock) = asr.getAnchorRoot();
         assertEq(anchorBlock, STARTING_ANCHOR_BLOCK);
     }
@@ -474,7 +540,8 @@ contract MultiProofGameTest is OPStackFixtures {
 
         assertEq(uint8(game.bondDistributionMode()), uint8(BondDistributionMode.REFUND));
         assertEq(game.credit(proposer), PROPOSER_BOND);
-        assertEq(game.credit(challengerAccount), CHALLENGER_BOND);
+        assertEq(game.credit(challengerAccount), CHALLENGER_BOND - CHALLENGE_FEE);
+        assertEq(game.credit(protocolFeeRecipient), CHALLENGE_FEE);
     }
 
     function test_IDisputeGameSurfaceAndProofDomain() public {

--- a/pkg/contracts/test/proofs/OPStackFixtures.sol
+++ b/pkg/contracts/test/proofs/OPStackFixtures.sol
@@ -33,6 +33,7 @@ abstract contract OPStackFixtures is Test {
     uint64 internal constant PROOF_PERIOD = 7 days;
     uint256 internal constant PROPOSER_BOND = 1 ether;
     uint256 internal constant CHALLENGER_BOND = 0.1 ether;
+    uint256 internal constant CHALLENGE_FEE = 0.01 ether;
     uint8 internal constant PROOF_THRESHOLD = 2;
 
     uint256 internal constant CHAIN_ID = 480;
@@ -46,7 +47,7 @@ abstract contract OPStackFixtures is Test {
     address internal guardian = makeAddr("guardian");
     address internal proposer = makeAddr("proposer");
     address internal challengerAccount = makeAddr("challenger");
-    address internal proofTimeoutRecipient = makeAddr("proof-timeout-recipient");
+    address internal protocolFeeRecipient = makeAddr("protocol-fee-recipient");
 
     MockSystemConfig internal systemConfig;
     IProxyAdmin internal proxyAdmin;
@@ -134,7 +135,8 @@ abstract contract OPStackFixtures is Test {
             proofPeriod: PROOF_PERIOD,
             proposerBond: PROPOSER_BOND,
             challengerBond: CHALLENGER_BOND,
-            proofTimeoutRecipient: proofTimeoutRecipient,
+            protocolFeeRecipient: protocolFeeRecipient,
+            challengeFee: CHALLENGE_FEE,
             proofThreshold: PROOF_THRESHOLD,
             validityProofVerifier: IWorldChainProofVerifier(address(validityVerifier)),
             teeVerifier: IWorldChainProofVerifier(address(teeVerifier)),

--- a/proofs/primitives/src/bindings.rs
+++ b/proofs/primitives/src/bindings.rs
@@ -51,6 +51,7 @@ sol! {
             address gameCreator
         );
         event Challenged(address indexed challenger, uint64 proofDeadline);
+        event ChallengeFeeCharged(address indexed recipient, uint256 amount);
         event ProofLaneSupported(uint8 indexed lane, bytes32 indexed rootId, uint8 proofBitmap);
         event ProofThresholdReached(bytes32 indexed rootId, uint8 proofBitmap);
         event DuplicateProofLane(uint8 indexed lane, bytes32 indexed rootId, uint8 proofBitmap);
@@ -66,7 +67,8 @@ sol! {
         function proofPeriod() external view returns (uint64);
         function proposerBond() external view returns (uint256);
         function challengerBond() external view returns (uint256);
-        function proofTimeoutRecipient() external view returns (address);
+        function protocolFeeRecipient() external view returns (address);
+        function challengeFee() external view returns (uint256);
         function disputeGameFactory() external view returns (address);
         function anchorStateRegistry() external view returns (address);
         function weth() external view returns (address);

--- a/wips/wip-1006.md
+++ b/wips/wip-1006.md
@@ -46,9 +46,10 @@ Activation parameters are set at hardfork activation and held as immutable value
 | --- | --- | --- |
 | `CHALLENGE_PERIOD` | `1 day` | Duration after proposal creation during which a staked participant MAY challenge a root and any party MAY submit the initial proof. Per-proposal `challengeDeadline = createdAt + CHALLENGE_PERIOD`. |
 | `PROOF_PERIOD` | `7 days` | Duration after proposal creation during which the proposer MAY defend a challenged root by accumulating lane submissions toward `PROOF_THRESHOLD`. Per-proposal `proofDeadline = createdAt + PROOF_PERIOD`. `PROOF_PERIOD` MUST be greater than `CHALLENGE_PERIOD`. A challenged root that the proposer has not defended to `PROOF_THRESHOLD` by `proofDeadline` MUST be invalidated. |
-| `PROPOSER_BOND` | TBD | ETH bond supplied to `DisputeGameFactory.create` and held as `DelayedWETH` credit by the game. Paid to the proposer after `DEFENDER_WINS`, to the challenger after a challenged proof timeout, to the configured protocol recipient after an unchallenged proof timeout, or refunded if the registry invalidates the game. |
-| `CHALLENGER_BOND` | TBD | ETH bond supplied by the challenger and held as `DelayedWETH` credit by the game. Paid to the proposer after a successful defense, to the challenger after proof timeout, or refunded if the registry invalidates the game. |
-| `PROOF_TIMEOUT_RECIPIENT` | TBD | Nonzero protocol-controlled recipient credited with the proposer bond when an unchallenged proposal expires without any valid proof lane. |
+| `PROPOSER_BOND` | TBD | ETH bond supplied to `DisputeGameFactory.create` and held as `DelayedWETH` credit by the game. Paid to the proposer after `DEFENDER_WINS`, to the challenger after a challenged proof timeout, to the configured protocol recipient after an unchallenged proof timeout, or refunded if the registry invalidates the game. It MUST exceed `CHALLENGE_FEE`, so successfully challenging an invalid root has a positive gross reward before transaction costs. |
+| `CHALLENGER_BOND` | TBD | ETH bond supplied by the challenger and held as `DelayedWETH` credit by the game. The non-refundable `CHALLENGE_FEE` is deducted whenever a challenge is accepted; the remainder is paid to the proposer after a successful defense, to the challenger after proof timeout, or refunded if the registry invalidates the game. |
+| `PROTOCOL_FEE_RECIPIENT` | TBD | Nonzero protocol-controlled recipient credited with the proposer bond when an unchallenged proposal expires without any valid proof lane and with `CHALLENGE_FEE` whenever a challenge is accepted. |
+| `CHALLENGE_FEE` | TBD | Nonzero flat amount deducted from `CHALLENGER_BOND` whenever a challenge is accepted. It MUST NOT exceed `CHALLENGER_BOND` and MUST remain charged under both normal and refund settlement. |
 
 ### Proof Lanes
 
@@ -190,10 +191,11 @@ The challenge transaction:
 - MUST verify that the caller is currently staked according to the configured staking registry.
 - MUST NOT require the caller to submit proof material.
 - MUST require the caller to supply `CHALLENGER_BOND` as ETH and deposit it into the game's `DelayedWETH`;
+- MUST irrevocably assign `CHALLENGE_FEE` of that bond to `PROTOCOL_FEE_RECIPIENT` in both normal and refund settlement modes;
 - MUST mark the root as `CHALLENGED`.
 - MUST record `challengedAt = block.timestamp` on the root the first time it transitions to `CHALLENGED`. The challenge MUST NOT change the `proofDeadline` recorded at proposal creation.
 
-If the challenged root resolves in favor of the proposer, the proposer receives both bonds. If it times out below threshold, the challenger receives both bonds. A game accepts only one challenger.
+If the challenged root resolves in favor of the proposer, the proposer receives the proposer bond plus the challenger bond remainder. If it times out below threshold, the challenger receives the proposer bond plus its challenger bond remainder. The protocol receives `CHALLENGE_FEE` in either case. A game accepts only one challenger.
 
 A challenge submitted at or after `challengeDeadline` MUST revert.
 
@@ -232,11 +234,11 @@ For each lane submission, the contract MUST:
 
 A lane submission at or after its applicable deadline MUST revert. Once threshold is met, anyone MAY call `resolve()`, which MUST resolve the game with `DEFENDER_WINS` whether or not it was challenged.
 
-If `block.timestamp >= proofDeadline` and the proof bitmap contains fewer than `PROOF_THRESHOLD` distinct lanes, anyone MAY call `resolve()`. The game MUST resolve with `CHALLENGER_WINS`, record proof timeout as the invalidation reason, and credit both bonds to the challenger.
+If `block.timestamp >= proofDeadline` and the proof bitmap contains fewer than `PROOF_THRESHOLD` distinct lanes, anyone MAY call `resolve()`. The game MUST resolve with `CHALLENGER_WINS`, record proof timeout as the invalidation reason, and credit the proposer bond plus the challenger bond remainder to the challenger.
 
 ### Invalidity and Conflicts
 
-Invalidation occurs either when a challenged root times out below threshold or when its parent is blacklisted or resolves with `CHALLENGER_WINS`. Parent invalidation MUST cascade before a descendant can resolve successfully. Because neither participant caused an ancestor failure, descendant proposer and challenger bonds MUST be refunded.
+Invalidation occurs either when a challenged root times out below threshold or when its parent is blacklisted or resolves with `CHALLENGER_WINS`. Parent invalidation MUST cascade before a descendant can resolve successfully. Because neither participant caused an ancestor failure, the descendant proposer bond and challenger bond remainder MUST be refunded. The challenge fee remains charged.
 
 An invalidated root MUST NOT become claim-valid or update the anchor.
 
@@ -277,6 +279,8 @@ Resolution assigns normal-mode credits. After the stock dispute-game finality de
 - `REFUND` when the game has been blacklisted, retired, or otherwise made improper.
 
 Closing SHOULD attempt to advance the anchor but MUST treat an ineligible or stale anchor update as non-fatal. Credit claims MUST use the two-phase `DelayedWETH` flow: first unlock the recipient's credit, then withdraw it after the configured delay. Claiming MAY be permissionless, but funds MUST only be transferred to the credited recipient.
+
+For every challenged game, `CHALLENGE_FEE` MUST be credited to `PROTOCOL_FEE_RECIPIENT` in both distribution modes. Blacklisting, retirement, invalid-parent resolution, and any other refund-mode outcome MUST NOT return that fee to the challenger.
 
 ### Portal Withdrawals
 
@@ -334,6 +338,8 @@ Before this WIP can move beyond Draft, implementations SHOULD cover at least:
 - an unstaked account cannot challenge;
 - a staked account can challenge without proof before the deadline;
 - a staked account can challenge after an initial proof, and the game then requires `PROOF_THRESHOLD` lanes;
+- a proposer that challenges its own valid game recovers at most both bonds minus `CHALLENGE_FEE`;
+- normal-mode and refund-mode settlement both credit `CHALLENGE_FEE` to the protocol recipient;
 - a challenge at or after the deadline reverts;
 - a configuration where `proofDeadline <= challengeDeadline` is rejected;
 - a challenged root with one supporting lane does not finalize;
@@ -362,7 +368,9 @@ Before this WIP can move beyond Draft, implementations SHOULD cover at least:
 
 **`gameUUID` is not a proof target.** It exists for factory duplicate prevention and discovery. Proofs and attestations MUST bind to `rootId`, because the factory UUID does not include the L1 origin captured at game creation.
 
-**Bond and stake calibration are security-critical.** If `CHALLENGER_BOND` is too cheap, attackers can grief honest roots into the slow path. If `CHALLENGER_BOND` is too expensive, honest watchers may fail to challenge invalid roots. If `PROPOSER_BOND` is too cheap, invalid-proposal spam is cheap and forces honest watchers to lock capital per challenge; if `PROPOSER_BOND` is too expensive, only well-capitalized actors can propose, which centralizes the role. Exact economic parameters are out of scope for this WIP but MUST be tuned before mainnet deployment.
+**Self-challenge bond recycling creates proof-amplification griefing.** A malicious proposer can create a consensus-valid game and challenge it through the same economic owner. Without a non-refundable charge, the owner recovers the nominal losing bond through the winning account while forcing third-party defenders to produce an additional proof lane. `CHALLENGE_FEE` makes that externalized proof burden carry a linear, unavoidable cost even if proposer and challenger collude. The fee deters but does not cryptographically prevent the attack, so its value MUST be calibrated against the marginal cost of the additional proof.
+
+**Bond, fee, and stake calibration are security-critical.** If `CHALLENGER_BOND` or `CHALLENGE_FEE` is too cheap, attackers can grief honest roots into the slow path or force repeated proof work. If either is too expensive, honest watchers may fail to challenge invalid roots. A successful challenger earns `PROPOSER_BOND - CHALLENGE_FEE` before transaction costs, so `PROPOSER_BOND` MUST exceed the fee and SHOULD cover the challenger's expected execution costs with a meaningful safety margin. If `PROPOSER_BOND` is too cheap, invalid-proposal spam is cheap and honest challenges become uneconomical; if it is too expensive, only well-capitalized actors can propose, which centralizes the role. Exact economic parameters are out of scope for this WIP but MUST be tuned before mainnet deployment.
 
 ## Copyright
 


### PR DESCRIPTION
deter the impact of an attempted self-challenge griefing attack that makes us generate proofs for eveything if a third party proposes and challenges their own games.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes dispute-game bond economics and settlement invariants on the withdrawal-critical proof path; misconfiguration or credit bugs could misallocate custodied ETH.
> 
> **Overview**
> Introduces **`CHALLENGE_FEE`** and renames **`proofTimeoutRecipient`** to **`protocolFeeRecipient`** across `MultiProofGame`, deploy config, Rust bindings, and WIP-1006.
> 
> On **`challenge()`**, the fee is credited to the protocol recipient in **both** normal and refund settlement modes; resolution pays winners from **`totalBonds - challengeFee`** when a challenge occurred, while unchallenged proof-timeout still sends the full proposer bond to the protocol recipient. Constructor and devnet deploy enforce **`0 < challengeFee ≤ challengerBond`** and **`proposerBond > challengeFee`**.
> 
> Docs and tests cover self-challenge griefing, fee retention on invalid-parent/blacklist/refund paths, and overlapping fee recipient with proposer or challenger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dad7d338ea684c62c73b0c28f08afc7f2b82b900. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->