### PR TITLE
ci: suppress non-deployment records

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -33,7 +33,9 @@ jobs:
   acceptance-tests:
     name: acceptance-tests (${{ matrix.network }})
     runs-on: arc-public-8xlarge-amd64-runner
-    environment: ${{ matrix.environment }}
+    environment:
+      name: ${{ matrix.environment }}
+      deployment: false
     timeout-minutes: 45
     concurrency:
       group: ${{ github.workflow }}-${{ matrix.network }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -26,7 +26,9 @@ env:
 jobs:
   benchmark:
     runs-on: arc-public-8xlarge-amd64-runner
-    environment: dev
+    environment:
+      name: dev
+      deployment: false
     timeout-minutes: 60
     env:
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/docker-proof.yml
+++ b/.github/workflows/docker-proof.yml
@@ -66,7 +66,9 @@ jobs:
   build-sp1-guests:
     name: build canonical SP1 guests
     needs: [resolve-sha]
-    environment: dev
+    environment:
+      name: dev
+      deployment: false
     runs-on: arc-public-8xlarge-amd64-runner
     steps:
       - name: Check Out Repo
@@ -118,7 +120,9 @@ jobs:
   build-service-images:
     name: build ${{ matrix.service.bin }} image
     needs: [resolve-sha, build-sp1-guests]
-    environment: dev
+    environment:
+      name: dev
+      deployment: false
     strategy:
       fail-fast: false
       matrix:
@@ -192,7 +196,9 @@ jobs:
   build-nitro-worker-image:
     name: build nitro-worker image
     needs: [resolve-sha]
-    environment: dev
+    environment:
+      name: dev
+      deployment: false
     runs-on: arc-public-8xlarge-amd64-runner
     steps:
       - name: Check Out Repo
@@ -238,7 +244,9 @@ jobs:
   build-nitro-enclave-image:
     name: build nitro-enclave image
     needs: [resolve-sha]
-    environment: dev
+    environment:
+      name: dev
+      deployment: false
     runs-on: arc-public-8xlarge-amd64-runner
     steps:
       - name: Check Out Repo

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,7 +47,9 @@ permissions:
 jobs:
   build-and-push:
     name: build and push docker
-    environment: dev
+    environment:
+      name: dev
+      deployment: false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,9 @@ jobs:
 
   build-and-push:
     name: build and push docker
-    environment: dev
+    environment:
+      name: dev
+      deployment: false
     needs: prepare-release
     strategy:
       fail-fast: false

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -48,7 +48,9 @@ env:
 jobs:
   cargo-tests:
     runs-on: arc-public-8xlarge-amd64-runner
-    environment: dev
+    environment:
+      name: dev
+      deployment: false
     env:
       RUSTC_WRAPPER: sccache
       SCCACHE_BUCKET: crypto-dev-us-east-1-workflow-build-cache
@@ -92,7 +94,9 @@ jobs:
 
   cargo-clippy:
     runs-on: arc-public-8xlarge-amd64-runner
-    environment: dev
+    environment:
+      name: dev
+      deployment: false
     timeout-minutes: 20
     name: clippy
     env:
@@ -135,7 +139,9 @@ jobs:
 
   cargo-docs:
     runs-on: arc-public-8xlarge-amd64-runner
-    environment: dev
+    environment:
+      name: dev
+      deployment: false
     timeout-minutes: 20
     name: docs
     env:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Workflow-only metadata; same environment names and secrets, with no application or deploy pipeline logic changes.
> 
> **Overview**
> CI jobs that only need GitHub **environment** secrets and protection rules no longer register as **deployments** in the Environments UI.
> 
> Across **acceptance-tests**, **benchmarks**, **docker**, **docker-proof**, **release** (image build job), and **rust-ci**, job `environment` is expanded from a string (e.g. `dev` or `${{ matrix.environment }}`) to an object with the same `name` plus **`deployment: false`**. Environment names are unchanged; only deployment tracking is turned off for these build/test/push workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5248129ec0e733384398393b123cd560b7c2ade. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->