### PR TITLE
feat: add semaphore + simple nonce manager to challenger

### DIFF
--- a/proofs/services/challenger/src/alloy.rs
+++ b/proofs/services/challenger/src/alloy.rs
@@ -11,7 +11,8 @@ use alloy_primitives::{Address, U256};
 use alloy_provider::{Provider, WalletProvider};
 use alloy_rpc_types_eth::BlockId;
 use async_trait::async_trait;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
+use tokio::sync::Semaphore;
 use world_chain_proof_protocol::{
     IAnchorStateRegistry, IDelayedWETH, IDisputeGameFactory, IMultiProofGame,
     MULTI_PROOF_GAME_TYPE, ProposalStatus, ResolutionStatus,
@@ -26,6 +27,7 @@ pub struct AlloyChallengerClient<P> {
     factory: IDisputeGameFactory::IDisputeGameFactoryInstance<P>,
     confirmations: u64,
     receipt_timeout: Duration,
+    semaphore: Arc<Semaphore>,
     provider: P,
 }
 
@@ -44,11 +46,12 @@ where
             factory_address,
             provider.clone(),
         );
-
+        let semaphore = Arc::new(Semaphore::new(1));
         Self {
             factory,
             confirmations,
             receipt_timeout,
+            semaphore,
             provider,
         }
     }
@@ -167,6 +170,7 @@ where
         &self,
         address: Address,
     ) -> Result<ChallengeSubmission, ChallengerError> {
+        let _permit = self.semaphore.acquire().await?;
         // The bond is an immutable of whichever implementation this clone was created from, so
         // it is read per game: a re-registered implementation would otherwise make every
         // challenge revert with `IncorrectBondAmount`.
@@ -202,6 +206,7 @@ where
     }
 
     async fn resolve(&self, address: Address) -> Result<ResolveSubmission, ChallengerError> {
+        let _permit = self.semaphore.acquire().await?;
         let pending = self.game(address).resolve().send().await?;
         let tx_hash = *pending.tx_hash();
         let receipt = pending
@@ -269,6 +274,7 @@ where
     }
 
     async fn claim_credit(&self, address: Address) -> Result<ClaimSubmission, ChallengerError> {
+        let _permit = self.semaphore.acquire().await?;
         let recipient = self.challenger_address();
         // Read both phases up front so the submission can report what the call moved; the
         // receipt carries no amount of its own.

--- a/proofs/services/challenger/src/error.rs
+++ b/proofs/services/challenger/src/error.rs
@@ -2,6 +2,7 @@ use alloy_primitives::{Address, TxHash};
 use alloy_provider::{PendingTransactionError, transport::RpcError};
 use alloy_transport::TransportErrorKind;
 use thiserror::Error;
+use tokio::sync::AcquireError;
 use world_chain_proof_protocol::{
     ConsensusError, GameStatusError, InvalidationReasonError, ProposalStatusError,
 };
@@ -54,6 +55,8 @@ pub enum ChallengerError {
         /// Block number included in the game.
         given_block: u64,
     },
+    #[error(transparent)]
+    Permit(#[from] AcquireError),
 }
 
 impl From<alloy_contract::Error> for ChallengerError {

--- a/proofs/services/challenger/src/main.rs
+++ b/proofs/services/challenger/src/main.rs
@@ -151,6 +151,11 @@ async fn main() -> Result<()> {
     )
     .context("failed to build the L1 RPC client")?;
     let provider = ProviderBuilder::new()
+        .disable_recommended_fillers()
+        .with_gas_estimation()
+        .with_blob_gas_estimation()
+        .with_simple_nonce_management()
+        .fetch_chain_id()
         .wallet(wallet)
         .connect_client(l1_rpc_client);
     world_chain_proof_metrics::refresh_wallet_balance(&provider, challenger_address).await;


### PR DESCRIPTION
### What

- add semaphore with 1 permit to challenger, so that it's allowed to send at max 1 transaction at a time onchain
- use SimpleNonceManager instead of the default CachedNonceManager to avoid problems of reorgs / reverts

These 2 features, combined with the timeout of the receipt, should avoid all problems related to onchain tx submission.

### Next Step

- do the same for defender

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the challenger submits and sequences L1 transactions (nonce handling and mutual exclusion), which can affect dispute timing if misconfigured but follows an existing proposer pattern.
> 
> **Overview**
> **Serializes challenger L1 submissions** so challenge, resolve, and claim-credit paths cannot broadcast concurrently. `AlloyChallengerClient` holds a single-permit `Semaphore`; each send acquires it before signing, and `AcquireError` surfaces as `ChallengerError::Permit`.
> 
> **Reconfigures the L1 provider** in `main` to match the proposer pattern: disable Alloy’s recommended fillers, keep gas/blob estimation, and use **`SimpleNonceManager`** instead of the default cached nonce filler—intended to avoid stale nonces after reorgs or reverted txs, alongside existing receipt timeouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7947d8c5451184eafefd3bcc7f4798142eecf4c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->