### PR TITLE
chore: Add initial telemetry to proof services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3063,6 +3063,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cadence"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca08f6db9f0c963249cf23a27820f9d973d2acaad4d6bfaeb858b58ebd58a6a"
+dependencies = [
+ "crossbeam-channel",
+]
+
+[[package]]
 name = "camino"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4058,7 +4067,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7553,15 +7562,28 @@ dependencies = [
  "evmap",
  "http-body-util",
  "hyper 1.9.0",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "indexmap 2.14.0",
  "ipnet",
  "metrics",
  "metrics-util",
  "quanta",
+ "rustls 0.23.40",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "metrics-exporter-statsd"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57971e32cdee88619fb6c673fd89cfd37c12f2dd7c187fb400b7aae0ede0ed9e"
+dependencies = [
+ "cadence",
+ "metrics",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -8372,6 +8394,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-datadog"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a6b2d4db32343691eb945e6153e5a4bd494dbf9d931d5bf7d1d7f59bee156d0"
+dependencies = [
+ "ahash",
+ "http 1.4.0",
+ "indexmap 2.14.0",
+ "itoa",
+ "opentelemetry 0.31.0",
+ "opentelemetry-http",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "reqwest 0.12.28",
+ "rmp",
+ "ryu",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
 name = "opentelemetry-http"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8435,6 +8478,8 @@ dependencies = [
  "percent-encoding",
  "rand 0.9.4",
  "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -16215,6 +16260,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "telemetry-batteries"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47bb4a5d51f7c46f394e1853046a9aceec3ba64156a3ac0017ad691b259d98e"
+dependencies = [
+ "backtrace",
+ "bon",
+ "chrono",
+ "dirs",
+ "eyre",
+ "http 1.4.0",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "metrics-exporter-statsd",
+ "opentelemetry 0.31.0",
+ "opentelemetry-datadog",
+ "opentelemetry-http",
+ "opentelemetry_sdk",
+ "pin-project",
+ "rand 0.9.4",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower 0.5.3",
+ "tracing",
+ "tracing-appender",
+ "tracing-opentelemetry",
+ "tracing-opentelemetry-instrumentation-sdk",
+ "tracing-serde 0.1.3",
+ "tracing-subscriber 0.3.23",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16997,6 +17077,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry-instrumentation-sdk"
+version = "0.32.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8f2540011f6d5ac30e1fc9ff169573b4559406498ac27e0242549d9bf527ed1"
+dependencies = [
+ "http 1.4.0",
+ "opentelemetry 0.31.0",
+ "opentelemetry-semantic-conventions",
+ "tracing",
+ "tracing-opentelemetry",
+]
+
+[[package]]
 name = "tracing-samply"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17010,6 +17103,16 @@ dependencies = [
  "smallvec",
  "tracing-core",
  "tracing-subscriber 0.3.23",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
 ]
 
 [[package]]
@@ -17049,7 +17152,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
+ "tracing-serde 0.2.0",
 ]
 
 [[package]]
@@ -18550,10 +18653,10 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "telemetry-batteries",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
  "url",
  "world-chain-proofs",
 ]
@@ -18607,10 +18710,10 @@ dependencies = [
  "clap",
  "dotenvy",
  "futures-util",
+ "telemetry-batteries",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
  "url",
  "world-chain-proof-core",
  "world-chain-proofs",
@@ -18725,9 +18828,9 @@ dependencies = [
  "clap",
  "dotenvy",
  "hex",
+ "telemetry-batteries",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
  "world-chain-chainspec",
  "world-chain-proof-kona-host-utils",
  "world-chain-proof-nitro",
@@ -19056,7 +19159,11 @@ dependencies = [
 name = "world-chain-proof-nitro"
 version = "2.4.0"
 dependencies = [
+ "alloy-contract",
+ "alloy-network 2.0.5",
  "alloy-primitives",
+ "alloy-provider",
+ "alloy-signer-local 2.0.5",
  "alloy-sol-types",
  "anyhow",
  "aws-nitro-enclaves-nsm-api",
@@ -19080,6 +19187,7 @@ dependencies = [
  "tokio-vsock",
  "tracing",
  "tracing-subscriber 0.3.23",
+ "url",
  "world-chain-proof-core",
  "world-chain-proof-kona-client-utils",
  "x509-parser",
@@ -19173,10 +19281,10 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "telemetry-batteries",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
  "url",
  "world-chain-proofs",
 ]
@@ -19226,6 +19334,7 @@ dependencies = [
  "hex",
  "serde_json",
  "tokio",
+ "tracing-subscriber 0.3.23",
  "world-chain-proof-nitro",
  "world-chain-prover",
 ]
@@ -19245,12 +19354,12 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "telemetry-batteries",
  "testcontainers",
  "testcontainers-modules",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
  "uuid",
 ]
 
@@ -19346,12 +19455,12 @@ dependencies = [
  "reqwest 0.12.28",
  "serde_cbor",
  "serde_json",
+ "telemetry-batteries",
  "testcontainers",
  "testcontainers-modules",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
  "world-chain-chainspec",
  "world-chain-proof-core",
  "world-chain-proof-kona-host-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -270,6 +270,7 @@ jsonrpsee-types = "0.26.0"
 # metrics
 metrics = "0.24.6"
 metrics-derive = "0.1"
+telemetry-batteries = "0.3"
 
 tokio = { version = "1.52.3", features = ["full"] }
 tokio-util = "0.7.15"

--- a/proofs/challenger/Cargo.toml
+++ b/proofs/challenger/Cargo.toml
@@ -39,5 +39,5 @@ serde_json.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "time"] }
 tracing.workspace = true
-tracing-subscriber.workspace = true
+telemetry-batteries.workspace = true
 url.workspace = true

--- a/proofs/challenger/src/main.rs
+++ b/proofs/challenger/src/main.rs
@@ -109,9 +109,8 @@ struct Cli {
 #[tokio::main]
 async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
-    tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .init();
+    let _telemetry_guard = telemetry_batteries::init()
+        .map_err(|error| anyhow::anyhow!("failed to initialize telemetry: {error:#}"))?;
 
     let cli = Cli::parse();
 

--- a/proofs/defender/Cargo.toml
+++ b/proofs/defender/Cargo.toml
@@ -36,5 +36,5 @@ dotenvy.workspace = true
 futures-util.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "time"] }
 tracing.workspace = true
-tracing-subscriber.workspace = true
+telemetry-batteries.workspace = true
 url.workspace = true

--- a/proofs/defender/src/main.rs
+++ b/proofs/defender/src/main.rs
@@ -68,9 +68,8 @@ struct Cli {
 #[tokio::main]
 async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
-    tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .init();
+    let _telemetry_guard = telemetry_batteries::init()
+        .map_err(|error| anyhow::anyhow!("failed to initialize telemetry: {error:#}"))?;
 
     let cli = Cli::parse();
 

--- a/proofs/nitro/worker/Cargo.toml
+++ b/proofs/nitro/worker/Cargo.toml
@@ -40,7 +40,7 @@ tokio = { workspace = true, features = ["full", "signal"] }
 anyhow.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
-tracing-subscriber.workspace = true
+telemetry-batteries.workspace = true
 
 # Config
 clap.workspace = true

--- a/proofs/nitro/worker/src/main.rs
+++ b/proofs/nitro/worker/src/main.rs
@@ -5,7 +5,6 @@ mod cmd;
 use clap::{Parser, Subcommand};
 #[cfg(target_os = "linux")]
 use cmd::{get_attestation::GetAttestationArgs, register::RegisterArgs, run::WorkerArgs};
-
 #[cfg(target_os = "linux")]
 #[derive(Parser)]
 #[command(name = "nitro-worker", about = "World Chain Nitro TEE proving worker")]
@@ -35,9 +34,8 @@ fn main() {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
-    tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .init();
+    let _telemetry_guard = telemetry_batteries::init()
+        .map_err(|error| anyhow::anyhow!("failed to initialize telemetry: {error:#}"))?;
 
     match Cli::parse().command {
         Command::Run(args) => cmd::run::run(*args).await?,

--- a/proofs/nitro/worker/src/main.rs
+++ b/proofs/nitro/worker/src/main.rs
@@ -34,11 +34,13 @@ fn main() {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
-    let _telemetry_guard = telemetry_batteries::init()
-        .map_err(|error| anyhow::anyhow!("failed to initialize telemetry: {error:#}"))?;
 
     match Cli::parse().command {
-        Command::Run(args) => cmd::run::run(*args).await?,
+        Command::Run(args) => {
+            let _telemetry_guard = telemetry_batteries::init()
+                .map_err(|error| anyhow::anyhow!("failed to initialize telemetry: {error:#}"))?;
+            cmd::run::run(*args).await?;
+        }
         Command::GetAttestation(args) => cmd::get_attestation::get_attestation(args).await?,
         Command::Register(args) => cmd::register::register(args).await?,
     }

--- a/proofs/proposer/Cargo.toml
+++ b/proofs/proposer/Cargo.toml
@@ -37,5 +37,5 @@ serde_json.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "time"] }
 tracing.workspace = true
-tracing-subscriber.workspace = true
+telemetry-batteries.workspace = true
 url.workspace = true

--- a/proofs/proposer/src/lib.rs
+++ b/proofs/proposer/src/lib.rs
@@ -7,6 +7,7 @@ mod alloy;
 mod bond_manager;
 mod config;
 mod error;
+pub mod metrics;
 mod proposer;
 mod traits;
 mod types;

--- a/proofs/proposer/src/main.rs
+++ b/proofs/proposer/src/main.rs
@@ -70,9 +70,9 @@ struct Cli {
 #[tokio::main]
 async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
-    tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .init();
+    let _telemetry_guard = telemetry_batteries::init()
+        .map_err(|error| anyhow::anyhow!("failed to initialize telemetry: {error:#}"))?;
+    world_chain_proposer::metrics::describe_metrics();
 
     let cli = Cli::parse();
 

--- a/proofs/proposer/src/metrics.rs
+++ b/proofs/proposer/src/metrics.rs
@@ -1,0 +1,20 @@
+//! Metrics definitions and helpers for the World Chain proposer.
+
+use telemetry_batteries::reexports::metrics;
+
+/// Count of proof-system proposals successfully confirmed on L1.
+pub const METRICS_PROPOSALS_SUBMITTED: &str = "proposals.submitted";
+
+/// Registers proposer metric metadata with the active recorder.
+pub fn describe_metrics() {
+    metrics::describe_counter!(
+        METRICS_PROPOSALS_SUBMITTED,
+        metrics::Unit::Count,
+        "Number of World Chain proof-system proposals successfully confirmed on L1."
+    );
+}
+
+/// Records a successfully confirmed proof-system proposal.
+pub fn increment_proposals_submitted() {
+    metrics::counter!(METRICS_PROPOSALS_SUBMITTED).increment(1);
+}

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -214,6 +214,7 @@ where
         };
 
         let submission = self.execution_provider.submit_proposal(&proposal).await?;
+        crate::metrics::increment_proposals_submitted();
         info!(
             tx_hash = ?submission.tx_hash,
             game_address = %submission.game_address,

--- a/proofs/prover-service/Cargo.toml
+++ b/proofs/prover-service/Cargo.toml
@@ -33,7 +33,7 @@ sqlx.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "time"] }
 tracing.workspace = true
-tracing-subscriber.workspace = true
+telemetry-batteries.workspace = true
 uuid.workspace = true
 auto_impl.workspace = true
 

--- a/proofs/prover-service/src/main.rs
+++ b/proofs/prover-service/src/main.rs
@@ -1,5 +1,5 @@
 //! `world-chain-prover-service` binary: hosts the proof-request JSON-RPC queue that sits
-//! between the defender (which requests proofs) and the SP1 workers (which lease and prove
+//! between the defender (which requests proofs) and the proof workers (which lease and prove
 //! them).
 //!
 //! Mirrors the in-process prover-service wired by the devnet harness
@@ -53,9 +53,8 @@ struct Cli {
 #[tokio::main]
 async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
-    tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .init();
+    let _telemetry_guard = telemetry_batteries::init()
+        .map_err(|error| anyhow::anyhow!("failed to initialize telemetry: {error:#}"))?;
 
     let cli = Cli::parse();
 

--- a/proofs/sp1-worker/Cargo.toml
+++ b/proofs/sp1-worker/Cargo.toml
@@ -39,7 +39,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "signal", "time"] }
 tracing.workspace = true
-tracing-subscriber.workspace = true
+telemetry-batteries.workspace = true
 
 [dev-dependencies]
 testcontainers.workspace = true

--- a/proofs/sp1-worker/src/main.rs
+++ b/proofs/sp1-worker/src/main.rs
@@ -173,9 +173,8 @@ struct Cli {
 #[tokio::main(flavor = "multi_thread", worker_threads = 2)]
 async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
-    tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .init();
+    let _telemetry_guard = telemetry_batteries::init()
+        .map_err(|error| anyhow::anyhow!("failed to initialize telemetry: {error:#}"))?;
 
     let cli = Cli::parse();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Observability-only startup changes and a single counter; no change to dispute-game or proving logic beyond when metrics fire.
> 
> **Overview**
> Proof stack binaries (**challenger**, **defender**, **proposer**, **prover-service**, **sp1-worker**, **nitro-worker**) now call **`telemetry_batteries::init()`** instead of hand-rolled **`tracing_subscriber::fmt()`** setup, with a held guard so tracing/metrics exporters stay alive for the process lifetime. Workspace **`telemetry-batteries`** is added (lockfile pulls Prometheus/StatsD/OpenTelemetry/Datadog-related crates transitively).
> 
> The **proposer** is the only service with new business metrics so far: a **`proposals.submitted`** counter is described at startup and incremented after a proposal is successfully submitted on L1. **prover-service** docs now refer to generic proof workers rather than only SP1 workers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e47771470447252b1379576594c856c42c47fc88. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->