### PR TITLE
fix: sync rust proof services with MultiProofGame ABI

### DIFF
--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -2843,6 +2843,7 @@ async fn start_world_chain_defender(
         provider,
         factory_address,
         DEFAULT_DEFENDER_L1_TX_CONFIRMATIONS,
+        defender_address,
     )
     .await
     .map_err(|error| eyre!("failed to connect defender to proof system: {error}"))?;

--- a/proofs/integration-tests/src/lib.rs
+++ b/proofs/integration-tests/src/lib.rs
@@ -21,10 +21,10 @@ use world_chain_defender::{
 use world_chain_proof_core::boot::TransitionPublicValues;
 use world_chain_proof_worker::{ClaimedProofJobHandler, ProofJob};
 use world_chain_proofs::{
-    ConsensusError, ConsensusProvider, InvalidationReason, LineageAnchor, LineageError,
-    LineageGame, LineageProvider, LineageTransition, MAX_ATTEMPT_SCAN, PROOF_SYSTEM_VERSION,
-    PROOF_THRESHOLD, ProofDomain, ProofLane, ProposalCommitment, ResolutionStatus, RootCommitment,
-    RootState, WorldChainGameCreated, has_threshold,
+    ClaimData, ConsensusError, ConsensusProvider, GameCreation, GameStatus, InvalidationReason,
+    LineageAnchor, LineageError, LineageGame, LineageProvider, LineageTransition, MAX_ATTEMPT_SCAN,
+    PROOF_SYSTEM_VERSION, PROOF_THRESHOLD, ProofDomain, ProofLane, ProposalCommitment,
+    ProposalStatus, ResolutionStatus, RootCommitment, has_threshold,
 };
 use world_chain_proposer::{
     CloseGameSubmission, Proposal, ProposalSubmission, ProposerClient, ProposerError,
@@ -43,11 +43,35 @@ pub const CHAIN_ID: u64 = 4801;
 pub const ANCHOR: Address = address!("0000000000000000000000000000000000001006");
 pub const FAKE_PROPOSER: Address = address!("a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1");
 
-const STATE_NONE: u8 = 0;
-const STATE_PROPOSED: u8 = 1;
-const STATE_CHALLENGED: u8 = 2;
-const STATE_FINALIZED: u8 = 3;
-const STATE_INVALIDATED: u8 = 4;
+/// Fake game lifecycle. The contract splits this across `ProposalStatus` (challenged or not)
+/// and `GameStatus` (the terminal outcome); the fake keeps one field and derives both.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GameLifecycle {
+    Proposed,
+    Challenged,
+    Finalized,
+    Invalidated,
+}
+
+impl GameLifecycle {
+    const fn outcome(self) -> GameStatus {
+        match self {
+            Self::Proposed | Self::Challenged => GameStatus::InProgress,
+            Self::Finalized => GameStatus::DefenderWins,
+            Self::Invalidated => GameStatus::ChallengerWins,
+        }
+    }
+
+    const fn proposal_status(self, proven: bool) -> ProposalStatus {
+        match self {
+            Self::Proposed if proven => ProposalStatus::UnchallengedAndValidProofProvided,
+            Self::Proposed => ProposalStatus::Unchallenged,
+            Self::Challenged if proven => ProposalStatus::ChallengedAndValidProofProvided,
+            Self::Challenged => ProposalStatus::Challenged,
+            Self::Finalized | Self::Invalidated => ProposalStatus::Resolved,
+        }
+    }
+}
 
 /// Domain used by the fake proof-system factory.
 #[must_use]
@@ -143,8 +167,8 @@ struct FakeExecutionState {
 
 #[derive(Debug, Clone)]
 struct GameRecord {
-    event: WorldChainGameCreated,
-    state: u8,
+    creation: GameCreation,
+    state: GameLifecycle,
     challenge_deadline: u64,
     proof_deadline: u64,
     proof_bitmap: u8,
@@ -178,25 +202,23 @@ impl FakeExecution {
     }
 
     #[must_use]
-    pub fn latest_game(&self) -> Option<WorldChainGameCreated> {
+    pub fn latest_game(&self) -> Option<GameCreation> {
         let state = self.state.lock().expect("fake execution mutex poisoned");
         state
             .game_order
             .last()
             .and_then(|game| state.games_by_address.get(game))
-            .map(|record| record.event)
+            .map(|record| record.creation)
     }
 
     #[must_use]
-    pub fn game_state(&self, game: Address) -> RootState {
-        let raw = self
-            .state
+    pub fn game_state(&self, game: Address) -> Option<GameLifecycle> {
+        self.state
             .lock()
             .expect("fake execution mutex poisoned")
             .games_by_address
             .get(&game)
-            .map_or(STATE_NONE, |record| record.state);
-        RootState::try_from(raw).expect("fake execution stores valid root states")
+            .map(|record| record.state)
     }
 
     #[must_use]
@@ -234,7 +256,7 @@ impl FakeExecution {
         challenge_record(state.games_by_address.get_mut(&game).expect("game exists"));
     }
 
-    fn create_game(state: &mut FakeExecutionState, proposal: &Proposal) -> WorldChainGameCreated {
+    fn create_game(state: &mut FakeExecutionState, proposal: &Proposal) -> GameCreation {
         let game = Address::with_last_byte(state.next_game_nonce);
         state.next_game_nonce = state.next_game_nonce.saturating_add(1);
 
@@ -245,7 +267,7 @@ impl FakeExecution {
             l1_origin_hash,
             l1_origin_number,
         };
-        let event = WorldChainGameCreated {
+        let creation = GameCreation {
             root_id: root.root_id(state.domain_hash),
             game,
             game_creator: FAKE_PROPOSER,
@@ -264,8 +286,8 @@ impl FakeExecution {
         state.games_by_address.insert(
             game,
             GameRecord {
-                event,
-                state: STATE_PROPOSED,
+                creation,
+                state: GameLifecycle::Proposed,
                 challenge_deadline: u64::MAX,
                 proof_deadline: u64::MAX,
                 proof_bitmap: 0,
@@ -273,34 +295,30 @@ impl FakeExecution {
                 submitted_lanes: Vec::new(),
             },
         );
-        event
+        creation
     }
 }
 
 fn challenge_record(record: &mut GameRecord) {
     record.challenge_count = record.challenge_count.saturating_add(1);
-    if record.state == STATE_PROPOSED {
-        record.state = STATE_CHALLENGED;
-    }
-}
-
-fn proof_lane(lane: u8) -> Option<ProofLane> {
-    match lane {
-        0 => Some(ProofLane::ValidityProof),
-        1 => Some(ProofLane::TeeAttestation),
-        2 => Some(ProofLane::SecurityCouncil),
-        _ => None,
+    if record.state == GameLifecycle::Proposed {
+        record.state = GameLifecycle::Challenged;
     }
 }
 
 fn parent_is_unresolved(state: &FakeExecutionState, record: &GameRecord) -> bool {
-    if record.event.parent_ref == ANCHOR {
+    if record.creation.parent_ref == ANCHOR {
         return false;
     }
     state
         .games_by_address
-        .get(&record.event.parent_ref)
-        .is_some_and(|parent| parent.state == STATE_PROPOSED || parent.state == STATE_CHALLENGED)
+        .get(&record.creation.parent_ref)
+        .is_some_and(|parent| {
+            matches!(
+                parent.state,
+                GameLifecycle::Proposed | GameLifecycle::Challenged
+            )
+        })
 }
 
 #[async_trait]
@@ -349,44 +367,46 @@ impl LineageProvider for FakeExecution {
             .get(&game)
             .ok_or_else(|| LineageError::Contract(format!("unknown game {game}")))?;
 
-        let root_state = RootState::try_from(record.state)?;
-        if root_state == RootState::Finalized {
+        let outcome = record.state.outcome();
+        if record.state == GameLifecycle::Finalized {
             return Ok(ResolutionStatus {
                 resolvable: false,
-                root_state,
+                outcome,
                 invalidation_reason: InvalidationReason::None,
             });
         }
         if parent_is_unresolved(&state, record) {
             return Ok(ResolutionStatus {
                 resolvable: false,
-                root_state,
+                outcome,
                 invalidation_reason: InvalidationReason::None,
             });
         }
-        if matches!(record.state, STATE_PROPOSED | STATE_CHALLENGED)
-            && has_threshold(record.proof_bitmap)
+        if matches!(
+            record.state,
+            GameLifecycle::Proposed | GameLifecycle::Challenged
+        ) && has_threshold(record.proof_bitmap)
         {
             return Ok(ResolutionStatus {
                 resolvable: true,
-                root_state: RootState::Finalized,
+                outcome: GameStatus::DefenderWins,
                 invalidation_reason: InvalidationReason::None,
             });
         }
-        if root_state == RootState::Challenged && record.proof_deadline == 0 {
+        if record.state == GameLifecycle::Challenged && record.proof_deadline == 0 {
             return Ok(ResolutionStatus {
                 resolvable: true,
-                root_state: RootState::Invalidated,
+                outcome: GameStatus::ChallengerWins,
                 invalidation_reason: InvalidationReason::ProofTimeout,
             });
         }
-        if root_state == RootState::Proposed && record.challenge_deadline == 0 {
+        if record.state == GameLifecycle::Proposed && record.challenge_deadline == 0 {
             return Ok(ResolutionStatus {
                 resolvable: true,
-                root_state: if record.proof_bitmap == 0 {
-                    RootState::Invalidated
+                outcome: if record.proof_bitmap == 0 {
+                    GameStatus::ChallengerWins
                 } else {
-                    RootState::Finalized
+                    GameStatus::DefenderWins
                 },
                 invalidation_reason: if record.proof_bitmap == 0 {
                     InvalidationReason::ProofTimeout
@@ -398,7 +418,7 @@ impl LineageProvider for FakeExecution {
 
         Ok(ResolutionStatus {
             resolvable: false,
-            root_state,
+            outcome,
             invalidation_reason: InvalidationReason::None,
         })
     }
@@ -423,10 +443,10 @@ impl ProposerClient for FakeExecution {
             .games_by_address
             .get_mut(&game)
             .ok_or_else(|| ProposerError::message(format!("unknown game {game}")))?;
-        record.state = match status.root_state {
-            RootState::Finalized => STATE_FINALIZED,
-            RootState::Invalidated => STATE_INVALIDATED,
-            _ => {
+        record.state = match status.outcome {
+            GameStatus::DefenderWins => GameLifecycle::Finalized,
+            GameStatus::ChallengerWins => GameLifecycle::Invalidated,
+            GameStatus::InProgress => {
                 return Err(ProposerError::message(format!(
                     "game {game} has no terminal outcome"
                 )));
@@ -444,12 +464,12 @@ impl ProposerClient for FakeExecution {
             .games_by_address
             .get(&game)
             .ok_or_else(|| ProposerError::message(format!("unknown game {game}")))?;
-        if record.state != STATE_FINALIZED {
+        if record.state != GameLifecycle::Finalized {
             return Err(ProposerError::message(format!(
                 "game {game} is not finalized"
             )));
         }
-        let l2_block_number = record.event.l2_block_number;
+        let l2_block_number = record.creation.l2_block_number;
         state.anchor = LineageAnchor {
             address: game,
             l2_block_number,
@@ -511,21 +531,22 @@ impl ChallengerClient for FakeExecution {
             .get(&game)
             .map(|record| ChallengerGameMetadata {
                 address: game,
-                root_claim: record.event.root_claim,
-                l2_block_number: record.event.l2_block_number,
+                root_claim: record.creation.root_claim,
+                l2_block_number: record.creation.l2_block_number,
             })
             .ok_or_else(|| ChallengerError::message(format!("unknown game {game}")))
     }
 
-    async fn root_state(&self, game: Address) -> Result<RootState, ChallengerError> {
-        let raw = self
+    async fn proposal_status(&self, game: Address) -> Result<ProposalStatus, ChallengerError> {
+        Ok(self
             .state
             .lock()
             .expect("fake execution mutex poisoned")
             .games_by_address
             .get(&game)
-            .map_or(STATE_NONE, |record| record.state);
-        RootState::try_from(raw).map_err(Into::into)
+            .map_or(ProposalStatus::Resolved, |record| {
+                record.state.proposal_status(record.proof_bitmap != 0)
+            }))
     }
 
     async fn challenge_deadline(&self, game: Address) -> Result<u64, ChallengerError> {
@@ -565,11 +586,11 @@ impl DefenderClient for FakeExecution {
             .map(|record| DefenderGameMetadata {
                 address: game,
                 domain_hash: state.domain_hash,
-                parent_ref: record.event.parent_ref,
-                root_claim: record.event.root_claim,
-                l2_block_number: record.event.l2_block_number,
-                l1_origin_hash: record.event.l1_origin_hash,
-                l1_origin_number: record.event.l1_origin_number,
+                parent_ref: record.creation.parent_ref,
+                root_claim: record.creation.root_claim,
+                l2_block_number: record.creation.l2_block_number,
+                l1_origin_hash: record.creation.l1_origin_hash,
+                l1_origin_number: record.creation.l1_origin_number,
                 challenge_deadline: record.challenge_deadline,
                 proof_deadline: record.proof_deadline,
                 proof_threshold: PROOF_THRESHOLD,
@@ -577,23 +598,28 @@ impl DefenderClient for FakeExecution {
             .ok_or_else(|| DefenderError::message(format!("unknown game {game}")))
     }
 
-    async fn proof_bitmap(&self, game: Address) -> Result<u8, DefenderError> {
+    async fn claim_data(&self, game: Address) -> Result<ClaimData, DefenderError> {
         self.state
             .lock()
             .expect("fake execution mutex poisoned")
             .games_by_address
             .get(&game)
-            .map(|record| record.proof_bitmap)
+            .map(|record| ClaimData {
+                status: record.state.proposal_status(record.proof_bitmap != 0),
+                challenger: Address::ZERO,
+                deadline: record.proof_deadline,
+                proof_bitmap: record.proof_bitmap,
+                invalidation_reason: InvalidationReason::None,
+            })
             .ok_or_else(|| DefenderError::message(format!("unknown game {game}")))
     }
 
     async fn submit_proof(
         &self,
         game: Address,
-        lane: u8,
+        lane: ProofLane,
         proof: Bytes,
     ) -> Result<DefenderSubmission, DefenderError> {
-        let lane = proof_lane(lane).ok_or_else(|| DefenderError::message("invalid lane"))?;
         if proof.is_empty() {
             return Err(DefenderError::message("empty proof"));
         }
@@ -603,7 +629,10 @@ impl DefenderClient for FakeExecution {
             .games_by_address
             .get_mut(&game)
             .ok_or_else(|| DefenderError::message(format!("unknown game {game}")))?;
-        if record.state != STATE_PROPOSED && record.state != STATE_CHALLENGED {
+        if !matches!(
+            record.state,
+            GameLifecycle::Proposed | GameLifecycle::Challenged
+        ) {
             return Err(DefenderError::message(format!(
                 "game {game} is not open for proofs"
             )));

--- a/proofs/integration-tests/tests/orchestration.rs
+++ b/proofs/integration-tests/tests/orchestration.rs
@@ -8,12 +8,13 @@ use tokio_util::sync::CancellationToken;
 use world_chain_challenger::{ChallengerConfig, WorldChainChallenger};
 use world_chain_defender::{DefenderClient, DefenderConfig, WorldChainDefender};
 use world_chain_proof_integration_tests::{
-    BLOCK_INTERVAL, FakeConsensus, FakeExecution, FakeProofBackend, SharedProverService,
+    BLOCK_INTERVAL, FakeConsensus, FakeExecution, FakeProofBackend, GameLifecycle,
+    SharedProverService,
 };
 use world_chain_proof_worker::{
     ProofWorker, ProofWorkerConfig, RetryConfig, WorkerHeartbeatConfig,
 };
-use world_chain_proofs::{LineageProvider, ProofLane, RootState, has_threshold};
+use world_chain_proofs::{GameStatus, LineageProvider, ProofLane, has_threshold};
 use world_chain_proposer::{
     ProposerClient, ProposerConfig, ProposerError, ProposerScan, WorldChainProposer,
 };
@@ -86,19 +87,11 @@ async fn fake_resolution_matches_contract_transition_semantics() {
     chain.challenge_game(game);
 
     chain
-        .submit_proof(
-            game,
-            ProofLane::ValidityProof as u8,
-            Bytes::from_static(&[1]),
-        )
+        .submit_proof(game, ProofLane::ValidityProof, Bytes::from_static(&[1]))
         .await
         .expect("validity proof submitted");
     chain
-        .submit_proof(
-            game,
-            ProofLane::TeeAttestation as u8,
-            Bytes::from_static(&[1]),
-        )
+        .submit_proof(game, ProofLane::TeeAttestation, Bytes::from_static(&[1]))
         .await
         .expect("TEE proof submitted");
 
@@ -106,8 +99,8 @@ async fn fake_resolution_matches_contract_transition_semantics() {
         .await
         .expect("resolution status available");
     assert!(ready.resolvable);
-    assert_eq!(ready.root_state, RootState::Finalized);
-    assert_eq!(chain.game_state(game), RootState::Challenged);
+    assert_eq!(ready.outcome, GameStatus::DefenderWins);
+    assert_eq!(chain.game_state(game), Some(GameLifecycle::Challenged));
 
     settle_with_proposer(&proposer).await;
 
@@ -115,7 +108,7 @@ async fn fake_resolution_matches_contract_transition_semantics() {
         .await
         .expect("resolution status available");
     assert!(!finalized.resolvable);
-    assert_eq!(finalized.root_state, RootState::Finalized);
+    assert_eq!(finalized.outcome, GameStatus::DefenderWins);
     assert!(ProposerClient::resolve_game(&chain, game).await.is_err());
 }
 
@@ -242,7 +235,7 @@ async fn invalid_root_is_challenged_by_real_challenger() {
         .await
         .expect("challenger scan succeeds");
 
-    assert_eq!(chain.game_state(game), RootState::Challenged);
+    assert_eq!(chain.game_state(game), Some(GameLifecycle::Challenged));
     assert_eq!(chain.challenge_count(game), 1);
 }
 
@@ -279,7 +272,7 @@ async fn valid_proposal_receives_initial_tee_proof_through_worker() {
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
 
-    assert_eq!(chain.game_state(game), RootState::Proposed);
+    assert_eq!(chain.game_state(game), Some(GameLifecycle::Proposed));
     assert_eq!(chain.submitted_lanes(game), [ProofLane::TeeAttestation]);
 
     stop_proof_stack(stack).await;
@@ -320,12 +313,12 @@ async fn valid_challenged_root_is_defended_through_workers() {
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
 
-    assert_eq!(chain.game_state(game), RootState::Challenged);
+    assert_eq!(chain.game_state(game), Some(GameLifecycle::Challenged));
     assert_defense_lanes(chain.submitted_lanes(game));
 
     settle_with_proposer(&proposer).await;
 
-    assert_eq!(chain.game_state(game), RootState::Finalized);
+    assert_eq!(chain.game_state(game), Some(GameLifecycle::Finalized));
 
     stop_proof_stack(stack).await;
 }
@@ -370,12 +363,12 @@ async fn valid_challenged_root_survives_transient_proof_failure() {
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
 
-    assert_eq!(chain.game_state(game), RootState::Challenged);
+    assert_eq!(chain.game_state(game), Some(GameLifecycle::Challenged));
     assert_defense_lanes(chain.submitted_lanes(game));
 
     settle_with_proposer(&proposer).await;
 
-    assert_eq!(chain.game_state(game), RootState::Finalized);
+    assert_eq!(chain.game_state(game), Some(GameLifecycle::Finalized));
 
     stop_proof_stack(stack).await;
 }
@@ -417,7 +410,7 @@ async fn defender_ignores_challenged_invalid_root() {
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
 
-    assert_eq!(chain.game_state(game), RootState::Challenged);
+    assert_eq!(chain.game_state(game), Some(GameLifecycle::Challenged));
     assert_eq!(chain.proof_bitmap(game), 0);
     assert!(chain.submitted_lanes(game).is_empty());
 

--- a/proofs/primitives/src/bindings.rs
+++ b/proofs/primitives/src/bindings.rs
@@ -33,22 +33,19 @@ sol! {
     /// proof-lane extensions.
     #[sol(rpc)]
     interface IMultiProofGame {
-        event WorldChainGameCreated(
-            bytes32 indexed rootId,
-            address indexed parentRef,
-            bytes32 rootClaim,
-            uint256 l2BlockNumber,
-            bytes32 l1OriginHash,
-            uint256 l1OriginNumber,
-            uint256 attempt,
-            address gameCreator
-        );
         event Challenged(address indexed challenger, uint64 proofDeadline);
-        event ProofLaneSupported(uint8 indexed lane, bytes32 indexed rootId, uint8 proofBitmap);
-        event ProofThresholdReached(bytes32 indexed rootId, uint8 proofBitmap);
-        event DuplicateProofLane(uint8 indexed lane, bytes32 indexed rootId, uint8 proofBitmap);
+        event Proved(uint8 indexed lane, bytes32 indexed rootId, address recipient, uint8 proofBitmap);
         event GameClosed(uint8 bondDistributionMode);
         event Resolved(uint8 indexed status);
+
+        // Reverts reachable from `submitProofLane`. Declared so a failed submission can be
+        // classified instead of retried blindly.
+        error ClaimAlreadyResolved();
+        error InvalidParentGame();
+        error GameOver();
+        error InvalidLane(uint8 lane);
+        error InvalidProof(uint8 lane, bytes32 rootId);
+        error DuplicateProofLane(uint8 lane, bytes32 rootId, uint8 proofBitmap);
 
         // Deployment parameters (immutables on the implementation).
         function PROOF_THRESHOLD() external view returns (uint8);
@@ -85,13 +82,13 @@ sol! {
         function createdAt() external view returns (uint64);
         function resolvedAt() external view returns (uint64);
         function status() external view returns (uint8);
-        function state() external view returns (uint8);
         function claimData()
             external
             view
             returns (uint8 status, address challenger, uint64 deadline, uint8 proofBitmap, uint8 invalidationReason);
         function invalidationReason() external view returns (uint8);
         function proofBitmap() external view returns (uint8);
+        function laneRecipient(uint8 laneId) external view returns (address);
         function challenger() external view returns (address);
         function challengeDeadline() external view returns (uint64);
         function proofDeadline() external view returns (uint64);
@@ -103,7 +100,8 @@ sol! {
 
         // Mutating entry points.
         function challenge() external payable returns (uint8 proposalStatus);
-        function submitProofLane(uint8 laneId, bytes calldata proof) external returns (uint8 proposalStatus);
+        /// `proof` is the compact payload built by `encode_compact_proof`.
+        function submitProofLane(bytes calldata proof) external returns (uint8 proposalStatus);
         function resolve() external returns (uint8 status);
         function closeGame() external;
         function claimCredit(address recipient) external;

--- a/proofs/primitives/src/lib.rs
+++ b/proofs/primitives/src/lib.rs
@@ -21,8 +21,9 @@ pub use lineage::{
     select_lineage,
 };
 pub use types::{
-    InvalidationReason, InvalidationReasonError, MAX_ATTEMPT_SCAN, MULTI_PROOF_GAME_TYPE,
+    ClaimData, GameCreation, GameStatus, GameStatusError, InvalidationReason,
+    InvalidationReasonError, MAX_ATTEMPT_SCAN, MULTI_PROOF_GAME_TYPE, PROOF_HEADER_LENGTH,
     PROOF_LANE_COUNT, PROOF_SYSTEM_VERSION, PROOF_THRESHOLD, ProofDomain, ProofLane,
-    ProposalCommitment, ResolutionStatus, RootCommitment, RootState, RootStateError,
-    WorldChainGameCreated, has_threshold, proof_count,
+    ProposalCommitment, ProposalStatus, ProposalStatusError, ResolutionStatus, RootCommitment,
+    encode_compact_proof, has_threshold, proof_count,
 };

--- a/proofs/primitives/src/lineage.rs
+++ b/proofs/primitives/src/lineage.rs
@@ -1,7 +1,7 @@
 use crate::{
-    ConsensusError, ConsensusProvider, IAnchorStateRegistry, IDisputeGameFactory, IMultiProofGame,
-    InvalidationReasonError, MAX_ATTEMPT_SCAN, MULTI_PROOF_GAME_TYPE, ProposalCommitment,
-    ResolutionStatus, RootState, RootStateError,
+    ConsensusError, ConsensusProvider, GameStatus, GameStatusError, IAnchorStateRegistry,
+    IDisputeGameFactory, IMultiProofGame, InvalidationReasonError, MAX_ATTEMPT_SCAN,
+    MULTI_PROOF_GAME_TYPE, ProposalCommitment, ResolutionStatus,
 };
 use alloy_primitives::{Address, B256};
 use alloy_provider::Provider;
@@ -112,12 +112,10 @@ pub enum LineageError {
     },
     #[error("lineage block interval must be greater than zero")]
     ZeroBlockInterval,
-    #[error("selected game {0} has unset root state")]
-    UnsetGame(Address),
     #[error(transparent)]
     Consensus(#[from] ConsensusError),
     #[error(transparent)]
-    InvalidRootState(#[from] RootStateError),
+    InvalidGameStatus(#[from] GameStatusError),
     #[error(transparent)]
     InvalidInvalidationReason(#[from] InvalidationReasonError),
 }
@@ -191,7 +189,7 @@ where
             });
         };
         let status = execution.lineage_resolution_status(game.address).await?;
-        if status.root_state == RootState::Invalidated {
+        if status.outcome == GameStatus::ChallengerWins {
             return Ok(SelectedLineage {
                 anchor,
                 games,
@@ -202,10 +200,6 @@ where
                 },
             });
         }
-        if status.root_state == RootState::None {
-            return Err(LineageError::UnsetGame(game.address));
-        }
-
         games.push(SelectedLineageGame { transition, game });
         parent = LineageAnchor {
             address: game.address,
@@ -345,7 +339,7 @@ where
 
     Ok(ResolutionStatus {
         resolvable: result.resolvable,
-        root_state: result.outcome.try_into()?,
+        outcome: result.outcome.try_into()?,
         invalidation_reason: result.reason.try_into()?,
     })
 }

--- a/proofs/primitives/src/types.rs
+++ b/proofs/primitives/src/types.rs
@@ -21,9 +21,14 @@ pub const MULTI_PROOF_GAME_TYPE: u32 = 1006;
 /// Maximum number of sequential retry attempts probed for one transition.
 pub const MAX_ATTEMPT_SCAN: u64 = 64;
 
-/// The `MultiProofGame.WorldChainGameCreated` event.
+/// Byte length of the `submitProofLane` compact header.
+///
+/// Must match `LibProof.PROOF_HEADER_LENGTH`.
+pub const PROOF_HEADER_LENGTH: usize = 21;
+
+/// Proposal context fixed when a `MultiProofGame` is created.
 #[derive(Debug, Clone, Copy)]
-pub struct WorldChainGameCreated {
+pub struct GameCreation {
     pub root_id: B256,
     pub game: Address,
     pub game_creator: Address,
@@ -35,33 +40,81 @@ pub struct WorldChainGameCreated {
     pub attempt: u64,
 }
 
-/// A game root state.
+/// Stock OP Stack `GameStatus`, as returned by `status()` and `resolutionStatus().outcome`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RootState {
-    None,
-    Proposed,
-    Challenged,
-    Finalized,
-    Invalidated,
+#[repr(u8)]
+pub enum GameStatus {
+    InProgress = 0,
+    /// The root claim was successfully challenged.
+    ChallengerWins = 1,
+    /// The root claim could not be contested.
+    DefenderWins = 2,
 }
 
 #[derive(Debug, Error)]
-pub enum RootStateError {
-    #[error("Invalid root state: {0}")]
-    InvalieRootState(u8),
+pub enum GameStatusError {
+    #[error("Invalid game status: {0}")]
+    InvalidGameStatus(u8),
 }
 
-impl TryFrom<u8> for RootState {
-    type Error = RootStateError;
+impl TryFrom<u8> for GameStatus {
+    type Error = GameStatusError;
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
-            0 => Ok(RootState::None),
-            1 => Ok(RootState::Proposed),
-            2 => Ok(RootState::Challenged),
-            3 => Ok(RootState::Finalized),
-            4 => Ok(RootState::Invalidated),
-            _ => Err(RootStateError::InvalieRootState(value)),
+            0 => Ok(Self::InProgress),
+            1 => Ok(Self::ChallengerWins),
+            2 => Ok(Self::DefenderWins),
+            _ => Err(GameStatusError::InvalidGameStatus(value)),
+        }
+    }
+}
+
+/// `IMultiProofGame.ProposalStatus`, the per-proposal state machine behind `claimData`.
+///
+/// Distinct from [`GameStatus`]: it splits an in-progress game into challenged and unchallenged,
+/// which the game's `GameStatus` cannot express.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ProposalStatus {
+    Unchallenged = 0,
+    Challenged = 1,
+    UnchallengedAndValidProofProvided = 2,
+    ChallengedAndValidProofProvided = 3,
+    Resolved = 4,
+}
+
+impl ProposalStatus {
+    /// Whether a challenger can still dispute this proposal.
+    ///
+    /// A proven proposal stays challengeable until its window closes: an accepted lane only
+    /// finalizes an unchallenged root, so a challenge still forces the full threshold.
+    #[must_use]
+    pub const fn is_challengeable(self) -> bool {
+        matches!(
+            self,
+            Self::Unchallenged | Self::UnchallengedAndValidProofProvided
+        )
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ProposalStatusError {
+    #[error("Invalid proposal status: {0}")]
+    InvalidProposalStatus(u8),
+}
+
+impl TryFrom<u8> for ProposalStatus {
+    type Error = ProposalStatusError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Unchallenged),
+            1 => Ok(Self::Challenged),
+            2 => Ok(Self::UnchallengedAndValidProofProvided),
+            3 => Ok(Self::ChallengedAndValidProofProvided),
+            4 => Ok(Self::Resolved),
+            _ => Err(ProposalStatusError::InvalidProposalStatus(value)),
         }
     }
 }
@@ -205,6 +258,20 @@ impl ProofLane {
     }
 }
 
+/// Encodes the compact payload `MultiProofGame.submitProofLane` takes.
+///
+/// Mirrors `LibProof.decodeCompact`: lane id at byte 0, reward recipient at bytes 1..21, then
+/// the lane-specific bytes its verifier consumes. Packed, not ABI-encoded — a leading offset
+/// word would shift every field the assembly decoder reads.
+#[must_use]
+pub fn encode_compact_proof(lane: ProofLane, recipient: Address, proof: &[u8]) -> Bytes {
+    let mut encoded = Vec::with_capacity(PROOF_HEADER_LENGTH + proof.len());
+    encoded.push(lane as u8);
+    encoded.extend_from_slice(recipient.as_slice());
+    encoded.extend_from_slice(proof);
+    encoded.into()
+}
+
 /// Count distinct lanes in a proof bitmap.
 #[must_use]
 pub const fn proof_count(bitmap: u8) -> u8 {
@@ -251,37 +318,47 @@ impl TryFrom<u8> for InvalidationReason {
     }
 }
 
+/// Decoded `MultiProofGame.resolutionStatus()`: what a resolve call would do right now.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ResolutionStatus {
     pub resolvable: bool,
-    pub root_state: RootState,
+    /// The outcome a resolve call would produce, or the outcome already reached.
+    pub outcome: GameStatus,
     pub invalidation_reason: InvalidationReason,
 }
 
 impl ResolutionStatus {
-    /// Returns true whether this resolution status is positive resolvable:
-    /// - `resolvable` is true AND
-    /// - the expected root state outcome is `Finalized`.
+    /// Whether resolving now would uphold the root claim.
     pub fn positive_resolvable(&self) -> bool {
-        self.resolvable && self.root_state == RootState::Finalized
+        self.resolvable && self.outcome == GameStatus::DefenderWins
     }
 
     /// Returns whether the game can be resolved as invalid because its parent is invalid.
     pub fn invalid_parent_resolvable(&self) -> bool {
         self.resolvable
-            && self.root_state == RootState::Invalidated
+            && self.outcome == GameStatus::ChallengerWins
             && self.invalidation_reason == InvalidationReason::InvalidParent
     }
 
     /// Returns whether the game has already reached a terminal state.
     ///
-    /// The root state may describe the expected outcome of a game that is currently resolvable,
-    /// so a terminal root state is considered resolved only when `resolvable` is false.
+    /// `outcome` describes the expected result while a game is still resolvable, so a terminal
+    /// outcome only means resolved once `resolvable` is false.
     pub fn is_resolved(&self) -> bool {
-        !self.resolvable
-            && (self.root_state == RootState::Finalized
-                || self.root_state == RootState::Invalidated)
+        !self.resolvable && self.outcome != GameStatus::InProgress
     }
+}
+
+/// Decoded `MultiProofGame.claimData()`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClaimData {
+    pub status: ProposalStatus,
+    /// Zero when the proposal has not been disputed.
+    pub challenger: Address,
+    /// Challenge deadline while unchallenged, proof deadline once challenged.
+    pub deadline: u64,
+    pub proof_bitmap: u8,
+    pub invalidation_reason: InvalidationReason,
 }
 
 #[cfg(test)]
@@ -296,6 +373,93 @@ mod tests {
         assert_eq!(proof_count(bitmap), 2);
         assert!(has_threshold(bitmap));
         assert!(!has_threshold(ProofLane::TeeAttestation.mask()));
+    }
+
+    #[test]
+    fn game_status_matches_op_stack_ordering() {
+        // `resolutionStatus().outcome` and `status()` are OP Stack `GameStatus`, not a
+        // proposal-level state: decoding them with any other ordering silently mislabels
+        // every game.
+        assert_eq!(GameStatus::try_from(0).unwrap(), GameStatus::InProgress);
+        assert_eq!(GameStatus::try_from(1).unwrap(), GameStatus::ChallengerWins);
+        assert_eq!(GameStatus::try_from(2).unwrap(), GameStatus::DefenderWins);
+        assert!(GameStatus::try_from(3).is_err());
+    }
+
+    #[test]
+    fn proposal_status_matches_contract_ordering() {
+        // Mirrors `IMultiProofGame.ProposalStatus`.
+        assert_eq!(
+            ProposalStatus::try_from(0).unwrap(),
+            ProposalStatus::Unchallenged
+        );
+        assert_eq!(
+            ProposalStatus::try_from(1).unwrap(),
+            ProposalStatus::Challenged
+        );
+        assert_eq!(
+            ProposalStatus::try_from(2).unwrap(),
+            ProposalStatus::UnchallengedAndValidProofProvided
+        );
+        assert_eq!(
+            ProposalStatus::try_from(3).unwrap(),
+            ProposalStatus::ChallengedAndValidProofProvided
+        );
+        assert_eq!(
+            ProposalStatus::try_from(4).unwrap(),
+            ProposalStatus::Resolved
+        );
+        assert!(ProposalStatus::try_from(5).is_err());
+
+        // A challenger may still dispute a proposal that already carries one lane.
+        assert!(ProposalStatus::UnchallengedAndValidProofProvided.is_challengeable());
+        assert!(!ProposalStatus::Challenged.is_challengeable());
+    }
+
+    #[test]
+    fn resolution_status_reads_outcomes_not_proposal_states() {
+        let finalized = ResolutionStatus {
+            resolvable: true,
+            outcome: GameStatus::DefenderWins,
+            invalidation_reason: InvalidationReason::None,
+        };
+        assert!(finalized.positive_resolvable());
+        assert!(!finalized.is_resolved());
+
+        let live = ResolutionStatus {
+            resolvable: false,
+            outcome: GameStatus::InProgress,
+            invalidation_reason: InvalidationReason::None,
+        };
+        assert!(!live.positive_resolvable());
+        assert!(!live.is_resolved());
+
+        let bad_parent = ResolutionStatus {
+            resolvable: true,
+            outcome: GameStatus::ChallengerWins,
+            invalidation_reason: InvalidationReason::InvalidParent,
+        };
+        assert!(bad_parent.invalid_parent_resolvable());
+    }
+
+    #[test]
+    fn compact_proof_matches_lib_proof_header_layout() {
+        let recipient = address!("00000000000000000000000000000000000000aa");
+        let encoded = encode_compact_proof(ProofLane::TeeAttestation, recipient, &[0xbb, 0xcc]);
+
+        // `LibProof.decodeCompact` reads the lane id from byte 0 and the recipient from the
+        // next 20 bytes with no padding; an ABI encoding would offset both.
+        assert_eq!(encoded[0], ProofLane::TeeAttestation as u8);
+        assert_eq!(&encoded[1..PROOF_HEADER_LENGTH], recipient.as_slice());
+        assert_eq!(&encoded[PROOF_HEADER_LENGTH..], &[0xbb, 0xcc]);
+    }
+
+    #[test]
+    fn empty_lane_proof_still_carries_a_full_header() {
+        // `submitProofLane` rejects anything shorter than the header before decoding it.
+        let encoded = encode_compact_proof(ProofLane::ValidityProof, Address::ZERO, &[]);
+
+        assert_eq!(encoded.len(), PROOF_HEADER_LENGTH);
     }
 
     #[test]

--- a/proofs/services/challenger/src/alloy.rs
+++ b/proofs/services/challenger/src/alloy.rs
@@ -13,7 +13,7 @@ use alloy_rpc_types_eth::BlockId;
 use async_trait::async_trait;
 use world_chain_proofs::{
     IAnchorStateRegistry, IDelayedWETH, IDisputeGameFactory, IMultiProofGame,
-    MULTI_PROOF_GAME_TYPE, ResolutionStatus, RootState,
+    MULTI_PROOF_GAME_TYPE, ProposalStatus, ResolutionStatus,
 };
 
 /// Alloy-backed implementation of the challenger contract clients.
@@ -78,7 +78,7 @@ where
         let result = self.game(address).resolutionStatus().call().await?;
         Ok(ResolutionStatus {
             resolvable: result.resolvable,
-            root_state: result.outcome.try_into()?,
+            outcome: result.outcome.try_into()?,
             invalidation_reason: result.reason.try_into()?,
         })
     }
@@ -146,9 +146,9 @@ where
         })
     }
 
-    async fn root_state(&self, address: Address) -> Result<RootState, ChallengerError> {
-        let raw = self.game(address).state().call().await?;
-        raw.try_into().map_err(Into::into)
+    async fn proposal_status(&self, address: Address) -> Result<ProposalStatus, ChallengerError> {
+        let claim = self.game(address).claimData().call().await?;
+        claim.status.try_into().map_err(Into::into)
     }
 
     async fn challenge_deadline(&self, address: Address) -> Result<u64, ChallengerError> {

--- a/proofs/services/challenger/src/challenger.rs
+++ b/proofs/services/challenger/src/challenger.rs
@@ -11,7 +11,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 use tracing::{info, warn};
-use world_chain_proofs::{ConsensusProvider, RootState};
+use world_chain_proofs::ConsensusProvider;
 
 /// World Chain output-root challenger.
 #[derive(Debug)]
@@ -124,15 +124,15 @@ where
         now: u64,
     ) -> Result<GameScanOutcome, GameScanError> {
         let address = game.address;
-        let root_state = self
+        let proposal_status = self
             .execution_provider
-            .root_state(address)
+            .proposal_status(address)
             .await
             .map_err(|error| GameScanError {
                 error: Box::new(error),
                 challenge_deadline: None,
             })?;
-        if root_state != RootState::Proposed {
+        if !proposal_status.is_challengeable() {
             return Ok(GameScanOutcome::Skip);
         }
 

--- a/proofs/services/challenger/src/challenger.rs
+++ b/proofs/services/challenger/src/challenger.rs
@@ -129,7 +129,7 @@ where
             .root_state(address)
             .await
             .map_err(|error| GameScanError {
-                error,
+                error: Box::new(error),
                 challenge_deadline: None,
             })?;
         if root_state != RootState::Proposed {
@@ -141,7 +141,7 @@ where
             .challenge_deadline(address)
             .await
             .map_err(|error| GameScanError {
-                error,
+                error: Box::new(error),
                 challenge_deadline: None,
             })?;
         if now >= challenge_deadline {
@@ -150,11 +150,11 @@ where
 
         if game.l2_block_number > latest_finalized_l2_block {
             return Err(GameScanError {
-                error: ChallengerError::L2BlockNotFinalized {
+                error: Box::new(ChallengerError::L2BlockNotFinalized {
                     game: address,
                     latest_finalized: latest_finalized_l2_block,
                     given_block: game.l2_block_number,
-                },
+                }),
                 challenge_deadline: Some(challenge_deadline),
             });
         }
@@ -169,7 +169,7 @@ where
             }
             Ok(_root) => Ok(GameScanOutcome::Valid),
             Err(error) => Err(GameScanError {
-                error: ChallengerError::OutputRoot(error),
+                error: Box::new(ChallengerError::OutputRoot(error)),
                 challenge_deadline: Some(challenge_deadline),
             }),
         }

--- a/proofs/services/challenger/src/error.rs
+++ b/proofs/services/challenger/src/error.rs
@@ -71,6 +71,7 @@ impl ChallengerError {
 /// Error returned while processing a single game.
 #[derive(Debug)]
 pub(crate) struct GameScanError {
-    pub error: ChallengerError,
+    /// Boxed to keep `Result<_, GameScanError>` small (`clippy::result_large_err`).
+    pub error: Box<ChallengerError>,
     pub challenge_deadline: Option<u64>,
 }

--- a/proofs/services/challenger/src/error.rs
+++ b/proofs/services/challenger/src/error.rs
@@ -2,7 +2,9 @@ use alloy_primitives::{Address, TxHash};
 use alloy_provider::{PendingTransactionError, transport::RpcError};
 use alloy_transport::TransportErrorKind;
 use thiserror::Error;
-use world_chain_proofs::{ConsensusError, InvalidationReasonError, RootStateError};
+use world_chain_proofs::{
+    ConsensusError, GameStatusError, InvalidationReasonError, ProposalStatusError,
+};
 
 /// Errors returned by the challenger and its lifecycle managers.
 #[derive(Debug, Error)]
@@ -26,7 +28,9 @@ pub enum ChallengerError {
     #[error("The challenge transaction didn't execute succesfully: {0}")]
     Revert(TxHash),
     #[error(transparent)]
-    InvalidRootState(#[from] RootStateError),
+    InvalidGameStatus(#[from] GameStatusError),
+    #[error(transparent)]
+    InvalidProposalStatus(#[from] ProposalStatusError),
     #[error(transparent)]
     NotExistingInvalidReason(#[from] InvalidationReasonError),
     #[error(transparent)]

--- a/proofs/services/challenger/src/resolution_manager.rs
+++ b/proofs/services/challenger/src/resolution_manager.rs
@@ -1,5 +1,5 @@
 use tracing::{info, warn};
-use world_chain_proofs::{InvalidationReason, RootState};
+use world_chain_proofs::{GameStatus, InvalidationReason};
 
 use crate::{ChallengerError, OwnedGames, ResolutionManagerClient, ResolutionManagerConfig};
 
@@ -54,12 +54,12 @@ where
                 if !status.resolvable {
                     return Ok(());
                 }
-                if status.root_state != RootState::Invalidated
+                if status.outcome != GameStatus::ChallengerWins
                     || status.invalidation_reason != InvalidationReason::ProofTimeout
                 {
                     warn!(
                         game_address = %game,
-                        outcome = ?status.root_state,
+                        outcome = ?status.outcome,
                         invalidation_reason = ?status.invalidation_reason,
                         "challenger-owned invalid game has an unexpected resolvable outcome"
                     );
@@ -69,7 +69,7 @@ where
                 info!(
                     game_address = %game,
                     tx_hash = ?submission.tx_hash,
-                    outcome = ?status.root_state,
+                    outcome = ?status.outcome,
                     invalidation_reason = ?status.invalidation_reason,
                     "resolved challenger-owned game"
                 );

--- a/proofs/services/challenger/src/tests.rs
+++ b/proofs/services/challenger/src/tests.rs
@@ -15,7 +15,8 @@ use std::{
     time::Duration,
 };
 use world_chain_proofs::{
-    ConsensusError, ConsensusProvider, InvalidationReason, ResolutionStatus, RootState,
+    ConsensusError, ConsensusProvider, GameStatus, InvalidationReason, ProposalStatus,
+    ResolutionStatus,
 };
 
 const CHALLENGER: Address = address!("00000000000000000000000000000000000000cc");
@@ -24,21 +25,17 @@ const GAME_2: Address = address!("0000000000000000000000000000000000000002");
 const GAME_3: Address = address!("0000000000000000000000000000000000000003");
 const L2_BLOCK: u64 = 100;
 
-const STATE_PROPOSED: u8 = 1;
-const STATE_CHALLENGED: u8 = 2;
-const STATE_FINALIZED: u8 = 3;
-const STATE_INVALIDATED: u8 = 4;
 const REASON_NONE: u8 = 0;
 const REASON_PROOF_TIMEOUT: u8 = 1;
 
 #[derive(Debug, Clone, Copy)]
 struct MockGame {
     metadata: GameMetadata,
-    state: u8,
+    proposal_status: ProposalStatus,
     challenge_deadline: u64,
     challenger: Address,
     resolvable: bool,
-    resolution_outcome: u8,
+    resolution_outcome: GameStatus,
     resolution_reason: u8,
     credit: U256,
     pending: PendingWithdrawal,
@@ -54,11 +51,11 @@ impl MockGame {
                 root_claim,
                 l2_block_number,
             },
-            state: STATE_PROPOSED,
+            proposal_status: ProposalStatus::Unchallenged,
             challenge_deadline: u64::MAX,
             challenger: Address::ZERO,
             resolvable: false,
-            resolution_outcome: STATE_PROPOSED,
+            resolution_outcome: GameStatus::InProgress,
             resolution_reason: REASON_NONE,
             credit: U256::ZERO,
             pending: PendingWithdrawal {
@@ -149,15 +146,14 @@ impl ChallengerClient for MockClient {
             .ok_or_else(|| ChallengerError::message(format!("unknown game {game}")))
     }
 
-    async fn root_state(&self, game: Address) -> Result<RootState, ChallengerError> {
-        let raw = self
+    async fn proposal_status(&self, game: Address) -> Result<ProposalStatus, ChallengerError> {
+        Ok(self
             .state
             .lock()
             .expect("not poisoned")
             .games
             .get(&game)
-            .map_or(0, |game| game.state);
-        RootState::try_from(raw).map_err(Into::into)
+            .map_or(ProposalStatus::Resolved, |game| game.proposal_status))
     }
 
     async fn challenge_deadline(&self, game: Address) -> Result<u64, ChallengerError> {
@@ -179,9 +175,9 @@ impl ChallengerClient for MockClient {
             .games
             .get_mut(&game)
             .ok_or_else(|| ChallengerError::message(format!("unknown game {game}")))?;
-        record.state = STATE_CHALLENGED;
+        record.proposal_status = ProposalStatus::Challenged;
         record.challenger = CHALLENGER;
-        record.resolution_outcome = STATE_CHALLENGED;
+        record.resolution_outcome = GameStatus::InProgress;
         state.challenges.push(game);
         Ok(ChallengeSubmission {
             tx_hash: B256::with_last_byte(state.challenges.len() as u8),
@@ -203,7 +199,7 @@ impl ResolutionManagerClient for MockClient {
             .ok_or_else(|| ChallengerError::message(format!("unknown game {game}")))?;
         Ok(ResolutionStatus {
             resolvable: record.resolvable,
-            root_state: RootState::try_from(record.resolution_outcome)?,
+            outcome: record.resolution_outcome,
             invalidation_reason: InvalidationReason::try_from(record.resolution_reason)?,
         })
     }
@@ -214,7 +210,7 @@ impl ResolutionManagerClient for MockClient {
             .games
             .get_mut(&game)
             .ok_or_else(|| ChallengerError::message(format!("unknown game {game}")))?;
-        record.state = record.resolution_outcome;
+        record.proposal_status = ProposalStatus::Resolved;
         record.resolvable = false;
         state.resolutions.push(game);
         Ok(ResolveSubmission {
@@ -472,7 +468,7 @@ async fn tick_rechecks_lookback_without_reducing_forward_progress() {
         .games
         .get_mut(&GAME_2)
         .expect("game exists")
-        .state = STATE_PROPOSED;
+        .proposal_status = ProposalStatus::Unchallenged;
 
     challenger.tick_at(1).await.unwrap();
 
@@ -485,7 +481,7 @@ async fn tick_leaves_valid_and_non_proposed_games() {
     let canonical_root = B256::repeat_byte(0x20);
     let valid = MockGame::proposed(GAME_1, canonical_root, L2_BLOCK);
     let mut challenged = MockGame::proposed(GAME_2, B256::repeat_byte(0x10), L2_BLOCK);
-    challenged.state = STATE_CHALLENGED;
+    challenged.proposal_status = ProposalStatus::Challenged;
     let client = MockClient::new(vec![valid, challenged]);
     let (output_roots, _) =
         mock_output_roots(HashMap::from([(L2_BLOCK, canonical_root)]), L2_BLOCK);
@@ -520,9 +516,9 @@ async fn retry_game_is_challenged_after_l2_finalizes() {
 #[tokio::test]
 async fn resolution_manager_obeys_transaction_budget() {
     let mut first = MockGame::proposed(GAME_1, B256::ZERO, L2_BLOCK);
-    first.state = STATE_CHALLENGED;
+    first.proposal_status = ProposalStatus::Challenged;
     first.resolvable = true;
-    first.resolution_outcome = STATE_INVALIDATED;
+    first.resolution_outcome = GameStatus::ChallengerWins;
     first.resolution_reason = REASON_PROOF_TIMEOUT;
     let mut second = first;
     second.metadata.address = GAME_2;
@@ -597,17 +593,17 @@ async fn bond_manager_scans_games_appended_after_recovery() {
 #[tokio::test]
 async fn bond_manager_completes_two_phase_claim_and_prunes_terminal_games() {
     let mut claimable = MockGame::proposed(GAME_1, B256::ZERO, L2_BLOCK);
-    claimable.state = STATE_INVALIDATED;
-    claimable.resolution_outcome = STATE_INVALIDATED;
+    claimable.proposal_status = ProposalStatus::Resolved;
+    claimable.resolution_outcome = GameStatus::ChallengerWins;
     claimable.resolution_reason = REASON_PROOF_TIMEOUT;
     claimable.credit = U256::from(10);
     let mut zero_credit = MockGame::proposed(GAME_2, B256::ZERO, L2_BLOCK);
-    zero_credit.state = STATE_FINALIZED;
-    zero_credit.resolution_outcome = STATE_FINALIZED;
+    zero_credit.proposal_status = ProposalStatus::Resolved;
+    zero_credit.resolution_outcome = GameStatus::DefenderWins;
     // Resolved but still inside the registry's finality airgap: `closeGame` would revert.
     let mut awaiting_airgap = MockGame::proposed(GAME_3, B256::ZERO, L2_BLOCK);
-    awaiting_airgap.state = STATE_FINALIZED;
-    awaiting_airgap.resolution_outcome = STATE_FINALIZED;
+    awaiting_airgap.proposal_status = ProposalStatus::Resolved;
+    awaiting_airgap.resolution_outcome = GameStatus::DefenderWins;
     awaiting_airgap.credit = U256::from(5);
     awaiting_airgap.finalized = false;
     let client = MockClient::new(vec![claimable, zero_credit, awaiting_airgap]);
@@ -645,8 +641,8 @@ async fn bond_manager_completes_two_phase_claim_and_prunes_terminal_games() {
 #[tokio::test]
 async fn bond_manager_retries_failed_claim() {
     let mut game = MockGame::proposed(GAME_1, B256::ZERO, L2_BLOCK);
-    game.state = STATE_INVALIDATED;
-    game.resolution_outcome = STATE_INVALIDATED;
+    game.proposal_status = ProposalStatus::Resolved;
+    game.resolution_outcome = GameStatus::ChallengerWins;
     game.resolution_reason = REASON_PROOF_TIMEOUT;
     game.credit = U256::from(10);
     let client = MockClient::new(vec![game]);
@@ -678,8 +674,8 @@ async fn bond_manager_retries_failed_claim() {
 #[tokio::test]
 async fn bond_manager_uses_l1_timestamp_for_delayed_withdrawal() {
     let mut game = MockGame::proposed(GAME_1, B256::ZERO, L2_BLOCK);
-    game.state = STATE_FINALIZED;
-    game.resolution_outcome = STATE_FINALIZED;
+    game.proposal_status = ProposalStatus::Resolved;
+    game.resolution_outcome = GameStatus::DefenderWins;
     game.pending = PendingWithdrawal {
         amount: U256::from(10),
         unlock_at: 100,

--- a/proofs/services/challenger/src/traits.rs
+++ b/proofs/services/challenger/src/traits.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use alloy_primitives::{Address, U256};
 use async_trait::async_trait;
-use world_chain_proofs::{ResolutionStatus, RootState};
+use world_chain_proofs::{ProposalStatus, ResolutionStatus};
 
 /// Contract surface needed by the output-root challenger.
 #[async_trait]
@@ -19,8 +19,8 @@ pub trait ChallengerClient: Send + Sync {
     async fn game_address_at(&self, index: u64) -> Result<Option<Address>, ChallengerError>;
     /// Reads the immutable game data needed to validate its root claim.
     async fn game_metadata(&self, game: Address) -> Result<GameMetadata, ChallengerError>;
-    /// Reads the root state of the provided game.
-    async fn root_state(&self, game: Address) -> Result<RootState, ChallengerError>;
+    /// Reads the proposal state machine of the provided game.
+    async fn proposal_status(&self, game: Address) -> Result<ProposalStatus, ChallengerError>;
     /// Reads the challenge deadline of the provided game.
     async fn challenge_deadline(&self, game: Address) -> Result<u64, ChallengerError>;
     /// Submits a challenge against an invalid game, bonded with that game's own

--- a/proofs/services/defender/src/alloy.rs
+++ b/proofs/services/defender/src/alloy.rs
@@ -5,12 +5,13 @@ use crate::{
 };
 use alloy_primitives::{Address, Bytes, U256};
 use alloy_provider::Provider;
+use alloy_sol_types::SolInterface;
 use async_trait::async_trait;
 use world_chain_proofs::{
-    IAnchorStateRegistry, IDisputeGameFactory, IMultiProofGame, LineageAnchor, LineageError,
-    LineageGame, LineageProvider, LineageTransition, PROOF_LANE_COUNT, RegisteredLineageConfig,
-    ResolutionStatus, read_game_for_transition, read_lineage_anchor,
-    read_lineage_resolution_status, read_registered_lineage_config,
+    ClaimData, IAnchorStateRegistry, IDisputeGameFactory, IMultiProofGame, LineageAnchor,
+    LineageError, LineageGame, LineageProvider, LineageTransition, PROOF_LANE_COUNT, ProofLane,
+    RegisteredLineageConfig, ResolutionStatus, encode_compact_proof, read_game_for_transition,
+    read_lineage_anchor, read_lineage_resolution_status, read_registered_lineage_config,
 };
 
 /// Alloy-backed implementation of [`DefenderClient`].
@@ -23,6 +24,8 @@ pub struct AlloyDefenderClient<P> {
     anchor: IAnchorStateRegistry::IAnchorStateRegistryInstance<P>,
     registered: RegisteredLineageConfig,
     confirmations: u64,
+    /// Credited this lane's share of a forfeited challenger bond when the game resolves.
+    reward_recipient: Address,
     provider: P,
 }
 
@@ -35,6 +38,7 @@ where
         provider: P,
         factory_address: Address,
         confirmations: u64,
+        reward_recipient: Address,
     ) -> Result<Self, DefenderError> {
         let factory = IDisputeGameFactory::IDisputeGameFactoryInstance::new(
             factory_address,
@@ -51,6 +55,7 @@ where
             anchor,
             registered,
             confirmations,
+            reward_recipient,
             provider,
         })
     }
@@ -140,21 +145,36 @@ where
         })
     }
 
-    async fn proof_bitmap(&self, address: Address) -> Result<u8, DefenderError> {
-        self.game(address)
-            .proofBitmap()
-            .call()
-            .await
-            .map_err(Into::into)
+    async fn claim_data(&self, address: Address) -> Result<ClaimData, DefenderError> {
+        let claim = self.game(address).claimData().call().await?;
+        Ok(ClaimData {
+            status: claim.status.try_into()?,
+            challenger: claim.challenger,
+            deadline: claim.deadline,
+            proof_bitmap: claim.proofBitmap,
+            invalidation_reason: claim.invalidationReason.try_into()?,
+        })
     }
 
     async fn submit_proof(
         &self,
         game: Address,
-        lane: u8,
+        lane: ProofLane,
         proof: Bytes,
     ) -> Result<DefenderSubmission, DefenderError> {
-        let pending = self.game(game).submitProofLane(lane, proof).send().await?;
+        let compact = encode_compact_proof(lane, self.reward_recipient, &proof);
+        let pending = self
+            .game(game)
+            .submitProofLane(compact)
+            .send()
+            .await
+            .map_err(|error| {
+                if is_duplicate_lane(&error) {
+                    DefenderError::LaneAlreadyProven { game, lane }
+                } else {
+                    error.into()
+                }
+            })?;
         let tx_hash = *pending.tx_hash();
         let receipt = pending
             .with_required_confirmations(self.confirmations)
@@ -170,4 +190,19 @@ where
 
 fn u256_to_u64(value: U256) -> Result<u64, DefenderError> {
     value.try_into().map_err(|_| DefenderError::Overflow)
+}
+
+/// Whether the game rejected the submission because the lane already counts toward its threshold.
+///
+/// `submitProofLane` reverts on a duplicate lane rather than no-opping, so a racing prover or a
+/// retry of a submission that actually landed surfaces here instead of succeeding.
+fn is_duplicate_lane(error: &alloy_contract::Error) -> bool {
+    error.as_revert_data().is_some_and(|data| {
+        matches!(
+            IMultiProofGame::IMultiProofGameErrors::abi_decode(&data),
+            Ok(IMultiProofGame::IMultiProofGameErrors::DuplicateProofLane(
+                _
+            ))
+        )
+    })
 }

--- a/proofs/services/defender/src/error.rs
+++ b/proofs/services/defender/src/error.rs
@@ -2,7 +2,7 @@ use alloy_primitives::{Address, TxHash};
 use alloy_provider::{MulticallError, PendingTransactionError, transport::RpcError};
 use alloy_transport::TransportErrorKind;
 use thiserror::Error;
-use world_chain_proofs::LineageError;
+use world_chain_proofs::{InvalidationReasonError, LineageError, ProofLane, ProposalStatusError};
 
 /// Errors returned by the defender.
 #[derive(Debug, Error)]
@@ -27,8 +27,15 @@ pub enum DefenderError {
     ProofEncoding(String),
     #[error(transparent)]
     Lineage(#[from] LineageError),
+    #[error(transparent)]
+    InvalidProposalStatus(#[from] ProposalStatusError),
+    #[error(transparent)]
+    InvalidInvalidationReason(#[from] InvalidationReasonError),
     #[error("The submitProofLane transaction didn't execute succesfully: {0}")]
     Revert(TxHash),
+    /// The game rejected the submission because the lane already counts toward its threshold.
+    #[error("lane {lane:?} already proven for game {game}")]
+    LaneAlreadyProven { game: Address, lane: ProofLane },
     #[error("Overflow error.")]
     Overflow,
     #[error("Invalid proof threshold {proof_threshold} for game {game}")]

--- a/proofs/services/defender/src/game.rs
+++ b/proofs/services/defender/src/game.rs
@@ -1,5 +1,5 @@
 use crate::{error::DefenderError, traits::DefenderClient, types::GameMetadata};
-use world_chain_proofs::{InvalidationReason, RootState, proof_count};
+use world_chain_proofs::{GameStatus, InvalidationReason, ProposalStatus, proof_count};
 
 /// On-chain state relevant to proof support for one selected game.
 #[derive(Debug, PartialEq, Eq)]
@@ -39,26 +39,38 @@ where
             .execution_client
             .lineage_resolution_status(game.address)
             .await?;
-        Ok(match status.root_state {
-            RootState::Proposed => {
-                let proof_bitmap = self.execution_client.proof_bitmap(game.address).await?;
+        // A resolvable game reports the outcome a resolve call would produce, so a proof that
+        // already landed shows up here before anyone resolves it.
+        match status.outcome {
+            GameStatus::DefenderWins => return Ok(GameObservation::Finalized),
+            GameStatus::ChallengerWins => {
+                return Ok(GameObservation::Invalidated {
+                    reason: status.invalidation_reason,
+                });
+            }
+            GameStatus::InProgress => {}
+        }
+
+        // `GameStatus` cannot distinguish a challenged proposal from an unchallenged one; only
+        // the proposal state machine can, and it carries the lane bitmap in the same slot.
+        let claim = self.execution_client.claim_data(game.address).await?;
+        let proof_bitmap = claim.proof_bitmap;
+        Ok(match claim.status {
+            ProposalStatus::Unchallenged | ProposalStatus::UnchallengedAndValidProofProvided => {
                 GameObservation::Proposed {
                     proof_bitmap,
                     has_initial_support: proof_bitmap != 0,
                 }
             }
-            RootState::Challenged => {
-                let proof_bitmap = self.execution_client.proof_bitmap(game.address).await?;
+            ProposalStatus::Challenged | ProposalStatus::ChallengedAndValidProofProvided => {
                 GameObservation::Challenged {
                     proof_bitmap,
                     has_required_support: proof_count(proof_bitmap) >= game.proof_threshold,
                 }
             }
-            RootState::Finalized => GameObservation::Finalized,
-            RootState::Invalidated => GameObservation::Invalidated {
-                reason: status.invalidation_reason,
-            },
-            RootState::None => GameObservation::Unset,
+            // The game sets `Resolved` and its `GameStatus` in the same call, so this is only
+            // reachable if the two ever diverge.
+            ProposalStatus::Resolved => GameObservation::Unset,
         })
     }
 

--- a/proofs/services/defender/src/lane.rs
+++ b/proofs/services/defender/src/lane.rs
@@ -173,7 +173,7 @@ where
             .execution_client
             .submit_proof(
                 game,
-                lane as u8,
+                lane,
                 match encode_proof(metadata, &response.proof) {
                     Ok(proof) => proof,
                     Err(error) => {
@@ -193,6 +193,17 @@ where
                     ?lane,
                     tx_hash = %submission.tx_hash,
                     "proof lane submitted"
+                );
+                LaneState::Proven
+            }
+            Err(DefenderError::LaneAlreadyProven { .. }) => {
+                info!(
+                    lifecycle_event = "proof_lane_submitted",
+                    outcome = "already_proven",
+                    game_address = %game,
+                    proof_id = %id,
+                    ?lane,
+                    "lane already counts toward the game threshold"
                 );
                 LaneState::Proven
             }

--- a/proofs/services/defender/src/main.rs
+++ b/proofs/services/defender/src/main.rs
@@ -51,6 +51,11 @@ struct Cli {
     #[arg(long, env = "DEFENDER_KEY", hide_env_values = true)]
     defender_key: PrivateKeySigner,
 
+    /// Address credited each submitted lane's share of a forfeited challenger bond.
+    /// Defaults to the defender signer.
+    #[arg(long, env = "PROOF_REWARD_RECIPIENT")]
+    proof_reward_recipient: Option<Address>,
+
     /// Seconds between selected-lineage scans.
     #[arg(long, env = "POLL_INTERVAL_SECONDS", default_value_t = 12)]
     poll_interval_seconds: u64,
@@ -88,6 +93,7 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     let defender_address = cli.defender_key.address();
+    let reward_recipient = cli.proof_reward_recipient.unwrap_or(defender_address);
     let l1_rpc_url = Url::parse(&cli.l1_rpc).context("invalid L1 RPC URL")?;
     let l1_rpc_client = world_chain_proof_metrics::metered_http_client(
         l1_rpc_url,
@@ -100,9 +106,14 @@ async fn main() -> Result<()> {
         .connect_client(l1_rpc_client);
     world_chain_proof_metrics::refresh_wallet_balance(&provider, defender_address).await;
 
-    let client = AlloyDefenderClient::new(provider, cli.factory_address, cli.l1_tx_confirmations)
-        .await
-        .context("failed to connect defender to the registered proof system")?;
+    let client = AlloyDefenderClient::new(
+        provider,
+        cli.factory_address,
+        cli.l1_tx_confirmations,
+        reward_recipient,
+    )
+    .await
+    .context("failed to connect defender to the registered proof system")?;
     let output_roots = VerifyingConsensusProvider::new(
         OptimismConsensusClient::new(cli.output_root_rpc.clone()),
         cli.verifying_output_root_rpc
@@ -124,6 +135,7 @@ async fn main() -> Result<()> {
         prover_service = %cli.prover_service_url,
         dispute_game_factory = %cli.factory_address,
         defender = %defender_address,
+        reward_recipient = %reward_recipient,
         l1_tx_confirmations = cli.l1_tx_confirmations,
         l1_rpc_timeout_seconds = cli.l1_rpc_timeout_seconds,
         "starting World Chain proof-system defender"

--- a/proofs/services/defender/src/tests.rs
+++ b/proofs/services/defender/src/tests.rs
@@ -18,9 +18,9 @@ use std::{
 };
 use world_chain_proof_core::boot::TransitionPublicValues;
 use world_chain_proofs::{
-    ConsensusError, ConsensusProvider, InvalidationReason, LineageAnchor, LineageError,
-    LineageGame, LineageProvider, LineageTransition, MAX_ATTEMPT_SCAN, PROOF_THRESHOLD, ProofLane,
-    ProposalCommitment, ResolutionStatus, RootState, proof_count,
+    ClaimData, ConsensusError, ConsensusProvider, GameStatus, InvalidationReason, LineageAnchor,
+    LineageError, LineageGame, LineageProvider, LineageTransition, MAX_ATTEMPT_SCAN,
+    PROOF_THRESHOLD, ProofLane, ProposalCommitment, ProposalStatus, ResolutionStatus, proof_count,
 };
 use world_chain_prover_service::{
     ProofBackend, ProofData, ProofRequest, ProofRequestError, ProofRequestId, ProofRequester,
@@ -36,10 +36,40 @@ const L2_BLOCK: u64 = 100;
 const L1_ORIGIN_HASH: B256 = B256::repeat_byte(0x42);
 const DOMAIN_HASH: B256 = B256::repeat_byte(0x43);
 
+/// Fake game lifecycle. The contract splits this across `ProposalStatus` (challenged or not)
+/// and `GameStatus` (the terminal outcome); the fake keeps one field and derives both.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GameLifecycle {
+    Proposed,
+    Challenged,
+    Finalized,
+    Invalidated,
+}
+
+impl GameLifecycle {
+    const fn outcome(self) -> GameStatus {
+        match self {
+            Self::Proposed | Self::Challenged => GameStatus::InProgress,
+            Self::Finalized => GameStatus::DefenderWins,
+            Self::Invalidated => GameStatus::ChallengerWins,
+        }
+    }
+
+    const fn proposal_status(self, proven: bool) -> ProposalStatus {
+        match self {
+            Self::Proposed if proven => ProposalStatus::UnchallengedAndValidProofProvided,
+            Self::Proposed => ProposalStatus::Unchallenged,
+            Self::Challenged if proven => ProposalStatus::ChallengedAndValidProofProvided,
+            Self::Challenged => ProposalStatus::Challenged,
+            Self::Finalized | Self::Invalidated => ProposalStatus::Resolved,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 struct GameRecord {
     metadata: GameMetadata,
-    state: RootState,
+    state: GameLifecycle,
     invalidation_reason: InvalidationReason,
     proof_bitmap: u8,
 }
@@ -49,7 +79,7 @@ struct MockState {
     anchor: LineageAnchor,
     games_by_uuid: HashMap<B256, Address>,
     games: HashMap<Address, GameRecord>,
-    submissions: Vec<(Address, u8)>,
+    submissions: Vec<(Address, ProofLane)>,
 }
 
 #[derive(Debug, Clone)]
@@ -79,7 +109,7 @@ impl MockClient {
         root_claim: B256,
         l2_block_number: u64,
         attempt: u64,
-        state: RootState,
+        state: GameLifecycle,
     ) {
         let metadata = GameMetadata {
             address,
@@ -122,7 +152,7 @@ impl MockClient {
         };
     }
 
-    fn set_state(&self, game: Address, state: RootState, reason: InvalidationReason) {
+    fn set_state(&self, game: Address, state: GameLifecycle, reason: InvalidationReason) {
         let mut guard = self.state.lock().expect("not poisoned");
         let record = guard.games.get_mut(&game).expect("game exists");
         record.state = state;
@@ -146,7 +176,7 @@ impl MockClient {
         metadata.proof_deadline = proof_deadline;
     }
 
-    fn submissions(&self) -> Vec<(Address, u8)> {
+    fn submissions(&self) -> Vec<(Address, ProofLane)> {
         self.state.lock().expect("not poisoned").submissions.clone()
     }
 }
@@ -192,17 +222,17 @@ impl LineageProvider for MockClient {
             .games
             .get(&game)
             .ok_or_else(|| LineageError::Contract(format!("unknown game {game}")))?;
-        let root_state = match record.state {
-            RootState::Proposed | RootState::Challenged
+        let lifecycle = match record.state {
+            GameLifecycle::Proposed | GameLifecycle::Challenged
                 if proof_count(record.proof_bitmap) >= record.metadata.proof_threshold =>
             {
-                RootState::Finalized
+                GameLifecycle::Finalized
             }
             state => state,
         };
         Ok(ResolutionStatus {
-            resolvable: root_state != record.state,
-            root_state,
+            resolvable: lifecycle != record.state,
+            outcome: lifecycle.outcome(),
             invalidation_reason: record.invalidation_reason,
         })
     }
@@ -220,20 +250,26 @@ impl DefenderClient for MockClient {
             .ok_or_else(|| DefenderError::message(format!("unknown game {game}")))
     }
 
-    async fn proof_bitmap(&self, game: Address) -> Result<u8, DefenderError> {
+    async fn claim_data(&self, game: Address) -> Result<ClaimData, DefenderError> {
         self.state
             .lock()
             .expect("not poisoned")
             .games
             .get(&game)
-            .map(|record| record.proof_bitmap)
+            .map(|record| ClaimData {
+                status: record.state.proposal_status(record.proof_bitmap != 0),
+                challenger: Address::ZERO,
+                deadline: record.metadata.proof_deadline,
+                proof_bitmap: record.proof_bitmap,
+                invalidation_reason: record.invalidation_reason,
+            })
             .ok_or_else(|| DefenderError::message(format!("unknown game {game}")))
     }
 
     async fn submit_proof(
         &self,
         game: Address,
-        lane: u8,
+        lane: ProofLane,
         _proof: Bytes,
     ) -> Result<DefenderSubmission, DefenderError> {
         let mut guard = self.state.lock().expect("not poisoned");
@@ -241,7 +277,7 @@ impl DefenderClient for MockClient {
             .games
             .get_mut(&game)
             .ok_or_else(|| DefenderError::message(format!("unknown game {game}")))?
-            .proof_bitmap |= 1 << lane;
+            .proof_bitmap |= lane.mask();
         guard.submissions.push((game, lane));
         Ok(DefenderSubmission {
             tx_hash: B256::repeat_byte(0xaa),
@@ -392,7 +428,7 @@ fn config() -> DefenderConfig {
 async fn selected_proposed_game_gets_initial_tee_proof() {
     let root = B256::repeat_byte(0x20);
     let client = MockClient::new();
-    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, RootState::Proposed);
+    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, GameLifecycle::Proposed);
     let prover = MockProver::default();
     let mut defender = WorldChainDefender::new(
         config(),
@@ -408,7 +444,7 @@ async fn selected_proposed_game_gets_initial_tee_proof() {
     defender.tick().await.unwrap();
     assert_eq!(
         client.submissions(),
-        vec![(GAME_1, ProofLane::TeeAttestation as u8)]
+        vec![(GAME_1, ProofLane::TeeAttestation)]
     );
 }
 
@@ -416,7 +452,7 @@ async fn selected_proposed_game_gets_initial_tee_proof() {
 async fn selected_proposed_game_with_council_support_needs_no_tee_proof() {
     let root = B256::repeat_byte(0x20);
     let client = MockClient::new();
-    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, RootState::Proposed);
+    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, GameLifecycle::Proposed);
     client.set_bitmap(GAME_1, ProofLane::SecurityCouncil.mask());
     let prover = MockProver::default();
     let mut defender = WorldChainDefender::new(
@@ -435,7 +471,7 @@ async fn selected_proposed_game_with_council_support_needs_no_tee_proof() {
 async fn selected_challenged_game_gets_threshold_lanes() {
     let root = B256::repeat_byte(0x20);
     let client = MockClient::new();
-    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, RootState::Challenged);
+    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, GameLifecycle::Challenged);
     let prover = MockProver::default();
     let mut defender = WorldChainDefender::new(
         config(),
@@ -467,7 +503,7 @@ async fn selected_challenged_game_gets_threshold_lanes() {
 async fn selected_challenged_game_with_council_support_only_requests_tee() {
     let root = B256::repeat_byte(0x20);
     let client = MockClient::new();
-    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, RootState::Challenged);
+    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, GameLifecycle::Challenged);
     client.set_bitmap(GAME_1, ProofLane::SecurityCouncil.mask());
     let prover = MockProver::default();
     let mut defender = WorldChainDefender::new(
@@ -484,7 +520,7 @@ async fn selected_challenged_game_with_council_support_only_requests_tee() {
     defender.tick().await.unwrap();
     assert_eq!(
         client.submissions(),
-        vec![(GAME_1, ProofLane::TeeAttestation as u8)]
+        vec![(GAME_1, ProofLane::TeeAttestation)]
     );
 
     defender.tick().await.unwrap();
@@ -496,7 +532,7 @@ async fn selected_descendant_is_defended_before_parent_resolves() {
     let root_1 = B256::repeat_byte(0x20);
     let root_2 = B256::repeat_byte(0x21);
     let client = MockClient::new();
-    client.insert_game(GAME_1, ANCHOR, root_1, L2_BLOCK, 0, RootState::Proposed);
+    client.insert_game(GAME_1, ANCHOR, root_1, L2_BLOCK, 0, GameLifecycle::Proposed);
     client.set_bitmap(GAME_1, ProofLane::TeeAttestation.mask());
     client.insert_game(
         GAME_2,
@@ -504,7 +540,7 @@ async fn selected_descendant_is_defended_before_parent_resolves() {
         root_2,
         L2_BLOCK + BLOCK_INTERVAL,
         0,
-        RootState::Challenged,
+        GameLifecycle::Challenged,
     );
     let prover = MockProver::default();
     let mut defender = WorldChainDefender::new(
@@ -538,7 +574,7 @@ async fn game_for_a_different_root_is_not_selected() {
         other_root,
         L2_BLOCK,
         0,
-        RootState::Challenged,
+        GameLifecycle::Challenged,
     );
     let prover = MockProver::default();
     let mut defender = WorldChainDefender::new(
@@ -557,7 +593,7 @@ async fn game_for_a_different_root_is_not_selected() {
 async fn retry_replaces_active_old_attempt() {
     let root = B256::repeat_byte(0x20);
     let client = MockClient::new();
-    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, RootState::Challenged);
+    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, GameLifecycle::Challenged);
     let prover = MockProver::default();
     let mut defender = WorldChainDefender::new(
         config(),
@@ -571,10 +607,10 @@ async fn retry_replaces_active_old_attempt() {
 
     client.set_state(
         GAME_1,
-        RootState::Invalidated,
+        GameLifecycle::Invalidated,
         InvalidationReason::ProofTimeout,
     );
-    client.insert_game(GAME_2, ANCHOR, root, L2_BLOCK, 1, RootState::Proposed);
+    client.insert_game(GAME_2, ANCHOR, root, L2_BLOCK, 1, GameLifecycle::Proposed);
     defender.tick().await.unwrap();
 
     assert_eq!(defender.active_defenses(), [GAME_2]);
@@ -586,14 +622,21 @@ async fn anchor_advance_drops_the_old_prefix() {
     let root_1 = B256::repeat_byte(0x20);
     let root_2 = B256::repeat_byte(0x21);
     let client = MockClient::new();
-    client.insert_game(GAME_1, ANCHOR, root_1, L2_BLOCK, 0, RootState::Challenged);
+    client.insert_game(
+        GAME_1,
+        ANCHOR,
+        root_1,
+        L2_BLOCK,
+        0,
+        GameLifecycle::Challenged,
+    );
     client.insert_game(
         GAME_2,
         GAME_1,
         root_2,
         L2_BLOCK + BLOCK_INTERVAL,
         0,
-        RootState::Proposed,
+        GameLifecycle::Proposed,
     );
     let mut defender = WorldChainDefender::new(
         config(),
@@ -618,10 +661,17 @@ async fn anchor_advance_drops_the_old_prefix() {
 async fn invalidated_selected_attempt_is_left_for_the_proposer() {
     let root = B256::repeat_byte(0x20);
     let client = MockClient::new();
-    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, RootState::Invalidated);
+    client.insert_game(
+        GAME_1,
+        ANCHOR,
+        root,
+        L2_BLOCK,
+        0,
+        GameLifecycle::Invalidated,
+    );
     client.set_state(
         GAME_1,
-        RootState::Invalidated,
+        GameLifecycle::Invalidated,
         InvalidationReason::ProofTimeout,
     );
     let prover = MockProver::default();
@@ -641,7 +691,7 @@ async fn invalidated_selected_attempt_is_left_for_the_proposer() {
 async fn unfinalized_transition_is_not_selected_yet() {
     let root = B256::repeat_byte(0x20);
     let client = MockClient::new();
-    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, RootState::Challenged);
+    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, GameLifecycle::Challenged);
     let prover = MockProver::default();
     let mut defender = WorldChainDefender::new(
         config(),
@@ -658,7 +708,7 @@ async fn unfinalized_transition_is_not_selected_yet() {
 async fn existing_lane_is_not_requested_again() {
     let root = B256::repeat_byte(0x20);
     let client = MockClient::new();
-    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, RootState::Challenged);
+    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, GameLifecycle::Challenged);
     client.set_bitmap(GAME_1, ProofLane::ValidityProof.mask());
     let prover = MockProver::default();
     let mut defender = WorldChainDefender::new(
@@ -677,7 +727,7 @@ async fn existing_lane_is_not_requested_again() {
 async fn existing_tee_lane_only_requests_sp1_when_challenged() {
     let root = B256::repeat_byte(0x20);
     let client = MockClient::new();
-    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, RootState::Challenged);
+    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, GameLifecycle::Challenged);
     client.set_bitmap(GAME_1, ProofLane::TeeAttestation.mask());
     let prover = MockProver::default();
     let mut defender = WorldChainDefender::new(
@@ -696,7 +746,7 @@ async fn existing_tee_lane_only_requests_sp1_when_challenged() {
 async fn exhausted_challenged_proofs_are_not_restarted() {
     let root = B256::repeat_byte(0x20);
     let client = MockClient::new();
-    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, RootState::Challenged);
+    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, GameLifecycle::Challenged);
     let prover = MockProver::failing(2);
     let mut defender = WorldChainDefender::new(
         config(),
@@ -718,7 +768,7 @@ async fn exhausted_challenged_proofs_are_not_restarted() {
 async fn selected_game_deadline_stops_proof_work() {
     let root = B256::repeat_byte(0x20);
     let client = MockClient::new();
-    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, RootState::Proposed);
+    client.insert_game(GAME_1, ANCHOR, root, L2_BLOCK, 0, GameLifecycle::Proposed);
     client.set_deadlines(GAME_1, 10, 20);
     let prover = MockProver::default();
     let mut defender = WorldChainDefender::new(

--- a/proofs/services/defender/src/traits.rs
+++ b/proofs/services/defender/src/traits.rs
@@ -4,19 +4,22 @@ use crate::{
 };
 use alloy_primitives::{Address, Bytes};
 use async_trait::async_trait;
-use world_chain_proofs::LineageProvider;
+use world_chain_proofs::{ClaimData, LineageProvider, ProofLane};
 
 #[async_trait]
 pub trait DefenderClient: LineageProvider {
     /// Reads the immutable game data needed to monitor and defend its root claim.
     async fn game_metadata(&self, game: Address) -> Result<GameMetadata, DefenderError>;
-    /// Get the bitmap of proof lanes already proven for the provided game.
-    async fn proof_bitmap(&self, game: Address) -> Result<u8, DefenderError>;
-    /// Submits a proof to support a proposed or challenged game.
+    /// Reads the proposal's mutable state: challenge status and the accepted proof lanes.
+    async fn claim_data(&self, game: Address) -> Result<ClaimData, DefenderError>;
+    /// Submits a lane's verifier proof to support a proposed or challenged game.
+    ///
+    /// `proof` is the verifier payload; the compact lane header is added by the implementation,
+    /// which owns the reward recipient.
     async fn submit_proof(
         &self,
         game: Address,
-        lane: u8,
+        lane: ProofLane,
         proof: Bytes,
     ) -> Result<DefenderSubmission, DefenderError>;
 }

--- a/proofs/services/proposer/src/proposer.rs
+++ b/proofs/services/proposer/src/proposer.rs
@@ -1,6 +1,6 @@
 use tracing::{info, warn};
 use world_chain_proofs::{
-    ConsensusProvider, InvalidationReason, LineageStop, RootState, SelectedLineageGame,
+    ConsensusProvider, GameStatus, InvalidationReason, LineageStop, SelectedLineageGame,
     select_lineage,
 };
 
@@ -138,7 +138,7 @@ where
                 );
                 highest_finalized_game = Some(*selected);
                 resolutions_submitted += 1;
-            } else if resolution_status.root_state == RootState::Finalized {
+            } else if resolution_status.outcome == GameStatus::DefenderWins {
                 // the game was finalized in an earlier iteration or by another keeper
                 highest_finalized_game = Some(*selected);
             }

--- a/proofs/services/proposer/src/tests.rs
+++ b/proofs/services/proposer/src/tests.rs
@@ -10,9 +10,9 @@ use std::{
 use alloy_primitives::{Address, B256, BlockNumber, U256, address, b256};
 use async_trait::async_trait;
 use world_chain_proofs::{
-    ConsensusError, ConsensusProvider, InvalidationReason, LineageAnchor, LineageError,
+    ConsensusError, ConsensusProvider, GameStatus, InvalidationReason, LineageAnchor, LineageError,
     LineageGame, LineageProvider, LineageTransition, ProposalCommitment, ResolutionStatus,
-    RootState, SelectedLineageGame,
+    SelectedLineageGame,
 };
 
 use crate::{
@@ -87,7 +87,7 @@ impl LineageProvider for MockContracts {
             .remove(&game)
             .unwrap_or(ResolutionStatus {
                 resolvable: false,
-                root_state: RootState::Proposed,
+                outcome: GameStatus::InProgress,
                 invalidation_reason: InvalidationReason::None,
             }))
     }
@@ -254,10 +254,10 @@ impl BondManagerClient for MockBondClient {
             .contains(&game);
         Ok(ResolutionStatus {
             resolvable: false,
-            root_state: if resolved {
-                RootState::Finalized
+            outcome: if resolved {
+                GameStatus::DefenderWins
             } else {
-                RootState::Proposed
+                GameStatus::InProgress
             },
             invalidation_reason: InvalidationReason::None,
         })
@@ -398,7 +398,7 @@ async fn advance_proposal(
 fn positive_ready_status() -> ResolutionStatus {
     ResolutionStatus {
         resolvable: true,
-        root_state: RootState::Finalized,
+        outcome: GameStatus::DefenderWins,
         invalidation_reason: InvalidationReason::None,
     }
 }
@@ -420,7 +420,7 @@ fn anchor_advanced_onto(anchor_game: Address, l2_block_number: u64) -> LineageAn
 fn timed_out_status() -> ResolutionStatus {
     ResolutionStatus {
         resolvable: false,
-        root_state: RootState::Invalidated,
+        outcome: GameStatus::ChallengerWins,
         invalidation_reason: InvalidationReason::ProofTimeout,
     }
 }
@@ -428,7 +428,7 @@ fn timed_out_status() -> ResolutionStatus {
 fn negatively_resolvable_timeout() -> ResolutionStatus {
     ResolutionStatus {
         resolvable: true,
-        root_state: RootState::Invalidated,
+        outcome: GameStatus::ChallengerWins,
         invalidation_reason: InvalidationReason::ProofTimeout,
     }
 }
@@ -696,7 +696,7 @@ async fn resolve_games_caps_submissions_and_keeps_scanning_finalized_games() {
                 game_3,
                 ResolutionStatus {
                     resolvable: false,
-                    root_state: RootState::Finalized,
+                    outcome: GameStatus::DefenderWins,
                     invalidation_reason: InvalidationReason::None,
                 },
             ),
@@ -751,7 +751,7 @@ async fn finalized_games_do_not_consume_resolution_budget() {
                 GAME_1,
                 ResolutionStatus {
                     resolvable: false,
-                    root_state: RootState::Finalized,
+                    outcome: GameStatus::DefenderWins,
                     invalidation_reason: InvalidationReason::None,
                 },
             ),
@@ -983,7 +983,7 @@ async fn bond_manager_resolves_invalid_parent_before_claiming_refund() {
             game,
             ResolutionStatus {
                 resolvable: true,
-                root_state: RootState::Invalidated,
+                outcome: GameStatus::ChallengerWins,
                 invalidation_reason: InvalidationReason::InvalidParent,
             },
         );
@@ -1028,7 +1028,7 @@ async fn bond_manager_leaves_direct_proof_timeout_to_lineage_proposer() {
             game,
             ResolutionStatus {
                 resolvable: true,
-                root_state: RootState::Invalidated,
+                outcome: GameStatus::ChallengerWins,
                 invalidation_reason: InvalidationReason::ProofTimeout,
             },
         );


### PR DESCRIPTION
Updates the Rust proof services for the contract changes on `osiris/split-defender-reward`, and fixes two enum-decoding bugs the ABI diff surfaced.

- `submitProofLane` now takes the packed compact payload (`laneId | recipient | proof`); defender gets a `--proof-reward-recipient` flag defaulting to its signer, and treats a `DuplicateProofLane` revert as lane-proven instead of retrying.
- Bindings match the compiled ABI exactly: `Proved` replaces the removed proof events, `WorldChainGameCreated` and the nonexistent `state()` are gone, `laneRecipient` and the `submitProofLane` reverts added.
- Pre-existing: `resolutionStatus().outcome` is OP Stack `GameStatus`, not the 5-value `RootState` it was decoded as — every in-progress game became `LineageError::UnsetGame`. Replaced with `GameStatus` + `ProposalStatus` (from `claimData()`), which the challenger also now uses in place of `state()`.
- Verified: 75 tests pass, workspace clippy clean with `-D warnings`, and every binding signature diffed against `forge build` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes decoding of on-chain game state and L1 proof submission encoding across defender, challenger, proposer, and lineage; misalignment would mis-route challenges, defenses, or retries on mainnet-style games.
> 
> **Overview**
> Rust proof primitives and services are brought in line with the updated **MultiProofGame** contract surface and state machine.
> 
> **Contract / types:** `RootState` and `WorldChainGameCreated` are dropped in favor of OP Stack **`GameStatus`** on `resolutionStatus().outcome` and **`ProposalStatus`** from `claimData()`. **`GameCreation`** replaces the old creation event shape; **`ResolutionStatus`** now carries `outcome` instead of `root_state`. **`encode_compact_proof`** builds the packed `lane | recipient | proof` payload for `submitProofLane`. Alloy bindings drop `state()` and lane-id args, add `Proved`, revert errors, and `laneRecipient`.
> 
> **Defender:** **`AlloyDefenderClient`** takes a **`reward_recipient`** (wired from devnet and **`--proof-reward-recipient`** on the binary). Submissions use compact encoding; **`DuplicateProofLane`** maps to **`LaneAlreadyProven`** and is treated as success on retry. Game observation uses **`claim_data()`** plus resolution outcome instead of a single root-state enum.
> 
> **Challenger / proposer / lineage:** Challenge eligibility uses **`proposal_status().is_challengeable()`** instead of `RootState::Proposed`. Resolution and lineage selection key off **`GameStatus`** (e.g. invalidated lineage on **`ChallengerWins`**). Integration fakes use **`GameLifecycle`** to mirror the split between proposal and game status.
> 
> **Tests:** Mocks and orchestration tests updated for the new APIs and assertions (`GameStatus`, `GameLifecycle`, typed **`ProofLane`** on submit).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5f756c6fdc43e81dbeaaf0f5be0af0c80b04d9d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->