### PR TITLE
refactor(nitro): decode attestation payload into AWS's AttestationDoc

### DIFF
--- a/proofs/backends/nitro/enclave/Cargo.toml
+++ b/proofs/backends/nitro/enclave/Cargo.toml
@@ -21,7 +21,6 @@ required-features = ["enclave"]
 default = []
 # Host-side prover (vsock) plus the enclave-side code path. Linux only.
 enclave = [
-    "dep:aws-nitro-enclaves-nsm-api",
     "dep:kona-proof",
     "dep:tokio-vsock",
     "dep:tracing-subscriber",
@@ -38,6 +37,8 @@ enclave = [
 alloy-primitives = { workspace = true, features = ["serde"] }
 alloy-sol-types.workspace = true
 anyhow.workspace = true
+# `default-features = false` drops `nix`, and with it the Linux-only NSM driver.
+aws-nitro-enclaves-nsm-api = { version = "0.5", default-features = false }
 base64 = { workspace = true }
 ciborium = "0.2"
 coset = "0.4"
@@ -66,7 +67,8 @@ k256 = { version = "0.13", features = ["ecdsa"] }
 # This table is what keeps the AF_VSOCK / NSM crates off non-Linux hosts.
 [target.'cfg(target_os = "linux")'.dependencies]
 tokio-vsock = { version = "0.5", optional = true }
-aws-nitro-enclaves-nsm-api = { version = "0.5", optional = true }
+# `nix` gates the NSM ioctl driver the enclave binary calls into.
+aws-nitro-enclaves-nsm-api = { version = "0.5", features = ["nix"] }
 kona-proof = { workspace = true, optional = true }
 world-chain-proof-kona-client = { workspace = true, optional = true }
 

--- a/proofs/backends/nitro/enclave/src/attestation.rs
+++ b/proofs/backends/nitro/enclave/src/attestation.rs
@@ -14,7 +14,6 @@
 use crate::{ExpectedPcrs, PCR_LEN, PcrDigest};
 use p384::ecdsa::{Signature, signature::Verifier as _};
 use rustls_pki_types::{CertificateDer, SignatureVerificationAlgorithm, UnixTime};
-use std::collections::BTreeMap;
 use webpki::{EndEntityCert, ExtendedKeyUsageValidator, KeyPurposeIdIter};
 
 /// DER-encoded AWS Nitro Attestation PKI root CA certificate.
@@ -118,154 +117,28 @@ pub enum AttestationError {
     },
 }
 
-/// Decodes the relevant subset of a Nitro attestation document.
-#[derive(Clone, Debug)]
-pub struct ParsedAttestationDoc {
-    /// `pcrs` map from PCR index to digest bytes.
-    pub pcrs: BTreeMap<u8, Vec<u8>>,
-    /// Optional `user_data` field. Present whenever the enclave passed one to `Request::Attestation`.
-    pub user_data: Option<Vec<u8>>,
-    /// `module_id` of the originating enclave.
-    pub module_id: Option<String>,
-    /// `digest` algorithm field (typically `"SHA384"`).
-    pub digest: Option<String>,
-    /// DER-encoded leaf certificate used to sign the COSE_Sign1 structure.
-    pub certificate: Option<Vec<u8>>,
-    /// DER-encoded CA bundle, root first. The last element issued `certificate`.
-    pub cabundle: Vec<Vec<u8>>,
-    /// Optional `public_key` field. Present when the enclave called `NsmRequest::Attestation`
-    /// with `public_key: Some(bytes)` — i.e., for [`EnclaveRequest::PublicKey`] responses.
-    /// The bytes are the uncompressed SEC1 encoding (`0x04 || X || Y`, 65 bytes) of the
-    /// enclave's ephemeral secp256k1 key.
-    ///
-    /// Use [`extract_nsm_public_key`] to obtain this value with a mandatory-presence check.
-    pub public_key: Option<Vec<u8>>,
-    /// Optional `nonce` field. Present when the host supplied a nonce in the request, which
-    /// the NSM embeds verbatim into the signed payload for replay protection.
-    pub nonce: Option<Vec<u8>>,
-}
+/// AWS's own definition of the signed attestation payload, re-exported so callers work against
+/// the field set AWS declares rather than a local subset kept in step by hand.
+///
+/// `certificate` and `cabundle` are mandatory there, so a decoded document always carries a leaf.
+pub use aws_nitro_enclaves_nsm_api::api::AttestationDoc;
 
-/// Parses a `COSE_Sign1` Nitro attestation document and returns the inner payload fields the
-/// host cares about.
+/// Parses a `COSE_Sign1` Nitro attestation document and returns the signed payload.
+///
+/// Decoding is `serde`-driven, so a `pcrs` entry with a non-integer key or non-bstr value fails
+/// the whole parse instead of being silently skipped.
 ///
 /// This does **not** verify the signature or certificate chain — call
 /// [`verify_cose_sign1_signature`] for full cryptographic verification.
-pub fn parse_attestation_doc(doc: &[u8]) -> Result<ParsedAttestationDoc, AttestationError> {
+pub fn parse_attestation_doc(doc: &[u8]) -> Result<AttestationDoc, AttestationError> {
     let sign1 = crate::cose::parse_cose_sign1(doc)
         .map_err(|err| AttestationError::Malformed(err.to_string()))?;
     // `parse_cose_sign1` rejects an absent payload, so this is always `Some`.
     let payload_bytes = sign1
         .payload
         .ok_or_else(|| AttestationError::Malformed("COSE_Sign1 payload is absent".into()))?;
-    let payload: ciborium::value::Value = ciborium::from_reader(payload_bytes.as_slice())
-        .map_err(|err| AttestationError::Malformed(format!("payload decode: {err}")))?;
-    let entries = match payload {
-        ciborium::value::Value::Map(m) => m,
-        _ => {
-            return Err(AttestationError::Malformed(
-                "attestation payload is not a CBOR map".into(),
-            ));
-        }
-    };
-
-    let mut pcrs: BTreeMap<u8, Vec<u8>> = BTreeMap::new();
-    let mut user_data: Option<Vec<u8>> = None;
-    let mut module_id: Option<String> = None;
-    let mut digest: Option<String> = None;
-    let mut certificate: Option<Vec<u8>> = None;
-    let mut cabundle: Vec<Vec<u8>> = Vec::new();
-    let mut public_key: Option<Vec<u8>> = None;
-    let mut nonce: Option<Vec<u8>> = None;
-
-    for (key, value) in entries {
-        let key_str = match key {
-            ciborium::value::Value::Text(t) => t,
-            _ => continue,
-        };
-        match key_str.as_str() {
-            "pcrs" => {
-                let entries = match value {
-                    ciborium::value::Value::Map(m) => m,
-                    _ => {
-                        return Err(AttestationError::Malformed(
-                            "pcrs field is not a map".into(),
-                        ));
-                    }
-                };
-                for (pcr_key, pcr_value) in entries {
-                    let idx: u8 = match pcr_key {
-                        ciborium::value::Value::Integer(i) => match u8::try_from(i) {
-                            Ok(idx) => idx,
-                            Err(_) => continue,
-                        },
-                        _ => continue,
-                    };
-                    let bytes = match pcr_value {
-                        ciborium::value::Value::Bytes(b) => b,
-                        _ => continue,
-                    };
-                    pcrs.insert(idx, bytes);
-                }
-            }
-            "user_data" => {
-                user_data = match value {
-                    ciborium::value::Value::Bytes(b) => Some(b),
-                    ciborium::value::Value::Null => None,
-                    _ => {
-                        return Err(AttestationError::Malformed(
-                            "user_data is not a byte string".into(),
-                        ));
-                    }
-                };
-            }
-            "module_id" => {
-                if let ciborium::value::Value::Text(t) = value {
-                    module_id = Some(t);
-                }
-            }
-            "digest" => {
-                if let ciborium::value::Value::Text(t) = value {
-                    digest = Some(t);
-                }
-            }
-            "certificate" => {
-                if let ciborium::value::Value::Bytes(b) = value {
-                    certificate = Some(b);
-                }
-            }
-            "cabundle" => {
-                if let ciborium::value::Value::Array(arr) = value {
-                    for item in arr {
-                        if let ciborium::value::Value::Bytes(b) = item {
-                            cabundle.push(b);
-                        }
-                    }
-                }
-            }
-            "public_key" => {
-                if let ciborium::value::Value::Bytes(b) = value {
-                    public_key = Some(b);
-                }
-            }
-            "nonce" => {
-                if let ciborium::value::Value::Bytes(b) = value {
-                    nonce = Some(b);
-                }
-            }
-            _ => {}
-        }
-    }
-
-    Ok(ParsedAttestationDoc {
-        pcrs,
-        user_data,
-        module_id,
-        digest,
-        certificate,
-        cabundle,
-        public_key,
-        nonce,
-    })
+    ciborium::from_reader(payload_bytes.as_slice())
+        .map_err(|err| AttestationError::Malformed(format!("payload decode: {err}")))
 }
 
 /// Verifies the COSE_Sign1 signature on an AWS Nitro attestation document.
@@ -288,52 +161,16 @@ pub fn verify_cose_sign1_signature(doc: &[u8]) -> Result<(), AttestationError> {
         .as_deref()
         .ok_or_else(|| AttestationError::Malformed("COSE_Sign1 payload is absent".into()))?;
 
-    let payload_value: ciborium::value::Value = ciborium::from_reader(payload_bstr)
+    let payload: AttestationDoc = ciborium::from_reader(payload_bstr)
         .map_err(|e| AttestationError::Malformed(format!("payload decode: {e}")))?;
 
-    let payload_map = match payload_value {
-        ciborium::value::Value::Map(m) => m,
-        _ => {
-            return Err(AttestationError::Malformed(
-                "attestation payload is not a CBOR map".into(),
-            ));
-        }
-    };
+    let cert_der = payload.certificate.into_vec();
+    let cabundle: Vec<Vec<u8>> = payload
+        .cabundle
+        .into_iter()
+        .map(serde_bytes::ByteBuf::into_vec)
+        .collect();
 
-    let mut cert_der: Option<Vec<u8>> = None;
-    let mut cabundle: Vec<Vec<u8>> = Vec::new();
-
-    for (k, v) in &payload_map {
-        match k {
-            ciborium::value::Value::Text(s) if s == "certificate" => {
-                if let ciborium::value::Value::Bytes(b) = v {
-                    cert_der = Some(b.clone());
-                }
-            }
-            ciborium::value::Value::Text(s) if s == "cabundle" => {
-                if let ciborium::value::Value::Array(arr) = v {
-                    for item in arr {
-                        if let ciborium::value::Value::Bytes(b) = item {
-                            cabundle.push(b.clone());
-                        }
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
-
-    // A valid Nitro attestation document must always carry a leaf certificate.
-    // Accepting a document without one would allow PCR / user_data checks to pass
-    // without any cryptographic proof that those values came from AWS hardware.
-    let cert_der = cert_der.ok_or_else(|| {
-        AttestationError::Malformed(
-            "attestation document missing required `certificate` field".into(),
-        )
-    })?;
-
-    // Walk leaf → intermediates → root, verifying each signature and anchoring
-    // the root to the hardcoded AWS Nitro Attestation PKI constant.
     verify_cert_chain(&cert_der, &cabundle)?;
 
     let verifying_key = extract_p384_key(&cert_der)?;
@@ -375,17 +212,10 @@ fn extract_p384_key(cert_der: &[u8]) -> Result<p384::ecdsa::VerifyingKey, Attest
 ///
 /// # Errors
 ///
-/// Returns [`AttestationError::Malformed`] if the document carries no leaf certificate,
-/// and [`AttestationError::CertChain`] if the certificate or its key cannot be parsed.
+/// Returns [`AttestationError::Malformed`] if the document does not decode, and
+/// [`AttestationError::CertChain`] if the certificate or its key cannot be parsed.
 pub fn leaf_cert_pubkey_xy(doc: &[u8]) -> Result<[u8; 96], AttestationError> {
-    let parsed = parse_attestation_doc(doc)?;
-    let cert_der = parsed.certificate.ok_or_else(|| {
-        AttestationError::Malformed(
-            "attestation document missing required `certificate` field".into(),
-        )
-    })?;
-
-    cert_pubkey_xy(&cert_der)
+    cert_pubkey_xy(&parse_attestation_doc(doc)?.certificate)
 }
 
 /// Extracts any certificate's P-384 public key as the uncompressed `x || y` coordinate pair
@@ -625,6 +455,7 @@ pub fn extract_nsm_public_key(doc: &[u8]) -> Result<Vec<u8>, AttestationError> {
     let parsed = parse_attestation_doc(doc)?;
     parsed
         .public_key
+        .map(serde_bytes::ByteBuf::into_vec)
         .ok_or(AttestationError::MissingField("public_key"))
 }
 
@@ -670,7 +501,7 @@ pub fn parse_and_check_pcrs(
     doc: &[u8],
     expected_pcrs: &ExpectedPcrs,
     expected_user_data: &[u8],
-) -> Result<ParsedAttestationDoc, AttestationError> {
+) -> Result<AttestationDoc, AttestationError> {
     let parsed = parse_attestation_doc(doc)?;
 
     check_pcr(&parsed, 0, &expected_pcrs.pcr0)?;
@@ -700,7 +531,7 @@ pub fn parse_check_and_verify(
     doc: &[u8],
     expected_pcrs: &ExpectedPcrs,
     expected_user_data: &[u8],
-) -> Result<ParsedAttestationDoc, AttestationError> {
+) -> Result<AttestationDoc, AttestationError> {
     let parsed = parse_and_check_pcrs(doc, expected_pcrs, expected_user_data)?;
     verify_cose_sign1_signature(doc)?;
     Ok(parsed)
@@ -736,7 +567,7 @@ pub fn verify_nonce(doc: &[u8], expected: &[u8]) -> Result<(), AttestationError>
 pub fn verify_pcrs_only(
     doc: &[u8],
     expected_pcrs: &ExpectedPcrs,
-) -> Result<ParsedAttestationDoc, AttestationError> {
+) -> Result<AttestationDoc, AttestationError> {
     let parsed = parse_attestation_doc(doc)?;
     check_pcr(&parsed, 0, &expected_pcrs.pcr0)?;
     check_pcr(&parsed, 1, &expected_pcrs.pcr1)?;
@@ -745,7 +576,7 @@ pub fn verify_pcrs_only(
 }
 
 fn check_pcr(
-    parsed: &ParsedAttestationDoc,
+    parsed: &AttestationDoc,
     index: u8,
     expected: &PcrDigest,
 ) -> Result<(), AttestationError> {
@@ -754,7 +585,7 @@ fn check_pcr(
     }
     let actual = parsed
         .pcrs
-        .get(&index)
+        .get(&usize::from(index))
         .ok_or(AttestationError::MissingField(match index {
             0 => "pcr0",
             1 => "pcr1",
@@ -775,45 +606,69 @@ fn check_pcr(
 mod tests {
     use super::*;
 
+    /// Carries every field AWS declares mandatory. `certificate` / `cabundle` are placeholders:
+    /// these documents exercise the PCR / `user_data` checks, not the chain.
     fn make_doc(pcrs: Vec<(u8, Vec<u8>)>, user_data: Option<Vec<u8>>) -> Vec<u8> {
-        let pcr_map: Vec<(ciborium::value::Value, ciborium::value::Value)> = pcrs
+        make_doc_inner(pcrs, user_data, true)
+    }
+
+    /// Same, minus the mandatory `certificate` field, which the typed decode must reject.
+    fn make_doc_without_certificate(
+        pcrs: Vec<(u8, Vec<u8>)>,
+        user_data: Option<Vec<u8>>,
+    ) -> Vec<u8> {
+        make_doc_inner(pcrs, user_data, false)
+    }
+
+    fn make_doc_inner(
+        pcrs: Vec<(u8, Vec<u8>)>,
+        user_data: Option<Vec<u8>>,
+        with_certificate: bool,
+    ) -> Vec<u8> {
+        use ciborium::value::Value as V;
+
+        let pcr_map: Vec<(V, V)> = pcrs
             .into_iter()
             .map(|(idx, bytes)| {
                 (
-                    ciborium::value::Value::Integer((idx as i128).try_into().unwrap()),
-                    ciborium::value::Value::Bytes(bytes),
+                    V::Integer((idx as i128).try_into().unwrap()),
+                    V::Bytes(bytes),
                 )
             })
             .collect();
-        let mut entries: Vec<(ciborium::value::Value, ciborium::value::Value)> = vec![
+
+        let mut entries: Vec<(V, V)> = vec![
+            (V::Text("pcrs".into()), V::Map(pcr_map)),
+            (V::Text("module_id".into()), V::Text("test-module".into())),
+            (V::Text("digest".into()), V::Text("SHA384".into())),
             (
-                ciborium::value::Value::Text("pcrs".into()),
-                ciborium::value::Value::Map(pcr_map),
+                V::Text("timestamp".into()),
+                V::Integer(1_785_790_194_000u64.into()),
             ),
             (
-                ciborium::value::Value::Text("module_id".into()),
-                ciborium::value::Value::Text("test-module".into()),
+                V::Text("cabundle".into()),
+                V::Array(vec![V::Bytes(vec![0xAAu8; 64])]),
             ),
             (
-                ciborium::value::Value::Text("digest".into()),
-                ciborium::value::Value::Text("SHA384".into()),
+                V::Text("user_data".into()),
+                match user_data {
+                    Some(bytes) => V::Bytes(bytes),
+                    None => V::Null,
+                },
             ),
         ];
-        entries.push((
-            ciborium::value::Value::Text("user_data".into()),
-            match user_data {
-                Some(bytes) => ciborium::value::Value::Bytes(bytes),
-                None => ciborium::value::Value::Null,
-            },
-        ));
-        let mut payload_bytes = Vec::new();
-        ciborium::into_writer(&ciborium::value::Value::Map(entries), &mut payload_bytes).unwrap();
+        if with_certificate {
+            entries.push((V::Text("certificate".into()), V::Bytes(vec![0xBBu8; 64])));
+        }
 
-        let cose = ciborium::value::Value::Array(vec![
-            ciborium::value::Value::Bytes(vec![]),
-            ciborium::value::Value::Map(vec![]),
-            ciborium::value::Value::Bytes(payload_bytes),
-            ciborium::value::Value::Bytes(vec![0u8; 96]),
+        let mut payload_bytes = Vec::new();
+        ciborium::into_writer(&V::Map(entries), &mut payload_bytes).unwrap();
+
+        let cose = V::Array(vec![
+            V::Bytes(vec![]),
+            V::Map(vec![]),
+            V::Bytes(payload_bytes),
+            V::Bytes(vec![0u8; 96]),
         ]);
         let mut out = Vec::new();
         ciborium::into_writer(&cose, &mut out).unwrap();
@@ -835,8 +690,8 @@ mod tests {
             Some(vec![7u8; 32]),
         );
         let parsed = parse_and_check_pcrs(&doc, &non_placeholder_pcrs(3), &[7u8; 32]).unwrap();
-        assert_eq!(parsed.user_data.unwrap(), vec![7u8; 32]);
-        assert_eq!(parsed.module_id.unwrap(), "test-module");
+        assert_eq!(parsed.user_data.unwrap().into_vec(), vec![7u8; 32]);
+        assert_eq!(parsed.module_id, "test-module");
     }
 
     #[test]
@@ -880,17 +735,59 @@ mod tests {
         assert!(matches!(err, AttestationError::UserDataMismatch { .. }));
     }
 
-    /// Documents without a `certificate` field must be rejected by the signature
-    /// verifier — accepting them would allow PCR/user_data checks to pass without
-    /// any AWS hardware proof.
+    /// A document without a `certificate` field would let PCR/`user_data` checks pass with no
+    /// AWS hardware proof. Being mandatory in AWS's schema, the decode now catches it first.
     #[test]
-    fn verify_cose_sign1_rejects_missing_certificate() {
+    fn rejects_missing_certificate() {
+        let doc = make_doc_without_certificate(
+            vec![(0, vec![3u8; 48]), (1, vec![3u8; 48]), (2, vec![3u8; 48])],
+            Some(vec![7u8; 32]),
+        );
+
+        for err in [
+            parse_attestation_doc(&doc).unwrap_err(),
+            verify_cose_sign1_signature(&doc).unwrap_err(),
+        ] {
+            assert!(
+                matches!(err, AttestationError::Malformed(_)),
+                "expected Malformed error, got: {err:?}"
+            );
+        }
+    }
+
+    /// A non-bstr `pcrs` value used to be skipped, leaving the PCR absent rather than rejected.
+    #[test]
+    fn rejects_malformed_pcr_entry() {
+        use ciborium::value::Value as V;
+
         let doc = make_doc(
             vec![(0, vec![3u8; 48]), (1, vec![3u8; 48]), (2, vec![3u8; 48])],
             Some(vec![7u8; 32]),
         );
-        // Must return an error when the certificate field is absent.
-        let err = verify_cose_sign1_signature(&doc).unwrap_err();
+        // Re-encode the payload with pcr1 replaced by a text string.
+        let sign1 = crate::cose::parse_cose_sign1(&doc).unwrap();
+        let mut payload: V = ciborium::from_reader(sign1.payload.unwrap().as_slice()).unwrap();
+        if let V::Map(entries) = &mut payload {
+            for (k, v) in entries.iter_mut() {
+                if *k == V::Text("pcrs".into())
+                    && let V::Map(pcrs) = v
+                {
+                    pcrs[1].1 = V::Text("not-a-digest".into());
+                }
+            }
+        }
+        let mut payload_bytes = Vec::new();
+        ciborium::into_writer(&payload, &mut payload_bytes).unwrap();
+        let cose = V::Array(vec![
+            V::Bytes(vec![]),
+            V::Map(vec![]),
+            V::Bytes(payload_bytes),
+            V::Bytes(vec![0u8; 96]),
+        ]);
+        let mut tampered = Vec::new();
+        ciborium::into_writer(&cose, &mut tampered).unwrap();
+
+        let err = parse_attestation_doc(&tampered).unwrap_err();
         assert!(
             matches!(err, AttestationError::Malformed(_)),
             "expected Malformed error, got: {err:?}"

--- a/proofs/backends/nitro/enclave/src/lib.rs
+++ b/proofs/backends/nitro/enclave/src/lib.rs
@@ -196,49 +196,46 @@ mod tests {
         protocol::transition_commitment,
     };
 
-    /// Builds a minimal synthetic COSE_Sign1 attestation document suitable for unit tests.
-    /// The signature bytes are a 96-byte placeholder — no cryptographic verification is
-    /// performed by `parse_attestation_doc` / `parse_and_check_pcrs` (see the TODO in
-    /// `attestation.rs`).
+    /// Carries every field AWS declares mandatory, since `parse_attestation_doc` decodes into
+    /// their schema. The certificate and signature are placeholders: nothing here verifies them.
     fn make_attestation_doc(pcrs: &[[u8; PCR_LEN]; 3], user_data: &[u8]) -> Vec<u8> {
-        let pcr_map: Vec<(ciborium::value::Value, ciborium::value::Value)> = pcrs
+        use ciborium::value::Value as V;
+
+        let pcr_map: Vec<(V, V)> = pcrs
             .iter()
             .enumerate()
             .map(|(idx, bytes)| {
                 (
-                    ciborium::value::Value::Integer((idx as i128).try_into().unwrap()),
-                    ciborium::value::Value::Bytes(bytes.to_vec()),
+                    V::Integer((idx as i128).try_into().unwrap()),
+                    V::Bytes(bytes.to_vec()),
                 )
             })
             .collect();
 
-        let entries: Vec<(ciborium::value::Value, ciborium::value::Value)> = vec![
+        let entries: Vec<(V, V)> = vec![
+            (V::Text("pcrs".into()), V::Map(pcr_map)),
+            (V::Text("user_data".into()), V::Bytes(user_data.to_vec())),
+            (V::Text("module_id".into()), V::Text("test-enclave".into())),
+            (V::Text("digest".into()), V::Text("SHA384".into())),
             (
-                ciborium::value::Value::Text("pcrs".into()),
-                ciborium::value::Value::Map(pcr_map),
+                V::Text("timestamp".into()),
+                V::Integer(1_785_790_194_000u64.into()),
             ),
+            (V::Text("certificate".into()), V::Bytes(vec![0xBBu8; 64])),
             (
-                ciborium::value::Value::Text("user_data".into()),
-                ciborium::value::Value::Bytes(user_data.to_vec()),
-            ),
-            (
-                ciborium::value::Value::Text("module_id".into()),
-                ciborium::value::Value::Text("test-enclave".into()),
-            ),
-            (
-                ciborium::value::Value::Text("digest".into()),
-                ciborium::value::Value::Text("SHA384".into()),
+                V::Text("cabundle".into()),
+                V::Array(vec![V::Bytes(vec![0xAAu8; 64])]),
             ),
         ];
 
         let mut payload_bytes = Vec::new();
-        ciborium::into_writer(&ciborium::value::Value::Map(entries), &mut payload_bytes).unwrap();
+        ciborium::into_writer(&V::Map(entries), &mut payload_bytes).unwrap();
 
-        let cose = ciborium::value::Value::Array(vec![
-            ciborium::value::Value::Bytes(vec![]),
-            ciborium::value::Value::Map(vec![]),
-            ciborium::value::Value::Bytes(payload_bytes),
-            ciborium::value::Value::Bytes(vec![0u8; 96]),
+        let cose = V::Array(vec![
+            V::Bytes(vec![]),
+            V::Map(vec![]),
+            V::Bytes(payload_bytes),
+            V::Bytes(vec![0u8; 96]),
         ]);
         let mut out = Vec::new();
         ciborium::into_writer(&cose, &mut out).unwrap();

--- a/proofs/backends/nitro/enclave/src/prewarm.rs
+++ b/proofs/backends/nitro/enclave/src/prewarm.rs
@@ -99,16 +99,14 @@ pub fn parse_cert_signature(der: &[u8]) -> Result<(Vec<u8>, Vec<u8>)> {
 ///
 /// # Errors
 ///
-/// Returns an error if the attestation document is malformed, carries no leaf certificate, or
-/// if its `cabundle` does not begin with the pinned AWS root CA (AWS orders `cabundle`
-/// root-first, and the on-chain walk depends on that ordering).
+/// Returns an error if the attestation document is malformed, or if its `cabundle` does not
+/// begin with the pinned AWS root CA (AWS orders `cabundle` root-first, and the on-chain walk
+/// depends on that ordering).
 pub fn build_prewarm_plan(attestation_doc: &[u8]) -> Result<Vec<ColdCert>> {
     let parsed = crate::attestation::parse_attestation_doc(attestation_doc)
         .map_err(|e| anyhow!("parsing attestation document: {e}"))?;
 
-    let leaf = parsed.certificate.ok_or_else(|| {
-        anyhow!("attestation document missing required `certificate` field (no leaf cert)")
-    })?;
+    let leaf = parsed.certificate;
     if parsed.cabundle.is_empty() {
         bail!("attestation document has an empty `cabundle`; cannot build a pre-warm plan");
     }
@@ -146,7 +144,7 @@ pub fn build_prewarm_plan(attestation_doc: &[u8]) -> Result<Vec<ColdCert>> {
             .with_context(|| format!("generating P-384 hints for cabundle[{i}]"))?;
 
         plan.push(ColdCert {
-            cert: cert.clone(),
+            cert: cert.to_vec(),
             parent_hash,
             cache_key,
             hints,
@@ -169,7 +167,7 @@ pub fn build_prewarm_plan(attestation_doc: &[u8]) -> Result<Vec<ColdCert>> {
 
     plan.push(ColdCert {
         cache_key: cert_cache_key(&leaf).context("computing cache key for the leaf cert")?,
-        cert: leaf,
+        cert: leaf.into_vec(),
         parent_hash,
         hints,
         is_ca: false,

--- a/proofs/backends/nitro/fuzz/fuzz_targets/attestation_parse.rs
+++ b/proofs/backends/nitro/fuzz/fuzz_targets/attestation_parse.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
-//! `parse_attestation_doc` walks hand-rolled CBOR over bytes an attacker controls, so the
-//! contract is: never panic, never hang — return `Err` instead.
+//! `parse_attestation_doc` decodes CBOR over bytes an attacker controls, so the contract is:
+//! never panic, never hang — return `Err` instead.
 
 use libfuzzer_sys::fuzz_target;
 use world_chain_proof_nitro_enclave::attestation::parse_attestation_doc;
@@ -11,10 +11,11 @@ fuzz_target!(|data: &[u8]| {
     if let Ok(doc) = parse_attestation_doc(data) {
         // Touch the decoded fields so a successful parse can't hide a bad length or index.
         let _ = doc.pcrs.len();
-        let _ = doc.cabundle.iter().map(Vec::len).sum::<usize>();
-        let _ = doc.certificate.as_ref().map(Vec::len);
-        let _ = doc.public_key.as_ref().map(Vec::len);
-        let _ = doc.nonce.as_ref().map(Vec::len);
-        let _ = doc.module_id.as_deref();
+        let _ = doc.cabundle.iter().map(|c| c.len()).sum::<usize>();
+        let _ = doc.certificate.len();
+        let _ = doc.public_key.as_ref().map(|k| k.len());
+        let _ = doc.nonce.as_ref().map(|n| n.len());
+        let _ = doc.module_id.len();
+        let _ = doc.timestamp;
     }
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes attestation parsing on the security-critical host verification path; stricter decode rules reduce silent acceptance of bad documents but could reject edge cases the old walker tolerated.
> 
> **Overview**
> Replaces the hand-rolled CBOR map walk for Nitro attestation payloads with **`serde`/`ciborium` decoding into `aws_nitro_enclaves_nsm_api::api::AttestationDoc`**, re-exported as the canonical parsed type everywhere (`parse_and_check_pcrs`, `prewarm`, fuzz).
> 
> **Parsing behavior tightens:** malformed or wrongly typed `pcrs` entries fail the whole decode instead of being skipped; **`certificate` is mandatory** at parse time (not only in `verify_cose_sign1_signature`). PCR lookup uses `usize` keys on the AWS `pcrs` map.
> 
> **Dependency layout:** `aws-nitro-enclaves-nsm-api` is a non-optional shared dep with `default-features = false` so host attestation parsing builds on macOS/Windows; Linux re-declares the crate with **`nix`** for the enclave NSM driver (removed from the `enclave` feature list).
> 
> Test fixtures and fuzz targets were updated for the full mandatory field set; new tests cover missing `certificate` and malformed `pcr` values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8c8b555417a952fd89af31d8dbf26203cb9176e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->