### PR TITLE
feat(proofs): pin verifier identities in game

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -401,8 +401,10 @@ proof-deploy-mocks env="alphanet":
 
 # The three proof-lane verifiers and the staking registry are required inputs — this
 # script never deploys them, and rejects addresses that hold no code or that repeat
-# across lanes. Point them at real contracts; for a devnet, run `proof-deploy-mocks`
-# first and read the four addresses out of deployments/<env>-proof-mocks.json.
+# across lanes. Reuse the SP1 verifier when only the game-pinned vkeys change; rotate
+# its address only if the verifier gateway or proof interface changes. For a devnet,
+# run `proof-deploy-mocks` first and read the four addresses out of
+# deployments/<env>-proof-mocks.json.
 # Phase 2 – Deploy the proof system contracts and register game type 1006.
 proof-deploy-system env="alphanet":
     #!/usr/bin/env bash
@@ -411,6 +413,9 @@ proof-deploy-system env="alphanet":
     : "${L1_RPC_URL:?L1_RPC_URL is required}"
     : "${WORLD_CHAIN_L2_CHAIN_ID:?WORLD_CHAIN_L2_CHAIN_ID is required}"
     : "${ROLLUP_CONFIG_HASH:?ROLLUP_CONFIG_HASH is required}"
+    : "${AGGREGATION_VKEY:?AGGREGATION_VKEY is required}"
+    : "${RANGE_VKEY_COMMITMENT:?RANGE_VKEY_COMMITMENT is required}"
+    : "${TEE_IMAGE_ID:?TEE_IMAGE_ID is required}"
     : "${DISPUTE_GAME_FACTORY:?DISPUTE_GAME_FACTORY is required (op-deployer DisputeGameFactoryProxy)}"
     : "${ANCHOR_STATE_REGISTRY:?ANCHOR_STATE_REGISTRY is required (op-deployer AnchorStateRegistryProxy)}"
     : "${SYSTEM_CONFIG:?SYSTEM_CONFIG is required (op-deployer SystemConfigProxy)}"
@@ -438,6 +443,9 @@ proof-deploy-system env="alphanet":
     echo "  proposer bond: $PROPOSER_BOND wei" >&2
     echo "  challenger bond: $CHALLENGER_BOND wei" >&2
     echo "  challenge fee: $CHALLENGE_FEE wei" >&2
+    echo "  aggregation vkey: $AGGREGATION_VKEY" >&2
+    echo "  range vkey commitment: $RANGE_VKEY_COMMITMENT" >&2
+    echo "  TEE image ID: $TEE_IMAGE_ID" >&2
     # A dry run must never overwrite the record of a live deployment: the simulated game and
     # WETH addresses are never deployed, so writing them to the real path silently replaces a
     # true record with fictional addresses.
@@ -752,16 +760,31 @@ proof-setup env="alphanet":
     fi
     export VALIDITY_PROOF_VERIFIER SECURITY_COUNCIL_VERIFIER
 
+    VKEYS="proofs/backends/sp1/elfs/vkeys.json"
+    : "${AGGREGATION_VKEY:=$(jq -r '.aggregation_vkey' "$VKEYS")}"
+    : "${RANGE_VKEY_COMMITMENT:=$(jq -r '.range_vkey_commitment' "$VKEYS")}"
+    export AGGREGATION_VKEY RANGE_VKEY_COMMITMENT
+
+    if [ -z "${PCR0:-}" ] || [ -z "${PCR1:-}" ] || [ -z "${PCR2:-}" ]; then
+        echo "=== Step 1c: Fetching PCRs from running enclave ===" >&2
+        eval $(just proof-get-pcrs {{env}})
+    fi
+    [[ "$PCR0" == 0x* ]] || PCR0="0x$PCR0"
+    [[ "$PCR1" == 0x* ]] || PCR1="0x$PCR1"
+    [[ "$PCR2" == 0x* ]] || PCR2="0x$PCR2"
+    export PCR0 PCR1 PCR2
+    PCR0_HASH=$(cast keccak "$PCR0")
+    TEE_IMAGE_ID=$PCR0_HASH
+    export TEE_IMAGE_ID
+    echo "AGGREGATION_VKEY=$AGGREGATION_VKEY" >&2
+    echo "RANGE_VKEY_COMMITMENT=$RANGE_VKEY_COMMITMENT" >&2
+    echo "TEE_IMAGE_ID=$TEE_IMAGE_ID" >&2
+
     echo "=== Step 2: Deploying proof system contracts ===" >&2
     just dry_run={{dry_run}} proof-deploy-system {{env}}
 
     echo "=== Step 3a: Pre-warming CertManager ===" >&2
     just dry_run={{dry_run}} proof-certmanager-prewarm {{env}}
-
-    if [ -z "${PCR0:-}" ] || [ -z "${PCR1:-}" ] || [ -z "${PCR2:-}" ]; then
-        echo "=== Step 3b-pre: Fetching PCRs from running enclave ===" >&2
-        eval $(just proof-get-pcrs {{env}})
-    fi
 
     echo "=== Step 3b: Approving PCR set ===" >&2
     just dry_run={{dry_run}} proof-approve-pcrs {{env}}

--- a/Justfile
+++ b/Justfile
@@ -161,6 +161,7 @@ install *args='':
 # Required env vars (varies by target):
 #   PRIVATE_KEY, OWNER, OWNER_KEY, L1_RPC_URL,
 #   WORLD_CHAIN_L2_CHAIN_ID, ROLLUP_CONFIG_HASH,
+#   AGGREGATION_VKEY, RANGE_VKEY_COMMITMENT, TEE_IMAGE_ID,
 #   CERT_MANAGER_ADDRESS, NITRO_ATTESTATION_VERIFIER
 #
 # Optional env vars (auto-fetched from enclave if not set):
@@ -708,8 +709,9 @@ proof-register-key env="alphanet":
         -n "$PROOF_NAMESPACE" "$NITRO_POD" -c "$CONTAINER" -- sh -s
 
 # Combined – Run all proof system deployment phases in sequence.
-# Automatically wires contract addresses between steps. PCR0/1/2 are
-# auto-fetched from the running enclave if not pre-set.
+# Automatically wires contract addresses between steps. The game verifier
+# identities are explicit inputs; PCR0/1/2 are fetched only to provision and
+# verify the Nitro allowlist if not pre-set.
 proof-setup env="alphanet":
     #!/usr/bin/env bash
     set -euo pipefail
@@ -717,6 +719,30 @@ proof-setup env="alphanet":
         echo "Error: unknown env '{{env}}' — create scripts/proof-envs/{{env}}.env to configure it" >&2
         exit 1
     fi
+    : "${AGGREGATION_VKEY:?AGGREGATION_VKEY is required}"
+    : "${RANGE_VKEY_COMMITMENT:?RANGE_VKEY_COMMITMENT is required}"
+    : "${TEE_IMAGE_ID:?TEE_IMAGE_ID is required}"
+    export AGGREGATION_VKEY RANGE_VKEY_COMMITMENT TEE_IMAGE_ID
+
+    if [ -z "${PCR0:-}" ] || [ -z "${PCR1:-}" ] || [ -z "${PCR2:-}" ]; then
+        echo "=== Preflight: Fetching PCRs from running enclave ===" >&2
+        eval "$(just proof-get-pcrs {{env}})"
+    fi
+    [[ "$PCR0" == 0x* ]] || PCR0="0x$PCR0"
+    [[ "$PCR1" == 0x* ]] || PCR1="0x$PCR1"
+    [[ "$PCR2" == 0x* ]] || PCR2="0x$PCR2"
+    export PCR0 PCR1 PCR2
+    PCR0_HASH=$(cast keccak "$PCR0")
+    if [ "${PCR0_HASH,,}" != "${TEE_IMAGE_ID,,}" ]; then
+        echo "Error: running enclave PCR0 image ID does not match TEE_IMAGE_ID" >&2
+        echo "  expected: $TEE_IMAGE_ID" >&2
+        echo "  measured: $PCR0_HASH" >&2
+        exit 1
+    fi
+    echo "AGGREGATION_VKEY=$AGGREGATION_VKEY" >&2
+    echo "RANGE_VKEY_COMMITMENT=$RANGE_VKEY_COMMITMENT" >&2
+    echo "TEE_IMAGE_ID=$TEE_IMAGE_ID" >&2
+
     if [ -z "${WORLD_CHAIN_L2_CHAIN_ID:-}" ]; then
         echo "=== Step 0-pre: Fetching L2 chain ID from op-node ===" >&2
         WORLD_CHAIN_L2_CHAIN_ID=$(just proof-get-chain-id {{env}})
@@ -759,26 +785,6 @@ proof-setup env="alphanet":
         : "${SECURITY_COUNCIL_VERIFIER:=$(jq -r '.securityCouncil' "$MOCKS")}"
     fi
     export VALIDITY_PROOF_VERIFIER SECURITY_COUNCIL_VERIFIER
-
-    VKEYS="proofs/backends/sp1/elfs/vkeys.json"
-    : "${AGGREGATION_VKEY:=$(jq -r '.aggregation_vkey' "$VKEYS")}"
-    : "${RANGE_VKEY_COMMITMENT:=$(jq -r '.range_vkey_commitment' "$VKEYS")}"
-    export AGGREGATION_VKEY RANGE_VKEY_COMMITMENT
-
-    if [ -z "${PCR0:-}" ] || [ -z "${PCR1:-}" ] || [ -z "${PCR2:-}" ]; then
-        echo "=== Step 1c: Fetching PCRs from running enclave ===" >&2
-        eval $(just proof-get-pcrs {{env}})
-    fi
-    [[ "$PCR0" == 0x* ]] || PCR0="0x$PCR0"
-    [[ "$PCR1" == 0x* ]] || PCR1="0x$PCR1"
-    [[ "$PCR2" == 0x* ]] || PCR2="0x$PCR2"
-    export PCR0 PCR1 PCR2
-    PCR0_HASH=$(cast keccak "$PCR0")
-    TEE_IMAGE_ID=$PCR0_HASH
-    export TEE_IMAGE_ID
-    echo "AGGREGATION_VKEY=$AGGREGATION_VKEY" >&2
-    echo "RANGE_VKEY_COMMITMENT=$RANGE_VKEY_COMMITMENT" >&2
-    echo "TEE_IMAGE_ID=$TEE_IMAGE_ID" >&2
 
     echo "=== Step 2: Deploying proof system contracts ===" >&2
     just dry_run={{dry_run}} proof-deploy-system {{env}}

--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -1201,6 +1201,18 @@ async fn deploy_world_proof_system(
         .env("WORLD_CHAIN_L2_CHAIN_ID", DEV_CHAIN_ID.to_string())
         .env("ROLLUP_CONFIG_HASH", &rollup_config_hash_hex)
         .env(
+            "AGGREGATION_VKEY",
+            "0x1111111111111111111111111111111111111111111111111111111111111111",
+        )
+        .env(
+            "RANGE_VKEY_COMMITMENT",
+            "0x2222222222222222222222222222222222222222222222222222222222222222",
+        )
+        .env(
+            "TEE_IMAGE_ID",
+            "0x3333333333333333333333333333333333333333333333333333333333333333",
+        )
+        .env(
             "PROOF_SYSTEM_BLOCK_INTERVAL",
             PROOF_SYSTEM_BLOCK_INTERVAL.to_string(),
         )

--- a/docs/proof/elf-management.md
+++ b/docs/proof/elf-management.md
@@ -31,8 +31,7 @@ Net effect: the ELFs are never on disk for the host crate to find — they're st
 into every binary that links `world-chain-proof-sp1-elfs` (e.g. `world-chain-proof-sp1-worker`).
 There is no committed ELF blob. The derived vkeys and ELF SHA-256s are recorded in
 `proofs/backends/sp1/elfs/vkeys.json`. The on-chain governance anchor is the SP1 vkey computed from the
-embedded bytes (`just proof-vkeys`), which is exactly what we register on
-`OPSuccinctFaultDisputeGame` (name subject to change once World Chain ships its own proof system).
+embedded bytes (`just proof-vkeys`), which is pinned in the `MultiProofGame` implementation.
 
 ## Reproducibility
 
@@ -81,17 +80,17 @@ because the design choice is to refuse to link a host binary against an absent g
 ## What changed when SP1 programs are updated
 
 A change to the guest source or a bump of the pinned `tag` produces new ELF bytes and therefore
-new vkeys. Both rotate the on-chain measurements (`range_vkey_commitment` and `aggregation_vkey`
-registered on `OPSuccinctFaultDisputeGame`), which is a governance event: the on-chain registries
-need a matching update before the new prover can be deployed.
+new vkeys. Both rotate the on-chain measurements (`range_vkey_commitment` and `aggregation_vkey`)
+pinned in the `MultiProofGame` implementation, which is a governance event: a new game
+implementation must be deployed and activated before the new prover is used.
 
 The workflow is just normal source-control:
 
 1. Edit the guest source or bump the SP1 toolchain `tag` in `proofs/backends/sp1/elfs/build.rs`.
 2. `cargo build -p world-chain-prover-sp1` to confirm the new ELFs build.
 3. `just proof-vkeys` to print the new vkey commitments.
-4. Mention the rotated vkeys in the PR description and link the matching on-chain registry
-   update.
+4. Mention the rotated vkeys in the PR description and link the matching game-implementation
+   deployment.
 
 ## CI
 
@@ -120,7 +119,7 @@ World Chain follows this pattern directly:
 |:---|:---|:---|
 | Source-of-truth artifact | SP1 guest ELF | SP1 guest ELF |
 | Build reproducibility    | `build_program_with_args` + pinned SP1 toolchain tag | `build_program_with_args` + pinned `tag` in `build.rs` (`docker: true`) |
-| On-chain anchor          | SP1 vkey on `OPSuccinctL2OutputOracle` | SP1 vkey on `OPSuccinctFaultDisputeGame` |
+| On-chain anchor          | SP1 vkey on `OPSuccinctL2OutputOracle` | SP1 vkeys pinned in `MultiProofGame` |
 | Where the artifact lives | **Embedded into the host binary via `include_elf!()`** | **Embedded into the host binary via `include_elf!()`** |
 | Committed ELF blob       | None | None |
 

--- a/docs/proof/nitro-worker.md
+++ b/docs/proof/nitro-worker.md
@@ -66,7 +66,7 @@ The `nitro-worker` Kubernetes pod contains two containers:
 
 ```
 NitroProofVerifier           ← World Chain addition: dispute game lane hook
-  │  ecrecover signature → check signer is registered
+  │  ecrecover signature → check signer is registered for the game's image ID
   ▼
 NitroEnclaveKeyRegistry      ← World Chain addition: 3-state signer lifecycle
   │  registerKey() / revokeSigner() / isSignerRegistered()
@@ -85,12 +85,12 @@ CertManager (ICertManager)   ← Base's library
 AWS Nitro Root CA (hardcoded)
 ```
 
-> **Base comparison:** Base's `SystemConfigGlobal` sits at approximately the
-> `NitroAttestationVerifier` + `NitroEnclaveKeyRegistry` layer — it validates the
-> attestation and stores valid signer addresses. World Chain adds `NitroProofVerifier`
-> on top to integrate with the OP Stack dispute game interface
-> (`IWorldChainProofVerifier`). Base doesn't have an equivalent because their system
-> replaces the proposer rather than plugging into the dispute game.
+> **Base comparison:** Base's `AggregateVerifier` pins `TEE_IMAGE_HASH`, while its
+> reusable `TEEVerifier` checks the recovered signer's `signerImageHash` in
+> `TEEProverRegistry`. World Chain follows that split with a game-pinned `teeImageId`, a
+> reusable `NitroProofVerifier`, and `signerImageId` in `NitroEnclaveKeyRegistry`. World Chain
+> retains its existing PCR0/1/2 approval gate at registration. Like Base, it uses the PCR0 hash as
+> the game image ID; Base currently permits registration before an image is active.
 
 ---
 
@@ -349,9 +349,11 @@ The two layers are linked through the **key registration** step:
    secp256k1 key belongs to which enclave (with specific PCRs).
 2. `NitroAttestationVerifier` verifies the full attestation (P-384 sig, cert chain,
    PCRs) and extracts the public key.
-3. `NitroEnclaveKeyRegistry` derives the Ethereum signer address and stores it as `Active`.
+3. `NitroEnclaveKeyRegistry` derives the Ethereum signer address, stores it as `Active`,
+   and records the attested PCR0 as that signer's image ID.
 4. During proof verification, `NitroProofVerifier` uses `ecrecover` on the secp256k1
-   signature and checks that the recovered signer address is registered.
+   signature and checks that the recovered signer is active and its registered image ID
+   matches the PCR0 pinned by the calling game.
 
 This design separates the **expensive operation** (P-384 attestation verification +
 cert chain validation, done once at key registration) from the **cheap operation**
@@ -455,34 +457,22 @@ NitroAttestationVerifier.verifyAttestation(attestationTbs, signature)
 ### Proof Verification (Every Proof)
 
 ```
-verify(rootId, proof)
+verify(signature, imageId, publicValues)
         │
         ▼
 NitroProofVerifier
         │
-        ├─ 1. ABI-decode proof:
-        │      (domainHash, parentRef, l1OriginNumber,
-        │       transitionPublicValues, signature)
-        │
-        ├─ 2. Reconstruct rootId from proof fields
-        │      └─ Assert reconstructed == supplied rootId
-        │
-        ├─ 3. Check l2PreRoot matches parentRef's root claim
-        │
-        ├─ 4. Compute signing commitment:
-        │      keccak256(abi.encode(transitionPublicValues))
-        │
-        ├─ 5. ecrecover(commitment, signature) → recovered signer
-        │      └─ EIP-2 low-s check: reject if s > secp256k1n/2
-        │
-        ├─ 6. Check recovered signer in NitroEnclaveKeyRegistry
-        │      └─ isSignerRegistered(recovered) must return true
-        │
-        └─ 7. Return true (or false on any failure — never reverts)
+        ├─ 1. Receive the exact ABI-encoded TransitionPublicValues
+        │      reconstructed by MultiProofGame
+        ├─ 2. Compute signing commitment: keccak256(publicValues)
+        ├─ 3. ecrecover(commitment, signature) → recovered signer
+        │      └─ EIP-2 low-s check rejects malleable signatures
+        ├─ 4. Require recovered signer is Active
+        └─ 5. Require signerImageId[signer] == game-pinned imageId
 ```
 
-> **Base comparison:** Base's `SystemConfigGlobal.registerSigner()` performs the same
-> steps 1–5 (attestation validation via `NitroValidator`), then derives an Ethereum
+> **Base comparison:** Base's `TEEProverRegistry.registerSigner()` validates a
+> ZK-proven Nitro attestation, then derives an Ethereum
 > address from the attestation's `public_key` field:
 > ```
 > publicKeyHash = keccak256(publicKey[1:])  // skip 0x04 prefix
@@ -764,47 +754,50 @@ oversized length prefix before allocating its receive buffer.
 
 ## Frequently Asked Questions
 
-### Q: Why are PCRs passed into `verifyAttestation` if they are already included in the attestation document?
+### Q: How does `verifyAttestation` know which PCRs are accepted?
 
-**A:** The attestation document contains the *actual* PCR values from the running
-enclave. But the verifier needs *expected* PCR values to compare against — without
-supplying expected PCRs, there is nothing to verify: any enclave image would be
-accepted. The caller provides expected PCRs so the contract can assert the enclave ran
-exactly the image the operator approved. The on-chain `NitroAttestationVerifier`
-maintains an `approvedPCRSets` allowlist; it hashes the PCRs extracted from the
-attestation and checks them against this set.
+**A:** The contract extracts PCR0/1/2 from the signed attestation document and checks
+their hashes against its owner-managed `approvedPCRSets` allowlist. The caller does not
+supply expected PCRs and therefore cannot choose which enclave image is accepted.
 
 ### Q: How does an upgrade to a new enclave version (with new PCRs) work?
 
-**A:** The upgrade is a rolling process:
+**A:** PCR approval controls which enclave keys may be registered, while the game
+implementation's `teeImageId` controls which registered keys may prove that game. Like Base, the
+image ID is `keccak256(rawPCR0)`.
+
+The upgrade is a rolling process:
 
 1. Build a new EIF → get new PCR0/1/2 measurements.
 2. Call `approvePCRSet(newPcr0, newPcr1, newPcr2)` — both old and new PCR sets are
    now approved simultaneously.
 3. Deploy new enclaves; each one registers its ephemeral key via `registerKey` (which
-   succeeds because the new PCRs are approved).
-4. Once all enclaves have migrated, call `revokePCRSet(oldPcr0, oldPcr1, oldPcr2)` —
-   this disallows future key registrations for the old image. Already-registered keys
-   from the old image remain valid until individually revoked if needed.
+   succeeds because the new PCRs are approved). The registry records the image ID alongside the
+   signer.
+4. Deploy and register a new game implementation pinned to the new image ID. The reusable Nitro
+   verifier is unchanged; existing games remain pinned to the old image.
+5. No revocation is required for a routine upgrade: the new game rejects old-image signers by
+   construction. Optionally call `revokePCRSet(oldPcr0, oldPcr1, oldPcr2)` when no further
+   old-image registrations should be admitted. Revoke an individual signer only when its key may
+   be compromised.
 
-This allows zero-downtime upgrades with a window where both old and new enclave
-images are active.
+This allows zero-downtime upgrades without changing what an already-created game trusts.
 
 ### Q: Does `NitroAttestationVerifier` need PCRs in its constructor?
 
 **A:** No. PCR management is fully dynamic — PCR sets are added and removed at runtime
 via `approvePCRSet` / `revokePCRSet`. No PCRs are baked into the contract constructor.
-This allows the owner to approve new enclave images and retire old ones without
-redeploying the verifier contract.
+This allows the owner to admit keys from new enclave images without redeploying the verifier
+contract. Accepting the new image for new games requires a new game implementation; existing games
+keep their original image pin.
 
 ### Q: Why store revoked signers in `NitroEnclaveKeyRegistry` instead of just deleting them?
 
-**A:** To prevent replay attacks. If a key were simply deleted on revocation, an
-attacker who captured that key's original attestation document could re-submit it to
-`registerKey` and restore the signer. The `Revoked` state is permanent — once revoked, a
-signer can never be re-registered regardless of whether a valid attestation document for
-it is available. The lifecycle is strictly `Unknown → Active → Revoked` with no path
-back.
+**A:** Ordinary enclave shutdown destroys the ephemeral signing key and does not need an
+on-chain revocation. Signer revocation is for the stronger incident assumption that the key may
+have been compromised. Because `registerKey` is permissionless, simply deleting the signer would
+also let anyone replay the same still-fresh attestation and reactivate it. The permanent tombstone
+prevents that; the lifecycle is `Unknown → Active → Revoked`.
 
 ### Q: Why is there an `Unknown` state in the key lifecycle enum? Isn't just Active/Revoked enough?
 
@@ -952,10 +945,18 @@ Enclave
 
 #### PCR upgrade flow
 
-1. Add new PCRs to the KMS key policy (both old and new approved simultaneously).
-2. Deploy new enclave — on first boot it reads the existing ciphertext; KMS now
-   accepts the new PCRs, so it can unseal → same secp256k1 key is restored.
-3. Remove old PCRs from the key policy.
+KMS persistence avoids re-registration when the same enclave image restarts. It does
+not let a signing key move to a new image: the on-chain registry permanently records
+the PCR0 image ID proven when that signer was registered.
+
+1. Add the new PCRs to the KMS key policy while retaining the old PCRs during rollout.
+2. Deploy the new image with a fresh secp256k1 key and sealed ciphertext.
+3. Register the fresh key so the registry binds it to the new PCR0 image ID.
+4. Activate a new game implementation pinned to that image ID.
+5. Remove the old PCRs from the KMS policy when the old image no longer needs to restart.
+
+Reusing the old key across image IDs would require a separate authenticated registry
+rebind mechanism and is not part of this proposal.
 
 #### Comparison
 

--- a/docs/proof/nitro-worker.md
+++ b/docs/proof/nitro-worker.md
@@ -352,8 +352,8 @@ The two layers are linked through the **key registration** step:
 3. `NitroEnclaveKeyRegistry` derives the Ethereum signer address, stores it as `Active`,
    and records the attested PCR0 as that signer's image ID.
 4. During proof verification, `NitroProofVerifier` uses `ecrecover` on the secp256k1
-   signature and checks that the recovered signer is active and its registered image ID
-   matches the PCR0 pinned by the calling game.
+   signature and checks that the recovered signer is active and registered for the image ID
+   supplied by the game from its immutable configuration.
 
 This design separates the **expensive operation** (P-384 attestation verification +
 cert chain validation, done once at key registration) from the **cheap operation**

--- a/docs/proof/proof-cli.md
+++ b/docs/proof/proof-cli.md
@@ -266,8 +266,8 @@ world-chain-prover-sp1 prove \
 
 Computes the on-chain verification keys for the (embedded) range and aggregation ELFs: the
 range vkey commitment (`multiBlockVKey` committed by the aggregation guest) and the
-aggregation vkey registered with the SP1 verifier. Runs SP1 setup locally — no proving, no RPC,
-no arguments.
+aggregation vkey. Both are pinned by the `MultiProofGame` implementation. Runs SP1 setup locally —
+no proving, no RPC, no arguments.
 
 ```
 world-chain-prover-sp1 vkeys [--output <FILE>]

--- a/docs/proof/release.md
+++ b/docs/proof/release.md
@@ -6,9 +6,10 @@ Prover deployables are released independently of the node via `proof/vX.Y.Z` tag
 
 ## Why a separate tag namespace
 
-A prover release is a governance event whenever its measurements change: the SP1 vkeys and the
-Nitro enclave PCRs are registered on-chain (per WIP-1006's proof-lane registries), and a release
-that changes them requires a registry update before it can be deployed. Decoupling the tag
+A prover release is a governance event whenever its measurements change. The active game
+implementation pins both SP1 vkeys and the PCR0 Nitro image ID; Nitro PCR approval separately
+controls which image-bound enclave keys may register. A release that changes a measurement requires
+a new game implementation, plus PCR approval for a changed Nitro image, before activation. Decoupling the tag
 namespaces lets prover releases follow proof-system iteration instead of node/hardfork cadence,
 and keeps measurement changes reviewable on their own.
 
@@ -25,7 +26,7 @@ and keeps measurement changes reviewable on their own.
 | `ghcr.io/worldcoin/world-chain-proof:<version>`          | Multi-arch prover image (sp1 + nitro backends, ELFs baked in) |
 
 The draft release notes include a measurements section that diffs the vkeys/PCRs against the
-previous `proof/v*` release and flags when an on-chain registry update is required.
+previous `proof/v*` release and flags when a new game implementation or PCR approval is required.
 
 ## Cutting a release
 
@@ -50,10 +51,11 @@ release for human review. Review the measurements section, then publish.
   reproducibility is enforced by the pinned `cargo-prove` toolchain (`docker: true` by default,
   or a pinned `sp1up --version v6.1.0` install inside `Dockerfile.proof`). See
   [elf-management.md](./elf-management.md).
-- **The enclave EIF** must be bit-for-bit reproducible so anyone can re-derive the registered
+- **The enclave EIF** must be bit-for-bit reproducible so anyone can re-derive the game-pinned
   PCRs from source: `proofs/backends/nitro/Dockerfile` pins base images by digest and apt packages to a
   fixed snapshot.debian.org timestamp, and `scripts/build-eif.sh` pins the nitro-cli version that
-  assembles the EIF. Bumping any of these pins changes the PCRs — expect to re-register them.
+  assembles the EIF. Bumping any of these pins changes the PCRs — expect to approve the new PCR set,
+  register new image-bound signers, and activate a game implementation pinned to its PCR0 image ID.
 
 ## Verifying a release locally
 

--- a/pkg/contracts/scripts/devnet/ActivateProofSystem.s.sol
+++ b/pkg/contracts/scripts/devnet/ActivateProofSystem.s.sol
@@ -85,6 +85,9 @@ contract ActivateProofSystem is Script {
         require(address(gameImpl.teeVerifier()).code.length > 0, "ActivateProofSystem: TEE verifier missing");
         require(address(gameImpl.securityCouncil()).code.length > 0, "ActivateProofSystem: council verifier missing");
         require(address(gameImpl.weth()).code.length > 0, "ActivateProofSystem: DelayedWETH missing");
+        require(gameImpl.aggregationVKey() != bytes32(0), "ActivateProofSystem: aggregation vkey missing");
+        require(gameImpl.rangeVKeyCommitment() != bytes32(0), "ActivateProofSystem: range vkey missing");
+        require(gameImpl.teeImageId() != bytes32(0), "ActivateProofSystem: TEE image ID missing");
 
         IDisputeGame anchorGame = config.anchorStateRegistry.anchorGame();
         if (config.requireFreshAnchor) {

--- a/pkg/contracts/scripts/devnet/DeployNitro.s.sol
+++ b/pkg/contracts/scripts/devnet/DeployNitro.s.sol
@@ -58,11 +58,15 @@ import {NitroProofVerifier} from "../../src/dispute/nitro/NitroProofVerifier.sol
 ///        3. Roll out new enclaves; each registers via
 ///           `NitroEnclaveKeyRegistry.registerKey`, which calls
 ///           `NitroAttestationVerifier.verifyAttestation`. The verifier
-///           accepts both old- and new-image attestations during overlap.
-///        4. After migration, `verifier.revokePCRSet(oldPcr0, oldPcr1,
-///           oldPcr2)` to stop accepting new registrations for the retired
-///           image. Already-registered signers remain in the registry until
-///           individually revoked via `registry.revokeSigner(signer)`.
+///           records each signer's PCR0 image ID.
+///        4. Deploy a new game implementation pinned to
+///           `newPcr0`. The Nitro
+///           verifier is reusable; existing games remain pinned to the old
+///           image.
+///        5. No revocation is required for a routine upgrade: games pinned to
+///           `newPcr0` reject old-image signers. Optionally revoke the old PCR
+///           set to stop future old-image registrations. Revoke an individual
+///           signer only if its key may be compromised.
 contract DeployNitro is Script {
     function run() external {
         address owner = vm.envAddress("OWNER");

--- a/pkg/contracts/scripts/devnet/DeployProofSystem.s.sol
+++ b/pkg/contracts/scripts/devnet/DeployProofSystem.s.sol
@@ -34,7 +34,7 @@ import {ISystemConfig} from "@optimism-bedrock/interfaces/L1/ISystemConfig.sol";
 /// That is deliberate — a script that can mint its own verifiers can silently register a game
 /// type that accepts any proof. Supply real contracts:
 ///
-///   `VALIDITY_PROOF_VERIFIER`   — e.g. `SP1ValidityVerifier`
+///   `VALIDITY_PROOF_VERIFIER`   — reusable `SP1ValidityVerifier`; a vkey change does not rotate it
 ///   `TEE_VERIFIER`              — e.g. `NitroProofVerifier` (see `DeployNitro.s.sol`)
 ///   `SECURITY_COUNCIL_VERIFIER` — council-controlled attestation verifier
 /// For a local devnet, deploy the test doubles with `DeployProofMocks.s.sol` first and pass
@@ -65,6 +65,9 @@ contract DeployProofSystem is Script {
         uint256 challengerBond;
         uint8 proofThreshold;
         address protocolFeeRecipient;
+        bytes32 aggregationVKey;
+        bytes32 rangeVKeyCommitment;
+        bytes32 teeImageId;
         IWorldChainProofVerifier validityProofVerifier;
         IWorldChainProofVerifier teeVerifier;
         IWorldChainProofVerifier securityCouncil;
@@ -153,7 +156,11 @@ contract DeployProofSystem is Script {
         config.proofThreshold = vm.envOr("PROOF_THRESHOLD", uint256(DEFAULT_PROOF_THRESHOLD)).toUint8();
         // Required: there is no sane default owner for proof-timeout forfeitures.
         config.protocolFeeRecipient = vm.envAddress("PROTOCOL_FEE_RECIPIENT");
-        // Proof lanes are required inputs, never deployed here.
+        config.aggregationVKey = vm.envBytes32("AGGREGATION_VKEY");
+        config.rangeVKeyCommitment = vm.envBytes32("RANGE_VKEY_COMMITMENT");
+        config.teeImageId = vm.envBytes32("TEE_IMAGE_ID");
+        // Proof lanes are required inputs, never deployed here. The SP1 address remains stable
+        // when a new game implementation pins different vkeys.
         config.validityProofVerifier = IWorldChainProofVerifier(vm.envAddress("VALIDITY_PROOF_VERIFIER"));
         config.teeVerifier = IWorldChainProofVerifier(vm.envAddress("TEE_VERIFIER"));
         config.securityCouncil = IWorldChainProofVerifier(vm.envAddress("SECURITY_COUNCIL_VERIFIER"));
@@ -208,6 +215,9 @@ contract DeployProofSystem is Script {
             "DeployProofSystem: ProxyAdmin owner key mismatch"
         );
         require(config.protocolFeeRecipient != address(0), "DeployProofSystem: protocol fee recipient required");
+        require(config.aggregationVKey != bytes32(0), "DeployProofSystem: aggregation vkey required");
+        require(config.rangeVKeyCommitment != bytes32(0), "DeployProofSystem: range vkey required");
+        require(config.teeImageId != bytes32(0), "DeployProofSystem: TEE image ID required");
         require(config.blockInterval > 0, "DeployProofSystem: block interval required");
         require(config.challengePeriod > 0, "DeployProofSystem: challenge period required");
         require(config.proofPeriod > config.challengePeriod, "DeployProofSystem: proof period must exceed challenge");
@@ -229,6 +239,9 @@ contract DeployProofSystem is Script {
             challengerBond: config.challengerBond,
             protocolFeeRecipient: config.protocolFeeRecipient,
             proofThreshold: config.proofThreshold,
+            aggregationVKey: config.aggregationVKey,
+            rangeVKeyCommitment: config.rangeVKeyCommitment,
+            teeImageId: config.teeImageId,
             validityProofVerifier: config.validityProofVerifier,
             teeVerifier: config.teeVerifier,
             securityCouncil: config.securityCouncil,
@@ -258,6 +271,9 @@ contract DeployProofSystem is Script {
         vm.serializeAddress(root, "delayedWethProxyAdmin", address(deployment.wethProxyAdmin));
         vm.serializeUint(root, "gameType", uint256(GameType.unwrap(GameTypes.MULTI_PROOF_GAME_TYPE)));
         vm.serializeBytes32(root, "rollupConfigHash", config.rollupConfigHash);
+        vm.serializeBytes32(root, "aggregationVKey", config.aggregationVKey);
+        vm.serializeBytes32(root, "rangeVKeyCommitment", config.rangeVKeyCommitment);
+        vm.serializeBytes32(root, "teeImageId", config.teeImageId);
         vm.serializeUint(root, "l2ChainId", config.l2ChainId);
         vm.serializeUint(root, "proofSystemVersion", LibProof.PROOF_SYSTEM_VERSION);
         vm.serializeUint(root, "blockInterval", config.blockInterval);

--- a/pkg/contracts/scripts/devnet/SubmitSecurityCouncilProof.s.sol
+++ b/pkg/contracts/scripts/devnet/SubmitSecurityCouncilProof.s.sol
@@ -5,7 +5,7 @@ import {Script} from "forge-std/Script.sol";
 
 import {SecurityCouncilVerifier} from "../../src/dispute/council/SecurityCouncilVerifier.sol";
 import {IMultiProofGame} from "../../src/dispute/interfaces/IMultiProofGame.sol";
-import {LibProof, ProofLane, TransitionPublicValues} from "../../src/dispute/lib/LibProof.sol";
+import {LibProof, ProofLane} from "../../src/dispute/lib/LibProof.sol";
 
 interface ICouncilSafe {
     function getMessageHash(bytes calldata message) external view returns (bytes32);
@@ -34,9 +34,7 @@ contract SubmitSecurityCouncilProof is Script {
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerKey, safeMessageHash);
         bytes memory proof = abi.encodePacked(r, s, v);
 
-        // The council lane attests over `rootId` alone; the transition is ignored by this verifier.
-        TransitionPublicValues memory transition;
-        require(verifier.verify(rootId, transition, proof), "Council proof verification failed");
+        require(verifier.verify(proof, bytes32(0), abi.encode(rootId)), "Council proof verification failed");
 
         uint256 transactionKey = vm.envOr("PRIVATE_KEY", signerKey);
         vm.startBroadcast(transactionKey);

--- a/pkg/contracts/scripts/mainnet/Deploy.s.sol
+++ b/pkg/contracts/scripts/mainnet/Deploy.s.sol
@@ -12,8 +12,8 @@ import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint
 import {Create2Factory} from "./Create2Deploy.sol";
 
 // TODO: add production WIP-1006 proof-system deployment wiring in a dedicated
-// script, including SP1ValidityVerifier as the validity lane with the Succinct
-// verifier gateway, aggregation vkey, range vkey commitment, and anchor registry.
+// script, including the reusable SP1ValidityVerifier with the Succinct verifier
+// gateway and a game implementation pinned to its aggregation/range vkeys.
 contract Deploy is Create2Factory, Script {
     address public pbhEntryPoint;
     address public pbhEntryPointImpl;

--- a/pkg/contracts/src/dispute/MultiProofGame.sol
+++ b/pkg/contracts/src/dispute/MultiProofGame.sol
@@ -504,11 +504,8 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
             revert DuplicateProofLane(lane, rootId_, claimData.proofBitmap);
         }
 
-        // Verify the proof against the verifier configured for this lane.
-        IWorldChainProofVerifier verifier = lane.verifierFor(validityProofVerifier, teeVerifier, securityCouncil);
-        bytes32 verifierId = lane.verifierIdFor(aggregationVKey, teeImageId);
-        // The generic interface carries each lane's expected statement into its reusable verifier.
-        bytes memory publicValues = lane.publicValuesFor(rootId_, _transition(), rangeVKeyCommitment);
+        (IWorldChainProofVerifier verifier, bytes32 verifierId, bytes memory publicValues) =
+            _verificationCallFor(lane, rootId_, _transition());
         if (!verifier.verify(compact.proof, verifierId, publicValues)) {
             revert InvalidProof(lane, rootId_);
         }
@@ -809,6 +806,22 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
     /// @inheritdoc IMultiProofGame
     function proofDeadline() public view returns (Timestamp) {
         return Timestamp.wrap(createdAt.raw() + proofPeriod.raw());
+    }
+
+    /// @dev Selects the verifier and game-pinned statement for `lane`. The generic public-values
+    ///      argument lets each proof system authenticate its native statement through one interface.
+    function _verificationCallFor(ProofLane lane, bytes32 rootId_, TransitionPublicValues memory transition)
+        internal
+        view
+        returns (IWorldChainProofVerifier verifier, bytes32 verifierId, bytes memory publicValues)
+    {
+        if (lane == ProofLane.VALIDITY_PROOF) {
+            return (validityProofVerifier, aggregationVKey, abi.encode(transition, rangeVKeyCommitment));
+        }
+        if (lane == ProofLane.TEE_ATTESTATION) {
+            return (teeVerifier, teeImageId, abi.encode(transition));
+        }
+        return (securityCouncil, bytes32(0), abi.encode(rootId_));
     }
 
     /// @notice The transition public values a proof for this game must attest.

--- a/pkg/contracts/src/dispute/MultiProofGame.sol
+++ b/pkg/contracts/src/dispute/MultiProofGame.sol
@@ -124,6 +124,15 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
     /// @notice Recipient of the share of forfeited proposer bonds not paid to a challenger.
     address public immutable protocolFeeRecipient;
 
+    /// @notice SP1 aggregation-program verification key used by the validity lane.
+    bytes32 public immutable aggregationVKey;
+
+    /// @notice SP1 range-program verification-key commitment used by the validity lane.
+    bytes32 public immutable rangeVKeyCommitment;
+
+    /// @notice Nitro PCR0 image identity accepted by the TEE lane.
+    bytes32 public immutable teeImageId;
+
     /// @notice Verifiers backing the proof lanes, indexed by `ProofLane`.
     IWorldChainProofVerifier public immutable validityProofVerifier;
     IWorldChainProofVerifier public immutable teeVerifier;
@@ -183,9 +192,10 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
             config.blockInterval == 0 || config.challengePeriod == 0 || config.proofPeriod <= config.challengePeriod
                 || config.proposerBond == 0 || config.challengerBond == 0 || config.proofThreshold == 0
                 || config.proofThreshold > LibProof.PROOF_LANE_COUNT || config.protocolFeeRecipient == address(0)
-                || address(config.anchorStateRegistry) == address(0) || address(config.weth) == address(0)
-                || address(config.validityProofVerifier) == address(0) || address(config.teeVerifier) == address(0)
-                || address(config.securityCouncil) == address(0)
+                || config.aggregationVKey == bytes32(0) || config.rangeVKeyCommitment == bytes32(0)
+                || config.teeImageId == bytes32(0) || address(config.anchorStateRegistry) == address(0)
+                || address(config.weth) == address(0) || address(config.validityProofVerifier) == address(0)
+                || address(config.teeVerifier) == address(0) || address(config.securityCouncil) == address(0)
         ) {
             revert InvalidActivationParameters();
         }
@@ -211,6 +221,9 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
         proposerBond = config.proposerBond;
         challengerBond = config.challengerBond;
         protocolFeeRecipient = config.protocolFeeRecipient;
+        aggregationVKey = config.aggregationVKey;
+        rangeVKeyCommitment = config.rangeVKeyCommitment;
+        teeImageId = config.teeImageId;
         PROOF_THRESHOLD = config.proofThreshold;
         validityProofVerifier = config.validityProofVerifier;
         teeVerifier = config.teeVerifier;
@@ -493,7 +506,9 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
 
         // Verify the proof against the verifier configured for this lane.
         IWorldChainProofVerifier verifier = lane.verifierFor(validityProofVerifier, teeVerifier, securityCouncil);
-        if (!verifier.verify(rootId_, _transition(), compact.proof)) {
+        bytes32 verifierId = lane.verifierIdFor(aggregationVKey, teeImageId);
+        bytes memory publicValues = lane.publicValuesFor(rootId_, _transition(), rangeVKeyCommitment);
+        if (!verifier.verify(compact.proof, verifierId, publicValues)) {
             revert InvalidProof(lane, rootId_);
         }
 

--- a/pkg/contracts/src/dispute/MultiProofGame.sol
+++ b/pkg/contracts/src/dispute/MultiProofGame.sol
@@ -507,6 +507,7 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
         // Verify the proof against the verifier configured for this lane.
         IWorldChainProofVerifier verifier = lane.verifierFor(validityProofVerifier, teeVerifier, securityCouncil);
         bytes32 verifierId = lane.verifierIdFor(aggregationVKey, teeImageId);
+        // The generic interface carries each lane's expected statement into its reusable verifier.
         bytes memory publicValues = lane.publicValuesFor(rootId_, _transition(), rangeVKeyCommitment);
         if (!verifier.verify(compact.proof, verifierId, publicValues)) {
             revert InvalidProof(lane, rootId_);

--- a/pkg/contracts/src/dispute/council/SecurityCouncilVerifier.sol
+++ b/pkg/contracts/src/dispute/council/SecurityCouncilVerifier.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.28;
 
 import {IWorldChainProofVerifier} from "../interfaces/IWorldChainProofVerifier.sol";
-import {LibProof, TransitionPublicValues} from "../lib/LibProof.sol";
 
 interface IERC1271 {
     function isValidSignature(bytes32 hash, bytes calldata signature) external view returns (bytes4);
@@ -37,12 +36,14 @@ contract SecurityCouncilVerifier is IWorldChainProofVerifier {
     }
 
     /// @inheritdoc IWorldChainProofVerifier
-    /// @dev The council attests the proposal identity (`rootId`) rather than the transition.
-    function verify(bytes32 rootId, TransitionPublicValues calldata, bytes calldata proof)
+    /// @dev The council public values are the ABI encoding of the proposal's `rootId`.
+    function verify(bytes calldata proof, bytes32 verifierId, bytes calldata publicValues)
         external
         view
         returns (bool)
     {
+        if (verifierId != bytes32(0) || publicValues.length != 32) return false;
+        bytes32 rootId = abi.decode(publicValues, (bytes32));
         try IERC1271(council).isValidSignature(attestationDigest(rootId), proof) returns (bytes4 magic) {
             return magic == ERC1271_MAGIC_VALUE;
         } catch {

--- a/pkg/contracts/src/dispute/interfaces/IMultiProofGame.sol
+++ b/pkg/contracts/src/dispute/interfaces/IMultiProofGame.sol
@@ -57,6 +57,9 @@ interface IMultiProofGame is IDisputeGame {
         uint256 challengerBond;
         address protocolFeeRecipient;
         uint8 proofThreshold;
+        bytes32 aggregationVKey;
+        bytes32 rangeVKeyCommitment;
+        bytes32 teeImageId;
         IWorldChainProofVerifier validityProofVerifier;
         IWorldChainProofVerifier teeVerifier;
         IWorldChainProofVerifier securityCouncil;
@@ -131,6 +134,15 @@ interface IMultiProofGame is IDisputeGame {
 
     /// @notice Recipient of the share of forfeited proposer bonds not paid to a challenger.
     function protocolFeeRecipient() external view returns (address);
+
+    /// @notice SP1 aggregation-program verification key pinned to this implementation.
+    function aggregationVKey() external view returns (bytes32);
+
+    /// @notice SP1 range-program verification-key commitment pinned to this implementation.
+    function rangeVKeyCommitment() external view returns (bytes32);
+
+    /// @notice Nitro enclave image identity pinned to this implementation.
+    function teeImageId() external view returns (bytes32);
 
     /// @notice Verifier backing the validity-proof lane.
     function validityProofVerifier() external view returns (IWorldChainProofVerifier);

--- a/pkg/contracts/src/dispute/interfaces/IWorldChainProofVerifier.sol
+++ b/pkg/contracts/src/dispute/interfaces/IWorldChainProofVerifier.sol
@@ -1,18 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {TransitionPublicValues} from "../lib/LibProof.sol";
-
 /// @title IWorldChainProofVerifier
 /// @author World Contributors
 /// @custom:security-contact security@toolsforhumanity.com
 interface IWorldChainProofVerifier {
-    /// @notice Verifies that `proof` attests `transition` for the proposal identified by
-    ///         `rootId`. The calling game supplies both, so implementations enforce the
-    ///         expected transition by construction: the ZK and TEE lanes bind `proof` to
-    ///         `transition`, the council lane attests `rootId` directly.
-    function verify(bytes32 rootId, TransitionPublicValues calldata transition, bytes calldata proof)
-        external
-        view
-        returns (bool);
+    /// @notice Verifies `proof` against a proof-system identity and its expected public values.
+    /// @param proof Lane-specific proof bytes.
+    /// @param verifierId Immutable identity selected by the game, such as a program vkey or TEE image ID.
+    /// @param publicValues Exact public values the proof must authenticate.
+    function verify(bytes calldata proof, bytes32 verifierId, bytes calldata publicValues) external view returns (bool);
 }

--- a/pkg/contracts/src/dispute/lib/LibProof.sol
+++ b/pkg/contracts/src/dispute/lib/LibProof.sol
@@ -61,7 +61,7 @@ library LibProof {
         return keccak256(abi.encode(chainId, proofSystemVersion, rollupConfigHash, blockInterval));
     }
 
-    /// @dev Identity a proposal's proof lanes attest to.
+    /// @dev Canonical proposal identity used by the game and council attestation.
     function rootId(
         bytes32 domainHash_,
         address parentRef,
@@ -83,6 +83,34 @@ library LibProof {
         if (lane == ProofLane.VALIDITY_PROOF) return validityProofVerifier;
         if (lane == ProofLane.TEE_ATTESTATION) return teeVerifier;
         return securityCouncil;
+    }
+
+    /// @dev Selects the immutable verifier identity backing `lane`.
+    function verifierIdFor(ProofLane lane, bytes32 aggregationVKey, bytes32 teeImageId)
+        internal
+        pure
+        returns (bytes32)
+    {
+        if (lane == ProofLane.VALIDITY_PROOF) return aggregationVKey;
+        if (lane == ProofLane.TEE_ATTESTATION) return teeImageId;
+        return bytes32(0);
+    }
+
+    /// @dev Encodes the exact public values authenticated by `lane`.
+    ///      The validity and TEE lanes bind the transition, not `rootId` or a separate upgrade
+    ///      schedule. A derivation upgrade must therefore rotate at least one bound value:
+    ///      `rollupConfigHash`, the relevant SP1 vkey, or the Nitro PCR0 image ID.
+    function publicValuesFor(
+        ProofLane lane,
+        bytes32 rootId_,
+        TransitionPublicValues memory transition,
+        bytes32 rangeVKeyCommitment
+    ) internal pure returns (bytes memory) {
+        if (lane == ProofLane.VALIDITY_PROOF) {
+            return abi.encode(transition, rangeVKeyCommitment);
+        }
+        if (lane == ProofLane.TEE_ATTESTATION) return abi.encode(transition);
+        return abi.encode(rootId_);
     }
 
     /// @dev Splits a compact payload into its lane id, reward recipient, and verifier proof

--- a/pkg/contracts/src/dispute/lib/LibProof.sol
+++ b/pkg/contracts/src/dispute/lib/LibProof.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {IWorldChainProofVerifier} from "../interfaces/IWorldChainProofVerifier.sol";
-
 /// The set of proof lanes accepted for a proposal, one bit per `ProofLane`.
 type Bitmap is uint8;
 
@@ -71,46 +69,6 @@ library LibProof {
         uint256 l1OriginNumber
     ) internal pure returns (bytes32) {
         return keccak256(abi.encode(domainHash_, parentRef, rootClaim, l2BlockNumber, l1OriginHash, l1OriginNumber));
-    }
-
-    /// @dev Selects the verifier backing `lane`.
-    function verifierFor(
-        ProofLane lane,
-        IWorldChainProofVerifier validityProofVerifier,
-        IWorldChainProofVerifier teeVerifier,
-        IWorldChainProofVerifier securityCouncil
-    ) internal pure returns (IWorldChainProofVerifier) {
-        if (lane == ProofLane.VALIDITY_PROOF) return validityProofVerifier;
-        if (lane == ProofLane.TEE_ATTESTATION) return teeVerifier;
-        return securityCouncil;
-    }
-
-    /// @dev Selects the immutable verifier identity backing `lane`.
-    function verifierIdFor(ProofLane lane, bytes32 aggregationVKey, bytes32 teeImageId)
-        internal
-        pure
-        returns (bytes32)
-    {
-        if (lane == ProofLane.VALIDITY_PROOF) return aggregationVKey;
-        if (lane == ProofLane.TEE_ATTESTATION) return teeImageId;
-        return bytes32(0);
-    }
-
-    /// @dev Encodes the exact public values authenticated by `lane`.
-    ///      The validity and TEE lanes bind the transition, not `rootId` or a separate upgrade
-    ///      schedule. A derivation upgrade must therefore rotate at least one bound value:
-    ///      `rollupConfigHash`, the relevant SP1 vkey, or the Nitro PCR0 image ID.
-    function publicValuesFor(
-        ProofLane lane,
-        bytes32 rootId_,
-        TransitionPublicValues memory transition,
-        bytes32 rangeVKeyCommitment
-    ) internal pure returns (bytes memory) {
-        if (lane == ProofLane.VALIDITY_PROOF) {
-            return abi.encode(transition, rangeVKeyCommitment);
-        }
-        if (lane == ProofLane.TEE_ATTESTATION) return abi.encode(transition);
-        return abi.encode(rootId_);
     }
 
     /// @dev Splits a compact payload into its lane id, reward recipient, and verifier proof

--- a/pkg/contracts/src/dispute/nitro/NitroAttestationVerifier.sol
+++ b/pkg/contracts/src/dispute/nitro/NitroAttestationVerifier.sol
@@ -158,19 +158,13 @@ contract NitroAttestationVerifier is NitroValidator, INitroAttestationVerifier, 
     ///      remain `NitroEnclaveKeyRegistry.SignerStatus.Active` until they are
     ///      individually revoked via `NitroEnclaveKeyRegistry.revokeSigner`.
     ///
-    ///      This is intentional. Nitro enclave signing keys are ephemeral:
-    ///      they are generated in-memory at enclave startup, never persisted,
-    ///      and destroyed when the enclave process stops. The intended
-    ///      incident-response flow for a compromised image is therefore:
-    ///        1. Stop the running enclave instances (kills their keys).
-    ///        2. Call `revokePCRSet` so no fresh enclave from the same image
-    ///           can re-register.
-    ///      Operators who want belt-and-suspenders may listen for
-    ///      `PCRSetRevoked` events off-chain and call
-    ///      `NitroEnclaveKeyRegistry.revokeSigner` for each affected signer (the
-    ///      `SignerRegistered` event carries the bound PCR triple). See
-    ///      `NitroEnclaveKeyRegistry` for the full rationale on why an
-    ///      on-chain cascade is deliberately not implemented.
+    ///      This is admission control, not a routine upgrade requirement or a
+    ///      complete response to a compromised image. Games pin PCR0 and reject
+    ///      signers from other images. Revocation is useful when no new signers
+    ///      from this PCR triple should be admitted, but already-registered
+    ///      signers can still prove for games pinned to it. Those games must be
+    ///      paused or blacklisted if the image itself is no longer trusted;
+    ///      individual signer revocation is only a key-specific kill switch.
     function revokePCRSet(bytes32 pcr0, bytes32 pcr1, bytes32 pcr2) external onlyOwner {
         _revokePCRSet(pcr0, pcr1, pcr2);
     }

--- a/pkg/contracts/src/dispute/nitro/NitroEnclaveKeyRegistry.sol
+++ b/pkg/contracts/src/dispute/nitro/NitroEnclaveKeyRegistry.sol
@@ -56,6 +56,9 @@ contract NitroEnclaveKeyRegistry is Ownable {
     /// @notice Enclave signer address to lifecycle status.
     mapping(address signer => SignerStatus status) private _signerStatus;
 
+    /// @notice Enclave signer address to the PCR0 image ID proven at registration.
+    mapping(address signer => bytes32 imageId) public signerImageId;
+
     /*//////////////////////////////////////////////////////////////
                               CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
@@ -100,6 +103,7 @@ contract NitroEnclaveKeyRegistry is Ownable {
         SignerStatus status = _signerStatus[signer];
         if (status == SignerStatus.Revoked) revert SignerRevokedPermanently();
         if (status == SignerStatus.Active) revert SignerAlreadyRegistered();
+        signerImageId[signer] = pcr0;
         _signerStatus[signer] = SignerStatus.Active;
 
         emit SignerRegistered(signer, pcr0, pcr1, pcr2);
@@ -110,43 +114,12 @@ contract NitroEnclaveKeyRegistry is Ownable {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Revoke a previously registered enclave signer.
-    /// @dev Only callable by the owner. Revocation is permanent — see
-    ///      `isSignerRevoked` — so a compromised signer cannot be silently restored
-    ///      by replaying its attestation document.
-    ///
-    ///      ## Relationship to `NitroAttestationVerifier.revokePCRSet`
-    ///      Revoking a PCR set on the verifier (i.e. retiring an enclave
-    ///      image) does **not** automatically transition signers registered
-    ///      under that image to `SignerStatus.Revoked` here. Each signer
-    ///      remains `SignerStatus.Active` until `revokeSigner` is called
-    ///      individually.
-    ///
-    ///      This is intentional. Nitro enclave signing keys are ephemeral:
-    ///      they are generated in-memory at startup, never persisted to
-    ///      disk, and destroyed the moment the enclave process exits. The
-    ///      designed incident-response flow for a compromised image is:
-    ///        1. Stop the running enclave instances (the AWS Nitro hardware
-    ///           isolation guarantees the key is destroyed with the process).
-    ///        2. Call `NitroAttestationVerifier.revokePCRSet` so no fresh
-    ///           enclave from the same image can re-register.
-    ///      The two steps together eliminate the threat without per-key
-    ///      cascading on-chain.
-    ///
-    ///      Belt-and-suspenders operators can still observe
-    ///      `NitroAttestationVerifier.PCRSetRevoked` events off-chain and
-    ///      call `revokeSigner` for every affected signer. The `SignerRegistered`
-    ///      event carries the bound PCR triple specifically to make this
-    ///      easy.
-    ///
-    ///      ## Why no on-chain cascade?
-    ///      An automatic on-chain cascade was considered and rejected:
-    ///        - Storing `pcrSetHash → signer[]` to enumerate affected signers
-    ///          requires an unbounded array per image, with O(N) gas on
-    ///          `registerKey` and on the cascade itself.
-    ///        - Doing the lookup lazily in `isSignerRegistered` would add an
-    ///          extra SLOAD on every proof-verification call (the hot path),
-    ///          for no security gain given Nitro's hardware key-destruction
-    ///          guarantee.
+    /// @dev Revocation is permanent because registration is permissionless: while an
+    ///      attestation is still fresh, deleting the signer would allow the same document to
+    ///      register it again. Normal enclave shutdown does not require revocation because the
+    ///      ephemeral key is destroyed. Use this function when the signer key may be compromised.
+    ///      PCR-set revocation separately prevents future registrations for an image and does
+    ///      not enumerate or revoke its existing signers.
     function revokeSigner(address signer) external onlyOwner {
         if (_signerStatus[signer] != SignerStatus.Active) revert SignerNotRegistered();
         _signerStatus[signer] = SignerStatus.Revoked;
@@ -165,6 +138,11 @@ contract NitroEnclaveKeyRegistry is Ownable {
     /// @notice Returns whether `signer` is currently registered and not revoked.
     function isSignerRegistered(address signer) external view returns (bool) {
         return _signerStatus[signer] == SignerStatus.Active;
+    }
+
+    /// @notice Returns whether `signer` is active and was attested for `imageId`.
+    function isSignerRegisteredForImage(address signer, bytes32 imageId) external view returns (bool) {
+        return _signerStatus[signer] == SignerStatus.Active && signerImageId[signer] == imageId;
     }
 
     /// @notice Returns whether `signer` has been permanently revoked.

--- a/pkg/contracts/src/dispute/nitro/NitroProofVerifier.sol
+++ b/pkg/contracts/src/dispute/nitro/NitroProofVerifier.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.28;
 
 import {IWorldChainProofVerifier} from "../interfaces/IWorldChainProofVerifier.sol";
-import {LibProof, TransitionPublicValues} from "../lib/LibProof.sol";
 import {NitroEnclaveKeyRegistry} from "./NitroEnclaveKeyRegistry.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
@@ -10,6 +9,9 @@ import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 /// @author World Contributors
 /// @custom:security-contact security@toolsforhumanity.com
 contract NitroProofVerifier is IWorldChainProofVerifier {
+    /// @dev `TransitionPublicValues` contains six ABI words.
+    uint256 internal constant PUBLIC_VALUES_LENGTH = 6 * 32;
+
     /// @notice Registry of attested enclave keys.
     NitroEnclaveKeyRegistry public immutable registry;
 
@@ -19,12 +21,13 @@ contract NitroProofVerifier is IWorldChainProofVerifier {
     }
 
     /// @inheritdoc IWorldChainProofVerifier
-    function verify(bytes32, TransitionPublicValues calldata transition, bytes calldata proof)
+    function verify(bytes calldata proof, bytes32 verifierId, bytes calldata publicValues)
         external
         view
         returns (bool)
     {
-        (address recovered, ECDSA.RecoverError err,) = ECDSA.tryRecover(keccak256(abi.encode(transition)), proof);
-        return err == ECDSA.RecoverError.NoError && registry.isSignerRegistered(recovered);
+        if (verifierId == bytes32(0) || publicValues.length != PUBLIC_VALUES_LENGTH) return false;
+        (address recovered, ECDSA.RecoverError err,) = ECDSA.tryRecover(keccak256(publicValues), proof);
+        return err == ECDSA.RecoverError.NoError && registry.isSignerRegisteredForImage(recovered, verifierId);
     }
 }

--- a/pkg/contracts/src/dispute/sp1/SP1ValidityVerifier.sol
+++ b/pkg/contracts/src/dispute/sp1/SP1ValidityVerifier.sol
@@ -8,9 +8,6 @@ import {ISP1Verifier} from "@sp1-contracts/src/ISP1Verifier.sol";
 /// @author World Contributors
 /// @custom:security-contact security@toolsforhumanity.com
 contract SP1ValidityVerifier is IWorldChainProofVerifier {
-    /// @dev Six transition words plus the range-program vkey commitment.
-    uint256 internal constant PUBLIC_VALUES_LENGTH = 7 * 32;
-
     /// @notice Thrown when the SP1 verifier gateway address is zero.
     error ZeroSP1Verifier();
 
@@ -31,12 +28,6 @@ contract SP1ValidityVerifier is IWorldChainProofVerifier {
         view
         returns (bool)
     {
-        if (verifierId == bytes32(0) || publicValues.length != PUBLIC_VALUES_LENGTH) return false;
-        bytes32 rangeVKeyCommitment;
-        assembly ("memory-safe") {
-            rangeVKeyCommitment := calldataload(add(publicValues.offset, sub(publicValues.length, 32)))
-        }
-        if (rangeVKeyCommitment == bytes32(0)) return false;
         try sp1Verifier.verifyProof(verifierId, publicValues, proof) {
             return true;
         } catch {

--- a/pkg/contracts/src/dispute/sp1/SP1ValidityVerifier.sol
+++ b/pkg/contracts/src/dispute/sp1/SP1ValidityVerifier.sol
@@ -3,61 +3,41 @@ pragma solidity 0.8.28;
 
 import {IWorldChainProofVerifier} from "../interfaces/IWorldChainProofVerifier.sol";
 import {ISP1Verifier} from "@sp1-contracts/src/ISP1Verifier.sol";
-import {LibProof, TransitionPublicValues} from "../lib/LibProof.sol";
-
-/// Must match `world_chain_proof_core::types::AggregationPublicValues`.
-struct AggregationPublicValues {
-    TransitionPublicValues transitionPublicValues;
-    bytes32 multiBlockVKey;
-}
 
 /// @title SP1ValidityVerifier
 /// @author World Contributors
 /// @custom:security-contact security@toolsforhumanity.com
 contract SP1ValidityVerifier is IWorldChainProofVerifier {
+    /// @dev Six transition words plus the range-program vkey commitment.
+    uint256 internal constant PUBLIC_VALUES_LENGTH = 7 * 32;
+
     /// @notice Thrown when the SP1 verifier gateway address is zero.
     error ZeroSP1Verifier();
-
-    /// @notice Thrown when the aggregation program verification key is zero.
-    error ZeroAggregationVKey();
-
-    /// @notice Thrown when the expected range program verification key is zero.
-    error ZeroRangeVKeyCommitment();
 
     /// @notice Succinct SP1 verifier gateway or verifier implementation.
     ISP1Verifier public immutable sp1Verifier;
 
-    /// @notice Verification key for the World Chain aggregation program.
-    bytes32 public immutable aggregationVKey;
-
-    /// @notice Range-program verification key committed by the aggregation proof.
-    bytes32 public immutable rangeVKeyCommitment;
-
-    constructor(ISP1Verifier sp1Verifier_, bytes32 aggregationVKey_, bytes32 rangeVKeyCommitment_) {
+    constructor(ISP1Verifier sp1Verifier_) {
         if (address(sp1Verifier_) == address(0)) revert ZeroSP1Verifier();
-        if (aggregationVKey_ == bytes32(0)) revert ZeroAggregationVKey();
-        if (rangeVKeyCommitment_ == bytes32(0)) revert ZeroRangeVKeyCommitment();
-
         sp1Verifier = sp1Verifier_;
-        aggregationVKey = aggregationVKey_;
-        rangeVKeyCommitment = rangeVKeyCommitment_;
     }
 
     /// @inheritdoc IWorldChainProofVerifier
     /// @dev `proof` is the SP1 on-chain proof payload; for gateway deployments its first four
-    ///      bytes select the concrete verifier route. The public values are reconstructed from
-    ///      the game-supplied transition and this verifier's range-program commitment, so the
-    ///      proof can only verify if it attests exactly that transition. Invalid or malformed
-    ///      proofs revert inside the gateway and surface as `false`.
-    function verify(bytes32, TransitionPublicValues calldata transition, bytes calldata proof)
+    ///      bytes select the concrete verifier route. Invalid or malformed proofs revert inside
+    ///      the gateway and surface as `false`.
+    function verify(bytes calldata proof, bytes32 verifierId, bytes calldata publicValues)
         external
         view
         returns (bool)
     {
-        bytes memory publicValues = abi.encode(
-            AggregationPublicValues({transitionPublicValues: transition, multiBlockVKey: rangeVKeyCommitment})
-        );
-        try sp1Verifier.verifyProof(aggregationVKey, publicValues, proof) {
+        if (verifierId == bytes32(0) || publicValues.length != PUBLIC_VALUES_LENGTH) return false;
+        bytes32 rangeVKeyCommitment;
+        assembly ("memory-safe") {
+            rangeVKeyCommitment := calldataload(add(publicValues.offset, sub(publicValues.length, 32)))
+        }
+        if (rangeVKeyCommitment == bytes32(0)) return false;
+        try sp1Verifier.verifyProof(verifierId, publicValues, proof) {
             return true;
         } catch {
             return false;

--- a/pkg/contracts/test/dispute/MultiProofGame.t.sol
+++ b/pkg/contracts/test/dispute/MultiProofGame.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.28;
 import {OPStackFixtures} from "./OPStackFixtures.sol";
 import {MultiProofGame} from "../../src/dispute/MultiProofGame.sol";
 import {IMultiProofGame} from "../../src/dispute/interfaces/IMultiProofGame.sol";
-import {LibProof, InvalidationReason, ProofLane} from "../../src/dispute/lib/LibProof.sol";
+import {LibProof, InvalidationReason, ProofLane, TransitionPublicValues} from "../../src/dispute/lib/LibProof.sol";
 
 import {
     BondDistributionMode,
@@ -195,6 +195,21 @@ contract MultiProofGameTest is OPStackFixtures {
         vm.expectRevert(IMultiProofGame.InvalidActivationParameters.selector);
         new MultiProofGame(config);
 
+        config = _gameConfig();
+        config.aggregationVKey = bytes32(0);
+        vm.expectRevert(IMultiProofGame.InvalidActivationParameters.selector);
+        new MultiProofGame(config);
+
+        config = _gameConfig();
+        config.rangeVKeyCommitment = bytes32(0);
+        vm.expectRevert(IMultiProofGame.InvalidActivationParameters.selector);
+        new MultiProofGame(config);
+
+        config = _gameConfig();
+        config.teeImageId = bytes32(0);
+        vm.expectRevert(IMultiProofGame.InvalidActivationParameters.selector);
+        new MultiProofGame(config);
+
         // A DelayedWETH wired to a different SystemConfig than the registry's must be rejected.
         config = _gameConfig();
         vm.mockCall(address(weth), abi.encodeWithSignature("systemConfig()"), abi.encode(address(0xdead)));
@@ -216,6 +231,37 @@ contract MultiProofGameTest is OPStackFixtures {
 
             assertEq(uint8(game.status()), uint8(GameStatus.DEFENDER_WINS));
             assertEq(game.credit(proposer), PROPOSER_BOND);
+        }
+    }
+
+    function test_SubmitProofLane_PassesExactGamePinnedVerifierInputs() public {
+        for (uint8 lane; lane < LibProof.PROOF_LANE_COUNT; lane++) {
+            (, uint256 anchorBlock) = asr.getAnchorRoot();
+            MultiProofGame game =
+                _propose(type(uint256).max, keccak256(abi.encode("parameters", lane)), anchorBlock + BLOCK_INTERVAL, 0);
+
+            (Hash startingRoot, uint256 startingBlockNumber) = game.startingProposal();
+            TransitionPublicValues memory transition = TransitionPublicValues({
+                l1Head: Hash.unwrap(game.l1Head()),
+                l2PreRoot: Hash.unwrap(startingRoot),
+                // `initialize` bounds the child block to uint64, so its parent is also safe.
+                // forge-lint: disable-next-line(unsafe-typecast)
+                l2PreBlockNumber: uint64(startingBlockNumber),
+                l2PostRoot: Claim.unwrap(game.rootClaim()),
+                l2PostBlockNumber: uint64(game.l2SequenceNumber()),
+                rollupConfigHash: ROLLUP_CONFIG_HASH
+            });
+
+            if (lane == uint8(ProofLane.VALIDITY_PROOF)) {
+                validityVerifier.setExpectedParameters(AGGREGATION_VKEY, abi.encode(transition, RANGE_VKEY_COMMITMENT));
+            } else if (lane == uint8(ProofLane.TEE_ATTESTATION)) {
+                teeVerifier.setExpectedParameters(TEE_IMAGE_ID, abi.encode(transition));
+            } else {
+                councilVerifier.setExpectedParameters(bytes32(0), abi.encode(game.rootId()));
+            }
+
+            game.submitProofLane(_compact(lane, laneRewardRecipient(lane), abi.encodePacked(game.rootId())));
+            assertTrue(game.proofBitmap().has(ProofLane(lane)));
         }
     }
 
@@ -611,6 +657,9 @@ contract MultiProofGameTest is OPStackFixtures {
         assertEq(Claim.unwrap(game.rootClaimByChainId(CHAIN_ID + 1)), Claim.unwrap(game.rootClaim()));
 
         assertEq(game.rollupConfigHash(), ROLLUP_CONFIG_HASH);
+        assertEq(game.aggregationVKey(), AGGREGATION_VKEY);
+        assertEq(game.rangeVKeyCommitment(), RANGE_VKEY_COMMITMENT);
+        assertEq(game.teeImageId(), TEE_IMAGE_ID);
         assertEq(game.blockInterval(), BLOCK_INTERVAL);
         assertEq(game.domainHash(), _domainHash());
     }

--- a/pkg/contracts/test/dispute/OPStackFixtures.sol
+++ b/pkg/contracts/test/dispute/OPStackFixtures.sol
@@ -35,6 +35,9 @@ abstract contract OPStackFixtures is Test {
 
     uint256 internal constant CHAIN_ID = 480;
     bytes32 internal constant ROLLUP_CONFIG_HASH = keccak256("world-chain-rollup-config");
+    bytes32 internal constant AGGREGATION_VKEY = keccak256("aggregation-vkey");
+    bytes32 internal constant RANGE_VKEY_COMMITMENT = keccak256("range-vkey-commitment");
+    bytes32 internal constant TEE_IMAGE_ID = keccak256("tee-image-id");
     uint256 internal constant BLOCK_INTERVAL = 100;
 
     bytes32 internal constant STARTING_ANCHOR_ROOT = keccak256("starting-anchor-root");
@@ -131,6 +134,9 @@ abstract contract OPStackFixtures is Test {
             challengerBond: CHALLENGER_BOND,
             protocolFeeRecipient: protocolFeeRecipient,
             proofThreshold: PROOF_THRESHOLD,
+            aggregationVKey: AGGREGATION_VKEY,
+            rangeVKeyCommitment: RANGE_VKEY_COMMITMENT,
+            teeImageId: TEE_IMAGE_ID,
             validityProofVerifier: IWorldChainProofVerifier(address(validityVerifier)),
             teeVerifier: IWorldChainProofVerifier(address(teeVerifier)),
             securityCouncil: IWorldChainProofVerifier(address(councilVerifier)),

--- a/pkg/contracts/test/dispute/SecurityCouncilVerifier.t.sol
+++ b/pkg/contracts/test/dispute/SecurityCouncilVerifier.t.sol
@@ -4,7 +4,6 @@ pragma solidity 0.8.28;
 import {Test} from "forge-std/Test.sol";
 
 import {SecurityCouncilVerifier} from "../../src/dispute/council/SecurityCouncilVerifier.sol";
-import {LibProof, TransitionPublicValues} from "../../src/dispute/lib/LibProof.sol";
 
 import {Safe} from "@safe-global/safe-contracts/contracts/Safe.sol";
 import {SafeProxyFactory} from "@safe-global/safe-contracts/contracts/proxies/SafeProxyFactory.sol";
@@ -33,16 +32,6 @@ contract SecurityCouncilVerifierTest is Test {
 
     bytes32 internal constant ROOT_ID = keccak256("rootId");
 
-    function _transition() internal pure returns (TransitionPublicValues memory) {
-        return TransitionPublicValues({
-            l1Head: bytes32(0),
-            l2PreRoot: bytes32(0),
-            l2PreBlockNumber: 0,
-            l2PostRoot: bytes32(0),
-            l2PostBlockNumber: 0,
-            rollupConfigHash: bytes32(0)
-        });
-    }
     uint256 internal constant THRESHOLD = 2;
 
     function setUp() public {
@@ -88,6 +77,10 @@ contract SecurityCouncilVerifierTest is Test {
         return abi.encodePacked(r, s, v);
     }
 
+    function _verify(bytes32 rootId, bytes memory proof) internal view returns (bool) {
+        return verifier.verify(proof, bytes32(0), abi.encode(rootId));
+    }
+
     /*//////////////////////////////////////////////////////////////
                     PATH 1 — AGGREGATED SIGNATURES
     //////////////////////////////////////////////////////////////*/
@@ -95,18 +88,18 @@ contract SecurityCouncilVerifierTest is Test {
     function test_verify_AggregatedSignatures_AtThreshold() public view {
         bytes32 h = _safeMessageHash(ROOT_ID);
         bytes memory sigs = abi.encodePacked(_sign(pk1, h), _sign(pk2, h));
-        assertTrue(verifier.verify(ROOT_ID, _transition(), sigs));
+        assertTrue(_verify(ROOT_ID, sigs));
     }
 
     function test_verify_AggregatedSignatures_AboveThreshold() public view {
         bytes32 h = _safeMessageHash(ROOT_ID);
         bytes memory sigs = abi.encodePacked(_sign(pk1, h), _sign(pk2, h), _sign(pk3, h));
-        assertTrue(verifier.verify(ROOT_ID, _transition(), sigs));
+        assertTrue(_verify(ROOT_ID, sigs));
     }
 
     function test_verify_RevertsInsideSafe_AreCaughtAsFalse_BelowThreshold() public view {
         bytes memory sigs = _sign(pk1, _safeMessageHash(ROOT_ID));
-        assertFalse(verifier.verify(ROOT_ID, _transition(), sigs));
+        assertFalse(_verify(ROOT_ID, sigs));
     }
 
     function test_verify_ReturnsFalse_NonOwnerSignature() public view {
@@ -115,7 +108,7 @@ contract SecurityCouncilVerifierTest is Test {
         // Two signatures, but one is not an owner. Ordering still ascending is not guaranteed,
         // so either the owner check or the ordering check rejects it — both must be `false`.
         bytes memory sigs = abi.encodePacked(_sign(pk1, h), _sign(intruderPk, h));
-        assertFalse(verifier.verify(ROOT_ID, _transition(), sigs));
+        assertFalse(_verify(ROOT_ID, sigs));
     }
 
     /// @dev The core replay guard: signatures collected for one root must not satisfy another.
@@ -123,12 +116,12 @@ contract SecurityCouncilVerifierTest is Test {
         bytes32 other = keccak256("some other root");
         bytes32 h = _safeMessageHash(other);
         bytes memory sigs = abi.encodePacked(_sign(pk1, h), _sign(pk2, h));
-        assertFalse(verifier.verify(ROOT_ID, _transition(), sigs));
-        assertTrue(verifier.verify(other, _transition(), sigs));
+        assertFalse(_verify(ROOT_ID, sigs));
+        assertTrue(_verify(other, sigs));
     }
 
     function test_verify_ReturnsFalse_GarbageProof() public view {
-        assertFalse(verifier.verify(ROOT_ID, _transition(), hex"deadbeef"));
+        assertFalse(_verify(ROOT_ID, hex"deadbeef"));
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -151,7 +144,7 @@ contract SecurityCouncilVerifierTest is Test {
             bytes32(0),
             uint8(1)
         );
-        assertTrue(verifier.verify(ROOT_ID, _transition(), sigs));
+        assertTrue(_verify(ROOT_ID, sigs));
     }
 
     function test_verify_ReturnsFalse_ApprovedHashBelowThreshold() public {
@@ -160,7 +153,7 @@ contract SecurityCouncilVerifierTest is Test {
         safe.approveHash(h);
 
         bytes memory sigs = abi.encodePacked(bytes32(uint256(uint160(owner1))), bytes32(0), uint8(1));
-        assertFalse(verifier.verify(ROOT_ID, _transition(), sigs));
+        assertFalse(_verify(ROOT_ID, sigs));
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -172,11 +165,11 @@ contract SecurityCouncilVerifierTest is Test {
         _execFromSafe(
             address(signMessageLib), abi.encodeCall(SignMessageLib.signMessage, (message)), Enum.Operation.DelegateCall
         );
-        assertTrue(verifier.verify(ROOT_ID, _transition(), ""));
+        assertTrue(_verify(ROOT_ID, ""));
     }
 
     function test_verify_ReturnsFalse_EmptyProofWithoutApproval() public view {
-        assertFalse(verifier.verify(ROOT_ID, _transition(), ""));
+        assertFalse(_verify(ROOT_ID, ""));
     }
 
     /// @dev signMessage only covers the root it was signed for.
@@ -185,7 +178,7 @@ contract SecurityCouncilVerifierTest is Test {
         _execFromSafe(
             address(signMessageLib), abi.encodeCall(SignMessageLib.signMessage, (message)), Enum.Operation.DelegateCall
         );
-        assertFalse(verifier.verify(keccak256("unapproved root"), _transition(), ""));
+        assertFalse(_verify(keccak256("unapproved root"), ""));
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/pkg/contracts/test/dispute/nitro/NitroEnclaveKeyRegistry.t.sol
+++ b/pkg/contracts/test/dispute/nitro/NitroEnclaveKeyRegistry.t.sol
@@ -61,6 +61,8 @@ contract NitroEnclaveKeyRegistryTest is Test {
         registry.registerKey(TBS, SIG, "");
 
         assertTrue(registry.isSignerRegistered(signer));
+        assertEq(registry.signerImageId(signer), PCR0);
+        assertTrue(registry.isSignerRegisteredForImage(signer, PCR0));
     }
 
     function test_RegisterKey_RevertsWhenVerifierRejects() public {
@@ -115,6 +117,8 @@ contract NitroEnclaveKeyRegistryTest is Test {
 
         assertTrue(registry.isSignerRegistered(signer));
         assertTrue(registry.isSignerRegistered(otherSigner));
+        assertEq(registry.signerImageId(signer), PCR0);
+        assertEq(registry.signerImageId(otherSigner), PCR0);
     }
 
     function test_Constructor_SetsOwnerAndVerifier() public view {
@@ -294,5 +298,11 @@ contract NitroEnclaveKeyRegistryTest is Test {
         // Both keys are registered.
         assertTrue(registry.isSignerRegistered(signer));
         assertTrue(registry.isSignerRegistered(otherSigner));
+        bytes32 imageA = PCR0;
+        bytes32 imageB = pcr0B;
+        assertTrue(registry.isSignerRegisteredForImage(signer, imageA));
+        assertFalse(registry.isSignerRegisteredForImage(signer, imageB));
+        assertTrue(registry.isSignerRegisteredForImage(otherSigner, imageB));
+        assertFalse(registry.isSignerRegisteredForImage(otherSigner, imageA));
     }
 }

--- a/pkg/contracts/test/dispute/nitro/NitroEndToEnd.t.sol
+++ b/pkg/contracts/test/dispute/nitro/NitroEndToEnd.t.sol
@@ -92,7 +92,7 @@ contract NitroEndToEndTest is Test {
     }
 
     function _verify(TransitionPublicValues memory transition, bytes memory sig) internal view returns (bool) {
-        return proofVerifier.verify(ROOT_ID, transition, sig);
+        return proofVerifier.verify(sig, PCR0, abi.encode(transition));
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/pkg/contracts/test/dispute/nitro/NitroProofVerifier.t.sol
+++ b/pkg/contracts/test/dispute/nitro/NitroProofVerifier.t.sol
@@ -81,8 +81,12 @@ contract NitroProofVerifierTest is Test {
         return keccak256(abi.encode(_transition()));
     }
 
+    function _imageId() internal pure returns (bytes32) {
+        return PCR0;
+    }
+
     function _verify(bytes memory sig) internal view returns (bool) {
-        return proofVerifier.verify(ROOT_ID, _transition(), sig);
+        return proofVerifier.verify(sig, _imageId(), abi.encode(_transition()));
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -98,7 +102,7 @@ contract NitroProofVerifierTest is Test {
         transition.l2PostBlockNumber = 0;
         bytes memory sig = _sign(keccak256(abi.encode(transition)));
 
-        assertTrue(proofVerifier.verify(ROOT_ID, transition, sig));
+        assertTrue(proofVerifier.verify(sig, _imageId(), abi.encode(transition)));
     }
 
     function test_Verify_PerCallIdempotent() public {
@@ -126,6 +130,14 @@ contract NitroProofVerifierTest is Test {
         bytes memory sig = _sign(keccak256(abi.encode(proven)));
 
         assertFalse(_verify(sig));
+    }
+
+    function test_Verify_FalseForDifferentGameImage() public {
+        assertFalse(proofVerifier.verify(_sign(_commitment()), keccak256("new-image"), abi.encode(_transition())));
+    }
+
+    function test_Verify_FalseForMalformedPublicValues() public {
+        assertFalse(proofVerifier.verify(_sign(_commitment()), _imageId(), abi.encode(bytes32(0))));
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/pkg/contracts/test/dispute/sp1/SP1ValidityVerifier.t.sol
+++ b/pkg/contracts/test/dispute/sp1/SP1ValidityVerifier.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.28;
 import {Test} from "forge-std/Test.sol";
 
 import {ISP1Verifier} from "@sp1-contracts/src/ISP1Verifier.sol";
-import {AggregationPublicValues, SP1ValidityVerifier} from "../../../src/dispute/sp1/SP1ValidityVerifier.sol";
+import {SP1ValidityVerifier} from "../../../src/dispute/sp1/SP1ValidityVerifier.sol";
 import {LibProof, TransitionPublicValues} from "../../../src/dispute/lib/LibProof.sol";
 
 contract StubSP1Verifier is ISP1Verifier {
@@ -50,7 +50,7 @@ contract SP1ValidityVerifierTest is Test {
 
     function setUp() public {
         sp1 = new StubSP1Verifier();
-        verifier = new SP1ValidityVerifier(ISP1Verifier(address(sp1)), AGGREGATION_VKEY, RANGE_VKEY_COMMITMENT);
+        verifier = new SP1ValidityVerifier(ISP1Verifier(address(sp1)));
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -73,7 +73,7 @@ contract SP1ValidityVerifierTest is Test {
         pure
         returns (bytes memory)
     {
-        return abi.encode(AggregationPublicValues({transitionPublicValues: transition, multiBlockVKey: multiBlockVKey}));
+        return abi.encode(transition, multiBlockVKey);
     }
 
     function _expectSp1Call(TransitionPublicValues memory transition) internal {
@@ -86,17 +86,7 @@ contract SP1ValidityVerifierTest is Test {
 
     function test_Constructor_RevertsForZeroSP1Verifier() public {
         vm.expectRevert(SP1ValidityVerifier.ZeroSP1Verifier.selector);
-        new SP1ValidityVerifier(ISP1Verifier(address(0)), AGGREGATION_VKEY, RANGE_VKEY_COMMITMENT);
-    }
-
-    function test_Constructor_RevertsForZeroAggregationVKey() public {
-        vm.expectRevert(SP1ValidityVerifier.ZeroAggregationVKey.selector);
-        new SP1ValidityVerifier(ISP1Verifier(address(sp1)), bytes32(0), RANGE_VKEY_COMMITMENT);
-    }
-
-    function test_Constructor_RevertsForZeroRangeVKeyCommitment() public {
-        vm.expectRevert(SP1ValidityVerifier.ZeroRangeVKeyCommitment.selector);
-        new SP1ValidityVerifier(ISP1Verifier(address(sp1)), AGGREGATION_VKEY, bytes32(0));
+        new SP1ValidityVerifier(ISP1Verifier(address(0)));
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -107,7 +97,7 @@ contract SP1ValidityVerifierTest is Test {
         TransitionPublicValues memory transition = _transition();
         _expectSp1Call(transition);
 
-        assertTrue(verifier.verify(ROOT_ID, transition, SP1_PROOF_BYTES));
+        assertTrue(verifier.verify(SP1_PROOF_BYTES, AGGREGATION_VKEY, _publicValues(transition, RANGE_VKEY_COMMITMENT)));
     }
 
     function test_Verify_FalseWhenSP1ProofInvalid() public {
@@ -115,14 +105,16 @@ contract SP1ValidityVerifierTest is Test {
         _expectSp1Call(transition);
         sp1.setReject(true);
 
-        assertFalse(verifier.verify(ROOT_ID, transition, SP1_PROOF_BYTES));
+        assertFalse(
+            verifier.verify(SP1_PROOF_BYTES, AGGREGATION_VKEY, _publicValues(transition, RANGE_VKEY_COMMITMENT))
+        );
     }
 
     function test_Verify_FalseForUnexpectedProofBytes() public {
         TransitionPublicValues memory transition = _transition();
         _expectSp1Call(transition);
 
-        assertFalse(verifier.verify(ROOT_ID, transition, hex"deadbeef"));
+        assertFalse(verifier.verify(hex"deadbeef", AGGREGATION_VKEY, _publicValues(transition, RANGE_VKEY_COMMITMENT)));
     }
 
     function test_Verify_FalseWhenProofAttestsDifferentTransition() public {
@@ -132,13 +124,44 @@ contract SP1ValidityVerifierTest is Test {
         TransitionPublicValues memory expected = _transition();
         expected.l2PostRoot = keccak256("other-post-root");
 
-        assertFalse(verifier.verify(ROOT_ID, expected, SP1_PROOF_BYTES));
+        assertFalse(verifier.verify(SP1_PROOF_BYTES, AGGREGATION_VKEY, _publicValues(expected, RANGE_VKEY_COMMITMENT)));
     }
 
     function test_Verify_BindsRangeVKeyCommitment() public {
         TransitionPublicValues memory transition = _transition();
         sp1.setExpectation(AGGREGATION_VKEY, _publicValues(transition, keccak256("wrong-range-vkey")), SP1_PROOF_BYTES);
 
-        assertFalse(verifier.verify(ROOT_ID, transition, SP1_PROOF_BYTES));
+        assertFalse(
+            verifier.verify(SP1_PROOF_BYTES, AGGREGATION_VKEY, _publicValues(transition, RANGE_VKEY_COMMITMENT))
+        );
+    }
+
+    function test_Verify_FalseForDifferentGameVKeys() public {
+        TransitionPublicValues memory transition = _transition();
+        _expectSp1Call(transition);
+        assertFalse(
+            verifier.verify(
+                SP1_PROOF_BYTES, keccak256("new-aggregation-vkey"), _publicValues(transition, RANGE_VKEY_COMMITMENT)
+            )
+        );
+    }
+
+    function test_Verify_ReusesContractAcrossProgramVersions() public {
+        TransitionPublicValues memory transition = _transition();
+        bytes32 newAggregationVKey = keccak256("new-aggregation-vkey");
+        bytes32 newRangeVKeyCommitment = keccak256("new-range-vkey");
+        bytes memory newPublicValues = _publicValues(transition, newRangeVKeyCommitment);
+        sp1.setExpectation(newAggregationVKey, newPublicValues, SP1_PROOF_BYTES);
+
+        assertTrue(verifier.verify(SP1_PROOF_BYTES, newAggregationVKey, newPublicValues));
+    }
+
+    function test_Verify_FalseForZeroGameVKeys() public view {
+        assertFalse(verifier.verify(SP1_PROOF_BYTES, bytes32(0), _publicValues(_transition(), RANGE_VKEY_COMMITMENT)));
+        assertFalse(verifier.verify(SP1_PROOF_BYTES, AGGREGATION_VKEY, _publicValues(_transition(), bytes32(0))));
+    }
+
+    function test_Verify_FalseForMalformedPublicValues() public view {
+        assertFalse(verifier.verify(SP1_PROOF_BYTES, AGGREGATION_VKEY, abi.encode(_transition())));
     }
 }

--- a/pkg/contracts/test/dispute/sp1/SP1ValidityVerifier.t.sol
+++ b/pkg/contracts/test/dispute/sp1/SP1ValidityVerifier.t.sol
@@ -156,12 +156,10 @@ contract SP1ValidityVerifierTest is Test {
         assertTrue(verifier.verify(SP1_PROOF_BYTES, newAggregationVKey, newPublicValues));
     }
 
-    function test_Verify_FalseForZeroGameVKeys() public view {
-        assertFalse(verifier.verify(SP1_PROOF_BYTES, bytes32(0), _publicValues(_transition(), RANGE_VKEY_COMMITMENT)));
-        assertFalse(verifier.verify(SP1_PROOF_BYTES, AGGREGATION_VKEY, _publicValues(_transition(), bytes32(0))));
-    }
+    function test_Verify_ForwardsPublicValuesWithoutInterpretingThem() public {
+        bytes memory publicValues = hex"deadbeef";
+        sp1.setExpectation(AGGREGATION_VKEY, publicValues, SP1_PROOF_BYTES);
 
-    function test_Verify_FalseForMalformedPublicValues() public view {
-        assertFalse(verifier.verify(SP1_PROOF_BYTES, AGGREGATION_VKEY, abi.encode(_transition())));
+        assertTrue(verifier.verify(SP1_PROOF_BYTES, AGGREGATION_VKEY, publicValues));
     }
 }

--- a/pkg/contracts/test/mocks/MockRootIdVerifier.sol
+++ b/pkg/contracts/test/mocks/MockRootIdVerifier.sol
@@ -2,7 +2,10 @@
 pragma solidity 0.8.28;
 
 import {IWorldChainProofVerifier} from "../../src/dispute/interfaces/IWorldChainProofVerifier.sol";
-import {LibProof, TransitionPublicValues} from "../../src/dispute/lib/LibProof.sol";
+
+interface IRootIdSource {
+    function rootId() external view returns (bytes32);
+}
 
 /// @title MockRootIdVerifier
 /// @author World Contributors
@@ -10,6 +13,9 @@ import {LibProof, TransitionPublicValues} from "../../src/dispute/lib/LibProof.s
 contract MockRootIdVerifier is IWorldChainProofVerifier {
     mapping(bytes32 rootId => bool accepted) public acceptedRoots;
     bool public acceptAny;
+    bool public enforceParameters;
+    bytes32 public expectedVerifierId;
+    bytes32 public expectedPublicValuesHash;
 
     constructor(bool acceptAny_) {
         acceptAny = acceptAny_;
@@ -23,13 +29,26 @@ contract MockRootIdVerifier is IWorldChainProofVerifier {
         acceptedRoots[rootId] = accepted;
     }
 
-    function verify(bytes32 rootId, TransitionPublicValues calldata, bytes calldata proof)
+    function setExpectedParameters(bytes32 verifierId, bytes calldata publicValues) external {
+        enforceParameters = true;
+        expectedVerifierId = verifierId;
+        expectedPublicValuesHash = keccak256(publicValues);
+    }
+
+    function verify(bytes calldata proof, bytes32 verifierId, bytes calldata publicValues)
         external
         view
         returns (bool)
     {
-        if (acceptAny || acceptedRoots[rootId]) return true;
+        if (enforceParameters && verifierId != expectedVerifierId) return false;
+        if (enforceParameters && keccak256(publicValues) != expectedPublicValuesHash) return false;
+        if (acceptAny) return true;
         if (proof.length != 32) return false;
-        return abi.decode(proof, (bytes32)) == rootId;
+        bytes32 rootId = abi.decode(proof, (bytes32));
+        try IRootIdSource(msg.sender).rootId() returns (bytes32 expectedRootId) {
+            return rootId == expectedRootId || acceptedRoots[rootId];
+        } catch {
+            return acceptedRoots[rootId];
+        }
     }
 }

--- a/scripts/proof-envs/README.md
+++ b/scripts/proof-envs/README.md
@@ -52,6 +52,13 @@ targets — they are intentionally **not** stored in config files:
 | `L1_RPC_URL` | `proof-deploy-nitro`, `proof-deploy-system`, `proof-certmanager-prewarm`, `proof-approve-pcrs` |
 | `WORLD_CHAIN_L2_CHAIN_ID` | `proof-deploy-system` |
 | `ROLLUP_CONFIG_HASH` | `proof-deploy-system` |
+| `AGGREGATION_VKEY` | `proof-deploy-system` |
+| `RANGE_VKEY_COMMITMENT` | `proof-deploy-system` |
+| `TEE_IMAGE_ID` | `proof-deploy-system` |
 | `CERT_MANAGER_ADDRESS` | `proof-certmanager-prewarm` |
 | `NITRO_ATTESTATION_VERIFIER` | `proof-approve-pcrs` |
 | `PCR0`, `PCR1`, `PCR2` | `proof-approve-pcrs` |
+
+`proof-setup` reads the two SP1 values from `proofs/backends/sp1/elfs/vkeys.json` and derives
+`TEE_IMAGE_ID` as `keccak256(rawPCR0)`.
+Standalone `proof-deploy-system` calls must supply all three values explicitly.

--- a/scripts/proof-envs/README.md
+++ b/scripts/proof-envs/README.md
@@ -59,6 +59,6 @@ targets — they are intentionally **not** stored in config files:
 | `NITRO_ATTESTATION_VERIFIER` | `proof-approve-pcrs` |
 | `PCR0`, `PCR1`, `PCR2` | `proof-approve-pcrs` |
 
-`proof-setup` reads the two SP1 values from `proofs/backends/sp1/elfs/vkeys.json` and derives
-`TEE_IMAGE_ID` as `keccak256(rawPCR0)`.
-Standalone `proof-deploy-system` calls must supply all three values explicitly.
+`proof-setup` and standalone `proof-deploy-system` calls require all three verifier identities
+explicitly. During setup, the measured `keccak256(rawPCR0)` must match `TEE_IMAGE_ID` before the
+PCR set is approved.

--- a/wips/wip-1006.md
+++ b/wips/wip-1006.md
@@ -42,6 +42,10 @@ Protocol constants are fixed by this WIP and MUST NOT be changed without a new W
 
 Activation parameters are set at hardfork activation and held as immutable values on the proof system contracts. They MAY be retuned only by a subsequent activation. All implementations MUST commit to these values in their deployed configuration and MUST NOT permit per-call overrides.
 
+Proof-system identities (`aggregationVKey`, `rangeVKeyCommitment`, and `teeImageId`) are also
+immutable game-implementation configuration, but are not fixed protocol constants. Rotating one
+requires activating a new game implementation; existing games retain their original identities.
+
 | Name | Initial Value | Meaning |
 | --- | --- | --- |
 | `PROOF_THRESHOLD` | `2` | Number of distinct proof lanes that MUST support a challenged root before it finalizes. The implementation accepts values from `1` through `PROOF_LANE_COUNT`. |
@@ -54,7 +58,7 @@ Activation parameters are set at hardfork activation and held as immutable value
 
 ### Proof Lanes
 
-A challenged root finalizes only when at least `PROOF_THRESHOLD` distinct lanes support the same root commitment. Each lane counts at most once per root.
+A challenged root finalizes only when at least `PROOF_THRESHOLD` distinct lanes are accepted by the same game. Each lane counts at most once per game. The lanes do not need to authenticate byte-identical payloads: the validity and TEE lanes authenticate the transition, while the Security Council authenticates the proposal's `rootId`. The game derives both statements from its own state.
 
 | Lane | Source | Submission |
 | --- | --- | --- |
@@ -64,9 +68,9 @@ A challenged root finalizes only when at least `PROOF_THRESHOLD` distinct lanes 
 
 Multiple proofs from the same lane MUST NOT increase the threshold count.
 
-### Root Commitments
+### Identifiers and Authenticated Statements
 
-The data bound by every proof and attestation is split into immutable domain configuration and per-game clone data. The implementation fixes the complete domain. Each proposal supplies that domain's hash in `extraData`, allowing the game to reject cross-domain proposals and ensuring that the factory UUID changes when the proof-system domain changes.
+The factory UUID identifies a game, while each proof lane authenticates a statement derived by that game. The implementation fixes the complete domain. Each proposal supplies that domain's hash in `extraData`, allowing the game to reject cross-domain proposals and ensuring that the factory UUID changes when the proof-system domain changes.
 
 #### Proposal (per-proposal)
 
@@ -91,7 +95,7 @@ extraData = abi.encode(domainHash, l2BlockNumber, parentRef, attempt)
 [op-dgi]: https://specs.optimism.io/fault-proof/stage-one/dispute-game-interface.html
 [base-azul]: https://docs.base.org/base-chain/specs/protocol/proofs/contracts
 
-#### Domain (verifier-immutable)
+#### Domain (game-immutable)
 
 | Field | Meaning |
 | --- | --- |
@@ -100,14 +104,15 @@ extraData = abi.encode(domainHash, l2BlockNumber, parentRef, attempt)
 | `rollupConfigHash` | Hash of the rollup configuration and World Chain hardfork schedule. |
 | `blockInterval` | Exact distance in L2 blocks between a parent root and a proposed root. |
 
-These values are set once on the game implementation. Their hash is supplied in each game's `extraData` and MUST equal the implementation's immutable `domainHash`. Lane-specific constants, such as the active TEE image hash and validity-proof program key, live in the lane verifiers and are committed to by those lanes' proof material.
+These values are set once on the game implementation (analogous to Base's `CONFIG_HASH` and `L2_CHAIN_ID` immutables). Their hash is supplied in each game's `extraData` and MUST equal the implementation's immutable `domainHash`. The game implementation also pins the aggregation vkey, range vkey commitment, and TEE image ID. Lane verifier contracts are reusable: the game supplies its pinned identity to the selected verifier for every proof.
 
-#### Canonical identifiers
+#### Identifiers and statements
 
-The contracts use two related identifiers:
+The contracts use two related identifiers and one transition statement:
 
-- `gameUUID` is the stock `DisputeGameFactory` lookup key. It commits to `gameType`, `rootClaim`, and the complete `extraData`, but excludes the factory-captured L1 origin.
-- `rootId` is the complete proposal commitment. It includes the factory-captured L1 origin and is attested directly by the Security Council lane. The validity and TEE lanes instead attest the transition reconstructed from the same game.
+- `gameUUID` is the stock `DisputeGameFactory` lookup key and the unique identifier for a game creation. It commits to `gameType`, `rootClaim`, and the complete `extraData`, but excludes the factory-captured L1 origin.
+- `rootId` is the Security Council's proposal commitment. It includes the factory-captured L1 origin and is also used to correlate proof events and errors. It is not the factory UUID and does not include `attempt`.
+- `transition` is the state-transition statement authenticated by the validity and TEE lanes. The game derives it from its L1 head, parent proposal, root claim, L2 block number, and immutable rollup configuration.
 
 The contract computes:
 
@@ -126,7 +131,7 @@ extraData = abi.encode(
     attempt
 )
 
-gameUUID = keccak256(abi.encodePacked(
+gameUUID = keccak256(abi.encode(
     gameType,
     rootClaim,
     extraData
@@ -140,9 +145,20 @@ rootId = keccak256(abi.encode(
     l1OriginHash,
     l1OriginNumber
 ))
+
+transition = TransitionPublicValues({
+    l1Head: l1OriginHash,
+    l2PreRoot: parentRoot,
+    l2PreBlockNumber: parentL2BlockNumber,
+    l2PostRoot: rootClaim,
+    l2PostBlockNumber: l2BlockNumber,
+    rollupConfigHash: rollupConfigHash
+})
 ```
 
-The factory MUST reject duplicate games with the same `gameUUID`. The validity and TEE lanes MUST bind to the game-reconstructed transition `(l1Head, l2PreRoot, l2PreBlockNumber, l2PostRoot, l2PostBlockNumber, rollupConfigHash)`. The Security Council lane MUST bind to `rootId`.
+The factory MUST reject duplicate games with the same `gameUUID`. The game MUST construct the expected lane statement from its own state; callers MUST NOT be able to override it. The validity lane MUST authenticate `abi.encode(transition, rangeVKeyCommitment)` under the game-pinned aggregation vkey. The TEE lane MUST authenticate `abi.encode(transition)` with a signer registered for the game-pinned TEE image ID. The Security Council lane MUST authenticate `abi.encode(rootId)` under a council-specific signature domain.
+
+Proof reuse across games is permitted only when the authenticated transition and relevant verifier identities are identical. Such reuse proves the same state transition and MUST NOT allow a proof for one parent, root, block range, rollup configuration, aggregation program, range program, or TEE image to authorize another.
 
 ### State Machine
 
@@ -203,8 +219,8 @@ Otherwise, if no valid challenge has been submitted by `challengeDeadline`, anyo
 - the root is still `PROPOSED`;
 - the parent is the anchor sentinel or has resolved with `DEFENDER_WINS`; and
 - the parent is not blacklisted; and
-- either at least `PROOF_THRESHOLD` configured lanes support the proposal, or
-  `block.timestamp >= challengeDeadline` and at least one configured lane supports the proposal.
+- either at least `PROOF_THRESHOLD` configured lanes have been accepted by the game, or
+  `block.timestamp >= challengeDeadline` and at least one configured lane has been accepted by the game.
 
 If no proof lane supports the root at `challengeDeadline`, the game MUST instead resolve with `CHALLENGER_WINS`, record proof timeout, and credit the proposer bond to the configured protocol recipient. This outcome MUST remain retryable even when no challenger exists.
 
@@ -223,9 +239,9 @@ For each lane submission, the contract MUST:
 1. Verify that the game is still in progress.
 2. Verify that `block.timestamp < challengeDeadline` when unchallenged, or `block.timestamp < proofDeadline` when challenged.
 3. Decode the lane, reward recipient, and lane-specific proof from the compact payload.
-4. Verify the proof or attestation according to the lane-specific verifier.
-5. Set the lane's bit in the root's proof bitmap.
-6. Record the lane recipient and emit `Proved` with the updated bitmap.
+4. Construct the lane-specific statement and verifier identity from the game's own state and immutable configuration.
+5. Verify the proof or attestation according to the lane-specific verifier.
+6. Set the lane's bit, record its reward recipient, and emit `Proved` with the updated bitmap.
 
 A lane submission at or after its applicable deadline MUST revert. Once threshold is met, anyone MAY call `resolve()`, which MUST resolve the game with `DEFENDER_WINS` whether or not it was challenged.
 
@@ -237,17 +253,17 @@ Invalidation occurs either when a challenged root times out below threshold or w
 
 An invalidated root MUST NOT become claim-valid or update the anchor.
 
-If invalidity of a finalized root is discovered after the fact — for example, via an offchain proof exhibiting a conflicting `(parent, l2BlockNumber) → rootId'` — the protocol MUST NOT silently roll back finalized state. The configured safety process MUST be triggered: pausing the proof game type, blacklisting the game, or routing the incident to governance.
+If invalidity of a finalized root is discovered after the fact — for example, via an offchain proof exhibiting a conflicting `(parentRoot, l2BlockNumber) → rootClaim'` — the protocol MUST NOT silently roll back finalized state. The configured safety process MUST be triggered: pausing the proof game type, blacklisting the game, or routing the incident to governance.
 
 ### Lane-Specific Requirements
 
 #### Validity Proof
 
-The validity proof lane verifies that the transition from `parentRoot` at `parentL2BlockNumber` to `rootClaim` at `l2BlockNumber` is valid under `rollupConfigHash`. The current verifier checks an SP1 aggregation proof against transition public values reconstructed by the game.
+The validity proof lane verifies that the transition from `parentRoot` at `parentL2BlockNumber` to `rootClaim` at `l2BlockNumber` is valid from `l1OriginHash` under `rollupConfigHash`. The verifier MAY be implemented with a zkVM, a SNARK, or another cryptographic proof system. For SP1, the proof MUST authenticate `abi.encode(transition, rangeVKeyCommitment)` under the aggregation vkey pinned by the game. It MUST be verified onchain or by an onchain verifier gateway.
 
 #### TEE Attestation
 
-The TEE lane accepts a signature from a registered TEE signer over transition public values reconstructed by the game. Signer admission MUST verify the hardware attestation, approved image measurements, and attestation freshness before deriving and activating the signer's identity. For each proof, the lane verifier MUST check the transition binding, recover the signer from the signature, and require that signer to remain active in the registry. Revocation MUST prevent all subsequent proofs from that signer.
+The TEE lane accepts a signature from a registered TEE signer over `abi.encode(transition)`. Signer admission MUST verify the hardware attestation, approved image measurements, and attestation freshness before deriving and activating the signer's identity. For each proof, the lane verifier MUST recover the signer from the transition signature and require that the signer is registered for the TEE image ID pinned by the game. Revocation MUST prevent all subsequent proofs from that signer.
 
 #### Security Council Attestation
 
@@ -291,7 +307,7 @@ WIP-1006 is implemented as a new game type on the stock OP Stack dispute infrast
 | `IDisputeGame` / `IMultiProofGame` | Per-proposal game; exposes the Portal-facing lifecycle and World Chain proof-lane extensions. | [`AggregateVerifier`][base-aggregate] |
 | `IAnchorStateRegistry` | Stock OP registry; evaluates registration, respect, blacklist, retirement, finality, claim validity, and the current anchor. | [`AnchorStateRegistry`][base-anchor] |
 | `IDelayedWETH` | Holds proposer and challenger bonds and enforces delayed two-phase credit withdrawal. | OP Stack `DelayedWETH`. |
-| `IWorldChainProofVerifier` | Common verifier interface for the validity, TEE, and Security Council lanes. | [`IWorldChainProofVerifier`](../pkg/contracts/src/dispute/interfaces/IWorldChainProofVerifier.sol) |
+| `IWorldChainProofVerifier` | Common interface for verifying lane proofs against a game-supplied verifier identity and game-derived public values. | [`IWorldChainProofVerifier`](../pkg/contracts/src/dispute/interfaces/IWorldChainProofVerifier.sol) |
 | `NitroEnclaveKeyRegistry` | Maintains TEE signer identities admitted through Nitro attestation. | [`NitroEnclaveKeyRegistry`](../pkg/contracts/src/dispute/nitro/NitroEnclaveKeyRegistry.sol) |
 | `SecurityCouncilVerifier` | Verifies the council Safe's ERC-1271 attestation over `rootId`. | [`SecurityCouncilVerifier`](../pkg/contracts/src/dispute/council/SecurityCouncilVerifier.sol) |
 
@@ -336,7 +352,7 @@ Before this WIP can move beyond Draft, implementations SHOULD cover at least:
 - a lane submission at or after `proofDeadline` reverts and does not affect the proof bitmap;
 - challenging a root does not change its creation-time `proofDeadline`;
 - duplicate submissions from the same lane revert without changing the threshold count or reward recipient;
-- validity and TEE proofs reject mismatched transition data, and council attestations reject a mismatched `rootId`;
+- the validity and TEE lanes reject a proof for a different transition or verifier identity, and the Security Council lane rejects an attestation for a different `rootId`;
 - parent invalidation cascades and refunds both descendant participants;
 - retry attempts reject an ineligible predecessor and accept each specified recovery case;
 - close and claim use normal mode for proper games and refund mode for blacklisted or retired games;
@@ -348,13 +364,13 @@ Before this WIP can move beyond Draft, implementations SHOULD cover at least:
 
 **Disputed-path safety depends on lane independence.** A false challenged finality requires two lanes to accept the same invalid root. Implementations MUST avoid shared signing keys, shared verifier keys, shared operator control, and shared offchain infrastructure across lanes, because any such sharing collapses the effective threshold below two.
 
-**TEE trust assumptions live in one lane.** The TEE lane rests on the hardware vendor, the enclave image measurement, the registrar that admits signers, and the revocation process. Each of these is a potential single point of failure for that lane. The TEE lane is counted exactly once. Deployments MAY use it as their preferred initial proof, but a challenge MUST require an additional independent lane. A compromised registrar, stale signer set, or weakened image-measurement policy can turn this lane unsafe without affecting the other two.
+**TEE trust assumptions live in one lane.** The TEE lane rests on the hardware vendor, attestation verification, the owner-managed PCR allowlist, the game-pinned PCR0 image ID, and enclave signer-key security. Registration is permissionless, but only an attestation for an approved PCR tuple can add a signer. A weakened PCR policy, compromised signer key, or vulnerable approved image can turn this lane unsafe without affecting the other two. The TEE lane is counted exactly once, and a challenge MUST require an additional independent lane.
 
 **Security Council is a safety valve, not a finality mechanism.** Council signing keys, quorum rules, and action domains MUST be isolated from unrelated governance actions. A council attestation alone MUST NOT finalize a challenged root.
 
-**Proof binding is lane-specific.** The validity and TEE lanes bind to transition public values reconstructed by the game, while the council binds directly to `rootId`. Changes to either encoding MUST preserve the intended chain, rollup configuration, parent, block range, output root, and L1-head separation.
+**Lane statement binding is critical.** The validity and TEE lanes MUST authenticate the exact transition reconstructed by the game. `rollupConfigHash` MUST commit to every derivation-affecting configuration value, including chain IDs and the World Chain hardfork schedule, and MUST change when any such value changes. A validity-program change MUST rotate the applicable vkey, and a TEE-program change MUST rotate the image ID. The Security Council attestation MUST bind to `rootId`, whose `domainHash` commits to `chainId`, `proofSystemVersion`, `rollupConfigHash`, and `blockInterval`. Missing any of these bindings can permit a proof or attestation to be accepted outside the context in which it was produced.
 
-**`gameUUID` is not a proof target.** It exists for factory duplicate prevention and discovery and does not include the L1 origin captured at game creation.
+**`gameUUID` is not a proof target.** It exists for factory duplicate prevention, deterministic deployment, and discovery. The validity and TEE lanes authenticate the game-derived transition instead; the Security Council authenticates `rootId`. The game, rather than the proof submitter, MUST construct each expected statement.
 
 **Self-challenge can amplify proof work.** A proposer can challenge its own valid game through another account and force defenders to produce another lane. If the game times out, the shared owner loses the protocol share of `PROPOSER_BOND`; if it is defended, accepted proof-lane recipients share `CHALLENGER_BOND`. A proposer that also controls those recipients can still recycle the successful-defense payout, so the economics limit but do not prevent proof-amplification griefing.
 


### PR DESCRIPTION
## Summary

- pin the SP1 aggregation vkey, SP1 range-vkey commitment, and Nitro PCR0 image ID in each `MultiProofGame` implementation
- pass game-derived verifier identities and exact public values into reusable SP1, Nitro, and council lane verifiers
- bind every registered Nitro signer to the PCR0 image ID proven by its attestation
- wire the new game configuration through deployment scripts, devnet setup, tests, and proof-system documentation

## Upgrade model

- an SP1 program or Nitro image change deploys a new game implementation; existing games keep their original verifier identities
- the SP1 and Nitro verifier contracts remain reusable unless their gateway or verification interface changes
- Nitro PCR approval remains owner-controlled admission policy, while signer registration remains permissionless
- routine image rotation does not require revoking the old PCR set or old signers; the new game rejects old-image signers by construction


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes dispute-game proof verification, verifier interfaces, and Nitro signer binding—core security paths where mistakes could accept wrong transitions or images.
> 
> **Overview**
> Pins **SP1 aggregation vkey**, **range vkey commitment**, and **Nitro `teeImageId` (PCR0 hash)** as immutables on each `MultiProofGame` implementation, so program or enclave upgrades deploy a new game instead of mutating shared verifier contracts.
> 
> **`IWorldChainProofVerifier`** now takes `(proof, verifierId, publicValues)`; the game derives lane-specific identities and encoded statements in `LibProof` and passes them on `submitProofLane`. **`SP1ValidityVerifier`** drops constructor-pinned vkeys and checks the game-supplied aggregation vkey and public values. **`NitroProofVerifier`** requires the recovered signer to match the game-pinned image via new **`signerImageId`** on **`NitroEnclaveKeyRegistry`**. The council lane verifies `abi.encode(rootId)` with a zero verifier id.
> 
> Deployment and **`proof-setup`** require **`AGGREGATION_VKEY`**, **`RANGE_VKEY_COMMITMENT`**, and **`TEE_IMAGE_ID`** (vkeys from `vkeys.json`, TEE image from `keccak256(PCR0)`); activation asserts the three are non-zero. WIP-1006 and proof docs describe the reusable-verifier / game-pinned-identity upgrade model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e726cc888853a57cd4bb819e04e0342c30d59709. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->