### PR TITLE
fix/nitro worker output root rpc

### DIFF
--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -3021,6 +3021,8 @@ async fn start_sp1_worker(
         l1_rpc_url.to_string(),
         l1_rpc_url.to_string(),
         l2_rpc_url.to_string(),
+        // Devnet reth serves eth_getProof directly; no op-node fallback needed.
+        None,
         Some(rollup_path.to_path_buf()),
         Duration::from_secs(900),
     )

--- a/proofs/kona-host/src/online.rs
+++ b/proofs/kona-host/src/online.rs
@@ -49,14 +49,8 @@ pub struct OnlineHostConfig {
     pub l1_beacon_rpc: String,
     /// World Chain L2 execution RPC URL.
     pub l2_rpc: String,
-    /// World Chain L2 *consensus* (op-node / rollup) RPC URL, serving
-    /// `optimism_outputAtBlock`.
-    ///
-    /// Only used as the fallback when `eth_getProof` against [`Self::l2_rpc`] fails. An
-    /// execution client does not implement `optimism_outputAtBlock`, so pointing this at
-    /// `l2_rpc` turns a recoverable proof failure into `-32601 Method not found` and hides
-    /// the real error. `None` disables the fallback and surfaces the `eth_getProof` failure
-    /// directly.
+    /// op-node RPC serving `optimism_outputAtBlock`, used only as the `eth_getProof`
+    /// fallback. Must not be the execution RPC. `None` disables the fallback.
     pub l2_consensus_rpc: Option<String>,
     /// World hardfork schedule baked into the witness.
     pub schedule: WorldRangeHardforkConfig,
@@ -514,11 +508,8 @@ async fn get_block(client: &Client, rpc_url: &str, tag: BlockTag) -> anyhow::Res
     .with_context(|| format!("eth_getBlockByNumber returned null for {}", tag.display()))
 }
 
-/// Builds the output-root witness for `block_number`, preferring `eth_getProof` against the
-/// execution client and falling back to `optimism_outputAtBlock` on the consensus client.
-///
-/// `consensus_rpc_url` MUST be an op-node / rollup RPC. Passing the execution URL makes the
-/// fallback fail with `-32601 Method not found`, which masks the real `eth_getProof` error.
+/// Builds the output-root witness, preferring `eth_getProof` and falling back to
+/// `optimism_outputAtBlock` on the consensus client.
 async fn output_root_witness(
     client: &Client,
     rpc_url: &str,

--- a/proofs/kona-host/src/online.rs
+++ b/proofs/kona-host/src/online.rs
@@ -49,7 +49,7 @@ pub struct OnlineHostConfig {
     pub l1_beacon_rpc: String,
     /// World Chain L2 execution RPC URL.
     pub l2_rpc: String,
-    /// op-node RPC serving `optimism_outputAtBlock`, used only as the `eth_getProof`
+    /// L2 consensus RPC serving `optimism_outputAtBlock`, used only as the `eth_getProof`
     /// fallback. Must not be the execution RPC. `None` disables the fallback.
     pub l2_consensus_rpc: Option<String>,
     /// World hardfork schedule baked into the witness.
@@ -536,7 +536,7 @@ async fn output_root_witness(
                 return Err(proof_err).context(
                     "eth_getProof failed and no L2 consensus RPC is configured for the \
                      optimism_outputAtBlock fallback (set --l2-consensus-rpc / \
-                     L2_CONSENSUS_RPC_URL to the op-node RPC)",
+                     L2_CONSENSUS_RPC_URL to the L2 consensus RPC)",
                 );
             };
             return output_root_witness_from_op_node(

--- a/proofs/kona-host/src/online.rs
+++ b/proofs/kona-host/src/online.rs
@@ -49,6 +49,15 @@ pub struct OnlineHostConfig {
     pub l1_beacon_rpc: String,
     /// World Chain L2 execution RPC URL.
     pub l2_rpc: String,
+    /// World Chain L2 *consensus* (op-node / rollup) RPC URL, serving
+    /// `optimism_outputAtBlock`.
+    ///
+    /// Only used as the fallback when `eth_getProof` against [`Self::l2_rpc`] fails. An
+    /// execution client does not implement `optimism_outputAtBlock`, so pointing this at
+    /// `l2_rpc` turns a recoverable proof failure into `-32601 Method not found` and hides
+    /// the real error. `None` disables the fallback and surfaces the `eth_getProof` failure
+    /// directly.
+    pub l2_consensus_rpc: Option<String>,
     /// World hardfork schedule baked into the witness.
     pub schedule: WorldRangeHardforkConfig,
     /// Rollup config hash recorded in the witness metadata.
@@ -89,6 +98,7 @@ impl OnlineHostConfig {
         l1_rpc: String,
         l1_beacon_rpc: String,
         l2_rpc: String,
+        l2_consensus_rpc: Option<String>,
         rollup_config_path: Option<PathBuf>,
         witness_timeout: Duration,
     ) -> anyhow::Result<Self> {
@@ -103,6 +113,7 @@ impl OnlineHostConfig {
             l1_rpc,
             l1_beacon_rpc,
             l2_rpc,
+            l2_consensus_rpc,
             schedule,
             rollup_config_hash,
             l2_chain_id: None,
@@ -146,6 +157,7 @@ pub fn build_online_config(
     l1_rpc: String,
     l1_beacon_rpc: String,
     l2_rpc: String,
+    l2_consensus_rpc: Option<String>,
     l2_chain_id: u64,
     schedule: &WorldRangeHardforkConfig,
     witness_timeout: Duration,
@@ -160,6 +172,7 @@ pub fn build_online_config(
             l1_rpc,
             l1_beacon_rpc,
             l2_rpc,
+            l2_consensus_rpc,
             Some(path),
             witness_timeout,
         );
@@ -171,6 +184,7 @@ pub fn build_online_config(
         l1_rpc,
         l1_beacon_rpc,
         l2_rpc,
+        l2_consensus_rpc,
         schedule: schedule.clone(),
         rollup_config_hash,
         l2_chain_id: Some(l2_chain_id),
@@ -301,10 +315,22 @@ pub async fn build_range_input(
     .await?;
     let post_block =
         get_block(&client, &config.l2_rpc, BlockTag::Number(request.end_block)).await?;
-    let pre_state =
-        output_root_witness(&client, &config.l2_rpc, request.start_block, &pre_block).await?;
-    let post_state =
-        output_root_witness(&client, &config.l2_rpc, request.end_block, &post_block).await?;
+    let pre_state = output_root_witness(
+        &client,
+        &config.l2_rpc,
+        config.l2_consensus_rpc.as_deref(),
+        request.start_block,
+        &pre_block,
+    )
+    .await?;
+    let post_state = output_root_witness(
+        &client,
+        &config.l2_rpc,
+        config.l2_consensus_rpc.as_deref(),
+        request.end_block,
+        &post_block,
+    )
+    .await?;
     let pre_root = pre_state.output_root();
     let post_root = post_state.output_root();
 
@@ -488,9 +514,15 @@ async fn get_block(client: &Client, rpc_url: &str, tag: BlockTag) -> anyhow::Res
     .with_context(|| format!("eth_getBlockByNumber returned null for {}", tag.display()))
 }
 
+/// Builds the output-root witness for `block_number`, preferring `eth_getProof` against the
+/// execution client and falling back to `optimism_outputAtBlock` on the consensus client.
+///
+/// `consensus_rpc_url` MUST be an op-node / rollup RPC. Passing the execution URL makes the
+/// fallback fail with `-32601 Method not found`, which masks the real `eth_getProof` error.
 async fn output_root_witness(
     client: &Client,
     rpc_url: &str,
+    consensus_rpc_url: Option<&str>,
     block_number: u64,
     block: &RpcBlock,
 ) -> anyhow::Result<OutputRootWitness> {
@@ -509,9 +541,21 @@ async fn output_root_witness(
         Ok(Some(proof)) => proof,
         Ok(None) => bail!("eth_getProof returned null"),
         Err(proof_err) => {
-            return output_root_witness_from_op_node(client, rpc_url, block_number, block)
-                .await
-                .with_context(|| format!("eth_getProof failed first: {proof_err}"));
+            let Some(consensus_rpc_url) = consensus_rpc_url else {
+                return Err(proof_err).context(
+                    "eth_getProof failed and no L2 consensus RPC is configured for the \
+                     optimism_outputAtBlock fallback (set --l2-consensus-rpc / \
+                     L2_CONSENSUS_RPC_URL to the op-node RPC)",
+                );
+            };
+            return output_root_witness_from_op_node(
+                client,
+                consensus_rpc_url,
+                block_number,
+                block,
+            )
+            .await
+            .with_context(|| format!("eth_getProof failed first: {proof_err}"));
         }
     };
 

--- a/proofs/nitro/worker/src/cmd/run.rs
+++ b/proofs/nitro/worker/src/cmd/run.rs
@@ -139,8 +139,8 @@ pub struct WorkerArgs {
     #[arg(long, env = "L2_RPC_URL")]
     l2_rpc: String,
 
-    /// op-node RPC serving `optimism_outputAtBlock`, used only as the `eth_getProof` fallback.
-    /// Must not be the execution RPC.
+    /// L2 consensus RPC serving `optimism_outputAtBlock`, used only as the `eth_getProof`
+    /// fallback. Must not be the execution RPC.
     #[arg(long, env = "L2_CONSENSUS_RPC_URL")]
     l2_consensus_rpc: Option<String>,
 

--- a/proofs/nitro/worker/src/cmd/run.rs
+++ b/proofs/nitro/worker/src/cmd/run.rs
@@ -139,12 +139,8 @@ pub struct WorkerArgs {
     #[arg(long, env = "L2_RPC_URL")]
     l2_rpc: String,
 
-    /// World Chain L2 consensus (op-node / rollup) RPC URL, serving `optimism_outputAtBlock`.
-    ///
-    /// Used only when `eth_getProof` against `--l2-rpc` fails. This must be the op-node RPC,
-    /// not the execution RPC: an execution client answers `optimism_outputAtBlock` with
-    /// `-32601 Method not found`, which masks the underlying `eth_getProof` error. When unset
-    /// the fallback is skipped and the `eth_getProof` failure is reported directly.
+    /// op-node RPC serving `optimism_outputAtBlock`, used only as the `eth_getProof` fallback.
+    /// Must not be the execution RPC.
     #[arg(long, env = "L2_CONSENSUS_RPC_URL")]
     l2_consensus_rpc: Option<String>,
 

--- a/proofs/nitro/worker/src/cmd/run.rs
+++ b/proofs/nitro/worker/src/cmd/run.rs
@@ -139,6 +139,15 @@ pub struct WorkerArgs {
     #[arg(long, env = "L2_RPC_URL")]
     l2_rpc: String,
 
+    /// World Chain L2 consensus (op-node / rollup) RPC URL, serving `optimism_outputAtBlock`.
+    ///
+    /// Used only when `eth_getProof` against `--l2-rpc` fails. This must be the op-node RPC,
+    /// not the execution RPC: an execution client answers `optimism_outputAtBlock` with
+    /// `-32601 Method not found`, which masks the underlying `eth_getProof` error. When unset
+    /// the fallback is skipped and the `eth_getProof` failure is reported directly.
+    #[arg(long, env = "L2_CONSENSUS_RPC_URL")]
+    l2_consensus_rpc: Option<String>,
+
     /// Ethereum L1 execution RPC URL.
     #[arg(long, env = "L1_RPC_URL")]
     l1_rpc: String,
@@ -263,6 +272,7 @@ pub async fn run(args: WorkerArgs) -> Result<()> {
         args.l1_rpc.clone(),
         args.l1_beacon_rpc.clone(),
         args.l2_rpc.clone(),
+        args.l2_consensus_rpc.clone(),
         args.network.chain_id(),
         &schedule,
         Duration::from_secs(args.witness_timeout_seconds),

--- a/proofs/prover-sp1/src/main.rs
+++ b/proofs/prover-sp1/src/main.rs
@@ -296,6 +296,7 @@ mod tests {
             start_block: 100,
             end_block: 110,
             l2_rpc: "http://localhost:9545".to_string(),
+            l2_consensus_rpc: None,
             l1_rpc: "http://localhost:8545".to_string(),
             l1_beacon_rpc: "http://localhost:5052".to_string(),
             rollup_config: None,

--- a/proofs/prover/src/lib.rs
+++ b/proofs/prover/src/lib.rs
@@ -69,6 +69,12 @@ pub struct RpcArgs {
     #[arg(long, env = "L2_RPC_URL")]
     pub l2_rpc: String,
 
+    /// World Chain L2 consensus (op-node / rollup) RPC URL, serving `optimism_outputAtBlock`.
+    /// Used only as the `eth_getProof` fallback; must be the op-node RPC, not the execution
+    /// RPC.
+    #[arg(long, env = "L2_CONSENSUS_RPC_URL")]
+    pub l2_consensus_rpc: Option<String>,
+
     /// Ethereum L1 execution RPC URL.
     #[arg(long, env = "L1_RPC_URL")]
     pub l1_rpc: String,
@@ -156,6 +162,7 @@ pub fn online_host_config(args: &RpcArgs) -> Result<OnlineHostConfig> {
         l1_rpc: args.l1_rpc.clone(),
         l1_beacon_rpc: args.l1_beacon_rpc.clone(),
         l2_rpc: args.l2_rpc.clone(),
+        l2_consensus_rpc: args.l2_consensus_rpc.clone(),
         schedule,
         rollup_config_hash,
         l2_chain_id: args

--- a/proofs/prover/src/lib.rs
+++ b/proofs/prover/src/lib.rs
@@ -69,9 +69,8 @@ pub struct RpcArgs {
     #[arg(long, env = "L2_RPC_URL")]
     pub l2_rpc: String,
 
-    /// World Chain L2 consensus (op-node / rollup) RPC URL, serving `optimism_outputAtBlock`.
-    /// Used only as the `eth_getProof` fallback; must be the op-node RPC, not the execution
-    /// RPC.
+    /// op-node RPC serving `optimism_outputAtBlock`, used only as the `eth_getProof` fallback.
+    /// Must not be the execution RPC.
     #[arg(long, env = "L2_CONSENSUS_RPC_URL")]
     pub l2_consensus_rpc: Option<String>,
 

--- a/proofs/prover/src/lib.rs
+++ b/proofs/prover/src/lib.rs
@@ -69,8 +69,8 @@ pub struct RpcArgs {
     #[arg(long, env = "L2_RPC_URL")]
     pub l2_rpc: String,
 
-    /// op-node RPC serving `optimism_outputAtBlock`, used only as the `eth_getProof` fallback.
-    /// Must not be the execution RPC.
+    /// L2 consensus RPC serving `optimism_outputAtBlock`, used only as the `eth_getProof`
+    /// fallback. Must not be the execution RPC.
     #[arg(long, env = "L2_CONSENSUS_RPC_URL")]
     pub l2_consensus_rpc: Option<String>,
 

--- a/proofs/sp1-worker/src/main.rs
+++ b/proofs/sp1-worker/src/main.rs
@@ -66,6 +66,15 @@ struct Cli {
     #[arg(long, env = "L2_RPC_URL")]
     l2_rpc: String,
 
+    /// World Chain L2 consensus (op-node / rollup) RPC URL, serving `optimism_outputAtBlock`.
+    ///
+    /// Used only when `eth_getProof` against `--l2-rpc` fails. This must be the op-node RPC,
+    /// not the execution RPC: an execution client answers `optimism_outputAtBlock` with
+    /// `-32601 Method not found`, which masks the underlying `eth_getProof` error. When unset
+    /// the fallback is skipped and the `eth_getProof` failure is reported directly.
+    #[arg(long, env = "L2_CONSENSUS_RPC_URL")]
+    l2_consensus_rpc: Option<String>,
+
     /// Ethereum L1 execution RPC URL.
     #[arg(long, env = "L1_RPC_URL")]
     l1_rpc: String,
@@ -186,6 +195,7 @@ async fn main() -> Result<()> {
         cli.l1_rpc.clone(),
         cli.l1_beacon_rpc.clone(),
         cli.l2_rpc.clone(),
+        cli.l2_consensus_rpc.clone(),
         cli.network.chain_id(),
         &schedule,
         Duration::from_secs(cli.witness_timeout_seconds),

--- a/proofs/sp1-worker/src/main.rs
+++ b/proofs/sp1-worker/src/main.rs
@@ -66,8 +66,8 @@ struct Cli {
     #[arg(long, env = "L2_RPC_URL")]
     l2_rpc: String,
 
-    /// op-node RPC serving `optimism_outputAtBlock`, used only as the `eth_getProof` fallback.
-    /// Must not be the execution RPC.
+    /// L2 consensus RPC serving `optimism_outputAtBlock`, used only as the `eth_getProof`
+    /// fallback. Must not be the execution RPC.
     #[arg(long, env = "L2_CONSENSUS_RPC_URL")]
     l2_consensus_rpc: Option<String>,
 

--- a/proofs/sp1-worker/src/main.rs
+++ b/proofs/sp1-worker/src/main.rs
@@ -66,12 +66,8 @@ struct Cli {
     #[arg(long, env = "L2_RPC_URL")]
     l2_rpc: String,
 
-    /// World Chain L2 consensus (op-node / rollup) RPC URL, serving `optimism_outputAtBlock`.
-    ///
-    /// Used only when `eth_getProof` against `--l2-rpc` fails. This must be the op-node RPC,
-    /// not the execution RPC: an execution client answers `optimism_outputAtBlock` with
-    /// `-32601 Method not found`, which masks the underlying `eth_getProof` error. When unset
-    /// the fallback is skipped and the `eth_getProof` failure is reported directly.
+    /// op-node RPC serving `optimism_outputAtBlock`, used only as the `eth_getProof` fallback.
+    /// Must not be the execution RPC.
     #[arg(long, env = "L2_CONSENSUS_RPC_URL")]
     l2_consensus_rpc: Option<String>,
 

--- a/proofs/sp1-worker/tests/e2e_proving.rs
+++ b/proofs/sp1-worker/tests/e2e_proving.rs
@@ -134,6 +134,8 @@ async fn worker_proves_real_range_end_to_end() {
         l1_rpc,
         l1_beacon_rpc,
         l2_rpc,
+        // No op-node in this fixture; the eth_getProof path is expected to succeed.
+        None,
         Some(PathBuf::from(rollup_config)),
         timeout,
     )


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Misconfigured L2 consensus URLs could break witness/output-root collection; new L1 RPC timeouts may surface failures on slow providers that previously hung silently.
> 
> **Overview**
> Witness building no longer uses the L2 **execution** RPC for `optimism_outputAtBlock` when `eth_getProof` fails. **`OnlineHostConfig`** gains optional **`l2_consensus_rpc`**; Nitro/SP1 workers and the prover CLI expose **`--l2-consensus-rpc` / `L2_CONSENSUS_RPC_URL`**, and missing consensus RPC now fails with an explicit error instead of calling the wrong endpoint.
> 
> **`metered_http_client`** takes a per-request **`request_timeout`** (default **10s** via **`DEFAULT_RPC_REQUEST_TIMEOUT_SECONDS`**). Challenger, defender, and proposer add **`L1_RPC_TIMEOUT_SECONDS`** so hung L1 connections cannot block poll loops indefinitely.
> 
> Devnet SP1 worker passes **`None`** for consensus RPC because local reth serves **`eth_getProof`** directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc17e5d48ee55c401ac61db595233a0c324dee55. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->