### PR TITLE
fix(defender): submit raw verifier proofs

### DIFF
--- a/proofs/services/defender/src/error.rs
+++ b/proofs/services/defender/src/error.rs
@@ -24,9 +24,6 @@ pub enum DefenderError {
     /// An Alloy JSON-RPC request failed.
     #[error(transparent)]
     AlloyJsonRpc(#[from] RpcError<TransportErrorKind>),
-    /// Prover response could not be encoded for its on-chain verifier.
-    #[error("invalid proof payload: {0}")]
-    ProofEncoding(String),
     #[error(transparent)]
     Lineage(#[from] LineageError),
     #[error(transparent)]

--- a/proofs/services/defender/src/lane.rs
+++ b/proofs/services/defender/src/lane.rs
@@ -1,8 +1,6 @@
 use crate::{error::DefenderError, traits::DefenderClient, types::GameMetadata};
-use alloy_primitives::{Bytes, U256};
-use alloy_sol_types::SolValue;
+use alloy_primitives::Bytes;
 use tracing::{error, info, warn};
-use world_chain_proof_core::boot::TransitionPublicValues;
 use world_chain_proof_protocol::ProofLane;
 use world_chain_prover_service::{
     ProofBackend, ProofData, ProofRequest, ProofRequestError, ProofRequestId, ProofRequester,
@@ -171,17 +169,7 @@ where
 
         match self
             .execution_client
-            .submit_proof(
-                game,
-                lane,
-                match encode_proof(metadata, &response.proof) {
-                    Ok(proof) => proof,
-                    Err(error) => {
-                        error!(game_address = %game, proof_id = %id, ?lane, %error, "prover returned an invalid proof payload");
-                        return LaneState::Abandoned;
-                    }
-                },
-            )
+            .submit_proof(game, lane, verifier_payload(&response.proof))
             .await
         {
             Ok(submission) => {
@@ -270,102 +258,38 @@ fn proof_request(game: &GameMetadata, backend: ProofBackend) -> ProofRequest {
     }
 }
 
-/// Encodes the verifier-specific payload passed to `submitProofLane`.
-fn encode_proof(metadata: &GameMetadata, proof: &ProofData) -> Result<Bytes, DefenderError> {
-    let l1_origin_number = U256::from(metadata.l1_origin_number);
+/// Selects the backend field passed verbatim to the on-chain lane verifier.
+fn verifier_payload(proof: &ProofData) -> Bytes {
     match proof {
-        ProofData::Sp1 {
-            proof,
-            public_values,
-        } => Ok((
-            metadata.domain_hash,
-            metadata.parent_ref,
-            l1_origin_number,
-            public_values.clone(),
-            proof.clone(),
-        )
-            .abi_encode_params()
-            .into()),
-        ProofData::Nitro {
-            attestation: _,
-            public_values,
-            signature,
-        } => {
-            // The prover API transports public values as bytes, but NitroProofVerifier embeds
-            // TransitionPublicValues as a static tuple. Encoding the bytes directly would add a
-            // dynamic ABI offset and produce a payload the verifier cannot decode.
-            let transition = <TransitionPublicValues as SolValue>::abi_decode(public_values)
-                .map_err(|error| DefenderError::ProofEncoding(error.to_string()))?;
-            Ok((
-                metadata.domain_hash,
-                metadata.parent_ref,
-                l1_origin_number,
-                transition,
-                signature.clone(),
-            )
-                .abi_encode_params()
-                .into())
-        }
+        ProofData::Sp1 { proof, .. } => proof.clone(),
+        ProofData::Nitro { signature, .. } => signature.clone(),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::{Address, B256};
 
     #[test]
-    fn nitro_encoding_matches_verifier_payload() {
-        let transition = TransitionPublicValues {
-            l1Head: B256::repeat_byte(0x11),
-            l2PreRoot: B256::repeat_byte(0x22),
-            l2PreBlockNumber: 10,
-            l2PostRoot: B256::repeat_byte(0x33),
-            l2PostBlockNumber: 20,
-            rollupConfigHash: B256::repeat_byte(0x44),
-        };
-        let metadata = GameMetadata {
-            address: Address::repeat_byte(0x55),
-            domain_hash: B256::repeat_byte(0x66),
-            parent_ref: Address::repeat_byte(0x77),
-            root_claim: transition.l2PostRoot,
-            l2_block_number: transition.l2PostBlockNumber,
-            l1_origin_hash: transition.l1Head,
-            l1_origin_number: 42,
-            challenge_deadline: 100,
-            proof_deadline: 200,
-            proof_threshold: 2,
-        };
+    fn nitro_verifier_payload_is_raw_signature() {
         let signature = Bytes::from(vec![0x88; 65]);
         let proof = ProofData::Nitro {
             attestation: Bytes::from_static(b"attestation"),
-            public_values: transition.abi_encode().into(),
+            public_values: Bytes::from_static(b"public values"),
             signature: signature.clone(),
         };
 
-        let encoded = encode_proof(&metadata, &proof).expect("valid Nitro proof payload");
+        assert_eq!(verifier_payload(&proof), signature);
+    }
 
-        // NitroProofVerifier does `abi.decode(proof, (bytes32, address, uint256,
-        // TransitionPublicValues, bytes))`, which is the params encoding. Asserting against
-        // `.abi_encode()` here would be tautological — and would have passed while the
-        // implementation shipped the single-value form, whose leading 0x20 offset makes the
-        // verifier's decode revert and `verify` return false.
-        assert_eq!(
-            &encoded[..32],
-            metadata.domain_hash.as_slice(),
-            "payload must start with domainHash, not an ABI offset"
-        );
-        // 3 head words + 6 transition words + signature offset/length + 3 signature words.
-        assert_eq!(encoded.len(), 448, "verifier-accepted payload size");
+    #[test]
+    fn sp1_verifier_payload_is_raw_proof() {
+        let raw_proof = Bytes::from_static(b"SP1 proof");
+        let proof = ProofData::Sp1 {
+            proof: raw_proof.clone(),
+            public_values: Bytes::from_static(b"public values"),
+        };
 
-        let (domain_hash, parent_ref, l1_origin_number, decoded_transition, decoded_signature) =
-            <(B256, Address, U256, TransitionPublicValues, Bytes)>::abi_decode_params(&encoded)
-                .expect("verifier-compatible params encoding");
-
-        assert_eq!(domain_hash, metadata.domain_hash);
-        assert_eq!(parent_ref, metadata.parent_ref);
-        assert_eq!(l1_origin_number, U256::from(metadata.l1_origin_number));
-        assert_eq!(decoded_transition, transition);
-        assert_eq!(decoded_signature, signature);
+        assert_eq!(verifier_payload(&proof), raw_proof);
     }
 }

--- a/proofs/services/defender/src/tests.rs
+++ b/proofs/services/defender/src/tests.rs
@@ -79,7 +79,7 @@ struct MockState {
     anchor: LineageAnchor,
     games_by_uuid: HashMap<B256, Address>,
     games: HashMap<Address, GameRecord>,
-    submissions: Vec<(Address, ProofLane)>,
+    submissions: Vec<(Address, ProofLane, Bytes)>,
 }
 
 #[derive(Debug, Clone)]
@@ -176,7 +176,7 @@ impl MockClient {
         metadata.proof_deadline = proof_deadline;
     }
 
-    fn submissions(&self) -> Vec<(Address, ProofLane)> {
+    fn submissions(&self) -> Vec<(Address, ProofLane, Bytes)> {
         self.state.lock().expect("not poisoned").submissions.clone()
     }
 }
@@ -270,7 +270,7 @@ impl DefenderClient for MockClient {
         &self,
         game: Address,
         lane: ProofLane,
-        _proof: Bytes,
+        proof: Bytes,
     ) -> Result<DefenderSubmission, DefenderError> {
         let mut guard = self.state.lock().expect("not poisoned");
         guard
@@ -278,7 +278,7 @@ impl DefenderClient for MockClient {
             .get_mut(&game)
             .ok_or_else(|| DefenderError::message(format!("unknown game {game}")))?
             .proof_bitmap |= lane.mask();
-        guard.submissions.push((game, lane));
+        guard.submissions.push((game, lane, proof));
         Ok(DefenderSubmission {
             tx_hash: B256::repeat_byte(0xaa),
         })
@@ -444,7 +444,11 @@ async fn selected_proposed_game_gets_initial_tee_proof() {
     defender.tick().await.unwrap();
     assert_eq!(
         client.submissions(),
-        vec![(GAME_1, ProofLane::TeeAttestation)]
+        vec![(
+            GAME_1,
+            ProofLane::TeeAttestation,
+            Bytes::from_static(b"signature")
+        )]
     );
 }
 
@@ -495,7 +499,18 @@ async fn selected_challenged_game_gets_threshold_lanes() {
     );
 
     defender.tick().await.unwrap();
-    assert_eq!(client.submissions().len(), 2);
+    let submissions = client.submissions();
+    assert_eq!(submissions.len(), 2);
+    assert!(submissions.contains(&(
+        GAME_1,
+        ProofLane::TeeAttestation,
+        Bytes::from_static(b"signature")
+    )));
+    assert!(submissions.contains(&(
+        GAME_1,
+        ProofLane::ValidityProof,
+        Bytes::from_static(b"proof")
+    )));
     assert!(defender.active_defenses().is_empty());
 }
 
@@ -520,7 +535,11 @@ async fn selected_challenged_game_with_council_support_only_requests_tee() {
     defender.tick().await.unwrap();
     assert_eq!(
         client.submissions(),
-        vec![(GAME_1, ProofLane::TeeAttestation)]
+        vec![(
+            GAME_1,
+            ProofLane::TeeAttestation,
+            Bytes::from_static(b"signature")
+        )]
     );
 
     defender.tick().await.unwrap();
@@ -614,7 +633,12 @@ async fn retry_replaces_active_old_attempt() {
     defender.tick().await.unwrap();
 
     assert_eq!(defender.active_defenses(), [GAME_2]);
-    assert!(client.submissions().iter().all(|(game, _)| *game != GAME_1));
+    assert!(
+        client
+            .submissions()
+            .iter()
+            .all(|(game, _, _)| *game != GAME_1)
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes the bytes sent in `submitProofLane`, which directly affects whether dispute games accept proofs; wrong payloads would fail verification or reject valid defenses.
> 
> **Overview**
> Fixes **on-chain proof submission** so `submitProofLane` receives the verifier’s expected bytes instead of a defender-built ABI tuple.
> 
> **Lane submission** now passes **raw backend output**: SP1 uses the `proof` field, Nitro uses the `signature` field. The previous `encode_proof` path that wrapped `domain_hash`, `parent_ref`, `l1_origin_number`, public values, and proof/signature is removed, along with Nitro-specific `TransitionPublicValues` decoding and the `ProofEncoding` defender error (and the lane-abandon path on encoding failure).
> 
> **Tests** record submitted `Bytes` and assert mocks see `b"signature"` / `b"proof"` rather than a full params-encoded payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a9e6c5f67e9468d85e116c2ca9fd3978934a8ab. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->