### PR TITLE
feat(proofs): verify output roots across clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19258,10 +19258,12 @@ dependencies = [
  "alloy-provider",
  "alloy-sol-types",
  "async-trait",
+ "futures-util",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]

--- a/proofs/challenger/src/main.rs
+++ b/proofs/challenger/src/main.rs
@@ -20,7 +20,7 @@ use world_chain_challenger::{
     DEFAULT_GAME_SCAN_LOOKBACK, DEFAULT_L1_TX_CONFIRMATIONS, OwnedGames, ResolutionManager,
     ResolutionManagerConfig, WorldChainChallenger,
 };
-use world_chain_proofs::OptimismConsensusClient;
+use world_chain_proofs::{OptimismConsensusClient, VerifyingConsensusProvider};
 
 #[derive(Debug, Parser)]
 #[command(
@@ -35,6 +35,10 @@ struct Cli {
     /// op-node rollup RPC URL used to read canonical L2 output roots.
     #[arg(long, env = "OUTPUT_ROOT_RPC_URL")]
     output_root_rpc: String,
+
+    /// Optional verifying op-node rollup RPC URL. Every result must match the primary endpoint.
+    #[arg(long, env = "VERIFYING_OUTPUT_ROOT_RPC_URL")]
+    verifying_output_root_rpc: Option<String>,
 
     /// OP Stack `DisputeGameFactory` address on L1.
     #[arg(long, env = "FACTORY_ADDRESS")]
@@ -121,7 +125,12 @@ async fn main() -> Result<()> {
         cli.anchor_registry_address,
         cli.l1_tx_confirmations,
     );
-    let output_roots = OptimismConsensusClient::new(cli.output_root_rpc.clone());
+    let output_roots = VerifyingConsensusProvider::new(
+        OptimismConsensusClient::new(cli.output_root_rpc.clone()),
+        cli.verifying_output_root_rpc
+            .clone()
+            .map(OptimismConsensusClient::new),
+    );
     let config = ChallengerConfig {
         poll_interval: Duration::from_secs(cli.poll_interval_seconds),
         max_game_concurrency: cli.max_game_concurrency,
@@ -150,6 +159,7 @@ async fn main() -> Result<()> {
     info!(
         l1_rpc_url = %cli.l1_rpc,
         output_root_rpc_url = %cli.output_root_rpc,
+        verifying_output_root_rpc_configured = cli.verifying_output_root_rpc.is_some(),
         dispute_game_factory = %cli.factory_address,
         anchor = %cli.anchor_registry_address,
         challenger = %challenger_address,

--- a/proofs/defender/src/main.rs
+++ b/proofs/defender/src/main.rs
@@ -18,7 +18,7 @@ use url::Url;
 use world_chain_defender::{
     AlloyDefenderClient, DEFAULT_L1_TX_CONFIRMATIONS, DefenderConfig, WorldChainDefender,
 };
-use world_chain_proofs::OptimismConsensusClient;
+use world_chain_proofs::{OptimismConsensusClient, VerifyingConsensusProvider};
 use world_chain_prover_service::RpcProverServiceClient;
 
 #[derive(Debug, Parser)]
@@ -34,6 +34,10 @@ struct Cli {
     /// op-node rollup RPC URL used to read canonical L2 output roots.
     #[arg(long, env = "OUTPUT_ROOT_RPC_URL")]
     output_root_rpc: String,
+
+    /// Optional verifying op-node rollup RPC URL. Every result must match the primary endpoint.
+    #[arg(long, env = "VERIFYING_OUTPUT_ROOT_RPC_URL")]
+    verifying_output_root_rpc: Option<String>,
 
     /// prover-service JSON-RPC URL.
     #[arg(long, env = "PROVER_SERVICE_URL")]
@@ -81,7 +85,12 @@ async fn main() -> Result<()> {
     let client = AlloyDefenderClient::new(provider, cli.factory_address, cli.l1_tx_confirmations)
         .await
         .context("failed to connect defender to the registered proof system")?;
-    let output_roots = OptimismConsensusClient::new(cli.output_root_rpc.clone());
+    let output_roots = VerifyingConsensusProvider::new(
+        OptimismConsensusClient::new(cli.output_root_rpc.clone()),
+        cli.verifying_output_root_rpc
+            .clone()
+            .map(OptimismConsensusClient::new),
+    );
     let proof_requester = RpcProverServiceClient::new(&cli.prover_service_url)
         .with_context(|| format!("failed to connect to {}", cli.prover_service_url))?;
     let config = DefenderConfig {
@@ -93,6 +102,7 @@ async fn main() -> Result<()> {
     info!(
         l1_rpc_url = %cli.l1_rpc,
         output_root_rpc_url = %cli.output_root_rpc,
+        verifying_output_root_rpc_configured = cli.verifying_output_root_rpc.is_some(),
         prover_service = %cli.prover_service_url,
         dispute_game_factory = %cli.factory_address,
         defender = %defender_address,

--- a/proofs/primitives/Cargo.toml
+++ b/proofs/primitives/Cargo.toml
@@ -21,10 +21,14 @@ alloy-sol-types.workspace = true
 
 # misc
 async-trait.workspace = true
+futures-util.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 reqwest = { workspace = true, features = ["json"] }
 thiserror.workspace = true
+
+[dev-dependencies]
+tokio.workspace = true
 
 [features]
 default = []

--- a/proofs/primitives/src/consensus_provider.rs
+++ b/proofs/primitives/src/consensus_provider.rs
@@ -23,6 +23,31 @@ pub enum ConsensusError {
     /// RPC transport or JSON-RPC failure.
     #[error("rpc error: {0}")]
     Rpc(String),
+    /// One endpoint in a verifying pair failed.
+    #[error("{endpoint} consensus endpoint failed: {source}")]
+    Endpoint {
+        endpoint: &'static str,
+        #[source]
+        source: Box<Self>,
+    },
+    /// Primary and verifying endpoints returned different output roots for the same L2 block.
+    #[error(
+        "consensus output root mismatch at L2 block {l2_block_number}: primary {primary}, verifying {verifying}"
+    )]
+    OutputRootMismatch {
+        l2_block_number: u64,
+        primary: B256,
+        verifying: B256,
+    },
+}
+
+impl ConsensusError {
+    fn endpoint(endpoint: &'static str, source: Self) -> Self {
+        Self::Endpoint {
+            endpoint,
+            source: Box::new(source),
+        }
+    }
 }
 
 /// HTTP client for OP consensus clients.
@@ -115,6 +140,59 @@ impl ConsensusProvider for OptimismConsensusClient {
     }
 }
 
+/// Consensus provider that requires two independent providers to return identical results.
+///
+/// When no verifying provider is configured, requests are delegated directly to the primary.
+/// When one is configured, output-root requests run concurrently and any error or disagreement
+/// fails the operation without selecting either result. The primary alone determines the latest
+/// finalized height because independently synchronized clients may advance that moving head at
+/// slightly different times.
+#[derive(Debug, Clone)]
+pub struct VerifyingConsensusProvider<C> {
+    primary: C,
+    verifying: Option<C>,
+}
+
+impl<C> VerifyingConsensusProvider<C> {
+    /// Creates a provider with an optional strict-agreement verifier.
+    pub const fn new(primary: C, verifying: Option<C>) -> Self {
+        Self { primary, verifying }
+    }
+}
+
+#[async_trait]
+impl<C> ConsensusProvider for VerifyingConsensusProvider<C>
+where
+    C: ConsensusProvider,
+{
+    async fn output_root_at_block(&self, l2_block_number: u64) -> Result<B256, ConsensusError> {
+        let Some(verifying) = &self.verifying else {
+            return self.primary.output_root_at_block(l2_block_number).await;
+        };
+
+        let (primary_result, verifying_result) = futures_util::join!(
+            self.primary.output_root_at_block(l2_block_number),
+            verifying.output_root_at_block(l2_block_number),
+        );
+        let primary = primary_result.map_err(|error| ConsensusError::endpoint("primary", error))?;
+        let verifying =
+            verifying_result.map_err(|error| ConsensusError::endpoint("verifying", error))?;
+
+        if primary != verifying {
+            return Err(ConsensusError::OutputRootMismatch {
+                l2_block_number,
+                primary,
+                verifying,
+            });
+        }
+        Ok(primary)
+    }
+
+    async fn latest_l2_finalized_block(&self) -> Result<BlockNumber, ConsensusError> {
+        self.primary.latest_l2_finalized_block().await
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct JsonRpcResponse<T> {
     result: Option<T>,
@@ -141,4 +219,98 @@ struct SyncStatusResponse {
 #[derive(Debug, Deserialize)]
 struct L2BlockRef {
     number: BlockNumber,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Clone)]
+    struct MockConsensusProvider {
+        output_root: Result<B256, &'static str>,
+        finalized_block: Result<BlockNumber, &'static str>,
+    }
+
+    #[async_trait]
+    impl ConsensusProvider for MockConsensusProvider {
+        async fn output_root_at_block(
+            &self,
+            _l2_block_number: u64,
+        ) -> Result<B256, ConsensusError> {
+            self.output_root
+                .map_err(|error| ConsensusError::Rpc(error.into()))
+        }
+
+        async fn latest_l2_finalized_block(&self) -> Result<BlockNumber, ConsensusError> {
+            self.finalized_block
+                .map_err(|error| ConsensusError::Rpc(error.into()))
+        }
+    }
+
+    fn provider(
+        output_root: Result<B256, &'static str>,
+        finalized_block: Result<BlockNumber, &'static str>,
+    ) -> MockConsensusProvider {
+        MockConsensusProvider {
+            output_root,
+            finalized_block,
+        }
+    }
+
+    #[tokio::test]
+    async fn delegates_to_primary_without_verifier() {
+        let root = B256::repeat_byte(0x11);
+        let consensus = VerifyingConsensusProvider::new(provider(Ok(root), Ok(42)), None);
+
+        assert_eq!(consensus.output_root_at_block(10).await.unwrap(), root);
+        assert_eq!(consensus.latest_l2_finalized_block().await.unwrap(), 42);
+    }
+
+    #[tokio::test]
+    async fn accepts_matching_verifying_results() {
+        let root = B256::repeat_byte(0x22);
+        let consensus = VerifyingConsensusProvider::new(
+            provider(Ok(root), Ok(42)),
+            Some(provider(Ok(root), Ok(41))),
+        );
+
+        assert_eq!(consensus.output_root_at_block(10).await.unwrap(), root);
+        assert_eq!(consensus.latest_l2_finalized_block().await.unwrap(), 42);
+    }
+
+    #[tokio::test]
+    async fn rejects_output_root_mismatch() {
+        let primary = B256::repeat_byte(0x11);
+        let verifying = B256::repeat_byte(0x22);
+        let consensus = VerifyingConsensusProvider::new(
+            provider(Ok(primary), Ok(42)),
+            Some(provider(Ok(verifying), Ok(42))),
+        );
+
+        assert!(matches!(
+            consensus.output_root_at_block(10).await,
+            Err(ConsensusError::OutputRootMismatch {
+                l2_block_number: 10,
+                primary: actual_primary,
+                verifying: actual_verifying,
+            }) if actual_primary == primary && actual_verifying == verifying
+        ));
+    }
+
+    #[tokio::test]
+    async fn fails_when_verifying_endpoint_fails() {
+        let root = B256::repeat_byte(0x11);
+        let consensus = VerifyingConsensusProvider::new(
+            provider(Ok(root), Ok(42)),
+            Some(provider(Err("unavailable"), Ok(42))),
+        );
+
+        assert!(matches!(
+            consensus.output_root_at_block(10).await,
+            Err(ConsensusError::Endpoint {
+                endpoint: "verifying",
+                ..
+            })
+        ));
+    }
 }

--- a/proofs/primitives/src/lib.rs
+++ b/proofs/primitives/src/lib.rs
@@ -11,7 +11,9 @@ mod types;
 
 // re-exports
 pub use bindings::{IAnchorStateRegistry, IDelayedWETH, IDisputeGameFactory, IMultiProofGame};
-pub use consensus_provider::{ConsensusError, ConsensusProvider, OptimismConsensusClient};
+pub use consensus_provider::{
+    ConsensusError, ConsensusProvider, OptimismConsensusClient, VerifyingConsensusProvider,
+};
 pub use lineage::{
     LineageAnchor, LineageError, LineageGame, LineageProvider, LineageStop, LineageTransition,
     RegisteredLineageConfig, SelectedLineage, SelectedLineageGame, read_game_for_transition,

--- a/proofs/proposer/src/main.rs
+++ b/proofs/proposer/src/main.rs
@@ -15,7 +15,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use tracing::info;
 use url::Url;
-use world_chain_proofs::OptimismConsensusClient;
+use world_chain_proofs::{OptimismConsensusClient, VerifyingConsensusProvider};
 use world_chain_proposer::{
     AlloyProofSystemClient, BondManager, BondManagerConfig, ProposerConfig, WorldChainProposer,
 };
@@ -33,6 +33,10 @@ struct Cli {
     /// op-node rollup RPC URL used to read canonical L2 output roots.
     #[arg(long, env = "OUTPUT_ROOT_RPC_URL")]
     output_root_rpc: String,
+
+    /// Optional verifying op-node rollup RPC URL. Every result must match the primary endpoint.
+    #[arg(long, env = "VERIFYING_OUTPUT_ROOT_RPC_URL")]
+    verifying_output_root_rpc: Option<String>,
 
     /// OP Stack `DisputeGameFactory` address on L1.
     #[arg(long, env = "FACTORY_ADDRESS")]
@@ -89,7 +93,12 @@ async fn main() -> Result<()> {
         initial_scan_limit: cli.bond_manager_initial_scan_limit,
     };
     let mut bond_manager = BondManager::new(bond_manager_config, contracts.clone());
-    let output_roots = OptimismConsensusClient::new(cli.output_root_rpc.clone());
+    let output_roots = VerifyingConsensusProvider::new(
+        OptimismConsensusClient::new(cli.output_root_rpc.clone()),
+        cli.verifying_output_root_rpc
+            .clone()
+            .map(OptimismConsensusClient::new),
+    );
     let registered = contracts.registered_lineage_config();
     let config = ProposerConfig {
         poll_interval: Duration::from_secs(cli.poll_interval_seconds),
@@ -100,6 +109,7 @@ async fn main() -> Result<()> {
     info!(
         l1_rpc_url = %cli.l1_rpc,
         output_root_rpc_url = %cli.output_root_rpc,
+        verifying_output_root_rpc_configured = cli.verifying_output_root_rpc.is_some(),
         dispute_game_factory = %cli.factory_address,
         anchor = %registered.anchor_registry,
         proposer = %proposer_address,


### PR DESCRIPTION
optional secondary consensus provider to verify root claims at an L2 block number for extra security

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how canonical output roots are sourced for L1 dispute actions; misconfiguration or transient disagreement between RPCs can halt proposing/challenging/defending until resolved, though the feature is opt-in.
> 
> **Overview**
> Adds optional **dual-endpoint verification** for canonical L2 output roots used by the proposer, challenger, and defender. Each binary accepts `VERIFYING_OUTPUT_ROOT_RPC_URL` (optional); when set, `output_root_at_block` is fetched from the primary and verifying op-node RPCs in parallel and the call **fails** on RPC error or root mismatch.
> 
> Introduces `VerifyingConsensusProvider` in `world-chain-proofs`, with new `ConsensusError` variants for per-endpoint failures and `OutputRootMismatch`. **Latest finalized L2 height** still comes from the primary only, so slightly out-of-sync heads between nodes do not block operation. Behavior is unchanged when the verifying URL is omitted (pass-through to `OptimismConsensusClient`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16d2cd7e6a4ac65ac37d5e4e71a5ecb291975d1a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->