### PR TITLE
Revert "Revert "fix: fblk v2 rlp decoding""

### DIFF
--- a/crates/p2p/src/protocol/connection.rs
+++ b/crates/p2p/src/protocol/connection.rs
@@ -11,7 +11,8 @@ use reth_ethereum::network::{api::PeerId, eth_wire::multiplex::ProtocolConnectio
 use reth_network::types::ReputationChangeKind;
 use world_chain_primitives::{
     p2p::{
-        Authorized, AuthorizedMsg, AuthorizedPayload, FlashblocksP2PMsg, StartPublish, StopPublish,
+        Authorized, AuthorizedMsg, AuthorizedPayload, FlashblocksP2PMsg, FlashblocksP2PMsgParts,
+        StartPublish, StopPublish,
     },
     primitives::FlashblocksPayloadV1,
 };
@@ -172,7 +173,7 @@ impl<N: FlashblocksP2PNetworkHandle> Stream for FlashblocksConnection<N> {
                 return Poll::Ready(None);
             };
 
-            let msg = match FlashblocksP2PMsg::decode(&mut &buf[..]) {
+            let msg = match FlashblocksP2PMsg::parse(&buf[..]) {
                 Ok(msg) => msg,
                 Err(error) => {
                     tracing::warn!(
@@ -189,8 +190,8 @@ impl<N: FlashblocksP2PNetworkHandle> Stream for FlashblocksConnection<N> {
             };
 
             match msg {
-                FlashblocksP2PMsg::Authorized(authorized) => {
-                    if Ok(authorized.authorization.builder_vk)
+                FlashblocksP2PMsgParts::Authorized(parts) => {
+                    if Ok(parts.authorization.builder_vk)
                         == this.protocol.handle.builder_sk().map(|s| s.verifying_key())
                     {
                         tracing::trace!(
@@ -201,7 +202,7 @@ impl<N: FlashblocksP2PNetworkHandle> Stream for FlashblocksConnection<N> {
                         continue;
                     }
 
-                    if let Err(error) = authorized.verify(this.protocol.handle.ctx.authorizer_vk) {
+                    if let Err(error) = parts.verify(this.protocol.handle.ctx.authorizer_vk) {
                         tracing::warn!(
                             target: "flashblocks::p2p",
                             peer_id = %this.peer_id,
@@ -213,6 +214,23 @@ impl<N: FlashblocksP2PNetworkHandle> Stream for FlashblocksConnection<N> {
                             .reputation_change(this.peer_id, ReputationChangeKind::BadMessage);
                         continue;
                     }
+
+                    // Sender is authenticated; only now is it safe to decode the message body.
+                    let authorized = match parts.into_authorized() {
+                        Ok(authorized) => authorized,
+                        Err(error) => {
+                            tracing::warn!(
+                                target: "flashblocks::p2p",
+                                peer_id = %this.peer_id,
+                                %error,
+                                "failed to decode authorized flashblocks message from peer",
+                            );
+                            this.protocol
+                                .network
+                                .reputation_change(this.peer_id, ReputationChangeKind::BadMessage);
+                            continue;
+                        }
+                    };
 
                     match &authorized.msg {
                         AuthorizedMsg::FlashblocksPayloadV1(_) => {
@@ -229,7 +247,7 @@ impl<N: FlashblocksP2PNetworkHandle> Stream for FlashblocksConnection<N> {
                         }
                     }
                 }
-                FlashblocksP2PMsg::RequestFlashblocks => {
+                FlashblocksP2PMsgParts::RequestFlashblocks => {
                     tracing::trace!(
                         target: "flashblocks::p2p",
                         peer_id = %this.peer_id,
@@ -246,7 +264,7 @@ impl<N: FlashblocksP2PNetworkHandle> Stream for FlashblocksConnection<N> {
                             .reputation_change(this.peer_id, ReputationChangeKind::BadMessage);
                     }
                 }
-                FlashblocksP2PMsg::AcceptFlashblocks => {
+                FlashblocksP2PMsgParts::AcceptFlashblocks => {
                     tracing::trace!(
                         target: "flashblocks::p2p",
                         peer_id = %this.peer_id,
@@ -263,7 +281,7 @@ impl<N: FlashblocksP2PNetworkHandle> Stream for FlashblocksConnection<N> {
                             .reputation_change(this.peer_id, ReputationChangeKind::BadMessage);
                     }
                 }
-                FlashblocksP2PMsg::RejectFlashblocks => {
+                FlashblocksP2PMsgParts::RejectFlashblocks => {
                     tracing::trace!(
                         target: "flashblocks::p2p",
                         peer_id = %this.peer_id,
@@ -280,7 +298,7 @@ impl<N: FlashblocksP2PNetworkHandle> Stream for FlashblocksConnection<N> {
                             .reputation_change(this.peer_id, ReputationChangeKind::BadMessage);
                     }
                 }
-                FlashblocksP2PMsg::CancelFlashblocks => {
+                FlashblocksP2PMsgParts::CancelFlashblocks => {
                     tracing::trace!(
                         target: "flashblocks::p2p",
                         peer_id = %this.peer_id,

--- a/crates/primitives/src/p2p.rs
+++ b/crates/primitives/src/p2p.rs
@@ -345,6 +345,48 @@ impl Authorized {
             .map_err(|_| FlashblocksError::InvalidBuilderSig)
     }
 
+    /// Parses a frame without decoding the message body.
+    ///
+    /// Only the fixed-size authorization and signature are decoded, so an unauthenticated peer
+    /// cannot force an unbounded allocation before [`AuthorizedParts::verify`] runs. The network
+    /// path must use this rather than [`Decodable::decode`].
+    pub fn parse<'a>(buf: &mut &'a [u8]) -> Result<AuthorizedParts<'a>, FlashblocksError> {
+        let header = Header::decode(buf)?;
+        if !header.list {
+            return Err(alloy_rlp::Error::UnexpectedString.into());
+        }
+        let body = &buf[..header.payload_length];
+
+        // 1. payload — sized from its header alone, decoded only once the signatures check out
+        let mut cursor = body;
+        let msg_header = Header::decode(&mut cursor)?;
+        if !msg_header.list {
+            return Err(alloy_rlp::Error::Custom("AuthorizedMsg must be an RLP list").into());
+        }
+        let msg_len = body.len() - cursor.len() + msg_header.payload_length;
+
+        // 2. authorization
+        let after_msg = &body[msg_len..];
+        let mut rest = after_msg;
+        let authorization = Authorization::decode(&mut rest)?;
+        let signed_len = msg_len + (after_msg.len() - rest.len());
+
+        // 3. builder signature
+        let sig_bytes = Bytes::decode(&mut rest)?;
+        let actor_sig = Signature::try_from(sig_bytes.as_ref())
+            .map_err(|_| alloy_rlp::Error::Custom("bad signature"))?;
+
+        // advance caller's cursor
+        *buf = &buf[header.payload_length..];
+
+        Ok(AuthorizedParts {
+            authorization,
+            actor_sig,
+            msg: &body[..msg_len],
+            signed: &body[..signed_len],
+        })
+    }
+
     /// Converts this `Authorized` message into a type-safe `AuthorizedPayload<T>` without verification.
     ///
     /// This is an unchecked conversion that bypasses type checking. The caller must ensure
@@ -444,6 +486,56 @@ impl Decodable for Authorized {
     }
 }
 
+/// An [`Authorized`] frame whose fixed-size fields are decoded but whose message body is not.
+#[derive(Clone, Debug)]
+pub struct AuthorizedParts<'a> {
+    /// The authorization that grants permission to send this message.
+    pub authorization: Authorization,
+    /// The signature of the actor, made over the hash of the message and authorization.
+    pub actor_sig: Signature,
+    /// RLP-encoded [`AuthorizedMsg`], left undecoded until the signatures verify.
+    msg: &'a [u8],
+    /// `rlp(msg) || rlp(authorization)` — the actor signature preimage, contiguous on the wire.
+    signed: &'a [u8],
+}
+
+impl AuthorizedParts<'_> {
+    /// Verifies the authorizer and actor signatures.
+    pub fn verify(&self, authorizer_vk: VerifyingKey) -> Result<(), FlashblocksError> {
+        self.authorization.verify(authorizer_vk)?;
+
+        let hash = blake3::hash(self.signed);
+        self.authorization
+            .builder_vk
+            .verify(hash.as_bytes(), &self.actor_sig)
+            .map_err(|_| FlashblocksError::InvalidBuilderSig)
+    }
+
+    /// Decodes the message body. Only call once [`Self::verify`] has succeeded.
+    pub fn into_authorized(self) -> Result<Authorized, FlashblocksError> {
+        Ok(Authorized {
+            msg: AuthorizedMsg::decode(&mut &self.msg[..])?,
+            authorization: self.authorization,
+            actor_sig: self.actor_sig,
+        })
+    }
+}
+
+/// A parsed [`FlashblocksP2PMsg`] whose [`Authorized`] body is still undecoded.
+#[derive(Clone, Debug)]
+pub enum FlashblocksP2PMsgParts<'a> {
+    /// An authorized message, pending signature verification.
+    Authorized(Box<AuthorizedParts<'a>>),
+    /// Requests that the remote peer begin forwarding flashblocks to us.
+    RequestFlashblocks,
+    /// Accepts a previously sent [`Self::RequestFlashblocks`] request.
+    AcceptFlashblocks,
+    /// Rejects a previously sent [`Self::RequestFlashblocks`] request.
+    RejectFlashblocks,
+    /// Sent by a receiver to terminate an active flashblocks feed from a sender.
+    CancelFlashblocks,
+}
+
 impl FlashblocksP2PMsg {
     pub fn encode(&self) -> BytesMut {
         let mut buf = BytesMut::new();
@@ -460,6 +552,28 @@ impl FlashblocksP2PMsg {
         buf
     }
 
+    /// Parses a wire frame, deferring the unbounded `Authorized` body decode until
+    /// [`AuthorizedParts::verify`] has authenticated the sender. Use this for peer input.
+    pub fn parse(buf: &[u8]) -> Result<FlashblocksP2PMsgParts<'_>, FlashblocksError> {
+        if buf.is_empty() {
+            return Err(FlashblocksError::InputTooShort);
+        }
+        let id = buf[0];
+        let mut rest = &buf[1..];
+        match id {
+            0x00 => Ok(FlashblocksP2PMsgParts::Authorized(Box::new(
+                Authorized::parse(&mut rest)?,
+            ))),
+            0x01 => Ok(FlashblocksP2PMsgParts::RequestFlashblocks),
+            0x02 => Ok(FlashblocksP2PMsgParts::AcceptFlashblocks),
+            0x03 => Ok(FlashblocksP2PMsgParts::RejectFlashblocks),
+            0x04 => Ok(FlashblocksP2PMsgParts::CancelFlashblocks),
+            _ => Err(FlashblocksError::UnknownMessageType),
+        }
+    }
+
+    /// Decodes a frame in full. Not for peer input — use [`Self::parse`], which authenticates
+    /// before decoding the attacker-sized message body.
     pub fn decode(buf: &mut &[u8]) -> Result<Self, FlashblocksError> {
         if buf.is_empty() {
             return Err(FlashblocksError::InputTooShort);
@@ -886,5 +1000,87 @@ mod tests {
         let err =
             FlashblocksP2PMsg::decode(&mut slice).expect_err("should fail on unknown message type");
         assert_eq!(err, FlashblocksError::UnknownMessageType);
+    }
+
+    fn authorized_frame(builder_sk: &SigningKey, msg: AuthorizedMsg) -> (BytesMut, VerifyingKey) {
+        let (authorizer_sk, authorizer_vk) = key_pair(1);
+        let authorization = Authorization::new(
+            PayloadId::default(),
+            1_700_000_001,
+            &authorizer_sk,
+            builder_sk.verifying_key(),
+        );
+
+        let authorized = Authorized::new(builder_sk, authorization, msg);
+        (
+            FlashblocksP2PMsg::Authorized(authorized).encode(),
+            authorizer_vk,
+        )
+    }
+
+    fn parse_authorized(buf: &[u8]) -> AuthorizedParts<'_> {
+        match FlashblocksP2PMsg::parse(buf).expect("parse succeeds") {
+            FlashblocksP2PMsgParts::Authorized(parts) => *parts,
+            other => panic!("expected Authorized, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_then_decode_matches_eager_decode() {
+        let (builder_sk, _) = key_pair(2);
+        let (frame, authorizer_vk) =
+            authorized_frame(&builder_sk, sample_flashblocks_payload().into());
+
+        let parts = parse_authorized(&frame);
+        parts.verify(authorizer_vk).expect("signatures verify");
+        let authorized = parts.into_authorized().expect("body decodes");
+
+        let mut slice: &[u8] = &frame;
+        let expected = match FlashblocksP2PMsg::decode(&mut slice).expect("decoding succeeds") {
+            FlashblocksP2PMsg::Authorized(authorized) => authorized,
+            other => panic!("expected Authorized, got {other:?}"),
+        };
+        assert_eq!(authorized, expected);
+    }
+
+    #[test]
+    fn parse_rejects_tampered_msg_body() {
+        let (builder_sk, _) = key_pair(2);
+        let (frame, authorizer_vk) =
+            authorized_frame(&builder_sk, sample_flashblocks_payload().into());
+
+        // Flip a bit inside the sole sample transaction, leaving the frame structurally valid.
+        let mut tampered = frame.to_vec();
+        let tx = tampered
+            .windows(4)
+            .position(|w| w == [0xDE, 0xAD, 0xBE, 0xEF])
+            .expect("sample transaction present");
+        tampered[tx] ^= 0x01;
+
+        let parts = parse_authorized(&tampered);
+        assert_eq!(
+            parts.verify(authorizer_vk),
+            Err(FlashblocksError::InvalidBuilderSig),
+        );
+    }
+
+    #[test]
+    fn parse_rejects_unauthorized_builder_before_decoding_body() {
+        // A well-formed frame whose transaction list is far larger than any real flashblock.
+        let mut payload = sample_flashblocks_payload();
+        payload.diff.transactions = vec![Bytes::new(); 100_000];
+
+        let (unauthorized_sk, _) = key_pair(9);
+        let (frame, _) = authorized_frame(&unauthorized_sk, payload.into());
+        let (_, authorizer_vk) = key_pair(3);
+
+        let parts = parse_authorized(&frame);
+        assert_eq!(
+            parts.verify(authorizer_vk),
+            Err(FlashblocksError::InvalidAuthorizerSig),
+        );
+
+        // The frame itself is valid, so only the failed verification stopped the body decode.
+        parts.into_authorized().expect("body would have decoded");
     }
 }


### PR DESCRIPTION
Reverts worldcoin/world-chain#1038

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches untrusted network input and signature verification ordering on the flashblocks P2P path; behavior should match prior valid messages but invalid frames fail earlier with a new parse pipeline.
> 
> **Overview**
> Restores **authenticate-then-decode** handling for inbound flashblocks P2P traffic so peers cannot trigger large allocations from bogus authorized frames.
> 
> **Primitives:** Adds `Authorized::parse`, `AuthorizedParts`, and `FlashblocksP2PMsg::parse` / `FlashblocksP2PMsgParts`. Parsing reads RLP headers and fixed-size authorization + builder signature only; the `AuthorizedMsg` body stays as raw bytes until `verify` succeeds, then `into_authorized` decodes it. Full `decode` remains for non-peer paths and is documented as unsafe for untrusted input.
> 
> **P2P connection:** Switches peer ingress from `FlashblocksP2PMsg::decode` to `parse`, runs signature verification on `AuthorizedParts`, and only then decodes the body (with reputation penalties on parse/verify/decode failures).
> 
> **Tests:** Cover parse-then-decode parity with eager decode, tampered bodies failing verification, and oversized payloads rejected before body decode when authorization is invalid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 155afc5872f54858968a3e2605943befcabec34d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->