### PR TITLE
feat(simulation): add CALL and CREATE trace outcomes

### DIFF
--- a/crates/rpc/src/simulate.rs
+++ b/crates/rpc/src/simulate.rs
@@ -115,15 +115,43 @@ pub struct ExposureChange {
     pub asset: AssetInfo,
 }
 
-/// A call made during execution, forming a full stack trace.
+/// Kind of EVM frame represented by a trace entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TraceKind {
+    Call,
+    CallCode,
+    DelegateCall,
+    StaticCall,
+    Create,
+    Create2,
+}
+
+/// Outcome of a completed EVM trace frame.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TraceOutcome {
+    Success,
+    Revert,
+    Halt,
+}
+
+/// A call or contract creation made during execution.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TraceEntry {
+    pub kind: TraceKind,
     pub from: Address,
-    pub to: Address,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to: Option<Address>,
     pub method: Option<String>,
-    pub selector: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selector: Option<String>,
     pub value: String,
+    pub depth: usize,
+    pub outcome: TraceOutcome,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revert_reason: Option<String>,
 }
 
 /// Type of contract-management state change detected during simulation.
@@ -195,10 +223,17 @@ pub struct SimulateUnsignedUserOpResult {
 
 #[derive(Debug)]
 struct RawTrace {
+    kind: TraceKind,
     from: Address,
-    to: Address,
-    selector: [u8; 4],
+    to: Option<Address>,
+    selector: Option<[u8; 4]>,
     value: U256,
+    depth: usize,
+    /// Populated by the matching `call_end` or `create_end` hook.
+    outcome: Option<TraceOutcome>,
+    /// Populated by the matching end hook for an explicit REVERT with a
+    /// non-empty payload.
+    revert_reason: Option<String>,
 }
 
 #[derive(Debug)]
@@ -216,13 +251,26 @@ type ContractCreation = (Address, Address);
 /// committed to the inspector's final lists if outermost). On revert/halt
 /// it's dropped — exactly mirroring the EVM's own state-revert semantics
 /// so we never report effects that didn't actually land.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct PendingFrame {
     native_transfers: Vec<NativeTransfer>,
     /// CREATE/CREATE2 deployments inside this frame.
     contract_creations: Vec<ContractCreation>,
     /// Addresses that executed SELFDESTRUCT inside this frame.
     self_destructs: Vec<Address>,
+    /// Index of this frame's entry in [`SimulationInspector::traces`].
+    trace_index: usize,
+}
+
+impl PendingFrame {
+    fn new(trace_index: usize) -> Self {
+        Self {
+            native_transfers: Vec::new(),
+            contract_creations: Vec::new(),
+            self_destructs: Vec::new(),
+            trace_index,
+        }
+    }
 }
 
 /// Captures the call stack and native ETH transfers of a single simulation.
@@ -232,8 +280,9 @@ struct PendingFrame {
 /// returns. No interior mutability needed.
 #[derive(Debug, Default)]
 pub struct SimulationInspector {
-    /// Full call stack trace — every CALL/STATICCALL/DELEGATECALL at every depth.
-    /// Includes reverted calls so debug consumers can see what was attempted.
+    /// Full frame trace — every CALL-family and CREATE-family operation at
+    /// every depth. Includes reverted frames so debug consumers can see what
+    /// was attempted.
     traces: Vec<RawTrace>,
     /// Native ETH transfers committed by successful frames.
     native_transfers: Vec<NativeTransfer>,
@@ -251,18 +300,36 @@ pub struct SimulationInspector {
     /// re-revert up the stack. Halt frames (OOG, invalid opcode, etc.) are
     /// skipped: they have no payload to decode.
     deepest_revert_payload: Option<Bytes>,
+    /// Internal frame-bookkeeping failure. Inspector hooks cannot return an
+    /// error to revm, so defer it until the caller collects the trace.
+    trace_error: Option<&'static str>,
 }
 
 impl SimulationInspector {
-    pub fn take_trace_entries(&mut self) -> Vec<TraceEntry> {
+    pub fn take_trace_entries(&mut self) -> Result<Vec<TraceEntry>, &'static str> {
+        if let Some(error) = self.trace_error.take() {
+            return Err(error);
+        }
+
         std::mem::take(&mut self.traces)
             .into_iter()
-            .map(|t| TraceEntry {
-                from: t.from,
-                to: t.to,
-                method: selector_to_name(t.selector).map(str::to_string),
-                selector: format!("0x{}", hex::encode(t.selector)),
-                value: format!("{:#x}", t.value),
+            .map(|t| {
+                let outcome = t
+                    .outcome
+                    .ok_or("simulation inspector trace frame did not complete")?;
+                Ok(TraceEntry {
+                    kind: t.kind,
+                    from: t.from,
+                    to: t.to,
+                    method: t.selector.and_then(selector_to_name).map(str::to_string),
+                    selector: t
+                        .selector
+                        .map(|selector| format!("0x{}", hex::encode(selector))),
+                    value: format!("{:#x}", t.value),
+                    depth: t.depth,
+                    outcome,
+                    revert_reason: t.revert_reason,
+                })
             })
             .collect()
     }
@@ -321,6 +388,33 @@ impl SimulationInspector {
             self.self_destructs.extend(frame.self_destructs);
         }
     }
+
+    /// Record the outcome of an exiting frame on its trace entry.
+    fn record_trace_outcome(
+        &mut self,
+        trace_index: usize,
+        result: &InstructionResult,
+        output: &Bytes,
+    ) -> Option<&mut RawTrace> {
+        let Some(trace) = self.traces.get_mut(trace_index) else {
+            self.trace_error
+                .get_or_insert("simulation inspector frame referenced a missing trace entry");
+            return None;
+        };
+
+        trace.outcome = Some(if result.is_ok() {
+            TraceOutcome::Success
+        } else if matches!(result, InstructionResult::Revert) {
+            TraceOutcome::Revert
+        } else {
+            TraceOutcome::Halt
+        });
+        if matches!(result, InstructionResult::Revert) && !output.is_empty() {
+            trace.revert_reason = Some(decode_revert_reason(output));
+        }
+
+        Some(trace)
+    }
 }
 
 impl<CTX: revm::context_interface::ContextTr> Inspector<CTX> for SimulationInspector {
@@ -350,18 +444,29 @@ impl<CTX: revm::context_interface::ContextTr> Inspector<CTX> for SimulationInspe
             }
             _ => [0u8; 4],
         };
+        let trace_index = self.traces.len();
+        let depth = self.pending_frames.len();
         let value = inputs.value.transfer().unwrap_or(U256::ZERO);
         self.traces.push(RawTrace {
+            kind: match inputs.scheme {
+                revm::interpreter::CallScheme::Call => TraceKind::Call,
+                revm::interpreter::CallScheme::CallCode => TraceKind::CallCode,
+                revm::interpreter::CallScheme::DelegateCall => TraceKind::DelegateCall,
+                revm::interpreter::CallScheme::StaticCall => TraceKind::StaticCall,
+            },
             from: inputs.caller,
-            to: inputs.target_address,
-            selector,
+            to: Some(inputs.target_address),
+            selector: Some(selector),
             value,
+            depth,
+            outcome: None,
+            revert_reason: None,
         });
 
         // Open a new frame. If this call reverts, `call_end` will drop the
         // frame and all its tentative effects (native transfers, creates,
         // selfdestructs). Only successful frames commit.
-        let mut frame = PendingFrame::default();
+        let mut frame = PendingFrame::new(trace_index);
         if let Some(value) = inputs.value.transfer()
             && value > U256::ZERO
         {
@@ -378,9 +483,12 @@ impl<CTX: revm::context_interface::ContextTr> Inspector<CTX> for SimulationInspe
 
     fn call_end(&mut self, _context: &mut CTX, _inputs: &CallInputs, outcome: &mut CallOutcome) {
         let Some(frame) = self.pending_frames.pop() else {
+            self.trace_error
+                .get_or_insert("simulation inspector CALL ended without a pending frame");
             return;
         };
         let result = outcome.instruction_result();
+        self.record_trace_outcome(frame.trace_index, result, outcome.output());
         if !result.is_ok() {
             // Frame reverted or halted — drop everything tentative inside it.
             // For explicit REVERTs, capture the deepest payload (the first
@@ -400,12 +508,27 @@ impl<CTX: revm::context_interface::ContextTr> Inspector<CTX> for SimulationInspe
     fn create(
         &mut self,
         _context: &mut CTX,
-        _inputs: &mut revm::interpreter::CreateInputs,
+        inputs: &mut revm::interpreter::CreateInputs,
     ) -> Option<revm::interpreter::CreateOutcome> {
-        // Mirror `call`: each CREATE/CREATE2 gets its own frame so a parent
-        // revert rolls the deployment back atomically with everything else
-        // that ran inside its constructor.
-        self.pending_frames.push(PendingFrame::default());
+        // Mirror `call`: every CREATE/CREATE2 gets a trace entry and its own
+        // frame so a parent revert rolls the deployment back atomically with
+        // everything else that ran inside its constructor.
+        let trace_index = self.traces.len();
+        self.traces.push(RawTrace {
+            kind: match inputs.scheme() {
+                revm::context_interface::CreateScheme::Create
+                | revm::context_interface::CreateScheme::Custom { .. } => TraceKind::Create,
+                revm::context_interface::CreateScheme::Create2 { .. } => TraceKind::Create2,
+            },
+            from: inputs.caller(),
+            to: None,
+            selector: None,
+            value: inputs.value(),
+            depth: self.pending_frames.len(),
+            outcome: None,
+            revert_reason: None,
+        });
+        self.pending_frames.push(PendingFrame::new(trace_index));
         None
     }
 
@@ -416,9 +539,16 @@ impl<CTX: revm::context_interface::ContextTr> Inspector<CTX> for SimulationInspe
         outcome: &mut revm::interpreter::CreateOutcome,
     ) {
         let Some(mut frame) = self.pending_frames.pop() else {
+            self.trace_error
+                .get_or_insert("simulation inspector CREATE ended without a pending frame");
             return;
         };
         let result = outcome.instruction_result();
+        if let Some(trace) = self.record_trace_outcome(frame.trace_index, result, outcome.output())
+            && result.is_ok()
+        {
+            trace.to = outcome.address;
+        }
         if !result.is_ok() {
             // CREATE itself failed — drop the frame. Capture an explicit
             // constructor REVERT before an outer call can replace its useful
@@ -769,7 +899,9 @@ where
         //     side-effects from the inspector. The EVM owns it; recover a
         //     `&mut` via `components_mut()` and drain.
         let (_, inspector, _) = evm.components_mut();
-        let trace = inspector.take_trace_entries();
+        let trace = inspector
+            .take_trace_entries()
+            .map_err(|error| internal_err(format!("simulation inspector failed: {error}")))?;
         asset_changes.extend(inspector.take_native_asset_changes());
         let inspector_creations = inspector.take_contract_creations();
         let force_metadata_refresh: HashSet<Address> = inspector_creations
@@ -1590,6 +1722,41 @@ fn internal_err(msg: impl std::fmt::Display) -> jsonrpsee::types::ErrorObjectOwn
 mod tests {
     use super::*;
     use std::time::{Duration, Instant};
+
+    #[test]
+    fn missing_trace_entry_is_reported_without_panicking() {
+        let mut inspector = SimulationInspector::default();
+
+        assert!(
+            inspector
+                .record_trace_outcome(0, &InstructionResult::Revert, &Bytes::new())
+                .is_none()
+        );
+        assert!(matches!(
+            inspector.take_trace_entries(),
+            Err("simulation inspector frame referenced a missing trace entry")
+        ));
+    }
+
+    #[test]
+    fn incomplete_trace_is_reported_without_panicking() {
+        let mut inspector = SimulationInspector::default();
+        inspector.traces.push(RawTrace {
+            kind: TraceKind::Call,
+            from: Address::ZERO,
+            to: Some(Address::ZERO),
+            selector: Some([0; 4]),
+            value: U256::ZERO,
+            depth: 0,
+            outcome: None,
+            revert_reason: None,
+        });
+
+        assert!(matches!(
+            inspector.take_trace_entries(),
+            Err("simulation inspector trace frame did not complete")
+        ));
+    }
 
     /// Stand-in "malicious payload": anything that pegs a worker for longer
     /// than `SIMULATION_TIMEOUT`. Crafting bytecode that reliably blows

--- a/crates/rpc/tests/fork_simulate.rs
+++ b/crates/rpc/tests/fork_simulate.rs
@@ -33,9 +33,10 @@ use revm_primitives::TxKind;
 use std::str::FromStr;
 
 use world_chain_rpc::simulate::{
-    AssetType, ContractManagementType, SimulationInspector, assemble_contract_management,
-    decode_revert_reason, parse_asset_changes, parse_contract_management_events,
-    parse_exposure_changes, relax_cfg_for_simulation, selector_to_name,
+    AssetType, ContractManagementType, SimulationInspector, TraceKind, TraceOutcome,
+    assemble_contract_management, decode_revert_reason, parse_asset_changes,
+    parse_contract_management_events, parse_exposure_changes, relax_cfg_for_simulation,
+    selector_to_name,
 };
 
 // ─── Constants ───────────────────────────────────────────────────────────────
@@ -901,9 +902,16 @@ async fn test_trace_captures_calls() {
     assert!(matches!(result.result, ExecutionResult::Success { .. }));
 
     let (_, inspector, _) = evm.components_mut();
-    let trace = inspector.take_trace_entries();
+    let trace = inspector
+        .take_trace_entries()
+        .expect("completed simulation should produce a complete trace");
     for entry in &trace {
-        assert!(entry.selector.starts_with("0x"));
+        assert!(
+            entry
+                .selector
+                .as_deref()
+                .is_some_and(|selector| selector.starts_with("0x"))
+        );
     }
 }
 
@@ -1044,11 +1052,13 @@ async fn test_trace_detects_malicious_safe_call() {
     ];
 
     let (_, inspector, _) = evm.components_mut();
-    let trace = inspector.take_trace_entries();
+    let trace = inspector
+        .take_trace_entries()
+        .expect("completed simulation should produce a complete trace");
     // Log what the trace captured (informational)
     for entry in &trace {
         println!(
-            "trace: to={} method={:?} selector={}",
+            "trace: to={:?} method={:?} selector={:?}",
             entry.to, entry.method, entry.selector
         );
         // If any trace entry matches a forbidden method, flag it
@@ -1546,6 +1556,18 @@ async fn test_inspector_captures_create_via_call_frame() {
     let (deployer, deployed) = creations[0];
     assert_eq!(deployer, trampoline, "deployer is the trampoline contract");
     assert_ne!(deployed, Address::ZERO, "deployed address populated");
+
+    let trace = inspector
+        .take_trace_entries()
+        .expect("completed simulation should produce a complete trace");
+    let create = trace
+        .iter()
+        .find(|entry| entry.kind == TraceKind::Create)
+        .expect("CREATE should appear in trace");
+    assert_eq!(create.depth, 1);
+    assert_eq!(create.outcome, TraceOutcome::Success);
+    assert_eq!(create.to, Some(deployed));
+    assert_eq!(create.revert_reason, None);
 }
 
 /// CREATE inside a frame that subsequently REVERTs is rolled back: the

--- a/crates/rpc/tests/inspector_create_revert.rs
+++ b/crates/rpc/tests/inspector_create_revert.rs
@@ -14,7 +14,9 @@ use revm::{
 use revm_database::{CacheDB, EmptyDB};
 use revm_primitives::TxKind;
 
-use world_chain_rpc::simulate::{SimulationInspector, TraceKind, TraceOutcome, relax_cfg_for_simulation};
+use world_chain_rpc::simulate::{
+    SimulationInspector, TraceKind, TraceOutcome, relax_cfg_for_simulation,
+};
 
 const CHAIN_ID: u64 = 480;
 const CALLER: Address = address!("00000000000000000000000000000000DeaDBeef");

--- a/crates/rpc/tests/inspector_create_revert.rs
+++ b/crates/rpc/tests/inspector_create_revert.rs
@@ -4,7 +4,7 @@
 
 use alloy_op_evm::{OpEvmFactory, OpTx};
 use alloy_primitives::{Address, Bytes, U256, address};
-use op_revm::{OpSpecId, OpTransaction};
+use op_revm::{OpHaltReason, OpSpecId, OpTransaction};
 use reth_evm::{Evm as RethEvm, EvmFactory};
 use revm::{
     bytecode::Bytecode,
@@ -14,9 +14,11 @@ use revm::{
 use revm_database::{CacheDB, EmptyDB};
 use revm_primitives::TxKind;
 
-use world_chain_rpc::simulate::{SimulationInspector, relax_cfg_for_simulation};
+use world_chain_rpc::simulate::{SimulationInspector, TraceKind, TraceOutcome, relax_cfg_for_simulation};
 
 const CHAIN_ID: u64 = 480;
+const CALLER: Address = address!("00000000000000000000000000000000DeaDBeef");
+const TRAMPOLINE: Address = address!("000000000000000000000000000000000000c0de");
 
 /// Runtime code that executes CREATE with a 12-byte constructor, then hides
 /// the constructor's revert data by reverting the outer frame with no output.
@@ -39,6 +41,30 @@ const CREATE_REVERT_TRAMPOLINE: &[u8] = &[
     0x5f, 0x5f, 0xfd, // REVERT(0, 0)
 ];
 
+/// Same constructor, but the outer frame catches CREATE's failure and STOPs.
+/// This distinguishes the parent and child outcomes and guards trace-index
+/// association across nested frames.
+const CAUGHT_CREATE_REVERT_TRAMPOLINE: &[u8] = &[
+    0x6b, // PUSH12 constructor
+    0x63, 0xde, 0xad, 0xbe, 0xef, // PUSH4 0xdeadbeef
+    0x5f, 0x52, // PUSH0; MSTORE
+    0x60, 0x04, // PUSH1 4 (revert-data length)
+    0x60, 0x1c, // PUSH1 28 (revert-data offset)
+    0xfd, // REVERT
+    0x5f, 0x52, // PUSH0; MSTORE constructor at memory[20..32]
+    0x60, 0x0c, // PUSH1 12 (init-code length)
+    0x60, 0x14, // PUSH1 20 (init-code offset)
+    0x5f, 0xf0, // PUSH0 value; CREATE
+    0x50, 0x00, // POP failed CREATE's zero address; STOP
+];
+
+/// Executes CREATE with empty init code and then stops. Empty init code
+/// successfully deploys an empty contract.
+const SUCCESSFUL_CREATE_TRAMPOLINE: &[u8] = &[
+    0x5f, 0x5f, 0x5f, 0xf0, // CREATE(value=0, offset=0, size=0)
+    0x50, 0x00, // POP deployed address; STOP
+];
+
 fn evm_env() -> reth_evm::EvmEnv<OpSpecId> {
     let mut cfg = CfgEnv::new_with_spec(OpSpecId::ISTHMUS);
     cfg.chain_id = CHAIN_ID;
@@ -59,19 +85,16 @@ fn install_runtime_code(db: &mut CacheDB<EmptyDB>, address: Address, code: Vec<u
     );
 }
 
-#[test]
-fn inspector_captures_constructor_revert_reason() {
-    let caller = address!("00000000000000000000000000000000DeaDBeef");
-    let trampoline = address!("000000000000000000000000000000000000c0de");
+fn run_trampoline(code: &[u8]) -> (ExecutionResult<OpHaltReason>, SimulationInspector) {
     let mut db = CacheDB::<EmptyDB>::default();
     db.insert_account_info(
-        caller,
+        CALLER,
         AccountInfo {
             balance: U256::from(10_u128.pow(21)),
             ..Default::default()
         },
     );
-    install_runtime_code(&mut db, trampoline, CREATE_REVERT_TRAMPOLINE.to_vec());
+    install_runtime_code(&mut db, TRAMPOLINE, code.to_vec());
 
     let mut evm = OpEvmFactory::default().create_evm_with_inspector(
         &mut db,
@@ -82,8 +105,8 @@ fn inspector_captures_constructor_revert_reason() {
         &mut evm,
         OpTx(OpTransaction {
             base: TxEnv {
-                caller,
-                kind: TxKind::Call(trampoline),
+                caller: CALLER,
+                kind: TxKind::Call(TRAMPOLINE),
                 gas_limit: 1_000_000,
                 gas_price: 0,
                 chain_id: Some(CHAIN_ID),
@@ -92,14 +115,94 @@ fn inspector_captures_constructor_revert_reason() {
             ..Default::default()
         }),
     )
-    .expect("EVM transaction should execute");
-
-    assert!(matches!(result.result, ExecutionResult::Revert { .. }));
+    .expect("EVM transaction should execute")
+    .result;
 
     let (_, inspector, _) = evm.components_mut();
+    (result, std::mem::take(inspector))
+}
+
+#[test]
+fn inspector_captures_constructor_revert_reason() {
+    let (result, mut inspector) = run_trampoline(CREATE_REVERT_TRAMPOLINE);
+
+    assert!(matches!(result, ExecutionResult::Revert { .. }));
     assert_eq!(
         inspector.take_deepest_revert_reason().as_deref(),
         Some("0xdeadbeef")
     );
     assert!(inspector.take_contract_creations().is_empty());
+
+    let trace = inspector
+        .take_trace_entries()
+        .expect("completed simulation should produce a complete trace");
+    let [parent, create] = trace.as_slice() else {
+        panic!("expected parent CALL and child CREATE, got {trace:?}");
+    };
+
+    assert_eq!(parent.kind, TraceKind::Call);
+    assert_eq!(parent.depth, 0);
+    assert_eq!(parent.outcome, TraceOutcome::Revert);
+    assert_eq!(parent.revert_reason, None);
+
+    assert_eq!(create.kind, TraceKind::Create);
+    assert_eq!(create.depth, 1);
+    assert_eq!(create.outcome, TraceOutcome::Revert);
+    assert_eq!(create.revert_reason.as_deref(), Some("0xdeadbeef"));
+    assert_eq!(create.to, None);
+    assert_eq!(create.selector, None);
+
+    let create_json = serde_json::to_value(create).expect("serialize CREATE trace entry");
+    assert_eq!(create_json["kind"], "create");
+    assert_eq!(create_json["outcome"], "revert");
+    assert_eq!(create_json["depth"], 1);
+    assert_eq!(create_json["revertReason"], "0xdeadbeef");
+    assert!(create_json.get("to").is_none());
+    assert!(create_json.get("selector").is_none());
+}
+
+#[test]
+fn nested_create_revert_does_not_overwrite_successful_parent_outcome() {
+    let (result, mut inspector) = run_trampoline(CAUGHT_CREATE_REVERT_TRAMPOLINE);
+
+    assert!(matches!(result, ExecutionResult::Success { .. }));
+    let trace = inspector
+        .take_trace_entries()
+        .expect("completed simulation should produce a complete trace");
+    let [parent, create] = trace.as_slice() else {
+        panic!("expected parent CALL and child CREATE, got {trace:?}");
+    };
+    assert_eq!(parent.kind, TraceKind::Call);
+    assert_eq!(parent.outcome, TraceOutcome::Success);
+    assert_eq!(create.kind, TraceKind::Create);
+    assert_eq!(create.outcome, TraceOutcome::Revert);
+    assert_eq!(create.revert_reason.as_deref(), Some("0xdeadbeef"));
+}
+
+#[test]
+fn inspector_traces_successful_create_with_deployed_address() {
+    let (result, mut inspector) = run_trampoline(SUCCESSFUL_CREATE_TRAMPOLINE);
+
+    assert!(matches!(result, ExecutionResult::Success { .. }));
+    let creations = inspector.take_contract_creations();
+    assert_eq!(creations.len(), 1);
+    let (deployer, deployed) = creations[0];
+    assert_eq!(deployer, TRAMPOLINE);
+    assert_ne!(deployed, Address::ZERO);
+
+    let trace = inspector
+        .take_trace_entries()
+        .expect("completed simulation should produce a complete trace");
+    let [parent, create] = trace.as_slice() else {
+        panic!("expected parent CALL and child CREATE, got {trace:?}");
+    };
+    assert_eq!(parent.kind, TraceKind::Call);
+    assert_eq!(parent.depth, 0);
+    assert_eq!(parent.outcome, TraceOutcome::Success);
+    assert_eq!(create.kind, TraceKind::Create);
+    assert_eq!(create.depth, 1);
+    assert_eq!(create.outcome, TraceOutcome::Success);
+    assert_eq!(create.to, Some(deployed));
+    assert_eq!(create.selector, None);
+    assert_eq!(create.revert_reason, None);
 }

--- a/crates/rpc/tests/inspector_shared_buffer.rs
+++ b/crates/rpc/tests/inspector_shared_buffer.rs
@@ -26,7 +26,7 @@ use revm::{
 use revm_database::{CacheDB, EmptyDB};
 use revm_primitives::TxKind;
 
-use world_chain_rpc::simulate::SimulationInspector;
+use world_chain_rpc::simulate::{SimulationInspector, TraceKind, TraceOutcome};
 
 const CHAIN_ID: u64 = 480;
 
@@ -143,15 +143,18 @@ async fn shared_buffer_call_resolves_selector() {
     }
 
     let (_, inspector, _) = evm.components_mut();
-    let trace = inspector.take_trace_entries();
+    let trace = inspector
+        .take_trace_entries()
+        .expect("completed simulation should produce a complete trace");
 
     let inner = trace
         .iter()
-        .find(|t| t.from == forwarder && t.to == target)
+        .find(|t| t.from == forwarder && t.to == Some(target))
         .expect("inner forwarder->target call should appear in trace");
 
     assert_eq!(
-        inner.selector, "0x0d582f13",
+        inner.selector.as_deref(),
+        Some("0x0d582f13"),
         "selector for SharedBuffer call must match the bytes written to memory"
     );
     assert_eq!(
@@ -159,4 +162,8 @@ async fn shared_buffer_call_resolves_selector() {
         Some("addOwnerWithThreshold"),
         "decoded method must surface so backend forbidden-method checks can detect it"
     );
+    assert_eq!(inner.kind, TraceKind::Call);
+    assert_eq!(inner.depth, 1);
+    assert_eq!(inner.outcome, TraceOutcome::Success);
+    assert_eq!(inner.revert_reason, None);
 }


### PR DESCRIPTION
Adds frame kind, depth, outcome, and local revert reasons to simulation traces. CREATE/CREATE2 frames are now included alongside CALL frames.

### Compatibility

Verified against [app-backend-main’s RPC response consumer](https://github.com/worldcoin/app-backend-main/blob/205ab8f16b89611bc9dd648c1e27c0ae61f0c476/src/transactions-security/worldchain-rpc/worldchain-rpc.service.ts#L167-L199). Existing CALL fields retain their current wire shape, and app-backend does not currently inspect individual trace entries, so the added metadata and CREATE entries are additive for current usage.

The app-backend `TraceEntry` type should be updated before it begins consuming CREATE-specific fields, since `to` and `selector` can be absent for CREATE entries.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shape of `simulate_unsignedUserOp` trace JSON (`to`/`selector` optional, new required fields); additive for current app-backend usage but breaking for strict consumers of CREATE entries.
> 
> **Overview**
> Simulation RPC traces are expanded from call-only rows into **per-frame execution records** that cover CALL-family and CREATE/CREATE2 operations at every depth.
> 
> Each `TraceEntry` now carries **`kind`** (call scheme or create type), **`depth`**, **`outcome`** (`success` / `revert` / `halt`), and an optional **per-frame `revertReason`**. **`to`** and **`selector`** are optional so CREATE frames can omit them while successful creates set **`to`** to the deployed address. CALL entries still populate selector/method when calldata is available.
> 
> `SimulationInspector` ties each pending frame to a trace index, records outcomes in `call_end` / `create_end`, and **`take_trace_entries`** returns **`Result`** (inspector bookkeeping failures surface as RPC internal errors instead of panics). Integration tests cover nested CREATE revert vs successful parent, SharedBuffer selectors, and CREATE wire JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 422b9e73bf64cf0f7594d389c3b83a4f03364ff2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->