### PR TITLE
fix: validate MultiProofGame 

### DIFF
--- a/pkg/contracts/src/dispute/MultiProofGame.sol
+++ b/pkg/contracts/src/dispute/MultiProofGame.sol
@@ -338,10 +338,9 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
         Claim rootClaim_ = rootClaim();
         uint256 attempt_ = attempt();
 
-        // INVARIANT: The parent must be a registered, respected, live game of this type.
-        if (parentRef_ != address(anchorStateRegistry) && !_isValidGame(IDisputeGame(parentRef_))) {
-            revert InvalidParentGame();
-        }
+        // INVARIANT: The registry sentinel is only valid while bootstrapping from the starting
+        // anchor. Once an anchor game exists, the parent must be an eligible game.
+        if (!_isValidParent(parentRef_)) revert InvalidParentGame();
 
         // INVARIANT: Each proposal must advance its parent by the configured cadence.
         (, uint256 startingBlockNumber_) = startingProposal();
@@ -394,10 +393,7 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
         // Set the game as initialized.
         initialized = true;
 
-        // Deposit the bond into DelayedWETH and track refund credit.
-        refundModeCredit[gameCreator()] += msg.value;
-        totalBonds += msg.value;
-        weth.deposit{value: msg.value}();
+        _depositBond(gameCreator());
 
         // Set the game's starting timestamp.
         createdAt = Timestamp.wrap(uint64(block.timestamp));
@@ -407,11 +403,25 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
             anchorStateRegistry.respectedGameType().raw() == GameTypes.MULTI_PROOF_GAME_TYPE.raw();
     }
 
-    /// @notice Checks if the game is registered, respected, not blacklisted, not retired, and not challenged.
+    /// @notice Checks if the game is factory-registered, was respected when created, and has not
+    ///         been invalidated by blacklisting, retirement, or a challenger win.
     function _isValidGame(IDisputeGame game) internal view returns (bool) {
         return anchorStateRegistry.isGameRegistered(game) && anchorStateRegistry.isGameRespected(game)
             && !anchorStateRegistry.isGameBlacklisted(game) && !anchorStateRegistry.isGameRetired(game)
             && (game.status() != GameStatus.CHALLENGER_WINS);
+    }
+
+    function _isValidParent(address parentRef_) internal view returns (bool) {
+        if (parentRef_ == address(anchorStateRegistry)) {
+            return address(anchorStateRegistry.anchorGame()) == address(0);
+        }
+        return _isValidGame(IDisputeGame(parentRef_));
+    }
+
+    function _depositBond(address refundRecipient) internal {
+        refundModeCredit[refundRecipient] += msg.value;
+        totalBonds += msg.value;
+        weth.deposit{value: msg.value}();
     }
 
     ////////////////////////////////////////////////////////////////
@@ -442,10 +452,7 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
         // at the challenge, so late challenges cannot extend the game.
         claimData.deadline = proofDeadline();
 
-        // Deposit the bond into DelayedWETH and track refund credit.
-        refundModeCredit[msg.sender] += msg.value;
-        totalBonds += msg.value;
-        weth.deposit{value: msg.value}();
+        _depositBond(msg.sender);
 
         emit Challenged(msg.sender, claimData.deadline.raw());
 
@@ -632,6 +639,8 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
         // claim, return instead of reverting so the close is not rolled back.
         bool gameWasOpen = bondDistributionMode == BondDistributionMode.UNDECIDED;
 
+        // Close lazily so claiming does not depend on a separate keeper transaction. This is a
+        // no-op once the distribution mode has been fixed.
         closeGame();
 
         uint256 recipientCredit;

--- a/pkg/contracts/test/dispute/MultiProofGame.t.sol
+++ b/pkg/contracts/test/dispute/MultiProofGame.t.sol
@@ -154,6 +154,21 @@ contract MultiProofGameTest is OPStackFixtures {
         assertEq(previousAnchorChild.startingBlockNumber(), parent.l2SequenceNumber());
     }
 
+    function test_Create_RejectsAnchorSentinelAfterAnchorAdvances() public {
+        MultiProofGame parent = _proposeAtAnchor();
+        _resolveUnchallenged(parent);
+        _passAirgap(parent);
+        parent.closeGame();
+        assertEq(address(asr.anchorGame()), address(parent));
+
+        uint256 target = STARTING_ANCHOR_BLOCK + BLOCK_INTERVAL;
+        vm.prank(proposer);
+        vm.expectRevert(InvalidParentGame.selector);
+        dgf.create{value: PROPOSER_BOND}(
+            WC_GAME_TYPE, Claim.wrap(keccak256("late-bootstrap-root")), _extraData(target, type(uint256).max, 0)
+        );
+    }
+
     function test_Constructor_RejectsInvalidConfiguration() public {
         IMultiProofGame.GameConfig memory config = _gameConfig();
         config.blockInterval = 0;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes dispute-game creation invariants on a security-sensitive path, but the diff is narrow and covered by a new regression test.
> 
> **Overview**
> Tightens **parent validation** on `MultiProofGame` creation so using the anchor registry as `parentRef` is only allowed while there is **no** `anchorGame` yet. After the anchor advances, new games must parent off a **factory-registered, respected, live** dispute game via `_isValidParent`.
> 
> Also **deduplicates bond custody** in `_depositBond` (proposer init + challenger), documents **lazy `closeGame()`** inside `claimCredit`, and adds **`test_Create_RejectsAnchorSentinelAfterAnchorAdvances`** to reject late bootstrap-style parents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0098797ea922030bc41a385d7d4d34140371733. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->