### PR TITLE
Fix docker-proof build.

### DIFF
--- a/.github/workflows/docker-proof.yml
+++ b/.github/workflows/docker-proof.yml
@@ -166,7 +166,7 @@ jobs:
         uses: ./.github/actions/docker-merge-manifest
         with:
           registry: ${{ env.REGISTRY }}
-          image_name: ${{ github.repository }}-nitro-worker
+          image_name: ${{ env.IMAGE_NAME }}-nitro-worker
           digest_artifact_prefix: digests-nitro-worker
           digest_artifact_pattern: digests-nitro-worker-linux-*
           tags: |
@@ -194,7 +194,7 @@ jobs:
           aws_region: ${{ env.AWS_REGION }}
           sccache_bucket: ${{ env.SCCACHE_BUCKET }}
           dockerfile: proofs/nitro/enclave/Dockerfile
-          digest_artifact_prefix: digests-nitro-worker-enclave
+          digest_artifact_prefix: digests-nitro-enclave
 
   merge-nitro-enclave-image:
     name: merge nitro-worker-enclave image manifest
@@ -245,7 +245,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
-          file: proofs/nitro/Dockerfile.eif
+          file: proofs/nitro/enclave/Dockerfile.eif
           push: true
           platforms: linux/amd64
           tags: |

--- a/.github/workflows/docker-proof.yml
+++ b/.github/workflows/docker-proof.yml
@@ -210,7 +210,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           image_name: ${{ env.IMAGE_NAME }}-nitro-enclave
-          digest_artifact_prefix: digests-nitro-worker-enclave
+          digest_artifact_prefix: digests-nitro-enclave
           tags: |
             type=raw,value=${{ inputs.image_tag || 'nightly' }}
             type=raw,value=sha-${{ needs.resolve-sha.outputs.short }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only workflow string and path fixes; no application runtime or security logic changes.
> 
> **Overview**
> **Fixes the `docker-proof` workflow** so Nitro-related image builds and manifest merges use the same naming as the rest of the pipeline.
> 
> The **nitro-worker merge** job now publishes **`${{ env.IMAGE_NAME }}-nitro-worker`** instead of **`${{ github.repository }}-nitro-worker`**, matching the build job and the `-proof` image prefix used elsewhere.
> 
> **Nitro enclave** digest artifact prefixes are renamed from **`digests-nitro-worker-enclave`** to **`digests-nitro-enclave`** on both build and merge, so merge can find the uploaded digests.
> 
> The **EIF carrier image** build now uses **`proofs/nitro/enclave/Dockerfile.eif`** instead of **`proofs/nitro/Dockerfile.eif`**, aligning with the enclave Dockerfile layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efcbda30fe010489bfce40d5e7a7696655538c9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->