### PR TITLE
Fix Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19056,7 +19056,11 @@ dependencies = [
 name = "world-chain-proof-nitro"
 version = "2.4.0"
 dependencies = [
+ "alloy-contract",
+ "alloy-network 2.0.5",
  "alloy-primitives",
+ "alloy-provider",
+ "alloy-signer-local 2.0.5",
  "alloy-sol-types",
  "anyhow",
  "aws-nitro-enclaves-nsm-api",
@@ -19080,6 +19084,7 @@ dependencies = [
  "tokio-vsock",
  "tracing",
  "tracing-subscriber 0.3.23",
+ "url",
  "world-chain-proof-core",
  "world-chain-proof-kona-client-utils",
  "x509-parser",
@@ -19226,6 +19231,7 @@ dependencies = [
  "hex",
  "serde_json",
  "tokio",
+ "tracing-subscriber 0.3.23",
  "world-chain-proof-nitro",
  "world-chain-prover",
 ]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Lockfile-only change; low risk unless the underlying Cargo.toml dependency additions were unintended.
> 
> **Overview**
> Updates **`Cargo.lock`** so it matches declared dependencies for the nitro prover stack—no application source changes in this diff.
> 
> For **`world-chain-proof-nitro`**, the lockfile now records **Alloy** crates (`alloy-contract`, `alloy-network`, `alloy-provider`, `alloy-signer-local`) plus **`url`**, which typically support on-chain RPC/contract interaction from the Nitro proof path.
> 
> For **`world-chain-prover-nitro`**, **`tracing-subscriber`** is added so logging setup in that binary is resolved in CI and reproducible builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 776de6a763164018c9522ed3b46143eb525fc11d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->