### PR TITLE
Fix EIF image build.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 target/
-!target/eif/world-chain-nitro-worker-enclave.eif
+!target/eif/world-chain-nitro-enclave.eif
 .env/
 pkg/contracts/
 assets/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 target/
-!target/eif/world-chain-nitro-enclave.eif
+!target/eif/world-chain-proof-nitro-enclave.eif
 .env/
 pkg/contracts/
 assets/

--- a/Justfile
+++ b/Justfile
@@ -342,7 +342,7 @@ proof-get-pcrs env="alphanet":
     echo "Pod: $NITRO_POD  Container: enclave-launcher" >&2
     MEASUREMENTS=$(kubectl --context="$KUBECONTEXT" exec \
         -n "$PROOF_NAMESPACE" "$NITRO_POD" -c enclave-launcher \
-        -- nitro-cli describe-eif --eif-path /home/world-chain-nitro-worker-enclave.eif \
+        -- nitro-cli describe-eif --eif-path /home/world-chain-nitro-enclave.eif \
         | jq -r '.Measurements')
     echo "PCR0=$(echo "$MEASUREMENTS" | jq -r '.PCR0')"
     echo "PCR1=$(echo "$MEASUREMENTS" | jq -r '.PCR1')"

--- a/Justfile
+++ b/Justfile
@@ -342,7 +342,7 @@ proof-get-pcrs env="alphanet":
     echo "Pod: $NITRO_POD  Container: enclave-launcher" >&2
     MEASUREMENTS=$(kubectl --context="$KUBECONTEXT" exec \
         -n "$PROOF_NAMESPACE" "$NITRO_POD" -c enclave-launcher \
-        -- nitro-cli describe-eif --eif-path /home/world-chain-nitro-enclave.eif \
+        -- nitro-cli describe-eif --eif-path /home/world-chain-proof-nitro-enclave.eif \
         | jq -r '.Measurements')
     echo "PCR0=$(echo "$MEASUREMENTS" | jq -r '.PCR0')"
     echo "PCR1=$(echo "$MEASUREMENTS" | jq -r '.PCR1')"

--- a/docs/proof/nitro-worker.md
+++ b/docs/proof/nitro-worker.md
@@ -36,22 +36,22 @@ The `nitro-worker` Kubernetes pod contains two containers:
 ┌─────────────────────────────────────────────────────────────────────────┐
 │  EC2 Node (Nitro-capable)                                               │
 │                                                                         │
-│  ┌──────────────────────────────────────────────────────────────────┐  │
-│  │  nitro-worker Pod                                                │  │
-│  │                                                                  │  │
-│  │  ┌──────────────────────────┐  ┌──────────────────────────────┐ │  │
-│  │  │  nitro-worker (main)     │  │  enclave-launcher (sidecar)  │ │  │
-│  │  │                          │  │                              │ │  │
-│  │  │  polls prover-service    │  │  runs nitro-cli run-enclave  │ │  │
-│  │  │  builds witnesses        │  │  writes CID ─────────────────┼─┼► │
-│  │  │  sends to enclave        │  │  to /run/nitro-shared/       │ │  │
-│  │  │  reads CID ◄─────────────┼──┼──────────────────────────── │ │  │
-│  │  └────────────┬─────────────┘  └──────────────────────────────┘ │  │
-│  └───────────────┼────────────────────────────────────────────────── ┘  │
+│  ┌───────────────────────────────────────────────────────────────────┐  │
+│  │  nitro-worker Pod                                                 │  │
+│  │                                                                   │  │
+│  │  ┌──────────────────────────┐  ┌───────────────────────────────┐  │  │
+│  │  │  nitro-worker (main)     │  │  enclave-launcher (sidecar)   │  │  │
+│  │  │                          │  │                               │  │  │
+│  │  │  polls prover-service    │  │  runs nitro-cli run-enclave   │  │  │
+│  │  │  builds witnesses        │  │  writes CID ──────────────────┼──┼► │
+│  │  │  sends to enclave        │  │  to /run/nitro-shared/        │  │  │
+│  │  │  reads CID ◄─────────────┼──┼────────────────────────────   │  │  │
+│  │  └────────────┬─────────────┘  └───────────────────────────────┘  │  │
+│  └───────────────┼───────────────────────────────────────────────────┘  │
 │                  │ vsock (CID from /run/nitro-shared/enclave-cid)       │
 │                  ▼                                                      │
 │  ┌───────────────────────────────────────────────────────────────────┐  │
-│  │  AWS Nitro Enclave  (world-chain-nitro-enclave)                   │  │
+│  │  AWS Nitro Enclave  (world-chain-proof-nitro-enclave)             │  │
 │  │                                                                   │  │
 │  │  - Listens on vsock port 5005                                     │  │
 │  │  - Re-executes Kona derivation pipeline                           │  │
@@ -732,7 +732,7 @@ a debug enclave is indistinguishable from a forged one.
 | `--poll-interval-seconds` / `POLL_INTERVAL_SECONDS` | Seconds between prover-service polls | `10` |
 | `--max-concurrent-jobs` | Max jobs proved in parallel | `1` |
 
-### `world-chain-nitro-enclave` (Enclave Binary)
+### `world-chain-proof-nitro-enclave` (Enclave Binary)
 
 | Env Var | Description | Default |
 |---------|-------------|---------|

--- a/docs/proof/proof-cli.md
+++ b/docs/proof/proof-cli.md
@@ -309,7 +309,7 @@ Run from the repo root. The Dockerfile at `proofs/nitro/Dockerfile` compiles the
 binary inside the container.
 
 ```bash
-docker build -t world-chain-nitro-enclave \
+docker build -t world-chain-proof-nitro-enclave \
   -f proofs/nitro/Dockerfile .
 ```
 
@@ -317,8 +317,8 @@ docker build -t world-chain-nitro-enclave \
 
 ```bash
 nitro-cli build-enclave \
-  --docker-uri world-chain-nitro-enclave:latest \
-  --output-file world-chain-nitro-enclave.eif
+  --docker-uri world-chain-proof-nitro-enclave:latest \
+  --output-file world-chain-proof-nitro-enclave.eif
 ```
 
 `nitro-cli` prints the PCR measurements on success:
@@ -335,7 +335,7 @@ Save these — they are passed to `world-chain-prover-nitro prove` as `--pcr0/1/
 
 ```bash
 nitro-cli run-enclave \
-  --eif-path world-chain-nitro-enclave.eif \
+  --eif-path world-chain-proof-nitro-enclave.eif \
   --memory 16384 \
   --cpu-count 4 \
   --enclave-cid 16

--- a/docs/proof/release.md
+++ b/docs/proof/release.md
@@ -14,15 +14,15 @@ and keeps measurement changes reviewable on their own.
 
 ## What a release produces
 
-| Artifact | Notes |
-|:---|:---|
-| `manifest.json` | Single source of truth binding git SHA, ELF sha256s, vkeys, PCRs, and image digests |
-| `vkeys.json` | Range vkey commitment + aggregation vkey, computed from the committed ELFs |
-| `pcrs.json` | PCR0/PCR1/PCR2 of the enclave EIF |
-| `world-chain-nitro-enclave.eif` | Enclave image, built reproducibly (see below) |
-| `world-chain-range-ethereum`, `world-chain-aggregation` | SP1 guest ELFs, rebuilt from source in CI via `sp1_build` (no committed binaries, no hash manifest — see [elf-management.md](./elf-management.md)) |
+| Artifact                                                 | Notes |
+|:---------------------------------------------------------|:---|
+| `manifest.json`                                          | Single source of truth binding git SHA, ELF sha256s, vkeys, PCRs, and image digests |
+| `vkeys.json`                                             | Range vkey commitment + aggregation vkey, computed from the committed ELFs |
+| `pcrs.json`                                              | PCR0/PCR1/PCR2 of the enclave EIF |
+| `world-chain-proof-nitro-enclave.eif`                    | Enclave image, built reproducibly (see below) |
+| `world-chain-range-ethereum`, `world-chain-aggregation`  | SP1 guest ELFs, rebuilt from source in CI via `sp1_build` (no committed binaries, no hash manifest — see [elf-management.md](./elf-management.md)) |
 | `world-chain-proof-<version>-<target>.tar.gz` (+ `.asc`) | GPG-signed `proof` CLI binaries (linux x86_64 / aarch64) |
-| `ghcr.io/worldcoin/world-chain-proof:<version>` | Multi-arch prover image (sp1 + nitro backends, ELFs baked in) |
+| `ghcr.io/worldcoin/world-chain-proof:<version>`          | Multi-arch prover image (sp1 + nitro backends, ELFs baked in) |
 
 The draft release notes include a measurements section that diffs the vkeys/PCRs against the
 previous `proof/v*` release and flags when an on-chain registry update is required.

--- a/proofs/nitro/enclave/Dockerfile
+++ b/proofs/nitro/enclave/Dockerfile
@@ -1,15 +1,15 @@
 # syntax=docker/dockerfile:1.7
 #
-# Container image used to produce the world-chain-nitro-enclave EIF.
+# Container image used to produce the world-chain-proof-nitro-enclave EIF.
 #
 # Build:
-#   docker build -t world-chain-nitro-enclave \
+#   docker build -t world-chain-proof-nitro-enclave \
 #     -f proofs/nitro/Dockerfile .
 #
 # Convert to an EIF:
 #   nitro-cli build-enclave \
-#     --docker-uri world-chain-nitro-enclave:latest \
-#     --output-file world-chain-nitro-enclave.eif
+#     --docker-uri world-chain-proof-nitro-enclave:latest \
+#     --output-file world-chain-proof-nitro-enclave.eif
 #
 # Or use scripts/build-eif.sh, which does both and emits the PCR measurements.
 #

--- a/proofs/nitro/enclave/Dockerfile.eif
+++ b/proofs/nitro/enclave/Dockerfile.eif
@@ -3,10 +3,10 @@
 # Used by Kubernetes pods to launch the enclave on Nitro-enabled EC2 instances.
 #
 # Build context: target/eif/  (produced by scripts/build-eif.sh)
-# Required file in context: world-chain-nitro-enclave.eif
+# Required file in context: world-chain-proof-nitro-enclave.eif
 #
 # Environment variables (defaults shown):
-#   EIF_PATH              /home/world-chain-nitro-enclave.eif
+#   EIF_PATH              /home/world-chain-proof-nitro-enclave.eif
 #   ENCLAVE_CPU_COUNT     2
 #   ENCLAVE_MEMORY_SIZE   16384 (MiB)
 #   ENCLAVE_DEBUG_MODE    false  (set to "true" or "1" to pass --debug-mode)
@@ -17,10 +17,10 @@ RUN dnf install -y aws-nitro-enclaves-cli aws-nitro-enclaves-cli-devel jq && \
     dnf clean all
 
 # EIF file from the build context (target/eif/).
-COPY target/eif/world-chain-nitro-enclave.eif /home/world-chain-nitro-enclave.eif
+COPY target/eif/world-chain-proof-nitro-enclave.eif /home/world-chain-proof-nitro-enclave.eif
 
 # Defaults; override at runtime via -e / K8s env:.
-ENV EIF_PATH="/home/world-chain-nitro-enclave.eif" \
+ENV EIF_PATH="/home/world-chain-proof-nitro-enclave.eif" \
     ENCLAVE_CPU_COUNT=2 \
     ENCLAVE_MEMORY_SIZE=16384 \
     ENCLAVE_DEBUG_MODE=false

--- a/proofs/nitro/enclave/Dockerfile.eif
+++ b/proofs/nitro/enclave/Dockerfile.eif
@@ -3,10 +3,10 @@
 # Used by Kubernetes pods to launch the enclave on Nitro-enabled EC2 instances.
 #
 # Build context: target/eif/  (produced by scripts/build-eif.sh)
-# Required file in context: world-chain-nitro-worker-enclave.eif
+# Required file in context: world-chain-nitro-enclave.eif
 #
 # Environment variables (defaults shown):
-#   EIF_PATH              /home/world-chain-nitro-worker-enclave.eif
+#   EIF_PATH              /home/world-chain-nitro-enclave.eif
 #   ENCLAVE_CPU_COUNT     2
 #   ENCLAVE_MEMORY_SIZE   16384 (MiB)
 #   ENCLAVE_DEBUG_MODE    false  (set to "true" or "1" to pass --debug-mode)
@@ -17,10 +17,10 @@ RUN dnf install -y aws-nitro-enclaves-cli aws-nitro-enclaves-cli-devel jq && \
     dnf clean all
 
 # EIF file from the build context (target/eif/).
-COPY target/eif/world-chain-nitro-worker-enclave.eif /home/world-chain-nitro-worker-enclave.eif
+COPY target/eif/world-chain-nitro-enclave.eif /home/world-chain-nitro-enclave.eif
 
 # Defaults; override at runtime via -e / K8s env:.
-ENV EIF_PATH="/home/world-chain-nitro-worker-enclave.eif" \
+ENV EIF_PATH="/home/world-chain-nitro-enclave.eif" \
     ENCLAVE_CPU_COUNT=2 \
     ENCLAVE_MEMORY_SIZE=16384 \
     ENCLAVE_DEBUG_MODE=false

--- a/proofs/nitro/enclave/src/bin/enclave.rs
+++ b/proofs/nitro/enclave/src/bin/enclave.rs
@@ -1,4 +1,4 @@
-//! Entry point for the `world-chain-nitro-enclave` binary.
+//! Entry point for the `world-chain-proof-nitro-enclave` binary.
 //!
 //! This file runs **inside** the Nitro Enclave. It is the same role the SP1 range program
 //! plays for the Succinct backend: it ingests a witness, drives the OP Stack derivation
@@ -40,5 +40,5 @@ async fn main() -> Result<()> {
 
 #[cfg(not(target_os = "linux"))]
 fn main() {
-    eprintln!("world-chain-nitro-enclave is only supported on Linux");
+    eprintln!("world-chain-proof-nitro-enclave is only supported on Linux");
 }

--- a/proofs/nitro/enclave/src/enclave.rs
+++ b/proofs/nitro/enclave/src/enclave.rs
@@ -1,6 +1,6 @@
 //! Enclave-side library code.
 //!
-//! This is the worker loop the `world-chain-nitro-enclave` binary runs inside the Nitro
+//! This is the worker loop the `world-chain-proof-nitro-enclave` binary runs inside the Nitro
 //! Enclave. It listens on vsock, runs the same OP Succinct Lite range logic the SP1 guest
 //! does, and attests the result via the local NSM device.
 //!

--- a/proofs/nitro/enclave/src/lib.rs
+++ b/proofs/nitro/enclave/src/lib.rs
@@ -20,7 +20,7 @@
 //!   on an attestation document.
 //! - [`host`] — `NitroProver` implementation that talks to a running enclave over vsock.
 //!
-//! The enclave-side guest is the `world-chain-nitro-enclave` binary (`src/enclave.rs`).
+//! The enclave-side guest is the `world-chain-proof-nitro-enclave` binary (`src/enclave.rs`).
 
 // clap is used by the p384-hints binary; reference it here so the
 // `unused_crate_dependencies` lint does not fire on the lib target.
@@ -84,7 +84,7 @@ pub type PcrDigest = [u8; PCR_LEN];
 /// before any production use.
 //
 // TODO(nitro): replace with real PCR values produced by `nitro-cli build-enclave` once we
-// have a reproducible EIF build for the world-chain-nitro-enclave image.
+// have a reproducible EIF build for the world-chain-proof-nitro-enclave image.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ExpectedPcrs {
     /// EIF measurement.

--- a/scripts/build-eif.sh
+++ b/scripts/build-eif.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 # Usage: scripts/build-eif.sh [output-dir]   (default: target/eif)
 #
 # Outputs in <output-dir>:
-#   world-chain-nitro-worker-enclave.eif   the enclave image
+#   world-chain-nitro-enclave.eif   the enclave image
 #   pcrs.json                       PCR0/PCR1/PCR2 measurements
 #
 # Env overrides:

--- a/scripts/build-eif.sh
+++ b/scripts/build-eif.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-# Build the world-chain-nitro-enclave EIF and emit its PCR measurements.
+# Build the world-chain-proof-nitro-enclave EIF and emit its PCR measurements.
 #
 # Builds the enclave container image from proofs/nitro/Dockerfile, then converts
 # it to an EIF with nitro-cli (built from source at a pinned tag so the EIF
@@ -11,7 +11,7 @@ set -euo pipefail
 # Usage: scripts/build-eif.sh [output-dir]   (default: target/eif)
 #
 # Outputs in <output-dir>:
-#   world-chain-nitro-enclave.eif   the enclave image
+#   world-chain-proof-nitro-enclave.eif   the enclave image
 #   pcrs.json                       PCR0/PCR1/PCR2 measurements
 #
 # Env overrides:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Rename-only across build, Docker, and docs; operators must use the new EIF filename in manual steps, but behavior and attestation logic are unchanged.
> 
> **Overview**
> **Renames the Nitro enclave EIF and related image paths** from the older `world-chain-nitro-enclave` / `world-chain-nitro-worker-enclave` names to **`world-chain-proof-nitro-enclave`**, matching the Rust package and binary already built as `world-chain-proof-nitro-enclave`.
> 
> The change threads the new filename through **EIF build and packaging**: `.dockerignore` whitelists `target/eif/world-chain-proof-nitro-enclave.eif`, `scripts/build-eif.sh` writes that artifact, `Dockerfile.eif` copies it and sets `EIF_PATH`, and **`just proof-get-pcrs`** runs `nitro-cli describe-eif` against `/home/world-chain-proof-nitro-enclave.eif` on the launcher container. Docs (`nitro-worker`, `proof-cli`, `release`) and enclave crate comments are updated to the same naming.
> 
> No proving logic or wire protocol changes—this is a **naming/consistency fix** so CI, K8s sidecars, and operator tooling reference the same EIF the build actually produces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c66f3180613f579c4dc7ebd81d097b3ba6ea927. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->