### PR TITLE
fix(proofs): derive worker ranges from game

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19200,12 +19200,14 @@ dependencies = [
  "alloy-sol-types",
  "alloy-transport",
  "async-trait",
+ "backon",
  "futures-util",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
  "tokio",
+ "tracing",
  "world-chain-proof-metrics",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19197,7 +19197,6 @@ dependencies = [
  "alloy-contract",
  "alloy-primitives",
  "alloy-provider",
- "alloy-rpc-client",
  "alloy-sol-types",
  "alloy-transport",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19170,6 +19170,7 @@ name = "world-chain-proof-nitro-worker"
 version = "2.4.2"
 dependencies = [
  "alloy-primitives",
+ "alloy-provider",
  "alloy-sol-types",
  "anyhow",
  "async-trait",
@@ -19184,6 +19185,7 @@ dependencies = [
  "world-chain-proof-kona-host",
  "world-chain-proof-metrics",
  "world-chain-proof-nitro-enclave",
+ "world-chain-proof-protocol",
  "world-chain-proof-worker",
  "world-chain-prover-service",
 ]
@@ -19195,7 +19197,9 @@ dependencies = [
  "alloy-contract",
  "alloy-primitives",
  "alloy-provider",
+ "alloy-rpc-client",
  "alloy-sol-types",
+ "alloy-transport",
  "async-trait",
  "futures-util",
  "reqwest 0.12.28",

--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -56,7 +56,9 @@ use world_chain_proof_core::{
     boot::TransitionPublicValues, hash_world_rollup_config, range::WorldRangeHardforkConfig,
 };
 use world_chain_proof_kona_host::online::OnlineHostConfig;
-use world_chain_proof_protocol::{OptimismConsensusClient, PROOF_SYSTEM_VERSION, PROOF_THRESHOLD};
+use world_chain_proof_protocol::{
+    AlloyProofGameProvider, OptimismConsensusClient, PROOF_SYSTEM_VERSION, PROOF_THRESHOLD,
+};
 use world_chain_proof_sp1_host::{
     Sp1ProverKind, WorldSuccinctProver,
     cpu_prover::{CpuSuccinctProver, SP1ProofMode},
@@ -3042,13 +3044,27 @@ async fn start_sp1_worker(
             let prover = CpuSuccinctProver::new(SP1ProofMode::Groth16)
                 .await
                 .map_err(|error| eyre!("failed to build SP1 prover: {error}"))?;
-            start_sp1_worker_with_prover(prover_service_url, deployment, kind, host, prover)
+            start_sp1_worker_with_prover(
+                l1_rpc_url,
+                prover_service_url,
+                deployment,
+                kind,
+                host,
+                prover,
+            )
         }
         Sp1ProverKind::Mock => {
             let prover = MockSuccinctProver::new(SP1ProofMode::Groth16)
                 .await
                 .map_err(|error| eyre!("failed to build SP1 prover: {error}"))?;
-            start_sp1_worker_with_prover(prover_service_url, deployment, kind, host, prover)
+            start_sp1_worker_with_prover(
+                l1_rpc_url,
+                prover_service_url,
+                deployment,
+                kind,
+                host,
+                prover,
+            )
         }
         Sp1ProverKind::Network => {
             let private_key = std::env::var(SP1_PRIVATE_KEY_ENV).wrap_err_with(|| {
@@ -3058,12 +3074,20 @@ async fn start_sp1_worker(
                 NetworkSuccinctProver::new(SP1ProofMode::Groth16, &private_key, SignerType::Local)
                     .await
                     .map_err(|error| eyre!("failed to build SP1 prover: {error}"))?;
-            start_sp1_worker_with_prover(prover_service_url, deployment, kind, host, prover)
+            start_sp1_worker_with_prover(
+                l1_rpc_url,
+                prover_service_url,
+                deployment,
+                kind,
+                host,
+                prover,
+            )
         }
     }
 }
 
 fn start_sp1_worker_with_prover<P>(
+    l1_rpc_url: &str,
     prover_service_url: &str,
     deployment: &WorldProofSystemDeployment,
     kind: Sp1ProverKind,
@@ -3073,11 +3097,13 @@ fn start_sp1_worker_with_prover<P>(
 where
     P: WorldSuccinctProver + Send + Sync + 'static,
 {
+    let game_provider =
+        AlloyProofGameProvider::new(ProviderBuilder::new().connect_http(Url::parse(l1_rpc_url)?));
     let backend = Sp1Backend::new(
         host,
         prover,
+        game_provider,
         Sp1BackendConfig {
-            block_interval: deployment.block_interval,
             split_count: 1,
             allow_unfinalized: false,
             session_poll_interval: Duration::from_secs(10),

--- a/docs/proof/nitro-worker.md
+++ b/docs/proof/nitro-worker.md
@@ -708,6 +708,10 @@ a debug enclave is indistinguishable from a forged one.
 
 ### `nitro-worker` (Host Binary)
 
+For every leased job, the host reads the proof interval and immutable transition metadata from the
+job's `MultiProofGame`. It rejects queued root, block, L1 head, or rollup-config values that do not
+match the game before collecting a witness or contacting the enclave.
+
 | Flag / Env Var | Description | Default |
 |----------------|-------------|---------|
 | `--prover-service-url` / `PROVER_SERVICE_URL` | URL of the prover-service API | Required |
@@ -717,7 +721,6 @@ a debug enclave is indistinguishable from a forged one.
 | `--network` / `NETWORK` | `worldchain` or `worldchain-sepolia` | `worldchain` |
 | `--rollup-config` / `ROLLUP_CONFIG` | Path to rollup config JSON file | — |
 | `--rollup-config-hash` / `ROLLUP_CONFIG_HASH` | Rollup config hash override | — |
-| `--block-interval` / `BLOCK_INTERVAL` | L2 blocks per proof (must match contract) | Required |
 | `--enclave-cid` / `ENCLAVE_CID` | vsock CID of the enclave | `16` |
 | `--enclave-port` / `ENCLAVE_PORT` | vsock port the enclave listens on | `5005` |
 | `--pcr0` / `PCR0` | Expected PCR0 (hex, 48 bytes) | All zeros (placeholder) |

--- a/docs/proof/sp1-worker.md
+++ b/docs/proof/sp1-worker.md
@@ -13,10 +13,13 @@ world-chain-proof-sp1-worker run \
   --l1-rpc "$L1_RPC_URL" \
   --l1-beacon-rpc "$L1_BEACON_RPC_URL" \
   --l2-rpc "$L2_RPC_URL" \
-  --block-interval 10 \
   --worker-id worker-0 \
   --prover network
 ```
+
+For every leased job, the worker reads the proof interval and immutable transition metadata from
+the job's `MultiProofGame`. It rejects queued root, block, L1 head, or rollup-config values that do
+not match the game before collecting a witness.
 
 The network prover additionally requires:
 

--- a/proofs/protocol/Cargo.toml
+++ b/proofs/protocol/Cargo.toml
@@ -18,6 +18,7 @@ world-chain-proof-metrics.workspace = true
 alloy-primitives.workspace = true
 alloy-contract.workspace = true
 alloy-provider.workspace = true
+alloy-rpc-client.workspace = true
 alloy-sol-types.workspace = true
 
 # misc
@@ -29,6 +30,7 @@ reqwest = { workspace = true, features = ["json", "rustls-tls"] }
 thiserror.workspace = true
 
 [dev-dependencies]
+alloy-transport.workspace = true
 tokio.workspace = true
 
 [features]

--- a/proofs/protocol/Cargo.toml
+++ b/proofs/protocol/Cargo.toml
@@ -22,11 +22,13 @@ alloy-sol-types.workspace = true
 
 # misc
 async-trait.workspace = true
+backon.workspace = true
 futures-util.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 reqwest = { workspace = true, features = ["json", "rustls-tls"] }
 thiserror.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 alloy-transport.workspace = true

--- a/proofs/protocol/Cargo.toml
+++ b/proofs/protocol/Cargo.toml
@@ -18,7 +18,6 @@ world-chain-proof-metrics.workspace = true
 alloy-primitives.workspace = true
 alloy-contract.workspace = true
 alloy-provider.workspace = true
-alloy-rpc-client.workspace = true
 alloy-sol-types.workspace = true
 
 # misc

--- a/proofs/protocol/src/lib.rs
+++ b/proofs/protocol/src/lib.rs
@@ -10,6 +10,7 @@ pub const DEFAULT_L1_TX_RECEIPT_TIMEOUT_SECONDS: u64 = 5 * 60;
 mod bindings;
 mod consensus_provider;
 mod lineage;
+mod proof_game;
 mod types;
 
 // re-exports
@@ -22,6 +23,9 @@ pub use lineage::{
     RegisteredLineageConfig, SelectedLineage, SelectedLineageGame, read_game_for_transition,
     read_lineage_anchor, read_lineage_resolution_status, read_registered_lineage_config,
     select_lineage,
+};
+pub use proof_game::{
+    AlloyProofGameProvider, ProofGameContext, ProofGameContextError, ProofGameProvider,
 };
 pub use types::{
     ClaimData, GameCreation, GameStatus, GameStatusError, InvalidationReason,

--- a/proofs/protocol/src/proof_game.rs
+++ b/proofs/protocol/src/proof_game.rs
@@ -1,7 +1,5 @@
-use alloy_primitives::{Address, B256, Bytes, U256};
+use alloy_primitives::{Address, B256, U256};
 use alloy_provider::Provider;
-use alloy_rpc_client::BatchRequest;
-use alloy_sol_types::SolCall;
 use async_trait::async_trait;
 
 use crate::IMultiProofGame;
@@ -82,7 +80,7 @@ pub trait ProofGameProvider: Send + Sync + 'static {
     ) -> Result<ProofGameContext, ProofGameContextError>;
 }
 
-/// Alloy-backed proof-game reader using one JSON-RPC batch without a Multicall3 dependency.
+/// Alloy-backed proof-game reader using typed contract calls without a Multicall3 dependency.
 #[derive(Clone, Debug)]
 pub struct AlloyProofGameProvider<P> {
     provider: P,
@@ -105,73 +103,20 @@ where
     ) -> Result<ProofGameContext, ProofGameContextError> {
         let game =
             IMultiProofGame::IMultiProofGameInstance::new(game_address, self.provider.clone());
-        let mut batch = BatchRequest::new(self.provider.client());
-        let block_interval = batch
-            .add_call::<_, Bytes>(
-                "eth_call",
-                &(game.blockInterval().into_transaction_request(), "latest"),
+        let block_interval_call = game.blockInterval();
+        let rollup_config_hash_call = game.rollupConfigHash();
+        let root_claim_call = game.rootClaim();
+        let l2_block_number_call = game.l2SequenceNumber();
+        let l1_head_call = game.l1Head();
+        let (block_interval, rollup_config_hash, root_claim, l2_block_number, l1_head) =
+            futures_util::try_join!(
+                async { block_interval_call.call().await },
+                async { rollup_config_hash_call.call().await },
+                async { root_claim_call.call().await },
+                async { l2_block_number_call.call().await },
+                async { l1_head_call.call().await },
             )
             .map_err(|error| contract_error(game_address, error))?;
-        let rollup_config_hash = batch
-            .add_call::<_, Bytes>(
-                "eth_call",
-                &(game.rollupConfigHash().into_transaction_request(), "latest"),
-            )
-            .map_err(|error| contract_error(game_address, error))?;
-        let root_claim = batch
-            .add_call::<_, Bytes>(
-                "eth_call",
-                &(game.rootClaim().into_transaction_request(), "latest"),
-            )
-            .map_err(|error| contract_error(game_address, error))?;
-        let l2_block_number = batch
-            .add_call::<_, Bytes>(
-                "eth_call",
-                &(game.l2SequenceNumber().into_transaction_request(), "latest"),
-            )
-            .map_err(|error| contract_error(game_address, error))?;
-        let l1_head = batch
-            .add_call::<_, Bytes>(
-                "eth_call",
-                &(game.l1Head().into_transaction_request(), "latest"),
-            )
-            .map_err(|error| contract_error(game_address, error))?;
-
-        batch
-            .send()
-            .await
-            .map_err(|error| contract_error(game_address, error))?;
-
-        let block_interval = IMultiProofGame::blockIntervalCall::abi_decode_returns(
-            &block_interval
-                .await
-                .map_err(|error| contract_error(game_address, error))?,
-        )
-        .map_err(|error| contract_error(game_address, error))?;
-        let rollup_config_hash = IMultiProofGame::rollupConfigHashCall::abi_decode_returns(
-            &rollup_config_hash
-                .await
-                .map_err(|error| contract_error(game_address, error))?,
-        )
-        .map_err(|error| contract_error(game_address, error))?;
-        let root_claim = IMultiProofGame::rootClaimCall::abi_decode_returns(
-            &root_claim
-                .await
-                .map_err(|error| contract_error(game_address, error))?,
-        )
-        .map_err(|error| contract_error(game_address, error))?;
-        let l2_block_number = IMultiProofGame::l2SequenceNumberCall::abi_decode_returns(
-            &l2_block_number
-                .await
-                .map_err(|error| contract_error(game_address, error))?,
-        )
-        .map_err(|error| contract_error(game_address, error))?;
-        let l1_head = IMultiProofGame::l1HeadCall::abi_decode_returns(
-            &l1_head
-                .await
-                .map_err(|error| contract_error(game_address, error))?,
-        )
-        .map_err(|error| contract_error(game_address, error))?;
 
         Ok(ProofGameContext {
             block_interval: u256_to_u64(game_address, "blockInterval", block_interval)?,
@@ -255,6 +200,7 @@ pub enum ProofGameContextError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_primitives::Bytes;
     use alloy_provider::ProviderBuilder;
     use alloy_sol_types::SolValue;
     use alloy_transport::mock::Asserter;
@@ -275,7 +221,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reads_game_context_from_batched_rpc_calls() {
+    async fn reads_game_context_from_typed_contract_calls() {
         let asserter = Asserter::new();
         for response in [
             Bytes::from(U256::from(450).abi_encode()),

--- a/proofs/protocol/src/proof_game.rs
+++ b/proofs/protocol/src/proof_game.rs
@@ -1,0 +1,353 @@
+use alloy_primitives::{Address, B256, Bytes, U256};
+use alloy_provider::Provider;
+use alloy_rpc_client::BatchRequest;
+use alloy_sol_types::SolCall;
+use async_trait::async_trait;
+
+use crate::IMultiProofGame;
+
+/// Immutable game context that defines the exact transition a proof worker must execute.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ProofGameContext {
+    pub block_interval: u64,
+    pub rollup_config_hash: B256,
+    pub root_claim: B256,
+    pub l2_block_number: u64,
+    pub l1_head: B256,
+}
+
+impl ProofGameContext {
+    /// Validates queued job metadata against the game and returns the exclusive range start.
+    pub fn validated_start_block(
+        self,
+        game: Address,
+        root_claim: B256,
+        l2_block_number: u64,
+        l1_head: B256,
+        rollup_config_hash: B256,
+    ) -> Result<u64, ProofGameContextError> {
+        if self.root_claim != root_claim {
+            return Err(ProofGameContextError::RootClaimMismatch {
+                game,
+                expected: self.root_claim,
+                actual: root_claim,
+            });
+        }
+        if self.l2_block_number != l2_block_number {
+            return Err(ProofGameContextError::L2BlockNumberMismatch {
+                game,
+                expected: self.l2_block_number,
+                actual: l2_block_number,
+            });
+        }
+        if self.l1_head != l1_head {
+            return Err(ProofGameContextError::L1HeadMismatch {
+                game,
+                expected: self.l1_head,
+                actual: l1_head,
+            });
+        }
+        if self.rollup_config_hash != rollup_config_hash {
+            return Err(ProofGameContextError::RollupConfigHashMismatch {
+                game,
+                expected: self.rollup_config_hash,
+                actual: rollup_config_hash,
+            });
+        }
+
+        if self.block_interval == 0 {
+            return Err(ProofGameContextError::InvalidBlockInterval {
+                game,
+                l2_block_number,
+                block_interval: self.block_interval,
+            });
+        }
+
+        l2_block_number.checked_sub(self.block_interval).ok_or(
+            ProofGameContextError::InvalidBlockInterval {
+                game,
+                l2_block_number,
+                block_interval: self.block_interval,
+            },
+        )
+    }
+}
+
+/// Reads proof-critical metadata from the game associated with a leased job.
+#[async_trait]
+pub trait ProofGameProvider: Send + Sync + 'static {
+    async fn proof_game_context(
+        &self,
+        game: Address,
+    ) -> Result<ProofGameContext, ProofGameContextError>;
+}
+
+/// Alloy-backed proof-game reader using one JSON-RPC batch without a Multicall3 dependency.
+#[derive(Clone, Debug)]
+pub struct AlloyProofGameProvider<P> {
+    provider: P,
+}
+
+impl<P> AlloyProofGameProvider<P> {
+    pub const fn new(provider: P) -> Self {
+        Self { provider }
+    }
+}
+
+#[async_trait]
+impl<P> ProofGameProvider for AlloyProofGameProvider<P>
+where
+    P: Provider + Clone + Send + Sync + 'static,
+{
+    async fn proof_game_context(
+        &self,
+        game_address: Address,
+    ) -> Result<ProofGameContext, ProofGameContextError> {
+        let game =
+            IMultiProofGame::IMultiProofGameInstance::new(game_address, self.provider.clone());
+        let mut batch = BatchRequest::new(self.provider.client());
+        let block_interval = batch
+            .add_call::<_, Bytes>(
+                "eth_call",
+                &(game.blockInterval().into_transaction_request(), "latest"),
+            )
+            .map_err(|error| contract_error(game_address, error))?;
+        let rollup_config_hash = batch
+            .add_call::<_, Bytes>(
+                "eth_call",
+                &(game.rollupConfigHash().into_transaction_request(), "latest"),
+            )
+            .map_err(|error| contract_error(game_address, error))?;
+        let root_claim = batch
+            .add_call::<_, Bytes>(
+                "eth_call",
+                &(game.rootClaim().into_transaction_request(), "latest"),
+            )
+            .map_err(|error| contract_error(game_address, error))?;
+        let l2_block_number = batch
+            .add_call::<_, Bytes>(
+                "eth_call",
+                &(game.l2SequenceNumber().into_transaction_request(), "latest"),
+            )
+            .map_err(|error| contract_error(game_address, error))?;
+        let l1_head = batch
+            .add_call::<_, Bytes>(
+                "eth_call",
+                &(game.l1Head().into_transaction_request(), "latest"),
+            )
+            .map_err(|error| contract_error(game_address, error))?;
+
+        batch
+            .send()
+            .await
+            .map_err(|error| contract_error(game_address, error))?;
+
+        let block_interval = IMultiProofGame::blockIntervalCall::abi_decode_returns(
+            &block_interval
+                .await
+                .map_err(|error| contract_error(game_address, error))?,
+        )
+        .map_err(|error| contract_error(game_address, error))?;
+        let rollup_config_hash = IMultiProofGame::rollupConfigHashCall::abi_decode_returns(
+            &rollup_config_hash
+                .await
+                .map_err(|error| contract_error(game_address, error))?,
+        )
+        .map_err(|error| contract_error(game_address, error))?;
+        let root_claim = IMultiProofGame::rootClaimCall::abi_decode_returns(
+            &root_claim
+                .await
+                .map_err(|error| contract_error(game_address, error))?,
+        )
+        .map_err(|error| contract_error(game_address, error))?;
+        let l2_block_number = IMultiProofGame::l2SequenceNumberCall::abi_decode_returns(
+            &l2_block_number
+                .await
+                .map_err(|error| contract_error(game_address, error))?,
+        )
+        .map_err(|error| contract_error(game_address, error))?;
+        let l1_head = IMultiProofGame::l1HeadCall::abi_decode_returns(
+            &l1_head
+                .await
+                .map_err(|error| contract_error(game_address, error))?,
+        )
+        .map_err(|error| contract_error(game_address, error))?;
+
+        Ok(ProofGameContext {
+            block_interval: u256_to_u64(game_address, "blockInterval", block_interval)?,
+            rollup_config_hash,
+            root_claim,
+            l2_block_number: u256_to_u64(game_address, "l2SequenceNumber", l2_block_number)?,
+            l1_head,
+        })
+    }
+}
+
+fn contract_error(game: Address, error: impl ToString) -> ProofGameContextError {
+    ProofGameContextError::Contract {
+        game,
+        error: error.to_string(),
+    }
+}
+
+fn u256_to_u64(
+    game: Address,
+    field: &'static str,
+    value: U256,
+) -> Result<u64, ProofGameContextError> {
+    value
+        .try_into()
+        .map_err(|_| ProofGameContextError::ValueOverflow { game, field, value })
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ProofGameContextError {
+    #[error("failed to read proof game {game}: {error}")]
+    Contract { game: Address, error: String },
+    #[error("proof game {game} field {field} overflows u64: {value}")]
+    ValueOverflow {
+        game: Address,
+        field: &'static str,
+        value: U256,
+    },
+    #[error(
+        "proof request root claim for game {game} does not match on-chain value: expected {expected}, got {actual}"
+    )]
+    RootClaimMismatch {
+        game: Address,
+        expected: B256,
+        actual: B256,
+    },
+    #[error(
+        "proof request L2 block for game {game} does not match on-chain value: expected {expected}, got {actual}"
+    )]
+    L2BlockNumberMismatch {
+        game: Address,
+        expected: u64,
+        actual: u64,
+    },
+    #[error(
+        "proof request L1 head for game {game} does not match on-chain value: expected {expected}, got {actual}"
+    )]
+    L1HeadMismatch {
+        game: Address,
+        expected: B256,
+        actual: B256,
+    },
+    #[error(
+        "worker rollup config for game {game} does not match on-chain value: expected {expected}, got {actual}"
+    )]
+    RollupConfigHashMismatch {
+        game: Address,
+        expected: B256,
+        actual: B256,
+    },
+    #[error(
+        "proof game {game} has invalid block interval {block_interval} for L2 block {l2_block_number}"
+    )]
+    InvalidBlockInterval {
+        game: Address,
+        l2_block_number: u64,
+        block_interval: u64,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_provider::ProviderBuilder;
+    use alloy_sol_types::SolValue;
+    use alloy_transport::mock::Asserter;
+
+    const GAME: Address = Address::repeat_byte(0x11);
+    const ROOT: B256 = B256::repeat_byte(0x22);
+    const L1_HEAD: B256 = B256::repeat_byte(0x33);
+    const ROLLUP_CONFIG_HASH: B256 = B256::repeat_byte(0x44);
+
+    fn context() -> ProofGameContext {
+        ProofGameContext {
+            block_interval: 450,
+            rollup_config_hash: ROLLUP_CONFIG_HASH,
+            root_claim: ROOT,
+            l2_block_number: 1_000,
+            l1_head: L1_HEAD,
+        }
+    }
+
+    #[tokio::test]
+    async fn reads_game_context_from_batched_rpc_calls() {
+        let asserter = Asserter::new();
+        for response in [
+            Bytes::from(U256::from(450).abi_encode()),
+            Bytes::from(ROLLUP_CONFIG_HASH.abi_encode()),
+            Bytes::from(ROOT.abi_encode()),
+            Bytes::from(U256::from(1_000).abi_encode()),
+            Bytes::from(L1_HEAD.abi_encode()),
+        ] {
+            asserter.push_success(&response);
+        }
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter.clone());
+        let game_provider = AlloyProofGameProvider::new(provider);
+
+        assert_eq!(
+            game_provider.proof_game_context(GAME).await.unwrap(),
+            context()
+        );
+        assert!(asserter.read_q().is_empty());
+    }
+
+    #[test]
+    fn validates_context_and_returns_range_start() {
+        assert_eq!(
+            context()
+                .validated_start_block(GAME, ROOT, 1_000, L1_HEAD, ROLLUP_CONFIG_HASH)
+                .unwrap(),
+            550
+        );
+    }
+
+    #[test]
+    fn rejects_request_metadata_that_differs_from_game() {
+        let error = context()
+            .validated_start_block(
+                GAME,
+                B256::repeat_byte(0xff),
+                1_000,
+                L1_HEAD,
+                ROLLUP_CONFIG_HASH,
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ProofGameContextError::RootClaimMismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn rejects_worker_rollup_config_that_differs_from_game() {
+        let error = context()
+            .validated_start_block(GAME, ROOT, 1_000, L1_HEAD, B256::repeat_byte(0xff))
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ProofGameContextError::RollupConfigHashMismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn rejects_zero_block_interval() {
+        let error = ProofGameContext {
+            block_interval: 0,
+            ..context()
+        }
+        .validated_start_block(GAME, ROOT, 1_000, L1_HEAD, ROLLUP_CONFIG_HASH)
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ProofGameContextError::InvalidBlockInterval { .. }
+        ));
+    }
+}

--- a/proofs/protocol/src/proof_game.rs
+++ b/proofs/protocol/src/proof_game.rs
@@ -1,8 +1,16 @@
+use std::time::Duration;
+
 use alloy_primitives::{Address, B256, U256};
 use alloy_provider::Provider;
 use async_trait::async_trait;
+use backon::{ExponentialBuilder, Retryable};
+use tracing::warn;
 
 use crate::IMultiProofGame;
+
+const GAME_CONTEXT_RPC_MAX_RETRIES: usize = 3;
+const GAME_CONTEXT_RPC_INITIAL_DELAY: Duration = Duration::from_millis(100);
+const GAME_CONTEXT_RPC_MAX_DELAY: Duration = Duration::from_secs(1);
 
 /// Immutable game context that defines the exact transition a proof worker must execute.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -92,12 +100,11 @@ impl<P> AlloyProofGameProvider<P> {
     }
 }
 
-#[async_trait]
-impl<P> ProofGameProvider for AlloyProofGameProvider<P>
+impl<P> AlloyProofGameProvider<P>
 where
-    P: Provider + Clone + Send + Sync + 'static,
+    P: Provider + Clone,
 {
-    async fn proof_game_context(
+    async fn read_game_context(
         &self,
         game_address: Address,
     ) -> Result<ProofGameContext, ProofGameContextError> {
@@ -125,6 +132,36 @@ where
             l2_block_number: u256_to_u64(game_address, "l2SequenceNumber", l2_block_number)?,
             l1_head,
         })
+    }
+}
+
+#[async_trait]
+impl<P> ProofGameProvider for AlloyProofGameProvider<P>
+where
+    P: Provider + Clone + Send + Sync + 'static,
+{
+    async fn proof_game_context(
+        &self,
+        game_address: Address,
+    ) -> Result<ProofGameContext, ProofGameContextError> {
+        (|| self.read_game_context(game_address))
+            .retry(
+                ExponentialBuilder::default()
+                    .with_min_delay(GAME_CONTEXT_RPC_INITIAL_DELAY)
+                    .with_max_delay(GAME_CONTEXT_RPC_MAX_DELAY)
+                    .with_max_times(GAME_CONTEXT_RPC_MAX_RETRIES)
+                    .with_jitter(),
+            )
+            .when(|error| matches!(error, ProofGameContextError::Contract { .. }))
+            .notify(|error, delay| {
+                warn!(
+                    game_address = %game_address,
+                    %error,
+                    ?delay,
+                    "failed to read proof game context, retrying"
+                );
+            })
+            .await
     }
 }
 
@@ -223,6 +260,29 @@ mod tests {
     #[tokio::test]
     async fn reads_game_context_from_typed_contract_calls() {
         let asserter = Asserter::new();
+        for response in [
+            Bytes::from(U256::from(450).abi_encode()),
+            Bytes::from(ROLLUP_CONFIG_HASH.abi_encode()),
+            Bytes::from(ROOT.abi_encode()),
+            Bytes::from(U256::from(1_000).abi_encode()),
+            Bytes::from(L1_HEAD.abi_encode()),
+        ] {
+            asserter.push_success(&response);
+        }
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter.clone());
+        let game_provider = AlloyProofGameProvider::new(provider);
+
+        assert_eq!(
+            game_provider.proof_game_context(GAME).await.unwrap(),
+            context()
+        );
+        assert!(asserter.read_q().is_empty());
+    }
+
+    #[tokio::test]
+    async fn retries_transient_game_context_failure() {
+        let asserter = Asserter::new();
+        asserter.push_failure_msg("temporary RPC failure");
         for response in [
             Bytes::from(U256::from(450).abi_encode()),
             Bytes::from(ROLLUP_CONFIG_HASH.abi_encode()),

--- a/proofs/workers/nitro/Cargo.toml
+++ b/proofs/workers/nitro/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/main.rs"
 # Generic worker infrastructure
 world-chain-proof-worker.workspace = true
 world-chain-proof-metrics.workspace = true
+world-chain-proof-protocol.workspace = true
 world-chain-prover-service.workspace = true
 
 # Nitro prover (host-side, requires Linux + enclave feature)
@@ -32,6 +33,7 @@ world-chain-chainspec.workspace = true
 
 # Alloy types
 alloy-primitives = { workspace = true, features = ["serde"] }
+alloy-provider = { workspace = true, features = ["reqwest", "reqwest-rustls-tls"] }
 alloy-sol-types.workspace = true
 
 # Async / runtime

--- a/proofs/workers/nitro/src/cmd/run.rs
+++ b/proofs/workers/nitro/src/cmd/run.rs
@@ -3,6 +3,7 @@
 use std::{path::PathBuf, sync::Arc, time::Duration};
 
 use alloy_primitives::B256;
+use alloy_provider::ProviderBuilder;
 use anyhow::{Context, Result};
 use backon::{ExponentialBuilder, Retryable};
 use clap::Parser;
@@ -13,6 +14,7 @@ use world_chain_proof_nitro_enclave::register::{
     RegisterParams, RegistrationOutcome, register_enclave_key,
 };
 use world_chain_proof_nitro_worker::{NitroBackend, NitroBackendConfig, build_expected_pcrs};
+use world_chain_proof_protocol::AlloyProofGameProvider;
 use world_chain_proof_worker::{
     ProofWorker, ProofWorkerConfig, RetryConfig, WorkerHeartbeatConfig,
 };
@@ -163,11 +165,6 @@ pub struct WorkerArgs {
     /// Rollup config hash override (required when --rollup-config is not supplied).
     #[arg(long, env = "ROLLUP_CONFIG_HASH")]
     rollup_config_hash: Option<B256>,
-
-    /// L2 blocks between a proposal's parent and its claimed block (the proof system's
-    /// `blockInterval` domain constant).
-    #[arg(long, env = "BLOCK_INTERVAL")]
-    block_interval: u64,
 
     /// vsock CID of the running Nitro Enclave.
     #[arg(long, env = "ENCLAVE_CID", default_value_t = 16)]
@@ -333,20 +330,24 @@ pub async fn run(args: WorkerArgs) -> Result<()> {
     info!(
         prover_service = %args.prover_service_url,
         enclave_cid = args.enclave_cid,
-        block_interval = args.block_interval,
         submit_proof_retry_max_retries = args.submit_proof_retry_max_retries,
         submit_proof_retry_initial_delay_ms = args.submit_proof_retry_initial_delay_ms,
         submit_proof_retry_max_delay_ms = args.submit_proof_retry_max_delay_ms,
         "nitro-worker starting"
     );
 
-    let backend = NitroBackend::new(NitroBackendConfig {
-        block_interval: args.block_interval,
-        online,
-        enclave_cid: args.enclave_cid,
-        enclave_port: args.enclave_port,
-        expected_pcrs,
-    });
+    let l1_rpc_url = args.l1_rpc.parse().context("invalid L1 RPC URL")?;
+    let game_provider =
+        AlloyProofGameProvider::new(ProviderBuilder::new().connect_http(l1_rpc_url));
+    let backend = NitroBackend::new(
+        NitroBackendConfig {
+            online,
+            enclave_cid: args.enclave_cid,
+            enclave_port: args.enclave_port,
+            expected_pcrs,
+        },
+        game_provider,
+    );
 
     let queue = RpcProverServiceClient::new(&args.prover_service_url)
         .with_context(|| format!("failed to connect to {}", args.prover_service_url))?;

--- a/proofs/workers/nitro/src/lib.rs
+++ b/proofs/workers/nitro/src/lib.rs
@@ -24,7 +24,7 @@
 
 use alloy_primitives::Bytes;
 use alloy_sol_types::SolValue;
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, Result, bail};
 use tracing::info;
 use world_chain_proof_kona_host::online::{
     OnlineHostConfig, RangeWitnessRequest, build_range_input,
@@ -33,6 +33,7 @@ use world_chain_proof_nitro_enclave::{
     ExpectedPcrs, NitroRangeProofRequest,
     host::{EnclaveEndpoint, NitroProver},
 };
+use world_chain_proof_protocol::ProofGameProvider;
 use world_chain_proof_worker::{ClaimedProofJobHandler, ProofJob};
 use world_chain_prover_service::{ProofBackend, ProofData};
 
@@ -42,25 +43,31 @@ use world_chain_prover_service::{ProofBackend, ProofData};
 
 #[derive(Clone, Debug)]
 pub struct NitroBackendConfig {
-    pub block_interval: u64,
     pub online: OnlineHostConfig,
     pub enclave_cid: u32,
     pub enclave_port: u32,
     pub expected_pcrs: ExpectedPcrs,
 }
 
-pub struct NitroBackend {
+pub struct NitroBackend<G> {
     config: NitroBackendConfig,
+    game_provider: G,
 }
 
-impl NitroBackend {
-    pub fn new(config: NitroBackendConfig) -> Self {
-        Self { config }
+impl<G> NitroBackend<G> {
+    pub fn new(config: NitroBackendConfig, game_provider: G) -> Self {
+        Self {
+            config,
+            game_provider,
+        }
     }
 }
 
 #[async_trait::async_trait]
-impl ClaimedProofJobHandler for NitroBackend {
+impl<G> ClaimedProofJobHandler for NitroBackend<G>
+where
+    G: ProofGameProvider,
+{
     fn lane(&self) -> ProofBackend {
         ProofBackend::Nitro
     }
@@ -68,24 +75,30 @@ impl ClaimedProofJobHandler for NitroBackend {
     async fn handle_claimed_job(&self, job: ProofJob) -> anyhow::Result<ProofData> {
         let request = &job.request;
 
-        let start_block = request
-            .l2_block_number
-            .checked_sub(self.config.block_interval)
-            .ok_or_else(|| {
-                anyhow!(
-                    "l2_block_number {} is below block_interval {}",
-                    request.l2_block_number,
-                    self.config.block_interval
-                )
-            })?;
+        let game_context = self
+            .game_provider
+            .proof_game_context(request.game)
+            .await
+            .context("failed to read proof game context")?;
+        let start_block = game_context
+            .validated_start_block(
+                request.game,
+                request.root_claim,
+                request.l2_block_number,
+                request.l1_head,
+                self.config.online.rollup_config_hash,
+            )
+            .context("proof request does not match its game")?;
 
         info!(
+            lifecycle_event = "proof_game_validated",
             proof_id = %request.id(),
             game_address = %request.game,
             l2_block_number = request.l2_block_number,
             pre_state_block = start_block,
+            block_interval = game_context.block_interval,
             worker_id = %job.worker_id,
-            "nitro worker claimed proof job"
+            "validated Nitro proof range against game"
         );
 
         let endpoint =

--- a/proofs/workers/nitro/src/lib.rs
+++ b/proofs/workers/nitro/src/lib.rs
@@ -25,7 +25,7 @@
 use alloy_primitives::Bytes;
 use alloy_sol_types::SolValue;
 use anyhow::{Context, Result, bail};
-use tracing::info;
+use tracing::{debug, info};
 use world_chain_proof_kona_host::online::{
     OnlineHostConfig, RangeWitnessRequest, build_range_input,
 };
@@ -90,8 +90,7 @@ where
             )
             .context("proof request does not match its game")?;
 
-        info!(
-            lifecycle_event = "proof_game_validated",
+        debug!(
             proof_id = %request.id(),
             game_address = %request.game,
             l2_block_number = request.l2_block_number,

--- a/proofs/workers/sp1/Cargo.toml
+++ b/proofs/workers/sp1/Cargo.toml
@@ -20,6 +20,7 @@ world-chain-chainspec.workspace = true
 world-chain-proof-core.workspace = true
 world-chain-proof-kona-host.workspace = true
 world-chain-proof-metrics.workspace = true
+world-chain-proof-protocol.workspace = true
 world-chain-proof-sp1-host = { workspace = true, features = ["sp1"] }
 world-chain-proof-sp1-types.workspace = true
 world-chain-proof-worker.workspace = true
@@ -54,4 +55,3 @@ url.workspace = true
 testcontainers.workspace = true
 testcontainers-modules.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
-world-chain-proof-protocol.workspace = true

--- a/proofs/workers/sp1/src/backend.rs
+++ b/proofs/workers/sp1/src/backend.rs
@@ -9,6 +9,7 @@ use world_chain_proof_core::artifacts::{AggregationProofArtifact, RangeProofArti
 use world_chain_proof_kona_host::online::{
     OnlineHostConfig, RangeWitnessRequest, build_range_input, fetch_l1_header_by_hash,
 };
+use world_chain_proof_protocol::ProofGameProvider;
 use world_chain_proof_sp1_host::{
     WorldSuccinctProver, aggregation_artifact_from_sp1_proof, range_artifact_from_sp1_proof,
 };
@@ -23,10 +24,6 @@ use world_chain_prover_service::{
 /// Configuration for [`Sp1Backend`].
 #[derive(Clone, Copy, Debug)]
 pub struct Sp1BackendConfig {
-    /// L2 blocks between a proposal's parent and its claimed block (the proof system's
-    /// `blockInterval` domain constant). The proved range is
-    /// `(l2_block_number - block_interval, l2_block_number]`.
-    pub block_interval: u64,
     /// Number of equal-length sub-ranges proved independently before aggregation.
     pub split_count: u64,
     /// Allow proving blocks newer than the finalized L2 head.
@@ -37,27 +34,35 @@ pub struct Sp1BackendConfig {
 
 /// [`ClaimedProofJobHandler`] for the [`ProofBackend::Sp1`] lane: builds witnesses over RPC
 /// and proves them with a [`WorldSuccinctProver`] (the sp1-sdk env prover in production).
-pub struct Sp1Backend<P> {
+pub struct Sp1Backend<P, G> {
     host: OnlineHostConfig,
     prover: P,
+    game_provider: G,
     config: Sp1BackendConfig,
 }
 
-impl<P> Sp1Backend<P> {
+impl<P, G> Sp1Backend<P, G> {
     /// Creates a backend over the given RPC host config and SP1 prover.
-    pub const fn new(host: OnlineHostConfig, prover: P, config: Sp1BackendConfig) -> Self {
+    pub const fn new(
+        host: OnlineHostConfig,
+        prover: P,
+        game_provider: G,
+        config: Sp1BackendConfig,
+    ) -> Self {
         Self {
             host,
             prover,
+            game_provider,
             config,
         }
     }
 }
 
 #[async_trait::async_trait]
-impl<P> ClaimedProofJobHandler for Sp1Backend<P>
+impl<P, G> ClaimedProofJobHandler for Sp1Backend<P, G>
 where
     P: WorldSuccinctProver + Send + Sync + 'static,
+    G: ProofGameProvider,
 {
     fn lane(&self) -> ProofBackend {
         ProofBackend::Sp1
@@ -65,7 +70,7 @@ where
 
     async fn handle_claimed_job(&self, job: ProofJob) -> anyhow::Result<ProofData> {
         let request = &job.request;
-        let start_block = self.start_block(request)?;
+        let start_block = self.start_block(request).await?;
 
         if let Some(snark_session) = self.get_session(&job, SessionType::Snark).await? {
             let agg = self
@@ -129,17 +134,31 @@ where
     }
 }
 
-impl<P: WorldSuccinctProver> Sp1Backend<P> {
-    fn start_block(&self, request: &ProofRequest) -> anyhow::Result<u64> {
-        request
-            .l2_block_number
-            .checked_sub(self.config.block_interval)
-            .with_context(|| {
-                format!(
-                    "l2 block number {} is below the block interval {}",
-                    request.l2_block_number, self.config.block_interval
-                )
-            })
+impl<P: WorldSuccinctProver, G: ProofGameProvider> Sp1Backend<P, G> {
+    async fn start_block(&self, request: &ProofRequest) -> anyhow::Result<u64> {
+        let context = self
+            .game_provider
+            .proof_game_context(request.game)
+            .await
+            .context("failed to read proof game context")?;
+        let start_block = context
+            .validated_start_block(
+                request.game,
+                request.root_claim,
+                request.l2_block_number,
+                request.l1_head,
+                self.host.rollup_config_hash,
+            )
+            .context("proof request does not match its game")?;
+        tracing::info!(
+            lifecycle_event = "proof_game_validated",
+            proof_id = %request.id(),
+            game_address = %request.game,
+            block_interval = context.block_interval,
+            pre_state_block = start_block,
+            "validated SP1 proof range against game"
+        );
+        Ok(start_block)
     }
 
     async fn get_session(

--- a/proofs/workers/sp1/src/backend.rs
+++ b/proofs/workers/sp1/src/backend.rs
@@ -150,8 +150,7 @@ impl<P: WorldSuccinctProver, G: ProofGameProvider> Sp1Backend<P, G> {
                 self.host.rollup_config_hash,
             )
             .context("proof request does not match its game")?;
-        tracing::info!(
-            lifecycle_event = "proof_game_validated",
+        tracing::debug!(
             proof_id = %request.id(),
             game_address = %request.game,
             block_interval = context.block_interval,

--- a/proofs/workers/sp1/src/cmd/run.rs
+++ b/proofs/workers/sp1/src/cmd/run.rs
@@ -1,12 +1,14 @@
 use std::{path::PathBuf, sync::Arc, time::Duration};
 
 use alloy_primitives::{Address, B256, U256};
+use alloy_provider::ProviderBuilder;
 use anyhow::{Context, Result, bail};
 use clap::Parser;
 use world_chain_chainspec::WorldChainSpec;
 use world_chain_proof_kona_host::online::{
     OnlineHostConfig, build_online_config, hardfork_config_from_chain_spec,
 };
+use world_chain_proof_protocol::AlloyProofGameProvider;
 use world_chain_proof_sp1_host::{
     Sp1ProverKind, WorldSuccinctProver,
     cpu_prover::{CpuSuccinctProver, SP1ProofMode},
@@ -98,11 +100,6 @@ pub struct WorkerArgs {
     /// Rollup config hash override (required when --rollup-config is not supplied).
     #[arg(long, env = "ROLLUP_CONFIG_HASH")]
     rollup_config_hash: Option<B256>,
-
-    /// L2 blocks between a proposal's parent and its claimed block (the proof system's
-    /// blockInterval domain constant).
-    #[arg(long, env = "BLOCK_INTERVAL")]
-    block_interval: u64,
 
     /// Number of equal-length sub-ranges proved independently per job.
     #[arg(long, default_value_t = 1)]
@@ -442,11 +439,14 @@ async fn run_worker<P>(cli: &WorkerArgs, host: OnlineHostConfig, prover: P) -> R
 where
     P: WorldSuccinctProver + Send + Sync + 'static,
 {
+    let l1_rpc_url = cli.l1_rpc.parse().context("invalid L1 RPC URL")?;
+    let game_provider =
+        AlloyProofGameProvider::new(ProviderBuilder::new().connect_http(l1_rpc_url));
     let backend = Sp1Backend::new(
         host,
         prover,
+        game_provider,
         Sp1BackendConfig {
-            block_interval: cli.block_interval,
             split_count: cli.ranges.max(1),
             allow_unfinalized: cli.allow_unfinalized,
             session_poll_interval: Duration::from_secs(cli.sp1_session_poll_interval_seconds),
@@ -481,7 +481,6 @@ where
 
     tracing::info!(
         prover_service = %cli.prover_service_url,
-        block_interval = cli.block_interval,
         ranges = cli.ranges.max(1),
         prover = %cli.prover,
         sp1_estimate_limits = cli.sp1_estimate_limits,
@@ -525,8 +524,6 @@ mod tests {
             "http://127.0.0.1:8545",
             "--l1-beacon-rpc",
             "http://127.0.0.1:5052",
-            "--block-interval",
-            "10",
             "--worker-id",
             "test",
         ]

--- a/proofs/workers/sp1/src/main.rs
+++ b/proofs/workers/sp1/src/main.rs
@@ -59,8 +59,6 @@ mod tests {
             "http://127.0.0.1:8545",
             "--l1-beacon-rpc",
             "http://127.0.0.1:5052",
-            "--block-interval",
-            "10",
             "--worker-id",
             "test",
         ]);

--- a/proofs/workers/sp1/tests/e2e_proving.rs
+++ b/proofs/workers/sp1/tests/e2e_proving.rs
@@ -32,7 +32,10 @@ use alloy_primitives::{Address, B256};
 use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::postgres;
 use world_chain_proof_kona_host::online::{OnlineHostConfig, resolve_l1_head};
-use world_chain_proof_protocol::{ConsensusProvider, OptimismConsensusClient};
+use world_chain_proof_protocol::{
+    ConsensusProvider, OptimismConsensusClient, ProofGameContext, ProofGameContextError,
+    ProofGameProvider,
+};
 use world_chain_proof_sp1_host::{
     Sp1ProverKind, WorldSuccinctProver,
     cpu_prover::{CpuSuccinctProver, SP1ProofMode},
@@ -214,11 +217,18 @@ async fn run_worker_proves_real_range_end_to_end_with_prover<P>(
 ) where
     P: WorldSuccinctProver + Send + Sync + 'static,
 {
+    let game_provider = StaticProofGameProvider(ProofGameContext {
+        block_interval,
+        rollup_config_hash: host.rollup_config_hash,
+        root_claim,
+        l2_block_number: claimed_block,
+        l1_head,
+    });
     let backend = Sp1Backend::new(
         host,
         prover,
+        game_provider,
         Sp1BackendConfig {
-            block_interval,
             split_count,
             allow_unfinalized: false,
             session_poll_interval: Duration::from_secs(10),
@@ -316,4 +326,17 @@ async fn run_worker_proves_real_range_end_to_end_with_prover<P>(
 
     token.cancel();
     let _ = tokio::time::timeout(Duration::from_secs(5), worker_handle).await;
+}
+
+#[derive(Clone, Copy)]
+struct StaticProofGameProvider(ProofGameContext);
+
+#[async_trait::async_trait]
+impl ProofGameProvider for StaticProofGameProvider {
+    async fn proof_game_context(
+        &self,
+        _game: Address,
+    ) -> Result<ProofGameContext, ProofGameContextError> {
+        Ok(self.0)
+    }
 }


### PR DESCRIPTION
passing block interval was brittle and error prone, instead we fetch it for each game and verify the other fields as well.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the proof worker hot path to depend on L1 reads and strict game/job alignment before witness work; misconfiguration or RPC failures will fail jobs rather than prove with a stale interval.
> 
> **Overview**
> **SP1 and Nitro workers no longer take a configured `block_interval`.** For each leased job they read `blockInterval`, `rollupConfigHash`, `rootClaim`, `l2SequenceNumber`, and `l1Head` from the job’s `MultiProofGame` on L1 (batched `eth_call`s via new `AlloyProofGameProvider` in `world-chain-proof-protocol`), reject the job if those fields disagree with the queued request or the worker’s rollup config hash, then derive the witness start block as `l2_block_number - block_interval`.
> 
> **`--block-interval` / `BLOCK_INTERVAL` are removed** from both worker CLIs and the nitro/sp1 worker docs; e2e tests inject a static `ProofGameProvider` instead of passing interval into the backend config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4e4bb14de39d5a46ef8fc76bcf4bfea0663b124. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->