### PR TITLE
fix(sp1-worker): install rustls backend at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19266,6 +19266,7 @@ dependencies = [
  "clap",
  "dotenvy",
  "reqwest 0.12.28",
+ "rustls 0.23.43",
  "serde_cbor",
  "serde_json",
  "telemetry-batteries",

--- a/proofs/workers/sp1/Cargo.toml
+++ b/proofs/workers/sp1/Cargo.toml
@@ -41,6 +41,7 @@ async-trait.workspace = true
 clap.workspace = true
 dotenvy.workspace = true
 reqwest = { workspace = true, features = ["blocking", "json", "rustls-tls"] }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 serde_cbor = "0.11"
 serde_json.workspace = true
 thiserror.workspace = true

--- a/proofs/workers/sp1/src/cmd/run.rs
+++ b/proofs/workers/sp1/src/cmd/run.rs
@@ -194,6 +194,11 @@ pub struct WorkerArgs {
 }
 
 pub async fn run(cli: WorkerArgs) -> Result<()> {
+    // The worker enables both rustls crypto backends transitively: AWS clients select AWS-LC,
+    // while SP1 and other HTTP clients select Ring. Rustls cannot infer a default when both are
+    // present, so install one before SP1 constructs its tonic TLS client.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     let spec = cli.network.chain_spec();
     let schedule = hardfork_config_from_chain_spec(spec.as_ref());
     let host = build_online_config(


### PR DESCRIPTION
### Problem

Sp1 proof worker is panicking with this erros msg:

```
Could not automatically determine the process-level Cr │
│ yptoProvider from Rustls crate features.\nCall CryptoProvider::install_default() before this point to select a provider manually, or make sure exactly one of the 'aws-lc-rs' and 'rin │
│ g' features is enabled.
```

### Solution

Install a rustls provider to fix this ambiguity

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small startup-only TLS initialization fix; no auth, data, or proof logic changes.
> 
> **Overview**
> Fixes SP1 proof worker panics when rustls cannot pick a default **CryptoProvider** because the binary transitively enables both **ring** (SP1/HTTP) and **aws-lc-rs** (AWS clients).
> 
> The worker now calls `rustls::crypto::ring::default_provider().install_default()` at the start of `run`, before SP1 builds its tonic TLS client. A direct **`rustls`** dependency with the **`ring`** feature is added so that provider is available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d361009ac4c511af81790fb61b0b4a5c6ddc717c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->