### PR TITLE
chore: update image prefixes

### DIFF
--- a/.github/workflows/docker-proof.yml
+++ b/.github/workflows/docker-proof.yml
@@ -34,7 +34,7 @@ on:
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}
-  IMAGE_NAME: ${{ github.repository }}-proof
+  IMAGE_NAME: ${{ github.repository }}
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
   AWS_REGION: us-east-1
@@ -62,7 +62,7 @@ jobs:
 
   # Service deployable images, built from the same Dockerfile.proof via
   # PROVER_PACKAGE/PROVER_BIN/FEATURES build-args. Each pushes to its own
-  # `<repo>-<service>` image so tags do not collide with the `proof` image.
+  # `<repo>-<service>` image so tags do not collide with the builder image.
   build-service-images:
     name: build ${{ matrix.service.bin }} image
     needs: [resolve-sha]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Renaming published container images breaks existing deploy manifests or pins that reference the old `*-proof-*` GHCR paths until they are updated.
> 
> **Overview**
> Updates **`docker-proof.yml`** so the shared **`IMAGE_NAME`** env var is **`github.repository`** instead of **`github.repository`-proof**, aligning prover deployable image names with other workflows (e.g. **`deploy-alphanet-build`**).
> 
> All images built by this workflow (service matrix, nitro-worker, nitro-enclave, EIF carrier, and the job summary table) therefore publish under **`ghcr.io/<repo>-<suffix>`** rather than **`ghcr.io/<repo>-proof-<suffix>`**. A comment in the service-images job is updated to refer to the **builder** image instead of the **proof** image when describing tag collision avoidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c00101facec1a96f7f1e511f225f3d3dedc9e231. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->