### PR TITLE
chore: better errors for world-chain-challenger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18639,12 +18639,14 @@ name = "world-chain-challenger"
 version = "2.4.0"
 dependencies = [
  "alloy-consensus 2.0.5",
+ "alloy-contract",
  "alloy-eips 2.0.5",
  "alloy-network 2.0.5",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types-eth 2.0.5",
  "alloy-signer-local 2.0.5",
+ "alloy-transport",
  "anyhow",
  "async-trait",
  "clap",

--- a/proofs/challenger/Cargo.toml
+++ b/proofs/challenger/Cargo.toml
@@ -26,6 +26,8 @@ alloy-primitives.workspace = true
 alloy-provider = { workspace = true, features = ["reqwest"] }
 alloy-rpc-types-eth.workspace = true
 alloy-signer-local.workspace = true
+alloy-contract.workspace = true
+alloy-transport.workspace = true
 
 # misc
 anyhow.workspace = true

--- a/proofs/challenger/src/alloy.rs
+++ b/proofs/challenger/src/alloy.rs
@@ -68,8 +68,8 @@ where
             .block(BlockId::finalized())
             .call()
             .await
-            .map_err(|error| ChallengerError::Contract(error.to_string()))?;
-        u256_to_u64(count, "gameCount")
+            .map_err(|error| ChallengerError::Contract(error))?;
+        u256_to_u64(count)
     }
 
     /// Resolves the WIP-1006 game at a factory index, skipping other game types.
@@ -80,7 +80,7 @@ where
             .block(BlockId::finalized())
             .call()
             .await
-            .map_err(|error| ChallengerError::Contract(error.to_string()))?;
+            .map_err(|error| ChallengerError::Contract(error))?;
 
         Ok((entry.gameType == MULTI_PROOF_GAME_TYPE).then_some(entry.proxy))
     }
@@ -94,17 +94,17 @@ where
             .resolutionStatus()
             .call()
             .await
-            .map_err(|error| ChallengerError::Contract(error.to_string()))?;
+            .map_err(|error| ChallengerError::Contract(error))?;
         let root_state = result
             .outcome
             .try_into()
-            .map_err(|error: RootStateError| ChallengerError::Contract(error.to_string()))?;
+            .map_err(|error: RootStateError| ChallengerError::InvalidRootState(error))?;
         let invalidation_reason =
             result
                 .reason
                 .try_into()
                 .map_err(|error: InvalidationReasonError| {
-                    ChallengerError::Contract(error.to_string())
+                    ChallengerError::NotExistingInvalidReason(error)
                 })?;
 
         Ok(ResolutionStatus {
@@ -123,7 +123,7 @@ where
             .credit(recipient)
             .call()
             .await
-            .map_err(|error| ChallengerError::Contract(error.to_string()))
+            .map_err(|error| ChallengerError::Contract(error))
     }
 
     async fn read_pending_withdrawal(
@@ -136,7 +136,7 @@ where
             .weth()
             .call()
             .await
-            .map_err(|error| ChallengerError::Contract(error.to_string()))?;
+            .map_err(|error| ChallengerError::Contract(error))?;
         let weth = IDelayedWETH::IDelayedWETHInstance::new(weth_address, self.provider.clone());
 
         let (pending, delay) = tokio::try_join!(
@@ -144,26 +144,27 @@ where
                 weth.withdrawals(address, recipient)
                     .call()
                     .await
-                    .map_err(|error| ChallengerError::Contract(error.to_string()))
+                    .map_err(|error| ChallengerError::Contract(error))
             },
             async {
                 weth.delay()
                     .call()
                     .await
-                    .map_err(|error| ChallengerError::Contract(error.to_string()))
+                    .map_err(|error| ChallengerError::Contract(error))
             }
         )?;
 
         if pending.amount.is_zero() {
             return Ok(PendingWithdrawal::default());
         }
-        let unlock_at = pending.timestamp.checked_add(delay).ok_or_else(|| {
-            ChallengerError::Contract("DelayedWETH unlock time overflows".to_string())
-        })?;
+        let unlock_at = pending
+            .timestamp
+            .checked_add(delay)
+            .ok_or_else(|| ChallengerError::Overflow)?;
 
         Ok(PendingWithdrawal {
             amount: pending.amount,
-            unlock_at: u256_to_u64(unlock_at, "DelayedWETH unlock time")?,
+            unlock_at: u256_to_u64(unlock_at)?,
         })
     }
 }
@@ -188,20 +189,20 @@ where
                 game.rootClaim()
                     .call()
                     .await
-                    .map_err(|error| ChallengerError::Contract(error.to_string()))
+                    .map_err(|error| ChallengerError::Contract(error))
             },
             async {
                 game.l2BlockNumber()
                     .call()
                     .await
-                    .map_err(|error| ChallengerError::Contract(error.to_string()))
+                    .map_err(|error| ChallengerError::Contract(error))
             }
         )?;
 
         Ok(GameMetadata {
             address,
             root_claim,
-            l2_block_number: u256_to_u64(l2_block_number, "l2BlockNumber")?,
+            l2_block_number: u256_to_u64(l2_block_number)?,
         })
     }
 
@@ -211,7 +212,7 @@ where
             .state()
             .call()
             .await
-            .map_err(|error| ChallengerError::Contract(error.to_string()))?;
+            .map_err(|error| ChallengerError::Contract(error))?;
         raw.try_into().map_err(Into::into)
     }
 
@@ -220,7 +221,7 @@ where
             .challengeDeadline()
             .call()
             .await
-            .map_err(|error| ChallengerError::Contract(error.to_string()))
+            .map_err(|error| ChallengerError::Contract(error))
     }
 
     async fn submit_challenge(
@@ -235,20 +236,20 @@ where
             .challengerBond()
             .call()
             .await
-            .map_err(|error| ChallengerError::Contract(error.to_string()))?;
+            .map_err(|error| ChallengerError::Contract(error))?;
 
         let pending = game
             .challenge()
             .value(challenger_bond)
             .send()
             .await
-            .map_err(|error| ChallengerError::Contract(error.to_string()))?;
+            .map_err(|error| ChallengerError::Contract(error))?;
         let tx_hash = *pending.tx_hash();
         let receipt = pending
             .with_required_confirmations(self.confirmations)
             .get_receipt()
             .await
-            .map_err(|error| ChallengerError::Contract(error.to_string()))?;
+            .map_err(|error| ChallengerError::PendingTransaction(error))?;
         if !receipt.status() {
             return Err(ChallengerError::Revert(tx_hash));
         }
@@ -274,13 +275,13 @@ where
             .resolve()
             .send()
             .await
-            .map_err(|error| ChallengerError::Contract(error.to_string()))?;
+            .map_err(|error| ChallengerError::Contract(error))?;
         let tx_hash = *pending.tx_hash();
         let receipt = pending
             .with_required_confirmations(self.confirmations)
             .get_receipt()
             .await
-            .map_err(|error| ChallengerError::Contract(error.to_string()))?;
+            .map_err(|error| ChallengerError::PendingTransaction(error))?;
         if !receipt.status() {
             return Err(ChallengerError::Revert(tx_hash));
         }
@@ -310,7 +311,7 @@ where
             .challenger()
             .call()
             .await
-            .map_err(|error| ChallengerError::Contract(error.to_string()))
+            .map_err(|error| ChallengerError::Contract(error))
     }
 
     async fn is_game_finalized(&self, address: Address) -> Result<bool, ChallengerError> {
@@ -318,7 +319,7 @@ where
             .isGameFinalized(address)
             .call()
             .await
-            .map_err(|error| ChallengerError::Contract(error.to_string()))
+            .map_err(|error| ChallengerError::Contract(error))
     }
 
     async fn credit(&self, address: Address) -> Result<U256, ChallengerError> {
@@ -337,9 +338,9 @@ where
         self.provider
             .get_block_by_number(BlockNumberOrTag::Latest)
             .await
-            .map_err(|error| ChallengerError::Contract(error.to_string()))?
+            .map_err(|error| ChallengerError::AlloyJsonRpc(error))?
             .map(|block| block.header.timestamp())
-            .ok_or_else(|| ChallengerError::Contract("latest L1 block is unavailable".into()))
+            .ok_or_else(|| ChallengerError::UnavailableLatestL1Block)
     }
 
     async fn claim_credit(&self, address: Address) -> Result<ClaimSubmission, ChallengerError> {
@@ -358,13 +359,13 @@ where
             .claimCredit(recipient)
             .send()
             .await
-            .map_err(|error| ChallengerError::Contract(error.to_string()))?;
+            .map_err(|error| ChallengerError::Contract(error))?;
         let tx_hash = *pending_tx.tx_hash();
         let receipt = pending_tx
             .with_required_confirmations(self.confirmations)
             .get_receipt()
             .await
-            .map_err(|error| ChallengerError::Contract(error.to_string()))?;
+            .map_err(|error| ChallengerError::PendingTransaction(error))?;
         if !receipt.status() {
             return Err(ChallengerError::Revert(tx_hash));
         }
@@ -385,8 +386,6 @@ where
     }
 }
 
-fn u256_to_u64(value: U256, field: &'static str) -> Result<u64, ChallengerError> {
-    value
-        .try_into()
-        .map_err(|_| ChallengerError::Contract(format!("{field} overflows u64")))
+fn u256_to_u64(value: U256) -> Result<u64, ChallengerError> {
+    value.try_into().map_err(|_| ChallengerError::Overflow)
 }

--- a/proofs/challenger/src/alloy.rs
+++ b/proofs/challenger/src/alloy.rs
@@ -13,7 +13,7 @@ use alloy_rpc_types_eth::BlockId;
 use async_trait::async_trait;
 use world_chain_proofs::{
     IAnchorStateRegistry, IDelayedWETH, IDisputeGameFactory, IMultiProofGame,
-    InvalidationReasonError, MULTI_PROOF_GAME_TYPE, ResolutionStatus, RootState, RootStateError,
+    MULTI_PROOF_GAME_TYPE, ResolutionStatus, RootState,
 };
 
 /// Alloy-backed implementation of the challenger contract clients.
@@ -67,8 +67,7 @@ where
             .gameCount()
             .block(BlockId::finalized())
             .call()
-            .await
-            .map_err(|error| ChallengerError::Contract(error))?;
+            .await?;
         u256_to_u64(count)
     }
 
@@ -79,8 +78,7 @@ where
             .gameAtIndex(U256::from(index))
             .block(BlockId::finalized())
             .call()
-            .await
-            .map_err(|error| ChallengerError::Contract(error))?;
+            .await?;
 
         Ok((entry.gameType == MULTI_PROOF_GAME_TYPE).then_some(entry.proxy))
     }
@@ -89,28 +87,11 @@ where
         &self,
         address: Address,
     ) -> Result<ResolutionStatus, ChallengerError> {
-        let result = self
-            .game(address)
-            .resolutionStatus()
-            .call()
-            .await
-            .map_err(|error| ChallengerError::Contract(error))?;
-        let root_state = result
-            .outcome
-            .try_into()
-            .map_err(|error: RootStateError| ChallengerError::InvalidRootState(error))?;
-        let invalidation_reason =
-            result
-                .reason
-                .try_into()
-                .map_err(|error: InvalidationReasonError| {
-                    ChallengerError::NotExistingInvalidReason(error)
-                })?;
-
+        let result = self.game(address).resolutionStatus().call().await?;
         Ok(ResolutionStatus {
             resolvable: result.resolvable,
-            root_state,
-            invalidation_reason,
+            root_state: result.outcome.try_into()?,
+            invalidation_reason: result.reason.try_into()?,
         })
     }
 
@@ -119,11 +100,7 @@ where
         address: Address,
         recipient: Address,
     ) -> Result<U256, ChallengerError> {
-        self.game(address)
-            .credit(recipient)
-            .call()
-            .await
-            .map_err(|error| ChallengerError::Contract(error))
+        Ok(self.game(address).credit(recipient).call().await?)
     }
 
     async fn read_pending_withdrawal(
@@ -131,27 +108,12 @@ where
         address: Address,
         recipient: Address,
     ) -> Result<PendingWithdrawal, ChallengerError> {
-        let weth_address = self
-            .game(address)
-            .weth()
-            .call()
-            .await
-            .map_err(|error| ChallengerError::Contract(error))?;
+        let weth_address = self.game(address).weth().call().await?;
         let weth = IDelayedWETH::IDelayedWETHInstance::new(weth_address, self.provider.clone());
 
         let (pending, delay) = tokio::try_join!(
-            async {
-                weth.withdrawals(address, recipient)
-                    .call()
-                    .await
-                    .map_err(|error| ChallengerError::Contract(error))
-            },
-            async {
-                weth.delay()
-                    .call()
-                    .await
-                    .map_err(|error| ChallengerError::Contract(error))
-            }
+            async { weth.withdrawals(address, recipient).call().await },
+            async { weth.delay().call().await },
         )?;
 
         if pending.amount.is_zero() {
@@ -160,7 +122,7 @@ where
         let unlock_at = pending
             .timestamp
             .checked_add(delay)
-            .ok_or_else(|| ChallengerError::Overflow)?;
+            .ok_or(ChallengerError::Overflow)?;
 
         Ok(PendingWithdrawal {
             amount: pending.amount,
@@ -184,20 +146,10 @@ where
 
     async fn game_metadata(&self, address: Address) -> Result<GameMetadata, ChallengerError> {
         let game = self.game(address);
-        let (root_claim, l2_block_number) = tokio::try_join!(
-            async {
-                game.rootClaim()
-                    .call()
-                    .await
-                    .map_err(|error| ChallengerError::Contract(error))
-            },
-            async {
-                game.l2BlockNumber()
-                    .call()
-                    .await
-                    .map_err(|error| ChallengerError::Contract(error))
-            }
-        )?;
+        let (root_claim, l2_block_number) =
+            tokio::try_join!(async { game.rootClaim().call().await }, async {
+                game.l2BlockNumber().call().await
+            },)?;
 
         Ok(GameMetadata {
             address,
@@ -207,21 +159,12 @@ where
     }
 
     async fn root_state(&self, address: Address) -> Result<RootState, ChallengerError> {
-        let raw = self
-            .game(address)
-            .state()
-            .call()
-            .await
-            .map_err(|error| ChallengerError::Contract(error))?;
+        let raw = self.game(address).state().call().await?;
         raw.try_into().map_err(Into::into)
     }
 
     async fn challenge_deadline(&self, address: Address) -> Result<u64, ChallengerError> {
-        self.game(address)
-            .challengeDeadline()
-            .call()
-            .await
-            .map_err(|error| ChallengerError::Contract(error))
+        Ok(self.game(address).challengeDeadline().call().await?)
     }
 
     async fn submit_challenge(
@@ -232,24 +175,14 @@ where
         // it is read per game: a re-registered implementation would otherwise make every
         // challenge revert with `IncorrectBondAmount`.
         let game = self.game(address);
-        let challenger_bond = game
-            .challengerBond()
-            .call()
-            .await
-            .map_err(|error| ChallengerError::Contract(error))?;
+        let challenger_bond = game.challengerBond().call().await?;
 
-        let pending = game
-            .challenge()
-            .value(challenger_bond)
-            .send()
-            .await
-            .map_err(|error| ChallengerError::Contract(error))?;
+        let pending = game.challenge().value(challenger_bond).send().await?;
         let tx_hash = *pending.tx_hash();
         let receipt = pending
             .with_required_confirmations(self.confirmations)
             .get_receipt()
-            .await
-            .map_err(|error| ChallengerError::PendingTransaction(error))?;
+            .await?;
         if !receipt.status() {
             return Err(ChallengerError::Revert(tx_hash));
         }
@@ -270,18 +203,12 @@ where
     }
 
     async fn resolve(&self, address: Address) -> Result<ResolveSubmission, ChallengerError> {
-        let pending = self
-            .game(address)
-            .resolve()
-            .send()
-            .await
-            .map_err(|error| ChallengerError::Contract(error))?;
+        let pending = self.game(address).resolve().send().await?;
         let tx_hash = *pending.tx_hash();
         let receipt = pending
             .with_required_confirmations(self.confirmations)
             .get_receipt()
-            .await
-            .map_err(|error| ChallengerError::PendingTransaction(error))?;
+            .await?;
         if !receipt.status() {
             return Err(ChallengerError::Revert(tx_hash));
         }
@@ -307,19 +234,11 @@ where
     }
 
     async fn game_challenger(&self, address: Address) -> Result<Address, ChallengerError> {
-        self.game(address)
-            .challenger()
-            .call()
-            .await
-            .map_err(|error| ChallengerError::Contract(error))
+        Ok(self.game(address).challenger().call().await?)
     }
 
     async fn is_game_finalized(&self, address: Address) -> Result<bool, ChallengerError> {
-        self.anchor
-            .isGameFinalized(address)
-            .call()
-            .await
-            .map_err(|error| ChallengerError::Contract(error))
+        Ok(self.anchor.isGameFinalized(address).call().await?)
     }
 
     async fn credit(&self, address: Address) -> Result<U256, ChallengerError> {
@@ -337,10 +256,9 @@ where
     async fn latest_l1_timestamp(&self) -> Result<u64, ChallengerError> {
         self.provider
             .get_block_by_number(BlockNumberOrTag::Latest)
-            .await
-            .map_err(|error| ChallengerError::AlloyJsonRpc(error))?
+            .await?
             .map(|block| block.header.timestamp())
-            .ok_or_else(|| ChallengerError::UnavailableLatestL1Block)
+            .ok_or(ChallengerError::UnavailableLatestL1Block)
     }
 
     async fn claim_credit(&self, address: Address) -> Result<ClaimSubmission, ChallengerError> {
@@ -354,18 +272,12 @@ where
             PendingWithdrawal::default()
         };
 
-        let pending_tx = self
-            .game(address)
-            .claimCredit(recipient)
-            .send()
-            .await
-            .map_err(|error| ChallengerError::Contract(error))?;
+        let pending_tx = self.game(address).claimCredit(recipient).send().await?;
         let tx_hash = *pending_tx.tx_hash();
         let receipt = pending_tx
             .with_required_confirmations(self.confirmations)
             .get_receipt()
-            .await
-            .map_err(|error| ChallengerError::PendingTransaction(error))?;
+            .await?;
         if !receipt.status() {
             return Err(ChallengerError::Revert(tx_hash));
         }

--- a/proofs/challenger/src/error.rs
+++ b/proofs/challenger/src/error.rs
@@ -1,6 +1,8 @@
 use alloy_primitives::{Address, TxHash};
+use alloy_provider::{PendingTransactionError, transport::RpcError};
+use alloy_transport::TransportErrorKind;
 use thiserror::Error;
-use world_chain_proofs::{ConsensusError, RootStateError};
+use world_chain_proofs::{ConsensusError, InvalidationReasonError, RootStateError};
 
 /// Errors returned by the challenger and its lifecycle managers.
 #[derive(Debug, Error)]
@@ -17,14 +19,24 @@ pub enum ChallengerError {
         block_interval: u64,
     },
     /// Contract call or transaction failure.
-    #[error("contract error: {0}")]
-    Contract(String),
+    #[error(transparent)]
+    Contract(#[from] alloy_contract::Error),
     #[error(transparent)]
     OutputRoot(#[from] ConsensusError),
     #[error("The challenge transaction didn't execute succesfully: {0}")]
     Revert(TxHash),
     #[error(transparent)]
     InvalidRootState(#[from] RootStateError),
+    #[error(transparent)]
+    NotExistingInvalidReason(#[from] InvalidationReasonError),
+    #[error(transparent)]
+    PendingTransaction(#[from] PendingTransactionError),
+    #[error("Latest L1 block is unavailable.")]
+    UnavailableLatestL1Block,
+    #[error("Overflow error.")]
+    Overflow,
+    #[error(transparent)]
+    AlloyJsonRpc(#[from] RpcError<TransportErrorKind>),
     #[error("RPC error: {0}")]
     Rpc(String),
     #[error("Latest L1 finalized block not found")]

--- a/proofs/challenger/src/error.rs
+++ b/proofs/challenger/src/error.rs
@@ -37,8 +37,6 @@ pub enum ChallengerError {
     Overflow,
     #[error(transparent)]
     AlloyJsonRpc(#[from] RpcError<TransportErrorKind>),
-    #[error("RPC error: {0}")]
-    Rpc(String),
     #[error("Latest L1 finalized block not found")]
     L1FinalizedBlockNotFound,
     #[error(
@@ -52,6 +50,16 @@ pub enum ChallengerError {
         /// Block number included in the game.
         given_block: u64,
     },
+}
+
+impl ChallengerError {
+    /// Builds an [`AlloyJsonRpc`](Self::AlloyJsonRpc) error from a free-form message.
+    ///
+    /// Intended for test fakes that need an ad-hoc failure without constructing a full transport
+    /// error by hand.
+    pub fn message(message: impl AsRef<str>) -> Self {
+        Self::AlloyJsonRpc(TransportErrorKind::custom_str(message.as_ref()))
+    }
 }
 
 /// Error returned while processing a single game.

--- a/proofs/challenger/src/tests.rs
+++ b/proofs/challenger/src/tests.rs
@@ -136,7 +136,7 @@ impl ChallengerClient for MockClient {
             .get(index as usize)
             .copied()
             .map(Some)
-            .ok_or_else(|| ChallengerError::Contract(format!("unknown game index {index}")))
+            .ok_or_else(|| ChallengerError::message(format!("unknown game index {index}")))
     }
 
     async fn game_metadata(&self, game: Address) -> Result<GameMetadata, ChallengerError> {
@@ -146,7 +146,7 @@ impl ChallengerClient for MockClient {
             .games
             .get(&game)
             .map(|game| game.metadata)
-            .ok_or_else(|| ChallengerError::Contract(format!("unknown game {game}")))
+            .ok_or_else(|| ChallengerError::message(format!("unknown game {game}")))
     }
 
     async fn root_state(&self, game: Address) -> Result<RootState, ChallengerError> {
@@ -167,7 +167,7 @@ impl ChallengerClient for MockClient {
             .games
             .get(&game)
             .map(|game| game.challenge_deadline)
-            .ok_or_else(|| ChallengerError::Contract(format!("unknown game {game}")))
+            .ok_or_else(|| ChallengerError::message(format!("unknown game {game}")))
     }
 
     async fn submit_challenge(
@@ -178,7 +178,7 @@ impl ChallengerClient for MockClient {
         let record = state
             .games
             .get_mut(&game)
-            .ok_or_else(|| ChallengerError::Contract(format!("unknown game {game}")))?;
+            .ok_or_else(|| ChallengerError::message(format!("unknown game {game}")))?;
         record.state = STATE_CHALLENGED;
         record.challenger = CHALLENGER;
         record.resolution_outcome = STATE_CHALLENGED;
@@ -200,12 +200,11 @@ impl ResolutionManagerClient for MockClient {
             .games
             .get(&game)
             .copied()
-            .ok_or_else(|| ChallengerError::Contract(format!("unknown game {game}")))?;
+            .ok_or_else(|| ChallengerError::message(format!("unknown game {game}")))?;
         Ok(ResolutionStatus {
             resolvable: record.resolvable,
             root_state: RootState::try_from(record.resolution_outcome)?,
-            invalidation_reason: InvalidationReason::try_from(record.resolution_reason)
-                .map_err(|error| ChallengerError::Contract(error.to_string()))?,
+            invalidation_reason: InvalidationReason::try_from(record.resolution_reason)?,
         })
     }
 
@@ -214,7 +213,7 @@ impl ResolutionManagerClient for MockClient {
         let record = state
             .games
             .get_mut(&game)
-            .ok_or_else(|| ChallengerError::Contract(format!("unknown game {game}")))?;
+            .ok_or_else(|| ChallengerError::message(format!("unknown game {game}")))?;
         record.state = record.resolution_outcome;
         record.resolvable = false;
         state.resolutions.push(game);
@@ -245,7 +244,7 @@ impl BondManagerClient for MockClient {
             .games
             .get(&game)
             .map(|game| game.challenger)
-            .ok_or_else(|| ChallengerError::Contract(format!("unknown game {game}")))
+            .ok_or_else(|| ChallengerError::message(format!("unknown game {game}")))
     }
 
     async fn is_game_finalized(&self, game: Address) -> Result<bool, ChallengerError> {
@@ -255,7 +254,7 @@ impl BondManagerClient for MockClient {
             .games
             .get(&game)
             .map(|game| game.finalized)
-            .ok_or_else(|| ChallengerError::Contract(format!("unknown game {game}")))
+            .ok_or_else(|| ChallengerError::message(format!("unknown game {game}")))
     }
 
     async fn credit(&self, game: Address) -> Result<U256, ChallengerError> {
@@ -265,7 +264,7 @@ impl BondManagerClient for MockClient {
             .games
             .get(&game)
             .map(|game| game.credit)
-            .ok_or_else(|| ChallengerError::Contract(format!("unknown game {game}")))
+            .ok_or_else(|| ChallengerError::message(format!("unknown game {game}")))
     }
 
     async fn pending_withdrawal(
@@ -278,7 +277,7 @@ impl BondManagerClient for MockClient {
             .games
             .get(&game)
             .map(|game| game.pending)
-            .ok_or_else(|| ChallengerError::Contract(format!("unknown game {game}")))
+            .ok_or_else(|| ChallengerError::message(format!("unknown game {game}")))
     }
 
     async fn latest_l1_timestamp(&self) -> Result<u64, ChallengerError> {
@@ -290,12 +289,12 @@ impl BondManagerClient for MockClient {
     async fn claim_credit(&self, game: Address) -> Result<ClaimSubmission, ChallengerError> {
         let mut state = self.state.lock().expect("not poisoned");
         if state.fail_claim_once.remove(&game) {
-            return Err(ChallengerError::Contract("injected claim failure".into()));
+            return Err(ChallengerError::message("injected claim failure"));
         }
         let record = state
             .games
             .get_mut(&game)
-            .ok_or_else(|| ChallengerError::Contract(format!("unknown game {game}")))?;
+            .ok_or_else(|| ChallengerError::message(format!("unknown game {game}")))?;
 
         if record.credit > U256::ZERO {
             let amount = record.credit;

--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -497,7 +497,7 @@ impl ChallengerClient for FakeExecution {
             .get(index as usize)
             .copied()
             .map(Some)
-            .ok_or_else(|| ChallengerError::Contract(format!("unknown game index {index}")))
+            .ok_or_else(|| ChallengerError::message(format!("unknown game index {index}")))
     }
 
     async fn game_metadata(
@@ -514,7 +514,7 @@ impl ChallengerClient for FakeExecution {
                 root_claim: record.event.root_claim,
                 l2_block_number: record.event.l2_block_number,
             })
-            .ok_or_else(|| ChallengerError::Contract(format!("unknown game {game}")))
+            .ok_or_else(|| ChallengerError::message(format!("unknown game {game}")))
     }
 
     async fn root_state(&self, game: Address) -> Result<RootState, ChallengerError> {
@@ -535,7 +535,7 @@ impl ChallengerClient for FakeExecution {
             .games_by_address
             .get(&game)
             .map(|record| record.challenge_deadline)
-            .ok_or_else(|| ChallengerError::Contract(format!("unknown game {game}")))
+            .ok_or_else(|| ChallengerError::message(format!("unknown game {game}")))
     }
 
     async fn submit_challenge(
@@ -546,7 +546,7 @@ impl ChallengerClient for FakeExecution {
         let record = state
             .games_by_address
             .get_mut(&game)
-            .ok_or_else(|| ChallengerError::Contract(format!("unknown game {game}")))?;
+            .ok_or_else(|| ChallengerError::message(format!("unknown game {game}")))?;
         challenge_record(record);
         Ok(ChallengeSubmission {
             tx_hash: B256::with_last_byte(record.challenge_count as u8),


### PR DESCRIPTION
This PR improves errors for `world-chain-challenger` with the goal of obtaining more info on the actual error that is happening.

This can (and will) be replicated to proposer and defender.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Error-type refactor only; challenger transaction and scan behavior is unchanged, with improved error detail for operations/logging.
> 
> **Overview**
> **Replaces string-wrapped contract/RPC failures** in `ChallengerError` with structured variants that preserve underlying Alloy errors (`alloy_contract::Error`, `RpcError`, `PendingTransactionError`, plus `InvalidationReasonError` via `?`).
> 
> The Alloy challenger client drops manual `.map_err(|e| ChallengerError::Contract(...))` on reads and txs in favor of `?`, and maps a few local cases to dedicated variants (`Overflow`, `UnavailableLatestL1Block`). Test and integration fakes use new `ChallengerError::message()` instead of ad-hoc `Contract` strings.
> 
> Adds `alloy-contract` and `alloy-transport` dependencies to the challenger crate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9c26e7764eb29dc9b56d3878d1328d34725a12e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->