### PR TITLE
fix(proofs): submit SP1 requests with fixed limits

### DIFF
--- a/docs/proof/sp1-worker.md
+++ b/docs/proof/sp1-worker.md
@@ -34,6 +34,22 @@ does not interrupt in-flight work.
 `NETWORK_RPC_URL` remains the optional override for the SP1 Network API itself. It is distinct from
 `SP1_NETWORK_L1_RPC_URL`.
 
+### SP1 Network execution limits
+
+Network requests skip local guest execution by default and submit with separate upper bounds for
+the range and aggregation guests:
+
+| Variable | Flag | Default |
+|---|---|---:|
+| `SP1_RANGE_CYCLE_LIMIT` | `--sp1-range-cycle-limit` | `1500000000000` |
+| `SP1_RANGE_GAS_LIMIT` | `--sp1-range-gas-limit` | `1300000000000` PGUs |
+| `SP1_AGGREGATION_CYCLE_LIMIT` | `--sp1-aggregation-cycle-limit` | `7000000` |
+| `SP1_AGGREGATION_GAS_LIMIT` | `--sp1-aggregation-gas-limit` | `6500000` PGUs |
+
+These are safety ceilings, not requested billing amounts. To execute each guest locally and let the
+SP1 SDK estimate both limits instead, set `SP1_ESTIMATE_LIMITS=true` or pass
+`--sp1-estimate-limits`. Local estimation conflicts with explicitly configured limit flags.
+
 ## Deposit PROVE
 
 The funding command signs an EIP-2612 permit and submits one `permitAndDeposit` transaction. Prefer

--- a/proofs/backends/sp1/host/src/network_prover.rs
+++ b/proofs/backends/sp1/host/src/network_prover.rs
@@ -27,6 +27,25 @@ pub struct NetworkSuccinctProver {
     agg_pk: SP1ProvingKey,
     multi_block_vkey: [u32; 8],
     agg_mode: SP1ProofMode,
+    limits: Option<NetworkProverLimits>,
+}
+
+/// Upper bounds supplied to SP1 Network instead of estimating them by executing guests locally.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ProofLimits {
+    /// Maximum guest cycles accepted by the network request.
+    pub cycle_limit: u64,
+    /// Maximum prover gas units accepted by the network request.
+    pub gas_limit: u64,
+}
+
+/// Separate limits for the much larger range guest and the small aggregation guest.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct NetworkProverLimits {
+    /// Limits for the range guest.
+    pub range: ProofLimits,
+    /// Limits for the aggregation guest.
+    pub aggregation: ProofLimits,
 }
 
 /// Lightweight client for reading an account's SP1 Network credit balance.
@@ -122,6 +141,16 @@ impl NetworkSuccinctProver {
         agg_mode: SP1ProofMode,
         connection: NetworkConnection,
     ) -> anyhow::Result<Self> {
+        Self::from_connection_with_limits(agg_mode, connection, None).await
+    }
+
+    /// Creates the prover with optional explicit execution limits. Supplying limits skips SP1's
+    /// local guest execution before each network request.
+    pub async fn from_connection_with_limits(
+        agg_mode: SP1ProofMode,
+        connection: NetworkConnection,
+        limits: Option<NetworkProverLimits>,
+    ) -> anyhow::Result<Self> {
         let range_elf = world_chain_proof_sp1_elfs::range_elf();
         let agg_elf = world_chain_proof_sp1_elfs::aggregation_elf();
         let client =
@@ -142,6 +171,7 @@ impl NetworkSuccinctProver {
             agg_pk,
             multi_block_vkey,
             agg_mode,
+            limits,
         })
     }
 
@@ -149,10 +179,15 @@ impl NetworkSuccinctProver {
         let mut stdin = SP1Stdin::new();
         stdin.write_vec(request.witness_rkyv);
 
-        let backend_session_id = self
-            .client
-            .prove(&self.range_pk, stdin)
-            .compressed()
+        let mut proof_request = self.client.prove(&self.range_pk, stdin).compressed();
+        if let Some(limits) = self.limits {
+            proof_request = proof_request
+                .cycle_limit(limits.range.cycle_limit)
+                .gas_limit(limits.range.gas_limit)
+                .skip_simulation(true);
+        }
+
+        let backend_session_id = proof_request
             .request()
             .await
             .context("request range proving failed")?;
@@ -177,10 +212,15 @@ impl NetworkSuccinctProver {
         stdin.write(&request.inputs);
         stdin.write_vec(request.l1_headers_cbor);
 
-        let backend_session_id = self
-            .client
-            .prove(&self.agg_pk, stdin)
-            .mode(self.agg_mode)
+        let mut proof_request = self.client.prove(&self.agg_pk, stdin).mode(self.agg_mode);
+        if let Some(limits) = self.limits {
+            proof_request = proof_request
+                .cycle_limit(limits.aggregation.cycle_limit)
+                .gas_limit(limits.aggregation.gas_limit)
+                .skip_simulation(true);
+        }
+
+        let backend_session_id = proof_request
             .request()
             .await
             .context("aggregation proving failed")?;

--- a/proofs/workers/sp1/src/cmd/run.rs
+++ b/proofs/workers/sp1/src/cmd/run.rs
@@ -11,7 +11,10 @@ use world_chain_proof_sp1_host::{
     Sp1ProverKind, WorldSuccinctProver,
     cpu_prover::{CpuSuccinctProver, SP1ProofMode},
     mock_prover::MockSuccinctProver,
-    network_prover::{NetworkConnection, NetworkCreditClient, NetworkSuccinctProver},
+    network_prover::{
+        NetworkConnection, NetworkCreditClient, NetworkProverLimits, NetworkSuccinctProver,
+        ProofLimits,
+    },
 };
 use world_chain_proof_sp1_worker::{
     ProofWorker, ProofWorkerConfig, RetryConfig, Sp1Backend, Sp1BackendConfig,
@@ -32,6 +35,10 @@ const DEFAULT_WORKER_MAX_CONSECUTIVE_HEARTBEAT_FAILURES: u32 = 5;
 const DEFAULT_SP1_SESSION_POLL_INTERVAL: Duration = Duration::from_secs(10);
 const SP1_NETWORK_BALANCE_POLL_INTERVAL: Duration = Duration::from_secs(30);
 const MINIMUM_DEPOSIT_MULTIPLIER: u64 = 10;
+const DEFAULT_SP1_RANGE_CYCLE_LIMIT: u64 = 1_500_000_000_000;
+const DEFAULT_SP1_RANGE_GAS_LIMIT: u64 = 1_300_000_000_000;
+const DEFAULT_SP1_AGGREGATION_CYCLE_LIMIT: u64 = 7_000_000;
+const DEFAULT_SP1_AGGREGATION_GAS_LIMIT: u64 = 6_500_000;
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
 enum Network {
@@ -150,6 +157,51 @@ pub struct WorkerArgs {
         value_parser = clap::value_parser!(u64).range(1..)
     )]
     sp1_session_poll_interval_seconds: u64,
+
+    /// Execute each SP1 guest locally to estimate its cycle and gas limits before submitting it.
+    /// By default, the worker skips local execution and uses the configured fixed limits.
+    #[arg(long, env = "SP1_ESTIMATE_LIMITS")]
+    sp1_estimate_limits: bool,
+
+    /// Cycle limit for optimistic SP1 range-proof requests.
+    #[arg(
+        long,
+        env = "SP1_RANGE_CYCLE_LIMIT",
+        default_value_t = DEFAULT_SP1_RANGE_CYCLE_LIMIT,
+        conflicts_with = "sp1_estimate_limits",
+        value_parser = clap::value_parser!(u64).range(1..)
+    )]
+    sp1_range_cycle_limit: u64,
+
+    /// Gas limit in PGUs for optimistic SP1 range-proof requests.
+    #[arg(
+        long,
+        env = "SP1_RANGE_GAS_LIMIT",
+        default_value_t = DEFAULT_SP1_RANGE_GAS_LIMIT,
+        conflicts_with = "sp1_estimate_limits",
+        value_parser = clap::value_parser!(u64).range(1..)
+    )]
+    sp1_range_gas_limit: u64,
+
+    /// Cycle limit for optimistic SP1 aggregation-proof requests.
+    #[arg(
+        long,
+        env = "SP1_AGGREGATION_CYCLE_LIMIT",
+        default_value_t = DEFAULT_SP1_AGGREGATION_CYCLE_LIMIT,
+        conflicts_with = "sp1_estimate_limits",
+        value_parser = clap::value_parser!(u64).range(1..)
+    )]
+    sp1_aggregation_cycle_limit: u64,
+
+    /// Gas limit in PGUs for optimistic SP1 aggregation-proof requests.
+    #[arg(
+        long,
+        env = "SP1_AGGREGATION_GAS_LIMIT",
+        default_value_t = DEFAULT_SP1_AGGREGATION_GAS_LIMIT,
+        conflicts_with = "sp1_estimate_limits",
+        value_parser = clap::value_parser!(u64).range(1..)
+    )]
+    sp1_aggregation_gas_limit: u64,
 
     /// Maximum number of jobs proved concurrently. One suits a local CPU prover; raise it for
     /// the Succinct proving network.
@@ -271,10 +323,25 @@ pub async fn run(cli: WorkerArgs) -> Result<()> {
             }
 
             monitor_network_balance(credit_client, minimum_balance, settlement.prove_decimals);
+            let limits = (!cli.sp1_estimate_limits).then_some(NetworkProverLimits {
+                range: ProofLimits {
+                    cycle_limit: cli.sp1_range_cycle_limit,
+                    gas_limit: cli.sp1_range_gas_limit,
+                },
+                aggregation: ProofLimits {
+                    cycle_limit: cli.sp1_aggregation_cycle_limit,
+                    gas_limit: cli.sp1_aggregation_gas_limit,
+                },
+            });
             run_worker(
                 &cli,
                 host,
-                NetworkSuccinctProver::from_connection(SP1ProofMode::Groth16, connection).await?,
+                NetworkSuccinctProver::from_connection_with_limits(
+                    SP1ProofMode::Groth16,
+                    connection,
+                    limits,
+                )
+                .await?,
             )
             .await
         }
@@ -417,6 +484,11 @@ where
         block_interval = cli.block_interval,
         ranges = cli.ranges.max(1),
         prover = %cli.prover,
+        sp1_estimate_limits = cli.sp1_estimate_limits,
+        sp1_range_cycle_limit = cli.sp1_range_cycle_limit,
+        sp1_range_gas_limit = cli.sp1_range_gas_limit,
+        sp1_aggregation_cycle_limit = cli.sp1_aggregation_cycle_limit,
+        sp1_aggregation_gas_limit = cli.sp1_aggregation_gas_limit,
         sp1_session_poll_interval_seconds = cli.sp1_session_poll_interval_seconds,
         submit_proof_retry_max_retries = cli.submit_proof_retry_max_retries,
         submit_proof_retry_initial_delay_ms = cli.submit_proof_retry_initial_delay_ms,
@@ -479,6 +551,44 @@ mod tests {
             WorkerArgs::try_parse_from(args).expect_err("zero poll interval should be rejected");
 
         assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
+    }
+
+    #[test]
+    fn uses_optimistic_sp1_limits_by_default() {
+        let cli = WorkerArgs::parse_from(base_args());
+
+        assert!(!cli.sp1_estimate_limits);
+        assert_eq!(cli.sp1_range_cycle_limit, DEFAULT_SP1_RANGE_CYCLE_LIMIT);
+        assert_eq!(cli.sp1_range_gas_limit, DEFAULT_SP1_RANGE_GAS_LIMIT);
+        assert_eq!(
+            cli.sp1_aggregation_cycle_limit,
+            DEFAULT_SP1_AGGREGATION_CYCLE_LIMIT
+        );
+        assert_eq!(
+            cli.sp1_aggregation_gas_limit,
+            DEFAULT_SP1_AGGREGATION_GAS_LIMIT
+        );
+    }
+
+    #[test]
+    fn local_limit_estimation_conflicts_with_explicit_limits() {
+        let mut args = base_args();
+        args.extend(["--sp1-estimate-limits", "--sp1-range-cycle-limit", "1000"]);
+
+        let error = WorkerArgs::try_parse_from(args)
+            .expect_err("local estimation and explicit limits should conflict");
+
+        assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn local_limit_estimation_can_use_defaulted_limit_arguments() {
+        let mut args = base_args();
+        args.push("--sp1-estimate-limits");
+
+        let cli = WorkerArgs::parse_from(args);
+
+        assert!(cli.sp1_estimate_limits);
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how network proof jobs are submitted; mis-tuned limits could cause unfulfillable proofs, but behavior is configurable and defaults preserve an explicit ceiling path.
> 
> **Overview**
> **Network SP1 proving now skips local guest simulation by default** and submits range and aggregation jobs with explicit cycle and gas ceilings plus `skip_simulation(true)`.
> 
> The network prover gains `NetworkProverLimits` / `ProofLimits` and `from_connection_with_limits`; when limits are set, both `request_range_proof` and `request_aggregation_proof` chain `.cycle_limit`, `.gas_limit`, and `.skip_simulation` on the SDK prove request before `.request()`.
> 
> The SP1 worker wires this through new CLI/env knobs (`SP1_RANGE_*`, `SP1_AGGREGATION_*`) with large default ceilings, logs them at startup, and only omits fixed limits when **`SP1_ESTIMATE_LIMITS` / `--sp1-estimate-limits`** is enabled (clap conflicts block mixing estimation with explicit limit flags). Operator docs describe the new section on execution limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22cc25b184be6e580bb1291c3b6d5f0d0fac8afe. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->