### PR TITLE
fix(nitro-worker): rebind to the running enclave before every job

### DIFF
--- a/proofs/nitro/worker/Cargo.toml
+++ b/proofs/nitro/worker/Cargo.toml
@@ -50,3 +50,6 @@ dotenvy.workspace = true
 
 # Misc
 hex.workspace = true
+
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+tempfile.workspace = true

--- a/proofs/nitro/worker/src/binding.rs
+++ b/proofs/nitro/worker/src/binding.rs
@@ -1,0 +1,199 @@
+//! Binding the worker to whichever enclave is currently running.
+//!
+//! A Nitro enclave's signing key is ephemeral: it is generated inside the enclave at
+//! startup and never persisted (see `world_chain_proof_nitro::enclave`). The worker is
+//! therefore bound to one specific enclave instance — its vsock CID *and* the on-chain
+//! registration of that instance's key. Resolving either one once at process start makes
+//! an enclave replacement unrecoverable: the worker keeps dialling a dead CID, or proves
+//! with a key no verifier accepts, while the process itself looks perfectly healthy.
+//!
+//! [`EnclaveBinding::bind`] re-establishes both before every job. The CID is re-read from
+//! its source and the key registration is re-asserted, so replacing the enclave costs one
+//! failed job instead of requiring an operator to restart the pod.
+
+use std::{fs, path::PathBuf};
+
+use anyhow::{Context, Result};
+use tracing::{info, warn};
+use world_chain_proof_nitro::{
+    ExpectedPcrs,
+    host::{EnclaveEndpoint, NitroProver},
+    register::{RegisterParams, RegistrationOutcome, register_enclave_key},
+};
+
+/// Where the running enclave's vsock CID comes from.
+#[derive(Clone, Debug)]
+pub enum EnclaveCidSource {
+    /// A CID fixed at startup, from `--enclave-cid`.
+    Fixed(u32),
+    /// A file the enclave launcher rewrites whenever it starts an enclave. Re-read on every
+    /// bind so a replacement is picked up without restarting the worker.
+    File(PathBuf),
+}
+
+impl EnclaveCidSource {
+    fn resolve(&self) -> Result<u32> {
+        match self {
+            Self::Fixed(cid) => Ok(*cid),
+            Self::File(path) => {
+                let raw = fs::read_to_string(path).with_context(|| {
+                    format!("failed to read enclave CID from {}", path.display())
+                })?;
+                raw.trim()
+                    .parse()
+                    .with_context(|| format!("{} does not contain a vsock CID", path.display()))
+            }
+        }
+    }
+}
+
+/// Credentials for asserting the current enclave's key is registered on-chain.
+#[derive(Clone, Debug)]
+pub struct RegistrationCredentials {
+    /// L1 execution RPC used to read the registry and submit `registerKey`.
+    pub l1_rpc_url: String,
+    /// `NitroEnclaveKeyRegistry` address on L1.
+    pub registry: String,
+    /// Funded key that pays for `registerKey`. Not owner-gated; any funded key works.
+    pub private_key: String,
+}
+
+/// Resolves the running enclave and guarantees its key is registered before it is used.
+#[derive(Clone, Debug)]
+pub struct EnclaveBinding {
+    cid_source: EnclaveCidSource,
+    port: u32,
+    expected_pcrs: ExpectedPcrs,
+    /// `None` disables the registration check — the operator is registering out of band.
+    registration: Option<RegistrationCredentials>,
+}
+
+/// A worker bound to a specific, registered enclave.
+#[derive(Clone, Debug)]
+pub struct EnclaveSession {
+    /// Prover pinned to the enclave resolved by this bind.
+    pub prover: NitroProver,
+    /// vsock CID this session is bound to.
+    pub cid: u32,
+    /// Registration result, or `None` when the check is disabled.
+    pub registration: Option<RegistrationOutcome>,
+}
+
+impl EnclaveBinding {
+    pub fn new(
+        cid_source: EnclaveCidSource,
+        port: u32,
+        expected_pcrs: ExpectedPcrs,
+        registration: Option<RegistrationCredentials>,
+    ) -> Self {
+        Self {
+            cid_source,
+            port,
+            expected_pcrs,
+            registration,
+        }
+    }
+
+    /// Resolves the current enclave and asserts its key is registered.
+    ///
+    /// `register_enclave_key` is idempotent — it fetches the attestation over vsock, derives
+    /// the signer, and returns [`RegistrationOutcome::AlreadyRegistered`] without sending a
+    /// transaction when the registry already knows it. So the steady-state cost is one vsock
+    /// round trip plus one `eth_call`, and the failure modes we care about (dead CID, swapped
+    /// enclave, unregistered key) all surface here rather than as an unusable proof.
+    pub async fn bind(&self) -> Result<EnclaveSession> {
+        let cid = self.cid_source.resolve()?;
+        let endpoint = EnclaveEndpoint::with_port(cid, self.port);
+
+        let Some(credentials) = self.registration.clone() else {
+            return Ok(EnclaveSession {
+                prover: NitroProver::new(endpoint, self.expected_pcrs),
+                cid,
+                registration: None,
+            });
+        };
+
+        let outcome = register_enclave_key(RegisterParams {
+            enclave_cid: cid,
+            enclave_port: self.port,
+            expected_pcrs: self.expected_pcrs,
+            l1_rpc_url: credentials.l1_rpc_url,
+            registry: credentials.registry,
+            private_key: credentials.private_key,
+        })
+        .await;
+
+        match outcome {
+            Ok(outcome) => {
+                let label = match &outcome {
+                    RegistrationOutcome::AlreadyRegistered => "already_registered",
+                    RegistrationOutcome::Registered { tx_hash } => {
+                        // Only ever logged when the enclave is new to the registry, which
+                        // outside of startup means it was replaced underneath us.
+                        info!(%tx_hash, enclave_cid = cid, "registered enclave key on-chain");
+                        "registered"
+                    }
+                };
+                world_chain_proof_metrics::increment_enclave_registration_attempts(label);
+                world_chain_proof_metrics::set_enclave_key_registered(true);
+                Ok(EnclaveSession {
+                    prover: NitroProver::new(endpoint, self.expected_pcrs),
+                    cid,
+                    registration: Some(outcome),
+                })
+            }
+            Err(error) => {
+                world_chain_proof_metrics::increment_enclave_registration_attempts("failed");
+                world_chain_proof_metrics::set_enclave_key_registered(false);
+                warn!(?error, enclave_cid = cid, "failed to bind to enclave");
+                Err(error.context(format!("failed to bind to enclave at cid {cid}")))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn fixed_source_returns_its_cid() {
+        assert_eq!(EnclaveCidSource::Fixed(16).resolve().unwrap(), 16);
+    }
+
+    /// The launcher writes the CID with a trailing newline.
+    #[test]
+    fn file_source_reads_and_trims() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(file, "34").unwrap();
+        let source = EnclaveCidSource::File(file.path().to_path_buf());
+        assert_eq!(source.resolve().unwrap(), 34);
+    }
+
+    /// A replaced enclave must be observed, not cached: the same source resolves to the new
+    /// CID after the launcher rewrites the file.
+    #[test]
+    fn file_source_observes_replacement() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let source = EnclaveCidSource::File(file.path().to_path_buf());
+        fs::write(file.path(), "34\n").unwrap();
+        assert_eq!(source.resolve().unwrap(), 34);
+        fs::write(file.path(), "36\n").unwrap();
+        assert_eq!(source.resolve().unwrap(), 36);
+    }
+
+    #[test]
+    fn file_source_rejects_garbage() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(file, "not-a-cid").unwrap();
+        let source = EnclaveCidSource::File(file.path().to_path_buf());
+        assert!(source.resolve().is_err());
+    }
+
+    #[test]
+    fn file_source_errors_when_missing() {
+        let source = EnclaveCidSource::File(PathBuf::from("/nonexistent/enclave-cid"));
+        assert!(source.resolve().is_err());
+    }
+}

--- a/proofs/nitro/worker/src/cmd/run.rs
+++ b/proofs/nitro/worker/src/cmd/run.rs
@@ -8,13 +8,14 @@ use backon::{ExponentialBuilder, Retryable};
 use clap::Parser;
 use tracing::{error, info};
 use world_chain_chainspec::WorldChainSpec;
-use world_chain_nitro_worker::{NitroBackend, NitroBackendConfig, build_expected_pcrs};
+use world_chain_nitro_worker::{
+    EnclaveBinding, EnclaveCidSource, NitroBackend, NitroBackendConfig, RegistrationCredentials,
+    build_expected_pcrs,
+};
 use world_chain_proof_kona_host_utils::online::{
     build_online_config, hardfork_config_from_chain_spec,
 };
-use world_chain_proof_nitro::register::{
-    RegisterParams, RegistrationOutcome, register_enclave_key,
-};
+use world_chain_proof_nitro::register::RegistrationOutcome;
 use world_chain_proof_worker::{
     ProofWorker, ProofWorkerConfig, RetryConfig, WorkerHeartbeatConfig,
 };
@@ -50,20 +51,16 @@ fn registration_backoff() -> ExponentialBuilder {
 /// This deliberately never aborts the process. Every way registration can fail — PCR set not
 /// yet approved on-chain, registration key unfunded, L1 unreachable, certificate chain not yet
 /// verifiable — is a condition an operator resolves *while the worker is running*.
-async fn register_with_retry(params: RegisterParams) -> bool {
-    let attempt = || {
-        let params = params.clone();
-        async move { register_enclave_key(params).await }
-    };
+async fn bind_with_retry(binding: &EnclaveBinding) -> bool {
+    let attempt = || async { binding.bind().await };
 
-    let registration = attempt
+    let bind = attempt
         .retry(registration_backoff())
         .notify(|error, delay| {
-            world_chain_proof_metrics::increment_enclave_registration_attempts("failed");
             error!(
                 ?error,
                 retry_in_secs = delay.as_secs(),
-                "enclave key registration failed; worker stays up and will retry without \
+                "enclave binding failed; worker stays up and will retry without \
              leasing proof jobs"
             );
         });
@@ -71,31 +68,28 @@ async fn register_with_retry(params: RegisterParams) -> bool {
     // Race the (unbounded) retry against shutdown so a pod being rolled does not have to wait
     // out a full backoff interval.
     tokio::select! {
-        outcome = registration => match outcome {
-            Ok(outcome) => {
-                let label = match outcome {
-                    RegistrationOutcome::AlreadyRegistered => {
-                        info!("enclave key already registered on-chain");
-                        "already_registered"
+        outcome = bind => match outcome {
+            Ok(session) => {
+                match session.registration {
+                    Some(RegistrationOutcome::AlreadyRegistered) => {
+                        info!(enclave_cid = session.cid, "enclave key already registered on-chain");
                     }
-                    RegistrationOutcome::Registered { tx_hash } => {
-                        info!(%tx_hash, "enclave key registered on-chain");
-                        "registered"
+                    Some(RegistrationOutcome::Registered { tx_hash }) => {
+                        info!(%tx_hash, enclave_cid = session.cid, "enclave key registered on-chain");
                     }
-                };
-                world_chain_proof_metrics::increment_enclave_registration_attempts(label);
-                world_chain_proof_metrics::set_enclave_key_registered(true);
+                    None => info!(enclave_cid = session.cid, "bound to enclave"),
+                }
                 true
             }
             // Unreachable while the backoff is unbounded, but treat it the same as shutdown
-            // rather than leasing jobs with an unregistered key.
+            // rather than leasing jobs against an enclave we could not bind to.
             Err(error) => {
-                error!(?error, "enclave key registration gave up; not leasing proof jobs");
+                error!(?error, "enclave binding gave up; not leasing proof jobs");
                 false
             }
         },
         _ = tokio::signal::ctrl_c() => {
-            info!("received ctrl-c while retrying registration, shutting down");
+            info!("received ctrl-c while retrying enclave binding, shutting down");
             false
         }
     }
@@ -169,9 +163,15 @@ pub struct WorkerArgs {
     #[arg(long, env = "BLOCK_INTERVAL")]
     block_interval: u64,
 
-    /// vsock CID of the running Nitro Enclave.
+    /// vsock CID of the running Nitro Enclave. Ignored when `--enclave-cid-file` is set.
     #[arg(long, env = "ENCLAVE_CID", default_value_t = 16)]
     enclave_cid: u32,
+
+    /// File the enclave launcher rewrites with the current vsock CID. Prefer this over
+    /// `--enclave-cid`: it is re-read before every job, so an enclave replaced underneath the
+    /// worker is picked up instead of stranding it on a dead CID.
+    #[arg(long, env = "ENCLAVE_CID_FILE")]
+    enclave_cid_file: Option<PathBuf>,
 
     /// vsock port the enclave listens on.
     #[arg(
@@ -279,45 +279,50 @@ pub async fn run(args: WorkerArgs) -> Result<()> {
         args.pcr2.as_deref(),
     )?;
 
-    // Self-register the enclave's generated signing key on-chain before leasing any jobs:
-    // proofs signed by an unregistered key do not verify, so an unregistered worker must not
-    // take work. Registration is a *precondition*, not a fatal error — see
-    // [`register_with_retry`] for why this never aborts the process.
-    if args.auto_register {
-        let registry = args
-            .registry
-            .clone()
-            .context("--auto-register requires --registry / NITRO_ENCLAVE_KEY_REGISTRY")?;
-        // Registration reuses the same L1 endpoint as witness building (`--l1-rpc`).
-        let l1_rpc_url = args.l1_rpc.clone();
-        let private_key = args
-            .register_private_key
-            .clone()
-            .or_else(|| std::env::var("PRIVATE_KEY").ok())
-            .context(
-                "--auto-register requires a key: set --register-private-key, \
-                 REGISTER_PRIVATE_KEY, or PRIVATE_KEY",
-            )?;
+    let cid_source = args.enclave_cid_file.clone().map_or_else(
+        || EnclaveCidSource::Fixed(args.enclave_cid),
+        EnclaveCidSource::File,
+    );
 
+    let registration = if args.auto_register {
+        Some(RegistrationCredentials {
+            // Registration reuses the same L1 endpoint as witness building (`--l1-rpc`).
+            l1_rpc_url: args.l1_rpc.clone(),
+            registry: args
+                .registry
+                .clone()
+                .context("--auto-register requires --registry / NITRO_ENCLAVE_KEY_REGISTRY")?,
+            private_key: args
+                .register_private_key
+                .clone()
+                .or_else(|| std::env::var("PRIVATE_KEY").ok())
+                .context(
+                    "--auto-register requires a key: set --register-private-key, \
+                     REGISTER_PRIVATE_KEY, or PRIVATE_KEY",
+                )?,
+        })
+    } else {
+        None
+    };
+
+    let binding = Arc::new(EnclaveBinding::new(
+        cid_source,
+        args.enclave_port,
+        expected_pcrs,
+        registration,
+    ));
+
+    // Bind before leasing any jobs: proofs signed by an unregistered key do not verify, so an
+    // unbound worker must not take work. Binding is a *precondition*, not a fatal error — see
+    // [`bind_with_retry`] for why this never aborts the process. Every job re-binds, so this
+    // only gates startup.
+    if args.auto_register {
         // Publish the gauge before the first attempt so "never registered" is a visible zero
         // rather than an absent series a threshold monitor would silently ignore.
         world_chain_proof_metrics::set_enclave_key_registered(false);
-        info!(
-            registry = %registry,
-            enclave_cid = args.enclave_cid,
-            "auto-register enabled; registering enclave key on-chain before leasing jobs"
-        );
+        info!("auto-register enabled; binding to the enclave before leasing jobs");
 
-        let registered = register_with_retry(RegisterParams {
-            enclave_cid: args.enclave_cid,
-            enclave_port: args.enclave_port,
-            expected_pcrs,
-            l1_rpc_url,
-            registry,
-            private_key,
-        })
-        .await;
-        if !registered {
+        if !bind_with_retry(&binding).await {
             // Shutdown was requested while retrying; exit cleanly rather than starting up.
             return Ok(());
         }
@@ -325,7 +330,6 @@ pub async fn run(args: WorkerArgs) -> Result<()> {
 
     info!(
         prover_service = %args.prover_service_url,
-        enclave_cid = args.enclave_cid,
         block_interval = args.block_interval,
         submit_proof_retry_max_retries = args.submit_proof_retry_max_retries,
         submit_proof_retry_initial_delay_ms = args.submit_proof_retry_initial_delay_ms,
@@ -336,9 +340,7 @@ pub async fn run(args: WorkerArgs) -> Result<()> {
     let backend = NitroBackend::new(NitroBackendConfig {
         block_interval: args.block_interval,
         online,
-        enclave_cid: args.enclave_cid,
-        enclave_port: args.enclave_port,
-        expected_pcrs,
+        binding: Arc::clone(&binding),
     });
 
     let queue = RpcProverServiceClient::new(&args.prover_service_url)

--- a/proofs/nitro/worker/src/lib.rs
+++ b/proofs/nitro/worker/src/lib.rs
@@ -22,6 +22,8 @@
 
 #![cfg(target_os = "linux")]
 
+use std::sync::Arc;
+
 use alloy_primitives::Bytes;
 use alloy_sol_types::SolValue;
 use anyhow::{Context, Result, anyhow, bail};
@@ -29,12 +31,13 @@ use tracing::info;
 use world_chain_proof_kona_host_utils::online::{
     OnlineHostConfig, RangeWitnessRequest, build_range_input,
 };
-use world_chain_proof_nitro::{
-    ExpectedPcrs, NitroRangeProofRequest,
-    host::{EnclaveEndpoint, NitroProver},
-};
+use world_chain_proof_nitro::{ExpectedPcrs, NitroRangeProofRequest};
 use world_chain_proof_worker::{ClaimedProofJobHandler, ProofJob};
 use world_chain_prover_service::{ProofBackend, ProofData};
+
+pub mod binding;
+
+pub use binding::{EnclaveBinding, EnclaveCidSource, EnclaveSession, RegistrationCredentials};
 
 // ──────────────────────────────────────────────────────────────────────────────────────
 // NitroBackend — ClaimedProofJobHandler implementation for the Nitro TEE lane
@@ -44,9 +47,8 @@ use world_chain_prover_service::{ProofBackend, ProofData};
 pub struct NitroBackendConfig {
     pub block_interval: u64,
     pub online: OnlineHostConfig,
-    pub enclave_cid: u32,
-    pub enclave_port: u32,
-    pub expected_pcrs: ExpectedPcrs,
+    /// Re-resolved before every job so a replaced enclave costs one job, not an operator.
+    pub binding: Arc<EnclaveBinding>,
 }
 
 pub struct NitroBackend {
@@ -88,9 +90,17 @@ impl ClaimedProofJobHandler for NitroBackend {
             "nitro worker claimed proof job"
         );
 
-        let endpoint =
-            EnclaveEndpoint::with_port(self.config.enclave_cid, self.config.enclave_port);
-        let prover = NitroProver::new(endpoint, self.config.expected_pcrs);
+        // Bind before spending minutes on a witness: this is the only point that proves the
+        // enclave we are about to sign with still exists and is registered. Failing here
+        // re-queues the job; proving with an unregistered key would instead produce a
+        // "successful" proof that every verifier rejects.
+        let session = self
+            .config
+            .binding
+            .bind()
+            .await
+            .context("enclave binding failed")?;
+        let prover = session.prover;
 
         info!(
             start_block,


### PR DESCRIPTION
The worker resolves its enclave exactly once: `--enclave-cid` is parsed at startup and `--auto-register` registers that enclave's key before the job loop begins. The enclave's signing key is ephemeral — regenerated on every enclave start (`proofs/nitro/src/enclave.rs`) — so if the enclave is ever replaced, the worker keeps dialling a dead CID and, if it can still reach one, signs with a key no verifier accepts. Neither shows up as unhealthy: the process is fine, jobs merely fail with `Connection timed out (os error 110)` at WARN and re-queue forever.

This happened four times on alphanet today, each needing a manual pod delete.

`EnclaveBinding::bind()` now re-establishes both before every job:

- **CID re-resolved per bind.** New `--enclave-cid-file` (env `ENCLAVE_CID_FILE`) re-reads the file the launcher rewrites; `--enclave-cid` stays as the fixed fallback.
- **Registration re-asserted per bind.** `register_enclave_key` is already idempotent — it fetches the attestation, derives the signer, and returns `AlreadyRegistered` without a transaction — so steady state is one vsock round trip plus one `eth_call`, and a replaced enclave re-registers itself.
- **Binding gates proving.** `bind()` runs before witness collection, so a bad bind costs one re-queued job instead of producing a proof that reverts `InvalidProof` on submission. Today an unregistered key still yields `outcome: success` and a `SUCCEEDED` row the defender then burns gas on.

Startup keeps its unbounded retry loop (`bind_with_retry`), so an unbound worker still refuses to lease jobs rather than crashlooping.

**Verification is incomplete and needs CI.** The crate is `#![cfg(target_os = "linux")]`, so `cargo check` on macOS compiles nothing, and cross-compiling needs a linux C toolchain for blst/ring/openssl-sys that isn't available locally — I tried, including a zig-cc shim. The change is formatted (`cargo +nightly fmt --check` clean) and self-reviewed, but it has **not been compiled or tested**. Please let rust-ci settle before merging.

Follow-up in crypto-apps: pass `--enclave-cid-file /run/nitro-shared/enclave-cid` instead of `--enclave-cid "${ENCLAVE_CID}"` once an image with this lands. Until then the fixed CID path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the critical path for every Nitro proof job (vsock + optional on-chain registration) and enclave replacement behavior; steady-state adds per-job bind overhead but fails before witness work.
> 
> **Overview**
> Fixes the nitro worker staying pinned to a **dead vsock CID** and an **ephemeral signing key** after the enclave is replaced, which previously looked healthy while jobs timed out or produced proofs verifiers reject.
> 
> Introduces **`EnclaveBinding`** with per-job **`bind()`**: re-resolve the enclave CID (new **`--enclave-cid-file` / `ENCLAVE_CID_FILE`**, re-read each bind; **`--enclave-cid`** remains the fixed fallback) and, when **`--auto-register`** is on, re-run idempotent **`register_enclave_key`** so the current key is registered before proving.
> 
> **`NitroBackend`** now holds a shared binding and calls **`bind()` before witness collection**, so a bad bind re-queues one job instead of burning time on an unusable proof. Startup still uses **`bind_with_retry`** (replacing one-shot registration) so the worker won’t lease jobs until the first successful bind.
> 
> Adds unit tests for CID file resolution (trim, replacement, errors) and **`tempfile`** as a Linux dev-dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19ef906395b741517ba7945ea9a9e7d883b47bf7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->