### PR TITLE
chore(simulation): decode Safe execution traces

### DIFF
--- a/crates/rpc/src/simulate.rs
+++ b/crates/rpc/src/simulate.rs
@@ -1467,11 +1467,19 @@ mod panic_code {
 }
 
 /// Decode revert data into a human-readable string.
-/// Handles `Error(string)` and `Panic(uint256)`; falls back to hex for
-/// custom errors and other unknown payloads.
+/// Handles `Error(string)`, `Panic(uint256)`, and known no-argument Safe
+/// errors; falls back to hex for other custom errors and unknown payloads.
 pub fn decode_revert_reason(output: &Bytes) -> String {
     if output.len() < 4 {
         return format!("0x{}", hex::encode(output.as_ref()));
+    }
+
+    if output.as_ref() == EXECUTION_FAILED_SELECTOR {
+        return "ExecutionFailed()".to_string();
+    }
+
+    if output.as_ref() == UNSUPPORTED_ENTRY_POINT_SELECTOR {
+        return "UnsupportedEntryPoint()".to_string();
     }
 
     let selector = &output[..4];
@@ -1541,6 +1549,9 @@ pub fn selector_to_name(selector: [u8; 4]) -> Option<&'static str> {
         [0xb6, 0x1d, 0x27, 0xf6] => Some("execute"),
         [0x51, 0x94, 0x54, 0x47] => Some("executeBatch"),
         [0x8d, 0x80, 0xff, 0x0a] => Some("multiSend"),
+        // Safe ERC-4337 execution
+        EXECUTE_USER_OP_SELECTOR => Some("executeUserOp"),
+        EXEC_TRANSACTION_FROM_MODULE_SELECTOR => Some("execTransactionFromModule"),
         // Safe admin methods (flagged by backend as forbidden)
         [0x0d, 0x58, 0x2f, 0x13] => Some("addOwnerWithThreshold"),
         [0xf8, 0xdc, 0x5d, 0xd9] => Some("removeOwner"),
@@ -2229,6 +2240,40 @@ mod tests {
         assert_eq!(
             decode_revert_reason(&output),
             format!("0x{}", hex::encode(&payload))
+        );
+    }
+
+    #[test]
+    fn decodes_known_safe_custom_errors_only_for_exact_payloads() {
+        let cases = [
+            (EXECUTION_FAILED_SELECTOR, "ExecutionFailed()"),
+            (UNSUPPORTED_ENTRY_POINT_SELECTOR, "UnsupportedEntryPoint()"),
+        ];
+
+        for (selector, expected) in cases {
+            assert_eq!(
+                decode_revert_reason(&Bytes::copy_from_slice(&selector)),
+                expected
+            );
+
+            let mut extended = selector.to_vec();
+            extended.push(0xaa);
+            assert_eq!(
+                decode_revert_reason(&Bytes::from(extended.clone())),
+                format!("0x{}", hex::encode(extended))
+            );
+        }
+    }
+
+    #[test]
+    fn decodes_safe_execution_method_selectors() {
+        assert_eq!(
+            selector_to_name(EXECUTE_USER_OP_SELECTOR),
+            Some("executeUserOp")
+        );
+        assert_eq!(
+            selector_to_name(EXEC_TRANSACTION_FROM_MODULE_SELECTOR),
+            Some("execTransactionFromModule")
         );
     }
 

--- a/crates/rpc/src/simulate.rs
+++ b/crates/rpc/src/simulate.rs
@@ -1467,8 +1467,9 @@ mod panic_code {
 }
 
 /// Decode revert data into a human-readable string.
-/// Handles `Error(string)`, `Panic(uint256)`, and known no-argument Safe
-/// errors; falls back to hex for other custom errors and unknown payloads.
+/// Handles `Error(string)`, `Panic(uint256)`, and Safe's no-argument
+/// `ExecutionFailed()` wrapper; falls back to hex for other custom errors and
+/// unknown payloads.
 pub fn decode_revert_reason(output: &Bytes) -> String {
     if output.len() < 4 {
         return format!("0x{}", hex::encode(output.as_ref()));
@@ -1476,10 +1477,6 @@ pub fn decode_revert_reason(output: &Bytes) -> String {
 
     if output.as_ref() == EXECUTION_FAILED_SELECTOR {
         return "ExecutionFailed()".to_string();
-    }
-
-    if output.as_ref() == UNSUPPORTED_ENTRY_POINT_SELECTOR {
-        return "UnsupportedEntryPoint()".to_string();
     }
 
     let selector = &output[..4];
@@ -2244,25 +2241,18 @@ mod tests {
     }
 
     #[test]
-    fn decodes_known_safe_custom_errors_only_for_exact_payloads() {
-        let cases = [
-            (EXECUTION_FAILED_SELECTOR, "ExecutionFailed()"),
-            (UNSUPPORTED_ENTRY_POINT_SELECTOR, "UnsupportedEntryPoint()"),
-        ];
+    fn decodes_execution_failed_only_for_exact_payload() {
+        assert_eq!(
+            decode_revert_reason(&Bytes::copy_from_slice(&EXECUTION_FAILED_SELECTOR)),
+            "ExecutionFailed()"
+        );
 
-        for (selector, expected) in cases {
-            assert_eq!(
-                decode_revert_reason(&Bytes::copy_from_slice(&selector)),
-                expected
-            );
-
-            let mut extended = selector.to_vec();
-            extended.push(0xaa);
-            assert_eq!(
-                decode_revert_reason(&Bytes::from(extended.clone())),
-                format!("0x{}", hex::encode(extended))
-            );
-        }
+        let mut extended = EXECUTION_FAILED_SELECTOR.to_vec();
+        extended.push(0xaa);
+        assert_eq!(
+            decode_revert_reason(&Bytes::from(extended.clone())),
+            format!("0x{}", hex::encode(extended))
+        );
     }
 
     #[test]

--- a/crates/rpc/src/simulate_consts.rs
+++ b/crates/rpc/src/simulate_consts.rs
@@ -137,6 +137,9 @@ pub const EXEC_TRANSACTION_FROM_MODULE_SELECTOR: [u8; 4] = [0x46, 0x87, 0x21, 0x
 /// Safe4337Module `ExecutionFailed()` selector.
 pub const EXECUTION_FAILED_SELECTOR: [u8; 4] = [0xac, 0xfd, 0xb4, 0x44];
 
+/// Safe4337Module `UnsupportedEntryPoint()` selector.
+pub(crate) const UNSUPPORTED_ENTRY_POINT_SELECTOR: [u8; 4] = [0x85, 0xdb, 0x24, 0x7d];
+
 /// Minimum payload length for a well-formed `Error(string)` revert:
 /// selector(4) + string-offset(32) + string-length(32).
 pub(crate) const MIN_ERROR_STRING_LEN: usize = 4 + 32 + 32;

--- a/crates/rpc/src/simulate_consts.rs
+++ b/crates/rpc/src/simulate_consts.rs
@@ -137,9 +137,6 @@ pub const EXEC_TRANSACTION_FROM_MODULE_SELECTOR: [u8; 4] = [0x46, 0x87, 0x21, 0x
 /// Safe4337Module `ExecutionFailed()` selector.
 pub const EXECUTION_FAILED_SELECTOR: [u8; 4] = [0xac, 0xfd, 0xb4, 0x44];
 
-/// Safe4337Module `UnsupportedEntryPoint()` selector.
-pub(crate) const UNSUPPORTED_ENTRY_POINT_SELECTOR: [u8; 4] = [0x85, 0xdb, 0x24, 0x7d];
-
 /// Minimum payload length for a well-formed `Error(string)` revert:
 /// selector(4) + string-offset(32) + string-length(32).
 pub(crate) const MIN_ERROR_STRING_LEN: usize = 4 + 32 + 32;

--- a/crates/rpc/tests/inspector_create_revert.rs
+++ b/crates/rpc/tests/inspector_create_revert.rs
@@ -369,7 +369,7 @@ fn safe_execution_failed_retains_revert_across_successful_catching_frame() {
         .trace_entries()
         .expect("completed simulation should produce a complete trace");
     assert_eq!(trace[0].selector.as_deref(), Some("0x7bb37428"));
-    assert_eq!(trace[0].revert_reason.as_deref(), Some("0xacfdb444"));
+    assert_eq!(trace[0].revert_reason.as_deref(), Some("ExecutionFailed()"));
     assert_eq!(trace[1].outcome, TraceOutcome::Success);
     assert_eq!(trace[1].selector.as_deref(), Some("0x468721a7"));
     assert_eq!(trace[2].revert_reason.as_deref(), Some("0xaaaaaaaa"));


### PR DESCRIPTION
Decode Safe execution methods and the `ExecutionFailed()` wrapper that appear in simulation traces.

A World Chain Sepolia curl currently produces output like:

```json
{
  "revertReason": "GS104",
  "trace": [
    {
      "method": null,
      "selector": "0x7bb37428",
      "revertReason": "0xacfdb444"
    },
    {
      "method": null,
      "selector": "0x468721a7",
      "outcome": "success"
    }
  ]
}
```

Those values require manually looking up the selectors. With this change, the same trace reads as:

```json
{
  "revertReason": "GS104",
  "trace": [
    {
      "method": "executeUserOp",
      "selector": "0x7bb37428",
      "revertReason": "ExecutionFailed()"
    },
    {
      "method": "execTransactionFromModule",
      "selector": "0x468721a7",
      "outcome": "success"
    }
  ]
}
```

`ExecutionFailed()` is decoded only when the complete payload exactly matches the no-argument error. Longer payloads that merely share the selector remain raw hex.

Checks: `cargo test -p world-chain-rpc --lib`; `cargo clippy -p world-chain-rpc --all-targets -- -D warnings`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only presentation changes in simulation decode/mapping with tests; no execution or auth behavior changes.
> 
> **Overview**
> Simulation traces and revert decoding now label **Safe ERC-4337** flows instead of leaving opaque selectors and hex.
> 
> `decode_revert_reason` recognizes Safe’s no-arg **`ExecutionFailed()`** when the revert payload is exactly the four-byte selector; longer payloads that share that prefix still surface as raw hex. **`selector_to_name`** maps **`executeUserOp`** and **`execTransactionFromModule`** so trace entries show method names. A regression test expectation is updated from hex to **`ExecutionFailed()`**, with new unit tests for exact-match decoding and selector naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5507484fac268198e66086e73a50a49431b9701. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->