### PR TITLE
fix(defender): abi-encode proof payloads as params

### DIFF
--- a/proofs/defender/src/lane.rs
+++ b/proofs/defender/src/lane.rs
@@ -273,7 +273,7 @@ fn encode_proof(metadata: &GameMetadata, proof: &ProofData) -> Result<Bytes, Def
             public_values.clone(),
             proof.clone(),
         )
-            .abi_encode()
+            .abi_encode_params()
             .into()),
         ProofData::Nitro {
             attestation: _,
@@ -292,7 +292,7 @@ fn encode_proof(metadata: &GameMetadata, proof: &ProofData) -> Result<Bytes, Def
                 transition,
                 signature.clone(),
             )
-                .abi_encode()
+                .abi_encode_params()
                 .into())
         }
     }
@@ -333,15 +333,28 @@ mod tests {
         };
 
         let encoded = encode_proof(&metadata, &proof).expect("valid Nitro proof payload");
-        let expected = (
-            metadata.domain_hash,
-            metadata.parent_ref,
-            U256::from(metadata.l1_origin_number),
-            transition,
-            signature,
-        )
-            .abi_encode();
 
-        assert_eq!(encoded.as_ref(), expected);
+        // NitroProofVerifier does `abi.decode(proof, (bytes32, address, uint256,
+        // TransitionPublicValues, bytes))`, which is the params encoding. Asserting against
+        // `.abi_encode()` here would be tautological — and would have passed while the
+        // implementation shipped the single-value form, whose leading 0x20 offset makes the
+        // verifier's decode revert and `verify` return false.
+        assert_eq!(
+            &encoded[..32],
+            metadata.domain_hash.as_slice(),
+            "payload must start with domainHash, not an ABI offset"
+        );
+        // 3 head words + 6 transition words + signature offset/length + 3 signature words.
+        assert_eq!(encoded.len(), 448, "verifier-accepted payload size");
+
+        let (domain_hash, parent_ref, l1_origin_number, decoded_transition, decoded_signature) =
+            <(B256, Address, U256, TransitionPublicValues, Bytes)>::abi_decode_params(&encoded)
+                .expect("verifier-compatible params encoding");
+
+        assert_eq!(domain_hash, metadata.domain_hash);
+        assert_eq!(parent_ref, metadata.parent_ref);
+        assert_eq!(l1_origin_number, U256::from(metadata.l1_origin_number));
+        assert_eq!(decoded_transition, transition);
+        assert_eq!(decoded_signature, signature);
     }
 }


### PR DESCRIPTION
The defender built `submitProofLane` payloads with alloy's `SolValue::abi_encode()`, which encodes a value "by wrapping it in a single-element sequence". The tuple ends in `bytes`, so it is dynamic and that wrapper prepends a 32-byte offset. `NitroProofVerifier._decodeAndVerify` does `abi.decode(proof, (bytes32, address, uint256, TransitionPublicValues, bytes))` — the params form — so every field shifted, the decode reverted, `verify`'s try/catch turned it into `false`, and the game raised `InvalidProof(lane, rootId)`. No nitro proof has ever landed on alphanet; the defender is still at nonce 0.

Verified against the live alphanet verifier `0xaF6dbf1e…` with a real stored proof (game `0x8073155C…`, L2 block 900): 448-byte params payload → `verify = true`; same bytes with `0x20` prepended (480) → `verify = false`. `submitProofLane(1, ...)` simulates clean from the defender address. The proofs were always valid — the signature recovers to registered enclave signer `0x486e1fbe…`.

The existing test computed its expected value with the same `.abi_encode()` call, so it asserted the bug against itself; it now round-trips through `abi_decode_params`, checks the first word is `domainHash` rather than an offset, and pins the length.

Verified: `cargo test -p world-chain-defender` 16/16, `cargo +nightly fmt --check`, clippy clean with `-D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the bytes sent on-chain for both proof lanes on a security-critical path, but aligns encoding with existing verifier `abi.decode` and adds stronger regression tests.
> 
> **Overview**
> Fixes **`submitProofLane` proof bytes** so they match what on-chain verifiers decode: SP1 and Nitro payloads in `encode_proof` now use **`abi_encode_params()`** instead of **`abi_encode()`**. The old single-value encoding prepended a **0x20 offset** on dynamic tuples, so **`NitroProofVerifier`** (and the same params-style decode for SP1) misread fields, decode reverted, and **`verify` returned false** even for valid proofs.
> 
> The Nitro unit test no longer builds expectations with the same buggy `.abi_encode()` call. It checks the payload **starts with `domainHash`**, pins **448-byte** length, and **round-trips via `abi_decode_params`** against the verifier tuple shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a522d6320dce352a205c8b6e28a2a4364cf9617. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->