### PR TITLE
docs: refresh WIP-1006

### DIFF
--- a/wips/wip-1006.md
+++ b/wips/wip-1006.md
@@ -45,7 +45,7 @@ Activation parameters are set at hardfork activation and held as immutable value
 | Name | Initial Value | Meaning |
 | --- | --- | --- |
 | `PROOF_THRESHOLD` | `2` | Number of distinct proof lanes that MUST support a challenged root before it finalizes. The implementation accepts values from `1` through `PROOF_LANE_COUNT`. |
-| `BLOCK_INTERVAL` | `450` L2 blocks | Exact distance each proposal MUST advance from its parent. |
+| `BLOCK_INTERVAL` | TBD | Exact distance each proposal MUST advance from its parent. |
 | `CHALLENGE_PERIOD` | `1 day` | Duration after proposal creation during which any participant MAY challenge a root and any party MAY submit the initial proof. Per-proposal `challengeDeadline = createdAt + CHALLENGE_PERIOD`. |
 | `PROOF_PERIOD` | `7 days` | Duration after proposal creation during which the proposer MAY defend a challenged root by accumulating lane submissions toward `PROOF_THRESHOLD`. Per-proposal `proofDeadline = createdAt + PROOF_PERIOD`. `PROOF_PERIOD` MUST be greater than `CHALLENGE_PERIOD`. A challenged root that the proposer has not defended to `PROOF_THRESHOLD` by `proofDeadline` MUST be invalidated. |
 | `PROPOSER_BOND` | TBD | ETH bond supplied to `DisputeGameFactory.create` and held by `DelayedWETH`. Paid to the proposer after `DEFENDER_WINS`, split between the challenger and protocol after a challenged proof timeout, paid to the protocol after an unchallenged proof timeout, or refunded if the registry invalidates the game. |

--- a/wips/wip-1006.md
+++ b/wips/wip-1006.md
@@ -20,7 +20,7 @@ The vanilla OP Stack fault-proof system inherits a multi-day challenge window fo
 World Chain targets two properties that neither model provides together:
 
 - **A stable factory identity.** Proof bytes are submitted to the created game rather than included in `extraData`, so the stock factory UUID remains predictable from the transition.
-- **A cheap common path.** Only one configured proof lane is required when no staked participant objects to a root.
+- **A cheap common path.** Only one configured proof lane is required when no participant objects to a root.
 - **A diversified disputed path.** When a root is challenged, the proposer must defend it, and no single prover, TEE vendor, or council action can finalize that defense. At least two independent lanes must agree.
 
 The result is fast finality in the common case and `n / m` threshold security in the dispute case.
@@ -35,8 +35,8 @@ Protocol constants are fixed by this WIP and MUST NOT be changed without a new W
 
 | Name | Value | Meaning |
 | --- | --- | --- |
-| `PROOF_THRESHOLD` | `2` | Number of distinct proof lanes that MUST support a challenged root before it finalizes. |
 | `PROOF_LANE_COUNT` | `3` | Number of configured proof lanes. |
+| `CHALLENGER_REWARD_BPS` | `5,000` | Share of a forfeited proposer bond paid to the challenger after a challenged proof timeout, in basis points. |
 
 ### Activation Parameters
 
@@ -44,12 +44,13 @@ Activation parameters are set at hardfork activation and held as immutable value
 
 | Name | Initial Value | Meaning |
 | --- | --- | --- |
-| `CHALLENGE_PERIOD` | `1 day` | Duration after proposal creation during which a staked participant MAY challenge a root and any party MAY submit the initial proof. Per-proposal `challengeDeadline = createdAt + CHALLENGE_PERIOD`. |
+| `PROOF_THRESHOLD` | `2` | Number of distinct proof lanes that MUST support a challenged root before it finalizes. The implementation accepts values from `1` through `PROOF_LANE_COUNT`. |
+| `BLOCK_INTERVAL` | `450` L2 blocks | Exact distance each proposal MUST advance from its parent. |
+| `CHALLENGE_PERIOD` | `1 day` | Duration after proposal creation during which any participant MAY challenge a root and any party MAY submit the initial proof. Per-proposal `challengeDeadline = createdAt + CHALLENGE_PERIOD`. |
 | `PROOF_PERIOD` | `7 days` | Duration after proposal creation during which the proposer MAY defend a challenged root by accumulating lane submissions toward `PROOF_THRESHOLD`. Per-proposal `proofDeadline = createdAt + PROOF_PERIOD`. `PROOF_PERIOD` MUST be greater than `CHALLENGE_PERIOD`. A challenged root that the proposer has not defended to `PROOF_THRESHOLD` by `proofDeadline` MUST be invalidated. |
-| `PROPOSER_BOND` | TBD | ETH bond supplied to `DisputeGameFactory.create` and held as `DelayedWETH` credit by the game. Paid to the proposer after `DEFENDER_WINS`, to the challenger after a challenged proof timeout, to the configured protocol recipient after an unchallenged proof timeout, or refunded if the registry invalidates the game. It MUST exceed `CHALLENGE_FEE`, so successfully challenging an invalid root has a positive gross reward before transaction costs. |
-| `CHALLENGER_BOND` | TBD | ETH bond supplied by the challenger and held as `DelayedWETH` credit by the game. The non-refundable `CHALLENGE_FEE` is deducted whenever a challenge is accepted; the remainder is paid to the proposer after a successful defense, to the challenger after proof timeout, or refunded if the registry invalidates the game. |
-| `PROTOCOL_FEE_RECIPIENT` | TBD | Nonzero protocol-controlled recipient credited with the proposer bond when an unchallenged proposal expires without any valid proof lane and with `CHALLENGE_FEE` whenever a challenge is accepted. |
-| `CHALLENGE_FEE` | TBD | Nonzero flat amount deducted from `CHALLENGER_BOND` whenever a challenge is accepted. It MUST NOT exceed `CHALLENGER_BOND` and MUST remain charged under both normal and refund settlement. |
+| `PROPOSER_BOND` | TBD | ETH bond supplied to `DisputeGameFactory.create` and held by `DelayedWETH`. Paid to the proposer after `DEFENDER_WINS`, split between the challenger and protocol after a challenged proof timeout, paid to the protocol after an unchallenged proof timeout, or refunded if the registry invalidates the game. |
+| `CHALLENGER_BOND` | TBD | ETH bond supplied by the challenger and held by `DelayedWETH`. Split between the proposer and accepted proof-lane recipients after a successful defense, returned to the challenger after proof timeout, or refunded if the registry invalidates the game. |
+| `PROTOCOL_FEE_RECIPIENT` | TBD | Nonzero protocol-controlled recipient credited with the proposer bond after an unchallenged proof timeout and with the portion not paid to the challenger after a challenged proof timeout. |
 
 ### Proof Lanes
 
@@ -76,7 +77,7 @@ The data bound by every proof and attestation is split into immutable domain con
 | `l2BlockNumber` | Proposer | L2 block number for `rootClaim`, matching the [`l2BlockNumber` field of an OP Stack L2 output proposal][op-proposals]. |
 | `parentRef` | Proposer | Address of the parent — the `AnchorStateRegistry` for the first proposal, otherwise the parent proposal. Same convention as the OP Stack [Fault Dispute Game `extraData` parent reference][op-dgi] and the parent reference encoded in Base Azul's `AggregateVerifier` extra-data layout (see [Base Azul proof system][base-azul]). The parent's `rootClaim` and `l2BlockNumber` are read from this reference rather than re-supplied. |
 | `attempt` | Proposer | Retry nonce for the same transition. Attempt zero is the initial game; later attempts are permitted only after an eligible predecessor fails or is made obsolete by activation. |
-| `l1OriginHash` | Factory | L1 origin hash captured at proposal creation. The proposer does not pass it as calldata; it is read via `blockhash()` or [EIP-2935][eip-2935] history and pinned by the factory, mirroring the OP Stack [`l1Head` snapshot at clone creation][op-dgi] that Base Azul inherits. |
+| `l1OriginHash` | Factory | Previous L1 block hash captured at proposal creation. The proposer does not pass it as calldata. |
 | `l1OriginNumber` | Game | L1 block number paired with the factory-captured `l1OriginHash`. |
 
 The proposer calls `DisputeGameFactory.create(gameType, rootClaim, extraData)`, where:
@@ -87,12 +88,8 @@ extraData = abi.encode(domainHash, l2BlockNumber, parentRef, attempt)
 
 [op-output-root]: https://specs.optimism.io/protocol/proposals.html#l2-output-commitment-construction
 [op-proposals]: https://specs.optimism.io/protocol/proposals.html
-[op-fdg]: https://specs.optimism.io/fault-proof/stage-one/fault-dispute-game.html
 [op-dgi]: https://specs.optimism.io/fault-proof/stage-one/dispute-game-interface.html
 [base-azul]: https://docs.base.org/base-chain/specs/protocol/proofs/contracts
-[base-azul-extradata]: https://docs.base.org/base-chain/specs/protocol/proofs/contracts#game-extra-data
-[base-azul-l1head]: https://docs.base.org/base-chain/specs/protocol/proofs/contracts#clone-arguments
-[eip-2935]: https://eips.ethereum.org/EIPS/eip-2935
 
 #### Domain (verifier-immutable)
 
@@ -101,15 +98,16 @@ extraData = abi.encode(domainHash, l2BlockNumber, parentRef, attempt)
 | `chainId` | World Chain L2 chain ID. |
 | `proofSystemVersion` | Version of this proof system's proof-domain encoding. |
 | `rollupConfigHash` | Hash of the rollup configuration and World Chain hardfork schedule. |
+| `blockInterval` | Exact distance in L2 blocks between a parent root and a proposed root. |
 
-These values are set once on the game implementation (analogous to Base's `CONFIG_HASH` and `L2_CHAIN_ID` immutables). Proposal cadence is deliberately absent: the game enforces only that each proposal advances its parent, so the distance between roots is proposer policy that the proposer and challenger agree on offchain. Their hash is supplied in each game's `extraData` and MUST equal the implementation's immutable `domainHash`. Lane-specific constants, such as the active TEE image hash and validity-proof program key, live in the lane verifiers and are committed to by those lanes' proof material.
+These values are set once on the game implementation. Their hash is supplied in each game's `extraData` and MUST equal the implementation's immutable `domainHash`. Lane-specific constants, such as the active TEE image hash and validity-proof program key, live in the lane verifiers and are committed to by those lanes' proof material.
 
 #### Canonical identifiers
 
 The contracts use two related identifiers:
 
 - `gameUUID` is the stock `DisputeGameFactory` lookup key. It commits to `gameType`, `rootClaim`, and the complete `extraData`, but excludes the factory-captured L1 origin.
-- `rootId` is the proof-bound commitment. It includes the factory-captured L1 origin and is the value every proof lane MUST bind to.
+- `rootId` is the complete proposal commitment. It includes the factory-captured L1 origin and is attested directly by the Security Council lane. The validity and TEE lanes instead attest the transition reconstructed from the same game.
 
 The contract computes:
 
@@ -117,7 +115,8 @@ The contract computes:
 domainHash = keccak256(abi.encode(
     chainId,
     proofSystemVersion,
-    rollupConfigHash
+    rollupConfigHash,
+    blockInterval
 ))
 
 extraData = abi.encode(
@@ -143,7 +142,7 @@ rootId = keccak256(abi.encode(
 ))
 ```
 
-The factory MUST reject duplicate games with the same `gameUUID`. All proofs and attestations MUST bind to `rootId`. A proof or attestation that binds to a different domain, parent, root, block range, or L1 origin MUST NOT be accepted for `rootId`.
+The factory MUST reject duplicate games with the same `gameUUID`. The validity and TEE lanes MUST bind to the game-reconstructed transition `(l1Head, l2PreRoot, l2PreBlockNumber, l2PostRoot, l2PostBlockNumber, rollupConfigHash)`. The Security Council lane MUST bind to `rootId`.
 
 ### State Machine
 
@@ -155,7 +154,7 @@ stateDiagram-v2
     PROPOSED --> FINALIZED: PROOF_THRESHOLD lanes
     PROPOSED --> FINALIZED: one proof + unchallenged deadline
     PROPOSED --> INVALIDATED: no proof at unchallenged deadline
-    PROPOSED --> CHALLENGED: staked challenge before challenge deadline
+    PROPOSED --> CHALLENGED: bonded challenge before challenge deadline
     CHALLENGED --> FINALIZED: resolve after PROOF_THRESHOLD lanes
     CHALLENGED --> INVALIDATED: resolve after proof timeout
     PROPOSED --> INVALIDATED: resolve after parent invalidation
@@ -182,18 +181,16 @@ An initial `attempt = 0` identifies the first game for a transition. A later att
 
 ### Challenge Lifecycle
 
-Any staked participant MAY challenge a proposed root before `challengeDeadline`, regardless of whether an initial proof lane already supports it. A challenge goes through optimistically: the challenger is not asked to prove that the root is invalid, and the challenge succeeds by default unless the proposer defends the root. The challenge raises the required support from one lane to `PROOF_THRESHOLD`.
+Any participant MAY challenge a proposed root before `challengeDeadline`, regardless of whether an initial proof lane already supports it. A challenge goes through optimistically: the challenger is not asked to prove that the root is invalid, and the challenge succeeds by default unless the proposer defends the root. The challenge raises the required support from one lane to `PROOF_THRESHOLD`.
 
 The challenge transaction:
 
-- MUST verify that the caller is currently staked according to the configured staking registry.
 - MUST NOT require the caller to submit proof material.
 - MUST require the caller to supply `CHALLENGER_BOND` as ETH and deposit it into the game's `DelayedWETH`;
-- MUST irrevocably assign `CHALLENGE_FEE` of that bond to `PROTOCOL_FEE_RECIPIENT` in both normal and refund settlement modes;
 - MUST mark the root as `CHALLENGED`.
-- MUST record `challengedAt = block.timestamp` on the root the first time it transitions to `CHALLENGED`. The challenge MUST NOT change the `proofDeadline` recorded at proposal creation.
+- MUST NOT change the `proofDeadline` derived from proposal creation.
 
-If the challenged root resolves in favor of the proposer, the proposer receives the proposer bond plus the challenger bond remainder. If it times out below threshold, the challenger receives the proposer bond plus its challenger bond remainder. The protocol receives `CHALLENGE_FEE` in either case. A game accepts only one challenger.
+If the challenged root resolves in favor of the proposer, the challenger bond is split equally between the proposer and each accepted proof-lane recipient; the proposer also recovers the proposer bond. If it times out below threshold, the challenger recovers the challenger bond plus `CHALLENGER_REWARD_BPS` of the proposer bond, and the protocol receives the remainder. A game accepts only one challenger.
 
 A challenge submitted at or after `challengeDeadline` MUST revert.
 
@@ -206,8 +203,8 @@ Otherwise, if no valid challenge has been submitted by `challengeDeadline`, anyo
 - the root is still `PROPOSED`;
 - the parent is the anchor sentinel or has resolved with `DEFENDER_WINS`; and
 - the parent is not blacklisted; and
-- either at least `PROOF_THRESHOLD` configured lanes support `rootId`, or
-  `block.timestamp >= challengeDeadline` and at least one configured lane supports `rootId`.
+- either at least `PROOF_THRESHOLD` configured lanes support the proposal, or
+  `block.timestamp >= challengeDeadline` and at least one configured lane supports the proposal.
 
 If no proof lane supports the root at `challengeDeadline`, the game MUST instead resolve with `CHALLENGER_WINS`, record proof timeout, and credit the proposer bond to the configured protocol recipient. This outcome MUST remain retryable even when no challenger exists.
 
@@ -219,24 +216,24 @@ Once a root is challenged, the burden of proof rests with the **proposer**, who 
 
 Defending the root is the proposer's responsibility because the proposer's `PROPOSER_BOND` is forfeited if the root fails to reach the threshold. Lane submission itself remains permissionless — any party MAY relay a valid lane submission, and a proposer MAY coordinate independent provers, TEE signers, and the Security Council to do so — but the protocol assigns the economic responsibility for the defense to the proposer and to no other party.
 
-Each root tracks a per-lane support set (the **proof bitmap**) with one bit per entry in [Proof Lanes](#proof-lanes). Each lane's bit is set at most once, so duplicate submissions from the same lane MUST NOT increase the threshold count.
+Each root tracks a per-lane support set (the **proof bitmap**) with one bit per entry in [Proof Lanes](#proof-lanes). Each lane's bit is set at most once, and a duplicate submission MUST revert. Each submission also names the recipient of that lane's share of a forfeited challenger bond.
 
 For each lane submission, the contract MUST:
 
 1. Verify that the game is still in progress.
 2. Verify that `block.timestamp < challengeDeadline` when unchallenged, or `block.timestamp < proofDeadline` when challenged.
-3. Verify that the proof or attestation binds to `rootId`.
+3. Decode the lane, reward recipient, and lane-specific proof from the compact payload.
 4. Verify the proof or attestation according to the lane-specific verifier.
 5. Set the lane's bit in the root's proof bitmap.
-6. Emit a threshold-reached signal when the bitmap first contains at least `PROOF_THRESHOLD` distinct lanes.
+6. Record the lane recipient and emit `Proved` with the updated bitmap.
 
 A lane submission at or after its applicable deadline MUST revert. Once threshold is met, anyone MAY call `resolve()`, which MUST resolve the game with `DEFENDER_WINS` whether or not it was challenged.
 
-If `block.timestamp >= proofDeadline` and the proof bitmap contains fewer than `PROOF_THRESHOLD` distinct lanes, anyone MAY call `resolve()`. The game MUST resolve with `CHALLENGER_WINS`, record proof timeout as the invalidation reason, and credit the proposer bond plus the challenger bond remainder to the challenger.
+If `block.timestamp >= proofDeadline` and the proof bitmap contains fewer than `PROOF_THRESHOLD` distinct lanes, anyone MAY call `resolve()`. The game MUST resolve with `CHALLENGER_WINS`, record proof timeout as the invalidation reason, return the challenger bond, credit `CHALLENGER_REWARD_BPS` of the proposer bond to the challenger, and credit the remainder to `PROTOCOL_FEE_RECIPIENT`.
 
 ### Invalidity and Conflicts
 
-Invalidation occurs either when a challenged root times out below threshold or when its parent is blacklisted or resolves with `CHALLENGER_WINS`. Parent invalidation MUST cascade before a descendant can resolve successfully. Because neither participant caused an ancestor failure, the descendant proposer bond and challenger bond remainder MUST be refunded. The challenge fee remains charged.
+Invalidation occurs either when a challenged root times out below threshold or when its parent is blacklisted or resolves with `CHALLENGER_WINS`. Parent invalidation MUST cascade before a descendant can resolve successfully. Because neither participant caused an ancestor failure, the descendant proposer and challenger MUST recover their full bonds.
 
 An invalidated root MUST NOT become claim-valid or update the anchor.
 
@@ -246,11 +243,11 @@ If invalidity of a finalized root is discovered after the fact — for example, 
 
 #### Validity Proof
 
-The validity proof lane verifies that the transition from `parentRoot` at `parentL2BlockNumber` to `rootClaim` at `l2BlockNumber` is valid under `rollupConfigHash`. The verifier MAY be implemented with a zkVM, a SNARK, or another cryptographic proof system. The proof MUST bind to `rootId` and MUST be verified onchain or by an onchain verifier gateway.
+The validity proof lane verifies that the transition from `parentRoot` at `parentL2BlockNumber` to `rootClaim` at `l2BlockNumber` is valid under `rollupConfigHash`. The current verifier checks an SP1 aggregation proof against transition public values reconstructed by the game.
 
 #### TEE Attestation
 
-The TEE lane accepts a signature from a registered TEE signer over transition data bound to `rootId`. Signer admission MUST verify the hardware attestation, approved image measurements, and attestation freshness before deriving and activating the signer's identity. For each proof, the lane verifier MUST check the transition binding, recover the signer from the signature, and require that signer to remain active in the registry. Revocation MUST prevent all subsequent proofs from that signer.
+The TEE lane accepts a signature from a registered TEE signer over transition public values reconstructed by the game. Signer admission MUST verify the hardware attestation, approved image measurements, and attestation freshness before deriving and activating the signer's identity. For each proof, the lane verifier MUST check the transition binding, recover the signer from the signature, and require that signer to remain active in the registry. Revocation MUST prevent all subsequent proofs from that signer.
 
 #### Security Council Attestation
 
@@ -278,7 +275,7 @@ Resolution assigns normal-mode credits. After the stock dispute-game finality de
 
 Closing SHOULD attempt to advance the anchor but MUST treat an ineligible or stale anchor update as non-fatal. Credit claims MUST use the two-phase `DelayedWETH` flow: first unlock the recipient's credit, then withdraw it after the configured delay. Claiming MAY be permissionless, but funds MUST only be transferred to the credited recipient.
 
-For every challenged game, `CHALLENGE_FEE` MUST be credited to `PROTOCOL_FEE_RECIPIENT` in both distribution modes. Blacklisting, retirement, invalid-parent resolution, and any other refund-mode outcome MUST NOT return that fee to the challenger.
+For challenged `DEFENDER_WINS`, `CHALLENGER_BOND` MUST be split equally between the proposer and every accepted proof-lane recipient, with any integer-division remainder credited to the proposer. For challenged `PROOF_TIMEOUT`, the challenger receives its bond plus `CHALLENGER_REWARD_BPS` of `PROPOSER_BOND`; `PROTOCOL_FEE_RECIPIENT` receives the rest of `PROPOSER_BOND`. `REFUND` mode returns the full deposited bonds to their depositors instead of applying normal-mode rewards.
 
 ### Portal Withdrawals
 
@@ -294,19 +291,13 @@ WIP-1006 is implemented as a new game type on the stock OP Stack dispute infrast
 | `IDisputeGame` / `IMultiProofGame` | Per-proposal game; exposes the Portal-facing lifecycle and World Chain proof-lane extensions. | [`AggregateVerifier`][base-aggregate] |
 | `IAnchorStateRegistry` | Stock OP registry; evaluates registration, respect, blacklist, retirement, finality, claim validity, and the current anchor. | [`AnchorStateRegistry`][base-anchor] |
 | `IDelayedWETH` | Holds proposer and challenger bonds and enforces delayed two-phase credit withdrawal. | OP Stack `DelayedWETH`. |
-| `IValidityProofVerifier` | Verifies the `VALIDITY_PROOF` lane against `rootId`. | [`ZKVerifier`][base-zk] |
-| `ITEEVerifier` | Verifies the `TEE_ATTESTATION` lane against `rootId`. | [`TEEVerifier`][base-tee] |
-| `ITEEProverRegistry` | Maintains accepted TEE signer identities, image hashes, and proposer allowlisting. | [`TEEProverRegistry`][base-tee-registry] |
-| `ISecurityCouncil` | Submits and verifies `SECURITY_COUNCIL` attestations bound to `rootId`. | World Chain Security Council multisig. |
-| `IStakingRegistry` | Checks challenger eligibility only. Bond custody and distribution remain in the game and `DelayedWETH`. | World Chain-specific; no Base analogue. |
+| `IWorldChainProofVerifier` | Common verifier interface for the validity, TEE, and Security Council lanes. | [`IWorldChainProofVerifier`](../pkg/contracts/src/dispute/interfaces/IWorldChainProofVerifier.sol) |
+| `NitroEnclaveKeyRegistry` | Maintains TEE signer identities admitted through Nitro attestation. | [`NitroEnclaveKeyRegistry`](../pkg/contracts/src/dispute/nitro/NitroEnclaveKeyRegistry.sol) |
+| `SecurityCouncilVerifier` | Verifies the council Safe's ERC-1271 attestation over `rootId`. | [`SecurityCouncilVerifier`](../pkg/contracts/src/dispute/council/SecurityCouncilVerifier.sol) |
 
-[base-contracts]: https://docs.base.org/base-chain/specs/protocol/proofs/contracts
 [base-factory]: https://docs.base.org/base-chain/specs/protocol/proofs/contracts#disputegamefactory
 [base-aggregate]: https://docs.base.org/base-chain/specs/protocol/proofs/contracts#aggregateverifier
 [base-anchor]: https://docs.base.org/base-chain/specs/protocol/proofs/contracts#anchorstateregistry
-[base-zk]: https://docs.base.org/base-chain/specs/protocol/proofs/contracts#zkverifier
-[base-tee]: https://docs.base.org/base-chain/specs/protocol/proofs/contracts#teeverifier
-[base-tee-registry]: https://docs.base.org/base-chain/specs/protocol/proofs/contracts#teeproverregistry
 
 ## Backwards Compatibility
 
@@ -333,11 +324,10 @@ Before this WIP can move beyond Draft, implementations SHOULD cover at least:
 - an unchallenged proofless root invalidates after exactly `CHALLENGE_PERIOD`, forfeits its proposer bond to the configured protocol recipient, and can be retried;
 - factory creation rejects an incorrect domain hash or malformed `extraData`;
 - factory UUID lookup and `findLatestGames` preserve the complete WIP-1006 `extraData`;
-- an unstaked account cannot challenge;
-- a staked account can challenge without proof before the deadline;
-- a staked account can challenge after an initial proof, and the game then requires `PROOF_THRESHOLD` lanes;
-- a proposer that challenges its own valid game recovers at most both bonds minus `CHALLENGE_FEE`;
-- normal-mode and refund-mode settlement both credit `CHALLENGE_FEE` to the protocol recipient;
+- any account can challenge without proof by posting `CHALLENGER_BOND` before the deadline;
+- an account can challenge after an initial proof, and the game then requires `PROOF_THRESHOLD` lanes;
+- a proposer that challenges its own game and lets it time out loses the protocol share of `PROPOSER_BOND`;
+- challenged `DEFENDER_WINS` splits `CHALLENGER_BOND` between the proposer and accepted proof-lane recipients;
 - a challenge at or after the deadline reverts;
 - a configuration where `proofDeadline <= challengeDeadline` is rejected;
 - a challenged root with one supporting lane does not finalize;
@@ -345,8 +335,8 @@ Before this WIP can move beyond Draft, implementations SHOULD cover at least:
 - a challenged root the proposer fails to defend to `PROOF_THRESHOLD` lanes by `proofDeadline` invalidates and forfeits `PROPOSER_BOND`;
 - a lane submission at or after `proofDeadline` reverts and does not affect the proof bitmap;
 - challenging a root does not change its creation-time `proofDeadline`;
-- duplicate submissions from the same lane do not increase the threshold count;
-- every proof lane rejects material that does not bind to `rootId`;
+- duplicate submissions from the same lane revert without changing the threshold count or reward recipient;
+- validity and TEE proofs reject mismatched transition data, and council attestations reject a mismatched `rootId`;
 - parent invalidation cascades and refunds both descendant participants;
 - retry attempts reject an ineligible predecessor and accept each specified recovery case;
 - close and claim use normal mode for proper games and refund mode for blacklisted or retired games;
@@ -354,7 +344,7 @@ Before this WIP can move beyond Draft, implementations SHOULD cover at least:
 
 ## Security Considerations
 
-**Unchallenged-path safety relies on one proof lane.** Any single configured lane may support the common path. An invalid root can therefore finalize if one lane is compromised and no honest staked participant challenges it before `challengeDeadline`. A timely challenge escalates the game to the independent-lane threshold.
+**Unchallenged-path safety relies on one proof lane.** Any single configured lane may support the common path. An invalid root can therefore finalize if one lane is compromised and no honest participant challenges it before `challengeDeadline`. A timely challenge escalates the game to the independent-lane threshold.
 
 **Disputed-path safety depends on lane independence.** A false challenged finality requires two lanes to accept the same invalid root. Implementations MUST avoid shared signing keys, shared verifier keys, shared operator control, and shared offchain infrastructure across lanes, because any such sharing collapses the effective threshold below two.
 
@@ -362,13 +352,13 @@ Before this WIP can move beyond Draft, implementations SHOULD cover at least:
 
 **Security Council is a safety valve, not a finality mechanism.** Council signing keys, quorum rules, and action domains MUST be isolated from unrelated governance actions. A council attestation alone MUST NOT finalize a challenged root.
 
-**`rootId` domain separation is critical.** Every lane MUST bind to the same `rootId`, and `rootId` itself MUST commit to `chainId`, `proofSystemVersion`, `rollupConfigHash`, and the parent/child block range. Missing domain separation allows replay across chains, hardfork schedules, game types, proof-system versions, or block ranges.
+**Proof binding is lane-specific.** The validity and TEE lanes bind to transition public values reconstructed by the game, while the council binds directly to `rootId`. Changes to either encoding MUST preserve the intended chain, rollup configuration, parent, block range, output root, and L1-head separation.
 
-**`gameUUID` is not a proof target.** It exists for factory duplicate prevention and discovery. Proofs and attestations MUST bind to `rootId`, because the factory UUID does not include the L1 origin captured at game creation.
+**`gameUUID` is not a proof target.** It exists for factory duplicate prevention and discovery and does not include the L1 origin captured at game creation.
 
-**Self-challenge bond recycling creates proof-amplification griefing.** A malicious proposer can create a consensus-valid game and challenge it through the same economic owner. Without a non-refundable charge, the owner recovers the nominal losing bond through the winning account while forcing third-party defenders to produce an additional proof lane. `CHALLENGE_FEE` makes that externalized proof burden carry a linear, unavoidable cost even if proposer and challenger collude. The fee deters but does not cryptographically prevent the attack, so its value MUST be calibrated against the marginal cost of the additional proof.
+**Self-challenge can amplify proof work.** A proposer can challenge its own valid game through another account and force defenders to produce another lane. If the game times out, the shared owner loses the protocol share of `PROPOSER_BOND`; if it is defended, accepted proof-lane recipients share `CHALLENGER_BOND`. A proposer that also controls those recipients can still recycle the successful-defense payout, so the economics limit but do not prevent proof-amplification griefing.
 
-**Bond, fee, and stake calibration are security-critical.** If `CHALLENGER_BOND` or `CHALLENGE_FEE` is too cheap, attackers can grief honest roots into the slow path or force repeated proof work. If either is too expensive, honest watchers may fail to challenge invalid roots. A successful challenger earns `PROPOSER_BOND - CHALLENGE_FEE` before transaction costs, so `PROPOSER_BOND` MUST exceed the fee and SHOULD cover the challenger's expected execution costs with a meaningful safety margin. If `PROPOSER_BOND` is too cheap, invalid-proposal spam is cheap and honest challenges become uneconomical; if it is too expensive, only well-capitalized actors can propose, which centralizes the role. Exact economic parameters are out of scope for this WIP but MUST be tuned before mainnet deployment.
+**Bond calibration is security-critical.** If `CHALLENGER_BOND` is too cheap, attackers can force valid roots into the slow path or create repeated proof work. If it is too expensive, honest watchers may fail to challenge invalid roots. `PROPOSER_BOND` must make invalid proposals expensive while keeping proposal participation viable. Exact economic parameters are out of scope for this WIP but MUST be tuned before mainnet deployment.
 
 ## Copyright
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes to a draft WIP; no runtime or contract code is modified in this PR.
> 
> **Overview**
> Refreshes **WIP-1006** so the written spec matches the current World Chain multi-proof dispute design instead of older staking/`CHALLENGE_FEE` assumptions.
> 
> **Challenges and bonds:** Participation no longer depends on a staking registry—anyone challenges by posting `CHALLENGER_BOND`. `CHALLENGE_FEE` is removed; challenged timeouts pay the challenger `CHALLENGER_REWARD_BPS` (50%) of the forfeited proposer bond, with the rest to the protocol. Successful defense splits `CHALLENGER_BOND` between the proposer and each accepted proof-lane recipient (named per submission). Parent invalidation refunds full bonds.
> 
> **Domain and proofs:** `BLOCK_INTERVAL` (450 L2 blocks) is an activation parameter and part of `domainHash`; proposals must advance the parent by exactly that interval. Proof binding is **lane-specific**: validity and TEE lanes attest game-reconstructed transition public values (SP1 aggregation / TEE signatures); the Security Council binds `rootId`. Lane proofs carry a reward recipient; duplicate lane submissions **revert**.
> 
> **Interfaces:** Contract references shift from Base Azul stubs to repo types (`IWorldChainProofVerifier`, `NitroEnclaveKeyRegistry`, `SecurityCouncilVerifier`). Test cases and security notes are updated for bonded challenges, lane-specific binding, and revised self-challenge economics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9200468a98a7191e54b91d5dad24b20de807c3ad. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->