### PR TITLE
fix(proofs): time out pending transaction receipts

### DIFF
--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -2684,9 +2684,14 @@ async fn start_world_chain_proposer(
         .connect_http(Url::parse(l1_rpc_url)?);
 
     let required_confirmations = 1;
-    let contracts = AlloyProofSystemClient::new(provider, factory_address, required_confirmations)
-        .await
-        .wrap_err("failed to bind the World Chain proof system")?;
+    let contracts = AlloyProofSystemClient::new(
+        provider,
+        factory_address,
+        required_confirmations,
+        Duration::from_secs(world_chain_proof_protocol::DEFAULT_L1_TX_RECEIPT_TIMEOUT_SECONDS),
+    )
+    .await
+    .wrap_err("failed to bind the World Chain proof system")?;
     let mut bond_manager = BondManager::new(
         BondManagerConfig {
             poll_interval: WORLD_PROPOSER_POLL_INTERVAL,
@@ -2761,7 +2766,12 @@ async fn start_world_chain_challenger(
         .wallet(EthereumWallet::from(signer))
         .connect_http(Url::parse(l1_rpc_url)?);
 
-    let client = AlloyChallengerClient::new(provider, factory_address, DEFAULT_L1_TX_CONFIRMATIONS);
+    let client = AlloyChallengerClient::new(
+        provider,
+        factory_address,
+        DEFAULT_L1_TX_CONFIRMATIONS,
+        Duration::from_secs(world_chain_proof_protocol::DEFAULT_L1_TX_RECEIPT_TIMEOUT_SECONDS),
+    );
     let output_roots = OptimismConsensusClient::new(output_root_rpc_url.to_string());
     let config = ChallengerConfig {
         poll_interval: WORLD_CHALLENGER_POLL_INTERVAL,
@@ -2855,6 +2865,7 @@ async fn start_world_chain_defender(
         provider,
         factory_address,
         DEFAULT_DEFENDER_L1_TX_CONFIRMATIONS,
+        Duration::from_secs(world_chain_proof_protocol::DEFAULT_L1_TX_RECEIPT_TIMEOUT_SECONDS),
         defender_address,
     )
     .await

--- a/proofs/protocol/src/lib.rs
+++ b/proofs/protocol/src/lib.rs
@@ -4,6 +4,9 @@
 //! codebase needs directly: proof-domain hashing, root commitments, lane
 //! bitmaps, and lightweight ABI bindings for the local proof contracts.
 
+/// Default timeout for confirming an L1 transaction receipt.
+pub const DEFAULT_L1_TX_RECEIPT_TIMEOUT_SECONDS: u64 = 5 * 60;
+
 mod bindings;
 mod consensus_provider;
 mod lineage;

--- a/proofs/services/challenger/src/alloy.rs
+++ b/proofs/services/challenger/src/alloy.rs
@@ -11,6 +11,7 @@ use alloy_primitives::{Address, U256};
 use alloy_provider::{Provider, WalletProvider};
 use alloy_rpc_types_eth::BlockId;
 use async_trait::async_trait;
+use std::time::Duration;
 use world_chain_proof_protocol::{
     IAnchorStateRegistry, IDelayedWETH, IDisputeGameFactory, IMultiProofGame,
     MULTI_PROOF_GAME_TYPE, ProposalStatus, ResolutionStatus,
@@ -24,6 +25,7 @@ use world_chain_proof_protocol::{
 pub struct AlloyChallengerClient<P> {
     factory: IDisputeGameFactory::IDisputeGameFactoryInstance<P>,
     confirmations: u64,
+    receipt_timeout: Duration,
     provider: P,
 }
 
@@ -32,7 +34,12 @@ where
     P: Provider + Clone,
 {
     /// Creates an Alloy-backed contract client.
-    pub fn new(provider: P, factory_address: Address, confirmations: u64) -> Self {
+    pub fn new(
+        provider: P,
+        factory_address: Address,
+        confirmations: u64,
+        receipt_timeout: Duration,
+    ) -> Self {
         let factory = IDisputeGameFactory::IDisputeGameFactoryInstance::new(
             factory_address,
             provider.clone(),
@@ -41,6 +48,7 @@ where
         Self {
             factory,
             confirmations,
+            receipt_timeout,
             provider,
         }
     }
@@ -169,6 +177,7 @@ where
         let tx_hash = *pending.tx_hash();
         let receipt = pending
             .with_required_confirmations(self.confirmations)
+            .with_timeout(Some(self.receipt_timeout))
             .get_receipt()
             .await?;
         world_chain_proof_metrics::refresh_wallet_balance(&self.provider, receipt.from).await;
@@ -197,6 +206,7 @@ where
         let tx_hash = *pending.tx_hash();
         let receipt = pending
             .with_required_confirmations(self.confirmations)
+            .with_timeout(Some(self.receipt_timeout))
             .get_receipt()
             .await?;
         world_chain_proof_metrics::refresh_wallet_balance(&self.provider, receipt.from).await;
@@ -273,6 +283,7 @@ where
         let tx_hash = *pending_tx.tx_hash();
         let receipt = pending_tx
             .with_required_confirmations(self.confirmations)
+            .with_timeout(Some(self.receipt_timeout))
             .get_receipt()
             .await?;
         world_chain_proof_metrics::refresh_wallet_balance(&self.provider, receipt.from).await;

--- a/proofs/services/challenger/src/main.rs
+++ b/proofs/services/challenger/src/main.rs
@@ -85,6 +85,15 @@ struct Cli {
     )]
     l1_tx_confirmations: u64,
 
+    /// Maximum seconds to wait for an L1 transaction receipt and required confirmations.
+    #[arg(
+        long,
+        env = "L1_TX_RECEIPT_TIMEOUT_SECONDS",
+        default_value_t = world_chain_proof_protocol::DEFAULT_L1_TX_RECEIPT_TIMEOUT_SECONDS,
+        value_parser = clap::value_parser!(u64).range(1..)
+    )]
+    l1_tx_receipt_timeout_seconds: u64,
+
     /// Seconds between challenger-owned game resolution passes.
     #[arg(
         long,
@@ -146,7 +155,12 @@ async fn main() -> Result<()> {
         .connect_client(l1_rpc_client);
     world_chain_proof_metrics::refresh_wallet_balance(&provider, challenger_address).await;
 
-    let client = AlloyChallengerClient::new(provider, cli.factory_address, cli.l1_tx_confirmations);
+    let client = AlloyChallengerClient::new(
+        provider,
+        cli.factory_address,
+        cli.l1_tx_confirmations,
+        Duration::from_secs(cli.l1_tx_receipt_timeout_seconds),
+    );
 
     // Preflight the factory index before entering the scan loop. Crash instead of reporting the
     // process alive while every scan tick fails.
@@ -202,6 +216,7 @@ async fn main() -> Result<()> {
         max_games_per_tick = cli.max_games_per_tick,
         game_scan_lookback = cli.game_scan_lookback,
         l1_tx_confirmations = cli.l1_tx_confirmations,
+        l1_tx_receipt_timeout_seconds = cli.l1_tx_receipt_timeout_seconds,
         resolution_manager_poll_interval_seconds =
             cli.resolution_manager_poll_interval_seconds,
         max_resolutions_per_tick = cli.max_resolutions_per_tick,

--- a/proofs/services/defender/src/alloy.rs
+++ b/proofs/services/defender/src/alloy.rs
@@ -7,6 +7,7 @@ use alloy_primitives::{Address, Bytes, U256};
 use alloy_provider::Provider;
 use alloy_sol_types::SolInterface;
 use async_trait::async_trait;
+use std::time::Duration;
 use world_chain_proof_protocol::{
     ClaimData, IAnchorStateRegistry, IDisputeGameFactory, IMultiProofGame, LineageAnchor,
     LineageError, LineageGame, LineageProvider, LineageTransition, PROOF_LANE_COUNT, ProofLane,
@@ -24,6 +25,7 @@ pub struct AlloyDefenderClient<P> {
     anchor: IAnchorStateRegistry::IAnchorStateRegistryInstance<P>,
     registered: RegisteredLineageConfig,
     confirmations: u64,
+    receipt_timeout: Duration,
     /// Credited this lane's share of a forfeited challenger bond when the game resolves.
     reward_recipient: Address,
     provider: P,
@@ -38,6 +40,7 @@ where
         provider: P,
         factory_address: Address,
         confirmations: u64,
+        receipt_timeout: Duration,
         reward_recipient: Address,
     ) -> Result<Self, DefenderError> {
         let factory = IDisputeGameFactory::IDisputeGameFactoryInstance::new(
@@ -55,6 +58,7 @@ where
             anchor,
             registered,
             confirmations,
+            receipt_timeout,
             reward_recipient,
             provider,
         })
@@ -187,6 +191,7 @@ where
         let tx_hash = *pending.tx_hash();
         let receipt = pending
             .with_required_confirmations(self.confirmations)
+            .with_timeout(Some(self.receipt_timeout))
             .get_receipt()
             .await?;
         world_chain_proof_metrics::refresh_wallet_balance(&self.provider, receipt.from).await;

--- a/proofs/services/defender/src/main.rs
+++ b/proofs/services/defender/src/main.rs
@@ -81,6 +81,15 @@ struct Cli {
     )]
     l1_tx_confirmations: u64,
 
+    /// Maximum seconds to wait for an L1 transaction receipt and required confirmations.
+    #[arg(
+        long,
+        env = "L1_TX_RECEIPT_TIMEOUT_SECONDS",
+        default_value_t = world_chain_proof_protocol::DEFAULT_L1_TX_RECEIPT_TIMEOUT_SECONDS,
+        value_parser = clap::value_parser!(u64).range(1..)
+    )]
+    l1_tx_receipt_timeout_seconds: u64,
+
     /// Per-request timeout applied to every L1 RPC call, in seconds.
     #[arg(
         long,
@@ -122,6 +131,7 @@ async fn main() -> Result<()> {
         provider,
         cli.factory_address,
         cli.l1_tx_confirmations,
+        Duration::from_secs(cli.l1_tx_receipt_timeout_seconds),
         reward_recipient,
     )
     .await
@@ -149,6 +159,7 @@ async fn main() -> Result<()> {
         defender = %defender_address,
         reward_recipient = %reward_recipient,
         l1_tx_confirmations = cli.l1_tx_confirmations,
+        l1_tx_receipt_timeout_seconds = cli.l1_tx_receipt_timeout_seconds,
         l1_rpc_timeout_seconds = cli.l1_rpc_timeout_seconds,
         "starting World Chain proof-system defender"
     );

--- a/proofs/services/proposer/src/alloy.rs
+++ b/proofs/services/proposer/src/alloy.rs
@@ -3,6 +3,7 @@ use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{Address, U256};
 use alloy_provider::{Provider, WalletProvider};
 use async_trait::async_trait;
+use std::time::Duration;
 use world_chain_proof_protocol::{
     IAnchorStateRegistry, IDelayedWETH, IDisputeGameFactory, IMultiProofGame, LineageAnchor,
     LineageError, LineageGame, LineageProvider, LineageTransition, MULTI_PROOF_GAME_TYPE,
@@ -27,6 +28,7 @@ pub struct AlloyProofSystemClient<P> {
     registered: RegisteredLineageConfig,
     /// Number of confirmations to require after sending a tx onchain.
     confirmations: u64,
+    receipt_timeout: Duration,
     provider: P,
 }
 
@@ -43,6 +45,7 @@ where
         provider: P,
         factory_address: Address,
         confirmations: u64,
+        receipt_timeout: Duration,
     ) -> Result<Self, ProposerError> {
         let factory = IDisputeGameFactory::IDisputeGameFactoryInstance::new(
             factory_address,
@@ -59,6 +62,7 @@ where
             anchor,
             registered,
             confirmations,
+            receipt_timeout,
             provider,
         })
     }
@@ -103,6 +107,7 @@ where
         let tx_hash = *pending.tx_hash();
         let receipt = pending
             .with_required_confirmations(self.confirmations)
+            .with_timeout(Some(self.receipt_timeout))
             .get_receipt()
             .await?;
         world_chain_proof_metrics::refresh_wallet_balance(&self.provider, receipt.from).await;
@@ -172,6 +177,7 @@ where
         let tx_hash = *pending_tx.tx_hash();
         let receipt = pending_tx
             .with_required_confirmations(self.confirmations)
+            .with_timeout(Some(self.receipt_timeout))
             .get_receipt()
             .await?;
         world_chain_proof_metrics::refresh_wallet_balance(&self.provider, receipt.from).await;
@@ -303,6 +309,7 @@ where
         let tx_hash = *pending.tx_hash();
         let receipt = pending
             .with_required_confirmations(self.confirmations)
+            .with_timeout(Some(self.receipt_timeout))
             .get_receipt()
             .await?;
         world_chain_proof_metrics::refresh_wallet_balance(&self.provider, receipt.from).await;
@@ -334,6 +341,7 @@ where
         let tx_hash = *pending.tx_hash();
         let receipt = pending
             .with_required_confirmations(self.confirmations)
+            .with_timeout(Some(self.receipt_timeout))
             .get_receipt()
             .await?;
         world_chain_proof_metrics::refresh_wallet_balance(&self.provider, receipt.from).await;

--- a/proofs/services/proposer/src/main.rs
+++ b/proofs/services/proposer/src/main.rs
@@ -78,6 +78,15 @@ struct Cli {
     #[arg(long, env = "CONFIRMATIONS", default_value_t = 5)]
     confirmations: u64,
 
+    /// Maximum seconds to wait for an L1 transaction receipt and required confirmations.
+    #[arg(
+        long,
+        env = "L1_TX_RECEIPT_TIMEOUT_SECONDS",
+        default_value_t = world_chain_proof_protocol::DEFAULT_L1_TX_RECEIPT_TIMEOUT_SECONDS,
+        value_parser = clap::value_parser!(u64).range(1..)
+    )]
+    l1_tx_receipt_timeout_seconds: u64,
+
     /// Per-request timeout applied to every L1 RPC call, in seconds.
     #[arg(
         long,
@@ -114,9 +123,14 @@ async fn main() -> Result<()> {
         .connect_client(l1_rpc_client);
     world_chain_proof_metrics::refresh_wallet_balance(&provider, proposer_address).await;
 
-    let contracts = AlloyProofSystemClient::new(provider, cli.factory_address, cli.confirmations)
-        .await
-        .context("failed to bind the World Chain proof system")?;
+    let contracts = AlloyProofSystemClient::new(
+        provider,
+        cli.factory_address,
+        cli.confirmations,
+        Duration::from_secs(cli.l1_tx_receipt_timeout_seconds),
+    )
+    .await
+    .context("failed to bind the World Chain proof system")?;
     let bond_manager_config = BondManagerConfig {
         poll_interval: Duration::from_secs(cli.bond_manager_poll_interval_seconds),
         initial_scan_limit: cli.bond_manager_initial_scan_limit,
@@ -147,6 +161,7 @@ async fn main() -> Result<()> {
         max_resolutions_per_tick = cli.max_resolutions_per_tick,
         bond_manager_poll_interval_seconds = cli.bond_manager_poll_interval_seconds,
         bond_manager_initial_scan_limit = cli.bond_manager_initial_scan_limit,
+        l1_tx_receipt_timeout_seconds = cli.l1_tx_receipt_timeout_seconds,
         l1_rpc_timeout_seconds = cli.l1_rpc_timeout_seconds,
         "starting World Chain proof-system proposer"
     );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how long proof services block on L1 inclusion; too-aggressive timeouts could fail legitimate txs on congested L1, while fixing stuck workers.
> 
> **Overview**
> Adds a **bounded wait** for L1 transaction receipts (including required confirmations) across the proof-system proposer, challenger, and defender so receipt polling cannot hang indefinitely on a slow or stuck RPC.
> 
> `world_chain_proof_protocol` now exports **`DEFAULT_L1_TX_RECEIPT_TIMEOUT_SECONDS`** (5 minutes). Each Alloy client stores a `receipt_timeout` and passes **`with_timeout(Some(...))`** on every `get_receipt()` after sends (proposals, challenges, resolves, proof lanes, bond claims, etc.). Standalone binaries gain **`L1_TX_RECEIPT_TIMEOUT_SECONDS`** (CLI/env); the full-stack devnet wires the same default into in-process services.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26d7390704cfd008f36255ec94f1afffccd4c829. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->