### PR TITLE
fix(ci): fix clippy

### DIFF
--- a/proofs/services/challenger/src/error.rs
+++ b/proofs/services/challenger/src/error.rs
@@ -20,7 +20,7 @@ pub enum ChallengerError {
     },
     /// Contract call or transaction failure.
     #[error(transparent)]
-    Contract(#[from] alloy_contract::Error),
+    Contract(Box<alloy_contract::Error>),
     #[error(transparent)]
     OutputRoot(#[from] ConsensusError),
     #[error("The challenge transaction didn't execute succesfully: {0}")]
@@ -50,6 +50,12 @@ pub enum ChallengerError {
         /// Block number included in the game.
         given_block: u64,
     },
+}
+
+impl From<alloy_contract::Error> for ChallengerError {
+    fn from(error: alloy_contract::Error) -> Self {
+        Self::Contract(Box::new(error))
+    }
 }
 
 impl ChallengerError {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mechanical error-type boxing with equivalent `From` behavior; no logic or API changes beyond enum layout.
> 
> **Overview**
> Addresses a Clippy lint on **`ChallengerError`** by boxing **`alloy_contract::Error`** in the **`Contract`** variant instead of storing it inline.
> 
> The **`#[from]`** derive on that variant is removed and replaced with an explicit **`From<alloy_contract::Error>`** implementation that wraps the error in **`Box::new`**, preserving **`?`** conversion behavior while shrinking the enum’s stack size.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec9da1940311d724af61912604d1eced87c27cd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->