### PR TITLE
feat(sp1-proof-worker): add deposit subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1017,7 +1017,9 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6913d06ccc0d9c6ab67e2f82e2fbe292706da1f91442f30cded2d04b56bf0d58"
 dependencies = [
+ "alloy-dyn-abi",
  "alloy-primitives",
+ "alloy-sol-types",
  "async-trait",
  "auto_impl",
  "either",
@@ -19251,7 +19253,12 @@ dependencies = [
 name = "world-chain-proof-sp1-worker"
 version = "2.4.1"
 dependencies = [
+ "alloy-contract",
+ "alloy-network 2.1.1",
  "alloy-primitives",
+ "alloy-provider",
+ "alloy-signer 2.1.1",
+ "alloy-signer-local 2.1.1",
  "alloy-sol-types",
  "anyhow",
  "async-trait",
@@ -19266,6 +19273,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tracing",
+ "url",
  "world-chain-chainspec",
  "world-chain-proof-core",
  "world-chain-proof-kona-host",

--- a/docs/proof/sp1-worker.md
+++ b/docs/proof/sp1-worker.md
@@ -1,0 +1,52 @@
+# SP1 worker
+
+`world-chain-proof-sp1-worker` has separate commands for running the worker and funding its
+Succinct proving-network account.
+
+## Run the worker
+
+The existing worker arguments follow the `run` command:
+
+```bash
+world-chain-proof-sp1-worker run \
+  --prover-service-url http://prover-service:8545 \
+  --l1-rpc "$L1_RPC_URL" \
+  --l1-beacon-rpc "$L1_BEACON_RPC_URL" \
+  --l2-rpc "$L2_RPC_URL" \
+  --block-interval 10 \
+  --worker-id worker-0 \
+  --prover network
+```
+
+The network prover additionally requires:
+
+- `SP1_PRIVATE_KEY`: signs SP1 proof requests and identifies the credited account.
+- `SP1_NETWORK_L1_RPC_URL`: Ethereum mainnet RPC used for Succinct settlement reads.
+- `SUCCINCT_VAPP_ADDRESS`: SuccinctVApp proxy address on Ethereum mainnet.
+
+At startup the worker validates that the settlement RPC is Ethereum mainnet, discovers the PROVE
+token and `minDepositAmount()` from the configured VApp, then waits until the account has at least
+`10 * minDepositAmount()` in SP1 Network credits. It retries the credit check every 30 seconds and
+does not lease jobs while waiting. Once running, a background check updates
+`sp1_network_prove_balance` and `sp1_network_balance_sufficient`; a later low balance is logged but
+does not interrupt in-flight work.
+
+`NETWORK_RPC_URL` remains the optional override for the SP1 Network API itself. It is distinct from
+`SP1_NETWORK_L1_RPC_URL`.
+
+## Deposit PROVE
+
+The funding command signs an EIP-2612 permit and submits one `permitAndDeposit` transaction. Prefer
+providing the key and settlement configuration through environment variables backed by your secret
+store:
+
+```bash
+# SP1_NETWORK_L1_RPC_URL, SUCCINCT_VAPP_ADDRESS, and SP1_PRIVATE_KEY are injected.
+world-chain-proof-sp1-worker deposit --amount 1000
+```
+
+The amount is human-readable PROVE; token decimals are read on-chain. The command validates the
+Ethereum mainnet contracts, the signer's PROVE and ETH balances, waits for a successful transaction
+receipt, prints the transaction hash and Succinct receipt ID, then polls until the SP1 Network
+credit balance increases. If credits have not changed within 30 minutes, it exits with an error
+that retains the successful transaction hash and receipt ID for investigation.

--- a/proofs/backends/sp1/host/src/network_prover.rs
+++ b/proofs/backends/sp1/host/src/network_prover.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, bail};
 use async_trait::async_trait;
 pub use sp1_sdk::SP1ProofMode;
 use sp1_sdk::{
-    HashableKey, NetworkProver, ProveRequest, Prover, ProverClient, ProvingKey, SP1Proof,
+    HashableKey, NetworkProver, ProveRequest, Prover, ProvingKey, SP1Proof,
     SP1ProofWithPublicValues, SP1ProvingKey, SP1Stdin,
     network::{
         NetworkClient, NetworkMode, get_default_rpc_url_for_mode,
@@ -39,16 +39,33 @@ pub struct NetworkCreditClient {
     client: NetworkClient,
 }
 
+struct NetworkConnection {
+    signer: NetworkSigner,
+    rpc_url: String,
+    mode: NetworkMode,
+}
+
+fn network_connection(private_key: &str) -> anyhow::Result<NetworkConnection> {
+    let signer = NetworkSigner::local(private_key).context("invalid SP1 private key")?;
+    // PROVE deposits fund the auction-based SP1 Network --> Network = Mainnet
+    let mode = NetworkMode::Mainnet;
+    let rpc_url =
+        std::env::var("NETWORK_RPC_URL").unwrap_or_else(|_| get_default_rpc_url_for_mode(mode));
+
+    Ok(NetworkConnection {
+        signer,
+        rpc_url,
+        mode,
+    })
+}
+
 impl NetworkCreditClient {
     /// Creates a mainnet credit client for `private_key`.
     pub fn new(private_key: &str) -> anyhow::Result<Self> {
-        let signer = NetworkSigner::local(private_key).context("invalid SP1 private key")?;
-        let network_mode = NetworkMode::Mainnet;
-        let rpc_url = std::env::var("NETWORK_RPC_URL")
-            .unwrap_or_else(|_| get_default_rpc_url_for_mode(network_mode));
+        let connection = network_connection(private_key)?;
 
         Ok(Self {
-            client: NetworkClient::new(signer, rpc_url, network_mode),
+            client: NetworkClient::new(connection.signer, connection.rpc_url, connection.mode),
         })
     }
 
@@ -67,11 +84,9 @@ impl NetworkSuccinctProver {
     pub async fn new(agg_mode: SP1ProofMode, private_key: &str) -> anyhow::Result<Self> {
         let range_elf = world_chain_proof_sp1_elfs::range_elf();
         let agg_elf = world_chain_proof_sp1_elfs::aggregation_elf();
-        let client = ProverClient::builder()
-            .network()
-            .private_key(private_key)
-            .build()
-            .await;
+        let connection = network_connection(private_key)?;
+        let client =
+            NetworkProver::new(connection.signer, &connection.rpc_url, connection.mode).await;
         let range_pk = client
             .setup(range_elf.clone())
             .await

--- a/proofs/backends/sp1/host/src/network_prover.rs
+++ b/proofs/backends/sp1/host/src/network_prover.rs
@@ -2,14 +2,18 @@
 //! verify them; the aggregation proof mode is configurable (Groth16 for on-chain verification).
 
 use crate::{SuccinctProverError, WorldSuccinctProver};
-use alloy_primitives::B256;
+use alloy_primitives::{B256, U256};
 use anyhow::{Context, bail};
 use async_trait::async_trait;
 pub use sp1_sdk::SP1ProofMode;
 use sp1_sdk::{
     HashableKey, NetworkProver, ProveRequest, Prover, ProverClient, ProvingKey, SP1Proof,
     SP1ProofWithPublicValues, SP1ProvingKey, SP1Stdin,
-    network::proto::{GetProofRequestStatusResponse, types::FulfillmentStatus},
+    network::{
+        NetworkClient, NetworkMode, get_default_rpc_url_for_mode,
+        proto::{GetProofRequestStatusResponse, types::FulfillmentStatus},
+        signer::NetworkSigner,
+    },
 };
 use world_chain_proof_core::types::AggregationInputs;
 use world_chain_proof_sp1_types::{
@@ -23,6 +27,38 @@ pub struct NetworkSuccinctProver {
     agg_pk: SP1ProvingKey,
     multi_block_vkey: [u32; 8],
     agg_mode: SP1ProofMode,
+}
+
+/// Lightweight client for reading an account's SP1 Network credit balance.
+///
+/// Unlike [`NetworkSuccinctProver`], this does not initialize the SP1 light node or set up the
+/// embedded proving programs. It uses the same private key and `NETWORK_RPC_URL` selection as
+/// the SDK's network prover builder.
+#[derive(Clone)]
+pub struct NetworkCreditClient {
+    client: NetworkClient,
+}
+
+impl NetworkCreditClient {
+    /// Creates a mainnet credit client for `private_key`.
+    pub fn new(private_key: &str) -> anyhow::Result<Self> {
+        let signer = NetworkSigner::local(private_key).context("invalid SP1 private key")?;
+        let network_mode = NetworkMode::Mainnet;
+        let rpc_url = std::env::var("NETWORK_RPC_URL")
+            .unwrap_or_else(|_| get_default_rpc_url_for_mode(network_mode));
+
+        Ok(Self {
+            client: NetworkClient::new(signer, rpc_url, network_mode),
+        })
+    }
+
+    /// Returns the account's available SP1 Network credits in PROVE base units.
+    pub async fn get_balance(&self) -> anyhow::Result<U256> {
+        self.client
+            .get_balance()
+            .await
+            .context("failed to get SP1 Network credit balance")
+    }
 }
 
 impl NetworkSuccinctProver {

--- a/proofs/metrics/src/lib.rs
+++ b/proofs/metrics/src/lib.rs
@@ -46,6 +46,10 @@ pub const METRICS_PROOF_JOB_DURATION_SECONDS: &str = "proof_job.duration_seconds
 pub const METRICS_ENCLAVE_KEY_REGISTERED: &str = "enclave_key.registered";
 /// Enclave key registration attempts, by outcome.
 pub const METRICS_ENCLAVE_REGISTRATION_ATTEMPTS: &str = "enclave_key.registration_attempts";
+/// Current SP1 Network credit balance in human-readable PROVE.
+pub const METRICS_SP1_NETWORK_PROVE_BALANCE: &str = "sp1_network_prove_balance";
+/// Whether the SP1 Network credit balance meets the worker's startup threshold.
+pub const METRICS_SP1_NETWORK_BALANCE_SUFFICIENT: &str = "sp1_network_balance_sufficient";
 
 /// Registers shared metric descriptions.
 pub fn describe_metrics() {
@@ -116,6 +120,27 @@ pub fn describe_metrics() {
         metrics::Unit::Count,
         "Enclave key registration attempts by outcome (registered, already_registered, failed)."
     );
+    metrics::describe_gauge!(
+        METRICS_SP1_NETWORK_PROVE_BALANCE,
+        metrics::Unit::Count,
+        "Current SP1 Network credit balance in human-readable PROVE."
+    );
+    metrics::describe_gauge!(
+        METRICS_SP1_NETWORK_BALANCE_SUFFICIENT,
+        metrics::Unit::Count,
+        "1 when SP1 Network credits meet the worker threshold, 0 otherwise."
+    );
+}
+
+/// Updates the SP1 Network credit balance and sufficiency gauges.
+pub fn record_sp1_network_balance(balance_prove: f64, sufficient: bool) {
+    metrics::gauge!(METRICS_SP1_NETWORK_PROVE_BALANCE).set(balance_prove);
+    metrics::gauge!(METRICS_SP1_NETWORK_BALANCE_SUFFICIENT).set(if sufficient { 1.0 } else { 0.0 });
+}
+
+/// Marks the SP1 Network credit balance as insufficient when it cannot be read.
+pub fn record_sp1_network_balance_unavailable() {
+    metrics::gauge!(METRICS_SP1_NETWORK_BALANCE_SUFFICIENT).set(0.0);
 }
 
 /// Sets the enclave-key registration gauge.

--- a/proofs/workers/sp1/Cargo.toml
+++ b/proofs/workers/sp1/Cargo.toml
@@ -26,7 +26,12 @@ world-chain-proof-worker.workspace = true
 world-chain-prover-service.workspace = true
 
 # alloy
+alloy-contract.workspace = true
+alloy-network.workspace = true
 alloy-primitives = { workspace = true, features = ["serde"] }
+alloy-provider = { workspace = true, features = ["reqwest", "reqwest-rustls-tls"] }
+alloy-signer = { workspace = true, features = ["eip712"] }
+alloy-signer-local.workspace = true
 alloy-sol-types.workspace = true
 
 # misc
@@ -41,6 +46,7 @@ thiserror.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "signal", "time"] }
 tracing.workspace = true
 telemetry-batteries.workspace = true
+url.workspace = true
 
 [dev-dependencies]
 testcontainers.workspace = true

--- a/proofs/workers/sp1/src/cmd/deposit.rs
+++ b/proofs/workers/sp1/src/cmd/deposit.rs
@@ -1,0 +1,267 @@
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use alloy_network::EthereumWallet;
+use alloy_primitives::{Address, B256, U256, utils::parse_units};
+use alloy_provider::{Provider, ProviderBuilder};
+use alloy_signer::SignerSync;
+use alloy_signer_local::PrivateKeySigner;
+use alloy_sol_types::eip712_domain;
+use anyhow::{Context, Result, bail};
+use clap::Args;
+use url::Url;
+use world_chain_proof_sp1_host::network_prover::NetworkCreditClient;
+
+use super::succinct::{
+    ETHEREUM_MAINNET_CHAIN_ID, IProveToken, ISuccinctVApp, Permit, format_prove,
+    load_settlement_config,
+};
+
+const PERMIT_VALIDITY: Duration = Duration::from_secs(60 * 60);
+const CREDIT_POLL_INTERVAL: Duration = Duration::from_secs(10);
+const CREDIT_REFLECTION_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+
+#[derive(Debug, Args)]
+pub struct DepositArgs {
+    /// Human-readable amount of PROVE to deposit (for example `1000` or `12.5`).
+    #[arg(long)]
+    amount: String,
+
+    /// Ethereum mainnet RPC used to submit the deposit transaction.
+    #[arg(long, env = "SP1_NETWORK_L1_RPC_URL")]
+    sp1_network_l1_rpc_url: String,
+
+    /// SuccinctVApp proxy address on Ethereum mainnet.
+    #[arg(long, env = "SUCCINCT_VAPP_ADDRESS")]
+    succinct_vapp_address: Address,
+
+    /// Private key for both the PROVE holder and the corresponding SP1 Network account.
+    #[arg(long, env = "SP1_PRIVATE_KEY")]
+    sp1_private_key: String,
+}
+
+pub async fn deposit(args: DepositArgs) -> Result<()> {
+    let settlement =
+        load_settlement_config(&args.sp1_network_l1_rpc_url, args.succinct_vapp_address)
+            .await
+            .context("validating Succinct settlement configuration")?;
+
+    let amount = parse_prove_amount(&args.amount, settlement.prove_decimals)?;
+    if amount < settlement.min_deposit_amount {
+        bail!(
+            "deposit amount {} PROVE is below SuccinctVApp.minDepositAmount() of {} PROVE",
+            format_prove(amount, settlement.prove_decimals),
+            format_prove(settlement.min_deposit_amount, settlement.prove_decimals),
+        );
+    }
+
+    let signer: PrivateKeySigner = args
+        .sp1_private_key
+        .parse()
+        .context("invalid SP1_PRIVATE_KEY")?;
+    let signer_address = signer.address();
+    let credit_client = NetworkCreditClient::new(&args.sp1_private_key)?;
+    let credit_before = credit_client
+        .get_balance()
+        .await
+        .context("reading SP1 Network credit balance before deposit")?;
+
+    let provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(signer.clone()))
+        .connect_http(
+            Url::parse(&args.sp1_network_l1_rpc_url).context("invalid SP1 Network L1 RPC URL")?,
+        );
+    let token = IProveToken::new(settlement.prove_token_address, provider.clone());
+    let vapp = ISuccinctVApp::new(settlement.vapp_address, provider.clone());
+
+    let token_balance = token
+        .balanceOf(signer_address)
+        .call()
+        .await
+        .context("reading signer PROVE balance")?;
+    if token_balance < amount {
+        bail!(
+            "insufficient PROVE balance for {signer_address}: have {} PROVE, need {} PROVE",
+            format_prove(token_balance, settlement.prove_decimals),
+            format_prove(amount, settlement.prove_decimals),
+        );
+    }
+
+    let eth_balance = provider
+        .get_balance(signer_address)
+        .await
+        .context("reading signer ETH balance")?;
+    if eth_balance.is_zero() {
+        bail!("{signer_address} has no ETH to pay Ethereum mainnet transaction fees");
+    }
+
+    let nonce = token
+        .nonces(signer_address)
+        .call()
+        .await
+        .context("reading PROVE permit nonce")?;
+    let domain_separator = token
+        .DOMAIN_SEPARATOR()
+        .call()
+        .await
+        .context("reading PROVE permit domain separator")?;
+    let token_name = token
+        .name()
+        .call()
+        .await
+        .context("reading PROVE token name")?;
+    let permit_domain = eip712_domain! {
+        name: token_name,
+        version: "1",
+        chain_id: ETHEREUM_MAINNET_CHAIN_ID,
+        verifying_contract: settlement.prove_token_address,
+    };
+    let expected_domain_separator = permit_domain.separator();
+    if expected_domain_separator != domain_separator {
+        bail!(
+            "PROVE token EIP-2612 domain mismatch: computed {expected_domain_separator}, on-chain {domain_separator}"
+        );
+    }
+    let deadline = permit_deadline()?;
+    let permit = Permit {
+        owner: signer_address,
+        spender: settlement.vapp_address,
+        value: amount,
+        nonce,
+        deadline,
+    };
+    let signature = signer
+        .sign_typed_data_sync(&permit, &permit_domain)
+        .context("signing PROVE permit")?
+        .as_bytes();
+    let r = B256::from_slice(&signature[..32]);
+    let s = B256::from_slice(&signature[32..64]);
+    let v = signature[64];
+
+    println!(
+        "Depositing {} PROVE from {signer_address} through SuccinctVApp {}...",
+        format_prove(amount, settlement.prove_decimals),
+        settlement.vapp_address,
+    );
+    let pending = vapp
+        .permitAndDeposit(signer_address, amount, deadline, v, r, s)
+        .send()
+        .await
+        .context("submitting permitAndDeposit transaction")?;
+    let tx_hash = *pending.tx_hash();
+    println!("Submitted deposit transaction {tx_hash}");
+
+    let receipt = pending
+        .get_receipt()
+        .await
+        .with_context(|| format!("waiting for deposit transaction {tx_hash}"))?;
+    if !receipt.status() {
+        bail!("deposit transaction {tx_hash} reverted on-chain");
+    }
+
+    let onchain_receipt = receipt
+        .logs()
+        .iter()
+        .filter(|log| log.address() == settlement.vapp_address)
+        .find_map(|log| {
+            log.log_decode_validate::<ISuccinctVApp::TransactionPending>()
+                .ok()
+                .map(|decoded| decoded.inner.data.onchainTx)
+        })
+        .with_context(|| {
+            format!("deposit transaction {tx_hash} succeeded but emitted no TransactionPending")
+        })?;
+    println!(
+        "Deposit transaction {tx_hash} confirmed; Succinct on-chain receipt ID: {onchain_receipt}"
+    );
+
+    wait_for_credit_reflection(
+        &credit_client,
+        credit_before,
+        settlement.prove_decimals,
+        tx_hash,
+        onchain_receipt,
+    )
+    .await
+}
+
+fn parse_prove_amount(input: &str, decimals: u8) -> Result<U256> {
+    let input = input.trim();
+    if input.is_empty() || input.starts_with('-') {
+        bail!("--amount must be a positive PROVE amount");
+    }
+    let amount: U256 = parse_units(input, decimals)
+        .with_context(|| format!("invalid PROVE amount `{input}`"))?
+        .into();
+    if amount.is_zero() {
+        bail!("--amount must be greater than zero");
+    }
+    Ok(amount)
+}
+
+fn permit_deadline() -> Result<U256> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock is before the Unix epoch")?;
+    let deadline = now
+        .checked_add(PERMIT_VALIDITY)
+        .context("permit deadline overflow")?;
+    Ok(U256::from(deadline.as_secs()))
+}
+
+async fn wait_for_credit_reflection(
+    client: &NetworkCreditClient,
+    credit_before: U256,
+    decimals: u8,
+    tx_hash: B256,
+    onchain_receipt: u64,
+) -> Result<()> {
+    let timeout_at = tokio::time::Instant::now() + CREDIT_REFLECTION_TIMEOUT;
+    loop {
+        match client.get_balance().await {
+            Ok(balance) if balance > credit_before => {
+                println!(
+                    "Deposit reflected in SP1 Network credits: {} -> {} PROVE",
+                    format_prove(credit_before, decimals),
+                    format_prove(balance, decimals),
+                );
+                return Ok(());
+            }
+            Ok(balance) => {
+                println!(
+                    "Waiting for Succinct receipt {onchain_receipt} to be reflected in SP1 Network credits (current: {} PROVE)...",
+                    format_prove(balance, decimals),
+                );
+            }
+            Err(error) => {
+                eprintln!("Failed to refresh SP1 Network credit balance: {error:#}");
+            }
+        }
+
+        if tokio::time::Instant::now() >= timeout_at {
+            bail!(
+                "deposit transaction {tx_hash} succeeded with Succinct on-chain receipt ID {onchain_receipt}, but the SP1 Network credit balance did not increase within {} minutes; the deposit is still pending network processing",
+                CREDIT_REFLECTION_TIMEOUT.as_secs() / 60,
+            );
+        }
+        tokio::time::sleep(CREDIT_POLL_INTERVAL).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_human_readable_prove_amount() {
+        assert_eq!(
+            parse_prove_amount("12.5", 6).unwrap(),
+            U256::from(12_500_000_u64)
+        );
+    }
+
+    #[test]
+    fn rejects_non_positive_prove_amounts() {
+        assert!(parse_prove_amount("0", 18).is_err());
+        assert!(parse_prove_amount("-1", 18).is_err());
+    }
+}

--- a/proofs/workers/sp1/src/cmd/mod.rs
+++ b/proofs/workers/sp1/src/cmd/mod.rs
@@ -1,0 +1,3 @@
+pub mod deposit;
+pub mod run;
+pub mod succinct;

--- a/proofs/workers/sp1/src/cmd/run.rs
+++ b/proofs/workers/sp1/src/cmd/run.rs
@@ -1,0 +1,474 @@
+use std::{path::PathBuf, sync::Arc, time::Duration};
+
+use alloy_primitives::{Address, B256, U256};
+use anyhow::{Context, Result, bail};
+use clap::Parser;
+use world_chain_chainspec::WorldChainSpec;
+use world_chain_proof_kona_host::online::{
+    OnlineHostConfig, build_online_config, hardfork_config_from_chain_spec,
+};
+use world_chain_proof_sp1_host::{
+    Sp1ProverKind, WorldSuccinctProver,
+    cpu_prover::{CpuSuccinctProver, SP1ProofMode},
+    mock_prover::MockSuccinctProver,
+    network_prover::{NetworkCreditClient, NetworkSuccinctProver},
+};
+use world_chain_proof_sp1_worker::{
+    ProofWorker, ProofWorkerConfig, RetryConfig, Sp1Backend, Sp1BackendConfig,
+};
+use world_chain_proof_worker::WorkerHeartbeatConfig;
+use world_chain_prover_service::RpcProverServiceClient;
+
+use super::succinct::{format_prove, load_settlement_config, prove_as_f64};
+
+const DEFAULT_SUBMIT_PROOF_RETRY_MAX_RETRIES: usize = 10;
+const DEFAULT_SUBMIT_PROOF_RETRY_INITIAL_DELAY_MS: u64 = 100;
+const DEFAULT_SUBMIT_PROOF_RETRY_MAX_DELAY_MS: u64 = 10_000;
+const DEFAULT_WORKER_HEARTBEAT_INTERVAL_SEC: u64 = 30;
+const DEFAULT_WORKER_MAX_CONSECUTIVE_HEARTBEAT_FAILURES: u32 = 5;
+const DEFAULT_SP1_SESSION_POLL_INTERVAL: Duration = Duration::from_secs(10);
+const SP1_NETWORK_BALANCE_POLL_INTERVAL: Duration = Duration::from_secs(30);
+const MINIMUM_DEPOSIT_MULTIPLIER: u64 = 10;
+
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+enum Network {
+    #[value(name = "worldchain")]
+    WorldChain,
+    #[value(name = "worldchain-sepolia")]
+    WorldChainSepolia,
+}
+
+impl Network {
+    fn chain_id(self) -> u64 {
+        match self {
+            Self::WorldChain => 480,
+            Self::WorldChainSepolia => 4801,
+        }
+    }
+
+    fn chain_spec(self) -> Arc<WorldChainSpec> {
+        match self {
+            Self::WorldChain => WorldChainSpec::mainnet(),
+            Self::WorldChainSepolia => WorldChainSpec::sepolia(),
+        }
+    }
+}
+
+#[derive(Debug, Parser)]
+pub struct WorkerArgs {
+    /// prover-service JSON-RPC URL.
+    #[arg(long, env = "PROVER_SERVICE_URL")]
+    prover_service_url: String,
+
+    /// World Chain L2 execution RPC URL.
+    #[arg(long, env = "L2_RPC_URL")]
+    l2_rpc: String,
+
+    /// L2 consensus RPC serving `optimism_outputAtBlock`, used only as the `eth_getProof`
+    /// fallback. Must not be the execution RPC.
+    #[arg(long, env = "L2_CONSENSUS_RPC_URL")]
+    l2_consensus_rpc: Option<String>,
+
+    /// Ethereum L1 execution RPC URL.
+    #[arg(long, env = "L1_RPC_URL")]
+    l1_rpc: String,
+
+    /// Ethereum L1 beacon API URL.
+    #[arg(long, env = "L1_BEACON_RPC_URL")]
+    l1_beacon_rpc: String,
+
+    /// World Chain network to prove.
+    #[arg(long, env = "NETWORK", default_value = "worldchain")]
+    network: Network,
+
+    /// Rollup config JSON file. If omitted, uses the built-in network config.
+    #[arg(long, env = "ROLLUP_CONFIG")]
+    rollup_config: Option<PathBuf>,
+
+    /// Rollup config hash override (required when --rollup-config is not supplied).
+    #[arg(long, env = "ROLLUP_CONFIG_HASH")]
+    rollup_config_hash: Option<B256>,
+
+    /// L2 blocks between a proposal's parent and its claimed block (the proof system's
+    /// blockInterval domain constant).
+    #[arg(long, env = "BLOCK_INTERVAL")]
+    block_interval: u64,
+
+    /// Number of equal-length sub-ranges proved independently per job.
+    #[arg(long, default_value_t = 1)]
+    ranges: u64,
+
+    /// Allow proving blocks newer than the finalized L2 head.
+    #[arg(long)]
+    allow_unfinalized: bool,
+
+    /// Maximum seconds to spend generating one Kona witness.
+    #[arg(long, default_value_t = 900)]
+    witness_timeout_seconds: u64,
+
+    /// Prover backend.
+    #[arg(
+        long,
+        env = "SP1_PROVER",
+        default_value_t = Sp1ProverKind::Cpu
+    )]
+    prover: Sp1ProverKind,
+
+    /// SP1 network private key. Required when --prover network.
+    #[arg(long, env = "SP1_PRIVATE_KEY")]
+    sp1_private_key: Option<String>,
+
+    /// Ethereum mainnet RPC used to validate the Succinct VApp and its deposit threshold.
+    /// Required when --prover network.
+    #[arg(long, env = "SP1_NETWORK_L1_RPC_URL")]
+    sp1_network_l1_rpc_url: Option<String>,
+
+    /// SuccinctVApp proxy address on Ethereum mainnet. Required when --prover network.
+    #[arg(long, env = "SUCCINCT_VAPP_ADDRESS")]
+    succinct_vapp_address: Option<Address>,
+
+    /// Seconds to sleep between job-queue polls when no work is available.
+    #[arg(long, default_value_t = 10)]
+    poll_interval_seconds: u64,
+
+    /// Seconds to sleep between SP1 prover session status polls while a proof is running.
+    #[arg(
+        long,
+        env = "SP1_SESSION_POLL_INTERVAL_SECONDS",
+        default_value_t = DEFAULT_SP1_SESSION_POLL_INTERVAL.as_secs(),
+        value_parser = clap::value_parser!(u64).range(1..)
+    )]
+    sp1_session_poll_interval_seconds: u64,
+
+    /// Maximum number of jobs proved concurrently. One suits a local CPU prover; raise it for
+    /// the Succinct proving network.
+    #[arg(long, default_value_t = 1)]
+    max_concurrent_jobs: usize,
+
+    /// Maximum retries after a retryable submitProof failure.
+    #[arg(
+        long,
+        env = "SUBMIT_PROOF_RETRY_MAX_RETRIES",
+        default_value_t = DEFAULT_SUBMIT_PROOF_RETRY_MAX_RETRIES
+    )]
+    submit_proof_retry_max_retries: usize,
+
+    /// Initial delay in milliseconds before retrying submitProof.
+    #[arg(
+        long,
+        env = "SUBMIT_PROOF_RETRY_INITIAL_DELAY_MS",
+        default_value_t = DEFAULT_SUBMIT_PROOF_RETRY_INITIAL_DELAY_MS
+    )]
+    submit_proof_retry_initial_delay_ms: u64,
+
+    /// Maximum delay in milliseconds between submitProof retries.
+    #[arg(
+        long,
+        env = "SUBMIT_PROOF_RETRY_MAX_DELAY_MS",
+        default_value_t = DEFAULT_SUBMIT_PROOF_RETRY_MAX_DELAY_MS
+    )]
+    submit_proof_retry_max_delay_ms: u64,
+
+    /// The unique worker id.
+    #[arg(long)]
+    worker_id: String,
+
+    #[arg(long, default_value_t = DEFAULT_WORKER_HEARTBEAT_INTERVAL_SEC)]
+    /// The worker heartbeat interval in seconds.
+    heartbeat_interval_sec: u64,
+
+    #[arg(long, default_value_t = DEFAULT_WORKER_MAX_CONSECUTIVE_HEARTBEAT_FAILURES)]
+    /// Maximum consecutive retryable heartbeat failures before aborting proof generation.
+    heartbeat_max_consecutive_failures: u32,
+}
+
+pub async fn run(cli: WorkerArgs) -> Result<()> {
+    let spec = cli.network.chain_spec();
+    let schedule = hardfork_config_from_chain_spec(spec.as_ref());
+    let host = build_online_config(
+        cli.rollup_config.clone(),
+        cli.rollup_config_hash,
+        cli.l1_rpc.clone(),
+        cli.l1_beacon_rpc.clone(),
+        cli.l2_rpc.clone(),
+        cli.l2_consensus_rpc.clone(),
+        cli.network.chain_id(),
+        &schedule,
+        Duration::from_secs(cli.witness_timeout_seconds),
+    )?;
+
+    // currently we don't support split_range != 1, therefore we ensure it's exactly 1
+    if cli.ranges != 1 {
+        bail!(
+            "Currently we don't support splitting the range proof into multiple ranges. Set `ranges` to 1."
+        )
+    }
+
+    // ELFs are embedded at compile time via `sp1_sdk::include_elf!()`
+    // (see `proofs/backends/sp1/elfs/build.rs`). Challenged roots are
+    // defended on-chain; Groth16 keeps verification ~100k gas.
+    let prover_kind = cli.prover;
+    match prover_kind {
+        Sp1ProverKind::Cpu => {
+            run_worker(
+                cli,
+                host,
+                CpuSuccinctProver::new(SP1ProofMode::Groth16).await?,
+            )
+            .await
+        }
+        Sp1ProverKind::Mock => {
+            run_worker(
+                cli,
+                host,
+                MockSuccinctProver::new(SP1ProofMode::Groth16).await?,
+            )
+            .await
+        }
+        Sp1ProverKind::Network => {
+            let private_key = cli
+                .sp1_private_key
+                .clone()
+                .context("SP1_PRIVATE_KEY is required when --prover network")?;
+            let l1_rpc_url = cli
+                .sp1_network_l1_rpc_url
+                .clone()
+                .context("SP1_NETWORK_L1_RPC_URL is required when --prover network")?;
+            let vapp_address = cli
+                .succinct_vapp_address
+                .context("SUCCINCT_VAPP_ADDRESS is required when --prover network")?;
+            let settlement = load_settlement_config(&l1_rpc_url, vapp_address)
+                .await
+                .context("validating Succinct settlement configuration")?;
+            let minimum_balance = minimum_network_balance(settlement.min_deposit_amount)?;
+            let credit_client = NetworkCreditClient::new(&private_key)?;
+
+            if !wait_for_sufficient_network_balance(
+                &credit_client,
+                minimum_balance,
+                settlement.prove_decimals,
+            )
+            .await?
+            {
+                return Ok(());
+            }
+
+            monitor_network_balance(credit_client, minimum_balance, settlement.prove_decimals);
+            run_worker(
+                cli,
+                host,
+                NetworkSuccinctProver::new(SP1ProofMode::Groth16, &private_key).await?,
+            )
+            .await
+        }
+    }
+}
+
+fn minimum_network_balance(min_deposit_amount: U256) -> Result<U256> {
+    min_deposit_amount
+        .checked_mul(U256::from(MINIMUM_DEPOSIT_MULTIPLIER))
+        .context("SP1 Network minimum balance overflow")
+}
+
+async fn wait_for_sufficient_network_balance(
+    client: &NetworkCreditClient,
+    minimum_balance: U256,
+    decimals: u8,
+) -> Result<bool> {
+    loop {
+        match client.get_balance().await {
+            Ok(balance) => {
+                let sufficient = record_network_balance(balance, minimum_balance, decimals);
+                if sufficient {
+                    tracing::info!(
+                        balance = %format_prove(balance, decimals),
+                        minimum_balance = %format_prove(minimum_balance, decimals),
+                        "SP1 Network credit balance is sufficient"
+                    );
+                    return Ok(true);
+                }
+                tracing::error!(
+                    balance = %format_prove(balance, decimals),
+                    minimum_balance = %format_prove(minimum_balance, decimals),
+                    retry_seconds = SP1_NETWORK_BALANCE_POLL_INTERVAL.as_secs(),
+                    "SP1 Network credit balance is too low; worker will not lease jobs"
+                );
+            }
+            Err(error) => {
+                world_chain_proof_metrics::record_sp1_network_balance_unavailable();
+                tracing::warn!(
+                    %error,
+                    retry_seconds = SP1_NETWORK_BALANCE_POLL_INTERVAL.as_secs(),
+                    "failed to read SP1 Network credit balance; worker will not lease jobs"
+                );
+            }
+        }
+
+        tokio::select! {
+            () = tokio::time::sleep(SP1_NETWORK_BALANCE_POLL_INTERVAL) => {}
+            result = tokio::signal::ctrl_c() => {
+                result.context("installing ctrl-c handler while waiting for SP1 Network credit")?;
+                tracing::info!("received ctrl-c while waiting for SP1 Network credit");
+                return Ok(false);
+            }
+        }
+    }
+}
+
+fn monitor_network_balance(client: NetworkCreditClient, minimum_balance: U256, decimals: u8) {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(SP1_NETWORK_BALANCE_POLL_INTERVAL);
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            match client.get_balance().await {
+                Ok(balance) => {
+                    if !record_network_balance(balance, minimum_balance, decimals) {
+                        tracing::error!(
+                            balance = %format_prove(balance, decimals),
+                            minimum_balance = %format_prove(minimum_balance, decimals),
+                            "SP1 Network credit balance is below the recommended minimum"
+                        );
+                    }
+                }
+                Err(error) => {
+                    world_chain_proof_metrics::record_sp1_network_balance_unavailable();
+                    tracing::warn!(%error, "failed to refresh SP1 Network credit balance");
+                }
+            }
+        }
+    });
+}
+
+fn record_network_balance(balance: U256, minimum_balance: U256, decimals: u8) -> bool {
+    let sufficient = balance >= minimum_balance;
+    match prove_as_f64(balance, decimals) {
+        Ok(balance_prove) => {
+            world_chain_proof_metrics::record_sp1_network_balance(balance_prove, sufficient);
+        }
+        Err(error) => {
+            world_chain_proof_metrics::record_sp1_network_balance_unavailable();
+            tracing::warn!(%error, ?balance, "failed to convert SP1 Network credit balance");
+        }
+    }
+    sufficient
+}
+
+async fn run_worker<P>(cli: WorkerArgs, host: OnlineHostConfig, prover: P) -> Result<()>
+where
+    P: WorldSuccinctProver + Send + Sync + 'static,
+{
+    let backend = Sp1Backend::new(
+        host,
+        prover,
+        Sp1BackendConfig {
+            block_interval: cli.block_interval,
+            split_count: cli.ranges.max(1),
+            allow_unfinalized: cli.allow_unfinalized,
+            session_poll_interval: Duration::from_secs(cli.sp1_session_poll_interval_seconds),
+        },
+    );
+
+    let queue = RpcProverServiceClient::new(&cli.prover_service_url)
+        .with_context(|| format!("failed to connect to {}", cli.prover_service_url))?;
+    let worker_id = format!("{}-sp1-worker", cli.worker_id);
+    let retry_initial_delay = Duration::from_millis(cli.submit_proof_retry_initial_delay_ms);
+    let retry_max_delay = Duration::from_millis(cli.submit_proof_retry_max_delay_ms);
+    let retry_config = RetryConfig::new(
+        cli.submit_proof_retry_max_retries,
+        retry_initial_delay,
+        retry_max_delay,
+    );
+    let heartbeat_config = WorkerHeartbeatConfig::with_max_consecutive_failures(
+        Duration::from_secs(cli.heartbeat_interval_sec),
+        cli.heartbeat_max_consecutive_failures,
+    );
+    let worker = ProofWorker::new(
+        queue,
+        backend,
+        ProofWorkerConfig {
+            worker_id,
+            poll_interval: Duration::from_secs(cli.poll_interval_seconds),
+            max_concurrent_jobs: cli.max_concurrent_jobs,
+            retry_config,
+            heartbeat_config,
+        },
+    );
+
+    tracing::info!(
+        prover_service = %cli.prover_service_url,
+        block_interval = cli.block_interval,
+        ranges = cli.ranges.max(1),
+        prover = %cli.prover,
+        sp1_session_poll_interval_seconds = cli.sp1_session_poll_interval_seconds,
+        submit_proof_retry_max_retries = cli.submit_proof_retry_max_retries,
+        submit_proof_retry_initial_delay_ms = cli.submit_proof_retry_initial_delay_ms,
+        submit_proof_retry_max_delay_ms = cli.submit_proof_retry_max_delay_ms,
+        "sp1-worker starting"
+    );
+
+    // Ctrl-C triggers a graceful shutdown: the worker stops leasing, flushes pending
+    // reports, and resolves.
+    let token = worker.cancellation_token();
+    tokio::spawn(async move {
+        if tokio::signal::ctrl_c().await.is_ok() {
+            tracing::info!("received ctrl-c, shutting down");
+            token.cancel();
+        }
+    });
+
+    worker.await;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_args() -> Vec<&'static str> {
+        vec![
+            "sp1-worker",
+            "--prover-service-url",
+            "http://127.0.0.1:8545",
+            "--l2-rpc",
+            "http://127.0.0.1:9545",
+            "--l1-rpc",
+            "http://127.0.0.1:8545",
+            "--l1-beacon-rpc",
+            "http://127.0.0.1:5052",
+            "--block-interval",
+            "10",
+            "--worker-id",
+            "test",
+        ]
+    }
+
+    #[test]
+    fn parses_sp1_session_poll_interval_seconds() {
+        let mut args = base_args();
+        args.extend(["--sp1-session-poll-interval-seconds", "3"]);
+
+        let cli = WorkerArgs::parse_from(args);
+
+        assert_eq!(cli.sp1_session_poll_interval_seconds, 3);
+    }
+
+    #[test]
+    fn rejects_zero_sp1_session_poll_interval_seconds() {
+        let mut args = base_args();
+        args.extend(["--sp1-session-poll-interval-seconds", "0"]);
+
+        let error =
+            WorkerArgs::try_parse_from(args).expect_err("zero poll interval should be rejected");
+
+        assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
+    }
+
+    #[test]
+    fn minimum_balance_is_ten_times_vapp_minimum() {
+        assert_eq!(
+            minimum_network_balance(U256::from(42)).unwrap(),
+            U256::from(420)
+        );
+    }
+}

--- a/proofs/workers/sp1/src/cmd/succinct.rs
+++ b/proofs/workers/sp1/src/cmd/succinct.rs
@@ -1,0 +1,143 @@
+use alloy_primitives::{Address, U256, utils::format_units};
+use alloy_provider::{Provider, ProviderBuilder};
+use alloy_sol_types::sol;
+use anyhow::{Context, Result, bail};
+use url::Url;
+
+pub const ETHEREUM_MAINNET_CHAIN_ID: u64 = 1;
+
+sol! {
+    #[sol(rpc)]
+    interface ISuccinctVApp {
+        event TransactionPending(uint64 indexed onchainTx, uint8 indexed variant, bytes data);
+
+        function minDepositAmount() external view returns (uint256);
+        function prove() external view returns (address);
+        function permitAndDeposit(
+            address from,
+            uint256 amount,
+            uint256 deadline,
+            uint8 v,
+            bytes32 r,
+            bytes32 s
+        ) external returns (uint64 receipt);
+    }
+
+    #[sol(rpc)]
+    interface IProveToken {
+        function balanceOf(address account) external view returns (uint256);
+        function decimals() external view returns (uint8);
+        function name() external view returns (string);
+        function nonces(address owner) external view returns (uint256);
+        function DOMAIN_SEPARATOR() external view returns (bytes32);
+    }
+
+    #[derive(Debug)]
+    struct Permit {
+        address owner;
+        address spender;
+        uint256 value;
+        uint256 nonce;
+        uint256 deadline;
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct SettlementConfig {
+    pub vapp_address: Address,
+    pub prove_token_address: Address,
+    pub min_deposit_amount: U256,
+    pub prove_decimals: u8,
+}
+
+/// Validates the settlement endpoint and discovers the VApp's mutable token configuration.
+pub async fn load_settlement_config(
+    rpc_url: &str,
+    vapp_address: Address,
+) -> Result<SettlementConfig> {
+    if vapp_address.is_zero() {
+        bail!("SUCCINCT_VAPP_ADDRESS must not be the zero address");
+    }
+
+    let rpc_url = Url::parse(rpc_url).context("invalid SP1 Network L1 RPC URL")?;
+    let provider = ProviderBuilder::new().connect_http(rpc_url);
+    let chain_id = provider
+        .get_chain_id()
+        .await
+        .context("reading settlement RPC chain ID")?;
+    if chain_id != ETHEREUM_MAINNET_CHAIN_ID {
+        bail!(
+            "Succinct settlement transactions are supported only on Ethereum mainnet (chain ID 1), but SP1_NETWORK_L1_RPC_URL reported chain ID {chain_id}"
+        );
+    }
+
+    let vapp_code = provider
+        .get_code_at(vapp_address)
+        .await
+        .context("reading SuccinctVApp bytecode")?;
+    if vapp_code.is_empty() {
+        bail!("SUCCINCT_VAPP_ADDRESS {vapp_address} has no bytecode on Ethereum mainnet");
+    }
+
+    let vapp = ISuccinctVApp::new(vapp_address, provider.clone());
+    let prove_token_address = vapp
+        .prove()
+        .call()
+        .await
+        .context("reading SuccinctVApp.prove()")?;
+    if prove_token_address.is_zero() {
+        bail!("SuccinctVApp.prove() returned the zero address");
+    }
+    let prove_code = provider
+        .get_code_at(prove_token_address)
+        .await
+        .context("reading PROVE token bytecode")?;
+    if prove_code.is_empty() {
+        bail!(
+            "SuccinctVApp.prove() returned {prove_token_address}, which has no bytecode on Ethereum mainnet"
+        );
+    }
+
+    let min_deposit_amount = vapp
+        .minDepositAmount()
+        .call()
+        .await
+        .context("reading SuccinctVApp.minDepositAmount()")?;
+    if min_deposit_amount.is_zero() {
+        bail!("SuccinctVApp.minDepositAmount() returned zero");
+    }
+
+    let prove_decimals = IProveToken::new(prove_token_address, provider)
+        .decimals()
+        .call()
+        .await
+        .context("reading PROVE token decimals()")?;
+
+    Ok(SettlementConfig {
+        vapp_address,
+        prove_token_address,
+        min_deposit_amount,
+        prove_decimals,
+    })
+}
+
+pub fn format_prove(amount: U256, decimals: u8) -> String {
+    format_units(amount, decimals).unwrap_or_else(|_| amount.to_string())
+}
+
+pub fn prove_as_f64(amount: U256, decimals: u8) -> Result<f64> {
+    format_units(amount, decimals)
+        .context("formatting PROVE base units")?
+        .parse::<f64>()
+        .context("parsing formatted PROVE balance")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn formats_prove_base_units() {
+        assert_eq!(format_prove(U256::from(1_250_000_u64), 6), "1.250000");
+    }
+}

--- a/proofs/workers/sp1/src/main.rs
+++ b/proofs/workers/sp1/src/main.rs
@@ -1,319 +1,53 @@
 //! `sp1-worker` binary: leases SP1 proof jobs from the `prover-service`, proves them, and
 //! submits the proofs back.
 
-use alloy_primitives::B256;
-use anyhow::{Context, Result, bail};
-use clap::Parser;
-use std::{path::PathBuf, sync::Arc, time::Duration};
-use world_chain_chainspec::WorldChainSpec;
-use world_chain_proof_kona_host::online::{
-    OnlineHostConfig, build_online_config, hardfork_config_from_chain_spec,
-};
-use world_chain_proof_sp1_host::{
-    Sp1ProverKind, WorldSuccinctProver,
-    cpu_prover::{CpuSuccinctProver, SP1ProofMode},
-    mock_prover::MockSuccinctProver,
-    network_prover::NetworkSuccinctProver,
-};
-use world_chain_proof_sp1_worker::{
-    ProofWorker, ProofWorkerConfig, RetryConfig, Sp1Backend, Sp1BackendConfig,
-};
-use world_chain_proof_worker::WorkerHeartbeatConfig;
-use world_chain_prover_service::RpcProverServiceClient;
+mod cmd;
 
-const DEFAULT_SUBMIT_PROOF_RETRY_MAX_RETRIES: usize = 10;
-const DEFAULT_SUBMIT_PROOF_RETRY_INITIAL_DELAY_MS: u64 = 100;
-const DEFAULT_SUBMIT_PROOF_RETRY_MAX_DELAY_MS: u64 = 10_000;
-const DEFAULT_WORKER_HEARTBEAT_INTERVAL_SEC: u64 = 30;
-const DEFAULT_WORKER_MAX_CONSECUTIVE_HEARTBEAT_FAILURES: u32 = 5;
-const DEFAULT_SP1_SESSION_POLL_INTERVAL: Duration = Duration::from_secs(10);
-
-#[derive(Debug, Clone, Copy, clap::ValueEnum)]
-enum Network {
-    #[value(name = "worldchain")]
-    WorldChain,
-    #[value(name = "worldchain-sepolia")]
-    WorldChainSepolia,
-}
-
-impl Network {
-    fn chain_id(self) -> u64 {
-        match self {
-            Self::WorldChain => 480,
-            Self::WorldChainSepolia => 4801,
-        }
-    }
-
-    fn chain_spec(self) -> Arc<WorldChainSpec> {
-        match self {
-            Self::WorldChain => WorldChainSpec::mainnet(),
-            Self::WorldChainSepolia => WorldChainSpec::sepolia(),
-        }
-    }
-}
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use cmd::{deposit::DepositArgs, run::WorkerArgs};
 
 #[derive(Debug, Parser)]
 #[command(
     name = "sp1-worker",
-    about = "World Chain SP1 proving worker: leases jobs from the prover-service, proves them, and submits the proofs back"
+    about = "World Chain SP1 proving worker and funding utility"
 )]
 struct Cli {
-    /// prover-service JSON-RPC URL.
-    #[arg(long, env = "PROVER_SERVICE_URL")]
-    prover_service_url: String,
+    #[command(subcommand)]
+    command: Command,
+}
 
-    /// World Chain L2 execution RPC URL.
-    #[arg(long, env = "L2_RPC_URL")]
-    l2_rpc: String,
-
-    /// L2 consensus RPC serving `optimism_outputAtBlock`, used only as the `eth_getProof`
-    /// fallback. Must not be the execution RPC.
-    #[arg(long, env = "L2_CONSENSUS_RPC_URL")]
-    l2_consensus_rpc: Option<String>,
-
-    /// Ethereum L1 execution RPC URL.
-    #[arg(long, env = "L1_RPC_URL")]
-    l1_rpc: String,
-
-    /// Ethereum L1 beacon API URL.
-    #[arg(long, env = "L1_BEACON_RPC_URL")]
-    l1_beacon_rpc: String,
-
-    /// World Chain network to prove.
-    #[arg(long, env = "NETWORK", default_value = "worldchain")]
-    network: Network,
-
-    /// Rollup config JSON file. If omitted, uses the built-in network config.
-    #[arg(long, env = "ROLLUP_CONFIG")]
-    rollup_config: Option<PathBuf>,
-
-    /// Rollup config hash override (required when --rollup-config is not supplied).
-    #[arg(long, env = "ROLLUP_CONFIG_HASH")]
-    rollup_config_hash: Option<B256>,
-
-    /// L2 blocks between a proposal's parent and its claimed block (the proof system's
-    /// blockInterval domain constant).
-    #[arg(long, env = "BLOCK_INTERVAL")]
-    block_interval: u64,
-
-    /// Number of equal-length sub-ranges proved independently per job.
-    #[arg(long, default_value_t = 1)]
-    ranges: u64,
-
-    /// Allow proving blocks newer than the finalized L2 head.
-    #[arg(long)]
-    allow_unfinalized: bool,
-
-    /// Maximum seconds to spend generating one Kona witness.
-    #[arg(long, default_value_t = 900)]
-    witness_timeout_seconds: u64,
-
-    /// Prover backend.
-    #[arg(
-        long,
-        env = "SP1_PROVER",
-        default_value_t = Sp1ProverKind::Cpu
-    )]
-    prover: Sp1ProverKind,
-
-    /// SP1 network private key. Required when --prover network.
-    #[arg(long, env = "SP1_PRIVATE_KEY")]
-    sp1_private_key: Option<String>,
-
-    /// Seconds to sleep between job-queue polls when no work is available.
-    #[arg(long, default_value_t = 10)]
-    poll_interval_seconds: u64,
-
-    /// Seconds to sleep between SP1 prover session status polls while a proof is running.
-    #[arg(
-        long,
-        env = "SP1_SESSION_POLL_INTERVAL_SECONDS",
-        default_value_t = DEFAULT_SP1_SESSION_POLL_INTERVAL.as_secs(),
-        value_parser = clap::value_parser!(u64).range(1..)
-    )]
-    sp1_session_poll_interval_seconds: u64,
-
-    /// Maximum number of jobs proved concurrently. One suits a local CPU prover; raise it for
-    /// the Succinct proving network.
-    #[arg(long, default_value_t = 1)]
-    max_concurrent_jobs: usize,
-
-    /// Maximum retries after a retryable submitProof failure.
-    #[arg(
-        long,
-        env = "SUBMIT_PROOF_RETRY_MAX_RETRIES",
-        default_value_t = DEFAULT_SUBMIT_PROOF_RETRY_MAX_RETRIES
-    )]
-    submit_proof_retry_max_retries: usize,
-
-    /// Initial delay in milliseconds before retrying submitProof.
-    #[arg(
-        long,
-        env = "SUBMIT_PROOF_RETRY_INITIAL_DELAY_MS",
-        default_value_t = DEFAULT_SUBMIT_PROOF_RETRY_INITIAL_DELAY_MS
-    )]
-    submit_proof_retry_initial_delay_ms: u64,
-
-    /// Maximum delay in milliseconds between submitProof retries.
-    #[arg(
-        long,
-        env = "SUBMIT_PROOF_RETRY_MAX_DELAY_MS",
-        default_value_t = DEFAULT_SUBMIT_PROOF_RETRY_MAX_DELAY_MS
-    )]
-    submit_proof_retry_max_delay_ms: u64,
-
-    /// The unique worker id.
-    #[arg(long)]
-    worker_id: String,
-
-    #[arg(long, default_value_t = DEFAULT_WORKER_HEARTBEAT_INTERVAL_SEC)]
-    /// The worker heartbeat interval in seconds.
-    heartbeat_interval_sec: u64,
-
-    #[arg(long, default_value_t = DEFAULT_WORKER_MAX_CONSECUTIVE_HEARTBEAT_FAILURES)]
-    /// Maximum consecutive retryable heartbeat failures before aborting proof generation.
-    heartbeat_max_consecutive_failures: u32,
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Start the SP1 proving worker.
+    Run(Box<WorkerArgs>),
+    /// Deposit PROVE into the Succinct VApp for this worker's SP1 Network account.
+    Deposit(DepositArgs),
 }
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 2)]
 async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
-    let _telemetry_guard = telemetry_batteries::init()
-        .map_err(|error| anyhow::anyhow!("failed to initialize telemetry: {error:#}"))?;
-    world_chain_proof_metrics::describe_metrics();
-    let cli = Cli::parse();
-
-    let spec = cli.network.chain_spec();
-    let schedule = hardfork_config_from_chain_spec(spec.as_ref());
-    let host = build_online_config(
-        cli.rollup_config.clone(),
-        cli.rollup_config_hash,
-        cli.l1_rpc.clone(),
-        cli.l1_beacon_rpc.clone(),
-        cli.l2_rpc.clone(),
-        cli.l2_consensus_rpc.clone(),
-        cli.network.chain_id(),
-        &schedule,
-        Duration::from_secs(cli.witness_timeout_seconds),
-    )?;
-
-    // currently we don't support split_range != 1, therefore we ensure it's exactly 1
-    if cli.ranges != 1 {
-        bail!(
-            "Currently we don't support splitting the range proof into multiple ranges. Set `ranges` to 1."
-        )
+    match Cli::parse().command {
+        Command::Run(args) => {
+            let _telemetry_guard = telemetry_batteries::init()
+                .map_err(|error| anyhow::anyhow!("failed to initialize telemetry: {error:#}"))?;
+            world_chain_proof_metrics::describe_metrics();
+            cmd::run::run(*args).await
+        }
+        Command::Deposit(args) => cmd::deposit::deposit(args).await,
     }
-
-    // ELFs are embedded at compile time via `sp1_sdk::include_elf!()`
-    // (see `proofs/backends/sp1/elfs/build.rs`). Challenged roots are
-    // defended on-chain; Groth16 keeps verification ~100k gas.
-    let prover_kind = cli.prover;
-    match prover_kind {
-        Sp1ProverKind::Cpu => {
-            run_worker(
-                cli,
-                host,
-                CpuSuccinctProver::new(SP1ProofMode::Groth16).await?,
-            )
-            .await
-        }
-        Sp1ProverKind::Mock => {
-            run_worker(
-                cli,
-                host,
-                MockSuccinctProver::new(SP1ProofMode::Groth16).await?,
-            )
-            .await
-        }
-        Sp1ProverKind::Network => {
-            let private_key = cli
-                .sp1_private_key
-                .clone()
-                .context("SP1_PRIVATE_KEY is required when --prover network")?;
-            run_worker(
-                cli,
-                host,
-                NetworkSuccinctProver::new(SP1ProofMode::Groth16, &private_key).await?,
-            )
-            .await
-        }
-    }
-}
-
-async fn run_worker<P>(cli: Cli, host: OnlineHostConfig, prover: P) -> Result<()>
-where
-    P: WorldSuccinctProver + Send + Sync + 'static,
-{
-    let backend = Sp1Backend::new(
-        host,
-        prover,
-        Sp1BackendConfig {
-            block_interval: cli.block_interval,
-            split_count: cli.ranges.max(1),
-            allow_unfinalized: cli.allow_unfinalized,
-            session_poll_interval: Duration::from_secs(cli.sp1_session_poll_interval_seconds),
-        },
-    );
-
-    let queue = RpcProverServiceClient::new(&cli.prover_service_url)
-        .with_context(|| format!("failed to connect to {}", cli.prover_service_url))?;
-    let worker_id = format!("{}-sp1-worker", cli.worker_id);
-    let retry_initial_delay = Duration::from_millis(cli.submit_proof_retry_initial_delay_ms);
-    let retry_max_delay = Duration::from_millis(cli.submit_proof_retry_max_delay_ms);
-    let retry_config = RetryConfig::new(
-        cli.submit_proof_retry_max_retries,
-        retry_initial_delay,
-        retry_max_delay,
-    );
-    let heartbeat_config = WorkerHeartbeatConfig::with_max_consecutive_failures(
-        Duration::from_secs(cli.heartbeat_interval_sec),
-        cli.heartbeat_max_consecutive_failures,
-    );
-    let worker = ProofWorker::new(
-        queue,
-        backend,
-        ProofWorkerConfig {
-            worker_id,
-            poll_interval: Duration::from_secs(cli.poll_interval_seconds),
-            max_concurrent_jobs: cli.max_concurrent_jobs,
-            retry_config,
-            heartbeat_config,
-        },
-    );
-
-    tracing::info!(
-        prover_service = %cli.prover_service_url,
-        block_interval = cli.block_interval,
-        ranges = cli.ranges.max(1),
-        prover = %cli.prover,
-        sp1_session_poll_interval_seconds = cli.sp1_session_poll_interval_seconds,
-        submit_proof_retry_max_retries = cli.submit_proof_retry_max_retries,
-        submit_proof_retry_initial_delay_ms = cli.submit_proof_retry_initial_delay_ms,
-        submit_proof_retry_max_delay_ms = cli.submit_proof_retry_max_delay_ms,
-        "sp1-worker starting"
-    );
-
-    // Ctrl-C triggers a graceful shutdown: the worker stops leasing, flushes pending
-    // reports, and resolves.
-    let token = worker.cancellation_token();
-    tokio::spawn(async move {
-        if tokio::signal::ctrl_c().await.is_ok() {
-            tracing::info!("received ctrl-c, shutting down");
-            token.cancel();
-        }
-    });
-
-    worker.await;
-    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn base_args() -> Vec<&'static str> {
-        vec![
+    #[test]
+    fn parses_run_subcommand() {
+        let cli = Cli::parse_from([
             "sp1-worker",
+            "run",
             "--prover-service-url",
             "http://127.0.0.1:8545",
             "--l2-rpc",
@@ -326,26 +60,26 @@ mod tests {
             "10",
             "--worker-id",
             "test",
-        ]
+        ]);
+
+        assert!(matches!(cli.command, Command::Run(_)));
     }
 
     #[test]
-    fn parses_sp1_session_poll_interval_seconds() {
-        let mut args = base_args();
-        args.extend(["--sp1-session-poll-interval-seconds", "3"]);
+    fn parses_deposit_subcommand() {
+        let cli = Cli::parse_from([
+            "sp1-worker",
+            "deposit",
+            "--amount",
+            "100",
+            "--sp1-network-l1-rpc-url",
+            "https://ethereum.example",
+            "--succinct-vapp-address",
+            "0x0000000000000000000000000000000000000001",
+            "--sp1-private-key",
+            "test-key",
+        ]);
 
-        let cli = Cli::parse_from(args);
-
-        assert_eq!(cli.sp1_session_poll_interval_seconds, 3);
-    }
-
-    #[test]
-    fn rejects_zero_sp1_session_poll_interval_seconds() {
-        let mut args = base_args();
-        args.extend(["--sp1-session-poll-interval-seconds", "0"]);
-
-        let error = Cli::try_parse_from(args).expect_err("zero poll interval should be rejected");
-
-        assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
+        assert!(matches!(cli.command, Command::Deposit(_)));
     }
 }


### PR DESCRIPTION
- add the `deposit` subcommand to deposit `PROVE` tokens into the `SuccinctVApp` contract on Ethereum mainnet to fund the sp1 proof worker address when using the sp1 network prover.
- add the `run` subcommand to start the sp1 proof worker. Before starting the worker it now ensures that:
    - the sp1 proof worker address is funded on the sp1 network (previously a deposit must have been done)
    - it spanws a task that periodically checks whether the address is funded in the sp1 network. If not funded, metrics and logs are emitted.

### Next Steps

- add aws kms support
- wire this new changes in `crypto-apps` then

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mainnet token deposits and private-key signing, and changes the worker CLI (breaking for callers that omit `run`); network mode now gates leasing on credit balance.
> 
> **Overview**
> Splits **`world-chain-proof-sp1-worker`** into **`run`** and **`deposit`** subcommands (worker startup args now require `run`), and documents both flows in **`docs/proof/sp1-worker.md`**.
> 
> For **`--prover network`**, **`run`** validates Ethereum mainnet Succinct VApp settlement (`SP1_NETWORK_L1_RPC_URL`, `SUCCINCT_VAPP_ADDRESS`), blocks job leasing until SP1 Network credits reach **10× `minDepositAmount()`**, and keeps polling balance in the background with new **`sp1_network_prove_balance`** / **`sp1_network_balance_sufficient`** metrics. Low balance after startup is logged only; in-flight work is not stopped.
> 
> **`deposit`** funds the worker’s SP1 account via EIP-2612 **`permitAndDeposit`** on mainnet, then polls until network credits increase (30-minute timeout with tx hash retained on failure). Shared settlement helpers live in **`cmd/succinct`**.
> 
> **`NetworkCreditClient`** in the SP1 host reads credit balances without loading ELFs; **`NetworkSuccinctProver`** is refactored to use the same **`network_connection`** path as the SDK network client.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31395de3990692d56b3b6ab4c926da0f92b000b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->