### PR TITLE
chore: better errors for world-chain-proposer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19294,11 +19294,13 @@ name = "world-chain-proposer"
 version = "2.4.0"
 dependencies = [
  "alloy-consensus 2.0.5",
+ "alloy-contract",
  "alloy-eips 2.0.5",
  "alloy-network 2.0.5",
  "alloy-primitives",
  "alloy-provider",
  "alloy-signer-local 2.0.5",
+ "alloy-transport",
  "anyhow",
  "async-trait",
  "clap",

--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -414,7 +414,7 @@ impl ProposerClient for FakeExecution {
     async fn resolve_game(&self, game: Address) -> Result<ResolveSubmission, ProposerError> {
         let status = self.lineage_resolution_status(game).await?;
         if !status.resolvable {
-            return Err(ProposerError::Contract(format!(
+            return Err(ProposerError::message(format!(
                 "game {game} is not resolvable"
             )));
         }
@@ -422,12 +422,12 @@ impl ProposerClient for FakeExecution {
         let record = state
             .games_by_address
             .get_mut(&game)
-            .ok_or_else(|| ProposerError::Contract(format!("unknown game {game}")))?;
+            .ok_or_else(|| ProposerError::message(format!("unknown game {game}")))?;
         record.state = match status.root_state {
             RootState::Finalized => STATE_FINALIZED,
             RootState::Invalidated => STATE_INVALIDATED,
             _ => {
-                return Err(ProposerError::Contract(format!(
+                return Err(ProposerError::message(format!(
                     "game {game} has no terminal outcome"
                 )));
             }
@@ -443,9 +443,9 @@ impl ProposerClient for FakeExecution {
         let record = state
             .games_by_address
             .get(&game)
-            .ok_or_else(|| ProposerError::Contract(format!("unknown game {game}")))?;
+            .ok_or_else(|| ProposerError::message(format!("unknown game {game}")))?;
         if record.state != STATE_FINALIZED {
-            return Err(ProposerError::Contract(format!(
+            return Err(ProposerError::message(format!(
                 "game {game} is not finalized"
             )));
         }
@@ -466,7 +466,7 @@ impl ProposerClient for FakeExecution {
         let mut state = self.state.lock().expect("fake execution mutex poisoned");
         let uuid = proposal.commitment().game_uuid(state.domain_hash);
         if let Some(existing) = state.games_by_key.get(&uuid) {
-            return Err(ProposerError::Contract(format!(
+            return Err(ProposerError::message(format!(
                 "game already exists for factory uuid {uuid} at {existing}"
             )));
         }

--- a/proofs/proposer/Cargo.toml
+++ b/proofs/proposer/Cargo.toml
@@ -21,11 +21,13 @@ world-chain-proof-metrics.workspace = true
 
 # alloy
 alloy-consensus.workspace = true
+alloy-contract.workspace = true
 alloy-network.workspace = true
 alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-provider = { workspace = true, features = ["reqwest", "reqwest-rustls-tls"] }
 alloy-signer-local.workspace = true
+alloy-transport.workspace = true
 
 # misc
 anyhow.workspace = true

--- a/proofs/proposer/src/alloy.rs
+++ b/proofs/proposer/src/alloy.rs
@@ -75,12 +75,7 @@ where
 
     /// Resolves the WIP-1006 game at a factory index, skipping other game types.
     async fn wip_1006_game_at(&self, index: u64) -> Result<Option<Address>, ProposerError> {
-        let entry = self
-            .factory
-            .gameAtIndex(U256::from(index))
-            .call()
-            .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+        let entry = self.factory.gameAtIndex(U256::from(index)).call().await?;
 
         Ok((entry.gameType == MULTI_PROOF_GAME_TYPE).then_some(entry.proxy))
     }
@@ -99,23 +94,17 @@ where
             .isGameFinalized(game)
             .call()
             .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))
+            .map_err(Into::into)
     }
 
     async fn send_resolve_game(&self, game: Address) -> Result<ResolveSubmission, ProposerError> {
-        let pending = self
-            .game(game)
-            .resolve()
-            .send()
-            .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+        let pending = self.game(game).resolve().send().await?;
 
         let tx_hash = *pending.tx_hash();
         let receipt = pending
             .with_required_confirmations(self.confirmations)
             .get_receipt()
-            .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+            .await?;
         world_chain_proof_metrics::refresh_wallet_balance(&self.provider, receipt.from).await;
         if !receipt.status() {
             return Err(ProposerError::Revert(tx_hash));
@@ -130,7 +119,7 @@ where
             .credit(recipient)
             .call()
             .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))
+            .map_err(Into::into)
     }
 
     /// Reads `recipient`'s pending `DelayedWETH` withdrawal for `game`.
@@ -139,12 +128,7 @@ where
         game: Address,
         recipient: Address,
     ) -> Result<PendingWithdrawal, ProposerError> {
-        let weth_address = self
-            .game(game)
-            .weth()
-            .call()
-            .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+        let weth_address = self.game(game).weth().call().await?;
         let weth = IDelayedWETH::IDelayedWETHInstance::new(weth_address, self.provider.clone());
 
         let (pending, delay) = self
@@ -153,8 +137,7 @@ where
             .add(weth.withdrawals(game, recipient))
             .add(weth.delay())
             .aggregate()
-            .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+            .await?;
 
         if pending.amount.is_zero() {
             return Ok(PendingWithdrawal::default());
@@ -162,11 +145,11 @@ where
         let unlock_at = pending
             .timestamp
             .checked_add(delay)
-            .ok_or_else(|| ProposerError::Contract("DelayedWETH unlock time overflows".into()))?;
+            .ok_or(ProposerError::Overflow)?;
 
         Ok(PendingWithdrawal {
             amount: pending.amount,
-            unlock_at: u256_to_u64(unlock_at, "DelayedWETH unlock time")?,
+            unlock_at: u256_to_u64(unlock_at)?,
         })
     }
 
@@ -185,18 +168,12 @@ where
             PendingWithdrawal::default()
         };
 
-        let pending_tx = self
-            .game(game)
-            .claimCredit(recipient)
-            .send()
-            .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+        let pending_tx = self.game(game).claimCredit(recipient).send().await?;
         let tx_hash = *pending_tx.tx_hash();
         let receipt = pending_tx
             .with_required_confirmations(self.confirmations)
             .get_receipt()
-            .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+            .await?;
         world_chain_proof_metrics::refresh_wallet_balance(&self.provider, receipt.from).await;
         if !receipt.status() {
             return Err(ProposerError::Revert(tx_hash));
@@ -228,13 +205,8 @@ where
     }
 
     async fn game_count(&self) -> Result<u64, ProposerError> {
-        let count = self
-            .factory
-            .gameCount()
-            .call()
-            .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))?;
-        u256_to_u64(count, "gameCount")
+        let count = self.factory.gameCount().call().await?;
+        u256_to_u64(count)
     }
 
     async fn game_at(&self, index: u64) -> Result<Option<Address>, ProposerError> {
@@ -246,7 +218,7 @@ where
             .gameCreator()
             .call()
             .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))
+            .map_err(Into::into)
     }
 
     async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError> {
@@ -273,10 +245,9 @@ where
     async fn latest_l1_timestamp(&self) -> Result<u64, ProposerError> {
         self.provider
             .get_block_by_number(BlockNumberOrTag::Latest)
-            .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))?
+            .await?
             .map(|block| block.header.timestamp())
-            .ok_or_else(|| ProposerError::Contract("latest L1 block is unavailable".into()))
+            .ok_or(ProposerError::UnavailableLatestL1Block)
     }
 
     async fn claim_credit(&self, game: Address) -> Result<ClaimSubmission, ProposerError> {
@@ -326,19 +297,13 @@ where
     }
 
     async fn close_game(&self, game: Address) -> Result<CloseGameSubmission, ProposerError> {
-        let pending = self
-            .game(game)
-            .closeGame()
-            .send()
-            .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+        let pending = self.game(game).closeGame().send().await?;
 
         let tx_hash = *pending.tx_hash();
         let receipt = pending
             .with_required_confirmations(self.confirmations)
             .get_receipt()
-            .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+            .await?;
         world_chain_proof_metrics::refresh_wallet_balance(&self.provider, receipt.from).await;
         if !receipt.status() {
             return Err(ProposerError::Revert(tx_hash));
@@ -353,12 +318,7 @@ where
     ) -> Result<ProposalSubmission, ProposerError> {
         // `DisputeGameFactory.create` reverts unless `msg.value` matches the configured init
         // bond exactly, so it is read per submission rather than cached in configuration.
-        let init_bond = self
-            .factory
-            .initBonds(MULTI_PROOF_GAME_TYPE)
-            .call()
-            .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+        let init_bond = self.factory.initBonds(MULTI_PROOF_GAME_TYPE).call().await?;
 
         let extra_data = proposal
             .commitment()
@@ -368,15 +328,13 @@ where
             .create(MULTI_PROOF_GAME_TYPE, proposal.root_claim, extra_data)
             .value(init_bond)
             .send()
-            .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+            .await?;
 
         let tx_hash = *pending.tx_hash();
         let receipt = pending
             .with_required_confirmations(self.confirmations)
             .get_receipt()
-            .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+            .await?;
         world_chain_proof_metrics::refresh_wallet_balance(&self.provider, receipt.from).await;
         if !receipt.status() {
             return Err(ProposerError::Revert(tx_hash));
@@ -395,11 +353,7 @@ where
                 event.gameType == MULTI_PROOF_GAME_TYPE && event.rootClaim == proposal.root_claim
             })
             .map(|event| event.disputeProxy)
-            .ok_or_else(|| {
-                ProposerError::Contract(format!(
-                    "DisputeGameCreated event missing from proposal transaction {tx_hash}"
-                ))
-            })?;
+            .ok_or(ProposerError::MissingProposalEvent(tx_hash))?;
 
         Ok(ProposalSubmission {
             tx_hash,
@@ -414,19 +368,12 @@ where
 {
     /// Reads an L2 block number from a game contract.
     pub async fn game_l2_block_number(&self, game: Address) -> Result<u64, ProposerError> {
-        let l2_block_number = self
-            .game(game)
-            .l2BlockNumber()
-            .call()
-            .await
-            .map_err(|error| ProposerError::Contract(error.to_string()))?;
+        let l2_block_number = self.game(game).l2BlockNumber().call().await?;
 
-        u256_to_u64(l2_block_number, "l2BlockNumber")
+        u256_to_u64(l2_block_number)
     }
 }
 
-fn u256_to_u64(value: U256, field: &'static str) -> Result<u64, ProposerError> {
-    value
-        .try_into()
-        .map_err(|_| ProposerError::Contract(format!("{field} overflows u64")))
+fn u256_to_u64(value: U256) -> Result<u64, ProposerError> {
+    value.try_into().map_err(|_| ProposerError::Overflow)
 }

--- a/proofs/proposer/src/error.rs
+++ b/proofs/proposer/src/error.rs
@@ -1,4 +1,6 @@
 use alloy_primitives::TxHash;
+use alloy_provider::{MulticallError, PendingTransactionError, transport::RpcError};
+use alloy_transport::TransportErrorKind;
 use thiserror::Error;
 use world_chain_proofs::LineageError;
 
@@ -9,10 +11,35 @@ pub enum ProposerError {
     #[error("invalid proposer config: {0}")]
     InvalidConfig(&'static str),
     /// Contract call or transaction failure.
-    #[error("contract error: {0}")]
-    Contract(String),
+    #[error(transparent)]
+    Contract(#[from] alloy_contract::Error),
+    /// A transaction failed while waiting for its receipt.
+    #[error(transparent)]
+    PendingTransaction(#[from] PendingTransactionError),
+    /// A multicall request failed.
+    #[error(transparent)]
+    Multicall(#[from] MulticallError),
+    /// An Alloy JSON-RPC request failed.
+    #[error(transparent)]
+    AlloyJsonRpc(#[from] RpcError<TransportErrorKind>),
     #[error(transparent)]
     Lineage(#[from] LineageError),
     #[error("The proposal transaction didn't execute succesfully: {0}")]
     Revert(TxHash),
+    #[error("Overflow error.")]
+    Overflow,
+    #[error("Latest L1 block is unavailable.")]
+    UnavailableLatestL1Block,
+    #[error("DisputeGameCreated event missing from proposal transaction {0}")]
+    MissingProposalEvent(TxHash),
+}
+
+impl ProposerError {
+    /// Builds an [`AlloyJsonRpc`](Self::AlloyJsonRpc) error from a free-form message.
+    ///
+    /// Intended for test fakes that need an ad-hoc failure without constructing a full transport
+    /// error by hand.
+    pub fn message(message: impl AsRef<str>) -> Self {
+        Self::AlloyJsonRpc(TransportErrorKind::custom_str(message.as_ref()))
+    }
 }

--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -85,9 +85,7 @@ where
                             parent_ref: transition.parent_ref,
                             root_claim: transition.root_claim,
                             l2_block_number: transition.l2_block_number,
-                            attempt: game.attempt.checked_add(1).ok_or_else(|| {
-                                ProposerError::Contract("proposal attempt overflows u64".into())
-                            })?,
+                            attempt: game.attempt.checked_add(1).ok_or(ProposerError::Overflow)?,
                         },
                         invalidated_game: game.address,
                     }

--- a/proofs/proposer/src/tests.rs
+++ b/proofs/proposer/src/tests.rs
@@ -124,8 +124,8 @@ impl ProposerClient for MockContracts {
         let mut failures = self.submission_failures.lock().expect("not poisoned");
         if *failures > 0 {
             *failures -= 1;
-            return Err(ProposerError::Contract(
-                "injected proposal submission failure".into(),
+            return Err(ProposerError::message(
+                "injected proposal submission failure",
             ));
         }
         drop(failures);
@@ -218,14 +218,14 @@ impl BondManagerClient for MockBondClient {
         let mut fail_index = self.fail_game_at_once.lock().expect("not poisoned");
         if *fail_index == Some(index) {
             *fail_index = None;
-            return Err(ProposerError::Contract("injected gameAt failure".into()));
+            return Err(ProposerError::message("injected gameAt failure"));
         }
         self.games
             .lock()
             .expect("not poisoned")
             .get(index as usize)
             .map(|(game, _)| *game)
-            .ok_or_else(|| ProposerError::Contract(format!("missing game at index {index}")))
+            .ok_or_else(|| ProposerError::message(format!("missing game at index {index}")))
     }
 
     async fn game_creator(&self, game: Address) -> Result<Address, ProposerError> {
@@ -234,7 +234,7 @@ impl BondManagerClient for MockBondClient {
             .expect("not poisoned")
             .iter()
             .find_map(|(candidate, creator)| (*candidate == Some(game)).then_some(*creator))
-            .ok_or_else(|| ProposerError::Contract(format!("unknown game {game}")))
+            .ok_or_else(|| ProposerError::message(format!("unknown game {game}")))
     }
 
     async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError> {
@@ -267,9 +267,9 @@ impl BondManagerClient for MockBondClient {
         let mut statuses = self.resolution_statuses.lock().expect("not poisoned");
         let status = statuses
             .get_mut(&game)
-            .ok_or_else(|| ProposerError::Contract(format!("game {game} is not resolvable")))?;
+            .ok_or_else(|| ProposerError::message(format!("game {game} is not resolvable")))?;
         if !status.resolvable {
-            return Err(ProposerError::Contract(format!(
+            return Err(ProposerError::message(format!(
                 "game {game} is not resolvable"
             )));
         }
@@ -319,7 +319,7 @@ impl BondManagerClient for MockBondClient {
             .expect("not poisoned")
             .remove(&game)
         {
-            return Err(ProposerError::Contract("injected claim failure".into()));
+            return Err(ProposerError::message("injected claim failure"));
         }
 
         let credit = self
@@ -604,7 +604,7 @@ async fn propose_can_retry_a_failed_submission() {
 
     assert!(matches!(
         advance_proposal(&proposer, &scan).await,
-        Err(ProposerError::Contract(_))
+        Err(ProposerError::AlloyJsonRpc(_))
     ));
     assert!(submissions.lock().expect("not poisoned").is_empty());
 


### PR DESCRIPTION
This PR makes world-chain-proposer errors way more explicit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Error-type refactor with no change to on-chain behavior; improves observability and test assertions (e.g. `AlloyJsonRpc` vs generic contract errors).
> 
> **Overview**
> **`ProposerError` is no longer a single `Contract(String)` bucket.** Alloy failures are surfaced as typed variants (`Contract`, `PendingTransaction`, `Multicall`, `AlloyJsonRpc`), and a few former string cases are named variants (`Overflow`, `UnavailableLatestL1Block`, `MissingProposalEvent`).
> 
> The Alloy client in `alloy.rs` drops manual `.map_err(|e| ProposerError::Contract(e.to_string()))` in favor of `?` / `Into::into`. Integration and unit fakes use **`ProposerError::message`** for ad-hoc failures instead of building contract error strings. **`alloy-contract`** and **`alloy-transport`** are added as dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e86b5242354108f21bab9ddcf1701d9d46668977. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->