### PR TITLE
feat(proofs): support AWS KMS transaction signers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19284,7 +19284,6 @@ dependencies = [
  "alloy-network 2.1.1",
  "alloy-primitives",
  "alloy-provider",
- "alloy-signer 2.1.1",
  "alloy-signer-aws 2.1.1",
  "alloy-signer-local 2.1.1",
  "alloy-transport",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,6 +1046,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-signer-aws"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddacf5492810b4bc33e341dd3213a30cf1f0cc0c526028368ce618f3f07258c"
+dependencies = [
+ "alloy-consensus 2.1.1",
+ "alloy-network 2.1.1",
+ "alloy-primitives",
+ "alloy-signer 2.1.1",
+ "async-trait",
+ "aws-config",
+ "aws-sdk-kms",
+ "k256",
+ "spki",
+ "thiserror 2.0.19",
+ "tracing",
+]
+
+[[package]]
 name = "alloy-signer-local"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15741,7 +15760,7 @@ checksum = "349ca86c7a88456c9f0fa1c8869e0d35bb63d6c811dc9ad8337c90909ce532ec"
 dependencies = [
  "alloy-primitives",
  "alloy-signer 1.8.3",
- "alloy-signer-aws",
+ "alloy-signer-aws 1.8.3",
  "alloy-signer-local 1.8.3",
  "anyhow",
  "async-trait",
@@ -18588,6 +18607,7 @@ dependencies = [
  "url",
  "world-chain-proof-metrics",
  "world-chain-proof-protocol",
+ "world-chain-proof-tx-signer",
 ]
 
 [[package]]
@@ -18667,6 +18687,7 @@ dependencies = [
  "world-chain-proof-core",
  "world-chain-proof-metrics",
  "world-chain-proof-protocol",
+ "world-chain-proof-tx-signer",
  "world-chain-prover-service",
 ]
 
@@ -19257,6 +19278,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "world-chain-proof-tx-signer"
+version = "2.4.1"
+dependencies = [
+ "alloy-network 2.1.1",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-signer 2.1.1",
+ "alloy-signer-aws 2.1.1",
+ "alloy-signer-local 2.1.1",
+ "alloy-transport",
+ "aws-config",
+ "aws-sdk-kms",
+ "thiserror 2.0.19",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "world-chain-proof-worker"
 version = "2.4.1"
 dependencies = [
@@ -19297,6 +19336,7 @@ dependencies = [
  "url",
  "world-chain-proof-metrics",
  "world-chain-proof-protocol",
+ "world-chain-proof-tx-signer",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ members = [
     "proofs/services/challenger",
     "proofs/services/prover-service",
     "proofs/services/defender",
+    "proofs/services/tx-signer",
     "proofs/debug/bin/prover-sp1",
     "proofs/debug/bin/prover-nitro",
     "proofs/debug/bin/prover-cli",
@@ -112,6 +113,7 @@ world-chain-proposer = { path = "proofs/services/proposer", default-features = f
 world-chain-challenger = { path = "proofs/services/challenger", default-features = false }
 world-chain-prover-service = { path = "proofs/services/prover-service", default-features = false }
 world-chain-defender = { path = "proofs/services/defender", default-features = false }
+world-chain-proof-tx-signer = { path = "proofs/services/tx-signer", default-features = false }
 
 # reth crates.io
 reth-codecs = { version = "0.5.0", default-features = false }
@@ -230,6 +232,7 @@ alloy-eip7928 = { version = "0.4.5", default-features = false, features = [
 alloy-genesis = { version = "=2.1.1", default-features = false }
 alloy-rpc-types-debug = "=2.1.1"
 alloy-signer = { version = "=2.1.1", default-features = false }
+alloy-signer-aws = { version = "=2.1.1", default-features = false }
 alloy-signer-local = { version = "=2.1.1", default-features = false, features = [
     "mnemonic",
 ] }
@@ -240,6 +243,9 @@ alloy-trie = { version = "0.9.4", default-features = false, features = [
     "ethereum",
 ] }
 
+# aws
+aws-config = { version = "1", default-features = false, features = ["rt-tokio", "rustls"] }
+aws-sdk-kms = { version = "1", default-features = false, features = ["rt-tokio", "rustls"] }
 
 # revm
 revm = { version = "41.0.0", default-features = false }

--- a/proofs/services/challenger/Cargo.toml
+++ b/proofs/services/challenger/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 # workspace
 world-chain-proof-protocol.workspace = true
 world-chain-proof-metrics.workspace = true
+world-chain-proof-tx-signer.workspace = true
 
 # alloy
 alloy-consensus.workspace = true

--- a/proofs/services/challenger/src/main.rs
+++ b/proofs/services/challenger/src/main.rs
@@ -7,7 +7,6 @@
 
 use std::time::Duration;
 
-use alloy_network::EthereumWallet;
 use alloy_primitives::Address;
 use alloy_provider::ProviderBuilder;
 use alloy_signer_local::PrivateKeySigner;
@@ -21,6 +20,7 @@ use world_chain_challenger::{
     ResolutionManagerConfig, WorldChainChallenger,
 };
 use world_chain_proof_protocol::{OptimismConsensusClient, VerifyingConsensusProvider};
+use world_chain_proof_tx_signer::build_transaction_wallet;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -46,7 +46,11 @@ struct Cli {
 
     /// Hex-encoded private key the challenger signs L1 transactions with.
     #[arg(long, env = "CHALLENGER_KEY", hide_env_values = true)]
-    challenger_key: PrivateKeySigner,
+    challenger_key: Option<PrivateKeySigner>,
+
+    /// AWS KMS key ID or alias the challenger signs L1 transactions with.
+    #[arg(long, env = "CHALLENGER_KMS_KEY_ID", hide_env_values = true)]
+    challenger_kms_key_id: Option<String>,
 
     /// Seconds between game-factory polls.
     #[arg(long, env = "POLL_INTERVAL_SECONDS", default_value_t = 12)]
@@ -120,8 +124,12 @@ async fn main() -> Result<()> {
 
     let cli = Cli::parse();
 
-    let challenger_address = cli.challenger_key.address();
     let l1_rpc_url = Url::parse(&cli.l1_rpc).context("invalid L1 RPC URL")?;
+    let signer =
+        build_transaction_wallet(cli.challenger_key, cli.challenger_kms_key_id, &l1_rpc_url)
+            .await
+            .context("failed to initialize challenger signer")?;
+    let challenger_address = signer.address;
     let l1_rpc_client = world_chain_proof_metrics::metered_http_client(
         l1_rpc_url,
         world_chain_proof_metrics::RPC_TARGET_L1_EXECUTION,
@@ -129,7 +137,7 @@ async fn main() -> Result<()> {
     )
     .context("failed to build the L1 RPC client")?;
     let provider = ProviderBuilder::new()
-        .wallet(EthereumWallet::from(cli.challenger_key))
+        .wallet(signer.wallet)
         .connect_client(l1_rpc_client);
     world_chain_proof_metrics::refresh_wallet_balance(&provider, challenger_address).await;
 

--- a/proofs/services/challenger/src/main.rs
+++ b/proofs/services/challenger/src/main.rs
@@ -11,7 +11,7 @@ use alloy_primitives::Address;
 use alloy_provider::ProviderBuilder;
 use alloy_signer_local::PrivateKeySigner;
 use anyhow::{Context, Result};
-use clap::Parser;
+use clap::{ArgGroup, Parser};
 use tracing::info;
 use url::Url;
 use world_chain_challenger::{
@@ -25,7 +25,11 @@ use world_chain_proof_tx_signer::build_transaction_wallet;
 #[derive(Debug, Parser)]
 #[command(
     name = "world-chain-challenger",
-    about = "World Chain proof-system challenger: challenges invalid output-root proposals on L1"
+    about = "World Chain proof-system challenger: challenges invalid output-root proposals on L1",
+    group = ArgGroup::new("transaction_signer")
+        .required(true)
+        .multiple(false)
+        .args(["challenger_key", "challenger_kms_key_id"])
 )]
 struct Cli {
     /// Ethereum L1 execution RPC URL.
@@ -125,11 +129,11 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     let l1_rpc_url = Url::parse(&cli.l1_rpc).context("invalid L1 RPC URL")?;
-    let signer =
+    let wallet =
         build_transaction_wallet(cli.challenger_key, cli.challenger_kms_key_id, &l1_rpc_url)
             .await
             .context("failed to initialize challenger signer")?;
-    let challenger_address = signer.address;
+    let challenger_address = wallet.default_signer().address();
     let l1_rpc_client = world_chain_proof_metrics::metered_http_client(
         l1_rpc_url,
         world_chain_proof_metrics::RPC_TARGET_L1_EXECUTION,
@@ -137,7 +141,7 @@ async fn main() -> Result<()> {
     )
     .context("failed to build the L1 RPC client")?;
     let provider = ProviderBuilder::new()
-        .wallet(signer.wallet)
+        .wallet(wallet)
         .connect_client(l1_rpc_client);
     world_chain_proof_metrics::refresh_wallet_balance(&provider, challenger_address).await;
 

--- a/proofs/services/defender/Cargo.toml
+++ b/proofs/services/defender/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 world-chain-proof-protocol.workspace = true
 world-chain-proof-core.workspace = true
 world-chain-proof-metrics.workspace = true
+world-chain-proof-tx-signer.workspace = true
 world-chain-prover-service.workspace = true
 
 # alloy

--- a/proofs/services/defender/src/main.rs
+++ b/proofs/services/defender/src/main.rs
@@ -7,7 +7,6 @@
 
 use std::time::Duration;
 
-use alloy_network::EthereumWallet;
 use alloy_primitives::Address;
 use alloy_provider::ProviderBuilder;
 use alloy_signer_local::PrivateKeySigner;
@@ -19,6 +18,7 @@ use world_chain_defender::{
     AlloyDefenderClient, DEFAULT_L1_TX_CONFIRMATIONS, DefenderConfig, WorldChainDefender,
 };
 use world_chain_proof_protocol::{OptimismConsensusClient, VerifyingConsensusProvider};
+use world_chain_proof_tx_signer::build_transaction_wallet;
 use world_chain_prover_service::RpcProverServiceClient;
 
 #[derive(Debug, Parser)]
@@ -49,7 +49,11 @@ struct Cli {
 
     /// Hex-encoded private key the defender signs L1 transactions with.
     #[arg(long, env = "DEFENDER_KEY", hide_env_values = true)]
-    defender_key: PrivateKeySigner,
+    defender_key: Option<PrivateKeySigner>,
+
+    /// AWS KMS key ID or alias the defender signs L1 transactions with.
+    #[arg(long, env = "DEFENDER_KMS_KEY_ID", hide_env_values = true)]
+    defender_kms_key_id: Option<String>,
 
     /// Address credited each submitted lane's share of a forfeited challenger bond.
     /// Defaults to the defender signer.
@@ -92,9 +96,12 @@ async fn main() -> Result<()> {
 
     let cli = Cli::parse();
 
-    let defender_address = cli.defender_key.address();
-    let reward_recipient = cli.proof_reward_recipient.unwrap_or(defender_address);
     let l1_rpc_url = Url::parse(&cli.l1_rpc).context("invalid L1 RPC URL")?;
+    let signer = build_transaction_wallet(cli.defender_key, cli.defender_kms_key_id, &l1_rpc_url)
+        .await
+        .context("failed to initialize defender signer")?;
+    let defender_address = signer.address;
+    let reward_recipient = cli.proof_reward_recipient.unwrap_or(defender_address);
     let l1_rpc_client = world_chain_proof_metrics::metered_http_client(
         l1_rpc_url,
         world_chain_proof_metrics::RPC_TARGET_L1_EXECUTION,
@@ -102,7 +109,7 @@ async fn main() -> Result<()> {
     )
     .context("failed to build the L1 RPC client")?;
     let provider = ProviderBuilder::new()
-        .wallet(EthereumWallet::from(cli.defender_key))
+        .wallet(signer.wallet)
         .connect_client(l1_rpc_client);
     world_chain_proof_metrics::refresh_wallet_balance(&provider, defender_address).await;
 

--- a/proofs/services/defender/src/main.rs
+++ b/proofs/services/defender/src/main.rs
@@ -11,7 +11,7 @@ use alloy_primitives::Address;
 use alloy_provider::ProviderBuilder;
 use alloy_signer_local::PrivateKeySigner;
 use anyhow::{Context, Result};
-use clap::Parser;
+use clap::{ArgGroup, Parser};
 use tracing::info;
 use url::Url;
 use world_chain_defender::{
@@ -24,7 +24,11 @@ use world_chain_prover_service::RpcProverServiceClient;
 #[derive(Debug, Parser)]
 #[command(
     name = "world-chain-defender",
-    about = "World Chain proof-system defender: proves the lineage selected from the anchor"
+    about = "World Chain proof-system defender: proves the lineage selected from the anchor",
+    group = ArgGroup::new("transaction_signer")
+        .required(true)
+        .multiple(false)
+        .args(["defender_key", "defender_kms_key_id"])
 )]
 struct Cli {
     /// Ethereum L1 execution RPC URL.
@@ -97,10 +101,10 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     let l1_rpc_url = Url::parse(&cli.l1_rpc).context("invalid L1 RPC URL")?;
-    let signer = build_transaction_wallet(cli.defender_key, cli.defender_kms_key_id, &l1_rpc_url)
+    let wallet = build_transaction_wallet(cli.defender_key, cli.defender_kms_key_id, &l1_rpc_url)
         .await
         .context("failed to initialize defender signer")?;
-    let defender_address = signer.address;
+    let defender_address = wallet.default_signer().address();
     let reward_recipient = cli.proof_reward_recipient.unwrap_or(defender_address);
     let l1_rpc_client = world_chain_proof_metrics::metered_http_client(
         l1_rpc_url,
@@ -109,7 +113,7 @@ async fn main() -> Result<()> {
     )
     .context("failed to build the L1 RPC client")?;
     let provider = ProviderBuilder::new()
-        .wallet(signer.wallet)
+        .wallet(wallet)
         .connect_client(l1_rpc_client);
     world_chain_proof_metrics::refresh_wallet_balance(&provider, defender_address).await;
 

--- a/proofs/services/proposer/Cargo.toml
+++ b/proofs/services/proposer/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 # workspace
 world-chain-proof-protocol.workspace = true
 world-chain-proof-metrics.workspace = true
+world-chain-proof-tx-signer.workspace = true
 
 # alloy
 alloy-consensus.workspace = true

--- a/proofs/services/proposer/src/main.rs
+++ b/proofs/services/proposer/src/main.rs
@@ -7,7 +7,6 @@
 
 use std::time::Duration;
 
-use alloy_network::EthereumWallet;
 use alloy_primitives::Address;
 use alloy_provider::ProviderBuilder;
 use alloy_signer_local::PrivateKeySigner;
@@ -16,6 +15,7 @@ use clap::Parser;
 use tracing::info;
 use url::Url;
 use world_chain_proof_protocol::{OptimismConsensusClient, VerifyingConsensusProvider};
+use world_chain_proof_tx_signer::build_transaction_wallet;
 use world_chain_proposer::{
     AlloyProofSystemClient, BondManager, BondManagerConfig, ProposerConfig, WorldChainProposer,
 };
@@ -44,7 +44,11 @@ struct Cli {
 
     /// Hex-encoded private key the proposer signs L1 transactions with.
     #[arg(long, env = "PROPOSER_KEY", hide_env_values = true)]
-    proposer_key: PrivateKeySigner,
+    proposer_key: Option<PrivateKeySigner>,
+
+    /// AWS KMS key ID or alias the proposer signs L1 transactions with.
+    #[arg(long, env = "PROPOSER_KMS_KEY_ID", hide_env_values = true)]
+    proposer_kms_key_id: Option<String>,
 
     /// Seconds between output-root polls.
     #[arg(long, env = "POLL_INTERVAL_SECONDS", default_value_t = 12)]
@@ -89,8 +93,11 @@ async fn main() -> Result<()> {
 
     let cli = Cli::parse();
 
-    let proposer_address = cli.proposer_key.address();
     let l1_rpc_url = Url::parse(&cli.l1_rpc).context("invalid L1 RPC URL")?;
+    let signer = build_transaction_wallet(cli.proposer_key, cli.proposer_kms_key_id, &l1_rpc_url)
+        .await
+        .context("failed to initialize proposer signer")?;
+    let proposer_address = signer.address;
     let l1_rpc_client = world_chain_proof_metrics::metered_http_client(
         l1_rpc_url,
         world_chain_proof_metrics::RPC_TARGET_L1_EXECUTION,
@@ -98,7 +105,7 @@ async fn main() -> Result<()> {
     )
     .context("failed to build the L1 RPC client")?;
     let provider = ProviderBuilder::new()
-        .wallet(EthereumWallet::from(cli.proposer_key))
+        .wallet(signer.wallet)
         .connect_client(l1_rpc_client);
     world_chain_proof_metrics::refresh_wallet_balance(&provider, proposer_address).await;
 

--- a/proofs/services/proposer/src/main.rs
+++ b/proofs/services/proposer/src/main.rs
@@ -11,7 +11,7 @@ use alloy_primitives::Address;
 use alloy_provider::ProviderBuilder;
 use alloy_signer_local::PrivateKeySigner;
 use anyhow::{Context, Result};
-use clap::Parser;
+use clap::{ArgGroup, Parser};
 use tracing::info;
 use url::Url;
 use world_chain_proof_protocol::{OptimismConsensusClient, VerifyingConsensusProvider};
@@ -23,7 +23,11 @@ use world_chain_proposer::{
 #[derive(Debug, Parser)]
 #[command(
     name = "world-chain-proposer",
-    about = "World Chain proof-system proposer: opens output-root proposals on L1"
+    about = "World Chain proof-system proposer: opens output-root proposals on L1",
+    group = ArgGroup::new("transaction_signer")
+        .required(true)
+        .multiple(false)
+        .args(["proposer_key", "proposer_kms_key_id"])
 )]
 struct Cli {
     /// Ethereum L1 execution RPC URL.
@@ -94,10 +98,10 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     let l1_rpc_url = Url::parse(&cli.l1_rpc).context("invalid L1 RPC URL")?;
-    let signer = build_transaction_wallet(cli.proposer_key, cli.proposer_kms_key_id, &l1_rpc_url)
+    let wallet = build_transaction_wallet(cli.proposer_key, cli.proposer_kms_key_id, &l1_rpc_url)
         .await
         .context("failed to initialize proposer signer")?;
-    let proposer_address = signer.address;
+    let proposer_address = wallet.default_signer().address();
     let l1_rpc_client = world_chain_proof_metrics::metered_http_client(
         l1_rpc_url,
         world_chain_proof_metrics::RPC_TARGET_L1_EXECUTION,
@@ -105,7 +109,7 @@ async fn main() -> Result<()> {
     )
     .context("failed to build the L1 RPC client")?;
     let provider = ProviderBuilder::new()
-        .wallet(signer.wallet)
+        .wallet(wallet)
         .connect_client(l1_rpc_client);
     world_chain_proof_metrics::refresh_wallet_balance(&provider, proposer_address).await;
 

--- a/proofs/services/tx-signer/Cargo.toml
+++ b/proofs/services/tx-signer/Cargo.toml
@@ -13,9 +13,7 @@ workspace = true
 [dependencies]
 # alloy
 alloy-network.workspace = true
-alloy-primitives.workspace = true
 alloy-provider = { workspace = true, features = ["reqwest", "reqwest-rustls-tls"] }
-alloy-signer.workspace = true
 alloy-signer-aws.workspace = true
 alloy-signer-local.workspace = true
 alloy-transport.workspace = true
@@ -29,4 +27,5 @@ thiserror.workspace = true
 url.workspace = true
 
 [dev-dependencies]
+alloy-primitives.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/proofs/services/tx-signer/Cargo.toml
+++ b/proofs/services/tx-signer/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "world-chain-proof-tx-signer"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# alloy
+alloy-network.workspace = true
+alloy-primitives.workspace = true
+alloy-provider = { workspace = true, features = ["reqwest", "reqwest-rustls-tls"] }
+alloy-signer.workspace = true
+alloy-signer-aws.workspace = true
+alloy-signer-local.workspace = true
+alloy-transport.workspace = true
+
+# aws
+aws-config.workspace = true
+aws-sdk-kms.workspace = true
+
+# misc
+thiserror.workspace = true
+url.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/proofs/services/tx-signer/src/lib.rs
+++ b/proofs/services/tx-signer/src/lib.rs
@@ -1,22 +1,12 @@
 //! Shared L1 transaction-signer construction for proof-system services.
 
 use alloy_network::EthereumWallet;
-use alloy_primitives::Address;
 use alloy_provider::{Provider, ProviderBuilder};
-use alloy_signer::Signer;
 use alloy_signer_aws::{AwsSigner, AwsSignerError};
 use alloy_signer_local::PrivateKeySigner;
 use alloy_transport::TransportError;
 use thiserror::Error;
 use url::Url;
-
-/// A configured L1 transaction wallet and its derived sender address.
-pub struct TransactionWallet {
-    /// Ethereum address derived from the configured signer.
-    pub address: Address,
-    /// Type-erased Alloy wallet used by provider construction.
-    pub wallet: EthereumWallet,
-}
 
 enum TransactionSignerSource {
     Local(PrivateKeySigner),
@@ -41,9 +31,9 @@ pub async fn build_transaction_wallet(
     private_key: Option<PrivateKeySigner>,
     aws_kms_key_id: Option<String>,
     rpc_url: &Url,
-) -> Result<TransactionWallet, TransactionSignerError> {
-    let (address, wallet) = match select_signer_source(private_key, aws_kms_key_id)? {
-        TransactionSignerSource::Local(signer) => (signer.address(), EthereumWallet::from(signer)),
+) -> Result<EthereumWallet, TransactionSignerError> {
+    match select_signer_source(private_key, aws_kms_key_id)? {
+        TransactionSignerSource::Local(signer) => Ok(EthereumWallet::from(signer)),
         TransactionSignerSource::AwsKms(key_id) => {
             let chain_id = ProviderBuilder::new()
                 .connect_http(rpc_url.clone())
@@ -60,11 +50,9 @@ pub async fn build_transaction_wallet(
             )
             .await
             .map_err(|error| TransactionSignerError::AwsKms(Box::new(error)))?;
-            (signer.address(), EthereumWallet::from(signer))
+            Ok(EthereumWallet::from(signer))
         }
-    };
-
-    Ok(TransactionWallet { address, wallet })
+    }
 }
 
 /// Errors returned while selecting or initializing an L1 transaction signer.
@@ -113,14 +101,13 @@ mod tests {
     async fn builds_local_wallet_with_derived_address() {
         let expected = local_signer().address();
         let rpc_url = "http://127.0.0.1:8545".parse().expect("valid URL");
-        let configured = build_transaction_wallet(Some(local_signer()), None, &rpc_url)
+        let wallet = build_transaction_wallet(Some(local_signer()), None, &rpc_url)
             .await
             .expect("local wallet builds");
 
-        assert_eq!(configured.address, expected);
+        assert_eq!(wallet.default_signer().address(), expected);
         assert!(<EthereumWallet as NetworkWallet<Ethereum>>::has_signer_for(
-            &configured.wallet,
-            &expected
+            &wallet, &expected
         ));
     }
 }

--- a/proofs/services/tx-signer/src/lib.rs
+++ b/proofs/services/tx-signer/src/lib.rs
@@ -1,0 +1,126 @@
+//! Shared L1 transaction-signer construction for proof-system services.
+
+use alloy_network::EthereumWallet;
+use alloy_primitives::Address;
+use alloy_provider::{Provider, ProviderBuilder};
+use alloy_signer::Signer;
+use alloy_signer_aws::{AwsSigner, AwsSignerError};
+use alloy_signer_local::PrivateKeySigner;
+use alloy_transport::TransportError;
+use thiserror::Error;
+use url::Url;
+
+/// A configured L1 transaction wallet and its derived sender address.
+pub struct TransactionWallet {
+    /// Ethereum address derived from the configured signer.
+    pub address: Address,
+    /// Type-erased Alloy wallet used by provider construction.
+    pub wallet: EthereumWallet,
+}
+
+enum TransactionSignerSource {
+    Local(PrivateKeySigner),
+    AwsKms(String),
+}
+
+fn select_signer_source(
+    private_key: Option<PrivateKeySigner>,
+    aws_kms_key_id: Option<String>,
+) -> Result<TransactionSignerSource, TransactionSignerError> {
+    match (private_key, aws_kms_key_id) {
+        (Some(signer), None) => Ok(TransactionSignerSource::Local(signer)),
+        (None, Some(key_id)) if !key_id.trim().is_empty() => {
+            Ok(TransactionSignerSource::AwsKms(key_id))
+        }
+        _ => Err(TransactionSignerError::InvalidConfiguration),
+    }
+}
+
+/// Builds an Alloy wallet from exactly one local private key or AWS KMS key ID.
+pub async fn build_transaction_wallet(
+    private_key: Option<PrivateKeySigner>,
+    aws_kms_key_id: Option<String>,
+    rpc_url: &Url,
+) -> Result<TransactionWallet, TransactionSignerError> {
+    let (address, wallet) = match select_signer_source(private_key, aws_kms_key_id)? {
+        TransactionSignerSource::Local(signer) => (signer.address(), EthereumWallet::from(signer)),
+        TransactionSignerSource::AwsKms(key_id) => {
+            let chain_id = ProviderBuilder::new()
+                .connect_http(rpc_url.clone())
+                .get_chain_id()
+                .await
+                .map_err(TransactionSignerError::ChainId)?;
+            let sdk_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+                .load()
+                .await;
+            let signer = AwsSigner::new(
+                aws_sdk_kms::Client::new(&sdk_config),
+                key_id,
+                Some(chain_id),
+            )
+            .await
+            .map_err(|error| TransactionSignerError::AwsKms(Box::new(error)))?;
+            (signer.address(), EthereumWallet::from(signer))
+        }
+    };
+
+    Ok(TransactionWallet { address, wallet })
+}
+
+/// Errors returned while selecting or initializing an L1 transaction signer.
+#[derive(Debug, Error)]
+pub enum TransactionSignerError {
+    #[error("configure exactly one local private key or AWS KMS key ID")]
+    InvalidConfiguration,
+    #[error("failed to fetch L1 chain ID: {0}")]
+    ChainId(TransportError),
+    #[error("failed to initialize AWS KMS signer: {0}")]
+    AwsKms(Box<AwsSignerError>),
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_network::{Ethereum, NetworkWallet};
+    use alloy_primitives::B256;
+
+    use super::*;
+
+    fn local_signer() -> PrivateKeySigner {
+        PrivateKeySigner::from_bytes(&B256::with_last_byte(1)).expect("valid private key")
+    }
+
+    #[test]
+    fn requires_exactly_one_signer_source() {
+        assert!(matches!(
+            select_signer_source(None, None),
+            Err(TransactionSignerError::InvalidConfiguration)
+        ));
+        assert!(matches!(
+            select_signer_source(Some(local_signer()), Some("alias/test".to_owned())),
+            Err(TransactionSignerError::InvalidConfiguration)
+        ));
+        assert!(matches!(
+            select_signer_source(None, Some("  ".to_owned())),
+            Err(TransactionSignerError::InvalidConfiguration)
+        ));
+        assert!(matches!(
+            select_signer_source(None, Some("alias/test".to_owned())),
+            Ok(TransactionSignerSource::AwsKms(key_id)) if key_id == "alias/test"
+        ));
+    }
+
+    #[tokio::test]
+    async fn builds_local_wallet_with_derived_address() {
+        let expected = local_signer().address();
+        let rpc_url = "http://127.0.0.1:8545".parse().expect("valid URL");
+        let configured = build_transaction_wallet(Some(local_signer()), None, &rpc_url)
+            .await
+            .expect("local wallet builds");
+
+        assert_eq!(configured.address, expected);
+        assert!(<EthereumWallet as NetworkWallet<Ethereum>>::has_signer_for(
+            &configured.wallet,
+            &expected
+        ));
+    }
+}


### PR DESCRIPTION
- add a shared proof-service transaction signer that selects exactly one local private key or AWS KMS key
- support optional KMS signing in the proposer, challenger, and defender
- bind AWS KMS signatures to the chain ID reported by the configured L1 RPC
- preserve the existing local-key configuration for backward-compatible rollout
- hide configured key values from CLI help output


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how L1 dispute-game transactions are signed across proposer, challenger, and defender; misconfigured KMS or chain ID would block or mis-sign critical on-chain actions.
> 
> **Overview**
> Adds **`world-chain-proof-tx-signer`**, a shared helper that builds an Alloy `EthereumWallet` from **either** a local private key **or** an AWS KMS key ID (not both). For KMS, it loads the default AWS SDK config, constructs `AwsSigner`, and sets **chain ID from the configured L1 RPC** before signing.
> 
> **Proposer**, **challenger**, and **defender** binaries now take optional `*_KEY` / `*_KMS_KEY_ID` flags (and env vars) behind a required clap `transaction_signer` group, wire the wallet through `build_transaction_wallet`, and derive the on-chain identity from `wallet.default_signer().address()`. Local-key-only deployments stay the same when only the existing key flag/env is set.
> 
> Workspace deps add **`alloy-signer-aws`**, **`aws-config`**, and **`aws-sdk-kms`** (2.1.1-aligned AWS signer crate in the lockfile).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0cf7fe5e0231e15496886696fab53b2036ff4d9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->