### PR TITLE
fix(challenger): fetch oldest challegable game at startup

### DIFF
--- a/proofs/challenger/src/alloy.rs
+++ b/proofs/challenger/src/alloy.rs
@@ -181,16 +181,6 @@ where
         self.read_game_address(index).await
     }
 
-    async fn game_created_at(&self, index: u64) -> Result<u64, ChallengerError> {
-        self.factory
-            .gameAtIndex(U256::from(index))
-            .block(BlockId::finalized())
-            .call()
-            .await
-            .map(|entry| entry.timestamp)
-            .map_err(|error| ChallengerError::Contract(error.to_string()))
-    }
-
     async fn game_metadata(&self, address: Address) -> Result<GameMetadata, ChallengerError> {
         let game = self.game(address);
         let (root_claim, l2_block_number) = tokio::try_join!(

--- a/proofs/challenger/src/challenger.rs
+++ b/proofs/challenger/src/challenger.rs
@@ -91,7 +91,7 @@ where
     async fn first_recent_game_index(
         &self,
         game_count: u64,
-        cutoff: u64,
+        now: u64,
     ) -> Result<u64, ChallengerError> {
         let mut low = 0;
         let mut high = game_count;
@@ -104,7 +104,7 @@ where
                 continue;
             };
             let deadline = self.execution_provider.challenge_deadline(game).await?;
-            if deadline < cutoff {
+            if deadline < now {
                 low = middle + 1;
             } else {
                 high = middle;
@@ -247,11 +247,10 @@ where
             .next_game_index
             .is_none_or(|next_game_index| next_game_index > game_count);
         if initialize_cursor {
-            let cutoff = now.saturating_sub(self.config.max_game_age.as_secs());
-            let first_recent = self.first_recent_game_index(game_count, cutoff).await?;
+            let first_recent = self.first_recent_game_index(game_count, now).await?;
             info!(
                 first_recent_game_index = first_recent,
-                game_count, cutoff, "initialized challenger game cursor"
+                game_count, now, "initialized challenger game cursor"
             );
             self.next_game_index = Some(first_recent);
         }

--- a/proofs/challenger/src/challenger.rs
+++ b/proofs/challenger/src/challenger.rs
@@ -98,7 +98,13 @@ where
 
         while low < high {
             let middle = low + (high - low) / 2;
-            if self.execution_provider.game_created_at(middle).await? < cutoff {
+            let Some(game) = self.execution_provider.game_address_at(middle).await? else {
+                // the game at this index is not a wip1006 game, which means it's an old game, advance iterator
+                low = middle + 1;
+                continue;
+            };
+            let deadline = self.execution_provider.challenge_deadline(game).await?;
+            if deadline < cutoff {
                 low = middle + 1;
             } else {
                 high = middle;

--- a/proofs/challenger/src/challenger.rs
+++ b/proofs/challenger/src/challenger.rs
@@ -86,8 +86,8 @@ where
     E: ChallengerClient,
     C: ConsensusProvider,
 {
-    /// Binary-searches the factory's monotonic creation timestamps for the first game that
-    /// can still have an open challenge window.
+    /// Binary-searches the factory's monotonic challenge deadline for the oldest game
+    /// that is still challengeable.
     async fn first_recent_game_index(
         &self,
         game_count: u64,

--- a/proofs/challenger/src/config.rs
+++ b/proofs/challenger/src/config.rs
@@ -9,8 +9,6 @@ pub const DEFAULT_L1_TX_CONFIRMATIONS: u64 = 5;
 pub const DEFAULT_MAX_GAMES_PER_TICK: u64 = 100;
 /// Default number of previously scanned games reconsidered per challenger tick.
 pub const DEFAULT_GAME_SCAN_LOOKBACK: u64 = 100;
-/// Default upper bound on the age of a game with an open challenge window.
-pub const DEFAULT_MAX_GAME_AGE: Duration = Duration::from_secs(7 * 24 * 60 * 60);
 /// Default delay between challenger-owned game resolution passes.
 pub const DEFAULT_RESOLUTION_POLL_INTERVAL: Duration = Duration::from_secs(30);
 /// Default maximum number of resolution transactions submitted per pass.
@@ -35,8 +33,6 @@ pub struct ChallengerConfig {
     pub max_games_per_tick: u64,
     /// Number of previously scanned games reconsidered to tolerate mutable-state L1 reorgs.
     pub game_scan_lookback: u64,
-    /// Upper bound on the age of any game whose challenge window can remain open.
-    pub max_game_age: Duration,
 }
 
 impl ChallengerConfig {
@@ -56,11 +52,6 @@ impl ChallengerConfig {
                 "max_games_per_tick must be greater than zero",
             ));
         }
-        if self.max_game_age.is_zero() {
-            return Err(ChallengerError::InvalidConfig(
-                "max_game_age must be greater than zero",
-            ));
-        }
         Ok(())
     }
 }
@@ -72,7 +63,6 @@ impl Default for ChallengerConfig {
             max_game_concurrency: DEFAULT_MAX_GAME_CONCURRENCY,
             max_games_per_tick: DEFAULT_MAX_GAMES_PER_TICK,
             game_scan_lookback: DEFAULT_GAME_SCAN_LOOKBACK,
-            max_game_age: DEFAULT_MAX_GAME_AGE,
         }
     }
 }

--- a/proofs/challenger/src/main.rs
+++ b/proofs/challenger/src/main.rs
@@ -77,10 +77,6 @@ struct Cli {
     )]
     l1_tx_confirmations: u64,
 
-    /// Conservative upper bound on the age of a game with an open challenge window.
-    #[arg(long, env = "MAX_GAME_AGE_SECONDS", default_value_t = 604_800)]
-    max_game_age_seconds: u64,
-
     /// Seconds between challenger-owned game resolution passes.
     #[arg(
         long,
@@ -132,7 +128,6 @@ async fn main() -> Result<()> {
         max_game_concurrency: cli.max_game_concurrency,
         max_games_per_tick: cli.max_games_per_tick,
         game_scan_lookback: cli.game_scan_lookback,
-        max_game_age: Duration::from_secs(cli.max_game_age_seconds),
     };
     let resolution_config = ResolutionManagerConfig {
         poll_interval: Duration::from_secs(cli.resolution_manager_poll_interval_seconds),

--- a/proofs/challenger/src/tests.rs
+++ b/proofs/challenger/src/tests.rs
@@ -363,7 +363,6 @@ fn config() -> ChallengerConfig {
         max_game_concurrency: 10,
         max_games_per_tick: 100,
         game_scan_lookback: 100,
-        max_game_age: Duration::from_secs(7 * 24 * 60 * 60),
     }
 }
 

--- a/proofs/challenger/src/tests.rs
+++ b/proofs/challenger/src/tests.rs
@@ -34,7 +34,6 @@ const REASON_PROOF_TIMEOUT: u8 = 1;
 #[derive(Debug, Clone, Copy)]
 struct MockGame {
     metadata: GameMetadata,
-    created_at: u64,
     state: u8,
     challenge_deadline: u64,
     challenger: Address,
@@ -55,7 +54,6 @@ impl MockGame {
                 root_claim,
                 l2_block_number,
             },
-            created_at: u64::MAX,
             state: STATE_PROPOSED,
             challenge_deadline: u64::MAX,
             challenger: Address::ZERO,
@@ -392,20 +390,20 @@ async fn scan_once_challenges_invalid_root_and_tracks_game() {
 }
 
 #[tokio::test]
-async fn startup_scans_older_live_game_when_deadlines_are_not_monotonic() {
+async fn startup_binary_search_finds_first_live_game_by_deadline() {
     let proposed_root = B256::repeat_byte(0x10);
     let canonical_root = B256::repeat_byte(0x20);
-    let active = MockGame::proposed(GAME_1, proposed_root, L2_BLOCK);
-    let mut expired = MockGame::proposed(GAME_2, proposed_root, L2_BLOCK);
+    let mut expired = MockGame::proposed(GAME_1, proposed_root, L2_BLOCK);
     expired.challenge_deadline = 0;
-    let client = MockClient::new(vec![active, expired]);
+    let active = MockGame::proposed(GAME_2, proposed_root, L2_BLOCK);
+    let client = MockClient::new(vec![expired, active]);
     let (output_roots, _) =
         mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
     let mut challenger = WorldChainChallenger::new(config(), client.clone(), output_roots);
 
     challenger.scan_once().await.unwrap();
 
-    assert_eq!(client.challenges(), vec![GAME_1]);
+    assert_eq!(client.challenges(), vec![GAME_2]);
     assert_eq!(challenger.next_game_index(), Some(2));
 }
 
@@ -414,7 +412,7 @@ async fn startup_binary_search_skips_games_older_than_max_age() {
     let proposed_root = B256::repeat_byte(0x10);
     let canonical_root = B256::repeat_byte(0x20);
     let mut old = MockGame::proposed(GAME_1, proposed_root, L2_BLOCK);
-    old.created_at = 0;
+    old.challenge_deadline = 0;
     let recent = MockGame::proposed(GAME_2, proposed_root, L2_BLOCK);
     let client = MockClient::new(vec![old, recent]);
     let (output_roots, _) =

--- a/proofs/challenger/src/tests.rs
+++ b/proofs/challenger/src/tests.rs
@@ -141,22 +141,6 @@ impl ChallengerClient for MockClient {
             .ok_or_else(|| ChallengerError::Contract(format!("unknown game index {index}")))
     }
 
-    async fn game_created_at(&self, index: u64) -> Result<u64, ChallengerError> {
-        let state = self.state.lock().expect("not poisoned");
-        if state.foreign_indices.contains(&index) {
-            return Ok(u64::MAX);
-        }
-        let address = state
-            .order
-            .get(index as usize)
-            .ok_or_else(|| ChallengerError::Contract(format!("unknown game index {index}")))?;
-        state
-            .games
-            .get(address)
-            .map(|game| game.created_at)
-            .ok_or_else(|| ChallengerError::Contract(format!("unknown game {address}")))
-    }
-
     async fn game_metadata(&self, game: Address) -> Result<GameMetadata, ChallengerError> {
         self.state
             .lock()

--- a/proofs/challenger/src/traits.rs
+++ b/proofs/challenger/src/traits.rs
@@ -17,8 +17,6 @@ pub trait ChallengerClient: Send + Sync {
     /// Returns the WIP-1006 game at the provided factory index, or `None` when that index
     /// holds a game of a different type.
     async fn game_address_at(&self, index: u64) -> Result<Option<Address>, ChallengerError>;
-    /// Returns the creation timestamp of any game at the provided factory index.
-    async fn game_created_at(&self, index: u64) -> Result<u64, ChallengerError>;
     /// Reads the immutable game data needed to validate its root claim.
     async fn game_metadata(&self, game: Address) -> Result<GameMetadata, ChallengerError>;
     /// Reads the root state of the provided game.

--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -500,16 +500,6 @@ impl ChallengerClient for FakeExecution {
             .ok_or_else(|| ChallengerError::Contract(format!("unknown game index {index}")))
     }
 
-    async fn game_created_at(&self, index: u64) -> Result<u64, ChallengerError> {
-        self.state
-            .lock()
-            .expect("fake execution mutex poisoned")
-            .game_order
-            .get(index as usize)
-            .map(|_| u64::MAX)
-            .ok_or_else(|| ChallengerError::Contract(format!("unknown game index {index}")))
-    }
-
     async fn game_metadata(
         &self,
         game: Address,


### PR DESCRIPTION
This PR fixes a small issue on the `world-chain-challenger`. At startup the challenger needs to start scanning games from the oldest games that is still challengeable.

Before it was using the creation timestamp of a game instead of the challenge deadline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which factory games are scanned on cold start—incorrect deadline ordering or foreign-index handling could skip still-challengeable games or over-scan, though behavior aligns with runtime challenge checks.
> 
> **Overview**
> **Startup scan cursor** no longer uses a configurable `max_game_age` window or factory **creation timestamps**. On first init it binary-searches for the first factory index whose WIP-1006 game still has `challenge_deadline >= now`, resolving each candidate’s game address (skipping non–WIP-1006 indices) and reading **on-chain challenge deadlines** instead of `gameAtIndex` timestamps.
> 
> **Config / API cleanup:** `max_game_age`, the `MAX_GAME_AGE_SECONDS` CLI/env knob, and `ChallengerClient::game_created_at` (including the Alloy `gameAtIndex` timestamp read) are removed. Mocks and integration fakes drop the same trait method; unit tests now drive startup behavior with `challenge_deadline` rather than `created_at`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec5fce63a2927442c99aaccef67c1dbd26ca4f73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->