### PR TITLE
chore: refactor world-chain-challenger

### DIFF
--- a/proofs/challenger/src/challenger.rs
+++ b/proofs/challenger/src/challenger.rs
@@ -64,11 +64,13 @@ impl<E, C> WorldChainChallenger<E, C> {
         self.next_game_index
     }
 
+    /// Returns the games currently queued for retry.
     #[cfg(test)]
     pub(crate) fn retry_games(&self) -> Vec<Address> {
         self.retry_games.keys().copied().collect()
     }
 
+    /// Adds a failed game scan to the retry queue.
     fn queue_retry_game(&mut self, game: GameMetadata, challenge_deadline: Option<u64>) {
         let existing = self.retry_games.get(&game.address);
         let retry_game = RetryGame {
@@ -114,6 +116,7 @@ where
         Ok(low)
     }
 
+    /// Determines whether a game should be challenged.
     async fn process_game(
         &self,
         game: &GameMetadata,
@@ -172,6 +175,7 @@ where
         }
     }
 
+    /// Processes games concurrently up to the configured limit.
     async fn process_games(
         &self,
         games: impl IntoIterator<Item = GameMetadata>,
@@ -190,6 +194,7 @@ where
             .await
     }
 
+    /// Handles scan outcomes and submits required challenges.
     async fn handle_game_results(
         &mut self,
         results: Vec<(GameMetadata, Result<GameScanOutcome, GameScanError>)>,
@@ -239,7 +244,8 @@ where
         }
     }
 
-    pub async fn select_range(&mut self, now: u64) -> Result<((u64, u64)), ChallengerError> {
+    /// Selects the factory index range to scan this tick.
+    pub async fn select_range(&mut self, now: u64) -> Result<(u64, u64), ChallengerError> {
         let game_count = self.execution_provider.game_count().await?;
         let initialize_cursor = self
             .next_game_index
@@ -269,6 +275,7 @@ where
         Ok((start, end))
     }
 
+    /// Loads metadata for newly discovered challenger games.
     pub async fn discover_new_games(
         &self,
         start: u64,
@@ -289,6 +296,7 @@ where
         Ok(new_games)
     }
 
+    /// Reprocesses games queued after transient failures.
     pub async fn handle_retry_games(
         &mut self,
         now: u64,
@@ -321,6 +329,7 @@ where
         Ok(())
     }
 
+    /// Processes games discovered in the selected scan range.
     pub async fn handle_new_games(
         &mut self,
         new_games: Vec<GameMetadata>,
@@ -336,6 +345,7 @@ where
         Ok(())
     }
 
+    /// Runs one challenger iteration at the given Unix timestamp.
     pub async fn tick_at(&mut self, now: u64) -> Result<(), ChallengerError> {
         self.config.validate()?;
         let (start, end) = self.select_range(now).await?;
@@ -353,6 +363,7 @@ where
         Ok(())
     }
 
+    /// Runs one challenger iteration.
     pub async fn tick(&mut self) -> Result<(), ChallengerError> {
         let now = unix_now();
         self.tick_at(now).await
@@ -372,6 +383,7 @@ where
     }
 }
 
+/// Returns the current Unix timestamp in seconds.
 fn unix_now() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/proofs/challenger/src/challenger.rs
+++ b/proofs/challenger/src/challenger.rs
@@ -239,11 +239,7 @@ where
         }
     }
 
-    /// Scans one bounded factory range and retries transient validation failures.
-    pub async fn scan_once(&mut self) -> Result<(), ChallengerError> {
-        self.config.validate()?;
-
-        let now = unix_now();
+    pub async fn select_range(&mut self, now: u64) -> Result<((u64, u64)), ChallengerError> {
         let game_count = self.execution_provider.game_count().await?;
         let initialize_cursor = self
             .next_game_index
@@ -269,6 +265,15 @@ where
         let end = cursor
             .saturating_add(self.config.max_games_per_tick)
             .min(game_count);
+
+        Ok((start, end))
+    }
+
+    pub async fn discover_new_games(
+        &self,
+        start: u64,
+        end: u64,
+    ) -> Result<Vec<GameMetadata>, ChallengerError> {
         let mut new_games = Vec::with_capacity((end - start) as usize);
         for index in start..end {
             // The dispute-game factory indexes every game type; skip the ones that are not ours.
@@ -281,12 +286,14 @@ where
             new_games.push(self.execution_provider.game_metadata(game).await?);
         }
 
-        if new_games.is_empty() && self.retry_games.is_empty() {
-            self.next_game_index = Some(end);
-            return Ok(());
-        }
+        Ok(new_games)
+    }
 
-        let latest_finalized_l2_block = self.consensus_provider.latest_l2_finalized_block().await?;
+    pub async fn handle_retry_games(
+        &mut self,
+        now: u64,
+        latest_finalized_l2_block: BlockNumber,
+    ) -> Result<(), ChallengerError> {
         let mut retry_games: Vec<RetryGame> = self.retry_games.values().copied().collect();
         retry_games.sort_by_key(|retry| retry.challenge_deadline.unwrap_or(0));
         retry_games.retain(|retry_game| {
@@ -311,14 +318,44 @@ where
         self.handle_game_results(retry_results, "retry game failed")
             .await;
 
+        Ok(())
+    }
+
+    pub async fn handle_new_games(
+        &mut self,
+        new_games: Vec<GameMetadata>,
+        now: u64,
+        latest_finalized_l2_block: BlockNumber,
+    ) -> Result<(), ChallengerError> {
         let scan_results = self
             .process_games(new_games, latest_finalized_l2_block, now)
             .await;
         self.handle_game_results(scan_results, "game scan failed; adding to retry list")
             .await;
 
+        Ok(())
+    }
+
+    pub async fn tick_at(&mut self, now: u64) -> Result<(), ChallengerError> {
+        self.config.validate()?;
+        let (start, end) = self.select_range(now).await?;
+        let new_games = self.discover_new_games(start, end).await?;
+        if new_games.is_empty() && self.retry_games.is_empty() {
+            self.next_game_index = Some(end);
+            return Ok(());
+        }
+        let latest_finalized_l2_block = self.consensus_provider.latest_l2_finalized_block().await?;
+        self.handle_retry_games(now, latest_finalized_l2_block)
+            .await?;
+        self.handle_new_games(new_games, now, latest_finalized_l2_block)
+            .await?;
         self.next_game_index = Some(end);
         Ok(())
+    }
+
+    pub async fn tick(&mut self) -> Result<(), ChallengerError> {
+        let now = unix_now();
+        self.tick_at(now).await
     }
 
     /// Runs the challenger forever, logging transient failures and retrying on each tick.
@@ -328,8 +365,8 @@ where
         let mut interval = tokio::time::interval(self.config.poll_interval);
         loop {
             interval.tick().await;
-            if let Err(error) = self.scan_once().await {
-                warn!(%error, "scan attempt failed");
+            if let Err(error) = self.tick().await {
+                warn!(%error, "challenger iteration failed; retrying on next tick");
             }
         }
     }

--- a/proofs/challenger/src/tests.rs
+++ b/proofs/challenger/src/tests.rs
@@ -366,7 +366,7 @@ fn config() -> ChallengerConfig {
 }
 
 #[tokio::test]
-async fn scan_once_challenges_invalid_root_and_tracks_game() {
+async fn tick_challenges_invalid_root_and_tracks_game() {
     let proposed_root = B256::repeat_byte(0x10);
     let canonical_root = B256::repeat_byte(0x20);
     let client = MockClient::new(vec![MockGame::proposed(GAME_1, proposed_root, L2_BLOCK)]);
@@ -380,7 +380,7 @@ async fn scan_once_challenges_invalid_root_and_tracks_game() {
         owned_games.clone(),
     );
 
-    challenger.scan_once().await.unwrap();
+    challenger.tick_at(1).await.unwrap();
 
     assert_eq!(client.challenges(), vec![GAME_1]);
     assert!(owned_games.contains(GAME_1));
@@ -399,7 +399,7 @@ async fn startup_binary_search_finds_first_live_game_by_deadline() {
         mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
     let mut challenger = WorldChainChallenger::new(config(), client.clone(), output_roots);
 
-    challenger.scan_once().await.unwrap();
+    challenger.tick_at(1).await.unwrap();
 
     assert_eq!(client.challenges(), vec![GAME_2]);
     assert_eq!(challenger.next_game_index(), Some(2));
@@ -417,14 +417,14 @@ async fn startup_binary_search_skips_games_older_than_max_age() {
         mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
     let mut challenger = WorldChainChallenger::new(config(), client.clone(), output_roots);
 
-    challenger.scan_once().await.unwrap();
+    challenger.tick_at(1).await.unwrap();
 
     assert_eq!(client.challenges(), vec![GAME_2]);
     assert_eq!(challenger.next_game_index(), Some(2));
 }
 
 #[tokio::test]
-async fn scan_once_respects_new_game_tick_budget() {
+async fn tick_respects_new_game_budget() {
     let proposed_root = B256::repeat_byte(0x10);
     let canonical_root = B256::repeat_byte(0x20);
     let client = MockClient::new(vec![
@@ -438,17 +438,17 @@ async fn scan_once_respects_new_game_tick_budget() {
     limited_config.max_games_per_tick = 2;
     let mut challenger = WorldChainChallenger::new(limited_config, client.clone(), output_roots);
 
-    challenger.scan_once().await.unwrap();
+    challenger.tick_at(1).await.unwrap();
     assert_eq!(client.challenges(), vec![GAME_1, GAME_2]);
     assert_eq!(challenger.next_game_index(), Some(2));
 
-    challenger.scan_once().await.unwrap();
+    challenger.tick_at(1).await.unwrap();
     assert_eq!(client.challenges(), vec![GAME_1, GAME_2, GAME_3]);
     assert_eq!(challenger.next_game_index(), Some(3));
 }
 
 #[tokio::test]
-async fn scan_once_rechecks_lookback_without_reducing_forward_progress() {
+async fn tick_rechecks_lookback_without_reducing_forward_progress() {
     let proposed_root = B256::repeat_byte(0x10);
     let canonical_root = B256::repeat_byte(0x20);
     let client = MockClient::new(vec![
@@ -464,7 +464,7 @@ async fn scan_once_rechecks_lookback_without_reducing_forward_progress() {
     challenger_config.game_scan_lookback = 1;
     let mut challenger = WorldChainChallenger::new(challenger_config, client.clone(), output_roots);
 
-    challenger.scan_once().await.unwrap();
+    challenger.tick_at(1).await.unwrap();
     client
         .state
         .lock()
@@ -474,14 +474,14 @@ async fn scan_once_rechecks_lookback_without_reducing_forward_progress() {
         .expect("game exists")
         .state = STATE_PROPOSED;
 
-    challenger.scan_once().await.unwrap();
+    challenger.tick_at(1).await.unwrap();
 
     assert_eq!(client.challenges(), vec![GAME_1, GAME_2, GAME_2, GAME_3]);
     assert_eq!(challenger.next_game_index(), Some(3));
 }
 
 #[tokio::test]
-async fn scan_once_leaves_valid_and_non_proposed_games() {
+async fn tick_leaves_valid_and_non_proposed_games() {
     let canonical_root = B256::repeat_byte(0x20);
     let valid = MockGame::proposed(GAME_1, canonical_root, L2_BLOCK);
     let mut challenged = MockGame::proposed(GAME_2, B256::repeat_byte(0x10), L2_BLOCK);
@@ -491,7 +491,7 @@ async fn scan_once_leaves_valid_and_non_proposed_games() {
         mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
     let mut challenger = WorldChainChallenger::new(config(), client.clone(), output_roots);
 
-    challenger.scan_once().await.unwrap();
+    challenger.tick_at(1).await.unwrap();
 
     assert!(client.challenges().is_empty());
     assert!(challenger.retry_games().is_empty());
@@ -506,12 +506,12 @@ async fn retry_game_is_challenged_after_l2_finalizes() {
         mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK - 1);
     let mut challenger = WorldChainChallenger::new(config(), client.clone(), output_roots);
 
-    challenger.scan_once().await.unwrap();
+    challenger.tick_at(1).await.unwrap();
     assert_eq!(challenger.retry_games(), vec![GAME_1]);
     assert!(client.challenges().is_empty());
 
     finalized_l2_block.store(L2_BLOCK, Ordering::SeqCst);
-    challenger.scan_once().await.unwrap();
+    challenger.tick_at(1).await.unwrap();
 
     assert_eq!(client.challenges(), vec![GAME_1]);
     assert!(challenger.retry_games().is_empty());
@@ -713,7 +713,7 @@ async fn bond_manager_uses_l1_timestamp_for_delayed_withdrawal() {
 }
 
 #[tokio::test]
-async fn scan_once_skips_foreign_game_types() {
+async fn tick_skips_foreign_game_types() {
     let proposed_root = B256::repeat_byte(0x10);
     let canonical_root = B256::repeat_byte(0x20);
     let client = MockClient::new(vec![MockGame::proposed(GAME_1, proposed_root, L2_BLOCK)]);
@@ -727,7 +727,7 @@ async fn scan_once_skips_foreign_game_types() {
         mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
     let mut challenger = WorldChainChallenger::new(config(), client.clone(), output_roots);
 
-    challenger.scan_once().await.unwrap();
+    challenger.tick_at(1).await.unwrap();
 
     assert_eq!(client.challenges(), vec![GAME_1]);
 }

--- a/proofs/integration-tests/tests/orchestration.rs
+++ b/proofs/integration-tests/tests/orchestration.rs
@@ -238,7 +238,7 @@ async fn invalid_root_is_challenged_by_real_challenger() {
     let mut challenger =
         WorldChainChallenger::new(challenger_config(), chain.clone(), honest_consensus);
     challenger
-        .scan_once()
+        .tick_at(1)
         .await
         .expect("challenger scan succeeds");
 


### PR DESCRIPTION
This PR refactors `world-chain-challenger` to make it easier to understand what it does each tick iteration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural refactor with the same orchestration order; tests were updated to the new API only.
> 
> **Overview**
> Refactors **`WorldChainChallenger`** so each poll cycle is a clear **`tick` / `tick_at(now)`** pipeline instead of a monolithic **`scan_once`**.
> 
> The former single scan method is broken into **`select_range`**, **`discover_new_games`**, **`handle_retry_games`**, and **`handle_new_games`**, with **`tick_at`** orchestrating them in order. **`run_forever`** now calls **`tick`** and logs *"challenger iteration failed"* instead of *"scan attempt failed"*. Doc comments were added on several internal helpers.
> 
> Tests and integration code call **`tick_at(1)`** instead of **`scan_once`**; test names were renamed from **`scan_once_*`** to **`tick_*`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1a49ff0c064975e934c5d028e225907c6710daa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->