### PR TITLE
fix(defender): bound the tick and emit a heartbeat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18809,6 +18809,7 @@ dependencies = [
  "dotenvy",
  "hex",
  "telemetry-batteries",
+ "tempfile",
  "tokio",
  "tracing",
  "world-chain-chainspec",

--- a/proofs/defender/Cargo.toml
+++ b/proofs/defender/Cargo.toml
@@ -37,7 +37,7 @@ async-trait.workspace = true
 clap.workspace = true
 dotenvy.workspace = true
 futures-util.workspace = true
-tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "time"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "time", "test-util"] }
 tracing.workspace = true
 telemetry-batteries.workspace = true
 url.workspace = true

--- a/proofs/defender/src/config.rs
+++ b/proofs/defender/src/config.rs
@@ -1,8 +1,12 @@
 use crate::error::DefenderError;
-use std::time::Duration;
+use std::{path::PathBuf, time::Duration};
 
 /// Default number of games processed concurrently.
 pub const DEFAULT_MAX_GAME_CONCURRENCY: usize = 10;
+
+/// Default ceiling on one tick. Generous: a tick fans out over every active game, so this is
+/// a stuck-detector, not a latency budget.
+pub const DEFAULT_TICK_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// Default number of L1 confirmations required for defender transactions.
 pub const DEFAULT_L1_TX_CONFIRMATIONS: u64 = 5;
@@ -14,6 +18,14 @@ pub struct DefenderConfig {
     pub poll_interval: Duration,
     /// Maximum number of games to process concurrently.
     pub max_game_concurrency: usize,
+    /// Ceiling on one tick. A tick that blocks forever — an RPC call with no timeout of its
+    /// own — stops the loop without stopping the process: it stays Ready, logs nothing, and
+    /// submits nothing until someone restarts the pod. Observed twice on alphanet
+    /// 2026-08-05, both times immediately after a failed submission.
+    pub tick_timeout: Duration,
+    /// File touched after every tick. Lets a liveness probe distinguish "loop running" from
+    /// "process alive", which is otherwise invisible from outside.
+    pub heartbeat_file: Option<PathBuf>,
 }
 
 impl DefenderConfig {
@@ -21,6 +33,11 @@ impl DefenderConfig {
         if self.poll_interval.is_zero() {
             return Err(DefenderError::InvalidConfig(
                 "poll_interval must be greater than zero",
+            ));
+        }
+        if self.tick_timeout.is_zero() {
+            return Err(DefenderError::InvalidConfig(
+                "tick_timeout must be greater than zero",
             ));
         }
         if self.max_game_concurrency == 0 {
@@ -37,6 +54,8 @@ impl Default for DefenderConfig {
         Self {
             poll_interval: Duration::from_mins(1),
             max_game_concurrency: DEFAULT_MAX_GAME_CONCURRENCY,
+            tick_timeout: DEFAULT_TICK_TIMEOUT,
+            heartbeat_file: None,
         }
     }
 }

--- a/proofs/defender/src/defender.rs
+++ b/proofs/defender/src/defender.rs
@@ -349,15 +349,40 @@ where
     }
 
     /// Runs the defender forever, logging transient failures and retrying on each tick.
+    ///
+    /// The tick is bounded: a single call that never returns would otherwise stop the loop
+    /// while leaving the process alive and Ready, which reads as a healthy defender that
+    /// silently submits nothing. Abandoning the tick loses one cycle; not abandoning it loses
+    /// every cycle until an operator notices.
     pub async fn run_forever(&mut self) -> Result<(), DefenderError> {
         self.config.validate()?;
 
         let mut interval = tokio::time::interval(self.config.poll_interval);
         loop {
             interval.tick().await;
-            if let Err(e) = self.tick().await {
-                warn!(%e, "defender iteration failed; retrying on next tick");
+            match tokio::time::timeout(self.config.tick_timeout, self.tick()).await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => warn!(%e, "defender iteration failed; retrying on next tick"),
+                Err(_) => error!(
+                    timeout_secs = self.config.tick_timeout.as_secs(),
+                    "defender tick timed out; abandoning it and retrying on next tick"
+                ),
             }
+            self.touch_heartbeat();
+        }
+    }
+
+    /// Records that the loop came back around. A liveness probe stats this file; without it
+    /// "the loop is wedged" is indistinguishable from "there is nothing to do", since both
+    /// look like an idle process.
+    fn touch_heartbeat(&self) {
+        let Some(path) = self.config.heartbeat_file.as_ref() else {
+            return;
+        };
+        if let Err(error) = std::fs::write(path, b"") {
+            // Never fatal: losing the heartbeat degrades detection, and killing the defender
+            // over a filesystem error would be the more damaging failure.
+            warn!(%error, path = %path.display(), "failed to touch defender heartbeat file");
         }
     }
 }

--- a/proofs/defender/src/main.rs
+++ b/proofs/defender/src/main.rs
@@ -5,7 +5,7 @@
 //! (`crates/devnet/src/full_stack.rs::start_world_chain_defender`), reading its
 //! configuration from flags/environment so it can run as a standalone service.
 
-use std::time::Duration;
+use std::{path::PathBuf, time::Duration};
 
 use alloy_network::EthereumWallet;
 use alloy_primitives::Address;
@@ -58,6 +58,14 @@ struct Cli {
     /// Maximum number of games processed concurrently.
     #[arg(long, env = "MAX_GAME_CONCURRENCY", default_value_t = 10)]
     max_game_concurrency: usize,
+
+    /// Seconds a single tick may run before it is abandoned.
+    #[arg(long, env = "TICK_TIMEOUT_SECONDS", default_value_t = 300)]
+    tick_timeout_seconds: u64,
+
+    /// File touched after every tick, for a liveness probe to stat.
+    #[arg(long, env = "HEARTBEAT_FILE")]
+    heartbeat_file: Option<PathBuf>,
 
     /// Number of L1 confirmations required before a proof submission is accepted.
     #[arg(
@@ -114,6 +122,8 @@ async fn main() -> Result<()> {
     let config = DefenderConfig {
         poll_interval: Duration::from_secs(cli.poll_interval_seconds),
         max_game_concurrency: cli.max_game_concurrency,
+        tick_timeout: Duration::from_secs(cli.tick_timeout_seconds),
+        heartbeat_file: cli.heartbeat_file.clone(),
     };
     let mut defender = WorldChainDefender::new(config, client, output_roots, proof_requester);
 

--- a/proofs/defender/src/tests.rs
+++ b/proofs/defender/src/tests.rs
@@ -12,7 +12,7 @@ use std::{
     collections::HashMap,
     sync::{
         Arc, Mutex,
-        atomic::{AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
     },
     time::Duration,
 };
@@ -55,6 +55,9 @@ struct MockState {
 #[derive(Debug, Clone)]
 struct MockClient {
     state: Arc<Mutex<MockState>>,
+    /// When set, `lineage_anchor` never returns — the shape of the hang seen on alphanet
+    /// 2026-08-05, where one un-timed-out call stopped the loop for 26 minutes.
+    stall: Arc<AtomicBool>,
 }
 
 impl MockClient {
@@ -69,6 +72,7 @@ impl MockClient {
                 games: HashMap::new(),
                 submissions: Vec::new(),
             })),
+            stall: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -158,6 +162,9 @@ impl LineageProvider for MockClient {
     }
 
     async fn lineage_anchor(&self) -> Result<LineageAnchor, LineageError> {
+        if self.stall.load(Ordering::SeqCst) {
+            std::future::pending::<()>().await;
+        }
         Ok(self.state.lock().expect("not poisoned").anchor)
     }
 
@@ -384,6 +391,8 @@ impl ProofRequester for MockProver {
 fn config() -> DefenderConfig {
     DefenderConfig {
         poll_interval: Duration::from_secs(1),
+        tick_timeout: Duration::from_secs(300),
+        heartbeat_file: None,
         max_game_concurrency: 10,
     }
 }
@@ -737,7 +746,43 @@ async fn selected_game_deadline_stops_proof_work() {
 fn config_rejects_zero_concurrency() {
     let config = DefenderConfig {
         poll_interval: Duration::from_secs(1),
+        tick_timeout: Duration::from_secs(300),
+        heartbeat_file: None,
         max_game_concurrency: 0,
     };
     assert!(config.validate().is_err());
+}
+
+/// A tick that never returns must not stop the loop: before `tick_timeout` existed, one
+/// un-timed-out call left the defender Ready, silent, and submitting nothing until an
+/// operator restarted the pod (alphanet, 2026-08-05, twice).
+#[tokio::test(start_paused = true)]
+async fn a_hung_tick_is_abandoned_and_the_loop_continues() {
+    let heartbeat = std::env::temp_dir().join("wc-defender-hung-tick-heartbeat");
+    let _ = std::fs::remove_file(&heartbeat);
+
+    let client = MockClient::new();
+    client.stall.store(true, Ordering::SeqCst);
+    let mut defender = WorldChainDefender::new(
+        DefenderConfig {
+            poll_interval: Duration::from_secs(1),
+            tick_timeout: Duration::from_secs(30),
+            heartbeat_file: Some(heartbeat.clone()),
+            max_game_concurrency: 10,
+        },
+        client,
+        output_roots(&[], 0),
+        MockProver::default(),
+    );
+
+    let run = tokio::spawn(async move { defender.run_forever().await });
+    // Paused time auto-advances, so this resolves as soon as the loop has had the chance to
+    // start a tick, hit the 30s ceiling, abandon it, and come back around.
+    tokio::time::sleep(Duration::from_secs(120)).await;
+    run.abort();
+
+    assert!(
+        heartbeat.exists(),
+        "the loop must survive a hung tick and touch its heartbeat"
+    );
 }


### PR DESCRIPTION
The defender wedged twice on alphanet today (19:52 and 21:08 UTC), both times mid-cycle immediately after a failed submission. Each time the process stayed alive and `Ready`, logged nothing at all, and submitted nothing — 26 minutes on the first occurrence — until the pod was deleted. `run_forever` awaits `tick()` with no ceiling, so one call that never returns stops the loop without stopping the process.

Nothing could see it. The container has no probes, CPU and memory look identical hung or idle (3m / 4Mi either way), and the only exported metric is `proof_lanes_submitted`, which is event-driven. The single distinguishing signal was the log timestamp.

- **`tick_timeout`** (default 300s, `--tick-timeout-seconds`): a tick that exceeds it is abandoned and the loop continues. Losing one cycle beats losing every cycle until someone notices. Deliberately generous — a tick fans out over every active game, so this is a stuck-detector, not a latency budget.
- **`heartbeat_file`** (`--heartbeat-file` / `HEARTBEAT_FILE`, off by default): touched after every tick, so a liveness probe can stat it. Failing to write it warns and never kills the defender.

Regression test `a_hung_tick_is_abandoned_and_the_loop_continues` reproduces the exact shape — `MockClient::lineage_anchor` returns `pending()` forever — and asserts the loop still comes back around and touches the heartbeat. It hangs indefinitely without the timeout.

Verified: `cargo test -p world-chain-defender` 17/17, `cargo +nightly fmt --check`, clippy clean with `-D warnings`.

Follow-up in crypto-apps once an image with this ships: set `HEARTBEAT_FILE` and add the matching stat-based livenessProbe, same pattern as the enclave heartbeat in crypto-apps#763. A probe today would have nothing to stat.

Root cause of the hang itself is still open — most likely an un-timed-out call in the submit path, since both hangs began there. The timeout contains it; it does not explain it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the main defender control loop and timeout behavior for proof submission; mis-tuned timeouts could abandon slow but valid ticks, though defaults are intentionally generous.
> 
> **Overview**
> Addresses defender **wedges** where `run_forever` could await a `tick()` that never returned—process stayed Ready and idle while proof work stopped.
> 
> **`run_forever`** now wraps each tick in `tokio::time::timeout` using **`tick_timeout`** (default 300s, CLI/env `TICK_TIMEOUT_SECONDS`). On timeout it logs an error, abandons that tick, and continues on the next poll interval.
> 
> Adds optional **`heartbeat_file`** (`--heartbeat-file` / `HEARTBEAT_FILE`): an empty file is rewritten after every loop iteration so external liveness probes can tell “loop advancing” from “process up but stuck.” Write failures are warned only.
> 
> Config validation rejects zero `tick_timeout`. The binary wires both settings into `DefenderConfig`. Tests add a stalling `MockClient` and **`a_hung_tick_is_abandoned_and_the_loop_continues`** (paused time + heartbeat assertion). Tokio **`test-util`** is enabled for that test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd524f6019252f427b8f57d5c05f7dc67bbc77ed. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->