### PR TITLE
feat(contracts): alphanet game implementation upgrade

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -148,6 +148,8 @@ install *args='':
 #   Phase 3b  proof-approve-pcrs          – Approve PCR set on verifier
 #   Phase 3c  proof-verify-pcrs           – Assert the RUNNING enclave's PCR set is approved
 #                                            (drift check; safe to run any time)
+#   Upgrade   proof-upgrade-game          – Swap the game type 1006 implementation in place
+#                                            (run on its own; NOT part of proof-setup)
 #   Phase 4   proof-register-key          – Register the enclave's generated key on-chain
 #                                            (run separately; NOT part of proof-setup)
 #   Combined  proof-setup                 – Run deploy phases 0a–3c in sequence (does NOT
@@ -465,6 +467,44 @@ proof-activate-system env="alphanet":
     echo "Activating WIP-1006 (require fresh anchor: $REQUIRE_FRESH_ANCHOR)$([ -n "$BROADCAST_FLAG" ] || echo ' [DRY RUN]')…" >&2
     cd pkg/contracts && forge script scripts/devnet/ActivateProofSystem.s.sol:ActivateProofSystem \
         --rpc-url "$L1_RPC_URL" --private-key "$GUARDIAN_KEY" $BROADCAST_FLAG --slow
+
+# Upgrade – Swap the registered game implementation for game type 1006, in place.
+#
+# Every constructor parameter defaults to the value read off the currently registered
+# implementation, so the default run changes bytecode and nothing else; the script reverts
+# if `domainHash` moves. Existing games keep the implementation they were cloned from, so
+# only games created after this call use the new code — plan the service rollout around
+# that drain window.
+#
+# Set NEW_GAME_IMPLEMENTATION to register an already-deployed implementation (this is also
+# the rollback path: point it at the previous address).
+proof-upgrade-game env="alphanet":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    : "${L1_RPC_URL:?L1_RPC_URL is required}"
+    : "${DISPUTE_GAME_FACTORY:?DISPUTE_GAME_FACTORY is required}"
+    : "${DGF_OWNER_KEY:?DGF_OWNER_KEY is required (DisputeGameFactory owner)}"
+    # The registered implementation predates the getters for these two, so they cannot be read
+    # back from chain. Both feed domainHash, which the script checks against the outgoing
+    # implementation — a wrong value fails there rather than forking the proof domain.
+    : "${ROLLUP_CONFIG_HASH:?ROLLUP_CONFIG_HASH is required (see deployments/{{env}}-proof-system.json)}"
+    export PROOF_SYSTEM_BLOCK_INTERVAL="${PROOF_SYSTEM_BLOCK_INTERVAL:-450}"
+    export PRIVATE_KEY="${PRIVATE_KEY:-$DGF_OWNER_KEY}"
+    BROADCAST_FLAG=""
+    if [ "{{dry_run}}" = "false" ]; then
+        BROADCAST_FLAG="--broadcast"
+    fi
+    # A dry run must never overwrite the record of a live deployment: the simulated
+    # implementation is never deployed, so writing its address to the real path replaces a
+    # true record with a fictional one.
+    if [ -n "$BROADCAST_FLAG" ]; then
+        export PROOF_SYSTEM_DEPLOYMENT_OUT="deployments/{{env}}-proof-system.json"
+    else
+        export PROOF_SYSTEM_DEPLOYMENT_OUT=""
+    fi
+    echo "Upgrading game type 1006 implementation (record → ${PROOF_SYSTEM_DEPLOYMENT_OUT:-none})$([ -n "$BROADCAST_FLAG" ] || echo ' [DRY RUN]')…" >&2
+    cd pkg/contracts && forge script scripts/devnet/UpgradeGameImplementation.s.sol:UpgradeGameImplementation \
+        --rpc-url "$L1_RPC_URL" --private-key "$DGF_OWNER_KEY" $BROADCAST_FLAG --slow
 
 # Phase 3a – Pre-warm CertManager with the AWS Nitro CA cert chain.
 proof-certmanager-prewarm env="alphanet":

--- a/Justfile
+++ b/Justfile
@@ -148,8 +148,9 @@ install *args='':
 #   Phase 3b  proof-approve-pcrs          – Approve PCR set on verifier
 #   Phase 3c  proof-verify-pcrs           – Assert the RUNNING enclave's PCR set is approved
 #                                            (drift check; safe to run any time)
+#   Upgrade   proof-deploy-validity-verifier – Re-key the SP1 validity lane to the built vkeys
 #   Upgrade   proof-upgrade-game          – Swap the game type 1006 implementation in place
-#                                            (run on its own; NOT part of proof-setup)
+#                                            (both run on their own; NOT part of proof-setup)
 #   Phase 4   proof-register-key          – Register the enclave's generated key on-chain
 #                                            (run separately; NOT part of proof-setup)
 #   Combined  proof-setup                 – Run deploy phases 0a–3c in sequence (does NOT
@@ -467,6 +468,30 @@ proof-activate-system env="alphanet":
     echo "Activating WIP-1006 (require fresh anchor: $REQUIRE_FRESH_ANCHOR)$([ -n "$BROADCAST_FLAG" ] || echo ' [DRY RUN]')…" >&2
     cd pkg/contracts && forge script scripts/devnet/ActivateProofSystem.s.sol:ActivateProofSystem \
         --rpc-url "$L1_RPC_URL" --private-key "$GUARDIAN_KEY" $BROADCAST_FLAG --slow
+
+# Upgrade – Deploy a replacement SP1ValidityVerifier keyed to the committed vkeys.
+#
+# Both vkeys are immutable on the verifier and the verifier is immutable on the game, so
+# re-keying the validity lane means a new verifier followed by a new game implementation.
+# The vkeys are read from the ELF build output rather than typed in, so they cannot drift
+# from the program the SP1 workers actually run.
+proof-deploy-validity-verifier env="alphanet":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    : "${PRIVATE_KEY:?PRIVATE_KEY is required}"
+    : "${L1_RPC_URL:?L1_RPC_URL is required}"
+    : "${SP1_VERIFIER_GATEWAY:?SP1_VERIFIER_GATEWAY is required (Succinct verifier gateway)}"
+    VKEYS=proofs/backends/sp1/elfs/vkeys.json
+    export AGGREGATION_VKEY=$(jq -r '.aggregation_vkey' "$VKEYS")
+    export RANGE_VKEY_COMMITMENT=$(jq -r '.range_vkey_commitment' "$VKEYS")
+    export CURRENT_GAME_IMPLEMENTATION="${CURRENT_GAME_IMPLEMENTATION:-$(jq -r '.gameImplementation' pkg/contracts/deployments/{{env}}-proof-system.json)}"
+    BROADCAST_FLAG=""
+    if [ "{{dry_run}}" = "false" ]; then
+        BROADCAST_FLAG="--broadcast"
+    fi
+    echo "Deploying SP1ValidityVerifier (aggregation $AGGREGATION_VKEY)$([ -n "$BROADCAST_FLAG" ] || echo ' [DRY RUN]')…" >&2
+    cd pkg/contracts && forge script scripts/devnet/DeployValidityVerifier.s.sol:DeployValidityVerifier \
+        --rpc-url "$L1_RPC_URL" --private-key "$PRIVATE_KEY" $BROADCAST_FLAG --slow
 
 # Upgrade – Swap the registered game implementation for game type 1006, in place.
 #

--- a/docs/proof/upgrade-game-implementation.md
+++ b/docs/proof/upgrade-game-implementation.md
@@ -1,0 +1,141 @@
+# Upgrading the game type 1006 implementation
+
+Swaps the `MultiProofGame` implementation registered on an existing `DisputeGameFactory`
+without redeploying the proof system around it. Written against alphanet; the same sequence
+applies anywhere `just proof-*` is configured.
+
+## What an in-place swap does and does not change
+
+`DisputeGameFactory.create` clones the implementation registered *at creation time*, and a
+clone keeps pointing at the address it was cloned from. So `setImplementation(1006, newImpl)`
+only affects games created after the call:
+
+- Games already in flight keep the old code, the old ABI, and the old bond accounting. They
+  resolve normally.
+- New games use the new code immediately.
+- For as long as both exist, every service that reads or writes games must handle both ABIs.
+  That window is bounded by the longest live game: one `proofPeriod` (7 days on alphanet)
+  worst case, one `challengePeriod` (24 h) for an unchallenged proposal.
+
+`domainHash` must not move. It is committed into each game's `extraData` and every prover
+derives `rootId` from it, so a changed domain hash silently invalidates every unresolved
+proposal and every queued proof instead of failing anywhere visible.
+`UpgradeGameImplementation.s.sol` compares it against the outgoing implementation and reverts
+on drift — that check is the reason the script reads its parameters off chain rather than
+taking them from a config file.
+
+## Before you start
+
+```bash
+source scripts/proof-envs/alphanet.env
+export L1_RPC_URL=<sepolia rpc>
+export DISPUTE_GAME_FACTORY=$(jq -r .disputeGameFactory pkg/contracts/deployments/alphanet-proof-system.json)
+export ROLLUP_CONFIG_HASH=$(jq -r .rollupConfigHash pkg/contracts/deployments/alphanet-proof-system.json)
+```
+
+`DGF_OWNER_KEY` must be the key for `DisputeGameFactory.owner()`. Confirm before signing:
+
+```bash
+cast call $DISPUTE_GAME_FACTORY 'owner()(address)' --rpc-url $L1_RPC_URL
+```
+
+## 1. Re-key the validity lane if the vkeys moved
+
+`aggregationVKey` and `rangeVKeyCommitment` are immutable on `SP1ValidityVerifier`, and the
+verifier address is immutable on `MultiProofGame`. A vkey change is therefore a two-contract
+operation, and it has no loud failure mode: a game wired to a stale verifier accepts proposals
+and rejects every proof the workers produce, surfacing only as challenge windows timing out.
+
+Compare first:
+
+```bash
+VERIFIER=$(jq -r .validityProofVerifier pkg/contracts/deployments/alphanet-proof-system.json)
+cast call $VERIFIER 'aggregationVKey()(bytes32)'      --rpc-url $L1_RPC_URL
+cast call $VERIFIER 'rangeVKeyCommitment()(bytes32)'  --rpc-url $L1_RPC_URL
+jq -r '.aggregation_vkey, .range_vkey_commitment' proofs/backends/sp1/elfs/vkeys.json
+```
+
+If they differ, deploy a replacement and carry its address into step 2:
+
+```bash
+export SP1_VERIFIER_GATEWAY=$(cast call $VERIFIER 'sp1Verifier()(address)' --rpc-url $L1_RPC_URL)
+just dry_run=true proof-deploy-validity-verifier alphanet
+just proof-deploy-validity-verifier alphanet
+export VALIDITY_PROOF_VERIFIER=<address printed above>
+```
+
+If they match, skip this step and leave `VALIDITY_PROOF_VERIFIER` unset — the upgrade then
+reuses the registered verifier.
+
+## 2. Deploy and register the new implementation
+
+Dry run first. It simulates the deploy, the `domainHash` check and the `setImplementation`
+call, and writes nothing:
+
+```bash
+just dry_run=true proof-upgrade-game alphanet
+```
+
+Check the printed `domainHash (unchanged)` against the live value before broadcasting:
+
+```bash
+cast call $(jq -r .gameImplementation pkg/contracts/deployments/alphanet-proof-system.json) \
+  'domainHash()(bytes32)' --rpc-url $L1_RPC_URL
+```
+
+Then broadcast. This is the only irreversible step; everything after it is a config rollout.
+
+```bash
+just proof-upgrade-game alphanet
+```
+
+The script updates `gameImplementation` and records `previousGameImplementation` in
+`pkg/contracts/deployments/alphanet-proof-system.json`. Commit that file.
+
+## 3. Roll out the services
+
+The prover services must be on a build that speaks the new ABI *before* the first game is
+created against the new implementation — the proposer creates games on a timer, so this
+window is short. Bump all six images together in `crypto-apps`:
+`world-chain-proof-{proposer,challenger,defender,prover-service,sp1-worker,nitro-worker}`.
+
+The defender additionally accepts `PROOF_REWARD_RECIPIENT`, the address credited each
+submitted lane's share of a forfeited challenger bond. It defaults to the defender signer;
+set it only if the reward should land somewhere else.
+
+## 4. Verify
+
+```bash
+NEW=$(cast call $DISPUTE_GAME_FACTORY 'gameImpls(uint32)(address)' 1006 --rpc-url $L1_RPC_URL)
+cast call $NEW 'domainHash()(bytes32)'    --rpc-url $L1_RPC_URL   # unchanged
+cast call $NEW 'laneRecipient(uint8)(address)' 0 --rpc-url $L1_RPC_URL   # new ABI present
+cast call $DISPUTE_GAME_FACTORY 'initBonds(uint32)(uint256)' 1006 --rpc-url $L1_RPC_URL
+```
+
+Then watch a full proposal cycle: a game created after the swap should reach
+`DEFENDER_WINS` through the normal path. Until one does, the upgrade is unproven.
+
+## Rollback
+
+Re-register the previous implementation. Nothing else is needed — the old address still holds
+code, and games created against the new implementation keep resolving under it.
+
+```bash
+NEW_GAME_IMPLEMENTATION=$(jq -r .previousGameImplementation pkg/contracts/deployments/alphanet-proof-system.json) \
+  just proof-upgrade-game alphanet
+```
+
+Roll the service images back in the same direction, since the reverted implementation speaks
+the old ABI.
+
+## Kill switch
+
+Stops new game creation without touching games in flight:
+
+```bash
+cast send $DISPUTE_GAME_FACTORY 'setImplementation(uint32,address)' 1006 \
+  0x0000000000000000000000000000000000000000 --rpc-url $L1_RPC_URL --private-key $DGF_OWNER_KEY
+```
+
+Proposals stop; existing games still resolve and pay out. Re-register an implementation to
+resume.

--- a/pkg/contracts/scripts/devnet/DeployValidityVerifier.s.sol
+++ b/pkg/contracts/scripts/devnet/DeployValidityVerifier.s.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Script, console} from "forge-std/Script.sol";
+
+import {SP1ValidityVerifier} from "../../src/dispute/sp1/SP1ValidityVerifier.sol";
+import {MultiProofGame} from "../../src/dispute/MultiProofGame.sol";
+import {IWorldChainProofVerifier} from "../../src/dispute/interfaces/IWorldChainProofVerifier.sol";
+import {ISP1Verifier} from "@sp1-contracts/src/ISP1Verifier.sol";
+
+/// @notice Deploys a replacement `SP1ValidityVerifier` for the validity proof lane.
+///
+/// Both verification keys are immutable on the verifier, and the verifier address is immutable
+/// on `MultiProofGame` — so re-keying the validity lane is a two-contract operation: deploy
+/// here, then pass the result to `UpgradeGameImplementation.s.sol` as `VALIDITY_PROOF_VERIFIER`.
+/// Registering a game whose verifier holds a stale `aggregationVKey` does not fail loudly; the
+/// lane simply rejects every proof the workers produce, and the failure only surfaces as
+/// proposals timing out a challenge window later.
+///
+/// `AGGREGATION_VKEY` and `RANGE_VKEY_COMMITMENT` must come from the `vkeys.json` built
+/// alongside the ELF the SP1 workers are running — `just proof-deploy-validity-verifier` reads
+/// them from that file rather than taking them by hand.
+contract DeployValidityVerifier is Script {
+    function run() external returns (SP1ValidityVerifier verifier) {
+        uint256 privateKey = vm.envUint("PRIVATE_KEY");
+        ISP1Verifier gateway = ISP1Verifier(vm.envAddress("SP1_VERIFIER_GATEWAY"));
+        bytes32 aggregationVKey = vm.envBytes32("AGGREGATION_VKEY");
+        bytes32 rangeVKeyCommitment = vm.envBytes32("RANGE_VKEY_COMMITMENT");
+
+        require(address(gateway).code.length > 0, "DeployValidityVerifier: SP1 gateway has no code");
+
+        // Deploying a verifier identical to the one already registered is almost always a
+        // stale vkeys.json rather than an intended no-op, so refuse rather than register a
+        // lane that will keep rejecting the workers' proofs.
+        address currentGame = vm.envOr("CURRENT_GAME_IMPLEMENTATION", address(0));
+        if (currentGame != address(0)) {
+            SP1ValidityVerifier current =
+                SP1ValidityVerifier(address(MultiProofGame(currentGame).validityProofVerifier()));
+            require(
+                current.aggregationVKey() != aggregationVKey || current.rangeVKeyCommitment() != rangeVKeyCommitment,
+                "DeployValidityVerifier: vkeys already match the registered verifier"
+            );
+            console.log("  replacing verifier:      ", address(current));
+            console.log("  old aggregationVKey:     ", vm.toString(current.aggregationVKey()));
+            console.log("  old rangeVKeyCommitment: ", vm.toString(current.rangeVKeyCommitment()));
+        }
+
+        vm.startBroadcast(privateKey);
+        verifier = new SP1ValidityVerifier(gateway, aggregationVKey, rangeVKeyCommitment);
+        vm.stopBroadcast();
+
+        console.log("SP1ValidityVerifier deployed");
+        console.log("  address:                 ", address(verifier));
+        console.log("  sp1Verifier gateway:     ", address(gateway));
+        console.log("  aggregationVKey:         ", vm.toString(aggregationVKey));
+        console.log("  rangeVKeyCommitment:     ", vm.toString(rangeVKeyCommitment));
+    }
+}

--- a/pkg/contracts/scripts/devnet/UpgradeGameImplementation.s.sol
+++ b/pkg/contracts/scripts/devnet/UpgradeGameImplementation.s.sol
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Script, console} from "forge-std/Script.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+
+import {GameTypes} from "../../src/dispute/lib/GameTypes.sol";
+import {LibProof} from "../../src/dispute/lib/LibProof.sol";
+import {MultiProofGame} from "../../src/dispute/MultiProofGame.sol";
+import {IMultiProofGame} from "../../src/dispute/interfaces/IMultiProofGame.sol";
+import {IWorldChainProofVerifier} from "../../src/dispute/interfaces/IWorldChainProofVerifier.sol";
+
+import {GameType} from "@optimism-bedrock/src/dispute/lib/Types.sol";
+import {IDisputeGame} from "@optimism-bedrock/interfaces/dispute/IDisputeGame.sol";
+import {IDisputeGameFactory} from "@optimism-bedrock/interfaces/dispute/IDisputeGameFactory.sol";
+import {IAnchorStateRegistry} from "@optimism-bedrock/interfaces/dispute/IAnchorStateRegistry.sol";
+import {IDelayedWETH} from "@optimism-bedrock/interfaces/dispute/IDelayedWETH.sol";
+
+/// @notice Swaps the `MultiProofGame` implementation registered for game type 1006 on an
+///         existing `DisputeGameFactory`, without redeploying the surrounding proof system.
+///
+/// Every constructor parameter defaults to the value read off the *currently registered*
+/// implementation, so the default run changes bytecode and nothing else. That is the point:
+/// the parameters are load-bearing offchain (`domainHash` is committed into every game's
+/// `extraData`, and every prover derives `rootId` from it), and re-specifying them by hand is
+/// how a "bytecode-only" upgrade silently becomes a chain split between the games already in
+/// flight and the workers proving them.
+///
+/// Each parameter can still be overridden by env var; each override is asserted and logged.
+/// `domainHash` is the one value that may never move — an upgrade that changes it invalidates
+/// every unresolved proposal and every proof in the prover-service queue — so it is checked
+/// against the outgoing implementation and the run reverts on drift.
+///
+/// `ROLLUP_CONFIG_HASH` and `PROOF_SYSTEM_BLOCK_INTERVAL` are the two required inputs: the
+/// implementation registered on alphanet predates the getters for them, so they cannot be
+/// recovered from chain. They are not taken on trust — both feed `domainHash`, so a wrong
+/// value fails the equality check above rather than shipping a forked proof domain.
+///
+/// Existing games are unaffected: `DisputeGameFactory.create` clones the implementation
+/// registered at creation time, and a clone keeps pointing at that address. Only games created
+/// after this call use the new code. Services that submit to both old and new games must
+/// therefore understand both ABIs for the length of the drain window.
+///
+/// Rollback is the same call with `NEW_GAME_IMPLEMENTATION` set to the previous address, and
+/// `setImplementation(1006, address(0))` remains the kill switch for new game creation.
+contract UpgradeGameImplementation is Script {
+    using SafeCast for uint256;
+
+    struct Config {
+        uint256 privateKey;
+        uint256 dgfOwnerKey;
+        IDisputeGameFactory disputeGameFactory;
+        MultiProofGame currentImpl;
+        /// @dev When set, register this pre-deployed implementation instead of deploying one.
+        address preDeployedImpl;
+        bytes32 rollupConfigHash;
+        uint256 blockInterval;
+        uint64 challengePeriod;
+        uint64 proofPeriod;
+        uint256 proposerBond;
+        uint256 challengerBond;
+        uint8 proofThreshold;
+        address protocolFeeRecipient;
+        IWorldChainProofVerifier validityProofVerifier;
+        IWorldChainProofVerifier teeVerifier;
+        IWorldChainProofVerifier securityCouncil;
+        IAnchorStateRegistry anchorStateRegistry;
+        IDelayedWETH weth;
+    }
+
+    function run() external returns (address newImpl) {
+        Config memory config = _readConfig();
+
+        // 1. Deploy (or adopt) the replacement implementation.
+        if (config.preDeployedImpl != address(0)) {
+            require(config.preDeployedImpl.code.length > 0, "Upgrade: NEW_GAME_IMPLEMENTATION has no code");
+            newImpl = config.preDeployedImpl;
+        } else {
+            vm.startBroadcast(config.privateKey);
+            newImpl = address(new MultiProofGame(_gameConfig(config)));
+            vm.stopBroadcast();
+        }
+
+        _validateReplacement(config, MultiProofGame(newImpl));
+
+        // 2. Register it on the factory. The three-argument overload clears any stale args.
+        vm.startBroadcast(config.dgfOwnerKey);
+        config.disputeGameFactory.setImplementation(GameTypes.MULTI_PROOF_GAME_TYPE, IDisputeGame(newImpl), hex"");
+        if (config.disputeGameFactory.initBonds(GameTypes.MULTI_PROOF_GAME_TYPE) != config.proposerBond) {
+            config.disputeGameFactory.setInitBond(GameTypes.MULTI_PROOF_GAME_TYPE, config.proposerBond);
+        }
+        vm.stopBroadcast();
+
+        require(
+            address(config.disputeGameFactory.gameImpls(GameTypes.MULTI_PROOF_GAME_TYPE)) == newImpl,
+            "Upgrade: implementation not registered"
+        );
+        require(
+            config.disputeGameFactory.gameArgs(GameTypes.MULTI_PROOF_GAME_TYPE).length == 0,
+            "Upgrade: stale game implementation args"
+        );
+        require(
+            config.disputeGameFactory.initBonds(GameTypes.MULTI_PROOF_GAME_TYPE)
+                == MultiProofGame(newImpl).proposerBond(),
+            "Upgrade: init bond does not match proposer bond"
+        );
+
+        _writeDeployment(config, newImpl);
+    }
+
+    function _readConfig() internal view returns (Config memory config) {
+        config.disputeGameFactory = IDisputeGameFactory(vm.envAddress("DISPUTE_GAME_FACTORY"));
+        config.dgfOwnerKey = vm.envUint("DGF_OWNER_KEY");
+        config.privateKey = vm.envOr("PRIVATE_KEY", config.dgfOwnerKey);
+        config.preDeployedImpl = vm.envOr("NEW_GAME_IMPLEMENTATION", address(0));
+
+        address current = address(config.disputeGameFactory.gameImpls(GameTypes.MULTI_PROOF_GAME_TYPE));
+        require(current != address(0), "Upgrade: no implementation registered for game type 1006");
+        require(current.code.length > 0, "Upgrade: registered implementation has no code");
+        config.currentImpl = MultiProofGame(current);
+
+        require(vm.addr(config.dgfOwnerKey) == config.disputeGameFactory.owner(), "Upgrade: DGF owner key mismatch");
+
+        // Defaults are the live values; every override is deliberate and asserted below.
+        MultiProofGame prev = config.currentImpl;
+        // Not readable off the deployed implementation; validated through `domainHash`.
+        config.rollupConfigHash = vm.envBytes32("ROLLUP_CONFIG_HASH");
+        config.blockInterval = vm.envUint("PROOF_SYSTEM_BLOCK_INTERVAL");
+        config.challengePeriod = vm.envOr("CHALLENGE_PERIOD", uint256(prev.challengePeriod().raw())).toUint64();
+        config.proofPeriod = vm.envOr("PROOF_PERIOD", uint256(prev.proofPeriod().raw())).toUint64();
+        config.proposerBond = vm.envOr("PROPOSER_BOND", prev.proposerBond());
+        config.challengerBond = vm.envOr("CHALLENGER_BOND", prev.challengerBond());
+        config.proofThreshold = vm.envOr("PROOF_THRESHOLD", uint256(prev.PROOF_THRESHOLD())).toUint8();
+        config.protocolFeeRecipient = vm.envOr("PROTOCOL_FEE_RECIPIENT", prev.protocolFeeRecipient());
+        config.validityProofVerifier =
+            IWorldChainProofVerifier(vm.envOr("VALIDITY_PROOF_VERIFIER", address(prev.validityProofVerifier())));
+        config.teeVerifier = IWorldChainProofVerifier(vm.envOr("TEE_VERIFIER", address(prev.teeVerifier())));
+        config.securityCouncil =
+            IWorldChainProofVerifier(vm.envOr("SECURITY_COUNCIL_VERIFIER", address(prev.securityCouncil())));
+        config.anchorStateRegistry =
+            IAnchorStateRegistry(vm.envOr("ANCHOR_STATE_REGISTRY", address(prev.anchorStateRegistry())));
+        config.weth = IDelayedWETH(payable(vm.envOr("DELAYED_WETH", address(prev.weth()))));
+
+        // A fresh DelayedWETH would strand every bond held for in-flight games in the old one.
+        require(address(config.weth) == address(prev.weth()), "Upgrade: DelayedWETH must be reused");
+        // Lane independence is what makes the threshold mean anything.
+        require(
+            address(config.validityProofVerifier) != address(config.teeVerifier)
+                && address(config.validityProofVerifier) != address(config.securityCouncil)
+                && address(config.teeVerifier) != address(config.securityCouncil),
+            "Upgrade: proof lane verifiers must be distinct"
+        );
+    }
+
+    /// @dev The invariants that separate a bytecode swap from a silent fork of the proof domain.
+    function _validateReplacement(Config memory config, MultiProofGame newImpl) internal view {
+        MultiProofGame prev = config.currentImpl;
+        require(address(newImpl) != address(prev), "Upgrade: implementation unchanged");
+        require(
+            newImpl.domainHash() == prev.domainHash(),
+            "Upgrade: domainHash drift invalidates every in-flight proposal and queued proof"
+        );
+        require(
+            address(newImpl.disputeGameFactory()) == address(config.disputeGameFactory),
+            "Upgrade: new implementation points at a different factory"
+        );
+        require(
+            address(newImpl.anchorStateRegistry()) == address(prev.anchorStateRegistry()),
+            "Upgrade: AnchorStateRegistry changed"
+        );
+        require(address(newImpl.weth()) == address(prev.weth()), "Upgrade: DelayedWETH changed");
+        require(newImpl.PROOF_THRESHOLD() == config.proofThreshold, "Upgrade: proof threshold mismatch");
+        require(newImpl.proposerBond() == config.proposerBond, "Upgrade: proposer bond mismatch");
+        require(newImpl.challengerBond() == config.challengerBond, "Upgrade: challenger bond mismatch");
+        require(
+            config.anchorStateRegistry.respectedGameType().raw() == GameTypes.MULTI_PROOF_GAME_TYPE.raw(),
+            "Upgrade: game type 1006 is not the respected game type"
+        );
+
+        console.log("MultiProofGame upgrade");
+        console.log("  previous implementation:", address(prev));
+        console.log("  new implementation:     ", address(newImpl));
+        console.log("  previous version:       ", prev.version());
+        console.log("  new version:            ", newImpl.version());
+        console.log("  domainHash (unchanged): ", vm.toString(newImpl.domainHash()));
+    }
+
+    function _gameConfig(Config memory config) internal pure returns (IMultiProofGame.GameConfig memory) {
+        return IMultiProofGame.GameConfig({
+            rollupConfigHash: config.rollupConfigHash,
+            blockInterval: config.blockInterval,
+            challengePeriod: config.challengePeriod,
+            proofPeriod: config.proofPeriod,
+            proposerBond: config.proposerBond,
+            challengerBond: config.challengerBond,
+            protocolFeeRecipient: config.protocolFeeRecipient,
+            proofThreshold: config.proofThreshold,
+            validityProofVerifier: config.validityProofVerifier,
+            teeVerifier: config.teeVerifier,
+            securityCouncil: config.securityCouncil,
+            anchorStateRegistry: config.anchorStateRegistry,
+            weth: config.weth
+        });
+    }
+
+    /// @dev Patches the two implementation keys in the existing deployment record instead of
+    ///      rewriting it, so the untouched addresses cannot drift from what is on chain.
+    function _writeDeployment(Config memory config, address newImpl) internal {
+        string memory out = vm.envOr("PROOF_SYSTEM_DEPLOYMENT_OUT", string(""));
+        if (bytes(out).length == 0) return;
+
+        vm.writeJson(vm.toString(address(config.currentImpl)), out, ".previousGameImplementation");
+        vm.writeJson(vm.toString(newImpl), out, ".gameImplementation");
+        vm.writeJson(vm.toString(uint256(LibProof.PROOF_SYSTEM_VERSION)), out, ".proofSystemVersion");
+    }
+}


### PR DESCRIPTION
Prepares the in-place upgrade of game type 1006 on alphanet to the `MultiProofGame` ABI from #1003.

- `UpgradeGameImplementation.s.sol` + `just proof-upgrade-game`: deploys the new implementation with every parameter read off the registered one, asserts `domainHash` is unchanged, then `setImplementation(1006, …)`.
- `DeployValidityVerifier.s.sol` + `just proof-deploy-validity-verifier`: the SP1 vkeys in #1003 differ from the ones on alphanet's deployed verifier, and both are immutable, so the validity lane needs a new verifier before the swap.
- `docs/proof/upgrade-game-implementation.md`: ordered cutover, rollback, kill switch.

Verified by running the upgrade end to end against an anvil fork of Sepolia at the live alphanet factory: `domainHash` preserved, `submitProofLane(bytes)` registered, deployment record patched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches L1 `DisputeGameFactory` registration and proof-domain invariants (`domainHash`, immutable vkeys); misconfiguration could fork provers from in-flight games or silently reject proofs until challenge timeouts.
> 
> **Overview**
> Adds **operational upgrade paths** for alphanet’s live proof dispute game (type **1006**) without redeploying the full proof system.
> 
> **`just proof-deploy-validity-verifier`** and **`DeployValidityVerifier.s.sol`** deploy a new **`SP1ValidityVerifier`** using vkeys from **`proofs/backends/sp1/elfs/vkeys.json`**, with a guard that refuses deployment when keys already match the verifier on the current game implementation.
> 
> **`just proof-upgrade-game`** and **`UpgradeGameImplementation.s.sol`** deploy (or adopt via **`NEW_GAME_IMPLEMENTATION`**) a replacement **`MultiProofGame`**, defaulting constructor params from the registered implementation, **reverting if `domainHash` drifts**, then call **`DisputeGameFactory.setImplementation(1006, …)`** and patch **`gameImplementation`** / **`previousGameImplementation`** in the env deployment JSON (skipped on dry run).
> 
> **`docs/proof/upgrade-game-implementation.md`** documents the ordered cutover (vkey re-key → upgrade → service rollout → verify), rollback, and a factory kill switch. The Justfile workflow comments now list these as separate **Upgrade** phases outside **`proof-setup`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61606236039cb1af19ec2b0c75d7d7c369f4a7b0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->