### PR TITLE
feat(nitro-proof-worker): add aws kms support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19133,9 +19133,9 @@ name = "world-chain-proof-nitro-enclave"
 version = "2.4.1"
 dependencies = [
  "alloy-contract",
- "alloy-network 2.1.1",
  "alloy-primitives",
  "alloy-provider",
+ "alloy-signer 2.1.1",
  "alloy-signer-local 2.1.1",
  "alloy-sol-types",
  "anyhow",
@@ -19163,6 +19163,7 @@ dependencies = [
  "url",
  "world-chain-proof-core",
  "world-chain-proof-kona-client",
+ "world-chain-proof-tx-signer",
  "x509-parser",
 ]
 

--- a/Justfile
+++ b/Justfile
@@ -642,7 +642,8 @@ proof-verify-pcrs env="alphanet":
 #            it to NitroEnclaveKeyRegistry. Idempotent: a no-op if already registered.
 #            `registerKey` is NOT owner-gated, so any funded key works.
 #
-# Required: L1_RPC_URL, and a funding key via REGISTER_PRIVATE_KEY or PRIVATE_KEY.
+# Required: L1_RPC_URL, and a funding signer via REGISTER_PRIVATE_KEY,
+#           REGISTER_KMS_KEY_ID, or the legacy PRIVATE_KEY fallback.
 # Optional: NITRO_ENCLAVE_KEY_REGISTRY (else read from the {{env}}-nitro.json deployment),
 #           PCR0/PCR1/PCR2 (else host-side attestation checks are skipped; the on-chain
 #           verifier still enforces the approved PCR allowlist).
@@ -666,8 +667,18 @@ proof-register-key env="alphanet":
     fi
     : "${NITRO_ENCLAVE_KEY_REGISTRY:?NITRO_ENCLAVE_KEY_REGISTRY is required (set it or run proof-deploy-nitro first)}"
     : "${L1_RPC_URL:?L1_RPC_URL is required}"
-    REGISTER_KEY="${REGISTER_PRIVATE_KEY:-${PRIVATE_KEY:-}}"
-    : "${REGISTER_KEY:?set REGISTER_PRIVATE_KEY or PRIVATE_KEY (any funded key — registerKey is not owner-gated)}"
+    if [ -n "${REGISTER_PRIVATE_KEY:-}" ] && [ -n "${REGISTER_KMS_KEY_ID:-}" ]; then
+        echo "Error: set exactly one of REGISTER_PRIVATE_KEY or REGISTER_KMS_KEY_ID" >&2
+        exit 1
+    fi
+    REGISTER_KEY="${REGISTER_PRIVATE_KEY:-}"
+    if [ -z "$REGISTER_KEY" ] && [ -z "${REGISTER_KMS_KEY_ID:-}" ]; then
+        REGISTER_KEY="${PRIVATE_KEY:-}"
+    fi
+    if [ -z "$REGISTER_KEY" ] && [ -z "${REGISTER_KMS_KEY_ID:-}" ]; then
+        echo "Error: set REGISTER_PRIVATE_KEY, REGISTER_KMS_KEY_ID, or PRIVATE_KEY (any funded key — registerKey is not owner-gated)" >&2
+        exit 1
+    fi
     NITRO_POD=$(kubectl --context="$KUBECONTEXT" get pod \
         -n "$PROOF_NAMESPACE" \
         -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
@@ -678,7 +689,7 @@ proof-register-key env="alphanet":
     CONTAINER=$(kubectl --context="$KUBECONTEXT" get pod "$NITRO_POD" \
         -n "$PROOF_NAMESPACE" \
         -o jsonpath='{.spec.containers[0].name}')
-    # Check the container is actually Running before we exec (and pipe the funding key) in.
+    # Check the container is actually Running before we exec and pass the signer config in.
     CONTAINER_STATE=$(kubectl --context="$KUBECONTEXT" get pod "$NITRO_POD" \
         -n "$PROOF_NAMESPACE" \
         -o jsonpath="{.status.containerStatuses[?(@.name==\"$CONTAINER\")].state.running}")
@@ -691,7 +702,7 @@ proof-register-key env="alphanet":
         -n "$PROOF_NAMESPACE" "$NITRO_POD" -c "$CONTAINER" \
         -- cat /run/nitro-shared/enclave-cid 2>/dev/null || echo "16")
     echo "Pod: $NITRO_POD  Container: $CONTAINER  CID: $ENCLAVE_CID  Registry: $NITRO_ENCLAVE_KEY_REGISTRY" >&2
-    # Pass everything (including the funding key) over STDIN rather than as `sh -c`
+    # Pass everything (including any local funding key) over STDIN rather than as `sh -c`
     # arguments, so secrets never appear in the container argv / kubectl audit logs, and
     # shell metacharacters in any value can't break out. Each value is single-quoted with
     # embedded single quotes escaped.
@@ -700,7 +711,11 @@ proof-register-key env="alphanet":
         printf 'export ENCLAVE_CID=%s\n' "$(shq "$ENCLAVE_CID")"
         printf 'export NITRO_ENCLAVE_KEY_REGISTRY=%s\n' "$(shq "$NITRO_ENCLAVE_KEY_REGISTRY")"
         printf 'export L1_RPC_URL=%s\n' "$(shq "$L1_RPC_URL")"
-        printf 'export REGISTER_PRIVATE_KEY=%s\n' "$(shq "$REGISTER_KEY")"
+        if [ -n "${REGISTER_KMS_KEY_ID:-}" ]; then
+            printf 'export REGISTER_KMS_KEY_ID=%s\n' "$(shq "$REGISTER_KMS_KEY_ID")"
+        else
+            printf 'export REGISTER_PRIVATE_KEY=%s\n' "$(shq "$REGISTER_KEY")"
+        fi
         if [ -n "${PCR0:-}" ]; then printf 'export PCR0=%s\n' "$(shq "$PCR0")"; fi
         if [ -n "${PCR1:-}" ]; then printf 'export PCR1=%s\n' "$(shq "$PCR1")"; fi
         if [ -n "${PCR2:-}" ]; then printf 'export PCR2=%s\n' "$(shq "$PCR2")"; fi

--- a/Justfile
+++ b/Justfile
@@ -711,6 +711,10 @@ proof-register-key env="alphanet":
         printf 'export ENCLAVE_CID=%s\n' "$(shq "$ENCLAVE_CID")"
         printf 'export NITRO_ENCLAVE_KEY_REGISTRY=%s\n' "$(shq "$NITRO_ENCLAVE_KEY_REGISTRY")"
         printf 'export L1_RPC_URL=%s\n' "$(shq "$L1_RPC_URL")"
+        # `kubectl exec` inherits the container environment. Clear both dedicated signer
+        # variables before setting the selected one so an auto-register configuration on
+        # the Deployment cannot make this one-shot command see two signer sources.
+        printf 'unset REGISTER_PRIVATE_KEY REGISTER_KMS_KEY_ID\n'
         if [ -n "${REGISTER_KMS_KEY_ID:-}" ]; then
             printf 'export REGISTER_KMS_KEY_ID=%s\n' "$(shq "$REGISTER_KMS_KEY_ID")"
         else

--- a/docs/proof/nitro-worker.md
+++ b/docs/proof/nitro-worker.md
@@ -529,6 +529,11 @@ The operator calls `NitroEnclaveKeyRegistry.registerKey(attestationTbs, signatur
 - Derives its Ethereum signer address as `keccak256(publicKey[1:65])[12:]`
 - Signer state transitions from `Unknown` → `Active`
 
+The host-side funding account that submits this transaction can use either a local private key
+(`REGISTER_PRIVATE_KEY`, with `PRIVATE_KEY` as a legacy fallback) or an AWS KMS key
+(`REGISTER_KMS_KEY_ID`). This is only transaction signing by the host worker; it is separate from
+the proposed KMS-based persistence of the enclave's ephemeral proof-signing key.
+
 ### 6. Prove
 
 The enclave can now produce range proofs whose secp256k1 signatures will be accepted

--- a/docs/proof/proof-cli.md
+++ b/docs/proof/proof-cli.md
@@ -499,14 +499,16 @@ in-pod invocation.
 world-chain-prover-nitro register \
   --registry <NitroEnclaveKeyRegistry address> \
   --l1-rpc <L1 RPC URL> \
-  [--private-key <hex>] [--cid <N>] [--port <N>] [--pcr0/1/2 <HEX>]
+  [--private-key <hex> | --kms-key-id <ID>] \
+  [--cid <N>] [--port <N>] [--pcr0/1/2 <HEX>]
 ```
 
 | Flag | Env | Default | Description |
 |---|---|---|---|
 | `--registry <ADDR>` | `NITRO_ENCLAVE_KEY_REGISTRY` | required | `NitroEnclaveKeyRegistry` address on L1 |
 | `--l1-rpc <URL>` | `L1_RPC_URL` | required | L1 execution RPC to submit `registerKey` to |
-| `--private-key <HEX>` | `REGISTER_PRIVATE_KEY` | falls back to `PRIVATE_KEY` | Funding key for the tx (not owner-gated) |
+| `--private-key <HEX>` | `REGISTER_PRIVATE_KEY` | falls back to `PRIVATE_KEY` | Local funding key for the tx (not owner-gated) |
+| `--kms-key-id <ID>` | `REGISTER_KMS_KEY_ID` | — | AWS KMS key ID or alias for the funding account |
 | `--cid <N>` | `ENCLAVE_CID` | `16` | vsock CID of the Nitro enclave |
 | `--port <N>` | `ENCLAVE_PORT` | `5005` | vsock port the enclave listens on |
 | `--pcr0/1/2 <HEX>` | `PCR0`/`PCR1`/`PCR2` | — | Optional; when all three are set the attestation is verified host-side before submission |
@@ -520,6 +522,16 @@ world-chain-prover-nitro register \
   --private-key $REGISTER_PRIVATE_KEY
 # enclave key registered on-chain (tx 0x...)
 ```
+
+For AWS KMS, set `REGISTER_KMS_KEY_ID` instead of `REGISTER_PRIVATE_KEY`; the standard AWS
+SDK credential and region providers are used. The KMS key must be an asymmetric
+`ECC_SECG_P256K1` signing key, and the worker's AWS identity needs `kms:GetPublicKey` and
+`kms:Sign`. Configure exactly one dedicated signer. The legacy `PRIVATE_KEY` fallback is
+consulted only when neither dedicated signer is set, so a KMS key ID can be used in environments
+that still define `PRIVATE_KEY` for unrelated tooling.
+
+The worker exposes the same choice through `nitro-worker register --kms-key-id` and through
+`nitro-worker run --auto-register --register-kms-key-id`.
 
 ---
 

--- a/proofs/backends/nitro/enclave/Cargo.toml
+++ b/proofs/backends/nitro/enclave/Cargo.toml
@@ -31,11 +31,12 @@ enclave = [
     "dep:tracing-subscriber",
     "dep:world-chain-proof-kona-client",
     # On-chain registration (register::submit) — host-side L1 client.
-    "dep:alloy-network",
     "dep:alloy-contract",
     "dep:alloy-provider",
+    "dep:alloy-signer",
     "dep:alloy-signer-local",
     "dep:url",
+    "dep:world-chain-proof-tx-signer",
 ]
 
 [dependencies]
@@ -85,14 +86,15 @@ world-chain-proof-kona-client = { workspace = true, optional = true }
 # On-chain registration (register module `submit` flow). Only used on Linux with the
 # `enclave` feature; optional + kept in the target table so non-Linux / non-enclave builds
 # don't pull them in.
-alloy-network = { workspace = true, optional = true }
 alloy-contract = { workspace = true, optional = true }
 alloy-provider = { workspace = true, features = [
     "reqwest",
     "reqwest-rustls-tls",
 ], optional = true }
+alloy-signer = { workspace = true, optional = true }
 alloy-signer-local = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
+world-chain-proof-tx-signer = { workspace = true, optional = true }
 
 # Feature-gated bin support -------------------------------------------------
 tracing-subscriber = { workspace = true, optional = true }

--- a/proofs/backends/nitro/enclave/src/register.rs
+++ b/proofs/backends/nitro/enclave/src/register.rs
@@ -19,21 +19,23 @@
 
 use std::time::Duration;
 
-use alloy_network::EthereumWallet;
 use alloy_primitives::{Address, Bytes, TxHash, keccak256};
 use alloy_provider::{Provider, ProviderBuilder};
+use alloy_signer::Signer;
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::sol;
 use anyhow::{Context, Result, anyhow, bail};
 use sha2::{Digest, Sha384};
 use tracing::{info, warn};
 use url::Url;
+use world_chain_proof_tx_signer::{TransactionSigner, build_transaction_signer};
 
 use crate::prewarm::{ColdCert, build_prewarm_plan, packed_cert_not_after};
 
 /// Max attempts for the `registerKey` submission. Retries let the flow survive transient
 /// RPC errors and funding-account nonce contention when several worker replicas share the
-/// same `REGISTER_PRIVATE_KEY`/`PRIVATE_KEY` and self-register simultaneously.
+/// same `REGISTER_PRIVATE_KEY`, `REGISTER_KMS_KEY_ID`, or `PRIVATE_KEY` and self-register
+/// simultaneously.
 const REGISTER_MAX_ATTEMPTS: u32 = 5;
 /// Base backoff between `registerKey` attempts (scaled by the attempt number).
 const REGISTER_RETRY_BASE_DELAY: Duration = Duration::from_secs(2);
@@ -312,9 +314,20 @@ pub struct RegisterParams {
     pub l1_rpc_url: String,
     /// `NitroEnclaveKeyRegistry` contract address on L1 (hex, `0x`-prefixed).
     pub registry: String,
-    /// Hex-encoded private key used to sign (and pay gas for) the `registerKey` tx.
-    /// `registerKey` is **not** owner-gated, so any funded key works.
-    pub private_key: String,
+    /// Local private key or AWS KMS key ID used to sign (and pay gas for) the
+    /// `registerKey` tx. `registerKey` is **not** owner-gated, so any funded key works.
+    pub signer_secret: String,
+    /// Registration transaction signer implementation.
+    pub signer_type: SignerType,
+}
+
+/// Signer type used to submit enclave registration transactions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SignerType {
+    /// Hex-encoded local secp256k1 private key.
+    Local,
+    /// AWS KMS key ID or alias.
+    AwsKms,
 }
 
 /// Result of a registration attempt.
@@ -351,7 +364,11 @@ pub async fn register_enclave_key(params: RegisterParams) -> Result<Registration
     //    precise error instead of a generic "invalid address/URL/key".
     let l1_rpc_url = non_empty(&params.l1_rpc_url, "L1 RPC URL")?;
     let registry = non_empty(&params.registry, "NitroEnclaveKeyRegistry address")?;
-    let private_key = non_empty(&params.private_key, "registration private key")?;
+    let signer_field = match params.signer_type {
+        SignerType::Local => "registration private key",
+        SignerType::AwsKms => "registration AWS KMS key ID",
+    };
+    let signer_secret = non_empty(&params.signer_secret, signer_field)?;
 
     // 1. Fetch a public-key-embedding attestation from the running enclave.
     let endpoint = EnclaveEndpoint::with_port(params.enclave_cid, params.enclave_port);
@@ -376,12 +393,24 @@ pub async fn register_enclave_key(params: RegisterParams) -> Result<Registration
     let registry_address: Address = registry
         .parse()
         .context("invalid NitroEnclaveKeyRegistry address")?;
-    let signer: PrivateKeySigner = private_key
-        .parse()
-        .context("invalid registration private key")?;
-    let signer_address = signer.address();
+    let signer = match params.signer_type {
+        SignerType::Local => {
+            let private_key = signer_secret
+                .parse::<PrivateKeySigner>()
+                .context("invalid registration private key")?;
+            build_transaction_signer(Some(private_key), None, &url).await
+        }
+        SignerType::AwsKms => {
+            build_transaction_signer(None, Some(signer_secret.to_owned()), &url).await
+        }
+    }
+    .context("initializing registration transaction signer")?;
+    let signer_address = match &signer {
+        TransactionSigner::Local(signer) => signer.address(),
+        TransactionSigner::Aws(signer) => signer.address(),
+    };
     let provider = ProviderBuilder::new()
-        .wallet(EthereumWallet::from(signer))
+        .wallet(signer.wallet())
         .connect_http(url);
     let registry = NitroEnclaveKeyRegistry::new(registry_address, provider.clone());
 
@@ -420,9 +449,9 @@ pub async fn register_enclave_key(params: RegisterParams) -> Result<Registration
 
     // 4-6. Submit registerKey with bounded retries. Each enclave registers its OWN distinct
     //      signer, so retries exist to survive transient RPC failures and funding-account
-    //      nonce contention when several worker replicas share REGISTER_PRIVATE_KEY and
-    //      register at the same time. Every attempt first re-checks isSignerRegistered so we
-    //      never resubmit once the signer is Active (by us or a peer).
+    //      nonce contention when several worker replicas share REGISTER_PRIVATE_KEY or
+    //      REGISTER_KMS_KEY_ID and register at the same time. Every attempt first re-checks
+    //      isSignerRegistered so we never resubmit once the signer is Active (by us or a peer).
     let calldata = build_registration_calldata(&attestation_doc)?;
     let mut last_err: Option<anyhow::Error> = None;
 

--- a/proofs/debug/bin/prover-nitro/src/main.rs
+++ b/proofs/debug/bin/prover-nitro/src/main.rs
@@ -65,10 +65,15 @@ struct RegisterArgs {
     l1_rpc: String,
 
     /// Hex-encoded private key used to sign and pay for the `registerKey` transaction.
-    /// Falls back to `PRIVATE_KEY` when `--private-key` / `REGISTER_PRIVATE_KEY` is unset.
-    /// `registerKey` is not owner-gated, so any funded key works.
+    /// Falls back to `PRIVATE_KEY` when neither registration signer is set. `registerKey`
+    /// is not owner-gated, so any funded key works.
     #[arg(long, env = "REGISTER_PRIVATE_KEY", hide_env_values = true)]
     private_key: Option<String>,
+
+    /// AWS KMS key ID or alias used to sign and pay for the `registerKey` transaction.
+    /// Mutually exclusive with `private_key`.
+    #[arg(long, env = "REGISTER_KMS_KEY_ID", hide_env_values = true)]
+    kms_key_id: Option<String>,
 
     /// PCR0 hex (48 bytes). Optional: when all three PCRs are set the attestation is
     /// verified host-side before submission; otherwise host-side checks are skipped (the
@@ -265,7 +270,7 @@ fn hex_to_pcr(hex: &str) -> Result<[u8; 48]> {
 async fn register(args: RegisterArgs) -> Result<()> {
     use world_chain_proof_nitro_enclave::{
         ExpectedPcrs,
-        register::{RegisterParams, RegistrationOutcome, register_enclave_key},
+        register::{RegisterParams, RegistrationOutcome, SignerType, register_enclave_key},
     };
 
     // Initialise logging so the registration flow's progress logs are visible. `info` by
@@ -293,8 +298,26 @@ async fn register(args: RegisterArgs) -> Result<()> {
 
     let private_key = args
         .private_key
-        .or_else(|| std::env::var("PRIVATE_KEY").ok())
-        .context("no registration key: set --private-key, REGISTER_PRIVATE_KEY, or PRIVATE_KEY")?;
+        .as_deref()
+        .filter(|value| !value.trim().is_empty());
+    let kms_key_id = args
+        .kms_key_id
+        .as_deref()
+        .filter(|value| !value.trim().is_empty());
+    let fallback_private_key = std::env::var("PRIVATE_KEY").ok();
+    let fallback_private_key = fallback_private_key
+        .as_deref()
+        .filter(|value| !value.trim().is_empty());
+    let private_key = if private_key.is_none() && kms_key_id.is_none() {
+        fallback_private_key
+    } else {
+        private_key
+    };
+    let (signer_secret, signer_type) = match (private_key, kms_key_id) {
+        (Some(private_key), None) => (private_key, SignerType::Local),
+        (None, Some(key_id)) => (key_id, SignerType::AwsKms),
+        _ => bail!("configure exactly one registration private key or AWS KMS key ID"),
+    };
 
     let outcome = register_enclave_key(RegisterParams {
         enclave_cid: args.cid,
@@ -302,7 +325,8 @@ async fn register(args: RegisterArgs) -> Result<()> {
         expected_pcrs,
         l1_rpc_url: args.l1_rpc,
         registry: args.registry,
-        private_key,
+        signer_secret: signer_secret.to_owned(),
+        signer_type,
     })
     .await?;
 

--- a/proofs/workers/nitro/src/cmd/mod.rs
+++ b/proofs/workers/nitro/src/cmd/mod.rs
@@ -1,4 +1,74 @@
+use anyhow::{Result, bail};
+use world_chain_proof_nitro_enclave::register::SignerType;
+
 pub mod common;
 pub mod get_attestation;
 pub mod register;
 pub mod run;
+
+fn select_registration_signer<'a>(
+    private_key: Option<&'a str>,
+    kms_key_id: Option<&'a str>,
+    fallback_private_key: Option<&'a str>,
+) -> Result<(&'a str, SignerType)> {
+    let private_key = private_key.filter(|value| !value.trim().is_empty());
+    let kms_key_id = kms_key_id.filter(|value| !value.trim().is_empty());
+    let fallback_private_key = fallback_private_key.filter(|value| !value.trim().is_empty());
+
+    // PRIVATE_KEY is a backwards-compatible fallback, not a second explicitly configured
+    // signer. A dedicated KMS key ID must therefore take precedence over it.
+    let private_key = if private_key.is_none() && kms_key_id.is_none() {
+        fallback_private_key
+    } else {
+        private_key
+    };
+
+    match (private_key, kms_key_id) {
+        (Some(private_key), None) => Ok((private_key, SignerType::Local)),
+        (None, Some(key_id)) => Ok((key_id, SignerType::AwsKms)),
+        _ => bail!("configure exactly one registration private key or AWS KMS key ID"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blank_private_key_does_not_mask_kms_key() {
+        let (secret, signer_type) =
+            select_registration_signer(Some("  "), Some("alias/register"), None).unwrap();
+
+        assert_eq!(secret, "alias/register");
+        assert_eq!(signer_type, SignerType::AwsKms);
+    }
+
+    #[test]
+    fn blank_kms_key_does_not_mask_private_key() {
+        let (secret, signer_type) =
+            select_registration_signer(Some("0x1234"), Some("\t"), None).unwrap();
+
+        assert_eq!(secret, "0x1234");
+        assert_eq!(signer_type, SignerType::Local);
+    }
+
+    #[test]
+    fn falls_back_to_private_key_only_when_no_dedicated_signer_is_set() {
+        let (secret, signer_type) =
+            select_registration_signer(None, None, Some("0xfallback")).unwrap();
+        assert_eq!(secret, "0xfallback");
+        assert_eq!(signer_type, SignerType::Local);
+
+        let (secret, signer_type) =
+            select_registration_signer(None, Some("alias/register"), Some("0xfallback")).unwrap();
+        assert_eq!(secret, "alias/register");
+        assert_eq!(signer_type, SignerType::AwsKms);
+    }
+
+    #[test]
+    fn rejects_missing_or_multiple_signers() {
+        assert!(select_registration_signer(None, None, None).is_err());
+        assert!(select_registration_signer(Some(" "), Some("\n"), Some("\t")).is_err());
+        assert!(select_registration_signer(Some("0x1234"), Some("alias/register"), None).is_err());
+    }
+}

--- a/proofs/workers/nitro/src/cmd/register.rs
+++ b/proofs/workers/nitro/src/cmd/register.rs
@@ -1,12 +1,12 @@
 #![cfg(target_os = "linux")]
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use world_chain_proof_nitro_enclave::register::{
     RegisterParams, RegistrationOutcome, register_enclave_key,
 };
 use world_chain_proof_nitro_worker::build_expected_pcrs;
 
-use crate::cmd::common::CommonArgs;
+use crate::cmd::{common::CommonArgs, select_registration_signer};
 
 /// Register the enclave's generated signing key on-chain.
 ///
@@ -31,9 +31,14 @@ pub struct RegisterArgs {
     pub l1_rpc: String,
 
     /// Hex-encoded private key used to sign and pay for the `registerKey` transaction.
-    /// Falls back to `PRIVATE_KEY` when unset.
+    /// Falls back to `PRIVATE_KEY` when neither registration signer is set.
     #[arg(long, env = "REGISTER_PRIVATE_KEY", hide_env_values = true)]
     pub private_key: Option<String>,
+
+    /// AWS KMS key ID or alias used to sign and pay for the `registerKey` transaction.
+    /// Mutually exclusive with `private_key`.
+    #[arg(long, env = "REGISTER_KMS_KEY_ID", hide_env_values = true)]
+    pub kms_key_id: Option<String>,
 
     /// PCR0 hex (48 bytes). When all three PCRs are set the attestation is verified
     /// host-side before submission; otherwise host-side checks are skipped (the on-chain
@@ -57,10 +62,12 @@ pub async fn register(args: RegisterArgs) -> Result<()> {
         args.pcr2.as_deref(),
     )?;
 
-    let private_key = args
-        .private_key
-        .or_else(|| std::env::var("PRIVATE_KEY").ok())
-        .context("no registration key: set --private-key, REGISTER_PRIVATE_KEY, or PRIVATE_KEY")?;
+    let fallback_private_key = std::env::var("PRIVATE_KEY").ok();
+    let (signer_secret, signer_type) = select_registration_signer(
+        args.private_key.as_deref(),
+        args.kms_key_id.as_deref(),
+        fallback_private_key.as_deref(),
+    )?;
 
     let outcome = register_enclave_key(RegisterParams {
         enclave_cid: args.common.enclave_cid,
@@ -68,7 +75,8 @@ pub async fn register(args: RegisterArgs) -> Result<()> {
         expected_pcrs,
         l1_rpc_url: args.l1_rpc,
         registry: args.registry,
-        private_key,
+        signer_secret: signer_secret.to_owned(),
+        signer_type,
     })
     .await?;
 

--- a/proofs/workers/nitro/src/cmd/run.rs
+++ b/proofs/workers/nitro/src/cmd/run.rs
@@ -18,6 +18,8 @@ use world_chain_proof_worker::{
 };
 use world_chain_prover_service::RpcProverServiceClient;
 
+use super::select_registration_signer;
+
 const DEFAULT_SUBMIT_PROOF_RETRY_MAX_RETRIES: usize = 10;
 const DEFAULT_SUBMIT_PROOF_RETRY_INITIAL_DELAY_MS: u64 = 100;
 const DEFAULT_SUBMIT_PROOF_RETRY_MAX_DELAY_MS: u64 = 10_000;
@@ -251,10 +253,15 @@ pub struct WorkerArgs {
     registry: Option<String>,
 
     /// Hex-encoded private key used to sign and pay for the `registerKey` transaction when
-    /// `--auto-register` is set. Falls back to `PRIVATE_KEY` when unset. `registerKey` is
-    /// not owner-gated, so any funded key works.
+    /// `--auto-register` is set. Falls back to `PRIVATE_KEY` when neither registration signer
+    /// is set. `registerKey` is not owner-gated, so any funded key works.
     #[arg(long, env = "REGISTER_PRIVATE_KEY", hide_env_values = true)]
     register_private_key: Option<String>,
+
+    /// AWS KMS key ID or alias used to sign and pay for the `registerKey` transaction when
+    /// `--auto-register` is set. Mutually exclusive with `register_private_key`.
+    #[arg(long, env = "REGISTER_KMS_KEY_ID", hide_env_values = true)]
+    register_kms_key_id: Option<String>,
 }
 
 pub async fn run(args: WorkerArgs) -> Result<()> {
@@ -288,14 +295,15 @@ pub async fn run(args: WorkerArgs) -> Result<()> {
             .context("--auto-register requires --registry / NITRO_ENCLAVE_KEY_REGISTRY")?;
         // Registration reuses the same L1 endpoint as witness building (`--l1-rpc`).
         let l1_rpc_url = args.l1_rpc.clone();
-        let private_key = args
-            .register_private_key
-            .clone()
-            .or_else(|| std::env::var("PRIVATE_KEY").ok())
-            .context(
-                "--auto-register requires a key: set --register-private-key, \
-                 REGISTER_PRIVATE_KEY, or PRIVATE_KEY",
-            )?;
+        let fallback_private_key = std::env::var("PRIVATE_KEY").ok();
+        let (signer_secret, signer_type) = select_registration_signer(
+            args.register_private_key.as_deref(),
+            args.register_kms_key_id.as_deref(),
+            fallback_private_key.as_deref(),
+        )
+        .context(
+            "--auto-register requires REGISTER_PRIVATE_KEY, REGISTER_KMS_KEY_ID, or PRIVATE_KEY",
+        )?;
 
         // Publish the gauge before the first attempt so "never registered" is a visible zero
         // rather than an absent series a threshold monitor would silently ignore.
@@ -312,7 +320,8 @@ pub async fn run(args: WorkerArgs) -> Result<()> {
             expected_pcrs,
             l1_rpc_url,
             registry,
-            private_key,
+            signer_secret: signer_secret.to_owned(),
+            signer_type,
         })
         .await;
         if !registered {


### PR DESCRIPTION
- add aws kms support to `nitro-proof-worker`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how L1 registration transactions are signed in production (KMS IAM and key configuration); mistakes could block registration or use the wrong funding account, but it does not alter on-chain attestation or enclave proof-signing logic.
> 
> **Overview**
> Adds **AWS KMS** as an alternative to a local hex key for the **host** account that pays gas and signs `NitroEnclaveKeyRegistry.registerKey` (unchanged on-chain semantics; still separate from enclave proof-signing keys).
> 
> Registration flows now take `signer_secret` plus `SignerType` (`Local` or `AwsKms`) and build the L1 wallet via `world_chain_proof_tx_signer::build_transaction_signer`, replacing the previous local-only `PrivateKeySigner` path in `register_enclave_key`.
> 
> **CLI and ops:** `world-chain-prover-nitro register`, `nitro-worker register`, and `nitro-worker run --auto-register` accept `--kms-key-id` / `REGISTER_KMS_KEY_ID`, mutually exclusive with `REGISTER_PRIVATE_KEY`. `PRIVATE_KEY` remains a fallback only when neither dedicated registration signer is set (so KMS can win over a leftover `PRIVATE_KEY`). `just proof-register-key` mirrors this and unsets both signer env vars inside `kubectl exec` so Deployment auto-register config cannot leak a second signer.
> 
> Docs describe the KMS key type (`ECC_SECG_P256K1`) and required IAM actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d3f62a372836b7154a499ed9eb6d2f85004ac9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->