### PR TITLE
feat: add sempahore + simple nonce manager to proposer

### DIFF
--- a/proofs/services/proposer/src/alloy.rs
+++ b/proofs/services/proposer/src/alloy.rs
@@ -3,7 +3,8 @@ use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{Address, U256};
 use alloy_provider::{Provider, WalletProvider};
 use async_trait::async_trait;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
+use tokio::sync::Semaphore;
 use world_chain_proof_protocol::{
     IAnchorStateRegistry, IDelayedWETH, IDisputeGameFactory, IMultiProofGame, LineageAnchor,
     LineageError, LineageGame, LineageProvider, LineageTransition, MULTI_PROOF_GAME_TYPE,
@@ -29,6 +30,7 @@ pub struct AlloyProofSystemClient<P> {
     /// Number of confirmations to require after sending a tx onchain.
     confirmations: u64,
     receipt_timeout: Duration,
+    semaphore: Arc<Semaphore>,
     provider: P,
 }
 
@@ -56,6 +58,7 @@ where
             registered.anchor_registry,
             provider.clone(),
         );
+        let semaphore = Arc::new(Semaphore::new(1));
 
         Ok(Self {
             factory,
@@ -64,6 +67,7 @@ where
             confirmations,
             receipt_timeout,
             provider,
+            semaphore,
         })
     }
 
@@ -102,6 +106,7 @@ where
     }
 
     async fn send_resolve_game(&self, game: Address) -> Result<ResolveSubmission, ProposerError> {
+        let _permit = self.semaphore.acquire().await?;
         let pending = self.game(game).resolve().send().await?;
 
         let tx_hash = *pending.tx_hash();
@@ -164,6 +169,7 @@ where
         game: Address,
         recipient: Address,
     ) -> Result<ClaimSubmission, ProposerError> {
+        let _permit = self.semaphore.acquire().await?;
         // Read both phases up front so the submission can report what the call moved; the
         // receipt carries no amount of its own.
         let credit = self.read_credit(game, recipient).await?;
@@ -304,6 +310,7 @@ where
     }
 
     async fn close_game(&self, game: Address) -> Result<CloseGameSubmission, ProposerError> {
+        let _permit = self.semaphore.acquire().await?;
         let pending = self.game(game).closeGame().send().await?;
 
         let tx_hash = *pending.tx_hash();
@@ -324,6 +331,7 @@ where
         &self,
         proposal: &Proposal,
     ) -> Result<ProposalSubmission, ProposerError> {
+        let _permit = self.semaphore.acquire().await?;
         // `DisputeGameFactory.create` reverts unless `msg.value` matches the configured init
         // bond exactly, so it is read per submission rather than cached in configuration.
         let init_bond = self.factory.initBonds(MULTI_PROOF_GAME_TYPE).call().await?;

--- a/proofs/services/proposer/src/error.rs
+++ b/proofs/services/proposer/src/error.rs
@@ -2,6 +2,7 @@ use alloy_primitives::TxHash;
 use alloy_provider::{MulticallError, PendingTransactionError, transport::RpcError};
 use alloy_transport::TransportErrorKind;
 use thiserror::Error;
+use tokio::sync::AcquireError;
 use world_chain_proof_protocol::LineageError;
 
 /// Errors returned by the proposer.
@@ -32,6 +33,8 @@ pub enum ProposerError {
     UnavailableLatestL1Block,
     #[error("DisputeGameCreated event missing from proposal transaction {0}")]
     MissingProposalEvent(TxHash),
+    #[error(transparent)]
+    Permit(#[from] AcquireError),
 }
 
 impl ProposerError {

--- a/proofs/services/proposer/src/main.rs
+++ b/proofs/services/proposer/src/main.rs
@@ -118,7 +118,13 @@ async fn main() -> Result<()> {
         Duration::from_secs(cli.l1_rpc_timeout_seconds),
     )
     .context("failed to build the L1 RPC client")?;
+    // Recommended fillers include CachedNonceManager, rebuild with SimpleNonceManager instead.
     let provider = ProviderBuilder::new()
+        .disable_recommended_fillers()
+        .with_gas_estimation()
+        .with_blob_gas_estimation()
+        .with_simple_nonce_management()
+        .fetch_chain_id()
         .wallet(wallet)
         .connect_client(l1_rpc_client);
     world_chain_proof_metrics::refresh_wallet_balance(&provider, proposer_address).await;


### PR DESCRIPTION
### What

- add semaphore with 1 permit to proposer, so that it's allowed to send at max 1 transaction at a time onchain
- use `SimpleNonceManager` instead of the default `CachedNonceManager` to avoid problems of reorgs / reverts

These 2 features, combined with the timeout of the receipt, should avoid all problems related to onchain tx submission.

### Next Step

- do the same for challenger
- do the same for defender

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every L1 transaction is nonce-managed and serialized; mistakes could stall or mis-order submissions, but contract logic and proposal content are unchanged.
> 
> **Overview**
> **Serializes all proposer L1 transaction sends** so only one on-chain submission runs at a time, even when the proposer loop and bond manager overlap.
> 
> `AlloyProofSystemClient` holds a **single-permit `Semaphore`**; `resolve`, `claimCredit`, `closeGame`, and `submit_proposal` acquire it before `send()` and hold it through receipt confirmation. Semaphore failures surface as **`ProposerError::Permit`**.
> 
> The L1 provider in **`main`** no longer uses Alloy’s recommended fillers (including **`CachedNonceManager`**). It is rebuilt with gas/blob gas estimation, **`with_simple_nonce_management()`**, and chain ID fetch so nonces stay correct after reorgs or reverts, alongside the existing receipt timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 231ecbd7a3c611f3cb03dc45b860daf50ad7621e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->