### PR TITLE
refactor(nitro): decode COSE_Sign1 with coset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3730,6 +3730,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "coset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eb98d5e9155e2cf7cd942c8b3033097d4563b6fb0a00b9caecb74669555c058"
+dependencies = [
+ "ciborium",
+ "ciborium-io",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19140,6 +19150,7 @@ dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "base64 0.22.1",
  "ciborium",
+ "coset",
  "hex",
  "k256",
  "kona-proof",

--- a/proofs/backends/nitro/enclave/Cargo.toml
+++ b/proofs/backends/nitro/enclave/Cargo.toml
@@ -40,6 +40,7 @@ alloy-sol-types.workspace = true
 anyhow.workspace = true
 base64 = { workspace = true }
 ciborium = "0.2"
+coset = "0.4"
 hex.workspace = true
 num-bigint = "0.4"
 num-traits = "0.2"

--- a/proofs/backends/nitro/enclave/src/attestation.rs
+++ b/proofs/backends/nitro/enclave/src/attestation.rs
@@ -151,40 +151,12 @@ pub struct ParsedAttestationDoc {
 /// This does **not** verify the signature or certificate chain — call
 /// [`verify_cose_sign1_signature`] for full cryptographic verification.
 pub fn parse_attestation_doc(doc: &[u8]) -> Result<ParsedAttestationDoc, AttestationError> {
-    // COSE_Sign1 layout: [protected, unprotected, payload, signature]
-    let cose: ciborium::value::Value =
-        ciborium::from_reader(doc).map_err(|err| AttestationError::Malformed(err.to_string()))?;
-    let array = match cose {
-        ciborium::value::Value::Array(a) => a,
-        // Tag 18 = COSE_Sign1 tag.
-        ciborium::value::Value::Tag(18, inner) => match *inner {
-            ciborium::value::Value::Array(a) => a,
-            _ => {
-                return Err(AttestationError::Malformed(
-                    "expected array under tag 18".into(),
-                ));
-            }
-        },
-        _ => {
-            return Err(AttestationError::Malformed(
-                "expected COSE_Sign1 array".into(),
-            ));
-        }
-    };
-    if array.len() != 4 {
-        return Err(AttestationError::Malformed(format!(
-            "expected 4-element COSE_Sign1 array, got {}",
-            array.len()
-        )));
-    }
-    let payload_bytes = match &array[2] {
-        ciborium::value::Value::Bytes(b) => b.clone(),
-        _ => {
-            return Err(AttestationError::Malformed(
-                "COSE_Sign1 payload is not a byte string".into(),
-            ));
-        }
-    };
+    let sign1 = crate::cose::parse_cose_sign1(doc)
+        .map_err(|err| AttestationError::Malformed(err.to_string()))?;
+    // `parse_cose_sign1` rejects an absent payload, so this is always `Some`.
+    let payload_bytes = sign1
+        .payload
+        .ok_or_else(|| AttestationError::Malformed("COSE_Sign1 payload is absent".into()))?;
     let payload: ciborium::value::Value = ciborium::from_reader(payload_bytes.as_slice())
         .map_err(|err| AttestationError::Malformed(format!("payload decode: {err}")))?;
     let entries = match payload {
@@ -300,73 +272,23 @@ pub fn parse_attestation_doc(doc: &[u8]) -> Result<ParsedAttestationDoc, Attesta
 ///
 /// # What this verifies
 ///
-/// 1. Parses the outer COSE_Sign1 envelope to extract `protected`, `payload`, and
-///    `signature` fields.
-/// 2. Extracts the DER-encoded leaf certificate from the payload's `certificate` field.
-/// 3. Extracts the P-384 public key from the leaf certificate.
-/// 4. Reconstructs the `Sig_Structure`: `CBOR(["Signature1", protected, b"", payload])`.
-/// 5. Verifies the P-384 / ES384 signature over the `Sig_Structure` bytes.
-/// 6. Builds and validates an RFC 5280 certification path from the leaf to the hardcoded
-///    AWS Nitro Attestation PKI root CA, anchored on the pinned root rather than on anything
-///    the document supplies.
-/// 7. Checks the keyUsage bits AWS requires on the CAs and on the leaf.
+/// 1. Decodes the COSE_Sign1 envelope via [`crate::cose::parse_cose_sign1`].
+/// 2. Validates an RFC 5280 path from the payload's leaf certificate to the pinned AWS Nitro
+///    root CA, plus the keyUsage bits AWS requires.
+/// 3. Verifies the ES384 signature over the `Sig_Structure`, using the leaf certificate's key.
 ///
 /// A document without a `certificate` field is rejected: accepting one would let PCR and
 /// `user_data` checks pass with no cryptographic proof the values came from AWS hardware.
 pub fn verify_cose_sign1_signature(doc: &[u8]) -> Result<(), AttestationError> {
-    let cose: ciborium::value::Value = ciborium::from_reader(doc)
+    let sign1 = crate::cose::parse_cose_sign1(doc)
         .map_err(|e| AttestationError::Malformed(format!("COSE parse: {e}")))?;
+    // `parse_cose_sign1` rejects an absent payload, so this is always `Some`.
+    let payload_bstr = sign1
+        .payload
+        .as_deref()
+        .ok_or_else(|| AttestationError::Malformed("COSE_Sign1 payload is absent".into()))?;
 
-    let array = match cose {
-        ciborium::value::Value::Array(a) => a,
-        ciborium::value::Value::Tag(18, inner) => match *inner {
-            ciborium::value::Value::Array(a) => a,
-            _ => {
-                return Err(AttestationError::Malformed(
-                    "expected array under tag 18".into(),
-                ));
-            }
-        },
-        _ => {
-            return Err(AttestationError::Malformed(
-                "expected COSE_Sign1 array".into(),
-            ));
-        }
-    };
-
-    if array.len() != 4 {
-        return Err(AttestationError::Malformed(format!(
-            "COSE_Sign1 must have 4 elements, got {}",
-            array.len()
-        )));
-    }
-
-    let protected_bstr = match &array[0] {
-        ciborium::value::Value::Bytes(b) => b.clone(),
-        _ => {
-            return Err(AttestationError::Malformed(
-                "COSE_Sign1 protected is not a bstr".into(),
-            ));
-        }
-    };
-    let payload_bstr = match &array[2] {
-        ciborium::value::Value::Bytes(b) => b.clone(),
-        _ => {
-            return Err(AttestationError::Malformed(
-                "COSE_Sign1 payload is not a bstr".into(),
-            ));
-        }
-    };
-    let signature_bytes = match &array[3] {
-        ciborium::value::Value::Bytes(b) => b.clone(),
-        _ => {
-            return Err(AttestationError::Malformed(
-                "COSE_Sign1 signature is not a bstr".into(),
-            ));
-        }
-    };
-
-    let payload_value: ciborium::value::Value = ciborium::from_reader(payload_bstr.as_slice())
+    let payload_value: ciborium::value::Value = ciborium::from_reader(payload_bstr)
         .map_err(|e| AttestationError::Malformed(format!("payload decode: {e}")))?;
 
     let payload_map = match payload_value {
@@ -414,33 +336,17 @@ pub fn verify_cose_sign1_signature(doc: &[u8]) -> Result<(), AttestationError> {
     // the root to the hardcoded AWS Nitro Attestation PKI constant.
     verify_cert_chain(&cert_der, &cabundle)?;
 
-    // RFC 8152 §4.4:
-    //   Sig_Structure = [
-    //     context:      "Signature1",
-    //     body_protected: protected_bstr,
-    //     external_aad: h'',
-    //     payload:      payload_bstr,
-    //   ]
-    let sig_structure = ciborium::value::Value::Array(vec![
-        ciborium::value::Value::Text("Signature1".into()),
-        ciborium::value::Value::Bytes(protected_bstr),
-        ciborium::value::Value::Bytes(vec![]), // external_aad
-        ciborium::value::Value::Bytes(payload_bstr),
-    ]);
-    let mut sig_struct_bytes = Vec::new();
-    ciborium::into_writer(&sig_structure, &mut sig_struct_bytes)
-        .map_err(|e| AttestationError::Malformed(format!("Sig_Structure encode: {e}")))?;
-
     let verifying_key = extract_p384_key(&cert_der)?;
 
+    // `coset` rebuilds the RFC 8152 §4.4 `Sig_Structure` from the original `protected` bytes.
     // COSE ES384 uses the fixed (r‖s) 96-byte encoding for P-384 signatures.
-    let sig = Signature::from_slice(&signature_bytes)
-        .map_err(|e| AttestationError::CoseSignature(format!("signature decode: {e}")))?;
-    verifying_key
-        .verify(&sig_struct_bytes, &sig)
-        .map_err(|e| AttestationError::CoseSignature(format!("ES384 verify: {e}")))?;
-
-    Ok(())
+    sign1.verify_signature(&[], |signature_bytes, sig_struct_bytes| {
+        let sig = Signature::from_slice(signature_bytes)
+            .map_err(|e| AttestationError::CoseSignature(format!("signature decode: {e}")))?;
+        verifying_key
+            .verify(sig_struct_bytes, &sig)
+            .map_err(|e| AttestationError::CoseSignature(format!("ES384 verify: {e}")))
+    })
 }
 
 /// Extracts the P-384 verifying key from a DER-encoded X.509 certificate.

--- a/proofs/backends/nitro/enclave/src/cose.rs
+++ b/proofs/backends/nitro/enclave/src/cose.rs
@@ -8,10 +8,37 @@
 //! `NitroAttestationVerifier.verifyAttestation`.
 
 use anyhow::{Result, bail};
-use ciborium::value::Value;
+use coset::{CborSerializable as _, CoseSign1, TaggedCborSerializable as _};
 
 /// Length in bytes of a P-384 COSE ES384 signature (`r || s`, 48 bytes each).
 pub const P384_SIGNATURE_LEN: usize = 96;
+
+/// Errors raised while decoding the outer `COSE_Sign1` envelope.
+#[derive(Debug, thiserror::Error)]
+pub enum CoseDecodeError {
+    /// The bytes are not a well-formed `COSE_Sign1` structure.
+    #[error("COSE_Sign1 decode failed: {0:?}")]
+    Malformed(coset::CoseError),
+    /// The `payload` element is CBOR `nil`. Every NSM attestation document carries one.
+    #[error("COSE_Sign1 payload is absent")]
+    MissingPayload,
+}
+
+/// Decodes the `COSE_Sign1` envelope, accepting both the bare array the NSM emits and the
+/// RFC 8152 tag-18 wrapping, and rejecting an absent payload.
+///
+/// `coset` retains the original `protected` bstr, so [`CoseSign1::tbs_data`] reproduces the
+/// bytes the NSM signed rather than a re-encoding — which is what keeps the TBS byte-identical
+/// to the on-chain `NitroValidator.decodeAttestationTbs`.
+pub fn parse_cose_sign1(raw: &[u8]) -> Result<CoseSign1, CoseDecodeError> {
+    let sign1 = CoseSign1::from_tagged_slice(raw)
+        .or_else(|_| CoseSign1::from_slice(raw))
+        .map_err(CoseDecodeError::Malformed)?;
+    if sign1.payload.is_none() {
+        return Err(CoseDecodeError::MissingPayload);
+    }
+    Ok(sign1)
+}
 
 /// Decodes a raw `COSE_Sign1` Nitro attestation document into `(attestation_tbs, signature)`.
 ///
@@ -23,66 +50,25 @@ pub const P384_SIGNATURE_LEN: usize = 96;
 ///
 /// # Errors
 ///
-/// Returns an error if the input is not a well-formed 4-element `COSE_Sign1` structure or if
-/// the signature is not exactly [`P384_SIGNATURE_LEN`] bytes.
+/// Returns an error if the input is not a well-formed `COSE_Sign1` structure or if the
+/// signature is not exactly [`P384_SIGNATURE_LEN`] bytes.
 pub fn decode_attestation_tbs(raw: &[u8]) -> Result<(Vec<u8>, Vec<u8>)> {
-    let value: Value = ciborium::de::from_reader(raw)
-        .map_err(|e| anyhow::anyhow!("COSE_Sign1 CBOR decode error: {e:?}"))?;
+    let sign1 = parse_cose_sign1(raw)?;
 
-    // A COSE_Sign1 document is a 4-element array, optionally wrapped in CBOR tag 18.
-    let array = match value {
-        Value::Tag(_, inner) => match *inner {
-            Value::Array(a) => a,
-            _ => bail!("expected CBOR array inside COSE_Sign1 tag"),
-        },
-        Value::Array(a) => a,
-        _ => bail!("expected CBOR array or tag at COSE_Sign1 root"),
-    };
-
-    if array.len() != 4 {
-        bail!("COSE_Sign1 must have 4 elements, got {}", array.len());
-    }
-
-    let protected = match &array[0] {
-        Value::Bytes(b) => b.clone(),
-        _ => bail!("COSE_Sign1 protected header must be a byte string"),
-    };
-    let payload = match &array[2] {
-        Value::Bytes(b) => b.clone(),
-        _ => bail!("COSE_Sign1 payload must be a byte string"),
-    };
-    let signature = match &array[3] {
-        Value::Bytes(b) => b.clone(),
-        _ => bail!("COSE_Sign1 signature must be a byte string"),
-    };
-
-    if signature.len() != P384_SIGNATURE_LEN {
+    if sign1.signature.len() != P384_SIGNATURE_LEN {
         bail!(
             "attestation signature must be {P384_SIGNATURE_LEN} bytes, got {}",
-            signature.len()
+            sign1.signature.len()
         );
     }
 
-    // Reconstruct the Sig_Structure: ["Signature1", protected, h'', payload].
-    // `Value::Bytes` always serialises to a definite-length, minimally-encoded byte string,
-    // which matches how the NSM originally encoded the protected/payload elements and how the
-    // on-chain `_constructAttestationTbs` slices them.
-    let tbs = Value::Array(vec![
-        Value::Text("Signature1".to_string()),
-        Value::Bytes(protected),
-        Value::Bytes(Vec::new()),
-        Value::Bytes(payload),
-    ]);
-    let mut tbs_bytes = Vec::new();
-    ciborium::ser::into_writer(&tbs, &mut tbs_bytes)
-        .map_err(|e| anyhow::anyhow!("COSE_Sign1 TBS CBOR encode error: {e:?}"))?;
-
-    Ok((tbs_bytes, signature))
+    Ok((sign1.tbs_data(&[]), sign1.signature))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ciborium::value::Value;
 
     /// Builds a minimal COSE_Sign1 array `[protected, unprotected, payload, signature]`.
     fn make_cose(protected: &[u8], payload: &[u8], signature: &[u8]) -> Vec<u8> {
@@ -95,6 +81,92 @@ mod tests {
         let mut out = Vec::new();
         ciborium::ser::into_writer(&cose, &mut out).unwrap();
         out
+    }
+
+    /// The construction this module used before `coset`, and the one the on-chain
+    /// `NitroValidator.decodeAttestationTbs` agrees with.
+    fn reference_tbs(protected: &[u8], payload: &[u8]) -> Vec<u8> {
+        let tbs = Value::Array(vec![
+            Value::Text("Signature1".to_string()),
+            Value::Bytes(protected.to_vec()),
+            Value::Bytes(Vec::new()),
+            Value::Bytes(payload.to_vec()),
+        ]);
+        let mut out = Vec::new();
+        ciborium::ser::into_writer(&tbs, &mut out).unwrap();
+        out
+    }
+
+    /// The property `registerKey` depends on: byte-for-byte equality with the old construction.
+    #[test]
+    fn tbs_matches_the_hand_rolled_construction() {
+        let protected = [0xa1, 0x01, 0x38, 0x22]; // {1: -35} (ES384)
+        let payload = b"hello-attestation-payload";
+
+        let doc = make_cose(&protected, payload, &[7u8; P384_SIGNATURE_LEN]);
+        let (tbs, _) = decode_attestation_tbs(&doc).unwrap();
+
+        assert_eq!(tbs, reference_tbs(&protected, payload));
+    }
+
+    /// A signature made over the reference `Sig_Structure` must verify through `coset`'s path,
+    /// or [`crate::attestation::verify_cose_sign1_signature`] cannot work at all.
+    #[test]
+    fn coset_tbs_verifies_a_real_p384_signature() {
+        use p384::ecdsa::{
+            Signature, SigningKey,
+            signature::{Signer as _, Verifier as _},
+        };
+
+        let protected = [0xa1, 0x01, 0x38, 0x22];
+        let payload = b"hello-attestation-payload";
+
+        let signing_key = SigningKey::random(&mut rand::thread_rng());
+        let signature: Signature = signing_key.sign(&reference_tbs(&protected, payload));
+
+        let doc = make_cose(&protected, payload, signature.to_bytes().as_slice());
+        let sign1 = parse_cose_sign1(&doc).unwrap();
+
+        let verifying_key = signing_key.verifying_key();
+        sign1
+            .verify_signature(&[], |sig, tbs| {
+                verifying_key.verify(tbs, &Signature::from_slice(sig)?)
+            })
+            .unwrap();
+    }
+
+    /// RFC 8152 permits the tag-18 wrapping; the NSM omits it. Both must decode to the same TBS.
+    #[test]
+    fn accepts_tag_18_wrapping() {
+        let protected = [0xa1, 0x01, 0x38, 0x22];
+        let payload = b"hello-attestation-payload";
+        let signature = vec![7u8; P384_SIGNATURE_LEN];
+
+        let bare = make_cose(&protected, payload, &signature);
+        let untagged: Value = ciborium::de::from_reader(bare.as_slice()).unwrap();
+        let mut tagged = Vec::new();
+        ciborium::ser::into_writer(&Value::Tag(18, Box::new(untagged)), &mut tagged).unwrap();
+
+        assert_eq!(
+            decode_attestation_tbs(&tagged).unwrap(),
+            decode_attestation_tbs(&bare).unwrap()
+        );
+    }
+
+    /// `tbs_data` treats an absent payload as empty, silently signing over nothing.
+    #[test]
+    fn rejects_absent_payload() {
+        let cose = Value::Array(vec![
+            Value::Bytes(vec![0xa0]),
+            Value::Map(Vec::new()),
+            Value::Null,
+            Value::Bytes(vec![7u8; P384_SIGNATURE_LEN]),
+        ]);
+        let mut doc = Vec::new();
+        ciborium::ser::into_writer(&cose, &mut doc).unwrap();
+
+        let err = decode_attestation_tbs(&doc).unwrap_err();
+        assert!(err.to_string().contains("payload is absent"), "got: {err}");
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches attestation signature verification and on-chain TBS alignment; behavior is guarded by new equivalence tests but any coset TBS mismatch would break trust in Nitro documents.
> 
> **Overview**
> Consolidates duplicate hand-rolled **COSE_Sign1** parsing in `cose.rs` and `attestation.rs` behind a shared **`coset`**-backed **`parse_cose_sign1`**, with **`coset` 0.4** added as a dependency. TBS / `Sig_Structure` bytes now come from **`CoseSign1::tbs_data`** and **`verify_signature`** instead of manual CBOR array assembly, preserving the original **`protected`** bstr so off-chain TBS stays aligned with on-chain **`NitroValidator.decodeAttestationTbs`**. P-384 ES384 verification still uses **`p384`**.
> 
> **Parsing and verification** in **`attestation.rs`** call the shared parser; signature check order is unchanged (cert chain first, then ES384 over the coset-built structure).
> 
> **Stricter decoding:** documents with a nil/absent COSE payload are rejected up front, avoiding a silent empty-payload TBS. New tests lock TBS byte equality with the old construction, real P-384 verify-through-coset, tag-18 vs bare encoding, and absent-payload rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e47d6aed42cc71c8b51502a8421525fc2a33ac15. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->