### PR TITLE
fix: add request timeout to clients

### DIFF
--- a/proofs/challenger/src/main.rs
+++ b/proofs/challenger/src/main.rs
@@ -100,6 +100,15 @@ struct Cli {
     /// Number of recent factory games scanned when the bond manager starts.
     #[arg(long, env = "BOND_MANAGER_INITIAL_SCAN_LIMIT", default_value_t = 1_000)]
     bond_manager_initial_scan_limit: u64,
+
+    /// Per-request timeout applied to every L1 RPC call, in seconds.
+    #[arg(
+        long,
+        env = "L1_RPC_TIMEOUT_SECONDS",
+        default_value_t = world_chain_proof_metrics::DEFAULT_RPC_REQUEST_TIMEOUT_SECONDS,
+        value_parser = clap::value_parser!(u64).range(1..)
+    )]
+    l1_rpc_timeout_seconds: u64,
 }
 
 #[tokio::main]
@@ -116,6 +125,7 @@ async fn main() -> Result<()> {
     let l1_rpc_client = world_chain_proof_metrics::metered_http_client(
         l1_rpc_url,
         world_chain_proof_metrics::RPC_TARGET_L1_EXECUTION,
+        Duration::from_secs(cli.l1_rpc_timeout_seconds),
     )
     .context("failed to build the L1 RPC client")?;
     let provider = ProviderBuilder::new()
@@ -184,6 +194,7 @@ async fn main() -> Result<()> {
         max_resolutions_per_tick = cli.max_resolutions_per_tick,
         bond_manager_poll_interval_seconds = cli.bond_manager_poll_interval_seconds,
         bond_manager_initial_scan_limit = cli.bond_manager_initial_scan_limit,
+        l1_rpc_timeout_seconds = cli.l1_rpc_timeout_seconds,
         "starting World Chain proof-system challenger"
     );
 

--- a/proofs/challenger/src/main.rs
+++ b/proofs/challenger/src/main.rs
@@ -116,7 +116,8 @@ async fn main() -> Result<()> {
     let l1_rpc_client = world_chain_proof_metrics::metered_http_client(
         l1_rpc_url,
         world_chain_proof_metrics::RPC_TARGET_L1_EXECUTION,
-    );
+    )
+    .context("failed to build the L1 RPC client")?;
     let provider = ProviderBuilder::new()
         .wallet(EthereumWallet::from(cli.challenger_key))
         .connect_client(l1_rpc_client);

--- a/proofs/defender/src/main.rs
+++ b/proofs/defender/src/main.rs
@@ -83,7 +83,8 @@ async fn main() -> Result<()> {
     let l1_rpc_client = world_chain_proof_metrics::metered_http_client(
         l1_rpc_url,
         world_chain_proof_metrics::RPC_TARGET_L1_EXECUTION,
-    );
+    )
+    .context("failed to build the L1 RPC client")?;
     let provider = ProviderBuilder::new()
         .wallet(EthereumWallet::from(cli.defender_key))
         .connect_client(l1_rpc_client);

--- a/proofs/defender/src/main.rs
+++ b/proofs/defender/src/main.rs
@@ -67,6 +67,15 @@ struct Cli {
         value_parser = clap::value_parser!(u64).range(1..)
     )]
     l1_tx_confirmations: u64,
+
+    /// Per-request timeout applied to every L1 RPC call, in seconds.
+    #[arg(
+        long,
+        env = "L1_RPC_TIMEOUT_SECONDS",
+        default_value_t = world_chain_proof_metrics::DEFAULT_RPC_REQUEST_TIMEOUT_SECONDS,
+        value_parser = clap::value_parser!(u64).range(1..)
+    )]
+    l1_rpc_timeout_seconds: u64,
 }
 
 #[tokio::main]
@@ -83,6 +92,7 @@ async fn main() -> Result<()> {
     let l1_rpc_client = world_chain_proof_metrics::metered_http_client(
         l1_rpc_url,
         world_chain_proof_metrics::RPC_TARGET_L1_EXECUTION,
+        Duration::from_secs(cli.l1_rpc_timeout_seconds),
     )
     .context("failed to build the L1 RPC client")?;
     let provider = ProviderBuilder::new()
@@ -115,6 +125,7 @@ async fn main() -> Result<()> {
         dispute_game_factory = %cli.factory_address,
         defender = %defender_address,
         l1_tx_confirmations = cli.l1_tx_confirmations,
+        l1_rpc_timeout_seconds = cli.l1_rpc_timeout_seconds,
         "starting World Chain proof-system defender"
     );
 

--- a/proofs/metrics/src/lib.rs
+++ b/proofs/metrics/src/lib.rs
@@ -148,11 +148,24 @@ where
     }
 }
 
+/// Per-request timeout applied to every outbound RPC call.
+///
+/// Bounds each request so a hung connection cannot stall a service's poll loop indefinitely.
+const RPC_REQUEST_TIMEOUT: Duration = Duration::from_secs(1);
+
 /// Builds an Alloy HTTP client that counts completed RPC outcomes.
-pub fn metered_http_client(url: Url, target: &'static str) -> RpcClient {
-    ClientBuilder::default()
+///
+/// Every request is bounded by [`RPC_REQUEST_TIMEOUT`].
+pub fn metered_http_client(
+    url: Url,
+    target: &'static str,
+) -> Result<RpcClient, alloy_transport_http::reqwest::Error> {
+    let client = alloy_transport_http::reqwest::Client::builder()
+        .timeout(RPC_REQUEST_TIMEOUT)
+        .build()?;
+    Ok(ClientBuilder::default()
         .layer(RpcMetricsLayer { target })
-        .http(url)
+        .http_with_client(client, url))
 }
 
 /// Renders an RPC endpoint for logs with any embedded credential removed.

--- a/proofs/metrics/src/lib.rs
+++ b/proofs/metrics/src/lib.rs
@@ -148,20 +148,26 @@ where
     }
 }
 
-/// Per-request timeout applied to every outbound RPC call.
+/// Default per-request timeout applied to every outbound RPC call.
 ///
-/// Bounds each request so a hung connection cannot stall a service's poll loop indefinitely.
-const RPC_REQUEST_TIMEOUT: Duration = Duration::from_secs(1);
+/// Sized for the slowest call the proof services make on a healthy endpoint — `eth_estimateGas`
+/// and `eth_call` against finalized state on a shared provider — not for the median one, so a
+/// merely slow provider does not fail ticks. Operators pointing a service at a slower or faster
+/// endpoint override it per service.
+pub const DEFAULT_RPC_REQUEST_TIMEOUT_SECONDS: u64 = 10;
 
 /// Builds an Alloy HTTP client that counts completed RPC outcomes.
 ///
-/// Every request is bounded by [`RPC_REQUEST_TIMEOUT`].
+/// `request_timeout` bounds each individual request so a hung connection cannot stall a
+/// service's poll loop indefinitely. It is per request, not per operation: a confirmation wait
+/// polls with fresh requests and so is not capped by this value.
 pub fn metered_http_client(
     url: Url,
     target: &'static str,
+    request_timeout: Duration,
 ) -> Result<RpcClient, alloy_transport_http::reqwest::Error> {
     let client = alloy_transport_http::reqwest::Client::builder()
-        .timeout(RPC_REQUEST_TIMEOUT)
+        .timeout(request_timeout)
         .build()?;
     Ok(ClientBuilder::default()
         .layer(RpcMetricsLayer { target })

--- a/proofs/proposer/src/main.rs
+++ b/proofs/proposer/src/main.rs
@@ -85,7 +85,8 @@ async fn main() -> Result<()> {
     let l1_rpc_client = world_chain_proof_metrics::metered_http_client(
         l1_rpc_url,
         world_chain_proof_metrics::RPC_TARGET_L1_EXECUTION,
-    );
+    )
+    .context("failed to build the L1 RPC client")?;
     let provider = ProviderBuilder::new()
         .wallet(EthereumWallet::from(cli.proposer_key))
         .connect_client(l1_rpc_client);

--- a/proofs/proposer/src/main.rs
+++ b/proofs/proposer/src/main.rs
@@ -69,6 +69,15 @@ struct Cli {
     /// Number of confirmations to require after sending a tx onchain.
     #[arg(long, env = "CONFIRMATIONS", default_value_t = 5)]
     confirmations: u64,
+
+    /// Per-request timeout applied to every L1 RPC call, in seconds.
+    #[arg(
+        long,
+        env = "L1_RPC_TIMEOUT_SECONDS",
+        default_value_t = world_chain_proof_metrics::DEFAULT_RPC_REQUEST_TIMEOUT_SECONDS,
+        value_parser = clap::value_parser!(u64).range(1..)
+    )]
+    l1_rpc_timeout_seconds: u64,
 }
 
 #[tokio::main]
@@ -85,6 +94,7 @@ async fn main() -> Result<()> {
     let l1_rpc_client = world_chain_proof_metrics::metered_http_client(
         l1_rpc_url,
         world_chain_proof_metrics::RPC_TARGET_L1_EXECUTION,
+        Duration::from_secs(cli.l1_rpc_timeout_seconds),
     )
     .context("failed to build the L1 RPC client")?;
     let provider = ProviderBuilder::new()
@@ -125,6 +135,7 @@ async fn main() -> Result<()> {
         max_resolutions_per_tick = cli.max_resolutions_per_tick,
         bond_manager_poll_interval_seconds = cli.bond_manager_poll_interval_seconds,
         bond_manager_initial_scan_limit = cli.bond_manager_initial_scan_limit,
+        l1_rpc_timeout_seconds = cli.l1_rpc_timeout_seconds,
         "starting World Chain proof-system proposer"
     );
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Tightening L1 RPC timeouts can surface as errors on slow endpoints and may affect dispute-game polling, but the change is limited to client construction and request bounds rather than on-chain logic.
> 
> **Overview**
> Outbound L1 RPC traffic from the proof binaries now uses a **1 second per-request timeout** on the shared `metered_http_client` builder, so a stuck HTTP call cannot block poll loops indefinitely.
> 
> `metered_http_client` now builds a custom `reqwest` client with that timeout, wires it through Alloy’s `http_with_client`, and **returns `Result`** if the HTTP client cannot be constructed. Challenger, defender, and proposer startup paths propagate that with **“failed to build the L1 RPC client”** context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07d779e637e3fce18360dd949a97cc6d4fc10511. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->