### PR TITLE
chore: refactor world-chain-proposer

### DIFF
--- a/proofs/proposer/src/proposer.rs
+++ b/proofs/proposer/src/proposer.rs
@@ -243,6 +243,18 @@ where
         Ok(())
     }
 
+    pub async fn tick(&self) -> Result<(), ProposerError> {
+        // 1. refresh the anchor and canonical line
+        let scan = self.scan_selected_lineage().await?;
+        // 2. resolve positive-ready games parent-first
+        let highest_finalized_game = self.resolve_games(scan.lineage().games()).await?;
+        // 3. advance the anchor to the highest finalized canonical game
+        self.advance_anchor(highest_finalized_game).await?;
+        // 4. resolve a negative tip, or submit a new proposal or retry
+        self.submit_next_proposal(&scan).await?;
+        Ok(())
+    }
+
     /// Runs the proposer forever, logging transient failures and retrying on each tick.
     pub async fn run_forever(&self) -> Result<(), ProposerError> {
         self.config.validate()?;
@@ -250,20 +262,7 @@ where
         let mut interval = tokio::time::interval(self.config.poll_interval);
         loop {
             interval.tick().await;
-            let iteration: Result<(), ProposerError> = async {
-                // 1. refresh the anchor and canonical line
-                let scan = self.scan_selected_lineage().await?;
-                // 2. resolve positive-ready games parent-first
-                let highest_finalized_game = self.resolve_games(scan.lineage().games()).await?;
-                // 3. advance the anchor to the highest finalized canonical game
-                self.advance_anchor(highest_finalized_game).await?;
-                // 4. resolve a negative tip, or submit a new proposal or retry
-                self.submit_next_proposal(&scan).await?;
-                Ok(())
-            }
-            .await;
-
-            if let Err(error) = iteration {
+            if let Err(error) = self.tick().await {
                 warn!(%error, "proposer iteration failed; retrying on next tick");
             }
         }


### PR DESCRIPTION
This PR refactors `world-chain-proposer` to make the `run_forever` fn equal to the `world-chain-challenger` and `world-chain-defender` structure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor with no logic changes; only moves existing iteration code into `tick()` and delegates from `run_forever`.
> 
> **Overview**
> **Refactors `WorldChainProposer` so one polling iteration is a dedicated `tick()` method**, with the same four steps that used to live inline in `run_forever`: scan lineage, resolve games, advance anchor, submit the next proposal.
> 
> `run_forever` now only validates config, waits on the poll interval, and invokes `self.tick().await`, logging and continuing on error—**the same loop shape as `world-chain-challenger` and `world-chain-defender`**. Behavior of a single iteration is unchanged; this is a structural extraction for consistency and so callers can drive one tick without the infinite loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d88b575389004fdad4df92a8e63a4de766cdeb42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->