### PR TITLE
ci: share canonical SP1 guests across architectures

### DIFF
--- a/.github/actions/docker-build-push-digest/action.yml
+++ b/.github/actions/docker-build-push-digest/action.yml
@@ -17,10 +17,6 @@ inputs:
   sccache_bucket:
     description: S3 bucket used by sccache and BuildKit cache.
     required: true
-  s3_cache_enabled:
-    description: Whether to use temporary AWS credentials for remote sccache and BuildKit caches.
-    required: false
-    default: "true"
   git_sha:
     description: Git commit SHA to embed via VERGEN_GIT_SHA (defaults to the triggering commit).
     required: false
@@ -41,6 +37,10 @@ inputs:
     description: Extra build args passed to docker build (newline-separated KEY=value).
     required: false
     default: ""
+  build_contexts:
+    description: Additional named Docker build contexts (newline-separated name=path entries).
+    required: false
+    default: ""
   cache_scope:
     description: BuildKit cache scope name.
     required: false
@@ -56,43 +56,17 @@ runs:
   using: composite
   steps:
     - name: Prepare
-      id: prepare
       shell: bash
       env:
         CACHE_SCOPE_INPUT: ${{ inputs.cache_scope }}
         IMAGE_NAME: ${{ inputs.image_name }}
         PLATFORM: ${{ inputs.platform }}
-        S3_CACHE_ENABLED: ${{ inputs.s3_cache_enabled }}
-        SCCACHE_BUCKET_INPUT: ${{ inputs.sccache_bucket }}
-        AWS_REGION_INPUT: ${{ inputs.aws_region }}
       run: |
         platform="${PLATFORM}"
         cache_scope="${CACHE_SCOPE_INPUT}"
         echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
-        cache_scope="${cache_scope//\//-}"
-
-        case "${S3_CACHE_ENABLED}" in
-          true)
-            cache_prefix="buildkit/${IMAGE_NAME}/${platform//\//-}"
-            echo "sccache_bucket=${SCCACHE_BUCKET_INPUT}" >> "$GITHUB_OUTPUT"
-            {
-              echo "cache_from<<EOF"
-              echo "type=s3,region=${AWS_REGION_INPUT},bucket=${SCCACHE_BUCKET_INPUT},prefix=${cache_prefix},name=${cache_scope}"
-              echo "type=s3,region=${AWS_REGION_INPUT},bucket=${SCCACHE_BUCKET_INPUT},prefix=${cache_prefix},name=main"
-              echo "EOF"
-              echo "cache_to=type=s3,region=${AWS_REGION_INPUT},bucket=${SCCACHE_BUCKET_INPUT},prefix=${cache_prefix},name=${cache_scope},mode=max"
-            } >> "$GITHUB_OUTPUT"
-            ;;
-          false)
-            echo "sccache_bucket=" >> "$GITHUB_OUTPUT"
-            echo "cache_from=" >> "$GITHUB_OUTPUT"
-            echo "cache_to=" >> "$GITHUB_OUTPUT"
-            ;;
-          *)
-            echo "s3_cache_enabled must be 'true' or 'false'" >&2
-            exit 1
-            ;;
-        esac
+        echo "CACHE_SCOPE=${cache_scope//\//-}" >> "$GITHUB_ENV"
+        echo "BUILDKIT_CACHE_PREFIX=buildkit/${IMAGE_NAME}/${platform//\//-}" >> "$GITHUB_ENV"
 
     - name: Log in to Registry
       uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
@@ -113,7 +87,6 @@ runs:
       uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Configure AWS credentials for S3 caches
-      if: inputs.s3_cache_enabled == 'true'
       uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
       with:
         aws-region: ${{ inputs.aws_region }}
@@ -124,11 +97,12 @@ runs:
       uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
       with:
         context: ${{ inputs.context }}
+        build-contexts: ${{ inputs.build_contexts }}
         file: ${{ inputs.dockerfile }}
         target: ${{ inputs.target }}
         build-args: |
           VERGEN_GIT_SHA=${{ inputs.git_sha }}
-          SCCACHE_BUCKET=${{ steps.prepare.outputs.sccache_bucket }}
+          SCCACHE_BUCKET=${{ inputs.sccache_bucket }}
           SCCACHE_REGION=${{ inputs.aws_region }}
           SCCACHE_S3_KEY_PREFIX=sccache/${{ github.repository }}/${{ env.PLATFORM_PAIR }}
           ${{ inputs.build_args }}
@@ -139,8 +113,10 @@ runs:
         tags: ${{ inputs.registry }}/${{ inputs.image_name }}
         platforms: ${{ inputs.platform }}
         labels: ${{ steps.meta.outputs.labels }}
-        cache-from: ${{ steps.prepare.outputs.cache_from }}
-        cache-to: ${{ steps.prepare.outputs.cache_to }}
+        cache-from: |
+          type=s3,region=${{ inputs.aws_region }},bucket=${{ inputs.sccache_bucket }},prefix=${{ env.BUILDKIT_CACHE_PREFIX }},name=${{ env.CACHE_SCOPE }}
+          type=s3,region=${{ inputs.aws_region }},bucket=${{ inputs.sccache_bucket }},prefix=${{ env.BUILDKIT_CACHE_PREFIX }},name=main
+        cache-to: type=s3,region=${{ inputs.aws_region }},bucket=${{ inputs.sccache_bucket }},prefix=${{ env.BUILDKIT_CACHE_PREFIX }},name=${{ env.CACHE_SCOPE }},mode=max
         outputs: type=registry,push-by-digest=true,name-canonical=true,push=true
 
     - name: Export digest

--- a/.github/actions/docker-build-push-digest/action.yml
+++ b/.github/actions/docker-build-push-digest/action.yml
@@ -17,6 +17,10 @@ inputs:
   sccache_bucket:
     description: S3 bucket used by sccache and BuildKit cache.
     required: true
+  s3_cache_enabled:
+    description: Whether to use temporary AWS credentials for remote sccache and BuildKit caches.
+    required: false
+    default: "true"
   git_sha:
     description: Git commit SHA to embed via VERGEN_GIT_SHA (defaults to the triggering commit).
     required: false
@@ -52,17 +56,43 @@ runs:
   using: composite
   steps:
     - name: Prepare
+      id: prepare
       shell: bash
       env:
         CACHE_SCOPE_INPUT: ${{ inputs.cache_scope }}
         IMAGE_NAME: ${{ inputs.image_name }}
         PLATFORM: ${{ inputs.platform }}
+        S3_CACHE_ENABLED: ${{ inputs.s3_cache_enabled }}
+        SCCACHE_BUCKET_INPUT: ${{ inputs.sccache_bucket }}
+        AWS_REGION_INPUT: ${{ inputs.aws_region }}
       run: |
         platform="${PLATFORM}"
         cache_scope="${CACHE_SCOPE_INPUT}"
         echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
-        echo "CACHE_SCOPE=${cache_scope//\//-}" >> "$GITHUB_ENV"
-        echo "BUILDKIT_CACHE_PREFIX=buildkit/${IMAGE_NAME}/${platform//\//-}" >> "$GITHUB_ENV"
+        cache_scope="${cache_scope//\//-}"
+
+        case "${S3_CACHE_ENABLED}" in
+          true)
+            cache_prefix="buildkit/${IMAGE_NAME}/${platform//\//-}"
+            echo "sccache_bucket=${SCCACHE_BUCKET_INPUT}" >> "$GITHUB_OUTPUT"
+            {
+              echo "cache_from<<EOF"
+              echo "type=s3,region=${AWS_REGION_INPUT},bucket=${SCCACHE_BUCKET_INPUT},prefix=${cache_prefix},name=${cache_scope}"
+              echo "type=s3,region=${AWS_REGION_INPUT},bucket=${SCCACHE_BUCKET_INPUT},prefix=${cache_prefix},name=main"
+              echo "EOF"
+              echo "cache_to=type=s3,region=${AWS_REGION_INPUT},bucket=${SCCACHE_BUCKET_INPUT},prefix=${cache_prefix},name=${cache_scope},mode=max"
+            } >> "$GITHUB_OUTPUT"
+            ;;
+          false)
+            echo "sccache_bucket=" >> "$GITHUB_OUTPUT"
+            echo "cache_from=" >> "$GITHUB_OUTPUT"
+            echo "cache_to=" >> "$GITHUB_OUTPUT"
+            ;;
+          *)
+            echo "s3_cache_enabled must be 'true' or 'false'" >&2
+            exit 1
+            ;;
+        esac
 
     - name: Log in to Registry
       uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
@@ -83,6 +113,7 @@ runs:
       uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Configure AWS credentials for S3 caches
+      if: inputs.s3_cache_enabled == 'true'
       uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
       with:
         aws-region: ${{ inputs.aws_region }}
@@ -97,7 +128,7 @@ runs:
         target: ${{ inputs.target }}
         build-args: |
           VERGEN_GIT_SHA=${{ inputs.git_sha }}
-          SCCACHE_BUCKET=${{ inputs.sccache_bucket }}
+          SCCACHE_BUCKET=${{ steps.prepare.outputs.sccache_bucket }}
           SCCACHE_REGION=${{ inputs.aws_region }}
           SCCACHE_S3_KEY_PREFIX=sccache/${{ github.repository }}/${{ env.PLATFORM_PAIR }}
           ${{ inputs.build_args }}
@@ -108,10 +139,8 @@ runs:
         tags: ${{ inputs.registry }}/${{ inputs.image_name }}
         platforms: ${{ inputs.platform }}
         labels: ${{ steps.meta.outputs.labels }}
-        cache-from: |
-          type=s3,region=${{ inputs.aws_region }},bucket=${{ inputs.sccache_bucket }},prefix=${{ env.BUILDKIT_CACHE_PREFIX }},name=${{ env.CACHE_SCOPE }}
-          type=s3,region=${{ inputs.aws_region }},bucket=${{ inputs.sccache_bucket }},prefix=${{ env.BUILDKIT_CACHE_PREFIX }},name=main
-        cache-to: type=s3,region=${{ inputs.aws_region }},bucket=${{ inputs.sccache_bucket }},prefix=${{ env.BUILDKIT_CACHE_PREFIX }},name=${{ env.CACHE_SCOPE }},mode=max
+        cache-from: ${{ steps.prepare.outputs.cache_from }}
+        cache-to: ${{ steps.prepare.outputs.cache_to }}
         outputs: type=registry,push-by-digest=true,name-canonical=true,push=true
 
     - name: Export digest

--- a/.github/workflows/docker-proof.yml
+++ b/.github/workflows/docker-proof.yml
@@ -100,6 +100,7 @@ jobs:
           image_name: ${{ env.IMAGE_NAME }}${{ matrix.service.suffix }}
           aws_region: ${{ env.AWS_REGION }}
           sccache_bucket: ${{ env.SCCACHE_BUCKET }}
+          s3_cache_enabled: ${{ matrix.service.target != 'sp1-worker' || matrix.platform.platform != 'linux/arm64' }}
           dockerfile: Dockerfile.prover
           target: ${{ matrix.service.target }}
           build_args: |

--- a/.github/workflows/docker-proof.yml
+++ b/.github/workflows/docker-proof.yml
@@ -17,6 +17,11 @@ on:
         description: Custom image tag to publish (e.g. "alpha-v0.1.0").
         required: false
         default: nightly
+      build_sp1_arm:
+        description: Build the SP1 worker for ARM64 under QEMU.
+        required: false
+        type: boolean
+        default: false
   push:
     branches: [main]
     paths:
@@ -86,13 +91,14 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
       # The guest ELFs are always compiled in the digest-pinned linux/amd64 SP1 image, so
-      # the vkeys are identical on every runner; arm64 runners emulate that stage.
+      # the vkeys are identical on every runner; optional arm64 builds emulate that stage.
       - name: Set up QEMU for the canonical SP1 guest compiler
-        if: matrix.service.target == 'sp1-worker' && matrix.platform.platform == 'linux/arm64'
+        if: matrix.service.target == 'sp1-worker' && matrix.platform.platform == 'linux/arm64' && inputs.build_sp1_arm
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
         with:
           platforms: amd64
       - name: Build and push digest
+        if: matrix.service.target != 'sp1-worker' || matrix.platform.platform != 'linux/arm64' || inputs.build_sp1_arm
         uses: ./.github/actions/docker-build-push-digest
         with:
           platform: ${{ matrix.platform.platform }}

--- a/.github/workflows/docker-proof.yml
+++ b/.github/workflows/docker-proof.yml
@@ -17,11 +17,6 @@ on:
         description: Custom image tag to publish (e.g. "alpha-v0.1.0").
         required: false
         default: nightly
-      build_sp1_arm:
-        description: Build the SP1 worker for ARM64 under QEMU.
-        required: false
-        type: boolean
-        default: false
   push:
     branches: [main]
     paths:
@@ -56,6 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       short: ${{ steps.sha.outputs.short }}
+      full: ${{ steps.sha.outputs.full }}
     steps:
       - name: Check Out Repo
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -63,14 +59,65 @@ jobs:
           ref: ${{ inputs.ref }}
       - name: Get short SHA
         id: sha
-        run: echo "short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "full=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+  build-sp1-guests:
+    name: build canonical SP1 guests
+    needs: [resolve-sha]
+    environment: dev
+    runs-on: arc-public-8xlarge-amd64-runner
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ needs.resolve-sha.outputs.full }}
+      - name: Prepare cache
+        id: cache
+        env:
+          CACHE_SCOPE: ${{ github.ref_name }}
+        run: |
+          cache_scope="${CACHE_SCOPE//\//-}"
+          cache_prefix="buildkit/${IMAGE_NAME}-sp1-guests/linux-amd64"
+          {
+            echo "from<<EOF"
+            echo "type=s3,region=${AWS_REGION},bucket=${SCCACHE_BUCKET},prefix=${cache_prefix},name=${cache_scope}"
+            echo "type=s3,region=${AWS_REGION},bucket=${SCCACHE_BUCKET},prefix=${cache_prefix},name=main"
+            echo "EOF"
+            echo "to=type=s3,region=${AWS_REGION},bucket=${SCCACHE_BUCKET},prefix=${cache_prefix},name=${cache_scope},mode=max"
+          } >> "$GITHUB_OUTPUT"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - name: Configure AWS credentials for BuildKit cache
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: arn:aws:iam::348981876543:role/oidc/github-deploy
+      - name: Build canonical guest ELFs
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: Dockerfile.prover
+          target: sp1-guests-context
+          platforms: linux/amd64
+          cache-from: ${{ steps.cache.outputs.from }}
+          cache-to: ${{ steps.cache.outputs.to }}
+          outputs: type=local,dest=${{ runner.temp }}/sp1-guests-context
+      - name: Upload canonical guest ELFs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: sp1-guests-context
+          path: ${{ runner.temp }}/sp1-guests-context/*
+          if-no-files-found: error
+          retention-days: 1
 
   # Service deployable images, built from the same Dockerfile.prover via
   # PROVER_PACKAGE/PROVER_BIN/FEATURES build-args. Each pushes to its own
   # `<repo>-<service>` image so tags do not collide with the builder image.
   build-service-images:
     name: build ${{ matrix.service.bin }} image
-    needs: [resolve-sha]
+    needs: [resolve-sha, build-sp1-guests]
     environment: dev
     strategy:
       fail-fast: false
@@ -89,16 +136,14 @@ jobs:
       - name: Check Out Repo
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: ${{ inputs.ref }}
-      # The guest ELFs are always compiled in the digest-pinned linux/amd64 SP1 image, so
-      # the vkeys are identical on every runner; optional arm64 builds emulate that stage.
-      - name: Set up QEMU for the canonical SP1 guest compiler
-        if: matrix.service.target == 'sp1-worker' && matrix.platform.platform == 'linux/arm64' && inputs.build_sp1_arm
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+          ref: ${{ needs.resolve-sha.outputs.full }}
+      - name: Download canonical SP1 guest ELFs
+        if: matrix.service.target == 'sp1-worker'
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4
         with:
-          platforms: amd64
+          name: sp1-guests-context
+          path: ${{ runner.temp }}/sp1-guests-context
       - name: Build and push digest
-        if: matrix.service.target != 'sp1-worker' || matrix.platform.platform != 'linux/arm64' || inputs.build_sp1_arm
         uses: ./.github/actions/docker-build-push-digest
         with:
           platform: ${{ matrix.platform.platform }}
@@ -106,9 +151,9 @@ jobs:
           image_name: ${{ env.IMAGE_NAME }}${{ matrix.service.suffix }}
           aws_region: ${{ env.AWS_REGION }}
           sccache_bucket: ${{ env.SCCACHE_BUCKET }}
-          s3_cache_enabled: ${{ matrix.service.target != 'sp1-worker' || matrix.platform.platform != 'linux/arm64' }}
           dockerfile: Dockerfile.prover
           target: ${{ matrix.service.target }}
+          build_contexts: ${{ matrix.service.target == 'sp1-worker' && format('sp1-guests-context={0}/sp1-guests-context', runner.temp) || '' }}
           build_args: |
             PROVER_PACKAGE=${{ matrix.service.package }}
             PROVER_BIN=${{ matrix.service.bin }}
@@ -131,7 +176,7 @@ jobs:
       - name: Check Out Repo
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ needs.resolve-sha.outputs.full }}
       - name: Merge multi-arch manifest
         uses: ./.github/actions/docker-merge-manifest
         with:
@@ -153,7 +198,7 @@ jobs:
       - name: Check Out Repo
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ needs.resolve-sha.outputs.full }}
       - name: Build and push digest
         uses: ./.github/actions/docker-build-push-digest
         with:
@@ -176,7 +221,7 @@ jobs:
       - name: Check Out Repo
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ needs.resolve-sha.outputs.full }}
       - name: Merge multi-arch manifest
         uses: ./.github/actions/docker-merge-manifest
         with:
@@ -199,7 +244,7 @@ jobs:
       - name: Check Out Repo
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ needs.resolve-sha.outputs.full }}
       - name: Build and push digest
         uses: ./.github/actions/docker-build-push-digest
         with:
@@ -219,7 +264,7 @@ jobs:
       - name: Check Out Repo
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ needs.resolve-sha.outputs.full }}
       - name: Merge multi-arch manifest
         uses: ./.github/actions/docker-merge-manifest
         with:
@@ -245,7 +290,7 @@ jobs:
       - name: Check Out Repo
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ needs.resolve-sha.outputs.full }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:

--- a/Dockerfile.prover
+++ b/Dockerfile.prover
@@ -41,6 +41,17 @@ RUN --mount=type=cache,target=/root/.cargo/registry \
     cargo run --locked --release --ignore-rust-version \
       -p world-chain-proof-sp1-guest-builder
 
+# Export only the final canonical guest ELFs. CI builds this target once on
+# amd64 and supplies it as a named `sp1-guests-context` build context to every
+# SP1 worker build, so arm64 never has to emulate the SP1 compiler.
+FROM scratch AS sp1-guests-context
+COPY --from=sp1-guests \
+    /root/program/proofs/backends/sp1/programs/target/elf-compilation/docker/riscv64im-succinct-zkvm-elf/release/world-chain-proof-succinct-range-ethereum \
+    /riscv64im-succinct-zkvm-elf/release/world-chain-proof-succinct-range-ethereum
+COPY --from=sp1-guests \
+    /root/program/proofs/backends/sp1/programs/target/elf-compilation/docker/riscv64im-succinct-zkvm-elf/release/world-chain-proof-succinct-aggregation \
+    /riscv64im-succinct-zkvm-elf/release/world-chain-proof-succinct-aggregation
+
 FROM base AS planner
 WORKDIR /app
 
@@ -113,9 +124,12 @@ RUN test "${PROVER_BIN}" = "world-chain-proof-sp1-worker" || \
 ENV SP1_BUILD_DOCKER=true \
     SP1_SKIP_PROGRAM_BUILD=true
 
-COPY --from=sp1-guests \
-    /root/program/proofs/backends/sp1/programs/target/elf-compilation/docker \
-    /app/proofs/backends/sp1/programs/target/elf-compilation/docker
+COPY --from=sp1-guests-context \
+    /riscv64im-succinct-zkvm-elf/release/world-chain-proof-succinct-range-ethereum \
+    /app/proofs/backends/sp1/programs/target/elf-compilation/docker/riscv64im-succinct-zkvm-elf/release/world-chain-proof-succinct-range-ethereum
+COPY --from=sp1-guests-context \
+    /riscv64im-succinct-zkvm-elf/release/world-chain-proof-succinct-aggregation \
+    /app/proofs/backends/sp1/programs/target/elf-compilation/docker/riscv64im-succinct-zkvm-elf/release/world-chain-proof-succinct-aggregation
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \


### PR DESCRIPTION
Building the amd64-only SP1 guest compiler under QEMU on ARM is extremely slow and caused the build credentials to expire. We now compile the guest once on amd64 and reuse the exact same ELF files when building both amd64 and arm64 workers.