### PR TITLE
fix(proofs): refresh guest builder lock entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19216,7 +19216,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-sp1-guest-builder"
-version = "2.4.1"
+version = "2.4.2"
 dependencies = [
  "anyhow",
  "sp1-build",


### PR DESCRIPTION
## Summary

Refresh the SP1 guest-builder package version in Cargo.lock from 2.4.1 to the workspace version 2.4.2.

## Root cause

PR #1037 added world-chain-proof-sp1-guest-builder with version.workspace = true, but its merged lock entry remained at 2.4.1. Every proof Docker target invokes Cargo with --locked, so Cargo correctly rejected the stale lockfile.

Failing main run: https://github.com/worldcoin/world-chain/actions/runs/31914422540

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only version alignment with no application logic changes.
> 
> **Overview**
> Updates **`Cargo.lock`** so **`world-chain-proof-sp1-guest-builder`** is recorded at **2.4.2** instead of **2.4.1**, matching the crate’s **`version.workspace = true`** declaration and sibling proof packages.
> 
> This fixes **`cargo … --locked`** failures in proof Docker targets (e.g. **`world-chain-proof-sp1-guest-builder`** in **`Dockerfile.prover`**) caused by a stale lock entry left after the guest-builder was added to the workspace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9278f124c1b6b16eec035bc11416b1812496b1b7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->