### PR TITLE
fix(txpool): reject replayed PBH transactions before validation

### DIFF
--- a/crates/pool/src/validator.rs
+++ b/crates/pool/src/validator.rs
@@ -8,7 +8,7 @@ use crate::{
 use alloy_eips::BlockId;
 use alloy_primitives::Address;
 use alloy_sol_types::{SolCall, SolValue};
-use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use reth_evm::ConfigureEvm;
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_node::txpool::OpTransactionValidator;
@@ -185,14 +185,40 @@ where
                     .to_outcome(tx);
             }
 
-            let payloads: Vec<PbhPayload> = match pbh_payloads
-                .into_par_iter()
+            // Decode and reject duplicate nullifiers before performing expensive proof
+            // verification. This prevents a bundle from amplifying one valid proof by repeating
+            // the same (UserOp, payload) pair many times.
+            let payload_ops = match pbh_payloads
+                .into_iter()
                 .zip(aggregated_ops.userOps)
                 .map(|(payload, op)| {
+                    PbhPayload::try_from(payload)
+                        .map(|payload| (payload, op))
+                        .map_err(|_| {
+                            WorldChainPoolTransactionError::from(
+                                PBHValidationError::InvalidCalldata,
+                            )
+                        })
+                })
+                .collect::<Result<Vec<_>, WorldChainPoolTransactionError>>()
+            {
+                Ok(payload_ops) => payload_ops,
+                Err(err) => return err.to_outcome(tx),
+            };
+
+            for (payload, _) in &payload_ops {
+                if !seen_nullifier_hashes.insert(payload.nullifier_hash) {
+                    return WorldChainPoolTransactionError::from(
+                        PBHValidationError::DuplicateNullifierHash,
+                    )
+                    .to_outcome(tx);
+                }
+            }
+
+            let payloads: Vec<PbhPayload> = match payload_ops
+                .into_par_iter()
+                .map(|(payload, op)| {
                     let signal = crate::eip4337::hash_user_op(&op);
-                    let Ok(payload) = PbhPayload::try_from(payload) else {
-                        return Err(PBHValidationError::InvalidCalldata.into());
-                    };
                     payload.validate(
                         signal,
                         &valid_roots,
@@ -205,16 +231,6 @@ where
                 Ok(payloads) => payloads,
                 Err(err) => return err.to_outcome(tx),
             };
-
-            // Now check for duplicate nullifier_hashes
-            for payload in &payloads {
-                if !seen_nullifier_hashes.insert(payload.nullifier_hash) {
-                    return WorldChainPoolTransactionError::from(
-                        PBHValidationError::DuplicateNullifierHash,
-                    )
-                    .to_outcome(tx);
-                }
-            }
 
             aggregated_payloads.extend(payloads);
         }
@@ -553,13 +569,13 @@ pub mod tests {
     }
 
     #[tokio::test]
-    async fn validate_pbh_bundle_duplicate_nullifier_hash() {
+    async fn reject_duplicate_nullifier_before_proof_validation() {
         const BUNDLER_ACCOUNT: u32 = 9;
         const USER_ACCOUNT: u32 = 0;
 
         let pool = setup().await;
 
-        let (user_op, proof) = user_op()
+        let (user_op, mut proof) = user_op()
             .acc(USER_ACCOUNT)
             .external_nullifier(ExternalNullifier::with_date_marker(
                 DateMarker::from(chrono::Utc::now()),
@@ -567,7 +583,10 @@ pub mod tests {
             ))
             .call();
 
-        // Lets add two of the same userOp in the bundle so the nullifier hash is the same and we should expect an error
+        // Make the proof invalid so this test also verifies that duplicate detection happens before
+        // cryptographic proof validation.
+        proof.proof = Default::default();
+
         let bundle = pbh_bundle(
             vec![user_op.clone(), user_op],
             vec![proof.clone().into(), proof.into()],

--- a/crates/pool/src/validator.rs
+++ b/crates/pool/src/validator.rs
@@ -192,13 +192,10 @@ where
                 .into_iter()
                 .zip(aggregated_ops.userOps)
                 .map(|(payload, op)| {
-                    PbhPayload::try_from(payload)
-                        .map(|payload| (payload, op))
-                        .map_err(|_| {
-                            WorldChainPoolTransactionError::from(
-                                PBHValidationError::InvalidCalldata,
-                            )
-                        })
+                    let pbh_payload = PbhPayload::try_from(payload).map_err(|_| {
+                        WorldChainPoolTransactionError::from(PBHValidationError::InvalidCalldata)
+                    })?;
+                    Ok((pbh_payload, op))
                 })
                 .collect::<Result<Vec<_>, WorldChainPoolTransactionError>>()
             {

--- a/crates/rpc/src/transactions.rs
+++ b/crates/rpc/src/transactions.rs
@@ -5,7 +5,10 @@ use reth_primitives_traits::SignedTransaction;
 use reth_provider::{BlockReaderIdExt, StateProviderFactory};
 use reth_rpc_eth_api::{AsEthApiError, FromEthApiError};
 use reth_rpc_eth_types::{EthApiError, utils::recover_raw_transaction};
-use reth_transaction_pool::{PoolPooledTx, PoolTransaction, TransactionOrigin, TransactionPool};
+use reth_transaction_pool::{
+    PoolPooledTx, PoolTransaction, TransactionOrigin, TransactionPool,
+    error::{PoolError, PoolErrorKind},
+};
 use revm_primitives::{B256, Bytes};
 
 use crate::{core::WorldChainEthApiExt, sequencer::SequencerClient};
@@ -36,6 +39,16 @@ where
     async fn send_raw_transaction(&self, tx: Bytes) -> Result<B256, Self::Error> {
         let recovered = recover_raw_transaction::<PoolPooledTx<Pool>>(&tx)?;
         let pool_transaction = Pool::Transaction::from_pooled(recovered);
+        let tx_hash = *pool_transaction.hash();
+
+        // Avoid expensive validation for transactions already present in the pool. The pool's
+        // insertion-time duplicate check remains authoritative for concurrent submissions.
+        if self.pool().contains(&tx_hash) {
+            return Err(Self::Error::from_eth_err(PoolError::new(
+                tx_hash,
+                PoolErrorKind::AlreadyImported,
+            )));
+        }
 
         // submit the transaction to the pool with a `Local` origin
         let outcome = self


### PR DESCRIPTION
### Problem

Replayed PBH transactions could trigger expensive proof verification before duplicate nullifiers or already-imported transaction hashes were rejected, enabling unnecessary CPU consumption.

### Solution

Check for duplicate nullifiers before PBH proof verification and reject transaction hashes already present in the pool before invoking pool validation. Retain the pool’s insertion-time duplicate check to handle concurrent submissions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ordering and early-exit paths in PBH proof validation and eth raw-tx submission; behavior for duplicates should match prior outcomes but timing and error surfacing on RPC replays differ slightly from running full validation.
> 
> **Overview**
> Hardens PBH bundle handling and raw-tx RPC against **replay-style CPU waste**.
> 
> **PBH validator:** Payloads are decoded sequentially, then **duplicate nullifier hashes** are rejected **before** parallel cryptographic proof verification. That stops a bundle from repeating the same `(UserOp, payload)` pair to multiply expensive proof work. A test now uses an invalid proof to assert duplicate detection runs ahead of proof validation.
> 
> **`send_raw_transaction`:** After recovering the tx, if the hash is **already in the pool**, the handler returns `AlreadyImported` immediately instead of running full pool validation again. Concurrent duplicates still rely on the pool’s insertion-time check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b51df4e0f1094298b5c68f15ac4df7fc9b564bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->