### PR TITLE
feat: Make defender proof requests threshold-aware

### DIFF
--- a/proofs/defender/src/defender.rs
+++ b/proofs/defender/src/defender.rs
@@ -13,7 +13,9 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 use tracing::{error, info, warn};
-use world_chain_proofs::{ConsensusProvider, InvalidationReason, ProofLane, select_lineage};
+use world_chain_proofs::{
+    ConsensusProvider, InvalidationReason, ProofLane, proof_count, select_lineage,
+};
 use world_chain_prover_service::ProofRequester;
 
 /// An active proof-support workflow for a selected game.
@@ -39,7 +41,19 @@ enum DefenseProgress {
     Closed,
     Complete,
     DeadlineElapsed,
-    Lanes([LaneState; DEFENDED_LANE_COUNT]),
+    Lanes {
+        lanes: [LaneState; DEFENDED_LANE_COUNT],
+        sufficient_support_submitted: bool,
+    },
+}
+
+fn effective_proof_bitmap(mut proof_bitmap: u8, lanes: &[LaneState; DEFENDED_LANE_COUNT]) -> u8 {
+    for (slot, (proof_lane, _)) in DEFENDED_LANES.into_iter().enumerate() {
+        if lanes[slot] == LaneState::Proven {
+            proof_bitmap |= proof_lane.mask();
+        }
+    }
+    proof_bitmap
 }
 
 /// Supplies proof support for every valid game on the proposer-selected lineage.
@@ -162,53 +176,74 @@ where
     ) -> Result<DefenseProgress, DefenderError> {
         let metadata = &defense.game;
         let evaluator = GameEvaluator::new(&self.execution_provider);
-        let (proof_bitmap, deadline, tee_only) = match evaluator.observe(metadata).await? {
-            GameObservation::Finalized => return Ok(DefenseProgress::Complete),
-            GameObservation::Invalidated { reason } => {
-                if reason == InvalidationReason::ProofTimeout {
-                    return Ok(DefenseProgress::DeadlineElapsed);
+        let (proof_bitmap, deadline, required_support, tee_only) =
+            match evaluator.observe(metadata).await? {
+                GameObservation::Finalized => return Ok(DefenseProgress::Complete),
+                GameObservation::Invalidated { reason } => {
+                    if reason == InvalidationReason::ProofTimeout {
+                        return Ok(DefenseProgress::DeadlineElapsed);
+                    }
+                    return Ok(DefenseProgress::Closed);
                 }
-                return Ok(DefenseProgress::Closed);
-            }
-            GameObservation::Proposed {
-                proof_bitmap,
-                has_initial_support,
-            } => {
-                if has_initial_support {
-                    return Ok(DefenseProgress::Complete);
+                GameObservation::Proposed {
+                    proof_bitmap,
+                    has_initial_support,
+                } => {
+                    if has_initial_support {
+                        return Ok(DefenseProgress::Complete);
+                    }
+                    (proof_bitmap, metadata.challenge_deadline, 1, true)
                 }
-                (proof_bitmap, metadata.challenge_deadline, true)
-            }
-            GameObservation::Challenged {
-                proof_bitmap,
-                has_required_support,
-            } => {
-                if has_required_support {
-                    return Ok(DefenseProgress::Complete);
+                GameObservation::Challenged {
+                    proof_bitmap,
+                    has_required_support,
+                } => {
+                    if has_required_support {
+                        return Ok(DefenseProgress::Complete);
+                    }
+                    (
+                        proof_bitmap,
+                        metadata.proof_deadline,
+                        metadata.proof_threshold,
+                        false,
+                    )
                 }
-                (proof_bitmap, metadata.proof_deadline, false)
-            }
-            GameObservation::Unset => return Ok(DefenseProgress::Closed),
-        };
+                GameObservation::Unset => return Ok(DefenseProgress::Closed),
+            };
         if now >= deadline {
             return Ok(DefenseProgress::DeadlineElapsed);
         }
 
         let mut lanes = defense.lanes;
+        let mut lanes_needed = required_support
+            .saturating_sub(proof_count(effective_proof_bitmap(proof_bitmap, &lanes)));
         let lane_driver = LaneDriver::new(&self.execution_provider, &self.proof_requester);
         for (slot, (proof_lane, backend)) in DEFENDED_LANES.into_iter().enumerate() {
+            if proof_bitmap & proof_lane.mask() != 0 {
+                lanes[slot] = LaneState::Proven;
+                continue;
+            }
             if tee_only && proof_lane != ProofLane::TeeAttestation {
                 continue;
             }
-            if proof_bitmap & proof_lane.mask() != 0 {
-                lanes[slot] = LaneState::Proven;
+            if lanes[slot] == LaneState::Proven || lanes_needed == 0 {
                 continue;
             }
             lanes[slot] = lane_driver
                 .advance(metadata, proof_lane, backend, lanes[slot])
                 .await;
+            // An active request reserves one of the remaining support slots so a lower-priority
+            // lane is not started unless this lane is permanently abandoned.
+            if lanes[slot] != LaneState::Abandoned {
+                lanes_needed -= 1;
+            }
         }
-        Ok(DefenseProgress::Lanes(lanes))
+
+        Ok(DefenseProgress::Lanes {
+            lanes,
+            sufficient_support_submitted: proof_count(effective_proof_bitmap(proof_bitmap, &lanes))
+                >= required_support,
+        })
     }
 
     async fn scan_active_defenses(
@@ -261,7 +296,10 @@ where
                     );
                     self.active_defenses.remove(&game);
                 }
-                Ok(DefenseProgress::Lanes(lanes)) => {
+                Ok(DefenseProgress::Lanes {
+                    lanes,
+                    sufficient_support_submitted,
+                }) => {
                     if lanes.iter().all(|lane| *lane == LaneState::Proven) {
                         info!(
                             lifecycle_event = "defense_completed",
@@ -270,6 +308,10 @@ where
                             "all proof lanes submitted; defense completed"
                         );
                         self.active_defenses.remove(&game);
+                    } else if sufficient_support_submitted {
+                        if let Some(defense) = self.active_defenses.get_mut(&game) {
+                            defense.lanes = lanes;
+                        }
                     } else if lanes.iter().all(|lane| lane.is_terminal()) {
                         error!(
                             lifecycle_event = "defense_failed",

--- a/proofs/defender/src/lane.rs
+++ b/proofs/defender/src/lane.rs
@@ -12,11 +12,11 @@ use world_chain_prover_service::{
 /// Number of proof lanes the defender drives.
 pub(crate) const DEFENDED_LANE_COUNT: usize = 2;
 
-/// The proof lanes the defender drives, paired with the prover-service
-/// backend that generates each proof.
+/// The proof lanes the defender drives, ordered by preference and paired with
+/// the prover-service backend that generates each proof.
 pub(crate) const DEFENDED_LANES: [(ProofLane, ProofBackend); DEFENDED_LANE_COUNT] = [
-    (ProofLane::ValidityProof, ProofBackend::Sp1),
     (ProofLane::TeeAttestation, ProofBackend::Nitro),
+    (ProofLane::ValidityProof, ProofBackend::Sp1),
 ];
 
 /// Progress of a single proof lane within an active defense.

--- a/proofs/defender/src/tests.rs
+++ b/proofs/defender/src/tests.rs
@@ -413,6 +413,25 @@ async fn selected_proposed_game_gets_initial_tee_proof() {
 }
 
 #[tokio::test]
+async fn selected_proposed_game_with_council_support_needs_no_tee_proof() {
+    let root = B256::repeat_byte(0x20);
+    let client = MockClient::new();
+    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, RootState::Proposed);
+    client.set_bitmap(GAME_1, ProofLane::SecurityCouncil.mask());
+    let prover = MockProver::default();
+    let mut defender = WorldChainDefender::new(
+        config(),
+        client,
+        output_roots(&[(L2_BLOCK, root)], L2_BLOCK),
+        prover.clone(),
+    );
+
+    defender.tick().await.unwrap();
+    assert!(prover.requests().is_empty());
+    assert!(defender.active_defenses().is_empty());
+}
+
+#[tokio::test]
 async fn selected_challenged_game_gets_threshold_lanes() {
     let root = B256::repeat_byte(0x20);
     let client = MockClient::new();
@@ -441,6 +460,34 @@ async fn selected_challenged_game_gets_threshold_lanes() {
 
     defender.tick().await.unwrap();
     assert_eq!(client.submissions().len(), 2);
+    assert!(defender.active_defenses().is_empty());
+}
+
+#[tokio::test]
+async fn selected_challenged_game_with_council_support_only_requests_tee() {
+    let root = B256::repeat_byte(0x20);
+    let client = MockClient::new();
+    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, RootState::Challenged);
+    client.set_bitmap(GAME_1, ProofLane::SecurityCouncil.mask());
+    let prover = MockProver::default();
+    let mut defender = WorldChainDefender::new(
+        config(),
+        client.clone(),
+        output_roots(&[(L2_BLOCK, root)], L2_BLOCK),
+        prover.clone(),
+    );
+
+    defender.tick().await.unwrap();
+    assert_eq!(prover.requests().len(), 1);
+    assert_eq!(prover.requests()[0].backend, ProofBackend::Nitro);
+
+    defender.tick().await.unwrap();
+    assert_eq!(
+        client.submissions(),
+        vec![(GAME_1, ProofLane::TeeAttestation as u8)]
+    );
+
+    defender.tick().await.unwrap();
     assert!(defender.active_defenses().is_empty());
 }
 
@@ -624,6 +671,25 @@ async fn existing_lane_is_not_requested_again() {
     defender.tick().await.unwrap();
     assert_eq!(prover.requests().len(), 1);
     assert_eq!(prover.requests()[0].backend, ProofBackend::Nitro);
+}
+
+#[tokio::test]
+async fn existing_tee_lane_only_requests_sp1_when_challenged() {
+    let root = B256::repeat_byte(0x20);
+    let client = MockClient::new();
+    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, RootState::Challenged);
+    client.set_bitmap(GAME_1, ProofLane::TeeAttestation.mask());
+    let prover = MockProver::default();
+    let mut defender = WorldChainDefender::new(
+        config(),
+        client,
+        output_roots(&[(L2_BLOCK, root)], L2_BLOCK),
+        prover.clone(),
+    );
+
+    defender.tick().await.unwrap();
+    assert_eq!(prover.requests().len(), 1);
+    assert_eq!(prover.requests()[0].backend, ProofBackend::Sp1);
 }
 
 #[tokio::test]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes when and which proofs are requested for disputed games; incorrect threshold or bitmap logic could leave games under-defended or waste prover capacity on-chain resolution paths depend on timely support.
> 
> **Overview**
> The defender now sizes proof work to the game’s **required support** (1 for proposed, `proof_threshold` when challenged) instead of always driving every defended lane. It uses `proof_count` on an **effective bitmap** (on-chain bits plus lanes already marked proven locally) to compute how many lanes are still needed, skips starting lower-priority work when the count is satisfied, and treats in-flight lanes as reserving a slot unless abandoned.
> 
> **Lane preference** is explicit: `DEFENDED_LANES` is reordered so **TEE (Nitro)** is tried before **validity (SP1)**. `DefenseProgress::Lanes` gains `sufficient_support_submitted` so a defense can persist with updated lane state once the threshold is met without requiring every lane to be proven. New tests cover **Security Council** bitmap support (no redundant TEE when proposed; only TEE when challenged with one council proof) and challenged games that already have TEE on-chain (only SP1 requested).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c09e7f45a6bfe9aead0eb86f540582ae0de3ce60. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->