### PR TITLE
ci: make releases manually versioned

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,15 @@ name: release
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - v*
+    inputs:
+      version:
+        description: Release version (for example, 2.4.1 or v2.4.1)
+        required: true
+        type: string
+
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}
@@ -35,8 +41,33 @@ jobs:
     needs: approve-release
     runs-on: ubuntu-latest
     steps:
-      - name: Extract version
-        run: echo "VERSION=$(echo ${GITHUB_REF#refs/tags/})" >> $GITHUB_OUTPUT
+      - name: Check Out Repo
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+      - name: Validate version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          version="${INPUT_VERSION#v}"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$ ]]; then
+            echo "Invalid release version: $INPUT_VERSION" >&2
+            exit 1
+          fi
+
+          manifest_version=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n 1)
+          if [[ "$version" != "$manifest_version" ]]; then
+            echo "Release version $version does not match Cargo.toml version $manifest_version" >&2
+            exit 1
+          fi
+
+          tag="v${version}"
+          if git show-ref --verify --quiet "refs/tags/$tag"; then
+            echo "Release tag $tag already exists" >&2
+            exit 1
+          fi
+
+          echo "VERSION=$tag" >> "$GITHUB_OUTPUT"
         id: extract_version
     outputs:
       VERSION: ${{ steps.extract_version.outputs.VERSION }}
@@ -70,6 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build-and-push
+      - extract-version
     steps:
       - name: Check Out Repo
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -80,7 +112,7 @@ jobs:
           image_name: ${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest
-            type=ref,event=tag
+            type=raw,value=${{ needs.extract-version.outputs.VERSION }}
             type=sha
 
   build-binaries:
@@ -162,8 +194,16 @@ jobs:
       - name: Generate full changelog
         id: changelog
         run: |
+          previous_version=$(git describe --tags --match 'v*' --abbrev=0 "${GITHUB_SHA}^" 2>/dev/null || true)
+          if [[ -n "$previous_version" ]]; then
+            range="$previous_version..$GITHUB_SHA"
+          else
+            range="$GITHUB_SHA"
+          fi
+
           echo "CHANGELOG<<EOF" >> $GITHUB_OUTPUT
-          echo "$(git log --pretty=format:"- %s" $(git describe --tags --abbrev=0 ${{ env.VERSION }}^)..${{ env.VERSION }})" >> $GITHUB_OUTPUT
+          git log --pretty=format:"- %s" "$range" >> $GITHUB_OUTPUT
+          echo >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Create release draft
@@ -194,4 +234,4 @@ jobs:
               assets+=("$asset/$asset")
           done
           tag_name="${{ env.VERSION }}"
-          echo "$body" | gh release create --draft -t "$tag_name" -F "-" "$tag_name" "${assets[@]}"
+          echo "$body" | gh release create --draft --target "$GITHUB_SHA" -t "$tag_name" -F "-" "$tag_name" "${assets[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ name: release
 on:
   workflow_dispatch:
     inputs:
+      ref:
+        description: Branch, tag, or commit SHA to release
+        required: true
+        type: string
       version:
         description: Release version (for example, 2.4.1 or v2.4.1)
         required: true
@@ -36,16 +40,17 @@ jobs:
     steps:
       - run: true
 
-  extract-version:
-    name: extract version
+  prepare-release:
+    name: prepare release
     needs: approve-release
     runs-on: ubuntu-latest
     steps:
       - name: Check Out Repo
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
-      - name: Validate version
+      - name: Prepare release
         env:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
@@ -61,6 +66,7 @@ jobs:
             exit 1
           fi
 
+          release_sha=$(git rev-parse HEAD)
           tag="v${version}"
           if git show-ref --verify --quiet "refs/tags/$tag"; then
             echo "Release tag $tag already exists" >&2
@@ -68,14 +74,18 @@ jobs:
           fi
 
           echo "VERSION=$tag" >> "$GITHUB_OUTPUT"
-        id: extract_version
+          echo "SHA=$release_sha" >> "$GITHUB_OUTPUT"
+          echo "SHORT_SHA=${release_sha::7}" >> "$GITHUB_OUTPUT"
+        id: release
     outputs:
-      VERSION: ${{ steps.extract_version.outputs.VERSION }}
+      VERSION: ${{ steps.release.outputs.VERSION }}
+      SHA: ${{ steps.release.outputs.SHA }}
+      SHORT_SHA: ${{ steps.release.outputs.SHORT_SHA }}
 
   build-and-push:
     name: build and push docker
     environment: dev
-    needs: extract-version
+    needs: prepare-release
     strategy:
       fail-fast: false
       matrix:
@@ -88,6 +98,8 @@ jobs:
     steps:
       - name: Check Out Repo
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ needs.prepare-release.outputs.SHA }}
       - name: Build and push digest
         uses: ./.github/actions/docker-build-push-digest
         with:
@@ -96,15 +108,19 @@ jobs:
           image_name: ${{ env.IMAGE_NAME }}
           aws_region: ${{ env.AWS_REGION }}
           sccache_bucket: ${{ env.SCCACHE_BUCKET }}
+          git_sha: ${{ needs.prepare-release.outputs.SHA }}
+          cache_scope: ${{ inputs.ref }}
 
   merge:
     runs-on: ubuntu-latest
     needs:
       - build-and-push
-      - extract-version
+      - prepare-release
     steps:
       - name: Check Out Repo
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ needs.prepare-release.outputs.SHA }}
       - name: Merge multi-arch manifest
         uses: ./.github/actions/docker-merge-manifest
         with:
@@ -112,12 +128,12 @@ jobs:
           image_name: ${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest
-            type=raw,value=${{ needs.extract-version.outputs.VERSION }}
-            type=sha
+            type=raw,value=${{ needs.prepare-release.outputs.VERSION }}
+            type=raw,value=sha-${{ needs.prepare-release.outputs.SHORT_SHA }}
 
   build-binaries:
     name: build binaries
-    needs: [extract-version]
+    needs: [prepare-release]
     strategy:
       fail-fast: false
       matrix:
@@ -135,6 +151,8 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ needs.prepare-release.outputs.SHA }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
@@ -157,35 +175,37 @@ jobs:
           export GPG_TTY=$(tty)
           echo -n "$GPG_SIGNING_KEY" | base64 --decode | gpg --batch --import
           cd artifacts
-          tar -czf ${{ env.REPO_NAME }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}.tar.gz ${{ matrix.binary }}*
-          echo "$GPG_PASSPHRASE" | gpg --passphrase-fd 0 --pinentry-mode loopback --batch -ab ${{ env.REPO_NAME }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}.tar.gz
+          tar -czf ${{ env.REPO_NAME }}-${{ needs.prepare-release.outputs.VERSION }}-${{ matrix.target }}.tar.gz ${{ matrix.binary }}*
+          echo "$GPG_PASSPHRASE" | gpg --passphrase-fd 0 --pinentry-mode loopback --batch -ab ${{ env.REPO_NAME }}-${{ needs.prepare-release.outputs.VERSION }}-${{ matrix.target }}.tar.gz
           mv *tar.gz* ..
         shell: bash
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: ${{ env.REPO_NAME }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}.tar.gz
-          path: ${{ env.REPO_NAME }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}.tar.gz
+          name: ${{ env.REPO_NAME }}-${{ needs.prepare-release.outputs.VERSION }}-${{ matrix.target }}.tar.gz
+          path: ${{ env.REPO_NAME }}-${{ needs.prepare-release.outputs.VERSION }}-${{ matrix.target }}.tar.gz
 
       - name: Upload signature
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: ${{ env.REPO_NAME }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}.tar.gz.asc
-          path: ${{ env.REPO_NAME }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}.tar.gz.asc
+          name: ${{ env.REPO_NAME }}-${{ needs.prepare-release.outputs.VERSION }}-${{ matrix.target }}.tar.gz.asc
+          path: ${{ env.REPO_NAME }}-${{ needs.prepare-release.outputs.VERSION }}-${{ matrix.target }}.tar.gz.asc
 
   draft-release:
     name: draft release
-    needs: [build-and-push, merge, extract-version, build-binaries]
+    needs: [build-and-push, merge, prepare-release, build-binaries]
     runs-on: ubuntu-latest
     env:
-      VERSION: ${{ needs.extract-version.outputs.VERSION }}
+      VERSION: ${{ needs.prepare-release.outputs.VERSION }}
+      RELEASE_SHA: ${{ needs.prepare-release.outputs.SHA }}
       REPO_NAME: ${{ github.event.repository.name }}
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
+          ref: ${{ needs.prepare-release.outputs.SHA }}
           fetch-depth: 0
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -194,11 +214,11 @@ jobs:
       - name: Generate full changelog
         id: changelog
         run: |
-          previous_version=$(git describe --tags --match 'v*' --abbrev=0 "${GITHUB_SHA}^" 2>/dev/null || true)
+          previous_version=$(git describe --tags --match 'v*' --abbrev=0 "${RELEASE_SHA}^" 2>/dev/null || true)
           if [[ -n "$previous_version" ]]; then
-            range="$previous_version..$GITHUB_SHA"
+            range="$previous_version..$RELEASE_SHA"
           else
-            range="$GITHUB_SHA"
+            range="$RELEASE_SHA"
           fi
 
           echo "CHANGELOG<<EOF" >> $GITHUB_OUTPUT
@@ -234,4 +254,4 @@ jobs:
               assets+=("$asset/$asset")
           done
           tag_name="${{ env.VERSION }}"
-          echo "$body" | gh release create --draft --target "$GITHUB_SHA" -t "$tag_name" -F "-" "$tag_name" "${assets[@]}"
+          echo "$body" | gh release create --draft --target "$RELEASE_SHA" -t "$tag_name" -F "-" "$tag_name" "${assets[@]}"


### PR DESCRIPTION
- replace tag-push releases with a manually dispatched `ref` and `version`
- resolve the requested branch, tag, or commit to an exact SHA and use it for every checkout
- accept `2.4.1` or `v2.4.1`, normalize to `v2.4.1`, verify it matches the selected ref's `Cargo.toml`, and reject existing release tags

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how production artifacts and GitHub releases are produced; mis-specified ref/version could ship wrong bits, though Cargo.toml and duplicate-tag checks reduce that risk.
> 
> **Overview**
> Releases are no longer triggered by pushing `v*` tags. The workflow runs only via **manual dispatch**, with required **`ref`** (branch, tag, or commit) and **`version`** inputs, plus a **`release`** concurrency group so overlapping runs do not cancel each other.
> 
> A new **`prepare-release`** job replaces tag-derived version extraction. It checks out the requested ref, validates semver (with optional prerelease suffix), normalizes to `vX.Y.Z`, requires a match with the root **`Cargo.toml`** version, rejects if that release tag already exists, and exports **`VERSION`**, full **`SHA`**, and **`SHORT_SHA`** for downstream jobs.
> 
> **Build, merge, binaries, and draft** steps all check out that fixed SHA. Docker builds pass **`git_sha`** and **`cache_scope`** from the release inputs; image tags are explicit **`latest`**, the release version, and **`sha-<short>`** instead of tag/ref metadata actions. Changelog generation compares the previous `v*` tag to the release commit (not the tag ref). The draft GitHub release is created with **`--target`** set to the release SHA.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb13224dd74dd5a2092caeaa4fea081b5f7b74ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->