### PR TITLE
feat(sp1-proof-worker): add aws kms support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19236,7 +19236,6 @@ dependencies = [
  "world-chain-proof-kona-host",
  "world-chain-proof-sp1-elfs",
  "world-chain-proof-sp1-types",
- "world-chain-proof-tx-signer",
  "world-chain-prover-service",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19236,6 +19236,7 @@ dependencies = [
  "world-chain-proof-kona-host",
  "world-chain-proof-sp1-elfs",
  "world-chain-proof-sp1-types",
+ "world-chain-proof-tx-signer",
  "world-chain-prover-service",
 ]
 
@@ -19281,6 +19282,7 @@ dependencies = [
  "world-chain-proof-protocol",
  "world-chain-proof-sp1-host",
  "world-chain-proof-sp1-types",
+ "world-chain-proof-tx-signer",
  "world-chain-proof-worker",
  "world-chain-prover-service",
 ]

--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -61,7 +61,7 @@ use world_chain_proof_sp1_host::{
     Sp1ProverKind, WorldSuccinctProver,
     cpu_prover::{CpuSuccinctProver, SP1ProofMode},
     mock_prover::MockSuccinctProver,
-    network_prover::NetworkSuccinctProver,
+    network_prover::{NetworkSuccinctProver, SignerType},
 };
 use world_chain_proof_sp1_worker::{Sp1Backend, Sp1BackendConfig};
 use world_chain_proof_worker::{
@@ -3043,9 +3043,10 @@ async fn start_sp1_worker(
             let private_key = std::env::var(SP1_PRIVATE_KEY_ENV).wrap_err_with(|| {
                 format!("{SP1_PRIVATE_KEY_ENV} is required when {SP1_WORKER_PROVER_ENV}=network")
             })?;
-            let prover = NetworkSuccinctProver::new(SP1ProofMode::Groth16, &private_key)
-                .await
-                .map_err(|error| eyre!("failed to build SP1 prover: {error}"))?;
+            let prover =
+                NetworkSuccinctProver::new(SP1ProofMode::Groth16, &private_key, SignerType::Local)
+                    .await
+                    .map_err(|error| eyre!("failed to build SP1 prover: {error}"))?;
             start_sp1_worker_with_prover(prover_service_url, deployment, kind, host, prover)
         }
     }

--- a/proofs/backends/sp1/host/Cargo.toml
+++ b/proofs/backends/sp1/host/Cargo.toml
@@ -9,7 +9,12 @@ repository.workspace = true
 
 [features]
 # SP1 zkVM proving via the sp1-sdk environment provers.
-sp1 = ["dep:sp1-sdk", "dep:bincode", "dep:alloy-sol-types", "dep:world-chain-proof-sp1-elfs"]
+sp1 = [
+    "dep:sp1-sdk",
+    "dep:bincode",
+    "dep:alloy-sol-types",
+    "dep:world-chain-proof-sp1-elfs",
+]
 
 [dependencies]
 alloy-primitives = { workspace = true, features = ["serde"] }
@@ -30,4 +35,3 @@ bincode = { version = "1", optional = true }
 sp1-sdk = { version = "=6.1.0", features = ["network"], optional = true }
 async-trait.workspace = true
 world-chain-prover-service.workspace = true
-world-chain-proof-tx-signer.workspace = true

--- a/proofs/backends/sp1/host/Cargo.toml
+++ b/proofs/backends/sp1/host/Cargo.toml
@@ -30,3 +30,4 @@ bincode = { version = "1", optional = true }
 sp1-sdk = { version = "=6.1.0", features = ["network"], optional = true }
 async-trait.workspace = true
 world-chain-prover-service.workspace = true
+world-chain-proof-tx-signer.workspace = true

--- a/proofs/backends/sp1/host/src/network_prover.rs
+++ b/proofs/backends/sp1/host/src/network_prover.rs
@@ -39,7 +39,9 @@ pub struct NetworkCreditClient {
     client: NetworkClient,
 }
 
-struct NetworkConnection {
+/// Initialized SP1 network signer and endpoint configuration reusable across network clients.
+#[derive(Clone)]
+pub struct NetworkConnection {
     signer: NetworkSigner,
     rpc_url: String,
     mode: NetworkMode,
@@ -52,36 +54,41 @@ pub enum SignerType {
     AwsKms,
 }
 
-async fn network_connection(
-    secret: &str,
-    signer_type: SignerType,
-) -> anyhow::Result<NetworkConnection> {
-    let signer = match signer_type {
-        SignerType::Local => NetworkSigner::local(secret).context("invalid SP1 private key")?,
-        SignerType::AwsKms => NetworkSigner::aws_kms(secret)
-            .await
-            .context("failed to initialize AWS KMS signer for SP1 SDK")?,
-    };
-    // PROVE deposits fund the auction-based SP1 Network --> Network = Mainnet
-    let mode = NetworkMode::Mainnet;
-    let rpc_url =
-        std::env::var("NETWORK_RPC_URL").unwrap_or_else(|_| get_default_rpc_url_for_mode(mode));
+impl NetworkConnection {
+    /// Initializes a reusable SP1 network connection.
+    pub async fn new(secret: &str, signer_type: SignerType) -> anyhow::Result<Self> {
+        let signer = match signer_type {
+            SignerType::Local => NetworkSigner::local(secret).context("invalid SP1 private key")?,
+            SignerType::AwsKms => Box::pin(NetworkSigner::aws_kms(secret))
+                .await
+                .context("failed to initialize AWS KMS signer for SP1 SDK")?,
+        };
+        // PROVE deposits fund the auction-based SP1 Network --> Network = Mainnet
+        let mode = NetworkMode::Mainnet;
+        let rpc_url =
+            std::env::var("NETWORK_RPC_URL").unwrap_or_else(|_| get_default_rpc_url_for_mode(mode));
 
-    Ok(NetworkConnection {
-        signer,
-        rpc_url,
-        mode,
-    })
+        Ok(Self {
+            signer,
+            rpc_url,
+            mode,
+        })
+    }
 }
 
 impl NetworkCreditClient {
     /// Creates a mainnet credit client for the provided signer.
     pub async fn new(secret: &str, signer_type: SignerType) -> anyhow::Result<Self> {
-        let connection = network_connection(secret, signer_type).await?;
+        let connection = NetworkConnection::new(secret, signer_type).await?;
 
-        Ok(Self {
+        Ok(Self::from_connection(connection))
+    }
+
+    /// Creates a credit client from an initialized network connection.
+    pub fn from_connection(connection: NetworkConnection) -> Self {
+        Self {
             client: NetworkClient::new(connection.signer, connection.rpc_url, connection.mode),
-        })
+        }
     }
 
     /// Returns the account's available SP1 Network credits in PROVE base units.
@@ -101,9 +108,18 @@ impl NetworkSuccinctProver {
         secret: &str,
         signer_type: SignerType,
     ) -> anyhow::Result<Self> {
+        let connection = NetworkConnection::new(secret, signer_type).await?;
+
+        Self::from_connection(agg_mode, connection).await
+    }
+
+    /// Creates the prover from an initialized network connection.
+    pub async fn from_connection(
+        agg_mode: SP1ProofMode,
+        connection: NetworkConnection,
+    ) -> anyhow::Result<Self> {
         let range_elf = world_chain_proof_sp1_elfs::range_elf();
         let agg_elf = world_chain_proof_sp1_elfs::aggregation_elf();
-        let connection = network_connection(secret, signer_type).await?;
         let client =
             NetworkProver::new(connection.signer, &connection.rpc_url, connection.mode).await;
         let range_pk = client

--- a/proofs/backends/sp1/host/src/network_prover.rs
+++ b/proofs/backends/sp1/host/src/network_prover.rs
@@ -2,7 +2,7 @@
 //! verify them; the aggregation proof mode is configurable (Groth16 for on-chain verification).
 
 use crate::{SuccinctProverError, WorldSuccinctProver};
-use alloy_primitives::{Address, B256, U256};
+use alloy_primitives::{B256, U256};
 use anyhow::{Context, bail};
 use async_trait::async_trait;
 pub use sp1_sdk::SP1ProofMode;
@@ -19,7 +19,6 @@ use world_chain_proof_core::types::AggregationInputs;
 use world_chain_proof_sp1_types::{
     AggregationProofRequest, RangeProofRequest, Sp1ProofRequest, Sp1SessionStatus,
 };
-use world_chain_proof_tx_signer::TransactionSigner;
 
 /// [`WorldSuccinctProver`] network implementation over the sp1-sdk network prover.
 pub struct NetworkSuccinctProver {
@@ -33,45 +32,56 @@ pub struct NetworkSuccinctProver {
 /// Lightweight client for reading an account's SP1 Network credit balance.
 ///
 /// Unlike [`NetworkSuccinctProver`], this does not initialize the SP1 light node or set up the
-/// embedded proving programs. It uses the same private key and `NETWORK_RPC_URL` selection as
+/// embedded proving programs. It uses the same credentials and `NETWORK_RPC_URL` selection as
 /// the SDK's network prover builder.
 #[derive(Clone)]
 pub struct NetworkCreditClient {
     client: NetworkClient,
 }
 
-#[derive(Debug)]
-pub struct NetworkConnection {
-    pub signer: NetworkSigner,
+struct NetworkConnection {
+    signer: NetworkSigner,
     rpc_url: String,
     mode: NetworkMode,
 }
 
-pub fn network_connection(transaction_signer: TransactionSigner) -> NetworkConnection {
-    let signer = match transaction_signer {
-        TransactionSigner::Local(local_signer) => NetworkSigner::Local(local_signer),
-        TransactionSigner::Aws(aws_signer) => NetworkSigner::Aws(aws_signer),
+/// Signer type used by the SP1 network clients.
+#[derive(Clone, Copy, Debug)]
+pub enum SignerType {
+    Local,
+    AwsKms,
+}
+
+async fn network_connection(
+    secret: &str,
+    signer_type: SignerType,
+) -> anyhow::Result<NetworkConnection> {
+    let signer = match signer_type {
+        SignerType::Local => NetworkSigner::local(secret).context("invalid SP1 private key")?,
+        SignerType::AwsKms => NetworkSigner::aws_kms(secret)
+            .await
+            .context("failed to initialize AWS KMS signer for SP1 SDK")?,
     };
     // PROVE deposits fund the auction-based SP1 Network --> Network = Mainnet
     let mode = NetworkMode::Mainnet;
     let rpc_url =
         std::env::var("NETWORK_RPC_URL").unwrap_or_else(|_| get_default_rpc_url_for_mode(mode));
 
-    NetworkConnection {
+    Ok(NetworkConnection {
         signer,
         rpc_url,
         mode,
-    }
+    })
 }
 
 impl NetworkCreditClient {
-    /// Creates a mainnet credit client for the provided secret.
-    pub fn new(transaction_signer: TransactionSigner) -> Self {
-        let connection = network_connection(transaction_signer);
+    /// Creates a mainnet credit client for the provided signer.
+    pub async fn new(secret: &str, signer_type: SignerType) -> anyhow::Result<Self> {
+        let connection = network_connection(secret, signer_type).await?;
 
-        Self {
+        Ok(Self {
             client: NetworkClient::new(connection.signer, connection.rpc_url, connection.mode),
-        }
+        })
     }
 
     /// Returns the account's available SP1 Network credits in PROVE base units.
@@ -88,11 +98,12 @@ impl NetworkSuccinctProver {
     /// ELFs embedded at compile time via `world_chain_proof_sp1_elfs`.
     pub async fn new(
         agg_mode: SP1ProofMode,
-        transaction_signer: TransactionSigner,
+        secret: &str,
+        signer_type: SignerType,
     ) -> anyhow::Result<Self> {
         let range_elf = world_chain_proof_sp1_elfs::range_elf();
         let agg_elf = world_chain_proof_sp1_elfs::aggregation_elf();
-        let connection = network_connection(transaction_signer);
+        let connection = network_connection(secret, signer_type).await?;
         let client =
             NetworkProver::new(connection.signer, &connection.rpc_url, connection.mode).await;
         let range_pk = client

--- a/proofs/backends/sp1/host/src/network_prover.rs
+++ b/proofs/backends/sp1/host/src/network_prover.rs
@@ -59,9 +59,13 @@ impl NetworkConnection {
     pub async fn new(secret: &str, signer_type: SignerType) -> anyhow::Result<Self> {
         let signer = match signer_type {
             SignerType::Local => NetworkSigner::local(secret).context("invalid SP1 private key")?,
-            SignerType::AwsKms => Box::pin(NetworkSigner::aws_kms(secret))
-                .await
-                .context("failed to initialize AWS KMS signer for SP1 SDK")?,
+            SignerType::AwsKms => {
+                // Keep the AWS SDK future boxed. Storing it inline makes the enclosing
+                // devnet futures exceed rustc's query-depth limit during workspace clippy.
+                Box::pin(NetworkSigner::aws_kms(secret))
+                    .await
+                    .context("failed to initialize AWS KMS signer for SP1 SDK")?
+            }
         };
         // PROVE deposits fund the auction-based SP1 Network --> Network = Mainnet
         let mode = NetworkMode::Mainnet;

--- a/proofs/backends/sp1/host/src/network_prover.rs
+++ b/proofs/backends/sp1/host/src/network_prover.rs
@@ -2,7 +2,7 @@
 //! verify them; the aggregation proof mode is configurable (Groth16 for on-chain verification).
 
 use crate::{SuccinctProverError, WorldSuccinctProver};
-use alloy_primitives::{B256, U256};
+use alloy_primitives::{Address, B256, U256};
 use anyhow::{Context, bail};
 use async_trait::async_trait;
 pub use sp1_sdk::SP1ProofMode;
@@ -19,15 +19,7 @@ use world_chain_proof_core::types::AggregationInputs;
 use world_chain_proof_sp1_types::{
     AggregationProofRequest, RangeProofRequest, Sp1ProofRequest, Sp1SessionStatus,
 };
-
-/// Signer type used by SP1 network prover.
-#[derive(Debug, Clone, Copy)]
-pub enum SignerType {
-    /// Local signer.
-    Local,
-    /// AWS KMS signer.
-    Aws,
-}
+use world_chain_proof_tx_signer::TransactionSigner;
 
 /// [`WorldSuccinctProver`] network implementation over the sp1-sdk network prover.
 pub struct NetworkSuccinctProver {
@@ -48,42 +40,38 @@ pub struct NetworkCreditClient {
     client: NetworkClient,
 }
 
-struct NetworkConnection {
-    signer: NetworkSigner,
+#[derive(Debug)]
+pub struct NetworkConnection {
+    pub signer: NetworkSigner,
     rpc_url: String,
     mode: NetworkMode,
 }
 
-async fn network_connection(
-    secret: &str,
-    signer_type: SignerType,
-) -> anyhow::Result<NetworkConnection> {
-    let signer = match signer_type {
-        SignerType::Local => NetworkSigner::local(secret).context("invalid SP1 private key")?,
-        SignerType::Aws => NetworkSigner::aws_kms(secret)
-            .await
-            .context("invalid AWS KMS key id")?,
+pub fn network_connection(transaction_signer: TransactionSigner) -> NetworkConnection {
+    let signer = match transaction_signer {
+        TransactionSigner::Local(local_signer) => NetworkSigner::Local(local_signer),
+        TransactionSigner::Aws(aws_signer) => NetworkSigner::Aws(aws_signer),
     };
     // PROVE deposits fund the auction-based SP1 Network --> Network = Mainnet
     let mode = NetworkMode::Mainnet;
     let rpc_url =
         std::env::var("NETWORK_RPC_URL").unwrap_or_else(|_| get_default_rpc_url_for_mode(mode));
 
-    Ok(NetworkConnection {
+    NetworkConnection {
         signer,
         rpc_url,
         mode,
-    })
+    }
 }
 
 impl NetworkCreditClient {
     /// Creates a mainnet credit client for the provided secret.
-    pub async fn new(secret: &str, signer_type: SignerType) -> anyhow::Result<Self> {
-        let connection = network_connection(secret, signer_type).await?;
+    pub fn new(transaction_signer: TransactionSigner) -> Self {
+        let connection = network_connection(transaction_signer);
 
-        Ok(Self {
+        Self {
             client: NetworkClient::new(connection.signer, connection.rpc_url, connection.mode),
-        })
+        }
     }
 
     /// Returns the account's available SP1 Network credits in PROVE base units.
@@ -100,12 +88,11 @@ impl NetworkSuccinctProver {
     /// ELFs embedded at compile time via `world_chain_proof_sp1_elfs`.
     pub async fn new(
         agg_mode: SP1ProofMode,
-        secret: &str,
-        signer_type: SignerType,
+        transaction_signer: TransactionSigner,
     ) -> anyhow::Result<Self> {
         let range_elf = world_chain_proof_sp1_elfs::range_elf();
         let agg_elf = world_chain_proof_sp1_elfs::aggregation_elf();
-        let connection = network_connection(secret, signer_type).await?;
+        let connection = network_connection(transaction_signer);
         let client =
             NetworkProver::new(connection.signer, &connection.rpc_url, connection.mode).await;
         let range_pk = client

--- a/proofs/backends/sp1/host/src/network_prover.rs
+++ b/proofs/backends/sp1/host/src/network_prover.rs
@@ -20,6 +20,15 @@ use world_chain_proof_sp1_types::{
     AggregationProofRequest, RangeProofRequest, Sp1ProofRequest, Sp1SessionStatus,
 };
 
+/// Signer type used by SP1 network prover.
+#[derive(Debug, Clone, Copy)]
+pub enum SignerType {
+    /// Local signer.
+    Local,
+    /// AWS KMS signer.
+    Aws,
+}
+
 /// [`WorldSuccinctProver`] network implementation over the sp1-sdk network prover.
 pub struct NetworkSuccinctProver {
     client: NetworkProver,
@@ -45,8 +54,16 @@ struct NetworkConnection {
     mode: NetworkMode,
 }
 
-fn network_connection(private_key: &str) -> anyhow::Result<NetworkConnection> {
-    let signer = NetworkSigner::local(private_key).context("invalid SP1 private key")?;
+async fn network_connection(
+    secret: &str,
+    signer_type: SignerType,
+) -> anyhow::Result<NetworkConnection> {
+    let signer = match signer_type {
+        SignerType::Local => NetworkSigner::local(secret).context("invalid SP1 private key")?,
+        SignerType::Aws => NetworkSigner::aws_kms(secret)
+            .await
+            .context("invalid AWS KMS key id")?,
+    };
     // PROVE deposits fund the auction-based SP1 Network --> Network = Mainnet
     let mode = NetworkMode::Mainnet;
     let rpc_url =
@@ -60,9 +77,9 @@ fn network_connection(private_key: &str) -> anyhow::Result<NetworkConnection> {
 }
 
 impl NetworkCreditClient {
-    /// Creates a mainnet credit client for `private_key`.
-    pub fn new(private_key: &str) -> anyhow::Result<Self> {
-        let connection = network_connection(private_key)?;
+    /// Creates a mainnet credit client for the provided secret.
+    pub async fn new(secret: &str, signer_type: SignerType) -> anyhow::Result<Self> {
+        let connection = network_connection(secret, signer_type).await?;
 
         Ok(Self {
             client: NetworkClient::new(connection.signer, connection.rpc_url, connection.mode),
@@ -81,10 +98,14 @@ impl NetworkCreditClient {
 impl NetworkSuccinctProver {
     /// Creates the prover using caller-supplied ELFs. Use this in production binaries with
     /// ELFs embedded at compile time via `world_chain_proof_sp1_elfs`.
-    pub async fn new(agg_mode: SP1ProofMode, private_key: &str) -> anyhow::Result<Self> {
+    pub async fn new(
+        agg_mode: SP1ProofMode,
+        secret: &str,
+        signer_type: SignerType,
+    ) -> anyhow::Result<Self> {
         let range_elf = world_chain_proof_sp1_elfs::range_elf();
         let agg_elf = world_chain_proof_sp1_elfs::aggregation_elf();
-        let connection = network_connection(private_key)?;
+        let connection = network_connection(secret, signer_type).await?;
         let client =
             NetworkProver::new(connection.signer, &connection.rpc_url, connection.mode).await;
         let range_pk = client

--- a/proofs/debug/bin/prover-sp1/src/main.rs
+++ b/proofs/debug/bin/prover-sp1/src/main.rs
@@ -150,7 +150,7 @@ async fn sp1_prove(args: Sp1ProveArgs) -> Result<()> {
     use world_chain_proof_sp1_host::{
         cpu_prover::CpuSuccinctProver,
         mock_prover::MockSuccinctProver,
-        network_prover::NetworkSuccinctProver,
+        network_prover::{NetworkSuccinctProver, SignerType},
         validity::{ValidityProofRequest, prove_validity},
     };
 
@@ -194,7 +194,7 @@ async fn sp1_prove(args: Sp1ProveArgs) -> Result<()> {
                 .sp1_private_key
                 .clone()
                 .context("SP1_PRIVATE_KEY is required when --prover network")?;
-            let prover = NetworkSuccinctProver::new(mode, &private_key).await?;
+            let prover = NetworkSuccinctProver::new(mode, &private_key, SignerType::Local).await?;
             prove_validity(&host, &prover, proof_request).await?
         }
     };

--- a/proofs/services/challenger/src/main.rs
+++ b/proofs/services/challenger/src/main.rs
@@ -20,7 +20,7 @@ use world_chain_challenger::{
     ResolutionManagerConfig, WorldChainChallenger,
 };
 use world_chain_proof_protocol::{OptimismConsensusClient, VerifyingConsensusProvider};
-use world_chain_proof_tx_signer::build_transaction_wallet;
+use world_chain_proof_tx_signer::build_transaction_signer;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -130,9 +130,10 @@ async fn main() -> Result<()> {
 
     let l1_rpc_url = Url::parse(&cli.l1_rpc).context("invalid L1 RPC URL")?;
     let wallet =
-        build_transaction_wallet(cli.challenger_key, cli.challenger_kms_key_id, &l1_rpc_url)
+        build_transaction_signer(cli.challenger_key, cli.challenger_kms_key_id, &l1_rpc_url)
             .await
-            .context("failed to initialize challenger signer")?;
+            .context("failed to initialize challenger signer")?
+            .wallet();
     let challenger_address = wallet.default_signer().address();
     let l1_rpc_client = world_chain_proof_metrics::metered_http_client(
         l1_rpc_url,

--- a/proofs/services/defender/src/main.rs
+++ b/proofs/services/defender/src/main.rs
@@ -18,7 +18,7 @@ use world_chain_defender::{
     AlloyDefenderClient, DEFAULT_L1_TX_CONFIRMATIONS, DefenderConfig, WorldChainDefender,
 };
 use world_chain_proof_protocol::{OptimismConsensusClient, VerifyingConsensusProvider};
-use world_chain_proof_tx_signer::build_transaction_wallet;
+use world_chain_proof_tx_signer::build_transaction_signer;
 use world_chain_prover_service::RpcProverServiceClient;
 
 #[derive(Debug, Parser)]
@@ -101,9 +101,10 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     let l1_rpc_url = Url::parse(&cli.l1_rpc).context("invalid L1 RPC URL")?;
-    let wallet = build_transaction_wallet(cli.defender_key, cli.defender_kms_key_id, &l1_rpc_url)
+    let wallet = build_transaction_signer(cli.defender_key, cli.defender_kms_key_id, &l1_rpc_url)
         .await
-        .context("failed to initialize defender signer")?;
+        .context("failed to initialize defender signer")?
+        .wallet();
     let defender_address = wallet.default_signer().address();
     let reward_recipient = cli.proof_reward_recipient.unwrap_or(defender_address);
     let l1_rpc_client = world_chain_proof_metrics::metered_http_client(

--- a/proofs/services/proposer/src/main.rs
+++ b/proofs/services/proposer/src/main.rs
@@ -15,7 +15,7 @@ use clap::{ArgGroup, Parser};
 use tracing::info;
 use url::Url;
 use world_chain_proof_protocol::{OptimismConsensusClient, VerifyingConsensusProvider};
-use world_chain_proof_tx_signer::build_transaction_wallet;
+use world_chain_proof_tx_signer::build_transaction_signer;
 use world_chain_proposer::{
     AlloyProofSystemClient, BondManager, BondManagerConfig, ProposerConfig, WorldChainProposer,
 };
@@ -98,9 +98,10 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     let l1_rpc_url = Url::parse(&cli.l1_rpc).context("invalid L1 RPC URL")?;
-    let wallet = build_transaction_wallet(cli.proposer_key, cli.proposer_kms_key_id, &l1_rpc_url)
+    let wallet = build_transaction_signer(cli.proposer_key, cli.proposer_kms_key_id, &l1_rpc_url)
         .await
-        .context("failed to initialize proposer signer")?;
+        .context("failed to initialize proposer signer")?
+        .wallet();
     let proposer_address = wallet.default_signer().address();
     let l1_rpc_client = world_chain_proof_metrics::metered_http_client(
         l1_rpc_url,

--- a/proofs/services/tx-signer/src/lib.rs
+++ b/proofs/services/tx-signer/src/lib.rs
@@ -119,9 +119,10 @@ mod tests {
     async fn builds_local_wallet_with_derived_address() {
         let expected = local_signer().address();
         let rpc_url = "http://127.0.0.1:8545".parse().expect("valid URL");
-        let wallet = build_transaction_wallet(Some(local_signer()), None, &rpc_url)
+        let wallet = build_transaction_signer(Some(local_signer()), None, &rpc_url)
             .await
-            .expect("local wallet builds");
+            .expect("local wallet builds")
+            .wallet();
 
         assert_eq!(wallet.default_signer().address(), expected);
         assert!(<EthereumWallet as NetworkWallet<Ethereum>>::has_signer_for(

--- a/proofs/services/tx-signer/src/lib.rs
+++ b/proofs/services/tx-signer/src/lib.rs
@@ -8,6 +8,13 @@ use alloy_transport::TransportError;
 use thiserror::Error;
 use url::Url;
 
+/// An L1 transaction signer backed by a local private key or AWS KMS.
+#[derive(Clone)]
+pub enum TransactionSigner {
+    Local(PrivateKeySigner),
+    Aws(AwsSigner),
+}
+
 enum TransactionSignerSource {
     Local(PrivateKeySigner),
     AwsKms(String),
@@ -26,14 +33,14 @@ fn select_signer_source(
     }
 }
 
-/// Builds an Alloy wallet from exactly one local private key or AWS KMS key ID.
-pub async fn build_transaction_wallet(
+/// Builds a transaction signer from exactly one local private key or AWS KMS key ID.
+pub async fn build_transaction_signer(
     private_key: Option<PrivateKeySigner>,
     aws_kms_key_id: Option<String>,
     rpc_url: &Url,
-) -> Result<EthereumWallet, TransactionSignerError> {
+) -> Result<TransactionSigner, TransactionSignerError> {
     match select_signer_source(private_key, aws_kms_key_id)? {
-        TransactionSignerSource::Local(signer) => Ok(EthereumWallet::from(signer)),
+        TransactionSignerSource::Local(signer) => Ok(TransactionSigner::Local(signer)),
         TransactionSignerSource::AwsKms(key_id) => {
             let chain_id = ProviderBuilder::new()
                 .connect_http(rpc_url.clone())
@@ -50,7 +57,18 @@ pub async fn build_transaction_wallet(
             )
             .await
             .map_err(|error| TransactionSignerError::AwsKms(Box::new(error)))?;
-            Ok(EthereumWallet::from(signer))
+            Ok(TransactionSigner::Aws(signer))
+        }
+    }
+}
+
+impl TransactionSigner {
+    /// Wraps this signer in an Ethereum wallet suitable for Alloy providers.
+    #[must_use]
+    pub fn wallet(&self) -> EthereumWallet {
+        match self {
+            Self::Local(signer) => EthereumWallet::from(signer.clone()),
+            Self::Aws(signer) => EthereumWallet::from(signer.clone()),
         }
     }
 }

--- a/proofs/workers/sp1/Cargo.toml
+++ b/proofs/workers/sp1/Cargo.toml
@@ -24,6 +24,7 @@ world-chain-proof-sp1-host = { workspace = true, features = ["sp1"] }
 world-chain-proof-sp1-types.workspace = true
 world-chain-proof-worker.workspace = true
 world-chain-prover-service.workspace = true
+world-chain-proof-tx-signer.workspace = true
 
 # alloy
 alloy-contract.workspace = true

--- a/proofs/workers/sp1/src/cmd/deposit.rs
+++ b/proofs/workers/sp1/src/cmd/deposit.rs
@@ -65,26 +65,17 @@ pub async fn deposit(args: DepositArgs) -> Result<()> {
     }
     let l1_rpc_url =
         Url::parse(&args.sp1_network_l1_rpc_url).context("invalid SP1 Network L1 RPC URL")?;
-    let l1_private_key = args
-        .sp1_private_key
-        .as_deref()
-        .map(str::parse::<PrivateKeySigner>)
-        .transpose()
-        .context("invalid SP1 private key")?;
-    let l1_signer =
-        build_transaction_signer(l1_private_key, args.sp1_kms_key_id.clone(), &l1_rpc_url)
-            .await
-            .context("initializing L1 transaction signer")?;
-    let (network_secret, signer_type) = match (&args.sp1_private_key, &args.sp1_kms_key_id) {
+    let (signer_secret, signer_type) = match (&args.sp1_private_key, &args.sp1_kms_key_id) {
         (Some(private_key), None) => (private_key.as_str(), SignerType::Local),
-        (None, Some(key_id)) => (key_id.as_str(), SignerType::AwsKms),
+        (None, Some(key_id)) if !key_id.trim().is_empty() => (key_id.as_str(), SignerType::AwsKms),
         _ => bail!("configure exactly one SP1 private key or AWS KMS key ID"),
     };
+    let l1_signer = build_l1_signer(signer_secret, signer_type, &l1_rpc_url).await?;
     let signer_address = match &l1_signer {
         TransactionSigner::Local(signer) => signer.address(),
         TransactionSigner::Aws(signer) => signer.address(),
     };
-    let credit_client = NetworkCreditClient::new(network_secret, signer_type).await?;
+    let credit_client = NetworkCreditClient::new(signer_secret, signer_type).await?;
     let credit_before = credit_client
         .get_balance()
         .await
@@ -269,6 +260,26 @@ async fn wait_for_credit_reflection(
         }
         tokio::time::sleep(CREDIT_POLL_INTERVAL).await;
     }
+}
+
+async fn build_l1_signer(
+    secret: &str,
+    signer_type: SignerType,
+    rpc_url: &Url,
+) -> Result<TransactionSigner> {
+    let signer = match signer_type {
+        SignerType::Local => {
+            let private_key = secret
+                .parse::<PrivateKeySigner>()
+                .context("invalid SP1 private key")?;
+            build_transaction_signer(Some(private_key), None, rpc_url).await
+        }
+        SignerType::AwsKms => {
+            build_transaction_signer(None, Some(secret.to_owned()), rpc_url).await
+        }
+    };
+
+    signer.context("initializing L1 transaction signer")
 }
 
 #[cfg(test)]

--- a/proofs/workers/sp1/src/cmd/deposit.rs
+++ b/proofs/workers/sp1/src/cmd/deposit.rs
@@ -8,9 +8,7 @@ use alloy_sol_types::eip712_domain;
 use anyhow::{Context, Result, bail};
 use clap::Args;
 use url::Url;
-use world_chain_proof_sp1_host::network_prover::{
-    NetworkCreditClient, SignerType, network_connection,
-};
+use world_chain_proof_sp1_host::network_prover::{NetworkCreditClient, SignerType};
 use world_chain_proof_tx_signer::{TransactionSigner, build_transaction_signer};
 
 use super::succinct::{
@@ -77,7 +75,16 @@ pub async fn deposit(args: DepositArgs) -> Result<()> {
         build_transaction_signer(l1_private_key, args.sp1_kms_key_id.clone(), &l1_rpc_url)
             .await
             .context("initializing L1 transaction signer")?;
-    let credit_client = NetworkCreditClient::new(l1_signer);
+    let (network_secret, signer_type) = match (&args.sp1_private_key, &args.sp1_kms_key_id) {
+        (Some(private_key), None) => (private_key.as_str(), SignerType::Local),
+        (None, Some(key_id)) => (key_id.as_str(), SignerType::AwsKms),
+        _ => bail!("configure exactly one SP1 private key or AWS KMS key ID"),
+    };
+    let signer_address = match &l1_signer {
+        TransactionSigner::Local(signer) => signer.address(),
+        TransactionSigner::Aws(signer) => signer.address(),
+    };
+    let credit_client = NetworkCreditClient::new(network_secret, signer_type).await?;
     let credit_before = credit_client
         .get_balance()
         .await

--- a/proofs/workers/sp1/src/cmd/deposit.rs
+++ b/proofs/workers/sp1/src/cmd/deposit.rs
@@ -1,15 +1,17 @@
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use alloy_network::EthereumWallet;
 use alloy_primitives::{Address, B256, U256, utils::parse_units};
 use alloy_provider::{Provider, ProviderBuilder};
-use alloy_signer::SignerSync;
+use alloy_signer::{Signer, SignerSync};
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::eip712_domain;
 use anyhow::{Context, Result, bail};
 use clap::Args;
 use url::Url;
-use world_chain_proof_sp1_host::network_prover::NetworkCreditClient;
+use world_chain_proof_sp1_host::network_prover::{
+    NetworkCreditClient, SignerType, network_connection,
+};
+use world_chain_proof_tx_signer::{TransactionSigner, build_transaction_signer};
 
 use super::succinct::{
     ETHEREUM_MAINNET_CHAIN_ID, IProveToken, ISuccinctVApp, Permit, format_prove,
@@ -21,6 +23,12 @@ const CREDIT_POLL_INTERVAL: Duration = Duration::from_secs(10);
 const CREDIT_REFLECTION_TIMEOUT: Duration = Duration::from_secs(30 * 60);
 
 #[derive(Debug, Args)]
+#[command(
+    group = clap::ArgGroup::new("transaction_signer")
+        .required(true)
+        .multiple(false)
+        .args(&["sp1_private_key", "sp1_kms_key_id"])
+)]
 pub struct DepositArgs {
     /// Human-readable amount of PROVE to deposit (for example `1000` or `12.5`).
     #[arg(long)]
@@ -36,7 +44,11 @@ pub struct DepositArgs {
 
     /// Private key for both the PROVE holder and the corresponding SP1 Network account.
     #[arg(long, env = "SP1_PRIVATE_KEY")]
-    sp1_private_key: String,
+    sp1_private_key: Option<String>,
+
+    /// AWS KMS key ID for both the PROVE holder and the corresponding SP1 Network account.
+    #[arg(long, env = "SP1_KMS_KEY_ID", hide_env_values = true)]
+    sp1_kms_key_id: Option<String>,
 }
 
 pub async fn deposit(args: DepositArgs) -> Result<()> {
@@ -53,23 +65,26 @@ pub async fn deposit(args: DepositArgs) -> Result<()> {
             format_prove(settlement.min_deposit_amount, settlement.prove_decimals),
         );
     }
-
-    let signer: PrivateKeySigner = args
+    let l1_rpc_url =
+        Url::parse(&args.sp1_network_l1_rpc_url).context("invalid SP1 Network L1 RPC URL")?;
+    let l1_private_key = args
         .sp1_private_key
-        .parse()
-        .context("invalid SP1_PRIVATE_KEY")?;
-    let signer_address = signer.address();
-    let credit_client = NetworkCreditClient::new(&args.sp1_private_key)?;
+        .as_deref()
+        .map(str::parse::<PrivateKeySigner>)
+        .transpose()
+        .context("invalid SP1 private key")?;
+    let l1_signer =
+        build_transaction_signer(l1_private_key, args.sp1_kms_key_id.clone(), &l1_rpc_url)
+            .await
+            .context("initializing L1 transaction signer")?;
+    let credit_client = NetworkCreditClient::new(l1_signer);
     let credit_before = credit_client
         .get_balance()
         .await
         .context("reading SP1 Network credit balance before deposit")?;
-
     let provider = ProviderBuilder::new()
-        .wallet(EthereumWallet::from(signer.clone()))
-        .connect_http(
-            Url::parse(&args.sp1_network_l1_rpc_url).context("invalid SP1 Network L1 RPC URL")?,
-        );
+        .wallet(l1_signer.wallet())
+        .connect_http(l1_rpc_url);
     let token = IProveToken::new(settlement.prove_token_address, provider.clone());
     let vapp = ISuccinctVApp::new(settlement.vapp_address, provider.clone());
 
@@ -129,10 +144,12 @@ pub async fn deposit(args: DepositArgs) -> Result<()> {
         nonce,
         deadline,
     };
-    let signature = signer
-        .sign_typed_data_sync(&permit, &permit_domain)
-        .context("signing PROVE permit")?
-        .as_bytes();
+    let signature = match &l1_signer {
+        TransactionSigner::Local(signer) => signer.sign_typed_data_sync(&permit, &permit_domain),
+        TransactionSigner::Aws(signer) => signer.sign_typed_data(&permit, &permit_domain).await,
+    }
+    .context("signing PROVE permit")?
+    .as_bytes();
     let r = B256::from_slice(&signature[..32]);
     let s = B256::from_slice(&signature[32..64]);
     let v = signature[64];

--- a/proofs/workers/sp1/src/cmd/deposit.rs
+++ b/proofs/workers/sp1/src/cmd/deposit.rs
@@ -11,9 +11,12 @@ use url::Url;
 use world_chain_proof_sp1_host::network_prover::{NetworkCreditClient, SignerType};
 use world_chain_proof_tx_signer::{TransactionSigner, build_transaction_signer};
 
-use super::succinct::{
-    ETHEREUM_MAINNET_CHAIN_ID, IProveToken, ISuccinctVApp, Permit, format_prove,
-    load_settlement_config,
+use super::{
+    select_network_signer,
+    succinct::{
+        ETHEREUM_MAINNET_CHAIN_ID, IProveToken, ISuccinctVApp, Permit, format_prove,
+        load_settlement_config,
+    },
 };
 
 const PERMIT_VALIDITY: Duration = Duration::from_secs(60 * 60);
@@ -21,12 +24,6 @@ const CREDIT_POLL_INTERVAL: Duration = Duration::from_secs(10);
 const CREDIT_REFLECTION_TIMEOUT: Duration = Duration::from_secs(30 * 60);
 
 #[derive(Debug, Args)]
-#[command(
-    group = clap::ArgGroup::new("transaction_signer")
-        .required(true)
-        .multiple(false)
-        .args(&["sp1_private_key", "sp1_kms_key_id"])
-)]
 pub struct DepositArgs {
     /// Human-readable amount of PROVE to deposit (for example `1000` or `12.5`).
     #[arg(long)]
@@ -65,11 +62,10 @@ pub async fn deposit(args: DepositArgs) -> Result<()> {
     }
     let l1_rpc_url =
         Url::parse(&args.sp1_network_l1_rpc_url).context("invalid SP1 Network L1 RPC URL")?;
-    let (signer_secret, signer_type) = match (&args.sp1_private_key, &args.sp1_kms_key_id) {
-        (Some(private_key), None) => (private_key.as_str(), SignerType::Local),
-        (None, Some(key_id)) if !key_id.trim().is_empty() => (key_id.as_str(), SignerType::AwsKms),
-        _ => bail!("configure exactly one SP1 private key or AWS KMS key ID"),
-    };
+    let (signer_secret, signer_type) = select_network_signer(
+        args.sp1_private_key.as_deref(),
+        args.sp1_kms_key_id.as_deref(),
+    )?;
     let l1_signer = build_l1_signer(signer_secret, signer_type, &l1_rpc_url).await?;
     let signer_address = match &l1_signer {
         TransactionSigner::Local(signer) => signer.address(),

--- a/proofs/workers/sp1/src/cmd/mod.rs
+++ b/proofs/workers/sp1/src/cmd/mod.rs
@@ -1,3 +1,49 @@
+use anyhow::{Result, bail};
+use world_chain_proof_sp1_host::network_prover::SignerType;
+
 pub mod deposit;
 pub mod run;
 pub mod succinct;
+
+fn select_network_signer<'a>(
+    private_key: Option<&'a str>,
+    kms_key_id: Option<&'a str>,
+) -> Result<(&'a str, SignerType)> {
+    let private_key = private_key.filter(|value| !value.trim().is_empty());
+    let kms_key_id = kms_key_id.filter(|value| !value.trim().is_empty());
+
+    match (private_key, kms_key_id) {
+        (Some(private_key), None) => Ok((private_key, SignerType::Local)),
+        (None, Some(key_id)) => Ok((key_id, SignerType::AwsKms)),
+        _ => bail!("configure exactly one SP1 private key or AWS KMS key ID"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blank_private_key_does_not_mask_kms_key() {
+        let (secret, signer_type) =
+            select_network_signer(Some("  "), Some("alias/prover")).unwrap();
+
+        assert_eq!(secret, "alias/prover");
+        assert!(matches!(signer_type, SignerType::AwsKms));
+    }
+
+    #[test]
+    fn blank_kms_key_does_not_mask_private_key() {
+        let (secret, signer_type) = select_network_signer(Some("0x1234"), Some("\t")).unwrap();
+
+        assert_eq!(secret, "0x1234");
+        assert!(matches!(signer_type, SignerType::Local));
+    }
+
+    #[test]
+    fn rejects_missing_or_multiple_signers() {
+        assert!(select_network_signer(None, None).is_err());
+        assert!(select_network_signer(Some(" "), Some("\n")).is_err());
+        assert!(select_network_signer(Some("0x1234"), Some("alias/prover")).is_err());
+    }
+}

--- a/proofs/workers/sp1/src/cmd/run.rs
+++ b/proofs/workers/sp1/src/cmd/run.rs
@@ -11,7 +11,7 @@ use world_chain_proof_sp1_host::{
     Sp1ProverKind, WorldSuccinctProver,
     cpu_prover::{CpuSuccinctProver, SP1ProofMode},
     mock_prover::MockSuccinctProver,
-    network_prover::{NetworkCreditClient, NetworkSuccinctProver},
+    network_prover::{NetworkCreditClient, NetworkSuccinctProver, SignerType},
 };
 use world_chain_proof_sp1_worker::{
     ProofWorker, ProofWorkerConfig, RetryConfig, Sp1Backend, Sp1BackendConfig,
@@ -114,9 +114,17 @@ pub struct WorkerArgs {
     )]
     prover: Sp1ProverKind,
 
-    /// SP1 network private key. Required when --prover network.
+    /// SP1 network private key.
+    ///
+    /// Required when --prover network and sp1_kms_key_id is not provided.
     #[arg(long, env = "SP1_PRIVATE_KEY")]
     sp1_private_key: Option<String>,
+
+    /// AWS KMS key ID or alias the sp1 proof worker signs proof requests.
+    ///
+    /// Required when --prover network and sp1_private_key is not provided.
+    #[arg(long, env = "SP1_KMS_KEY_ID", hide_env_values = true)]
+    sp1_kms_key_id: Option<String>,
 
     /// Ethereum mainnet RPC used to validate the Succinct VApp and its deposit threshold.
     /// Required when --prover network.
@@ -211,7 +219,7 @@ pub async fn run(cli: WorkerArgs) -> Result<()> {
     match prover_kind {
         Sp1ProverKind::Cpu => {
             run_worker(
-                cli,
+                &cli,
                 host,
                 CpuSuccinctProver::new(SP1ProofMode::Groth16).await?,
             )
@@ -219,17 +227,25 @@ pub async fn run(cli: WorkerArgs) -> Result<()> {
         }
         Sp1ProverKind::Mock => {
             run_worker(
-                cli,
+                &cli,
                 host,
                 MockSuccinctProver::new(SP1ProofMode::Groth16).await?,
             )
             .await
         }
         Sp1ProverKind::Network => {
-            let private_key = cli
-                .sp1_private_key
-                .clone()
-                .context("SP1_PRIVATE_KEY is required when --prover network")?;
+            let (secret, signer_type) = match (
+                cli.sp1_private_key.as_ref(),
+                cli.sp1_kms_key_id.as_ref(),
+            ) {
+                (Some(sp1_private_key), None) => (sp1_private_key, SignerType::Local),
+                (None, Some(sp1_aws_kms_id)) => (sp1_aws_kms_id, SignerType::Aws),
+                _ => {
+                    bail!(
+                        "You should provide exactly one between `sp1_private_key` or `sp1_aws_kms_id`"
+                    )
+                }
+            };
             let l1_rpc_url = cli
                 .sp1_network_l1_rpc_url
                 .clone()
@@ -241,7 +257,7 @@ pub async fn run(cli: WorkerArgs) -> Result<()> {
                 .await
                 .context("validating Succinct settlement configuration")?;
             let minimum_balance = minimum_network_balance(settlement.min_deposit_amount)?;
-            let credit_client = NetworkCreditClient::new(&private_key)?;
+            let credit_client = NetworkCreditClient::new(secret, signer_type).await?;
 
             if !wait_for_sufficient_network_balance(
                 &credit_client,
@@ -255,9 +271,9 @@ pub async fn run(cli: WorkerArgs) -> Result<()> {
 
             monitor_network_balance(credit_client, minimum_balance, settlement.prove_decimals);
             run_worker(
-                cli,
+                &cli,
                 host,
-                NetworkSuccinctProver::new(SP1ProofMode::Groth16, &private_key).await?,
+                NetworkSuccinctProver::new(SP1ProofMode::Groth16, secret, signer_type).await?,
             )
             .await
         }
@@ -354,7 +370,7 @@ fn record_network_balance(balance: U256, minimum_balance: U256, decimals: u8) ->
     sufficient
 }
 
-async fn run_worker<P>(cli: WorkerArgs, host: OnlineHostConfig, prover: P) -> Result<()>
+async fn run_worker<P>(cli: &WorkerArgs, host: OnlineHostConfig, prover: P) -> Result<()>
 where
     P: WorldSuccinctProver + Send + Sync + 'static,
 {

--- a/proofs/workers/sp1/src/cmd/run.rs
+++ b/proofs/workers/sp1/src/cmd/run.rs
@@ -1,8 +1,10 @@
 use std::{path::PathBuf, sync::Arc, time::Duration};
 
 use alloy_primitives::{Address, B256, U256};
+use alloy_signer_local::PrivateKeySigner;
 use anyhow::{Context, Result, bail};
 use clap::Parser;
+use url::Url;
 use world_chain_chainspec::WorldChainSpec;
 use world_chain_proof_kona_host::online::{
     OnlineHostConfig, build_online_config, hardfork_config_from_chain_spec,
@@ -16,6 +18,7 @@ use world_chain_proof_sp1_host::{
 use world_chain_proof_sp1_worker::{
     ProofWorker, ProofWorkerConfig, RetryConfig, Sp1Backend, Sp1BackendConfig,
 };
+use world_chain_proof_tx_signer::build_transaction_signer;
 use world_chain_proof_worker::WorkerHeartbeatConfig;
 use world_chain_prover_service::RpcProverServiceClient;
 
@@ -234,30 +237,29 @@ pub async fn run(cli: WorkerArgs) -> Result<()> {
             .await
         }
         Sp1ProverKind::Network => {
-            let (secret, signer_type) = match (
-                cli.sp1_private_key.as_ref(),
-                cli.sp1_kms_key_id.as_ref(),
-            ) {
-                (Some(sp1_private_key), None) => (sp1_private_key, SignerType::Local),
-                (None, Some(sp1_aws_kms_id)) => (sp1_aws_kms_id, SignerType::Aws),
-                _ => {
-                    bail!(
-                        "You should provide exactly one between `sp1_private_key` or `sp1_aws_kms_id`"
-                    )
-                }
-            };
-            let l1_rpc_url = cli
-                .sp1_network_l1_rpc_url
-                .clone()
-                .context("SP1_NETWORK_L1_RPC_URL is required when --prover network")?;
+            let l1_rpc_url = Url::parse(
+                &cli.sp1_network_l1_rpc_url
+                    .context("SP1_NETWORK_L1_RPC_URL is required when --prover network")?,
+            )
+            .context("invalid SP1 Network L1 RPC URL")?;
+            let l1_private_key = cli
+                .sp1_private_key
+                .as_deref()
+                .map(str::parse::<PrivateKeySigner>)
+                .transpose()
+                .context("invalid SP1 private key")?;
+            let l1_signer =
+                build_transaction_signer(l1_private_key, cli.sp1_kms_key_id.clone(), &l1_rpc_url)
+                    .await
+                    .context("initializing L1 transaction signer")?;
             let vapp_address = cli
                 .succinct_vapp_address
                 .context("SUCCINCT_VAPP_ADDRESS is required when --prover network")?;
-            let settlement = load_settlement_config(&l1_rpc_url, vapp_address)
+            let settlement = load_settlement_config(l1_rpc_url.as_str(), vapp_address)
                 .await
                 .context("validating Succinct settlement configuration")?;
             let minimum_balance = minimum_network_balance(settlement.min_deposit_amount)?;
-            let credit_client = NetworkCreditClient::new(secret, signer_type).await?;
+            let credit_client = NetworkCreditClient::new(l1_signer);
 
             if !wait_for_sufficient_network_balance(
                 &credit_client,
@@ -273,7 +275,7 @@ pub async fn run(cli: WorkerArgs) -> Result<()> {
             run_worker(
                 &cli,
                 host,
-                NetworkSuccinctProver::new(SP1ProofMode::Groth16, secret, signer_type).await?,
+                NetworkSuccinctProver::new(SP1ProofMode::Groth16, l1_signer).await?,
             )
             .await
         }

--- a/proofs/workers/sp1/src/cmd/run.rs
+++ b/proofs/workers/sp1/src/cmd/run.rs
@@ -3,7 +3,6 @@ use std::{path::PathBuf, sync::Arc, time::Duration};
 use alloy_primitives::{Address, B256, U256};
 use anyhow::{Context, Result, bail};
 use clap::Parser;
-use url::Url;
 use world_chain_chainspec::WorldChainSpec;
 use world_chain_proof_kona_host::online::{
     OnlineHostConfig, build_online_config, hardfork_config_from_chain_spec,

--- a/proofs/workers/sp1/src/cmd/run.rs
+++ b/proofs/workers/sp1/src/cmd/run.rs
@@ -1,7 +1,6 @@
 use std::{path::PathBuf, sync::Arc, time::Duration};
 
 use alloy_primitives::{Address, B256, U256};
-use alloy_signer_local::PrivateKeySigner;
 use anyhow::{Context, Result, bail};
 use clap::Parser;
 use url::Url;
@@ -18,7 +17,6 @@ use world_chain_proof_sp1_host::{
 use world_chain_proof_sp1_worker::{
     ProofWorker, ProofWorkerConfig, RetryConfig, Sp1Backend, Sp1BackendConfig,
 };
-use world_chain_proof_tx_signer::build_transaction_signer;
 use world_chain_proof_worker::WorkerHeartbeatConfig;
 use world_chain_prover_service::RpcProverServiceClient;
 
@@ -238,20 +236,16 @@ pub async fn run(cli: WorkerArgs) -> Result<()> {
         }
         Sp1ProverKind::Network => {
             let l1_rpc_url = Url::parse(
-                &cli.sp1_network_l1_rpc_url
+                cli.sp1_network_l1_rpc_url
+                    .as_deref()
                     .context("SP1_NETWORK_L1_RPC_URL is required when --prover network")?,
             )
             .context("invalid SP1 Network L1 RPC URL")?;
-            let l1_private_key = cli
-                .sp1_private_key
-                .as_deref()
-                .map(str::parse::<PrivateKeySigner>)
-                .transpose()
-                .context("invalid SP1 private key")?;
-            let l1_signer =
-                build_transaction_signer(l1_private_key, cli.sp1_kms_key_id.clone(), &l1_rpc_url)
-                    .await
-                    .context("initializing L1 transaction signer")?;
+            let (network_secret, signer_type) = match (&cli.sp1_private_key, &cli.sp1_kms_key_id) {
+                (Some(private_key), None) => (private_key.as_str(), SignerType::Local),
+                (None, Some(key_id)) => (key_id.as_str(), SignerType::AwsKms),
+                _ => bail!("configure exactly one SP1 private key or AWS KMS key ID"),
+            };
             let vapp_address = cli
                 .succinct_vapp_address
                 .context("SUCCINCT_VAPP_ADDRESS is required when --prover network")?;
@@ -259,7 +253,7 @@ pub async fn run(cli: WorkerArgs) -> Result<()> {
                 .await
                 .context("validating Succinct settlement configuration")?;
             let minimum_balance = minimum_network_balance(settlement.min_deposit_amount)?;
-            let credit_client = NetworkCreditClient::new(l1_signer);
+            let credit_client = NetworkCreditClient::new(network_secret, signer_type).await?;
 
             if !wait_for_sufficient_network_balance(
                 &credit_client,
@@ -275,7 +269,8 @@ pub async fn run(cli: WorkerArgs) -> Result<()> {
             run_worker(
                 &cli,
                 host,
-                NetworkSuccinctProver::new(SP1ProofMode::Groth16, l1_signer).await?,
+                NetworkSuccinctProver::new(SP1ProofMode::Groth16, network_secret, signer_type)
+                    .await?,
             )
             .await
         }

--- a/proofs/workers/sp1/src/cmd/run.rs
+++ b/proofs/workers/sp1/src/cmd/run.rs
@@ -11,7 +11,7 @@ use world_chain_proof_sp1_host::{
     Sp1ProverKind, WorldSuccinctProver,
     cpu_prover::{CpuSuccinctProver, SP1ProofMode},
     mock_prover::MockSuccinctProver,
-    network_prover::{NetworkCreditClient, NetworkSuccinctProver, SignerType},
+    network_prover::{NetworkConnection, NetworkCreditClient, NetworkSuccinctProver, SignerType},
 };
 use world_chain_proof_sp1_worker::{
     ProofWorker, ProofWorkerConfig, RetryConfig, Sp1Backend, Sp1BackendConfig,
@@ -250,7 +250,8 @@ pub async fn run(cli: WorkerArgs) -> Result<()> {
                 .await
                 .context("validating Succinct settlement configuration")?;
             let minimum_balance = minimum_network_balance(settlement.min_deposit_amount)?;
-            let credit_client = NetworkCreditClient::new(network_secret, signer_type).await?;
+            let connection = NetworkConnection::new(network_secret, signer_type).await?;
+            let credit_client = NetworkCreditClient::from_connection(connection.clone());
 
             if !wait_for_sufficient_network_balance(
                 &credit_client,
@@ -266,8 +267,7 @@ pub async fn run(cli: WorkerArgs) -> Result<()> {
             run_worker(
                 &cli,
                 host,
-                NetworkSuccinctProver::new(SP1ProofMode::Groth16, network_secret, signer_type)
-                    .await?,
+                NetworkSuccinctProver::from_connection(SP1ProofMode::Groth16, connection).await?,
             )
             .await
         }

--- a/proofs/workers/sp1/src/cmd/run.rs
+++ b/proofs/workers/sp1/src/cmd/run.rs
@@ -235,12 +235,10 @@ pub async fn run(cli: WorkerArgs) -> Result<()> {
             .await
         }
         Sp1ProverKind::Network => {
-            let l1_rpc_url = Url::parse(
-                cli.sp1_network_l1_rpc_url
-                    .as_deref()
-                    .context("SP1_NETWORK_L1_RPC_URL is required when --prover network")?,
-            )
-            .context("invalid SP1 Network L1 RPC URL")?;
+            let l1_rpc_url = cli
+                .sp1_network_l1_rpc_url
+                .as_ref()
+                .context("SP1_NETWORK_L1_RPC_URL is required when --prover network")?;
             let (network_secret, signer_type) = match (&cli.sp1_private_key, &cli.sp1_kms_key_id) {
                 (Some(private_key), None) => (private_key.as_str(), SignerType::Local),
                 (None, Some(key_id)) => (key_id.as_str(), SignerType::AwsKms),
@@ -249,7 +247,7 @@ pub async fn run(cli: WorkerArgs) -> Result<()> {
             let vapp_address = cli
                 .succinct_vapp_address
                 .context("SUCCINCT_VAPP_ADDRESS is required when --prover network")?;
-            let settlement = load_settlement_config(l1_rpc_url.as_str(), vapp_address)
+            let settlement = load_settlement_config(l1_rpc_url, vapp_address)
                 .await
                 .context("validating Succinct settlement configuration")?;
             let minimum_balance = minimum_network_balance(settlement.min_deposit_amount)?;

--- a/proofs/workers/sp1/src/cmd/run.rs
+++ b/proofs/workers/sp1/src/cmd/run.rs
@@ -11,7 +11,7 @@ use world_chain_proof_sp1_host::{
     Sp1ProverKind, WorldSuccinctProver,
     cpu_prover::{CpuSuccinctProver, SP1ProofMode},
     mock_prover::MockSuccinctProver,
-    network_prover::{NetworkConnection, NetworkCreditClient, NetworkSuccinctProver, SignerType},
+    network_prover::{NetworkConnection, NetworkCreditClient, NetworkSuccinctProver},
 };
 use world_chain_proof_sp1_worker::{
     ProofWorker, ProofWorkerConfig, RetryConfig, Sp1Backend, Sp1BackendConfig,
@@ -19,7 +19,10 @@ use world_chain_proof_sp1_worker::{
 use world_chain_proof_worker::WorkerHeartbeatConfig;
 use world_chain_prover_service::RpcProverServiceClient;
 
-use super::succinct::{format_prove, load_settlement_config, prove_as_f64};
+use super::{
+    select_network_signer,
+    succinct::{format_prove, load_settlement_config, prove_as_f64},
+};
 
 const DEFAULT_SUBMIT_PROOF_RETRY_MAX_RETRIES: usize = 10;
 const DEFAULT_SUBMIT_PROOF_RETRY_INITIAL_DELAY_MS: u64 = 100;
@@ -238,11 +241,10 @@ pub async fn run(cli: WorkerArgs) -> Result<()> {
                 .sp1_network_l1_rpc_url
                 .as_ref()
                 .context("SP1_NETWORK_L1_RPC_URL is required when --prover network")?;
-            let (network_secret, signer_type) = match (&cli.sp1_private_key, &cli.sp1_kms_key_id) {
-                (Some(private_key), None) => (private_key.as_str(), SignerType::Local),
-                (None, Some(key_id)) => (key_id.as_str(), SignerType::AwsKms),
-                _ => bail!("configure exactly one SP1 private key or AWS KMS key ID"),
-            };
+            let (network_secret, signer_type) = select_network_signer(
+                cli.sp1_private_key.as_deref(),
+                cli.sp1_kms_key_id.as_deref(),
+            )?;
             let vapp_address = cli
                 .succinct_vapp_address
                 .context("SUCCINCT_VAPP_ADDRESS is required when --prover network")?;

--- a/proofs/workers/sp1/tests/e2e_proving.rs
+++ b/proofs/workers/sp1/tests/e2e_proving.rs
@@ -37,7 +37,7 @@ use world_chain_proof_sp1_host::{
     Sp1ProverKind, WorldSuccinctProver,
     cpu_prover::{CpuSuccinctProver, SP1ProofMode},
     mock_prover::MockSuccinctProver,
-    network_prover::NetworkSuccinctProver,
+    network_prover::{NetworkSuccinctProver, SignerType},
 };
 use world_chain_proof_sp1_worker::{
     ProofWorker, ProofWorkerConfig, RetryConfig, Sp1Backend, Sp1BackendConfig,
@@ -181,9 +181,10 @@ async fn worker_proves_real_range_end_to_end() {
             let Some(private_key) = required("SP1_PRIVATE_KEY") else {
                 return;
             };
-            let prover = NetworkSuccinctProver::new(SP1ProofMode::Groth16, &private_key)
-                .await
-                .expect("build prover");
+            let prover =
+                NetworkSuccinctProver::new(SP1ProofMode::Groth16, &private_key, SignerType::Local)
+                    .await
+                    .expect("build prover");
             run_worker_proves_real_range_end_to_end_with_prover(
                 host,
                 prover,


### PR DESCRIPTION
- add aws kms support for sp1 proof worker

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how SP1 Network and mainnet PROVE deposit transactions are signed (new KMS path and async permit signing); mistakes could block proving or mis-attribute network credits, though the design mirrors existing KMS usage on other L1 services.
> 
> **Overview**
> Adds **AWS KMS** as an alternative to local private keys for SP1 Network proving and PROVE deposits, aligned with how other proof-system services already sign L1 transactions.
> 
> The SP1 host layer introduces `SignerType` (`Local` / `AwsKms`) and a shared, async `NetworkConnection` that can build the SDK’s `NetworkSigner` from either a key or a KMS key ID. Network credit checks and `NetworkSuccinctProver` are wired through that connection (`from_connection` reuses one init for balance monitoring and proving).
> 
> The SP1 worker **`run`** and **`deposit`** commands accept `SP1_KMS_KEY_ID` (mutually exclusive with `SP1_PRIVATE_KEY` via `select_network_signer`). Deposits sign EIP-2612 permits with sync local signing or async KMS signing and use `world-chain-proof-tx-signer` for L1 txs.
> 
> `build_transaction_wallet` is renamed to **`build_transaction_signer`**, returning a `TransactionSigner` with a `.wallet()` helper; proposer, challenger, and defender call sites are updated accordingly. Existing network paths keep **`SignerType::Local`** where only a private key is supplied.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00dadd67a342d48664ae93ae9845d7e77d554d9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->