### PR TITLE
fix(simulation): capture CREATE revert reasons

### DIFF
--- a/crates/rpc/src/simulate.rs
+++ b/crates/rpc/src/simulate.rs
@@ -245,11 +245,11 @@ pub struct SimulationInspector {
     /// matching `*_end` pops it. See [`PendingFrame`].
     pending_frames: Vec<PendingFrame>,
     /// Raw payload of the deepest frame that exited via REVERT. Set on the
-    /// first non-ok `call_end` whose `InstructionResult` is `Revert` — since
-    /// `call_end` fires bottom-up, that's the innermost reverter and so the
-    /// root cause when wrappers like EntryPoint's `FailedOp(...)` re-revert
-    /// up the stack. Halt frames (OOG, invalid opcode, etc.) are skipped:
-    /// they have no payload to decode.
+    /// first `call_end` or `create_end` whose `InstructionResult` is `Revert`
+    /// — since end hooks fire bottom-up, that's the innermost reverter and so
+    /// the root cause when wrappers like EntryPoint's `FailedOp(...)`
+    /// re-revert up the stack. Halt frames (OOG, invalid opcode, etc.) are
+    /// skipped: they have no payload to decode.
     deepest_revert_payload: Option<Bytes>,
 }
 
@@ -418,8 +418,15 @@ impl<CTX: revm::context_interface::ContextTr> Inspector<CTX> for SimulationInspe
         let Some(mut frame) = self.pending_frames.pop() else {
             return;
         };
-        if !outcome.instruction_result().is_ok() {
-            // CREATE itself failed — drop the frame.
+        let result = outcome.instruction_result();
+        if !result.is_ok() {
+            // CREATE itself failed — drop the frame. Capture an explicit
+            // constructor REVERT before an outer call can replace its useful
+            // payload with a wrapper error.
+            if matches!(result, InstructionResult::Revert) && self.deepest_revert_payload.is_none()
+            {
+                self.deepest_revert_payload = Some(outcome.output().clone());
+            }
             return;
         }
         // Successful create: record `(deployer, deployed)` into the create

--- a/crates/rpc/tests/inspector_create_revert.rs
+++ b/crates/rpc/tests/inspector_create_revert.rs
@@ -1,0 +1,107 @@
+//! Regression tests for CREATE/CREATE2 handling in `SimulationInspector`.
+//!
+//! Runs entirely against an in-memory `CacheDB<EmptyDB>` — no fork URL needed.
+
+use alloy_op_evm::{OpEvmFactory, OpTx};
+use alloy_primitives::{Address, Bytes, U256, address};
+use op_revm::{OpSpecId, OpTransaction};
+use reth_evm::{Evm as RethEvm, EvmFactory};
+use revm::{
+    bytecode::Bytecode,
+    context::{BlockEnv, CfgEnv, TxEnv, result::ExecutionResult},
+    state::AccountInfo,
+};
+use revm_database::{CacheDB, EmptyDB};
+use revm_primitives::TxKind;
+
+use world_chain_rpc::simulate::SimulationInspector;
+
+const CHAIN_ID: u64 = 480;
+
+/// Runtime code that executes CREATE with a 12-byte constructor, then hides
+/// the constructor's revert data by reverting the outer frame with no output.
+///
+/// The constructor is:
+/// `PUSH4 0xdeadbeef PUSH0 MSTORE PUSH1 4 PUSH1 28 REVERT`.
+/// It writes `0xdeadbeef` to memory and reverts with those four bytes.
+const CREATE_REVERT_TRAMPOLINE: &[u8] = &[
+    0x6b, // PUSH12 constructor
+    0x63, 0xde, 0xad, 0xbe, 0xef, // PUSH4 0xdeadbeef
+    0x5f, 0x52, // PUSH0; MSTORE
+    0x60, 0x04, // PUSH1 4 (revert-data length)
+    0x60, 0x1c, // PUSH1 28 (revert-data offset)
+    0xfd, // REVERT
+    0x5f, 0x52, // PUSH0; MSTORE constructor at memory[20..32]
+    0x60, 0x0c, // PUSH1 12 (init-code length)
+    0x60, 0x14, // PUSH1 20 (init-code offset)
+    0x5f, 0xf0, // PUSH0 value; CREATE
+    0x50, // POP failed CREATE's zero address
+    0x5f, 0x5f, 0xfd, // REVERT(0, 0)
+];
+
+fn evm_env() -> reth_evm::EvmEnv<OpSpecId> {
+    let mut cfg = CfgEnv::new_with_spec(OpSpecId::ISTHMUS);
+    cfg.chain_id = CHAIN_ID;
+    cfg.disable_nonce_check = true;
+    cfg.disable_balance_check = true;
+    cfg.disable_base_fee = true;
+    reth_evm::EvmEnv::new(cfg, BlockEnv::default())
+}
+
+fn install_runtime_code(db: &mut CacheDB<EmptyDB>, address: Address, code: Vec<u8>) {
+    let bytecode = Bytecode::new_raw(Bytes::from(code));
+    db.insert_account_info(
+        address,
+        AccountInfo {
+            nonce: 1,
+            code_hash: bytecode.hash_slow(),
+            code: Some(bytecode),
+            ..Default::default()
+        },
+    );
+}
+
+#[test]
+fn inspector_captures_constructor_revert_reason() {
+    let caller = address!("00000000000000000000000000000000DeaDBeef");
+    let trampoline = address!("000000000000000000000000000000000000c0de");
+    let mut db = CacheDB::<EmptyDB>::default();
+    db.insert_account_info(
+        caller,
+        AccountInfo {
+            balance: U256::from(10_u128.pow(21)),
+            ..Default::default()
+        },
+    );
+    install_runtime_code(&mut db, trampoline, CREATE_REVERT_TRAMPOLINE.to_vec());
+
+    let mut evm = OpEvmFactory::default().create_evm_with_inspector(
+        &mut db,
+        evm_env(),
+        SimulationInspector::default(),
+    );
+    let result = RethEvm::transact(
+        &mut evm,
+        OpTx(OpTransaction {
+            base: TxEnv {
+                caller,
+                kind: TxKind::Call(trampoline),
+                gas_limit: 1_000_000,
+                gas_price: 0,
+                chain_id: Some(CHAIN_ID),
+                ..Default::default()
+            },
+            ..Default::default()
+        }),
+    )
+    .expect("EVM transaction should execute");
+
+    assert!(matches!(result.result, ExecutionResult::Revert { .. }));
+
+    let (_, inspector, _) = evm.components_mut();
+    assert_eq!(
+        inspector.take_deepest_revert_reason().as_deref(),
+        Some("0xdeadbeef")
+    );
+    assert!(inspector.take_contract_creations().is_empty());
+}

--- a/crates/rpc/tests/inspector_create_revert.rs
+++ b/crates/rpc/tests/inspector_create_revert.rs
@@ -14,7 +14,7 @@ use revm::{
 use revm_database::{CacheDB, EmptyDB};
 use revm_primitives::TxKind;
 
-use world_chain_rpc::simulate::SimulationInspector;
+use world_chain_rpc::simulate::{SimulationInspector, relax_cfg_for_simulation};
 
 const CHAIN_ID: u64 = 480;
 
@@ -42,9 +42,7 @@ const CREATE_REVERT_TRAMPOLINE: &[u8] = &[
 fn evm_env() -> reth_evm::EvmEnv<OpSpecId> {
     let mut cfg = CfgEnv::new_with_spec(OpSpecId::ISTHMUS);
     cfg.chain_id = CHAIN_ID;
-    cfg.disable_nonce_check = true;
-    cfg.disable_balance_check = true;
-    cfg.disable_base_fee = true;
+    relax_cfg_for_simulation(&mut cfg);
     reth_evm::EvmEnv::new(cfg, BlockEnv::default())
 }
 


### PR DESCRIPTION
Mirrors the existing `call_end` revert capture in `create_end`, capturing revert data from failed contract deployments before an outer call can mask it.

Test: `cargo test -p world-chain-rpc --test inspector_create_revert`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, symmetric change to simulation inspector revert capture with an in-memory regression test; no auth, persistence, or consensus impact.
> 
> **Overview**
> **Simulation** now surfaces constructor revert data when a **CREATE/CREATE2** fails, not only when a nested **CALL** reverts.
> 
> `SimulationInspector::create_end` records the first `InstructionResult::Revert` output into `deepest_revert_payload`, matching the existing `call_end` behavior so `revert_reason` on `simulate_unsignedUserOp` stays the innermost payload instead of being replaced by an outer frame with empty or wrapper revert data (e.g. EntryPoint `FailedOp`).
> 
> Docs on `deepest_revert_payload` now note both `call_end` and `create_end`. A new in-memory regression test (`inspector_create_revert`) uses bytecode that CREATE-reverts with `0xdeadbeef` then outer-reverts with no data, asserting the inspector still returns `0xdeadbeef` and no committed creations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b63c4a23be8a66717edfb24ed00fe3fc02e815aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->