### PR TITLE
feat(simulation): update how we select revert reason

### DIFF
--- a/crates/rpc/src/simulate.rs
+++ b/crates/rpc/src/simulate.rs
@@ -426,11 +426,11 @@ fn terminal_revert_payload(traces: &[RawTrace]) -> Option<&Bytes> {
 /// - A reverted frame's own non-empty payload wins — it is the terminal
 ///   failure at that level — except Safe4337Module's bare `ExecutionFailed()`
 ///   from an `executeUserOp` frame, which deliberately replaces the revert
-///   its Safe call caught; recover that via [`latest_descendant_revert`].
+///   its Safe call caught; recover that via [`safe_execution_revert`].
 /// - An empty revert inherits from its last child if that child also failed.
 ///   Earlier failed siblings were superseded by whatever ran after them.
 fn frame_revert_payload(traces: &[RawTrace], index: usize) -> Option<&Bytes> {
-    let frame = &traces[index];
+    let frame: &RawTrace = &traces[index];
     if frame.outcome != Some(TraceOutcome::Revert) {
         return None;
     }
@@ -439,7 +439,7 @@ fn frame_revert_payload(traces: &[RawTrace], index: usize) -> Option<&Bytes> {
             if output.as_ref() == EXECUTION_FAILED_SELECTOR
                 && frame.selector == Some(EXECUTE_USER_OP_SELECTOR) =>
         {
-            latest_descendant_revert(traces, index).or(Some(output))
+            safe_execution_revert(traces, index).or(Some(output))
         }
         Some(output) => Some(output),
         None => {
@@ -449,18 +449,48 @@ fn frame_revert_payload(traces: &[RawTrace], index: usize) -> Option<&Bytes> {
     }
 }
 
+/// Revert caught by a successful Safe `execTransactionFromModule` call below
+/// the `executeUserOp` frame. Proxy and delegatecall layers may produce more
+/// than one matching frame; the first contains the others and the target.
+fn safe_execution_revert(traces: &[RawTrace], index: usize) -> Option<&Bytes> {
+    let frame_depth = traces[index].depth;
+    for (descendant, trace) in traces.iter().enumerate().skip(index + 1) {
+        if trace.depth <= frame_depth {
+            break;
+        }
+        if trace.outcome == Some(TraceOutcome::Success)
+            && trace.selector == Some(EXEC_TRANSACTION_FROM_MODULE_SELECTOR)
+        {
+            return latest_descendant_revert(traces, descendant);
+        }
+    }
+    None
+}
+
 /// Payload of the most recent revert below the frame at `index`, crossing
 /// successful frames: Safe's `execTransactionFromModule` catches the target
 /// revert and succeeds returning `false`, so the revert that explains
-/// `ExecutionFailed()` sits inside a successful subtree. Only the chain of
-/// *last* children is followed — anything that ran later superseded earlier
-/// failures.
+/// `ExecutionFailed()` sits inside a successful subtree. The latest child
+/// branch containing a revert wins; a later successful module-guard callback
+/// with no revert therefore does not hide the target failure.
 fn latest_descendant_revert(traces: &[RawTrace], index: usize) -> Option<&Bytes> {
-    let last_child = last_direct_child(traces, index)?;
-    match traces[last_child].outcome {
-        Some(TraceOutcome::Success) => latest_descendant_revert(traces, last_child),
-        _ => frame_revert_payload(traces, last_child),
+    let parent_depth = traces[index].depth;
+    let mut latest = None;
+    for (child, trace) in traces.iter().enumerate().skip(index + 1) {
+        if trace.depth <= parent_depth {
+            break;
+        }
+        if trace.depth == parent_depth + 1 {
+            let candidate = match trace.outcome {
+                Some(TraceOutcome::Success) => latest_descendant_revert(traces, child),
+                _ => frame_revert_payload(traces, child),
+            };
+            if candidate.is_some() {
+                latest = candidate;
+            }
+        }
     }
+    latest
 }
 
 /// Index of the last direct child of the frame at `parent`, if any.
@@ -1770,8 +1800,18 @@ mod tests {
         selector: Option<[u8; 4]>,
         revert_output: Option<&'static [u8]>,
     ) -> RawTrace {
+        completed_trace_with_kind(TraceKind::Call, depth, outcome, selector, revert_output)
+    }
+
+    fn completed_trace_with_kind(
+        kind: TraceKind,
+        depth: usize,
+        outcome: TraceOutcome,
+        selector: Option<[u8; 4]>,
+        revert_output: Option<&'static [u8]>,
+    ) -> RawTrace {
         RawTrace {
-            kind: TraceKind::Call,
+            kind,
             from: Address::ZERO,
             to: Some(Address::ZERO),
             selector,
@@ -1844,8 +1884,69 @@ mod tests {
     #[test]
     fn safe_execution_failed_recovers_revert_from_successful_subtree() {
         let execution_failed: &'static [u8] = &EXECUTION_FAILED_SELECTOR;
-        // executeUserOp frame reverts bare ExecutionFailed(); the caught
-        // target revert sits under a successful execTransactionFromModule.
+        // executeUserOp frame reverts bare ExecutionFailed(); proxy and
+        // delegatecall layers both retain the execTransactionFromModule
+        // selector, with the caught target revert below them.
+        let traces = [
+            completed_trace(
+                0,
+                TraceOutcome::Revert,
+                Some(EXECUTE_USER_OP_SELECTOR),
+                Some(execution_failed),
+            ),
+            // Safe4337Module calls the Safe proxy.
+            completed_trace(
+                1,
+                TraceOutcome::Success,
+                Some(EXEC_TRANSACTION_FROM_MODULE_SELECTOR),
+                None,
+            ),
+            // The proxy delegates the same calldata to the Safe singleton.
+            completed_trace_with_kind(
+                TraceKind::DelegateCall,
+                2,
+                TraceOutcome::Success,
+                Some(EXEC_TRANSACTION_FROM_MODULE_SELECTOR),
+                None,
+            ),
+            completed_trace(3, TraceOutcome::Revert, None, Some(b"\xaa")),
+        ];
+        assert_eq!(
+            terminal_revert_payload(&traces),
+            Some(&Bytes::from_static(b"\xaa"))
+        );
+    }
+
+    #[test]
+    fn safe_execution_failed_recovers_revert_before_trailing_success() {
+        let execution_failed: &'static [u8] = &EXECUTION_FAILED_SELECTOR;
+        let traces = [
+            completed_trace(
+                0,
+                TraceOutcome::Revert,
+                Some(EXECUTE_USER_OP_SELECTOR),
+                Some(execution_failed),
+            ),
+            completed_trace(
+                1,
+                TraceOutcome::Success,
+                Some(EXEC_TRANSACTION_FROM_MODULE_SELECTOR),
+                None,
+            ),
+            completed_trace(2, TraceOutcome::Revert, None, Some(b"\xbb")),
+            // Safe 1.5 may run a successful post-execution check after the
+            // target call; that later success must not hide the target revert.
+            completed_trace(2, TraceOutcome::Success, None, None),
+        ];
+        assert_eq!(
+            terminal_revert_payload(&traces),
+            Some(&Bytes::from_static(b"\xbb"))
+        );
+    }
+
+    #[test]
+    fn safe_recovery_requires_exec_transaction_from_module() {
+        let execution_failed: &'static [u8] = &EXECUTION_FAILED_SELECTOR;
         let traces = [
             completed_trace(
                 0,
@@ -1858,21 +1959,29 @@ mod tests {
         ];
         assert_eq!(
             terminal_revert_payload(&traces),
-            Some(&Bytes::from_static(b"\xaa"))
+            Some(&Bytes::from_static(execution_failed))
         );
+    }
 
+    #[test]
+    fn safe_execution_failed_falls_back_without_descendant_revert() {
+        let execution_failed: &'static [u8] = &EXECUTION_FAILED_SELECTOR;
         // Without a descendant revert the wrapper itself is all we know.
-        let bare = [completed_trace(
+        let traces = [completed_trace(
             0,
             TraceOutcome::Revert,
             Some(EXECUTE_USER_OP_SELECTOR),
             Some(execution_failed),
         )];
         assert_eq!(
-            terminal_revert_payload(&bare),
+            terminal_revert_payload(&traces),
             Some(&Bytes::from_static(execution_failed))
         );
+    }
 
+    #[test]
+    fn safe_recovery_requires_exact_selector_and_payload() {
+        let execution_failed: &'static [u8] = &EXECUTION_FAILED_SELECTOR;
         // Recovery is gated on the executeUserOp selector: any other frame
         // reverting with the same bytes keeps its own payload.
         let wrong_selector = [
@@ -1882,7 +1991,12 @@ mod tests {
                 Some([0xde, 0xad, 0xbe, 0xef]),
                 Some(execution_failed),
             ),
-            completed_trace(1, TraceOutcome::Success, None, None),
+            completed_trace(
+                1,
+                TraceOutcome::Success,
+                Some(EXEC_TRANSACTION_FROM_MODULE_SELECTOR),
+                None,
+            ),
             completed_trace(2, TraceOutcome::Revert, None, Some(b"\xaa")),
         ];
         assert_eq!(
@@ -1900,7 +2014,12 @@ mod tests {
                 Some(EXECUTE_USER_OP_SELECTOR),
                 Some(inexact),
             ),
-            completed_trace(1, TraceOutcome::Success, None, None),
+            completed_trace(
+                1,
+                TraceOutcome::Success,
+                Some(EXEC_TRANSACTION_FROM_MODULE_SELECTOR),
+                None,
+            ),
             completed_trace(2, TraceOutcome::Revert, None, Some(b"\xaa")),
         ];
         assert_eq!(

--- a/crates/rpc/src/simulate.rs
+++ b/crates/rpc/src/simulate.rs
@@ -195,10 +195,8 @@ pub enum SimulationStatus {
 #[serde(rename_all = "camelCase")]
 pub struct SimulateUnsignedUserOpResult {
     pub status: SimulationStatus,
-    /// Decoded reason for a top-level revert/halt; `None` on success.
-    /// For nested reverts this is the *deepest* reverted frame's payload
-    /// (the root cause), not the outermost — important for ERC-4337 where
-    /// EntryPoint always wraps inner reverts in `FailedOp(...)`.
+    /// Best-effort decoded explanation of the execution failure; `None` on
+    /// success.
     pub revert_reason: Option<String>,
     pub block_number: u64,
     pub gas_used: String,
@@ -233,7 +231,7 @@ struct RawTrace {
     outcome: Option<TraceOutcome>,
     /// Populated by the matching end hook for an explicit REVERT with a
     /// non-empty payload.
-    revert_reason: Option<String>,
+    revert_output: Option<Bytes>,
 }
 
 #[derive(Debug)]
@@ -293,26 +291,19 @@ pub struct SimulationInspector {
     /// Active frame stack. Each CALL or CREATE pushes a new entry; the
     /// matching `*_end` pops it. See [`PendingFrame`].
     pending_frames: Vec<PendingFrame>,
-    /// Raw payload of the deepest frame that exited via REVERT. Set on the
-    /// first `call_end` or `create_end` whose `InstructionResult` is `Revert`
-    /// — since end hooks fire bottom-up, that's the innermost reverter and so
-    /// the root cause when wrappers like EntryPoint's `FailedOp(...)`
-    /// re-revert up the stack. Halt frames (OOG, invalid opcode, etc.) are
-    /// skipped: they have no payload to decode.
-    deepest_revert_payload: Option<Bytes>,
     /// Internal frame-bookkeeping failure. Inspector hooks cannot return an
     /// error to revm, so defer it until the caller collects the trace.
     trace_error: Option<&'static str>,
 }
 
 impl SimulationInspector {
-    pub fn take_trace_entries(&mut self) -> Result<Vec<TraceEntry>, &'static str> {
-        if let Some(error) = self.trace_error.take() {
+    pub fn trace_entries(&self) -> Result<Vec<TraceEntry>, &'static str> {
+        if let Some(error) = self.trace_error {
             return Err(error);
         }
 
-        std::mem::take(&mut self.traces)
-            .into_iter()
+        self.traces
+            .iter()
             .map(|t| {
                 let outcome = t
                     .outcome
@@ -328,7 +319,7 @@ impl SimulationInspector {
                     value: format!("{:#x}", t.value),
                     depth: t.depth,
                     outcome,
-                    revert_reason: t.revert_reason,
+                    revert_reason: t.revert_output.as_ref().map(decode_revert_reason),
                 })
             })
             .collect()
@@ -354,11 +345,9 @@ impl SimulationInspector {
             .collect()
     }
 
-    /// Take the decoded reason of the deepest reverted frame, if any.
-    pub fn take_deepest_revert_reason(&mut self) -> Option<String> {
-        self.deepest_revert_payload
-            .take()
-            .map(|output| decode_revert_reason(&output))
+    /// Decoded reason from the terminally failing frame path, if any.
+    pub fn terminal_revert_reason(&self) -> Option<String> {
+        terminal_revert_payload(&self.traces).map(decode_revert_reason)
     }
 
     /// Drain captured CREATE/CREATE2 deployments. Each entry is
@@ -410,11 +399,83 @@ impl SimulationInspector {
             TraceOutcome::Halt
         });
         if matches!(result, InstructionResult::Revert) && !output.is_empty() {
-            trace.revert_reason = Some(decode_revert_reason(output));
+            trace.revert_output = Some(output.clone());
         }
 
         Some(trace)
     }
+}
+
+/// Response-level revert payload: the best explanation of the failure that
+/// caused the whole simulation to fail, selected from the completed trace.
+///
+/// The trace is a pre-order flattening of the call tree (entries appear in
+/// call order, parents before their children), so `depth` alone recovers
+/// the tree shape. Selection is [`frame_revert_payload`] applied to the
+/// root frame.
+fn terminal_revert_payload(traces: &[RawTrace]) -> Option<&Bytes> {
+    if traces.is_empty() {
+        return None;
+    }
+    frame_revert_payload(traces, 0)
+}
+
+/// Best revert payload attributable to the frame at `index`:
+///
+/// - A successful or halted frame explains nothing (halts have no payload).
+/// - A reverted frame's own non-empty payload wins — it is the terminal
+///   failure at that level — except Safe4337Module's bare `ExecutionFailed()`
+///   from an `executeUserOp` frame, which deliberately replaces the revert
+///   its Safe call caught; recover that via [`latest_descendant_revert`].
+/// - An empty revert inherits from its last child if that child also failed.
+///   Earlier failed siblings were superseded by whatever ran after them.
+fn frame_revert_payload(traces: &[RawTrace], index: usize) -> Option<&Bytes> {
+    let frame = &traces[index];
+    if frame.outcome != Some(TraceOutcome::Revert) {
+        return None;
+    }
+    match &frame.revert_output {
+        Some(output)
+            if output.as_ref() == EXECUTION_FAILED_SELECTOR
+                && frame.selector == Some(EXECUTE_USER_OP_SELECTOR) =>
+        {
+            latest_descendant_revert(traces, index).or(Some(output))
+        }
+        Some(output) => Some(output),
+        None => {
+            let last_child = last_direct_child(traces, index)?;
+            frame_revert_payload(traces, last_child)
+        }
+    }
+}
+
+/// Payload of the most recent revert below the frame at `index`, crossing
+/// successful frames: Safe's `execTransactionFromModule` catches the target
+/// revert and succeeds returning `false`, so the revert that explains
+/// `ExecutionFailed()` sits inside a successful subtree. Only the chain of
+/// *last* children is followed — anything that ran later superseded earlier
+/// failures.
+fn latest_descendant_revert(traces: &[RawTrace], index: usize) -> Option<&Bytes> {
+    let last_child = last_direct_child(traces, index)?;
+    match traces[last_child].outcome {
+        Some(TraceOutcome::Success) => latest_descendant_revert(traces, last_child),
+        _ => frame_revert_payload(traces, last_child),
+    }
+}
+
+/// Index of the last direct child of the frame at `parent`, if any.
+fn last_direct_child(traces: &[RawTrace], parent: usize) -> Option<usize> {
+    let parent_depth = traces[parent].depth;
+    let mut last = None;
+    for (index, trace) in traces.iter().enumerate().skip(parent + 1) {
+        if trace.depth <= parent_depth {
+            break;
+        }
+        if trace.depth == parent_depth + 1 {
+            last = Some(index);
+        }
+    }
+    last
 }
 
 impl<CTX: revm::context_interface::ContextTr> Inspector<CTX> for SimulationInspector {
@@ -460,7 +521,7 @@ impl<CTX: revm::context_interface::ContextTr> Inspector<CTX> for SimulationInspe
             value,
             depth,
             outcome: None,
-            revert_reason: None,
+            revert_output: None,
         });
 
         // Open a new frame. If this call reverts, `call_end` will drop the
@@ -491,15 +552,6 @@ impl<CTX: revm::context_interface::ContextTr> Inspector<CTX> for SimulationInspe
         self.record_trace_outcome(frame.trace_index, result, outcome.output());
         if !result.is_ok() {
             // Frame reverted or halted — drop everything tentative inside it.
-            // For explicit REVERTs, capture the deepest payload (the first
-            // one we see, since `call_end` fires bottom-up) so wrappers like
-            // EntryPoint's `FailedOp(...)` don't mask the root cause. Halts
-            // and the other `is_revert()` variants (CallTooDeep, OutOfFunds,
-            // EOF init-code) have empty outputs.
-            if matches!(result, InstructionResult::Revert) && self.deepest_revert_payload.is_none()
-            {
-                self.deepest_revert_payload = Some(outcome.output().clone());
-            }
             return;
         }
         self.commit_or_bubble(frame);
@@ -526,7 +578,7 @@ impl<CTX: revm::context_interface::ContextTr> Inspector<CTX> for SimulationInspe
             value: inputs.value(),
             depth: self.pending_frames.len(),
             outcome: None,
-            revert_reason: None,
+            revert_output: None,
         });
         self.pending_frames.push(PendingFrame::new(trace_index));
         None
@@ -550,13 +602,7 @@ impl<CTX: revm::context_interface::ContextTr> Inspector<CTX> for SimulationInspe
             trace.to = outcome.address;
         }
         if !result.is_ok() {
-            // CREATE itself failed — drop the frame. Capture an explicit
-            // constructor REVERT before an outer call can replace its useful
-            // payload with a wrapper error.
-            if matches!(result, InstructionResult::Revert) && self.deepest_revert_payload.is_none()
-            {
-                self.deepest_revert_payload = Some(outcome.output().clone());
-            }
+            // CREATE itself failed — drop the frame.
             return;
         }
         // Successful create: record `(deployer, deployed)` into the create
@@ -899,8 +945,9 @@ where
         //     side-effects from the inspector. The EVM owns it; recover a
         //     `&mut` via `components_mut()` and drain.
         let (_, inspector, _) = evm.components_mut();
+        let terminal_revert_reason = inspector.terminal_revert_reason();
         let trace = inspector
-            .take_trace_entries()
+            .trace_entries()
             .map_err(|error| internal_err(format!("simulation inspector failed: {error}")))?;
         asset_changes.extend(inspector.take_native_asset_changes());
         let inspector_creations = inspector.take_contract_creations();
@@ -910,24 +957,17 @@ where
             .collect();
         let inspector_destructs = inspector.take_self_destructs();
 
-        // `revert_reason` is the *root cause* — the deepest reverted frame's
-        // payload — so consumers see the contract-specific custom error from
-        // the inner call rather than wrappers like EntryPoint's
-        // `FailedOp(...)` that live further up the stack. Falls back to the
-        // outer payload if the inspector somehow saw no `Revert` frame, and
-        // halts surface their `HaltReason` debug name unchanged.
+        // Halts surface their `HaltReason` debug name unchanged; the outer
+        // payload is the last resort when trace selection produced nothing.
+        let outer_revert_reason = match &result_and_state.result {
+            ExecutionResult::Revert { output, .. } => Some(decode_revert_reason(output)),
+            _ => None,
+        };
         let revert_reason = match status {
             SimulationStatus::Success => None,
-            SimulationStatus::Revert => halt_reason.or_else(|| {
-                inspector
-                    .take_deepest_revert_reason()
-                    .or_else(|| match &result_and_state.result {
-                        ExecutionResult::Revert { output, .. } => {
-                            Some(decode_revert_reason(output))
-                        }
-                        _ => None,
-                    })
-            }),
+            SimulationStatus::Revert => halt_reason
+                .or(terminal_revert_reason)
+                .or(outer_revert_reason),
         };
 
         // Apply the simulated state diff to the in-memory DB before metadata
@@ -1723,6 +1763,166 @@ mod tests {
     use super::*;
     use std::time::{Duration, Instant};
 
+    /// Completed trace entry for hand-built `terminal_revert_payload` trees.
+    fn completed_trace(
+        depth: usize,
+        outcome: TraceOutcome,
+        selector: Option<[u8; 4]>,
+        revert_output: Option<&'static [u8]>,
+    ) -> RawTrace {
+        RawTrace {
+            kind: TraceKind::Call,
+            from: Address::ZERO,
+            to: Some(Address::ZERO),
+            selector,
+            value: U256::ZERO,
+            depth,
+            outcome: Some(outcome),
+            revert_output: revert_output.map(Bytes::from_static),
+        }
+    }
+
+    #[test]
+    fn terminal_selection_handles_trivial_shapes() {
+        assert_eq!(terminal_revert_payload(&[]), None);
+        assert_eq!(
+            terminal_revert_payload(&[completed_trace(0, TraceOutcome::Success, None, None)]),
+            None
+        );
+        assert_eq!(
+            terminal_revert_payload(&[completed_trace(0, TraceOutcome::Halt, None, None)]),
+            None
+        );
+    }
+
+    #[test]
+    fn empty_revert_inherits_only_from_a_failed_last_child() {
+        // Failed child then successful sibling: nothing to inherit.
+        let superseded = [
+            completed_trace(0, TraceOutcome::Revert, None, None),
+            completed_trace(1, TraceOutcome::Revert, None, Some(b"\xaa")),
+            completed_trace(1, TraceOutcome::Success, None, None),
+        ];
+        assert_eq!(terminal_revert_payload(&superseded), None);
+
+        // Successful child then failed sibling: the last child explains it.
+        let inherited = [
+            completed_trace(0, TraceOutcome::Revert, None, None),
+            completed_trace(1, TraceOutcome::Success, None, None),
+            completed_trace(1, TraceOutcome::Revert, None, Some(b"\xbb")),
+        ];
+        assert_eq!(
+            terminal_revert_payload(&inherited),
+            Some(&Bytes::from_static(b"\xbb"))
+        );
+
+        // A halted last child has no payload to inherit.
+        let halted = [
+            completed_trace(0, TraceOutcome::Revert, None, None),
+            completed_trace(1, TraceOutcome::Halt, None, None),
+        ];
+        assert_eq!(terminal_revert_payload(&halted), None);
+    }
+
+    #[test]
+    fn last_direct_child_ignores_an_earlier_siblings_grandchildren() {
+        // Root reverts empty. First child succeeded (its own inner revert was
+        // caught and is irrelevant); the *last direct child* is the later
+        // sibling, not the deeper grandchild that appears between them.
+        let traces = [
+            completed_trace(0, TraceOutcome::Revert, None, None),
+            completed_trace(1, TraceOutcome::Success, None, None),
+            completed_trace(2, TraceOutcome::Revert, None, Some(b"\xaa")),
+            completed_trace(1, TraceOutcome::Revert, None, Some(b"\xbb")),
+        ];
+        assert_eq!(
+            terminal_revert_payload(&traces),
+            Some(&Bytes::from_static(b"\xbb"))
+        );
+    }
+
+    #[test]
+    fn safe_execution_failed_recovers_revert_from_successful_subtree() {
+        let execution_failed: &'static [u8] = &EXECUTION_FAILED_SELECTOR;
+        // executeUserOp frame reverts bare ExecutionFailed(); the caught
+        // target revert sits under a successful execTransactionFromModule.
+        let traces = [
+            completed_trace(
+                0,
+                TraceOutcome::Revert,
+                Some(EXECUTE_USER_OP_SELECTOR),
+                Some(execution_failed),
+            ),
+            completed_trace(1, TraceOutcome::Success, None, None),
+            completed_trace(2, TraceOutcome::Revert, None, Some(b"\xaa")),
+        ];
+        assert_eq!(
+            terminal_revert_payload(&traces),
+            Some(&Bytes::from_static(b"\xaa"))
+        );
+
+        // Without a descendant revert the wrapper itself is all we know.
+        let bare = [completed_trace(
+            0,
+            TraceOutcome::Revert,
+            Some(EXECUTE_USER_OP_SELECTOR),
+            Some(execution_failed),
+        )];
+        assert_eq!(
+            terminal_revert_payload(&bare),
+            Some(&Bytes::from_static(execution_failed))
+        );
+
+        // Recovery is gated on the executeUserOp selector: any other frame
+        // reverting with the same bytes keeps its own payload.
+        let wrong_selector = [
+            completed_trace(
+                0,
+                TraceOutcome::Revert,
+                Some([0xde, 0xad, 0xbe, 0xef]),
+                Some(execution_failed),
+            ),
+            completed_trace(1, TraceOutcome::Success, None, None),
+            completed_trace(2, TraceOutcome::Revert, None, Some(b"\xaa")),
+        ];
+        assert_eq!(
+            terminal_revert_payload(&wrong_selector),
+            Some(&Bytes::from_static(execution_failed))
+        );
+
+        // ...and on an exact payload: ExecutionFailed with appended data is
+        // some other error that happens to share the selector.
+        let inexact: &'static [u8] = b"\xac\xfd\xb4\x44\xde\xad\xbe\xef";
+        let inexact_payload = [
+            completed_trace(
+                0,
+                TraceOutcome::Revert,
+                Some(EXECUTE_USER_OP_SELECTOR),
+                Some(inexact),
+            ),
+            completed_trace(1, TraceOutcome::Success, None, None),
+            completed_trace(2, TraceOutcome::Revert, None, Some(b"\xaa")),
+        ];
+        assert_eq!(
+            terminal_revert_payload(&inexact_payload),
+            Some(&Bytes::from_static(inexact))
+        );
+    }
+
+    #[test]
+    fn terminal_reason_remains_available_after_reading_trace_entries() {
+        let mut inspector = SimulationInspector::default();
+        inspector.traces.push(completed_trace(
+            0,
+            TraceOutcome::Revert,
+            None,
+            Some(b"\xaa"),
+        ));
+
+        assert_eq!(inspector.trace_entries().expect("complete trace").len(), 1);
+        assert_eq!(inspector.terminal_revert_reason().as_deref(), Some("0xaa"));
+    }
+
     #[test]
     fn missing_trace_entry_is_reported_without_panicking() {
         let mut inspector = SimulationInspector::default();
@@ -1733,7 +1933,7 @@ mod tests {
                 .is_none()
         );
         assert!(matches!(
-            inspector.take_trace_entries(),
+            inspector.trace_entries(),
             Err("simulation inspector frame referenced a missing trace entry")
         ));
     }
@@ -1749,11 +1949,11 @@ mod tests {
             value: U256::ZERO,
             depth: 0,
             outcome: None,
-            revert_reason: None,
+            revert_output: None,
         });
 
         assert!(matches!(
-            inspector.take_trace_entries(),
+            inspector.trace_entries(),
             Err("simulation inspector trace frame did not complete")
         ));
     }

--- a/crates/rpc/src/simulate.rs
+++ b/crates/rpc/src/simulate.rs
@@ -430,21 +430,21 @@ fn terminal_revert_payload(traces: &[RawTrace]) -> Option<&Bytes> {
 /// - An empty revert inherits from its last child if that child also failed.
 ///   Earlier failed siblings were superseded by whatever ran after them.
 fn frame_revert_payload(traces: &[RawTrace], index: usize) -> Option<&Bytes> {
-    let frame: &RawTrace = &traces[index];
-    if frame.outcome != Some(TraceOutcome::Revert) {
-        return None;
-    }
-    match &frame.revert_output {
-        Some(output)
-            if output.as_ref() == EXECUTION_FAILED_SELECTOR
-                && frame.selector == Some(EXECUTE_USER_OP_SELECTOR) =>
-        {
-            safe_execution_revert(traces, index).or(Some(output))
+    let mut current = index;
+    loop {
+        let frame = &traces[current];
+        if frame.outcome != Some(TraceOutcome::Revert) {
+            return None;
         }
-        Some(output) => Some(output),
-        None => {
-            let last_child = last_direct_child(traces, index)?;
-            frame_revert_payload(traces, last_child)
+        match &frame.revert_output {
+            Some(output)
+                if output.as_ref() == EXECUTION_FAILED_SELECTOR
+                    && frame.selector == Some(EXECUTE_USER_OP_SELECTOR) =>
+            {
+                return safe_execution_revert(traces, current).or(Some(output));
+            }
+            Some(output) => return Some(output),
+            None => current = last_direct_child(traces, current)?,
         }
     }
 }
@@ -461,36 +461,38 @@ fn safe_execution_revert(traces: &[RawTrace], index: usize) -> Option<&Bytes> {
         if trace.outcome == Some(TraceOutcome::Success)
             && trace.selector == Some(EXEC_TRANSACTION_FROM_MODULE_SELECTOR)
         {
-            return latest_descendant_revert(traces, descendant);
+            return safe_transaction_revert(traces, descendant);
         }
     }
     None
 }
 
-/// Payload of the most recent revert below the frame at `index`, crossing
-/// successful frames: Safe's `execTransactionFromModule` catches the target
-/// revert and succeeds returning `false`, so the revert that explains
-/// `ExecutionFailed()` sits inside a successful subtree. The latest child
-/// branch containing a revert wins; a later successful module-guard callback
-/// with no revert therefore does not hide the target failure.
-fn latest_descendant_revert(traces: &[RawTrace], index: usize) -> Option<&Bytes> {
+/// Payload of the failed target call made by `execTransactionFromModule`.
+///
+/// Proxy and delegatecall layers preserve the selector, so cross only those
+/// successful wrapper frames. At the implementation frame, the failed direct
+/// child is the target call that made Safe return `false`. Other successful
+/// children may be module-guard callbacks; their internally caught reverts do
+/// not explain `ExecutionFailed()`.
+fn safe_transaction_revert(traces: &[RawTrace], index: usize) -> Option<&Bytes> {
     let parent_depth = traces[index].depth;
-    let mut latest = None;
     for (child, trace) in traces.iter().enumerate().skip(index + 1) {
         if trace.depth <= parent_depth {
             break;
         }
         if trace.depth == parent_depth + 1 {
-            let candidate = match trace.outcome {
-                Some(TraceOutcome::Success) => latest_descendant_revert(traces, child),
-                _ => frame_revert_payload(traces, child),
-            };
-            if candidate.is_some() {
-                latest = candidate;
+            if trace.outcome == Some(TraceOutcome::Success)
+                && trace.selector == Some(EXEC_TRANSACTION_FROM_MODULE_SELECTOR)
+            {
+                if let Some(candidate) = safe_transaction_revert(traces, child) {
+                    return Some(candidate);
+                }
+            } else if trace.outcome == Some(TraceOutcome::Revert) {
+                return frame_revert_payload(traces, child);
             }
         }
     }
-    latest
+    None
 }
 
 /// Index of the last direct child of the frame at `parent`, if any.
@@ -1941,6 +1943,36 @@ mod tests {
         assert_eq!(
             terminal_revert_payload(&traces),
             Some(&Bytes::from_static(b"\xbb"))
+        );
+    }
+
+    #[test]
+    fn safe_execution_failed_ignores_revert_caught_by_post_execution_check() {
+        let execution_failed: &'static [u8] = &EXECUTION_FAILED_SELECTOR;
+        let traces = [
+            completed_trace(
+                0,
+                TraceOutcome::Revert,
+                Some(EXECUTE_USER_OP_SELECTOR),
+                Some(execution_failed),
+            ),
+            completed_trace(
+                1,
+                TraceOutcome::Success,
+                Some(EXEC_TRANSACTION_FROM_MODULE_SELECTOR),
+                None,
+            ),
+            // This failed target call makes execTransactionFromModule return
+            // false and is the reason executeUserOp reverts ExecutionFailed().
+            completed_trace(2, TraceOutcome::Revert, None, Some(b"\xaa")),
+            // A later post-execution check succeeds after catching an
+            // unrelated revert inside its own subtree.
+            completed_trace(2, TraceOutcome::Success, None, None),
+            completed_trace(3, TraceOutcome::Revert, None, Some(b"\xbb")),
+        ];
+        assert_eq!(
+            terminal_revert_payload(&traces),
+            Some(&Bytes::from_static(b"\xaa"))
         );
     }
 

--- a/crates/rpc/src/simulate_consts.rs
+++ b/crates/rpc/src/simulate_consts.rs
@@ -128,6 +128,12 @@ pub(crate) const ERROR_STRING_SELECTOR: [u8; 4] = [0x08, 0xc3, 0x79, 0xa0];
 /// `Panic(uint256)` selector — `keccak256("Panic(uint256)")[..4]`.
 pub(crate) const PANIC_UINT256_SELECTOR: [u8; 4] = [0x4e, 0x48, 0x7b, 0x71];
 
+/// Safe4337Module `executeUserOp(address,uint256,bytes,uint8)` selector.
+pub const EXECUTE_USER_OP_SELECTOR: [u8; 4] = [0x7b, 0xb3, 0x74, 0x28];
+
+/// Safe4337Module `ExecutionFailed()` selector.
+pub const EXECUTION_FAILED_SELECTOR: [u8; 4] = [0xac, 0xfd, 0xb4, 0x44];
+
 /// Minimum payload length for a well-formed `Error(string)` revert:
 /// selector(4) + string-offset(32) + string-length(32).
 pub(crate) const MIN_ERROR_STRING_LEN: usize = 4 + 32 + 32;

--- a/crates/rpc/src/simulate_consts.rs
+++ b/crates/rpc/src/simulate_consts.rs
@@ -131,6 +131,9 @@ pub(crate) const PANIC_UINT256_SELECTOR: [u8; 4] = [0x4e, 0x48, 0x7b, 0x71];
 /// Safe4337Module `executeUserOp(address,uint256,bytes,uint8)` selector.
 pub const EXECUTE_USER_OP_SELECTOR: [u8; 4] = [0x7b, 0xb3, 0x74, 0x28];
 
+/// Safe `execTransactionFromModule(address,uint256,bytes,uint8)` selector.
+pub const EXEC_TRANSACTION_FROM_MODULE_SELECTOR: [u8; 4] = [0x46, 0x87, 0x21, 0xa7];
+
 /// Safe4337Module `ExecutionFailed()` selector.
 pub const EXECUTION_FAILED_SELECTOR: [u8; 4] = [0xac, 0xfd, 0xb4, 0x44];
 

--- a/crates/rpc/tests/fork_simulate.rs
+++ b/crates/rpc/tests/fork_simulate.rs
@@ -751,12 +751,10 @@ async fn test_revert_with_reason() {
     }
 }
 
-/// The inspector exposes the deepest reverted frame's decoded payload —
-/// which the handler uses for `revertReason` so wrappers like EntryPoint's
-/// `FailedOp(...)` don't mask the root cause. Single-frame case: WLD reverts
-/// directly with no wrapper.
+/// The inspector exposes the terminal failure path's decoded payload. In this
+/// single-frame case, WLD reverts directly with no wrapper.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_deepest_revert_reason_decodes_payload() {
+async fn test_terminal_revert_reason_decodes_payload() {
     let mut db = forked_db!();
     let caller = address!("00000000000000000000000000ffffffffffffff");
     db.insert_account_info(
@@ -799,7 +797,7 @@ async fn test_deepest_revert_reason_decodes_payload() {
 
     let (_, inspector, _) = evm.components_mut();
     assert_eq!(
-        inspector.take_deepest_revert_reason().as_deref(),
+        inspector.terminal_revert_reason().as_deref(),
         Some("ERC20: transfer amount exceeds balance"),
     );
 }
@@ -808,7 +806,7 @@ async fn test_deepest_revert_reason_decodes_payload() {
 /// the inspector returns `None` and the handler falls back to the
 /// `HaltReason` debug name for `revertReason`.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_deepest_revert_reason_skips_halts() {
+async fn test_terminal_revert_reason_skips_halts() {
     let mut db = forked_db!();
     let caller = address!("00000000000000000000000000ffffffffffffff");
     db.insert_account_info(
@@ -856,7 +854,7 @@ async fn test_deepest_revert_reason_skips_halts() {
     );
 
     let (_, inspector, _) = evm.components_mut();
-    assert!(inspector.take_deepest_revert_reason().is_none());
+    assert!(inspector.terminal_revert_reason().is_none());
 }
 
 /// Trace captures top-level calls from a simulated execution.
@@ -903,7 +901,7 @@ async fn test_trace_captures_calls() {
 
     let (_, inspector, _) = evm.components_mut();
     let trace = inspector
-        .take_trace_entries()
+        .trace_entries()
         .expect("completed simulation should produce a complete trace");
     for entry in &trace {
         assert!(
@@ -1053,7 +1051,7 @@ async fn test_trace_detects_malicious_safe_call() {
 
     let (_, inspector, _) = evm.components_mut();
     let trace = inspector
-        .take_trace_entries()
+        .trace_entries()
         .expect("completed simulation should produce a complete trace");
     // Log what the trace captured (informational)
     for entry in &trace {
@@ -1558,7 +1556,7 @@ async fn test_inspector_captures_create_via_call_frame() {
     assert_ne!(deployed, Address::ZERO, "deployed address populated");
 
     let trace = inspector
-        .take_trace_entries()
+        .trace_entries()
         .expect("completed simulation should produce a complete trace");
     let create = trace
         .iter()

--- a/crates/rpc/tests/inspector_create_revert.rs
+++ b/crates/rpc/tests/inspector_create_revert.rs
@@ -17,7 +17,9 @@ use revm_primitives::TxKind;
 
 use world_chain_rpc::{
     simulate::{SimulationInspector, TraceKind, TraceOutcome, relax_cfg_for_simulation},
-    simulate_consts::{EXECUTE_USER_OP_SELECTOR, EXECUTION_FAILED_SELECTOR},
+    simulate_consts::{
+        EXEC_TRANSACTION_FROM_MODULE_SELECTOR, EXECUTE_USER_OP_SELECTOR, EXECUTION_FAILED_SELECTOR,
+    },
 };
 
 const CHAIN_ID: u64 = 480;
@@ -25,6 +27,7 @@ const CALLER: Address = address!("00000000000000000000000000000000DeaDBeef");
 const TRAMPOLINE: Address = address!("000000000000000000000000000000000000c0de");
 const REVERTING_CHILD: Address = address!("000000000000000000000000000000000000cafe");
 const CATCHING_CHILD: Address = address!("000000000000000000000000000000000000beef");
+const MODULE_GUARD: Address = address!("000000000000000000000000000000000000feed");
 
 /// Reverts with `0xaaaaaaaa`.
 const CHILD_REVERT: &[u8] = &[
@@ -149,13 +152,34 @@ fn run_trampoline_with_input(
     (result, std::mem::take(inspector))
 }
 
-/// Calls `child` (discarding its result), then reverts with the supplied
-/// four-byte payload.
-fn call_then_revert(child: Address, parent_payload: [u8; 4]) -> Vec<u8> {
-    let mut code = vec![
-        0x5f, 0x5f, 0x5f, 0x5f, 0x5f, // Empty CALL output/input and zero value
+/// Calls `child` with an optional four-byte selector (discarding its result),
+/// then reverts with the supplied four-byte payload.
+fn call_then_revert(
+    child: Address,
+    child_selector: Option<[u8; 4]>,
+    parent_payload: [u8; 4],
+) -> Vec<u8> {
+    let mut code = Vec::new();
+    if let Some(selector) = child_selector {
+        code.push(0x63); // PUSH4 selector
+        code.extend_from_slice(&selector);
+        code.extend_from_slice(&[0x5f, 0x52]); // PUSH0; MSTORE
+    }
+    code.extend_from_slice(&[
+        0x5f, 0x5f, // Empty CALL output
+    ]);
+    if child_selector.is_some() {
+        code.extend_from_slice(&[
+            0x60, 0x04, // PUSH1 4 (input length)
+            0x60, 0x1c, // PUSH1 28 (input offset)
+        ]);
+    } else {
+        code.extend_from_slice(&[0x5f, 0x5f]); // Empty CALL input
+    }
+    code.extend_from_slice(&[
+        0x5f, // Zero value
         0x73, // PUSH20 child address
-    ];
+    ]);
     code.extend_from_slice(child.as_slice());
     code.extend_from_slice(&[
         0x61, 0xff, 0xff, // PUSH2 65535 gas
@@ -183,6 +207,24 @@ fn call_then_stop(child: Address) -> Vec<u8> {
         0xf1, 0x50, // CALL; POP result
         0x00, // STOP
     ]);
+    code
+}
+
+/// Calls `first` and then `second`, discarding both results, before stopping.
+fn call_two_then_stop(first: Address, second: Address) -> Vec<u8> {
+    let mut code = Vec::new();
+    for child in [first, second] {
+        code.extend_from_slice(&[
+            0x5f, 0x5f, 0x5f, 0x5f, 0x5f, // Empty CALL output/input and zero value
+            0x73, // PUSH20 child address
+        ]);
+        code.extend_from_slice(child.as_slice());
+        code.extend_from_slice(&[
+            0x61, 0xff, 0xff, // PUSH2 65535 gas
+            0xf1, 0x50, // CALL; POP result
+        ]);
+    }
+    code.push(0x00); // STOP
     code
 }
 
@@ -274,7 +316,7 @@ fn inspector_traces_successful_create_with_deployed_address() {
 
 #[test]
 fn terminal_parent_revert_ignores_earlier_caught_child() {
-    let trampoline = call_then_revert(REVERTING_CHILD, [0xbb; 4]);
+    let trampoline = call_then_revert(REVERTING_CHILD, None, [0xbb; 4]);
     let (result, inspector) = run_trampoline_with_input(
         &trampoline,
         &[(REVERTING_CHILD, CHILD_REVERT)],
@@ -303,7 +345,11 @@ fn safe_execution_failed_retains_revert_across_successful_catching_frame() {
     // false successfully. Safe4337Module.executeUserOp then replaces that
     // return value with the exact `ExecutionFailed()` custom error.
     let catching_child = call_then_stop(REVERTING_CHILD);
-    let trampoline = call_then_revert(CATCHING_CHILD, EXECUTION_FAILED_SELECTOR);
+    let trampoline = call_then_revert(
+        CATCHING_CHILD,
+        Some(EXEC_TRANSACTION_FROM_MODULE_SELECTOR),
+        EXECUTION_FAILED_SELECTOR,
+    );
     let (result, inspector) = run_trampoline_with_input(
         &trampoline,
         &[
@@ -325,5 +371,45 @@ fn safe_execution_failed_retains_revert_across_successful_catching_frame() {
     assert_eq!(trace[0].selector.as_deref(), Some("0x7bb37428"));
     assert_eq!(trace[0].revert_reason.as_deref(), Some("0xacfdb444"));
     assert_eq!(trace[1].outcome, TraceOutcome::Success);
+    assert_eq!(trace[1].selector.as_deref(), Some("0x468721a7"));
     assert_eq!(trace[2].revert_reason.as_deref(), Some("0xaaaaaaaa"));
+}
+
+#[test]
+fn safe_execution_failed_retains_revert_before_successful_module_guard() {
+    // Safe 1.5 calls checkAfterModuleExecution after the target. The trailing
+    // successful guard call must not hide the target revert that caused
+    // execTransactionFromModule to return false.
+    let catching_child = call_two_then_stop(REVERTING_CHILD, MODULE_GUARD);
+    let trampoline = call_then_revert(
+        CATCHING_CHILD,
+        Some(EXEC_TRANSACTION_FROM_MODULE_SELECTOR),
+        EXECUTION_FAILED_SELECTOR,
+    );
+    let (result, inspector) = run_trampoline_with_input(
+        &trampoline,
+        &[
+            (CATCHING_CHILD, &catching_child),
+            (REVERTING_CHILD, CHILD_REVERT),
+            (MODULE_GUARD, &[0x00]),
+        ],
+        Bytes::copy_from_slice(&EXECUTE_USER_OP_SELECTOR),
+    );
+
+    assert!(matches!(result, ExecutionResult::Revert { .. }));
+    assert_eq!(
+        inspector.terminal_revert_reason().as_deref(),
+        Some("0xaaaaaaaa")
+    );
+
+    let trace = inspector
+        .trace_entries()
+        .expect("completed simulation should produce a complete trace");
+    let [execute_user_op, safe, target, guard] = trace.as_slice() else {
+        panic!("expected executeUserOp, Safe, target, and guard frames, got {trace:?}");
+    };
+    assert_eq!(execute_user_op.outcome, TraceOutcome::Revert);
+    assert_eq!(safe.outcome, TraceOutcome::Success);
+    assert_eq!(target.revert_reason.as_deref(), Some("0xaaaaaaaa"));
+    assert_eq!(guard.outcome, TraceOutcome::Success);
 }

--- a/crates/rpc/tests/inspector_create_revert.rs
+++ b/crates/rpc/tests/inspector_create_revert.rs
@@ -1,4 +1,5 @@
-//! Regression tests for CREATE/CREATE2 handling in `SimulationInspector`.
+//! Regression tests for CREATE/CREATE2 handling and terminal revert selection
+//! in `SimulationInspector`.
 //!
 //! Runs entirely against an in-memory `CacheDB<EmptyDB>` — no fork URL needed.
 
@@ -14,13 +15,25 @@ use revm::{
 use revm_database::{CacheDB, EmptyDB};
 use revm_primitives::TxKind;
 
-use world_chain_rpc::simulate::{
-    SimulationInspector, TraceKind, TraceOutcome, relax_cfg_for_simulation,
+use world_chain_rpc::{
+    simulate::{SimulationInspector, TraceKind, TraceOutcome, relax_cfg_for_simulation},
+    simulate_consts::{EXECUTE_USER_OP_SELECTOR, EXECUTION_FAILED_SELECTOR},
 };
 
 const CHAIN_ID: u64 = 480;
 const CALLER: Address = address!("00000000000000000000000000000000DeaDBeef");
 const TRAMPOLINE: Address = address!("000000000000000000000000000000000000c0de");
+const REVERTING_CHILD: Address = address!("000000000000000000000000000000000000cafe");
+const CATCHING_CHILD: Address = address!("000000000000000000000000000000000000beef");
+
+/// Reverts with `0xaaaaaaaa`.
+const CHILD_REVERT: &[u8] = &[
+    0x63, 0xaa, 0xaa, 0xaa, 0xaa, // PUSH4 0xaaaaaaaa
+    0x5f, 0x52, // PUSH0; MSTORE
+    0x60, 0x04, // PUSH1 4 (revert-data length)
+    0x60, 0x1c, // PUSH1 28 (revert-data offset)
+    0xfd, // REVERT
+];
 
 /// Runtime code that executes CREATE with a 12-byte constructor, then hides
 /// the constructor's revert data by reverting the outer frame with no output.
@@ -88,6 +101,14 @@ fn install_runtime_code(db: &mut CacheDB<EmptyDB>, address: Address, code: Vec<u
 }
 
 fn run_trampoline(code: &[u8]) -> (ExecutionResult<OpHaltReason>, SimulationInspector) {
+    run_trampoline_with_input(code, &[], Bytes::new())
+}
+
+fn run_trampoline_with_input(
+    code: &[u8],
+    contracts: &[(Address, &[u8])],
+    input: Bytes,
+) -> (ExecutionResult<OpHaltReason>, SimulationInspector) {
     let mut db = CacheDB::<EmptyDB>::default();
     db.insert_account_info(
         CALLER,
@@ -97,6 +118,9 @@ fn run_trampoline(code: &[u8]) -> (ExecutionResult<OpHaltReason>, SimulationInsp
         },
     );
     install_runtime_code(&mut db, TRAMPOLINE, code.to_vec());
+    for (address, code) in contracts {
+        install_runtime_code(&mut db, *address, code.to_vec());
+    }
 
     let mut evm = OpEvmFactory::default().create_evm_with_inspector(
         &mut db,
@@ -109,6 +133,7 @@ fn run_trampoline(code: &[u8]) -> (ExecutionResult<OpHaltReason>, SimulationInsp
             base: TxEnv {
                 caller: CALLER,
                 kind: TxKind::Call(TRAMPOLINE),
+                data: input,
                 gas_limit: 1_000_000,
                 gas_price: 0,
                 chain_id: Some(CHAIN_ID),
@@ -124,19 +149,56 @@ fn run_trampoline(code: &[u8]) -> (ExecutionResult<OpHaltReason>, SimulationInsp
     (result, std::mem::take(inspector))
 }
 
+/// Calls `child` (discarding its result), then reverts with the supplied
+/// four-byte payload.
+fn call_then_revert(child: Address, parent_payload: [u8; 4]) -> Vec<u8> {
+    let mut code = vec![
+        0x5f, 0x5f, 0x5f, 0x5f, 0x5f, // Empty CALL output/input and zero value
+        0x73, // PUSH20 child address
+    ];
+    code.extend_from_slice(child.as_slice());
+    code.extend_from_slice(&[
+        0x61, 0xff, 0xff, // PUSH2 65535 gas
+        0xf1, 0x50, // CALL; POP failure result
+        0x63, // PUSH4 parent payload
+    ]);
+    code.extend_from_slice(&parent_payload);
+    code.extend_from_slice(&[
+        0x5f, 0x52, // PUSH0; MSTORE
+        0x60, 0x04, // PUSH1 4 (revert-data length)
+        0x60, 0x1c, // PUSH1 28 (revert-data offset)
+        0xfd, // REVERT
+    ]);
+    code
+}
+
+fn call_then_stop(child: Address) -> Vec<u8> {
+    let mut code = vec![
+        0x5f, 0x5f, 0x5f, 0x5f, 0x5f, // Empty CALL output/input and zero value
+        0x73, // PUSH20 child address
+    ];
+    code.extend_from_slice(child.as_slice());
+    code.extend_from_slice(&[
+        0x61, 0xff, 0xff, // PUSH2 65535 gas
+        0xf1, 0x50, // CALL; POP result
+        0x00, // STOP
+    ]);
+    code
+}
+
 #[test]
 fn inspector_captures_constructor_revert_reason() {
     let (result, mut inspector) = run_trampoline(CREATE_REVERT_TRAMPOLINE);
 
     assert!(matches!(result, ExecutionResult::Revert { .. }));
     assert_eq!(
-        inspector.take_deepest_revert_reason().as_deref(),
+        inspector.terminal_revert_reason().as_deref(),
         Some("0xdeadbeef")
     );
     assert!(inspector.take_contract_creations().is_empty());
 
     let trace = inspector
-        .take_trace_entries()
+        .trace_entries()
         .expect("completed simulation should produce a complete trace");
     let [parent, create] = trace.as_slice() else {
         panic!("expected parent CALL and child CREATE, got {trace:?}");
@@ -165,11 +227,12 @@ fn inspector_captures_constructor_revert_reason() {
 
 #[test]
 fn nested_create_revert_does_not_overwrite_successful_parent_outcome() {
-    let (result, mut inspector) = run_trampoline(CAUGHT_CREATE_REVERT_TRAMPOLINE);
+    let (result, inspector) = run_trampoline(CAUGHT_CREATE_REVERT_TRAMPOLINE);
 
     assert!(matches!(result, ExecutionResult::Success { .. }));
+    assert!(inspector.terminal_revert_reason().is_none());
     let trace = inspector
-        .take_trace_entries()
+        .trace_entries()
         .expect("completed simulation should produce a complete trace");
     let [parent, create] = trace.as_slice() else {
         panic!("expected parent CALL and child CREATE, got {trace:?}");
@@ -193,7 +256,7 @@ fn inspector_traces_successful_create_with_deployed_address() {
     assert_ne!(deployed, Address::ZERO);
 
     let trace = inspector
-        .take_trace_entries()
+        .trace_entries()
         .expect("completed simulation should produce a complete trace");
     let [parent, create] = trace.as_slice() else {
         panic!("expected parent CALL and child CREATE, got {trace:?}");
@@ -207,4 +270,60 @@ fn inspector_traces_successful_create_with_deployed_address() {
     assert_eq!(create.to, Some(deployed));
     assert_eq!(create.selector, None);
     assert_eq!(create.revert_reason, None);
+}
+
+#[test]
+fn terminal_parent_revert_ignores_earlier_caught_child() {
+    let trampoline = call_then_revert(REVERTING_CHILD, [0xbb; 4]);
+    let (result, inspector) = run_trampoline_with_input(
+        &trampoline,
+        &[(REVERTING_CHILD, CHILD_REVERT)],
+        Bytes::new(),
+    );
+
+    assert!(matches!(result, ExecutionResult::Revert { .. }));
+    assert_eq!(
+        inspector.terminal_revert_reason().as_deref(),
+        Some("0xbbbbbbbb")
+    );
+
+    let trace = inspector
+        .trace_entries()
+        .expect("completed simulation should produce a complete trace");
+    let [parent, child] = trace.as_slice() else {
+        panic!("expected parent and child CALL frames, got {trace:?}");
+    };
+    assert_eq!(parent.revert_reason.as_deref(), Some("0xbbbbbbbb"));
+    assert_eq!(child.revert_reason.as_deref(), Some("0xaaaaaaaa"));
+}
+
+#[test]
+fn safe_execution_failed_retains_revert_across_successful_catching_frame() {
+    // Safe.execTransactionFromModule catches the target revert and returns
+    // false successfully. Safe4337Module.executeUserOp then replaces that
+    // return value with the exact `ExecutionFailed()` custom error.
+    let catching_child = call_then_stop(REVERTING_CHILD);
+    let trampoline = call_then_revert(CATCHING_CHILD, EXECUTION_FAILED_SELECTOR);
+    let (result, inspector) = run_trampoline_with_input(
+        &trampoline,
+        &[
+            (CATCHING_CHILD, &catching_child),
+            (REVERTING_CHILD, CHILD_REVERT),
+        ],
+        Bytes::copy_from_slice(&EXECUTE_USER_OP_SELECTOR),
+    );
+
+    assert!(matches!(result, ExecutionResult::Revert { .. }));
+    assert_eq!(
+        inspector.terminal_revert_reason().as_deref(),
+        Some("0xaaaaaaaa")
+    );
+
+    let trace = inspector
+        .trace_entries()
+        .expect("completed simulation should produce a complete trace");
+    assert_eq!(trace[0].selector.as_deref(), Some("0x7bb37428"));
+    assert_eq!(trace[0].revert_reason.as_deref(), Some("0xacfdb444"));
+    assert_eq!(trace[1].outcome, TraceOutcome::Success);
+    assert_eq!(trace[2].revert_reason.as_deref(), Some("0xaaaaaaaa"));
 }

--- a/crates/rpc/tests/inspector_shared_buffer.rs
+++ b/crates/rpc/tests/inspector_shared_buffer.rs
@@ -144,7 +144,7 @@ async fn shared_buffer_call_resolves_selector() {
 
     let (_, inspector, _) = evm.components_mut();
     let trace = inspector
-        .take_trace_entries()
+        .trace_entries()
         .expect("completed simulation should produce a complete trace");
 
     let inner = trace


### PR DESCRIPTION
## What

The response-level `revertReason` now follows the terminally failing frame path instead of "first revert seen bottom-up":

- A reverted frame's own non-empty payload wins.
- An empty revert inherits from its last child, only if that child also failed — a caught sibling revert followed by successful work is discarded.
- Safe4337Module's bare `ExecutionFailed()` on an `executeUserOp` frame is replaced by the revert its Safe call caught (gated on the exact selector and exact payload). This RPC calls the smart account directly, so EntryPoint wrappers like `FailedOp` never appear and get no special case.

Every frame still carries its own local `revertReason` in the trace; this only changes which one the response surfaces.

## How

Selection is a pure recursive function (`terminal_revert_payload`) over the completed trace — the inspector records raw revert payloads and does no candidate bookkeeping during execution. 

`take_trace_entries` became the borrowing `trace_entries`, so reason selection and trace extraction are order-independent (no drain-ordering footgun).

## Testing

- Unit tests drive the selection function with hand-built trace fixtures (inheritance, superseding siblings, halts, Safe recovery, selector and exact-payload gating).
- In-memory integration tests cover the record→select pipeline end to end, including the Safe scenario with real calldata.
- Both Safe selectors verified against `cast sig`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only how failure messages are chosen for a simulation RPC, but the new tree-walking logic (Safe-specific cases, sibling ordering) could mis-rank edge-case traces and confuse operators if wrong.
> 
> **Overview**
> **`simulate_unsignedUserOp`’s top-level `revertReason`** is no longer “first explicit REVERT seen bottom-up in the inspector.” The inspector stores raw **`revert_output`** per frame; after execution, **`terminal_revert_payload`** walks the pre-order trace to pick the best explanation (non-empty revert wins; empty reverts inherit from the **last failed direct child**; bare Safe4337Module **`ExecutionFailed()`** on **`executeUserOp`** is replaced by the revert caught under **`execTransactionFromModule`**). Response assembly prefers halt reason, then that selection, then the outer EVM revert payload.
> 
> **API shape:** `take_trace_entries` / `take_deepest_revert_reason` become borrowing **`trace_entries()`** and **`terminal_revert_reason()`** so trace export and reason selection are order-independent. Per-frame **`revertReason`** in the trace is still decoded locally from each frame’s payload.
> 
> **Constants** for Safe selectors live in `simulate_consts.rs`. Coverage adds unit tests on the selection tree and in-memory EVM tests for Safe/caught-revert scenarios; fork tests are renamed/updated for the new APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb4b0aa7c2cf37dce994265c329196b103bf32b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->