### PR TITLE
feat(defender): read game verifier identities

### DIFF
--- a/proofs/it/src/lib.rs
+++ b/proofs/it/src/lib.rs
@@ -42,6 +42,9 @@ pub const BLOCK_INTERVAL: u64 = 10;
 pub const CHAIN_ID: u64 = 4801;
 pub const ANCHOR: Address = address!("0000000000000000000000000000000000001006");
 pub const FAKE_PROPOSER: Address = address!("a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1");
+const AGGREGATION_VKEY: B256 = B256::repeat_byte(0x44);
+const RANGE_VKEY_COMMITMENT: B256 = B256::repeat_byte(0x45);
+const TEE_IMAGE_ID: B256 = B256::repeat_byte(0x46);
 
 /// Fake game lifecycle. The contract splits this across `ProposalStatus` (challenged or not)
 /// and `GameStatus` (the terminal outcome); the fake keeps one field and derives both.
@@ -586,6 +589,9 @@ impl DefenderClient for FakeExecution {
             .map(|record| DefenderGameMetadata {
                 address: game,
                 domain_hash: state.domain_hash,
+                aggregation_vkey: AGGREGATION_VKEY,
+                range_vkey_commitment: RANGE_VKEY_COMMITMENT,
+                tee_image_id: TEE_IMAGE_ID,
                 parent_ref: record.creation.parent_ref,
                 root_claim: record.creation.root_claim,
                 l2_block_number: record.creation.l2_block_number,

--- a/proofs/protocol/src/bindings.rs
+++ b/proofs/protocol/src/bindings.rs
@@ -52,6 +52,9 @@ sol! {
         function PROOF_LANE_COUNT() external view returns (uint8);
         function domainHash() external view returns (bytes32);
         function rollupConfigHash() external view returns (bytes32);
+        function aggregationVKey() external view returns (bytes32);
+        function rangeVKeyCommitment() external view returns (bytes32);
+        function teeImageId() external view returns (bytes32);
         function blockInterval() external view returns (uint256);
         function challengePeriod() external view returns (uint64);
         function proofPeriod() external view returns (uint64);

--- a/proofs/services/defender/src/alloy.rs
+++ b/proofs/services/defender/src/alloy.rs
@@ -102,6 +102,9 @@ where
         let game = self.game(address);
         let (
             domain_hash,
+            aggregation_vkey,
+            range_vkey_commitment,
+            tee_image_id,
             parent_ref,
             root_claim,
             l2_block_number,
@@ -114,6 +117,9 @@ where
             .provider
             .multicall()
             .add(game.proposalDomainHash())
+            .add(game.aggregationVKey())
+            .add(game.rangeVKeyCommitment())
+            .add(game.teeImageId())
             .add(game.parentRef())
             .add(game.rootClaim())
             .add(game.l2SequenceNumber())
@@ -134,6 +140,9 @@ where
         Ok(GameMetadata {
             address,
             domain_hash,
+            aggregation_vkey,
+            range_vkey_commitment,
+            tee_image_id,
             parent_ref,
             root_claim,
             l2_block_number: u256_to_u64(l2_block_number)?,

--- a/proofs/services/defender/src/tests.rs
+++ b/proofs/services/defender/src/tests.rs
@@ -35,6 +35,9 @@ const BLOCK_INTERVAL: u64 = 10;
 const L2_BLOCK: u64 = 100;
 const L1_ORIGIN_HASH: B256 = B256::repeat_byte(0x42);
 const DOMAIN_HASH: B256 = B256::repeat_byte(0x43);
+const AGGREGATION_VKEY: B256 = B256::repeat_byte(0x44);
+const RANGE_VKEY_COMMITMENT: B256 = B256::repeat_byte(0x45);
+const TEE_IMAGE_ID: B256 = B256::repeat_byte(0x46);
 
 /// Fake game lifecycle. The contract splits this across `ProposalStatus` (challenged or not)
 /// and `GameStatus` (the terminal outcome); the fake keeps one field and derives both.
@@ -114,6 +117,9 @@ impl MockClient {
         let metadata = GameMetadata {
             address,
             domain_hash: DOMAIN_HASH,
+            aggregation_vkey: AGGREGATION_VKEY,
+            range_vkey_commitment: RANGE_VKEY_COMMITMENT,
+            tee_image_id: TEE_IMAGE_ID,
             parent_ref,
             root_claim,
             l2_block_number,

--- a/proofs/services/defender/src/types.rs
+++ b/proofs/services/defender/src/types.rs
@@ -5,6 +5,9 @@ use alloy_primitives::{Address, B256, TxHash};
 pub struct GameMetadata {
     pub address: Address,
     pub domain_hash: B256,
+    pub aggregation_vkey: B256,
+    pub range_vkey_commitment: B256,
+    pub tee_image_id: B256,
     pub parent_ref: Address,
     pub root_claim: B256,
     pub l2_block_number: u64,


### PR DESCRIPTION
- expose the game-pinned aggregation vkey, range vkey commitment, and Nitro image ID in the Rust `IMultiProofGame` binding
- load those immutable identities into Defender `GameMetadata`
- update Defender fixtures for the expanded metadata

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only binding and metadata plumbing with no changes to submission or defense logic.
> 
> **Overview**
> Defender now loads **game-pinned proof verifier identities** from chain alongside existing proposal metadata.
> 
> The `IMultiProofGame` binding exposes immutable views for `aggregationVKey`, `rangeVKeyCommitment`, and `teeImageId`. `AlloyDefenderClient::game_metadata` fetches them in the same multicall as `proposalDomainHash` and related fields, and **`GameMetadata`** carries the three new `B256` fields. Defender tests and mock game fixtures were updated to populate them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c148e60c95248998c034b7f4e0e5965d36b3e9d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->