### PR TITLE
chore: better errors for world-chain-defender

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18703,11 +18703,13 @@ dependencies = [
 name = "world-chain-defender"
 version = "2.4.0"
 dependencies = [
+ "alloy-contract",
  "alloy-network 2.0.5",
  "alloy-primitives",
  "alloy-provider",
  "alloy-signer-local 2.0.5",
  "alloy-sol-types",
+ "alloy-transport",
  "anyhow",
  "async-trait",
  "clap",

--- a/proofs/defender/Cargo.toml
+++ b/proofs/defender/Cargo.toml
@@ -22,11 +22,13 @@ world-chain-proof-metrics.workspace = true
 world-chain-prover-service.workspace = true
 
 # alloy
+alloy-contract.workspace = true
 alloy-network.workspace = true
 alloy-primitives.workspace = true
 alloy-provider = { workspace = true, features = ["reqwest", "reqwest-rustls-tls"] }
 alloy-signer-local.workspace = true
 alloy-sol-types.workspace = true
+alloy-transport.workspace = true
 
 # misc
 anyhow.workspace = true

--- a/proofs/defender/src/alloy.rs
+++ b/proofs/defender/src/alloy.rs
@@ -118,12 +118,12 @@ where
             .add(game.proofDeadline())
             .add(game.PROOF_THRESHOLD())
             .aggregate()
-            .await
-            .map_err(|error| DefenderError::Contract(error.to_string()))?;
+            .await?;
         if proof_threshold == 0 || proof_threshold > PROOF_LANE_COUNT {
-            return Err(DefenderError::Contract(format!(
-                "invalid proof threshold {proof_threshold} for game {address}"
-            )));
+            return Err(DefenderError::InvalidProofThreshold {
+                proof_threshold,
+                game: address,
+            });
         }
 
         Ok(GameMetadata {
@@ -131,9 +131,9 @@ where
             domain_hash,
             parent_ref,
             root_claim,
-            l2_block_number: u256_to_u64(l2_block_number, "l2BlockNumber")?,
+            l2_block_number: u256_to_u64(l2_block_number)?,
             l1_origin_hash,
-            l1_origin_number: u256_to_u64(l1_origin_number, "l1OriginNumber")?,
+            l1_origin_number: u256_to_u64(l1_origin_number)?,
             challenge_deadline,
             proof_deadline,
             proof_threshold,
@@ -145,7 +145,7 @@ where
             .proofBitmap()
             .call()
             .await
-            .map_err(|error| DefenderError::Contract(error.to_string()))
+            .map_err(Into::into)
     }
 
     async fn submit_proof(
@@ -154,18 +154,12 @@ where
         lane: u8,
         proof: Bytes,
     ) -> Result<DefenderSubmission, DefenderError> {
-        let pending = self
-            .game(game)
-            .submitProofLane(lane, proof)
-            .send()
-            .await
-            .map_err(|err| DefenderError::Contract(err.to_string()))?;
+        let pending = self.game(game).submitProofLane(lane, proof).send().await?;
         let tx_hash = *pending.tx_hash();
         let receipt = pending
             .with_required_confirmations(self.confirmations)
             .get_receipt()
-            .await
-            .map_err(|err| DefenderError::Contract(err.to_string()))?;
+            .await?;
         world_chain_proof_metrics::refresh_wallet_balance(&self.provider, receipt.from).await;
         if !receipt.status() {
             return Err(DefenderError::Revert(tx_hash));
@@ -174,8 +168,6 @@ where
     }
 }
 
-fn u256_to_u64(value: U256, field: &'static str) -> Result<u64, DefenderError> {
-    value
-        .try_into()
-        .map_err(|_| DefenderError::Contract(format!("{field} overflows u64")))
+fn u256_to_u64(value: U256) -> Result<u64, DefenderError> {
+    value.try_into().map_err(|_| DefenderError::Overflow)
 }

--- a/proofs/defender/src/error.rs
+++ b/proofs/defender/src/error.rs
@@ -1,4 +1,6 @@
-use alloy_primitives::TxHash;
+use alloy_primitives::{Address, TxHash};
+use alloy_provider::{MulticallError, PendingTransactionError, transport::RpcError};
+use alloy_transport::TransportErrorKind;
 use thiserror::Error;
 use world_chain_proofs::LineageError;
 
@@ -9,8 +11,17 @@ pub enum DefenderError {
     #[error("invalid defender config: {0}")]
     InvalidConfig(&'static str),
     /// Contract call or transaction failure.
-    #[error("contract error: {0}")]
-    Contract(String),
+    #[error(transparent)]
+    Contract(#[from] alloy_contract::Error),
+    /// A transaction failed while waiting for its receipt.
+    #[error(transparent)]
+    PendingTransaction(#[from] PendingTransactionError),
+    /// A multicall request failed.
+    #[error(transparent)]
+    Multicall(#[from] MulticallError),
+    /// An Alloy JSON-RPC request failed.
+    #[error(transparent)]
+    AlloyJsonRpc(#[from] RpcError<TransportErrorKind>),
     /// Prover response could not be encoded for its on-chain verifier.
     #[error("invalid proof payload: {0}")]
     ProofEncoding(String),
@@ -18,4 +29,18 @@ pub enum DefenderError {
     Lineage(#[from] LineageError),
     #[error("The submitProofLane transaction didn't execute succesfully: {0}")]
     Revert(TxHash),
+    #[error("Overflow error.")]
+    Overflow,
+    #[error("Invalid proof threshold {proof_threshold} for game {game}")]
+    InvalidProofThreshold { proof_threshold: u8, game: Address },
+}
+
+impl DefenderError {
+    /// Builds an [`AlloyJsonRpc`](Self::AlloyJsonRpc) error from a free-form message.
+    ///
+    /// Intended for test fakes that need an ad-hoc failure without constructing a full transport
+    /// error by hand.
+    pub fn message(message: impl AsRef<str>) -> Self {
+        Self::AlloyJsonRpc(TransportErrorKind::custom_str(message.as_ref()))
+    }
 }

--- a/proofs/defender/src/tests.rs
+++ b/proofs/defender/src/tests.rs
@@ -217,7 +217,7 @@ impl DefenderClient for MockClient {
             .games
             .get(&game)
             .map(|record| record.metadata)
-            .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))
+            .ok_or_else(|| DefenderError::message(format!("unknown game {game}")))
     }
 
     async fn proof_bitmap(&self, game: Address) -> Result<u8, DefenderError> {
@@ -227,7 +227,7 @@ impl DefenderClient for MockClient {
             .games
             .get(&game)
             .map(|record| record.proof_bitmap)
-            .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))
+            .ok_or_else(|| DefenderError::message(format!("unknown game {game}")))
     }
 
     async fn submit_proof(
@@ -240,7 +240,7 @@ impl DefenderClient for MockClient {
         guard
             .games
             .get_mut(&game)
-            .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))?
+            .ok_or_else(|| DefenderError::message(format!("unknown game {game}")))?
             .proof_bitmap |= 1 << lane;
         guard.submissions.push((game, lane));
         Ok(DefenderSubmission {

--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -574,7 +574,7 @@ impl DefenderClient for FakeExecution {
                 proof_deadline: record.proof_deadline,
                 proof_threshold: PROOF_THRESHOLD,
             })
-            .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))
+            .ok_or_else(|| DefenderError::message(format!("unknown game {game}")))
     }
 
     async fn proof_bitmap(&self, game: Address) -> Result<u8, DefenderError> {
@@ -584,7 +584,7 @@ impl DefenderClient for FakeExecution {
             .games_by_address
             .get(&game)
             .map(|record| record.proof_bitmap)
-            .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))
+            .ok_or_else(|| DefenderError::message(format!("unknown game {game}")))
     }
 
     async fn submit_proof(
@@ -593,19 +593,18 @@ impl DefenderClient for FakeExecution {
         lane: u8,
         proof: Bytes,
     ) -> Result<DefenderSubmission, DefenderError> {
-        let lane =
-            proof_lane(lane).ok_or_else(|| DefenderError::Contract("invalid lane".into()))?;
+        let lane = proof_lane(lane).ok_or_else(|| DefenderError::message("invalid lane"))?;
         if proof.is_empty() {
-            return Err(DefenderError::Contract("empty proof".into()));
+            return Err(DefenderError::message("empty proof"));
         }
 
         let mut state = self.state.lock().expect("fake execution mutex poisoned");
         let record = state
             .games_by_address
             .get_mut(&game)
-            .ok_or_else(|| DefenderError::Contract(format!("unknown game {game}")))?;
+            .ok_or_else(|| DefenderError::message(format!("unknown game {game}")))?;
         if record.state != STATE_PROPOSED && record.state != STATE_CHALLENGED {
-            return Err(DefenderError::Contract(format!(
+            return Err(DefenderError::message(format!(
                 "game {game} is not open for proofs"
             )));
         }


### PR DESCRIPTION
This PR makes world-chain-defender errors way more explicit


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Error-type and messaging refactor only; defender behavior and on-chain submission flow are unchanged.
> 
> **Overview**
> **Replaces** the catch-all `DefenderError::Contract(String)` with **structured, Alloy-backed variants** so RPC, multicall, contract, and pending-transaction failures preserve their original error types and display text.
> 
> The Alloy client path now relies on `?` / `Into` instead of manually stringifying errors. Domain checks use dedicated variants: **`InvalidProofThreshold`** (bad on-chain threshold) and **`Overflow`** (u256→u64 conversion), instead of formatted contract strings.
> 
> Test and integration **fakes** return ad-hoc failures via **`DefenderError::message`**, which wraps a custom transport error for cases that are not real chain calls. **`alloy-contract`** and **`alloy-transport`** were added as dependencies to support the new error types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ce0696362b97928b6f3e3aa1430e67d42aa694e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->