### PR TITLE
feat: add semaphore + simple nonce manager to defender

### DIFF
--- a/proofs/services/defender/src/alloy.rs
+++ b/proofs/services/defender/src/alloy.rs
@@ -7,7 +7,8 @@ use alloy_primitives::{Address, Bytes, U256};
 use alloy_provider::Provider;
 use alloy_sol_types::SolInterface;
 use async_trait::async_trait;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
+use tokio::sync::Semaphore;
 use world_chain_proof_protocol::{
     ClaimData, IAnchorStateRegistry, IDisputeGameFactory, IMultiProofGame, LineageAnchor,
     LineageError, LineageGame, LineageProvider, LineageTransition, PROOF_LANE_COUNT, ProofLane,
@@ -28,6 +29,7 @@ pub struct AlloyDefenderClient<P> {
     receipt_timeout: Duration,
     /// Credited this lane's share of a forfeited challenger bond when the game resolves.
     reward_recipient: Address,
+    semaphore: Arc<Semaphore>,
     provider: P,
 }
 
@@ -52,6 +54,7 @@ where
             registered.anchor_registry,
             provider.clone(),
         );
+        let semaphore = Arc::new(Semaphore::new(1));
 
         Ok(Self {
             factory,
@@ -60,6 +63,7 @@ where
             confirmations,
             receipt_timeout,
             reward_recipient,
+            semaphore,
             provider,
         })
     }
@@ -175,6 +179,7 @@ where
         lane: ProofLane,
         proof: Bytes,
     ) -> Result<DefenderSubmission, DefenderError> {
+        let _permit = self.semaphore.acquire().await?;
         let compact = encode_compact_proof(lane, self.reward_recipient, &proof);
         let pending = self
             .game(game)

--- a/proofs/services/defender/src/error.rs
+++ b/proofs/services/defender/src/error.rs
@@ -2,6 +2,7 @@ use alloy_primitives::{Address, TxHash};
 use alloy_provider::{MulticallError, PendingTransactionError, transport::RpcError};
 use alloy_transport::TransportErrorKind;
 use thiserror::Error;
+use tokio::sync::AcquireError;
 use world_chain_proof_protocol::{
     InvalidationReasonError, LineageError, ProofLane, ProposalStatusError,
 };
@@ -39,6 +40,8 @@ pub enum DefenderError {
     Overflow,
     #[error("Invalid proof threshold {proof_threshold} for game {game}")]
     InvalidProofThreshold { proof_threshold: u8, game: Address },
+    #[error(transparent)]
+    Permit(#[from] AcquireError),
 }
 
 impl DefenderError {

--- a/proofs/services/defender/src/main.rs
+++ b/proofs/services/defender/src/main.rs
@@ -123,6 +123,11 @@ async fn main() -> Result<()> {
     )
     .context("failed to build the L1 RPC client")?;
     let provider = ProviderBuilder::new()
+        .disable_recommended_fillers()
+        .with_gas_estimation()
+        .with_blob_gas_estimation()
+        .with_simple_nonce_management()
+        .fetch_chain_id()
         .wallet(wallet)
         .connect_client(l1_rpc_client);
     world_chain_proof_metrics::refresh_wallet_balance(&provider, defender_address).await;


### PR DESCRIPTION
### What

- add semaphore with 1 permit to defender, so that it's allowed to send at max 1 transaction at a time onchain
- use SimpleNonceManager instead of the default CachedNonceManager to avoid problems of reorgs / reverts

These 2 features, combined with the timeout of the receipt, should avoid all problems related to onchain tx submission.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how L1 nonces and concurrency work for dispute-game operations; mis-serialization or nonce handling could stall or mis-order txs, but scope is limited to tx submission plumbing.
> 
> **Overview**
> **Serializes L1 transaction submission** across challenger, defender, and proposer by adding a **single-permit `Semaphore`** on each Alloy client. Every path that calls `.send()` (challenges, resolves, claims, proposals, proof lanes, close game, etc.) **acquires the permit first**, so at most one in-flight signed tx per wallet per process even when higher layers use concurrent game processing.
> 
> **Reconfigures the Alloy `ProviderBuilder`** in each service’s `main`: disables recommended fillers (including the default **cached nonce** behavior), then explicitly enables gas/blob gas estimation, **`SimpleNonceManager`**, and chain ID fetch before attaching the wallet.
> 
> Service error enums gain a **`Permit`** variant wrapping `tokio::sync::AcquireError` from failed semaphore acquisition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42beefc2b61777a26185d4a977e4c61b50cbfc30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->