### PR TITLE
feat: add security council verifier

### DIFF
--- a/pkg/contracts/scripts/devnet/DeployCouncilSafe.s.sol
+++ b/pkg/contracts/scripts/devnet/DeployCouncilSafe.s.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Script} from "forge-std/Script.sol";
+
+import {SecurityCouncilVerifier} from "../../src/proofs/council/SecurityCouncilVerifier.sol";
+
+import {Safe} from "@safe-global/safe-contracts/contracts/Safe.sol";
+import {SafeProxyFactory} from "@safe-global/safe-contracts/contracts/proxies/SafeProxyFactory.sol";
+import {
+    CompatibilityFallbackHandler
+} from "@safe-global/safe-contracts/contracts/handler/CompatibilityFallbackHandler.sol";
+
+/// @notice Deploys the security-council Safe and the `SecurityCouncilVerifier` that fronts it, for
+///         use as `SECURITY_COUNCIL_VERIFIER` in `DeployProofSystem.s.sol`.
+///
+/// Required:
+///   `PRIVATE_KEY`        — deployer
+///   `COUNCIL_OWNERS`     — comma-separated owner addresses
+///   `COUNCIL_THRESHOLD`  — signatures required
+///
+/// Optional — reuse canonical Safe 1.4.1 infrastructure instead of deploying fresh copies.
+/// Set all three together on a chain where Safe is already deployed:
+///   `SAFE_SINGLETON`, `SAFE_PROXY_FACTORY`, `SAFE_FALLBACK_HANDLER`
+///
+/// @dev The fallback handler is mandatory, not cosmetic: `SecurityCouncilVerifier` reaches the Safe
+///      through EIP-1271, which only exists on `CompatibilityFallbackHandler`. A Safe set up with
+///      a zero handler makes every council `verify` return false and silently disables the lane,
+///      so this script refuses to configure one.
+contract DeployCouncilSafe is Script {
+    struct Deployment {
+        Safe councilSafe;
+        SecurityCouncilVerifier verifier;
+        address singleton;
+        address proxyFactory;
+        address fallbackHandler;
+        uint256 threshold;
+    }
+
+    function run() external returns (Deployment memory deployment) {
+        uint256 privateKey = vm.envUint("PRIVATE_KEY");
+        address[] memory owners = vm.envAddress("COUNCIL_OWNERS", ",");
+        uint256 threshold = vm.envUint("COUNCIL_THRESHOLD");
+
+        require(owners.length > 0, "DeployCouncilSafe: COUNCIL_OWNERS is empty");
+        require(threshold > 0, "DeployCouncilSafe: COUNCIL_THRESHOLD must be non-zero");
+        require(threshold <= owners.length, "DeployCouncilSafe: COUNCIL_THRESHOLD exceeds owner count");
+
+        address singleton = vm.envOr("SAFE_SINGLETON", address(0));
+        address factory = vm.envOr("SAFE_PROXY_FACTORY", address(0));
+        address handler = vm.envOr("SAFE_FALLBACK_HANDLER", address(0));
+        bool reuse = singleton != address(0) || factory != address(0) || handler != address(0);
+        if (reuse) {
+            // Partial reuse silently mixes a fresh singleton with a foreign factory; demand all
+            // three or none so the resulting Safe's provenance is unambiguous.
+            require(
+                singleton != address(0) && factory != address(0) && handler != address(0),
+                "DeployCouncilSafe: set SAFE_SINGLETON, SAFE_PROXY_FACTORY and SAFE_FALLBACK_HANDLER together"
+            );
+            require(singleton.code.length > 0, "DeployCouncilSafe: SAFE_SINGLETON has no code");
+            require(factory.code.length > 0, "DeployCouncilSafe: SAFE_PROXY_FACTORY has no code");
+            require(handler.code.length > 0, "DeployCouncilSafe: SAFE_FALLBACK_HANDLER has no code");
+        }
+
+        vm.startBroadcast(privateKey);
+        if (!reuse) {
+            singleton = address(new Safe());
+            factory = address(new SafeProxyFactory());
+            handler = address(new CompatibilityFallbackHandler());
+        }
+
+        deployment.councilSafe =
+            Safe(payable(address(SafeProxyFactory(factory).createProxyWithNonce(singleton, "", 0))));
+        deployment.councilSafe.setup(owners, threshold, address(0), "", handler, address(0), 0, payable(address(0)));
+
+        deployment.verifier = new SecurityCouncilVerifier(address(deployment.councilSafe));
+        vm.stopBroadcast();
+
+        deployment.singleton = singleton;
+        deployment.proxyFactory = factory;
+        deployment.fallbackHandler = handler;
+        deployment.threshold = threshold;
+
+        require(deployment.councilSafe.getThreshold() == threshold, "DeployCouncilSafe: threshold not set");
+        require(
+            address(deployment.verifier.council()) == address(deployment.councilSafe),
+            "DeployCouncilSafe: verifier not bound to the council Safe"
+        );
+
+        _writeDeployment(deployment, owners);
+    }
+
+    function _writeDeployment(Deployment memory deployment, address[] memory owners) internal {
+        string memory out = vm.envOr("COUNCIL_DEPLOYMENT_OUT", string(""));
+        if (bytes(out).length == 0) return;
+
+        string memory root = "council";
+        vm.serializeAddress(root, "securityCouncilVerifier", address(deployment.verifier));
+        vm.serializeAddress(root, "councilSafe", address(deployment.councilSafe));
+        vm.serializeAddress(root, "safeSingleton", deployment.singleton);
+        vm.serializeAddress(root, "safeProxyFactory", deployment.proxyFactory);
+        vm.serializeAddress(root, "safeFallbackHandler", deployment.fallbackHandler);
+        vm.serializeAddress(root, "councilOwners", owners);
+        string memory json = vm.serializeUint(root, "councilThreshold", deployment.threshold);
+        vm.writeJson(json, out);
+    }
+}

--- a/pkg/contracts/src/proofs/council/SecurityCouncilVerifier.sol
+++ b/pkg/contracts/src/proofs/council/SecurityCouncilVerifier.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {IWorldChainProofVerifier} from "../interfaces/IWorldChainProofVerifier.sol";
+
+interface IERC1271 {
+    function isValidSignature(bytes32 hash, bytes calldata signature) external view returns (bytes4);
+}
+
+/// @title SecurityCouncilVerifier
+/// @author World Contributors
+/// @custom:security-contact security@toolsforhumanity.com
+contract SecurityCouncilVerifier is IWorldChainProofVerifier {
+    /// @notice `bytes4(keccak256("isValidSignature(bytes32,bytes)"))`
+    bytes4 internal constant ERC1271_MAGIC_VALUE = 0x1626ba7e;
+
+    /// @notice Domain tag for council attestations over a proposal root.
+    bytes32 public constant ATTESTATION_TYPEHASH = keccak256("WorldChainCouncilAttestation(bytes32 rootId)");
+
+    /// @notice The council Safe.
+    address public immutable council;
+
+    /// @notice Thrown when constructor args are invalid.
+    error InvalidAddress(address);
+
+    constructor(address council_) {
+        if (council_ == address(0)) revert InvalidAddress(council_);
+
+        if (council_.code.length == 0) revert InvalidAddress(council_);
+        council = council_;
+    }
+
+    /// @dev EIP-712 Attestation digest.
+    function attestationDigest(bytes32 rootId) public view returns (bytes32) {
+        return keccak256(abi.encode(ATTESTATION_TYPEHASH, block.chainid, address(this), rootId));
+    }
+
+    /// @inheritdoc IWorldChainProofVerifier
+    function verify(bytes32 rootId, bytes calldata proof) external view returns (bool) {
+        try IERC1271(council).isValidSignature(attestationDigest(rootId), proof) returns (bytes4 magic) {
+            return magic == ERC1271_MAGIC_VALUE;
+        } catch {
+            return false;
+        }
+    }
+}

--- a/pkg/contracts/test/proofs/SecurityCouncilVerifier.t.sol
+++ b/pkg/contracts/test/proofs/SecurityCouncilVerifier.t.sol
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+
+import {SecurityCouncilVerifier} from "../../src/proofs/council/SecurityCouncilVerifier.sol";
+
+import {Safe} from "@safe-global/safe-contracts/contracts/Safe.sol";
+import {SafeProxyFactory} from "@safe-global/safe-contracts/contracts/proxies/SafeProxyFactory.sol";
+import {
+    CompatibilityFallbackHandler
+} from "@safe-global/safe-contracts/contracts/handler/CompatibilityFallbackHandler.sol";
+import {SignMessageLib} from "@safe-global/safe-contracts/contracts/libraries/SignMessageLib.sol";
+import {Enum} from "@safe-global/safe-contracts/contracts/common/Enum.sol";
+
+/// @dev Exercised against a real Safe 1.4.1 rather than a stub: the whole contract is a thin
+///      delegation to Safe's EIP-1271 path, so a stub would only test the assertion, not the
+///      integration that can actually break.
+contract SecurityCouncilVerifierTest is Test {
+    Safe internal safe;
+    SecurityCouncilVerifier internal verifier;
+    SignMessageLib internal signMessageLib;
+    CompatibilityFallbackHandler internal handler;
+
+    // Sorted ascending by address — Safe's checkSignatures requires increasing owner order.
+    uint256 internal pk1;
+    uint256 internal pk2;
+    uint256 internal pk3;
+    address internal owner1;
+    address internal owner2;
+    address internal owner3;
+
+    bytes32 internal constant ROOT_ID = keccak256("rootId");
+    uint256 internal constant THRESHOLD = 2;
+
+    function setUp() public {
+        (pk1, pk2, pk3) = (0xA11CE, 0xB0B, 0xC0FFEE);
+        address[3] memory unsorted = [vm.addr(pk1), vm.addr(pk2), vm.addr(pk3)];
+        uint256[3] memory keys = [pk1, pk2, pk3];
+        // Insertion sort by address so signature blobs are always in Safe's required order.
+        for (uint256 i = 1; i < 3; i++) {
+            for (uint256 j = i; j > 0 && unsorted[j - 1] > unsorted[j]; j--) {
+                (unsorted[j - 1], unsorted[j]) = (unsorted[j], unsorted[j - 1]);
+                (keys[j - 1], keys[j]) = (keys[j], keys[j - 1]);
+            }
+        }
+        (owner1, owner2, owner3) = (unsorted[0], unsorted[1], unsorted[2]);
+        (pk1, pk2, pk3) = (keys[0], keys[1], keys[2]);
+
+        handler = new CompatibilityFallbackHandler();
+        signMessageLib = new SignMessageLib();
+        Safe singleton = new Safe();
+        SafeProxyFactory factory = new SafeProxyFactory();
+
+        address[] memory owners = new address[](3);
+        (owners[0], owners[1], owners[2]) = (owner1, owner2, owner3);
+
+        safe = Safe(payable(address(factory.createProxyWithNonce(address(singleton), "", 0))));
+        safe.setup(owners, THRESHOLD, address(0), "", address(handler), address(0), 0, payable(address(0)));
+
+        verifier = new SecurityCouncilVerifier(address(safe));
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                              HELPERS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev The hash Safe owners actually sign: the verifier digest, wrapped by the handler as
+    ///      `abi.encode(digest)` and then in Safe's EIP-712 `SafeMessage`.
+    function _safeMessageHash(bytes32 rootId) internal view returns (bytes32) {
+        return handler.getMessageHashForSafe(safe, abi.encode(verifier.attestationDigest(rootId)));
+    }
+
+    function _sign(uint256 pk, bytes32 hash) internal pure returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk, hash);
+        return abi.encodePacked(r, s, v);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    PATH 1 — AGGREGATED SIGNATURES
+    //////////////////////////////////////////////////////////////*/
+
+    function test_verify_AggregatedSignatures_AtThreshold() public view {
+        bytes32 h = _safeMessageHash(ROOT_ID);
+        bytes memory sigs = abi.encodePacked(_sign(pk1, h), _sign(pk2, h));
+        assertTrue(verifier.verify(ROOT_ID, sigs));
+    }
+
+    function test_verify_AggregatedSignatures_AboveThreshold() public view {
+        bytes32 h = _safeMessageHash(ROOT_ID);
+        bytes memory sigs = abi.encodePacked(_sign(pk1, h), _sign(pk2, h), _sign(pk3, h));
+        assertTrue(verifier.verify(ROOT_ID, sigs));
+    }
+
+    function test_verify_RevertsInsideSafe_AreCaughtAsFalse_BelowThreshold() public view {
+        bytes memory sigs = _sign(pk1, _safeMessageHash(ROOT_ID));
+        assertFalse(verifier.verify(ROOT_ID, sigs));
+    }
+
+    function test_verify_ReturnsFalse_NonOwnerSignature() public view {
+        bytes32 h = _safeMessageHash(ROOT_ID);
+        uint256 intruderPk = 0xDEADBEEF;
+        // Two signatures, but one is not an owner. Ordering still ascending is not guaranteed,
+        // so either the owner check or the ordering check rejects it — both must be `false`.
+        bytes memory sigs = abi.encodePacked(_sign(pk1, h), _sign(intruderPk, h));
+        assertFalse(verifier.verify(ROOT_ID, sigs));
+    }
+
+    /// @dev The core replay guard: signatures collected for one root must not satisfy another.
+    function test_verify_ReturnsFalse_SignaturesForDifferentRootId() public view {
+        bytes32 other = keccak256("some other root");
+        bytes32 h = _safeMessageHash(other);
+        bytes memory sigs = abi.encodePacked(_sign(pk1, h), _sign(pk2, h));
+        assertFalse(verifier.verify(ROOT_ID, sigs));
+        assertTrue(verifier.verify(other, sigs));
+    }
+
+    function test_verify_ReturnsFalse_GarbageProof() public view {
+        assertFalse(verifier.verify(ROOT_ID, hex"deadbeef"));
+    }
+
+    /*//////////////////////////////////////////////////////////////
+              PATH 2 — PRE-APPROVED ON-CHAIN (approveHash)
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev `v=1` marks an approved-hash entry; `r` carries the owner address.
+    function test_verify_PreApprovedHash_viaApproveHash() public {
+        bytes32 h = _safeMessageHash(ROOT_ID);
+        vm.prank(owner1);
+        safe.approveHash(h);
+        vm.prank(owner2);
+        safe.approveHash(h);
+
+        bytes memory sigs = abi.encodePacked(
+            bytes32(uint256(uint160(owner1))),
+            bytes32(0),
+            uint8(1),
+            bytes32(uint256(uint160(owner2))),
+            bytes32(0),
+            uint8(1)
+        );
+        assertTrue(verifier.verify(ROOT_ID, sigs));
+    }
+
+    function test_verify_ReturnsFalse_ApprovedHashBelowThreshold() public {
+        bytes32 h = _safeMessageHash(ROOT_ID);
+        vm.prank(owner1);
+        safe.approveHash(h);
+
+        bytes memory sigs = abi.encodePacked(bytes32(uint256(uint160(owner1))), bytes32(0), uint8(1));
+        assertFalse(verifier.verify(ROOT_ID, sigs));
+    }
+
+    /*//////////////////////////////////////////////////////////////
+          PATH 3 — PRE-APPROVED MESSAGE (signMessage, empty proof)
+    //////////////////////////////////////////////////////////////*/
+
+    function test_verify_PreApprovedMessage_EmptyProof() public {
+        bytes memory message = abi.encode(verifier.attestationDigest(ROOT_ID));
+        _execFromSafe(
+            address(signMessageLib), abi.encodeCall(SignMessageLib.signMessage, (message)), Enum.Operation.DelegateCall
+        );
+        assertTrue(verifier.verify(ROOT_ID, ""));
+    }
+
+    function test_verify_ReturnsFalse_EmptyProofWithoutApproval() public view {
+        assertFalse(verifier.verify(ROOT_ID, ""));
+    }
+
+    /// @dev signMessage only covers the root it was signed for.
+    function test_verify_PreApprovedMessage_DoesNotCoverOtherRoots() public {
+        bytes memory message = abi.encode(verifier.attestationDigest(ROOT_ID));
+        _execFromSafe(
+            address(signMessageLib), abi.encodeCall(SignMessageLib.signMessage, (message)), Enum.Operation.DelegateCall
+        );
+        assertFalse(verifier.verify(keccak256("unapproved root"), ""));
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                        DIGEST + CONSTRUCTOR
+    //////////////////////////////////////////////////////////////*/
+
+    function test_attestationDigest_BindsRootId(bytes32 a, bytes32 b) public view {
+        vm.assume(a != b);
+        assertTrue(verifier.attestationDigest(a) != verifier.attestationDigest(b));
+    }
+
+    function test_attestationDigest_BindsChainId() public {
+        bytes32 before = verifier.attestationDigest(ROOT_ID);
+        vm.chainId(block.chainid + 1);
+        assertTrue(verifier.attestationDigest(ROOT_ID) != before);
+    }
+
+    function test_attestationDigest_BindsVerifierInstance() public {
+        SecurityCouncilVerifier other = new SecurityCouncilVerifier(address(safe));
+        assertTrue(other.attestationDigest(ROOT_ID) != verifier.attestationDigest(ROOT_ID));
+    }
+
+    function test_constructor_RevertIf_ZeroCouncil() public {
+        vm.expectRevert(abi.encodeWithSelector(SecurityCouncilVerifier.InvalidAddress.selector, address(0)));
+        new SecurityCouncilVerifier(address(0));
+    }
+
+    function test_constructor_RevertIf_CouncilIsEOA() public {
+        address eoa = address(0xBEEF);
+        vm.expectRevert(abi.encodeWithSelector(SecurityCouncilVerifier.InvalidAddress.selector, eoa));
+        new SecurityCouncilVerifier(eoa);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                          SAFE TX PLUMBING
+    //////////////////////////////////////////////////////////////*/
+
+    function _execFromSafe(address to, bytes memory data, Enum.Operation op) internal {
+        bytes32 txHash =
+            safe.getTransactionHash(to, 0, data, op, 0, 0, 0, address(0), payable(address(0)), safe.nonce());
+        bytes memory sigs = abi.encodePacked(_sign(pk1, txHash), _sign(pk2, txHash));
+        assertTrue(safe.execTransaction(to, 0, data, op, 0, 0, 0, address(0), payable(address(0)), sigs));
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> New authorization path for the `SECURITY_COUNCIL` proof lane; incorrect Safe/handler setup or digest binding could allow or block valid council approvals in production.
> 
> **Overview**
> Adds a **security council proof lane** where council approval for a proposal `rootId` is checked via a Gnosis Safe and EIP-1271.
> 
> **`SecurityCouncilVerifier`** implements `IWorldChainProofVerifier`: it builds a chain- and instance-bound `attestationDigest(rootId)` and delegates `verify` to the council Safe’s `isValidSignature`, treating failures/reverts as `false`. The council must be a contract (typically a Safe with `CompatibilityFallbackHandler`).
> 
> **`DeployCouncilSafe`** is a Forge script that deploys (or reuses) Safe 1.4.1 infrastructure, sets up the council multisig with owners/threshold and the fallback handler, deploys the verifier, and optionally writes deployment JSON for wiring into `DeployProofSystem` as `SECURITY_COUNCIL_VERIFIER`.
> 
> Tests cover aggregated ECDSA proofs, `approveHash`, on-chain `signMessage` (empty proof), digest binding, and constructor validation against a real Safe 1.4.1.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d60922bcfddaaadb85cf79c1b8aec7179146090. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->