### PR TITLE
Refactor and add proof system e2e tests.

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,10 +3,8 @@ failure-output = "immediate-final"
 success-output = "never"
 slow-timeout = { period = "120s", terminate-after = 3 }
 
-# Each Docker-backed devnet test stands up a whole OP Stack (Anvil, sequencers, op-nodes,
-# conductors, batcher, proposer, prover-service + Postgres, observability). Two of those at once
-# oversubscribe the Docker daemon badly enough that both miss their deadlines, so they run strictly
-# one at a time. Other tests still use the remaining threads.
+# Each Docker-backed devnet test stands up a whole OP Stack; two at once oversubscribe the Docker
+# daemon badly enough that both miss their deadlines. Other tests still use the remaining threads.
 [test-groups.devnet-stack]
 max-threads = 1
 
@@ -14,8 +12,7 @@ max-threads = 1
 filter = 'package(world-chain-tests)'
 threads-required = 4
 
-# `devnet_run_until_shutdown_uses_continuous_block_driver` is excluded: it builds `without_l1()`
-# fully in-process and needs no Docker, so serializing it behind the stack tests buys nothing.
+# The excluded test builds `without_l1()` in-process and needs no Docker.
 [[profile.default.overrides]]
 filter = 'test(/^it::devnet_/) - test(=it::devnet_smoke::devnet_run_until_shutdown_uses_continuous_block_driver)'
 test-group = "devnet-stack"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,9 +3,23 @@ failure-output = "immediate-final"
 success-output = "never"
 slow-timeout = { period = "120s", terminate-after = 3 }
 
+# Each Docker-backed devnet test stands up a whole OP Stack (Anvil, sequencers, op-nodes,
+# conductors, batcher, proposer, prover-service + Postgres, observability). Two of those at once
+# oversubscribe the Docker daemon badly enough that both miss their deadlines, so they run strictly
+# one at a time. Other tests still use the remaining threads.
+[test-groups.devnet-stack]
+max-threads = 1
+
 [[profile.default.overrides]]
 filter = 'package(world-chain-tests)'
 threads-required = 4
+
+# `devnet_run_until_shutdown_uses_continuous_block_driver` is excluded: it builds `without_l1()`
+# fully in-process and needs no Docker, so serializing it behind the stack tests buys nothing.
+[[profile.default.overrides]]
+filter = 'test(/^it::devnet_/) - test(=it::devnet_smoke::devnet_run_until_shutdown_uses_continuous_block_driver)'
+test-group = "devnet-stack"
+slow-timeout = { period = "300s", terminate-after = 8 }
 
 [[profile.default.overrides]]
 filter = 'test(/acceptance_tests::/)'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19661,6 +19661,7 @@ dependencies = [
  "world-chain-p2p",
  "world-chain-primitives",
  "world-chain-proof-protocol",
+ "world-chain-proposer",
  "world-chain-test-utils",
  "world-chain-validator",
 ]

--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -127,7 +127,11 @@ const WORLD_DEFENDER_GENESIS_BALANCE_WEI: &str = "0x56bc75e2d63100000";
 
 const DEVNET_PRIVATE_KEY: &str =
     "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
-const SUPERCHAIN_GUARDIAN_PRIVATE_KEY: &str =
+/// Superchain Guardian key (Anvil dev account 2, `0x3C44Cdd…4293BC`).
+///
+/// Registered as `SuperchainGuardian` in the op-deployer intent and prefunded in both the L1 and
+/// L2 genesis, so E2E tests can also use it as a general-purpose funded account on either chain.
+pub const SUPERCHAIN_GUARDIAN_PRIVATE_KEY: &str =
     "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a";
 const L1_PROXY_ADMIN_OWNER_PRIVATE_KEY: &str =
     "0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a";
@@ -435,6 +439,20 @@ impl FullStackWorldDevnet {
         let topology = HaSequencerTopology::from_config(config.clone());
         let artifacts = generate_op_artifacts(&config, &hardforks).await?;
         let workdir_path = artifacts.workdir.path().to_path_buf();
+        // Doubles as the Docker network name and the naming prefix for every OP Stack container
+        // on it (op-node, op-conductor, op-batcher, op-proposer, op-challenger), so those
+        // containers reach each other by container-name DNS instead of bouncing through
+        // `host.docker.internal`. Derived from the workdir's unique suffix so concurrent devnet
+        // instances (e.g. parallel tests) never collide on the Docker daemon's global network
+        // and container namespaces. L1 (Anvil) and the L2 sequencer remain native host
+        // processes, so links to them still legitimately go through `host.docker.internal`.
+        let network = workdir_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(|name| format!("{name}-net"))
+            .ok_or_else(|| {
+                eyre!("OP deployer workdir has no file name to derive a network id from")
+            })?;
 
         let mut l1_config = L1DevChainConfig {
             block_time_secs: block_time.as_secs().max(1),
@@ -510,6 +528,7 @@ impl FullStackWorldDevnet {
                 index,
                 port_mode,
                 &mut op_service_port_reservations,
+                &network,
             )?);
         }
 
@@ -534,7 +553,7 @@ impl FullStackWorldDevnet {
                 l1_slot_duration_secs,
                 &l1_internal_rpc,
                 &sequencers[index],
-                &conductor_plans[index].rpc_url,
+                &network,
             )
         }))
         .await?;
@@ -549,6 +568,7 @@ impl FullStackWorldDevnet {
                 &workdir_path,
                 &sequencers[0],
                 &conductor_plans[0],
+                &network,
             )
             .await?,
         );
@@ -573,6 +593,7 @@ impl FullStackWorldDevnet {
                     &workdir_path,
                     &sequencers[index],
                     &conductor_plans[index],
+                    &network,
                 )
                 .await?,
             );
@@ -589,7 +610,11 @@ impl FullStackWorldDevnet {
         )
         .await?;
 
-        let conductor_rpc_internal = host_internal_url(&conductors[0].rpc_url)?;
+        // op-conductor is a Docker container on the shared devnet network, so op-batcher,
+        // op-proposer, and op-challenger dial it directly by container name/internal port
+        // instead of bouncing through the host.
+        let conductor_rpc_internal =
+            format!("http://{network}-op-conductor-0:{CONDUCTOR_RPC_PORT}");
         let l2_rpc_internal = host_internal_url(&sequencers[0].rpc_url)?;
         let game_factory = l1_address(&artifacts.l1_addresses, "DisputeGameFactoryProxy")?;
         let optimism_portal = l1_address(&artifacts.l1_addresses, "OptimismPortalProxy")?;
@@ -600,12 +625,14 @@ impl FullStackWorldDevnet {
                     &config.images.op_batcher,
                     &l1_internal_rpc,
                     &conductor_rpc_internal,
+                    &network,
                 ),
                 start_proposer(
                     &config.images.op_proposer,
                     &l1_internal_rpc,
                     &conductor_rpc_internal,
                     &game_factory,
+                    &network,
                 ),
                 start_challenger(
                     &config.images.op_challenger,
@@ -614,6 +641,7 @@ impl FullStackWorldDevnet {
                     &l2_rpc_internal,
                     &conductor_rpc_internal,
                     &game_factory,
+                    &network,
                 ),
             )?;
             (Some(batcher), Some(proposer), Some(challenger))
@@ -623,12 +651,14 @@ impl FullStackWorldDevnet {
                     &config.images.op_batcher,
                     &l1_internal_rpc,
                     &conductor_rpc_internal,
+                    &network,
                 ),
                 start_proposer(
                     &config.images.op_proposer,
                     &l1_internal_rpc,
                     &conductor_rpc_internal,
                     &game_factory,
+                    &network,
                 ),
             )?;
             (Some(batcher), Some(proposer), None)
@@ -1191,8 +1221,6 @@ async fn deploy_world_proof_system(
             L1_PROXY_ADMIN_OWNER_PRIVATE_KEY,
         )
         .env("DGF_OWNER_KEY", L1_PROXY_ADMIN_OWNER_PRIVATE_KEY)
-        .env("GUARDIAN_KEY", SUPERCHAIN_GUARDIAN_PRIVATE_KEY)
-        .env("SET_RESPECTED_GAME_TYPE", "true")
         .env(
             "PROTOCOL_FEE_RECIPIENT",
             world_challenger_address()?.to_string(),
@@ -1273,7 +1301,84 @@ async fn deploy_world_proof_system(
         "World Chain proof-system contracts deployed"
     );
 
+    // `DeployProofSystem` only registers the WIP-1006 implementation on the factory; it never
+    // flips the AnchorStateRegistry's respected game type, so no WIP-1006 game is ever "proper"
+    // (`wasRespectedGameTypeWhenCreated`) or eligible to anchor Portal withdrawals until this
+    // runs. This mirrors what a real chain operator's guardian would do post-deployment.
+    activate_world_proof_system(
+        l1_rpc_url,
+        &contracts_dir,
+        &dispute_game_factory,
+        &anchor_state_registry,
+        &system_config,
+    )
+    .await?;
+
     Ok(deployment)
+}
+
+/// Flips the AnchorStateRegistry's respected game type to WIP-1006 via the guardian key, the
+/// activation step `DeployProofSystem.s.sol` deliberately leaves to a separate script (see
+/// `ActivateProofSystem.s.sol`'s header comment: it verifies wiring, bond, and anchor validity
+/// before activating, and never touches the ASR retirement timestamp).
+async fn activate_world_proof_system(
+    l1_rpc_url: &str,
+    contracts_dir: &Path,
+    dispute_game_factory: &str,
+    anchor_state_registry: &str,
+    system_config: &str,
+) -> Result<()> {
+    let output = Command::new("forge")
+        .current_dir(contracts_dir)
+        .arg("script")
+        .arg("scripts/devnet/ActivateProofSystem.s.sol:ActivateProofSystem")
+        .arg("--broadcast")
+        .arg("--rpc-url")
+        .arg(l1_rpc_url)
+        .arg("--private-key")
+        .arg(SUPERCHAIN_GUARDIAN_PRIVATE_KEY)
+        .arg("--slow")
+        .arg("--evm-version")
+        .arg("cancun")
+        .env("GUARDIAN_KEY", SUPERCHAIN_GUARDIAN_PRIVATE_KEY)
+        .env("DISPUTE_GAME_FACTORY", dispute_game_factory)
+        .env("ANCHOR_STATE_REGISTRY", anchor_state_registry)
+        .env("SYSTEM_CONFIG", system_config)
+        .output()
+        .await
+        .wrap_err("failed to spawn forge proof-system activation")?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !stdout.trim().is_empty() {
+        emit_command_logs(
+            "world-proof-system activate",
+            ProcessLogTarget::OpDeployer,
+            &stdout,
+        );
+    }
+    if !stderr.trim().is_empty() {
+        emit_command_logs(
+            "world-proof-system activate",
+            ProcessLogTarget::OpDeployer,
+            &stderr,
+        );
+    }
+    if !output.status.success() {
+        bail!(
+            "forge proof-system activation failed with status {:?}\nstdout:\n{}\nstderr:\n{}",
+            output.status.code(),
+            stdout,
+            stderr
+        );
+    }
+
+    info!(
+        anchor = anchor_state_registry,
+        "World Chain proof-system WIP-1006 respected game type activated"
+    );
+
+    Ok(())
 }
 
 fn write_l1_genesis(state_path: &Path, output_path: &Path) -> Result<()> {
@@ -1960,6 +2065,7 @@ fn plan_conductor(
     index: usize,
     port_mode: DevnetPortMode,
     reservations: &mut Vec<TcpListener>,
+    network: &str,
 ) -> Result<ConductorPlan> {
     let consensus_host_port = match port_mode {
         DevnetPortMode::Stable => 50_050 + index as u16,
@@ -1978,7 +2084,12 @@ fn plan_conductor(
         DevnetPortMode::Dynamic => reserve_host_port(reservations)?,
     };
     let server_id = format!("sequencer-{}", index + 1);
-    let consensus_advertised = format!("host.docker.internal:{consensus_host_port}");
+    // Raft consensus is exclusively container-to-container traffic (every op-conductor is a
+    // Docker container on the shared devnet network), so peers dial each other directly by
+    // container name/internal port rather than bouncing through the host. Bouncing through
+    // `host.docker.internal` for this link was a source of intermittent connection failures
+    // (unreachable IPv6 routes, dropped requests) that container-to-container DNS avoids.
+    let consensus_advertised = format!("{network}-op-conductor-{index}:{CONDUCTOR_CONSENSUS_PORT}");
 
     Ok(ConductorPlan {
         server_id,
@@ -2009,7 +2120,7 @@ fn plan_op_nodes(
         fs::write(workdir.join(&filename), &private_key)
             .wrap_err_with(|| format!("failed to write op-node P2P key {filename}"))?;
         plans.push(OpNodePlan {
-            rpc_host_port: 19_545 + index as u16,
+            rpc_host_port: reserve_host_port(reservations)?,
             metrics_host_port: reserve_host_port(reservations)?,
             p2p_host_port,
             bootnode: devnet_trusted_peer(&private_key, "host.docker.internal", p2p_host_port)?,
@@ -2065,8 +2176,11 @@ async fn start_conductor(
     workdir: &Path,
     sequencer: &SequencerService,
     plan: &ConductorPlan,
+    network: &str,
 ) -> Result<ConductorService> {
-    let node_rpc = format!("http://host.docker.internal:{}", 19_545 + index as u16);
+    // op-node is a Docker container on the same shared devnet network as op-conductor, so this
+    // dials it directly by container name/internal port instead of bouncing through the host.
+    let node_rpc = format!("http://{network}-op-node-{index}:{OP_NODE_RPC_PORT}");
     let execution_rpc = host_internal_url(&sequencer.rpc_url)?;
     let min_peer_count = sequencer_count.saturating_sub(1).max(1).to_string();
     let mut cmd = vec![
@@ -2126,6 +2240,8 @@ async fn start_conductor(
             format!("op-conductor-{index}"),
             ProcessLogTarget::OpConductor,
         ))
+        .with_container_name(format!("{network}-op-conductor-{index}"))
+        .with_network(network)
         .with_cmd(cmd)
         .with_startup_timeout(Duration::from_secs(90))
         .with_mount(Mount::bind_mount(
@@ -2170,9 +2286,13 @@ async fn start_op_node(
     l1_slot_duration_secs: u64,
     l1_rpc: &str,
     sequencer: &SequencerService,
-    conductor_rpc_url: &str,
+    network: &str,
 ) -> Result<OpNodeService> {
-    let conductor_rpc = host_internal_url(conductor_rpc_url)?;
+    // op-conductor is a Docker container on the same shared devnet network, so op-node dials it
+    // directly by container name/internal port instead of bouncing through the host. `network`
+    // doubles as the naming prefix for every container on it, keeping names unique per devnet
+    // instance so concurrent devnets (e.g. parallel tests) never collide on the Docker daemon.
+    let conductor_rpc = format!("http://{network}-op-conductor-{index}:{CONDUCTOR_RPC_PORT}");
     let l2_engine_rpc = host_internal_url(&sequencer.auth_url)?;
     let p2p_host_port = plan.p2p_host_port.to_string();
     let l1_slot_duration_secs = l1_slot_duration_secs.to_string();
@@ -2257,6 +2377,8 @@ async fn start_op_node(
             format!("op-node-{index}"),
             ProcessLogTarget::OpNode,
         ))
+        .with_container_name(format!("{network}-op-node-{index}"))
+        .with_network(network)
         .with_cmd(cmd)
         .with_startup_timeout(Duration::from_secs(120))
         .with_mount(Mount::bind_mount(
@@ -2506,6 +2628,7 @@ async fn start_batcher(
     image: &ContainerImage,
     l1_rpc: &str,
     conductor_rpc: &str,
+    network: &str,
 ) -> Result<ContainerService> {
     let cmd = vec![
         "--l1-eth-rpc".to_string(),
@@ -2551,6 +2674,7 @@ async fn start_batcher(
         image,
         cmd,
         None,
+        network,
     )
     .await
 }
@@ -2560,6 +2684,7 @@ async fn start_proposer(
     l1_rpc: &str,
     rollup_rpc: &str,
     game_factory: &str,
+    network: &str,
 ) -> Result<ContainerService> {
     let cmd = vec![
         "--l1-eth-rpc".to_string(),
@@ -2604,6 +2729,7 @@ async fn start_proposer(
         image,
         cmd,
         None,
+        network,
     )
     .await
 }
@@ -2615,6 +2741,7 @@ async fn start_challenger(
     l2_rpc: &str,
     rollup_rpc: &str,
     game_factory: &str,
+    network: &str,
 ) -> Result<ContainerService> {
     let cmd = vec![
         "--l1-eth-rpc".to_string(),
@@ -2659,6 +2786,7 @@ async fn start_challenger(
         image,
         cmd,
         Some(workdir),
+        network,
     )
     .await
 }
@@ -3146,6 +3274,7 @@ async fn start_aux_service(
     image: &ContainerImage,
     cmd: Vec<String>,
     mount: Option<&Path>,
+    network: &str,
 ) -> Result<ContainerService> {
     info!(
         id,
@@ -3154,6 +3283,10 @@ async fn start_aux_service(
         "starting OP Stack devnet service"
     );
 
+    // Attaches to the shared devnet network so this service can resolve op-conductor (and any
+    // other container it needs) by container name instead of bouncing through the host. This
+    // service isn't itself dialed by name from another container, so it doesn't need a stable
+    // `with_container_name` — testcontainers' generated name is fine.
     let mut request = GenericImage::new(image.repository.clone(), image.tag.clone())
         .with_entrypoint(id)
         .with_wait_for(WaitFor::seconds(3))
@@ -3163,6 +3296,7 @@ async fn start_aux_service(
             id.to_string(),
             service_log_target(id),
         ))
+        .with_network(network)
         .with_cmd(cmd)
         .with_startup_timeout(Duration::from_secs(90));
 

--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -129,8 +129,7 @@ const DEVNET_PRIVATE_KEY: &str =
     "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
 /// Superchain Guardian key (Anvil dev account 2, `0x3C44Cdd…4293BC`).
 ///
-/// Registered as `SuperchainGuardian` in the op-deployer intent and prefunded in both the L1 and
-/// L2 genesis, so E2E tests can also use it as a general-purpose funded account on either chain.
+/// Prefunded in both the L1 and L2 genesis, so E2E tests can reuse it as a funded account.
 pub const SUPERCHAIN_GUARDIAN_PRIVATE_KEY: &str =
     "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a";
 const L1_PROXY_ADMIN_OWNER_PRIVATE_KEY: &str =

--- a/crates/devnet/src/lib.rs
+++ b/crates/devnet/src/lib.rs
@@ -54,6 +54,7 @@ use full_stack::FullStackWorldDevnet;
 pub use component::{
     ContainerImage, DevnetComponent, DevnetComponentKind, DevnetComponentStatus, DevnetEndpoint,
 };
+pub use full_stack::SUPERCHAIN_GUARDIAN_PRIVATE_KEY;
 pub use hardforks::{WORLD_CHAIN_DEVNET_HARDFORK_ORDER, WorldChainHardforkConfig};
 pub use l1::{L1DevChain, L1DevChainConfig};
 pub use observability::{MetricsTarget, ObservabilityConfig, ObservabilityStack};

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 world-chain-node.workspace = true
 world-chain-devnet.workspace = true
 world-chain-proof-protocol.workspace = true
+world-chain-proposer.workspace = true
 world-chain-test-utils = { workspace = true}
 world-chain-primitives.workspace = true
 world-chain-validator.workspace = true

--- a/e2e-tests/src/it/devnet_challenge.rs
+++ b/e2e-tests/src/it/devnet_challenge.rs
@@ -8,17 +8,13 @@ use crate::it::utils::devnet::{
     l1_rpc_url, proof_system_client, try_build_ha_devnet, wait_for_challenge, wait_for_status,
 };
 
-/// End-to-end test of the fault path: a dishonest proposer posts a root that disagrees with
-/// consensus, the real World Chain challenger (running in-process against the devnet, exactly
-/// as it would in production) detects and challenges it, the real defender correctly declines
-/// to defend the bad claim, and the game resolves `ChallengerWins` with the proposer's bond
-/// forfeited.
+/// End-to-end fault path: a dishonest proposer posts a root that disagrees with consensus, the
+/// real challenger detects and challenges it, the real defender declines to defend it, and the
+/// game resolves `ChallengerWins` with the proposer's bond forfeited.
 ///
-/// This is the fault-injection counterpart to `devnet_withdrawal`'s happy path: that test proves
-/// an honest root survives to finalization, this one proves a dishonest root does not survive
-/// challenge. Mirrors how Base/Optimism validate their fault-proof dispute game — via op-e2e
-/// style tests that submit an invalid claim and assert the challenger wins — but exercises World
-/// Chain's own proposer/challenger/defender services rather than op-challenger.
+/// The fault-injection counterpart to `devnet_withdrawal`'s happy path — that proves an honest root
+/// reaches finalization, this proves a dishonest one doesn't. Same shape as Optimism's op-e2e
+/// dispute-game tests, but exercising World Chain's own services rather than op-challenger.
 #[ignore = "requires Docker, Foundry, and the full local OP Stack"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn bad_root_proposal_is_challenged_and_invalidated() -> eyre::Result<()> {
@@ -35,10 +31,8 @@ async fn bad_root_proposal_is_challenged_and_invalidated() -> eyre::Result<()> {
     let (malicious_address, malicious_provider) = funded_throwaway_provider(l1_rpc).await?;
     let contracts = proof_system_client(malicious_provider.clone(), factory_address).await?;
 
-    // Race the honest in-process World Chain proposer to the very first proposal window. The
-    // honest proposer can't submit until at least `block_interval` L2 blocks are safe/finalized
-    // (several seconds away at devnet block time), so submitting immediately after devnet startup
-    // reliably wins the slot for the malicious claim instead.
+    // Wins the first proposal window: the honest proposer can't submit until `block_interval` L2
+    // blocks are safe, several seconds out at devnet block time.
     let anchor = contracts.lineage_anchor().await?;
     let registered = contracts.registered_lineage_config();
     let bad_root = B256::repeat_byte(0xba);
@@ -64,9 +58,7 @@ async fn bad_root_proposal_is_challenged_and_invalidated() -> eyre::Result<()> {
     let challenger = wait_for_challenge(&game).await?;
     println!("devnet challenge: challenged by {challenger}");
 
-    // The real World Chain defender must never submit a proof for a claim that doesn't match its
-    // own consensus-derived root. This is the key invariant: an honest defender does not
-    // "accidentally" rescue an invalid proposal.
+    // The key invariant: an honest defender never accidentally rescues an invalid proposal.
     ensure!(
         game.proofBitmap().call().await? == 0,
         "defender must not submit any proof lane for a bad root claim"

--- a/e2e-tests/src/it/devnet_challenge.rs
+++ b/e2e-tests/src/it/devnet_challenge.rs
@@ -1,0 +1,93 @@
+use alloy_primitives::{B256, U256};
+use eyre::eyre::ensure;
+use world_chain_proof_protocol::LineageProvider;
+use world_chain_proposer::{Proposal, ProposerClient};
+
+use crate::it::utils::devnet::{
+    GAME_CHALLENGER_WINS, advance_to_timestamp, funded_throwaway_provider, game_at, l1_contract,
+    l1_rpc_url, proof_system_client, try_build_ha_devnet, wait_for_challenge, wait_for_status,
+};
+
+/// End-to-end test of the fault path: a dishonest proposer posts a root that disagrees with
+/// consensus, the real World Chain challenger (running in-process against the devnet, exactly
+/// as it would in production) detects and challenges it, the real defender correctly declines
+/// to defend the bad claim, and the game resolves `ChallengerWins` with the proposer's bond
+/// forfeited.
+///
+/// This is the fault-injection counterpart to `devnet_withdrawal`'s happy path: that test proves
+/// an honest root survives to finalization, this one proves a dishonest root does not survive
+/// challenge. Mirrors how Base/Optimism validate their fault-proof dispute game — via op-e2e
+/// style tests that submit an invalid claim and assert the challenger wins — but exercises World
+/// Chain's own proposer/challenger/defender services rather than op-challenger.
+#[ignore = "requires Docker, Foundry, and the full local OP Stack"]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn bad_root_proposal_is_challenged_and_invalidated() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let Some(devnet) = try_build_ha_devnet("bad-root challenge E2E").await? else {
+        return Ok(());
+    };
+
+    let l1_rpc = l1_rpc_url(&devnet)?;
+    let factory_address = l1_contract(devnet.dispute_game_factory(), "DisputeGameFactory")?;
+
+    // A throwaway signer standing in for a dishonest proposer.
+    let (malicious_address, malicious_provider) = funded_throwaway_provider(l1_rpc).await?;
+    let contracts = proof_system_client(malicious_provider.clone(), factory_address).await?;
+
+    // Race the honest in-process World Chain proposer to the very first proposal window. The
+    // honest proposer can't submit until at least `block_interval` L2 blocks are safe/finalized
+    // (several seconds away at devnet block time), so submitting immediately after devnet startup
+    // reliably wins the slot for the malicious claim instead.
+    let anchor = contracts.lineage_anchor().await?;
+    let registered = contracts.registered_lineage_config();
+    let bad_root = B256::repeat_byte(0xba);
+    let bad_proposal = Proposal {
+        parent_ref: anchor.address,
+        root_claim: bad_root,
+        l2_block_number: anchor
+            .l2_block_number
+            .saturating_add(registered.block_interval),
+        attempt: 0,
+    };
+
+    let submission = contracts.submit_proposal(&bad_proposal).await?;
+    let game_address = submission.game_address;
+    println!(
+        "devnet challenge: malicious proposer {malicious_address} posted bad root {bad_root} for l2 block {} at game {game_address}",
+        bad_proposal.l2_block_number
+    );
+
+    let game = game_at(game_address, malicious_provider.clone());
+
+    // The real World Chain challenger recomputes the output root from consensus and disagrees.
+    let challenger = wait_for_challenge(&game).await?;
+    println!("devnet challenge: challenged by {challenger}");
+
+    // The real World Chain defender must never submit a proof for a claim that doesn't match its
+    // own consensus-derived root. This is the key invariant: an honest defender does not
+    // "accidentally" rescue an invalid proposal.
+    ensure!(
+        game.proofBitmap().call().await? == 0,
+        "defender must not submit any proof lane for a bad root claim"
+    );
+
+    // Skip past the proof deadline so the challenge can resolve without waiting on real time.
+    let proof_deadline = game.proofDeadline().call().await?;
+    advance_to_timestamp(&malicious_provider, proof_deadline.saturating_add(1)).await?;
+
+    wait_for_status(&game, GAME_CHALLENGER_WINS).await?;
+
+    ensure!(
+        game.proofBitmap().call().await? == 0,
+        "no proof lane should ever land on an invalidated game"
+    );
+    ensure!(
+        game.credit(malicious_address).call().await? == U256::ZERO,
+        "the dishonest proposer's bond must not be creditable back to them"
+    );
+
+    println!("devnet challenge: bad root at game {game_address} correctly resolved ChallengerWins");
+
+    Ok(())
+}

--- a/e2e-tests/src/it/devnet_proof_invariants.rs
+++ b/e2e-tests/src/it/devnet_proof_invariants.rs
@@ -1,18 +1,9 @@
-//! Devnet-level tests for World Chain proof-system invariants that mirror the *properties*
-//! exercised by Optimism's `op-e2e/faultproofs` Cannon test suite, adapted to WIP-1006's
-//! non-interactive, multi-lane-proof-or-timeout design (no bisection game, no Cannon FPVM, no
-//! preimage oracle — so those specific mechanics don't have an analog here).
+//! Devnet-level tests for WIP-1006 proof-system invariants, mirroring the properties Optimism
+//! exercises in `op-e2e/faultproofs`.
 //!
-//! - [`unproven_proposal_times_out_to_challenger_wins`] is the analog of Optimism's
-//!   `TestInvalidateUnsafeProposal`/`TestInvalidateProposalForFutureBlock`: a proposal that never
-//!   accumulates a valid proof cannot win merely by going unchallenged.
-//! - [`invalid_parent_cascades_to_challenger_wins`] is untested anywhere else: a game built on an
-//!   already-invalidated parent must resolve `ChallengerWins` via `INVALID_PARENT` regardless of
-//!   its own proof/challenge state.
-//! - [`valid_proposal_survives_adversarial_challenge`] is the analog of Optimism's
-//!   `AttackWithCorrectTrace`/`DefendWithCorrectTrace`: a genuinely honest claim must resolve
-//!   `DefenderWins` even when maliciously challenged, once the real defender escalates to the
-//!   proof threshold.
+//! `MultiProofGame.t.sol` already covers each property at the contract level, and asserts more
+//! about bonds. These drive the same properties through the real deployed stack — real proposer,
+//! challenger and defender services racing the test — instead of `vm.prank`/`vm.warp`.
 
 use alloy_primitives::{Address, B256};
 use eyre::eyre::ensure;
@@ -29,13 +20,11 @@ use crate::it::utils::devnet::{
 
 /// A proposal that never accumulates a valid proof cannot win merely by going unchallenged.
 ///
-/// Mirrors Optimism's `TestInvalidateUnsafeProposal`/`TestInvalidateProposalForFutureBlock`,
-/// which need a special-cased honest-actor strategy to defeat a claim about unavailable data.
-/// WIP-1006 doesn't need that: `MultiProofGame.resolve()` treats `Unchallenged` and `Challenged`
-/// identically once the (challenge- or proof-) deadline passes with `proofBitmap == 0` — a
-/// proofless proposal always loses, whether or not anyone bothered to formally challenge it. This
-/// test submits a bad root and, regardless of whether the real challenger races in first, asserts
-/// the deadline-driven `ChallengerWins`/`PROOF_TIMEOUT` outcome.
+/// Optimism's `TestInvalidateUnsafeProposal`/`TestInvalidateProposalForFutureBlock` need a
+/// special-cased honest-actor strategy here; WIP-1006 doesn't. `resolve()` treats `Unchallenged`
+/// and `Challenged` identically once the deadline passes with `proofBitmap == 0`, so a proofless
+/// proposal always loses. Submits a bad root and asserts the deadline-driven
+/// `ChallengerWins`/`PROOF_TIMEOUT` outcome, whether or not the real challenger races in first.
 #[ignore = "requires Docker, Foundry, and the full local OP Stack"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn unproven_proposal_times_out_to_challenger_wins() -> eyre::Result<()> {
@@ -64,9 +53,8 @@ async fn unproven_proposal_times_out_to_challenger_wins() -> eyre::Result<()> {
     let submission = contracts.submit_proposal(&proposal).await?;
     let game = game_at(submission.game_address, provider.clone());
 
-    // Advance past `proofDeadline()` (always the later of the two deadlines: the contract
-    // requires `proofPeriod > challengePeriod`) so `gameOver()` is true regardless of whether the
-    // real challenger raced in and challenged this proposal before we got here.
+    // `proofDeadline()` is always the later deadline (`proofPeriod > challengePeriod`), so
+    // `gameOver()` holds whether or not the real challenger challenged this first.
     let proof_deadline = game.proofDeadline().call().await?;
     advance_to_timestamp(&provider, proof_deadline.saturating_add(1)).await?;
 
@@ -91,9 +79,13 @@ async fn unproven_proposal_times_out_to_challenger_wins() -> eyre::Result<()> {
 /// A game built on an already-invalidated parent must resolve `ChallengerWins` via
 /// `INVALID_PARENT`, regardless of its own proof or challenge state.
 ///
-/// Untested anywhere else in this repo. `MultiProofGame.resolve()` checks parent validity before
-/// anything about the game's own claim (`pkg/contracts/src/dispute/MultiProofGame.sol:552-561`),
-/// so a child of an invalid parent can never win even with a perfectly correct root claim.
+/// `resolve()` checks parent validity before anything about the game's own claim
+/// (`MultiProofGame.sol:552-561`), so a child of an invalid parent can never win.
+///
+/// Forge covers this via `test_InvalidParent_CascadesAndRefundsChildBonds` (which also asserts bond
+/// refunds) and `test_BlacklistedParent_CascadesBeforeParentResolution` (the blacklist route, not
+/// exercised here). This adds the cascade from a real proposer-submitted lineage with the real
+/// challenger contesting the parent.
 #[ignore = "requires Docker, Foundry, and the full local OP Stack"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn invalid_parent_cascades_to_challenger_wins() -> eyre::Result<()> {
@@ -125,13 +117,9 @@ async fn invalid_parent_cascades_to_challenger_wins() -> eyre::Result<()> {
     let parent_submission = contracts.submit_proposal(&parent_proposal).await?;
     let parent_game = game_at(parent_submission.game_address, provider.clone());
 
-    // Child: must be submitted *before* the parent resolves. `initialize()`'s `_isValidParent`
-    // check (MultiProofGame.sol:421-424) requires `parent.status() != CHALLENGER_WINS` at
-    // creation time — it only rejects parents that are *already known* to be invalid, since a
-    // still-in-progress parent might yet turn out valid. The INVALID_PARENT cascade this test
-    // targets is enforced dynamically inside `resolve()`, not at creation time, so the ordering
-    // here (child created while parent is still healthy-looking, then parent invalidated) is the
-    // realistic case a chain would actually see.
+    // Child must be created *before* the parent resolves: `_isValidParent`
+    // (MultiProofGame.sol:421-424) rejects parents already known invalid. The cascade under test is
+    // enforced dynamically in `resolve()`, so this ordering is the realistic case.
     let child_proposal = Proposal {
         parent_ref: parent_submission.game_address,
         root_claim: B256::repeat_byte(0xcd),
@@ -148,12 +136,10 @@ async fn invalid_parent_cascades_to_challenger_wins() -> eyre::Result<()> {
     let parent_proof_deadline = parent_game.proofDeadline().call().await?;
     advance_to_timestamp(&provider, parent_proof_deadline.saturating_add(1)).await?;
 
-    // The parent resolves ChallengerWins via the real challenger's resolution manager, or we fall
-    // back to resolving it ourselves.
+    // Resolved by the real challenger's resolution manager, or by us as a fallback.
     wait_for_status_or_resolve(&parent_game, GAME_CHALLENGER_WINS).await?;
 
-    // The child is never discovered by the real challenger as challengeable (its l2 block number
-    // is far beyond the finalized head), so nothing else will resolve it — do it ourselves.
+    // Its l2 block is far beyond the finalized head, so the real challenger never picks it up.
     resolve_if_still_in_progress(&child_game).await?;
 
     ensure!(
@@ -171,27 +157,19 @@ async fn invalid_parent_cascades_to_challenger_wins() -> eyre::Result<()> {
 /// A genuinely honest claim must resolve `DefenderWins` even when maliciously challenged, once
 /// the proof threshold is reached.
 ///
-/// Mirrors Optimism's `AttackWithCorrectTrace`/`DefendWithCorrectTrace`: challenging a valid claim
-/// should not be able to invalidate it.
+/// Mirrors Optimism's `AttackWithCorrectTrace`/`DefendWithCorrectTrace`.
 ///
-/// This does *not* route through the in-process SP1 worker. That worker's `OnlineHostConfig`
-/// unconditionally requires a real beacon-API endpoint (kona's `OnlineBlobProvider` calls
-/// `/eth/v1/config/spec` on startup) even though this devnet's batcher runs
-/// `--data-availability-type calldata` and never touches blobs — Anvil has no consensus-layer
-/// component to serve that endpoint, so the worker panics before it can produce a validity proof.
-/// Fixing that is a real gap in how the worker is wired up, but not one worth taking on just to
-/// exercise this invariant.
+/// Does *not* route through the in-process SP1 worker: its `OnlineHostConfig` unconditionally
+/// requires a beacon-API endpoint (kona's `OnlineBlobProvider` calls `/eth/v1/config/spec`) even
+/// though this devnet's batcher uses calldata DA and never touches blobs, and Anvil has no
+/// consensus layer to serve it — so the worker panics before producing a validity proof. That's a
+/// real wiring gap, just not one worth fixing to exercise this invariant.
 ///
-/// Instead this test submits the validity-proof lane itself, directly on the game contract.
-/// `MultiProofGame.submitProofLane()` builds `TransitionPublicValues` from the game's own on-chain
-/// state (`pkg/contracts/src/dispute/MultiProofGame.sol`, `_transition()`); the submitted proof
-/// bytes are opaque to the contract and are handed straight to the verifier. The devnet only ever
-/// deploys `MockRootIdVerifier(acceptAny=true)` for every lane (`DeployProofMocks.s.sol`), so a
-/// well-formed but otherwise arbitrary proof payload is accepted — the same trick
-/// `DevnetNitroBackend::handle_claimed_job` (`crates/devnet/src/full_stack.rs`) already relies on
-/// for the Nitro lane. The real defender still proactively supplies the TEE lane; this test
-/// supplies the validity lane, so together they reach `PROOF_THRESHOLD` without needing real or
-/// mock SP1 proving.
+/// Instead the validity lane is submitted directly. `submitProofLane()` builds
+/// `TransitionPublicValues` from the game's own on-chain state and passes the proof bytes straight
+/// to the verifier, and the devnet only deploys `MockRootIdVerifier(acceptAny=true)`
+/// (`DeployProofMocks.s.sol`) — the same trick `DevnetNitroBackend::handle_claimed_job` uses for the
+/// Nitro lane. The real defender still supplies the TEE lane, so the two reach `PROOF_THRESHOLD`.
 #[ignore = "requires Docker, Foundry, and the full local OP Stack"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn valid_proposal_survives_adversarial_challenge() -> eyre::Result<()> {
@@ -204,8 +182,7 @@ async fn valid_proposal_survives_adversarial_challenge() -> eyre::Result<()> {
     let l1_rpc = l1_rpc_url(&devnet)?;
     let factory_address = l1_contract(devnet.dispute_game_factory(), "DisputeGameFactory")?;
 
-    // An adversary challenges the perfectly valid claim posted by the real, honest World Chain
-    // proposer, just to grief.
+    // An adversary griefs the honest proposer's perfectly valid claim.
     let (adversary_address, adversary_provider) = funded_throwaway_provider(l1_rpc).await?;
     let (_, honest_game_address, _) =
         wait_for_multi_proof_game(adversary_provider.clone(), factory_address, 0).await?;
@@ -228,14 +205,10 @@ async fn valid_proposal_survives_adversarial_challenge() -> eyre::Result<()> {
         "challenge should have registered"
     );
 
-    // Wait for the real defender to proactively land the TEE lane before we add the validity
-    // lane ourselves. Since we never enable an SP1 worker in this test, the real defender will
-    // never attempt to submit the validity lane itself, so there's no risk of racing it.
+    // No SP1 worker runs here, so the defender only ever lands the TEE lane — no race with ours.
     wait_for_proof_lane(&game).await?;
 
-    // Submit the validity-proof lane directly, bypassing SP1 proving entirely — see the doc
-    // comment above for why this is a faithful devnet exercise of the invariant rather than a
-    // shortcut around it.
+    // Validity lane submitted directly, bypassing SP1 proving — see the doc comment above.
     let compact_proof = encode_compact_proof(ProofLane::ValidityProof, adversary_address, &[0x01]);
     let proof_receipt = game
         .submitProofLane(compact_proof)
@@ -248,8 +221,7 @@ async fn valid_proposal_survives_adversarial_challenge() -> eyre::Result<()> {
         "direct validity-proof-lane submission reverted"
     );
 
-    // With both lanes landed, `gameOver()` triggers immediately, and the real proposer's periodic
-    // resolution pass will resolve it DefenderWins.
+    // Both lanes landed, so `gameOver()` holds and the proposer's resolution pass takes it.
     wait_for_status_or_resolve(&game, GAME_DEFENDER_WINS).await?;
 
     ensure!(

--- a/e2e-tests/src/it/devnet_proof_invariants.rs
+++ b/e2e-tests/src/it/devnet_proof_invariants.rs
@@ -1,0 +1,261 @@
+//! Devnet-level tests for World Chain proof-system invariants that mirror the *properties*
+//! exercised by Optimism's `op-e2e/faultproofs` Cannon test suite, adapted to WIP-1006's
+//! non-interactive, multi-lane-proof-or-timeout design (no bisection game, no Cannon FPVM, no
+//! preimage oracle — so those specific mechanics don't have an analog here).
+//!
+//! - [`unproven_proposal_times_out_to_challenger_wins`] is the analog of Optimism's
+//!   `TestInvalidateUnsafeProposal`/`TestInvalidateProposalForFutureBlock`: a proposal that never
+//!   accumulates a valid proof cannot win merely by going unchallenged.
+//! - [`invalid_parent_cascades_to_challenger_wins`] is untested anywhere else: a game built on an
+//!   already-invalidated parent must resolve `ChallengerWins` via `INVALID_PARENT` regardless of
+//!   its own proof/challenge state.
+//! - [`valid_proposal_survives_adversarial_challenge`] is the analog of Optimism's
+//!   `AttackWithCorrectTrace`/`DefendWithCorrectTrace`: a genuinely honest claim must resolve
+//!   `DefenderWins` even when maliciously challenged, once the real defender escalates to the
+//!   proof threshold.
+
+use alloy_primitives::{Address, B256};
+use eyre::eyre::ensure;
+use world_chain_proof_protocol::{LineageProvider, ProofLane, encode_compact_proof};
+use world_chain_proposer::{Proposal, ProposerClient};
+
+use crate::it::utils::devnet::{
+    GAME_CHALLENGER_WINS, GAME_DEFENDER_WINS, INVALIDATION_REASON_INVALID_PARENT,
+    INVALIDATION_REASON_PROOF_TIMEOUT, advance_to_timestamp, funded_throwaway_provider, game_at,
+    l1_contract, l1_rpc_url, proof_system_client, resolve_if_still_in_progress,
+    try_build_ha_devnet, wait_for_challenge, wait_for_multi_proof_game, wait_for_proof_lane,
+    wait_for_status_or_resolve,
+};
+
+/// A proposal that never accumulates a valid proof cannot win merely by going unchallenged.
+///
+/// Mirrors Optimism's `TestInvalidateUnsafeProposal`/`TestInvalidateProposalForFutureBlock`,
+/// which need a special-cased honest-actor strategy to defeat a claim about unavailable data.
+/// WIP-1006 doesn't need that: `MultiProofGame.resolve()` treats `Unchallenged` and `Challenged`
+/// identically once the (challenge- or proof-) deadline passes with `proofBitmap == 0` — a
+/// proofless proposal always loses, whether or not anyone bothered to formally challenge it. This
+/// test submits a bad root and, regardless of whether the real challenger races in first, asserts
+/// the deadline-driven `ChallengerWins`/`PROOF_TIMEOUT` outcome.
+#[ignore = "requires Docker, Foundry, and the full local OP Stack"]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn unproven_proposal_times_out_to_challenger_wins() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let Some(devnet) = try_build_ha_devnet("proof-timeout E2E").await? else {
+        return Ok(());
+    };
+
+    let l1_rpc = l1_rpc_url(&devnet)?;
+    let factory_address = l1_contract(devnet.dispute_game_factory(), "DisputeGameFactory")?;
+
+    let (_, provider) = funded_throwaway_provider(l1_rpc).await?;
+    let contracts = proof_system_client(provider.clone(), factory_address).await?;
+
+    let anchor = contracts.lineage_anchor().await?;
+    let registered = contracts.registered_lineage_config();
+    let proposal = Proposal {
+        parent_ref: anchor.address,
+        root_claim: B256::repeat_byte(0xba),
+        l2_block_number: anchor
+            .l2_block_number
+            .saturating_add(registered.block_interval),
+        attempt: 0,
+    };
+    let submission = contracts.submit_proposal(&proposal).await?;
+    let game = game_at(submission.game_address, provider.clone());
+
+    // Advance past `proofDeadline()` (always the later of the two deadlines: the contract
+    // requires `proofPeriod > challengePeriod`) so `gameOver()` is true regardless of whether the
+    // real challenger raced in and challenged this proposal before we got here.
+    let proof_deadline = game.proofDeadline().call().await?;
+    advance_to_timestamp(&provider, proof_deadline.saturating_add(1)).await?;
+
+    resolve_if_still_in_progress(&game).await?;
+
+    ensure!(
+        game.proofBitmap().call().await? == 0,
+        "no proof lane should ever land on a proposal nobody proved"
+    );
+    ensure!(
+        game.status().call().await? == GAME_CHALLENGER_WINS,
+        "unproven proposal must resolve ChallengerWins on deadline, whether or not it was formally challenged"
+    );
+    ensure!(
+        game.invalidationReason().call().await? == INVALIDATION_REASON_PROOF_TIMEOUT,
+        "unproven proposal must invalidate with PROOF_TIMEOUT"
+    );
+
+    Ok(())
+}
+
+/// A game built on an already-invalidated parent must resolve `ChallengerWins` via
+/// `INVALID_PARENT`, regardless of its own proof or challenge state.
+///
+/// Untested anywhere else in this repo. `MultiProofGame.resolve()` checks parent validity before
+/// anything about the game's own claim (`pkg/contracts/src/dispute/MultiProofGame.sol:552-561`),
+/// so a child of an invalid parent can never win even with a perfectly correct root claim.
+#[ignore = "requires Docker, Foundry, and the full local OP Stack"]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn invalid_parent_cascades_to_challenger_wins() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let Some(devnet) = try_build_ha_devnet("invalid-parent cascade E2E").await? else {
+        return Ok(());
+    };
+
+    let l1_rpc = l1_rpc_url(&devnet)?;
+    let factory_address = l1_contract(devnet.dispute_game_factory(), "DisputeGameFactory")?;
+
+    let (_, provider) = funded_throwaway_provider(l1_rpc).await?;
+    let contracts = proof_system_client(provider.clone(), factory_address).await?;
+
+    let anchor = contracts.lineage_anchor().await?;
+    let registered = contracts.registered_lineage_config();
+
+    // Parent: a bad root that the real challenger will contest.
+    let parent_l2_block_number = anchor
+        .l2_block_number
+        .saturating_add(registered.block_interval);
+    let parent_proposal = Proposal {
+        parent_ref: anchor.address,
+        root_claim: B256::repeat_byte(0xba),
+        l2_block_number: parent_l2_block_number,
+        attempt: 0,
+    };
+    let parent_submission = contracts.submit_proposal(&parent_proposal).await?;
+    let parent_game = game_at(parent_submission.game_address, provider.clone());
+
+    // Child: must be submitted *before* the parent resolves. `initialize()`'s `_isValidParent`
+    // check (MultiProofGame.sol:421-424) requires `parent.status() != CHALLENGER_WINS` at
+    // creation time — it only rejects parents that are *already known* to be invalid, since a
+    // still-in-progress parent might yet turn out valid. The INVALID_PARENT cascade this test
+    // targets is enforced dynamically inside `resolve()`, not at creation time, so the ordering
+    // here (child created while parent is still healthy-looking, then parent invalidated) is the
+    // realistic case a chain would actually see.
+    let child_proposal = Proposal {
+        parent_ref: parent_submission.game_address,
+        root_claim: B256::repeat_byte(0xcd),
+        l2_block_number: parent_l2_block_number.saturating_add(registered.block_interval),
+        attempt: 0,
+    };
+    let child_submission = contracts.submit_proposal(&child_proposal).await?;
+    let child_game = game_at(child_submission.game_address, provider.clone());
+
+    // Wait for the real World Chain challenger to contest the bad parent.
+    wait_for_challenge(&parent_game).await?;
+
+    // Skip past the parent's proof deadline so its challenge can resolve.
+    let parent_proof_deadline = parent_game.proofDeadline().call().await?;
+    advance_to_timestamp(&provider, parent_proof_deadline.saturating_add(1)).await?;
+
+    // The parent resolves ChallengerWins via the real challenger's resolution manager, or we fall
+    // back to resolving it ourselves.
+    wait_for_status_or_resolve(&parent_game, GAME_CHALLENGER_WINS).await?;
+
+    // The child is never discovered by the real challenger as challengeable (its l2 block number
+    // is far beyond the finalized head), so nothing else will resolve it — do it ourselves.
+    resolve_if_still_in_progress(&child_game).await?;
+
+    ensure!(
+        child_game.status().call().await? == GAME_CHALLENGER_WINS,
+        "child of an invalidated parent must resolve ChallengerWins regardless of its own root claim"
+    );
+    ensure!(
+        child_game.invalidationReason().call().await? == INVALIDATION_REASON_INVALID_PARENT,
+        "child of an invalidated parent must invalidate with INVALID_PARENT, not PROOF_TIMEOUT"
+    );
+
+    Ok(())
+}
+
+/// A genuinely honest claim must resolve `DefenderWins` even when maliciously challenged, once
+/// the proof threshold is reached.
+///
+/// Mirrors Optimism's `AttackWithCorrectTrace`/`DefendWithCorrectTrace`: challenging a valid claim
+/// should not be able to invalidate it.
+///
+/// This does *not* route through the in-process SP1 worker. That worker's `OnlineHostConfig`
+/// unconditionally requires a real beacon-API endpoint (kona's `OnlineBlobProvider` calls
+/// `/eth/v1/config/spec` on startup) even though this devnet's batcher runs
+/// `--data-availability-type calldata` and never touches blobs — Anvil has no consensus-layer
+/// component to serve that endpoint, so the worker panics before it can produce a validity proof.
+/// Fixing that is a real gap in how the worker is wired up, but not one worth taking on just to
+/// exercise this invariant.
+///
+/// Instead this test submits the validity-proof lane itself, directly on the game contract.
+/// `MultiProofGame.submitProofLane()` builds `TransitionPublicValues` from the game's own on-chain
+/// state (`pkg/contracts/src/dispute/MultiProofGame.sol`, `_transition()`); the submitted proof
+/// bytes are opaque to the contract and are handed straight to the verifier. The devnet only ever
+/// deploys `MockRootIdVerifier(acceptAny=true)` for every lane (`DeployProofMocks.s.sol`), so a
+/// well-formed but otherwise arbitrary proof payload is accepted — the same trick
+/// `DevnetNitroBackend::handle_claimed_job` (`crates/devnet/src/full_stack.rs`) already relies on
+/// for the Nitro lane. The real defender still proactively supplies the TEE lane; this test
+/// supplies the validity lane, so together they reach `PROOF_THRESHOLD` without needing real or
+/// mock SP1 proving.
+#[ignore = "requires Docker, Foundry, and the full local OP Stack"]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn valid_proposal_survives_adversarial_challenge() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let Some(devnet) = try_build_ha_devnet("adversarial-challenge E2E").await? else {
+        return Ok(());
+    };
+
+    let l1_rpc = l1_rpc_url(&devnet)?;
+    let factory_address = l1_contract(devnet.dispute_game_factory(), "DisputeGameFactory")?;
+
+    // An adversary challenges the perfectly valid claim posted by the real, honest World Chain
+    // proposer, just to grief.
+    let (adversary_address, adversary_provider) = funded_throwaway_provider(l1_rpc).await?;
+    let (_, honest_game_address, _) =
+        wait_for_multi_proof_game(adversary_provider.clone(), factory_address, 0).await?;
+    let game = game_at(honest_game_address, adversary_provider.clone());
+
+    let challenger_bond = game.challengerBond().call().await?;
+    let receipt = game
+        .challenge()
+        .value(challenger_bond)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    ensure!(
+        receipt.status(),
+        "adversarial challenge() transaction reverted"
+    );
+    ensure!(
+        game.challenger().call().await? != Address::ZERO,
+        "challenge should have registered"
+    );
+
+    // Wait for the real defender to proactively land the TEE lane before we add the validity
+    // lane ourselves. Since we never enable an SP1 worker in this test, the real defender will
+    // never attempt to submit the validity lane itself, so there's no risk of racing it.
+    wait_for_proof_lane(&game).await?;
+
+    // Submit the validity-proof lane directly, bypassing SP1 proving entirely — see the doc
+    // comment above for why this is a faithful devnet exercise of the invariant rather than a
+    // shortcut around it.
+    let compact_proof = encode_compact_proof(ProofLane::ValidityProof, adversary_address, &[0x01]);
+    let proof_receipt = game
+        .submitProofLane(compact_proof)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    ensure!(
+        proof_receipt.status(),
+        "direct validity-proof-lane submission reverted"
+    );
+
+    // With both lanes landed, `gameOver()` triggers immediately, and the real proposer's periodic
+    // resolution pass will resolve it DefenderWins.
+    wait_for_status_or_resolve(&game, GAME_DEFENDER_WINS).await?;
+
+    ensure!(
+        game.invalidationReason().call().await? == 0,
+        "a defended honest claim must have no invalidation reason"
+    );
+
+    Ok(())
+}

--- a/e2e-tests/src/it/devnet_smoke.rs
+++ b/e2e-tests/src/it/devnet_smoke.rs
@@ -4,33 +4,20 @@ use eyre::eyre::eyre;
 use tokio::sync::watch;
 use world_chain_chainspec::{WorldChainHardfork, WorldChainHardforks};
 use world_chain_devnet::{
-    DevnetComponentKind, DevnetComponentStatus, HaSequencerConfig, ObservabilityConfig,
-    WorldDevnet, WorldDevnetBuilder, WorldDevnetPreset, ensure_dev_chain_id, is_docker_unavailable,
+    DevnetComponentKind, DevnetComponentStatus, WorldDevnet, WorldDevnetBuilder,
+    ensure_dev_chain_id,
 };
 use world_chain_test_utils::DEV_CHAIN_ID;
+
+use crate::it::utils::devnet::try_build_ha_devnet;
 
 #[ignore = "Does not run in CI"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn direct_sequencer_devnet_smoke() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    let ha_config = HaSequencerConfig::default()
-        .with_sequencer_count(2)
-        .with_observability(ObservabilityConfig::default());
-
-    let mut devnet = match WorldDevnetBuilder::new()
-        .preset(WorldDevnetPreset::HaSequencer)
-        .ha_sequencer(ha_config)
-        .block_time(Duration::from_secs(1))
-        .build()
-        .await
-    {
-        Ok(devnet) => devnet,
-        Err(err) if is_docker_unavailable(&err) => {
-            eprintln!("skipping devnet smoke because Docker is unavailable: {err:#}");
-            return Ok(());
-        }
-        Err(err) => return Err(err),
+    let Some(mut devnet) = try_build_ha_devnet("devnet smoke").await? else {
+        return Ok(());
     };
 
     print_devnet_summary(&devnet);

--- a/e2e-tests/src/it/devnet_withdrawal.rs
+++ b/e2e-tests/src/it/devnet_withdrawal.rs
@@ -1,28 +1,21 @@
-use std::time::{Duration, Instant};
-
 use alloy_consensus::BlockHeader;
 use alloy_eips::{BlockId, BlockNumberOrTag};
-use alloy_network::EthereumWallet;
 use alloy_primitives::{Address, B256, Bytes, U256, address, keccak256};
-use alloy_provider::{Provider, ProviderBuilder, ext::AnvilApi};
+use alloy_provider::Provider;
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::{SolValue, sol};
-use eyre::eyre::{OptionExt, bail, ensure};
-use url::Url;
-use world_chain_devnet::{
-    HaSequencerConfig, ObservabilityConfig, WorldDevnetBuilder, WorldDevnetPreset,
-    is_docker_unavailable,
-};
-use world_chain_proof_protocol::{
-    IAnchorStateRegistry, IDelayedWETH, IDisputeGameFactory, IMultiProofGame, MULTI_PROOF_GAME_TYPE,
+use eyre::eyre::{OptionExt, ensure};
+use world_chain_devnet::SUPERCHAIN_GUARDIAN_PRIVATE_KEY;
+use world_chain_proof_protocol::MULTI_PROOF_GAME_TYPE;
+
+use crate::it::utils::devnet::{
+    GAME_DEFENDER_WINS, advance_to_timestamp, anchor_at, game_at, l1_contract, l1_rpc_url,
+    latest_timestamp, signing_provider, try_build_ha_devnet, wait_for_anchor_at_or_beyond,
+    wait_for_bond_unlock, wait_for_bond_withdrawal, wait_for_game_finality,
+    wait_for_multi_proof_game, wait_for_proof_lane, wait_for_status, weth_at,
 };
 
-const DEVNET_SIGNER_KEY: &str =
-    "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a";
 const L2_TO_L1_MESSAGE_PASSER: Address = address!("4200000000000000000000000000000000000016");
-const GAME_WAIT_TIMEOUT: Duration = Duration::from_secs(300);
-const GAME_IN_PROGRESS: u8 = 0;
-const GAME_DEFENDER_WINS: u8 = 2;
 
 sol! {
     struct WithdrawalTransaction {
@@ -85,54 +78,24 @@ struct InitiatedWithdrawal {
 async fn op_native_wip_1006_portal_withdrawal_and_bond_claim() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    let ha_config = HaSequencerConfig::default()
-        .with_sequencer_count(2)
-        .with_observability(ObservabilityConfig::default());
-    let devnet = match WorldDevnetBuilder::new()
-        .preset(WorldDevnetPreset::HaSequencer)
-        .ha_sequencer(ha_config)
-        .block_time(Duration::from_secs(1))
-        .build()
-        .await
-    {
-        Ok(devnet) => devnet,
-        Err(err) if is_docker_unavailable(&err) => {
-            eprintln!("skipping Portal withdrawal E2E because Docker is unavailable: {err:#}");
-            return Ok(());
-        }
-        Err(err) => return Err(err),
+    let Some(devnet) = try_build_ha_devnet("Portal withdrawal E2E").await? else {
+        return Ok(());
     };
 
-    let l1_rpc = devnet
-        .l1_rpc_url()
-        .ok_or_eyre("full-stack devnet missing L1 RPC")?;
-    let portal_address: Address = devnet
-        .optimism_portal()
-        .ok_or_eyre("full-stack devnet missing OptimismPortal")?
-        .parse()?;
-    let factory_address: Address = devnet
-        .dispute_game_factory()
-        .ok_or_eyre("full-stack devnet missing DisputeGameFactory")?
-        .parse()?;
-    let anchor_address: Address = devnet
-        .anchor_state_registry()
-        .ok_or_eyre("full-stack devnet missing AnchorStateRegistry")?
-        .parse()?;
+    let l1_rpc = l1_rpc_url(&devnet)?;
+    let portal_address = l1_contract(devnet.optimism_portal(), "OptimismPortal")?;
+    let factory_address = l1_contract(devnet.dispute_game_factory(), "DisputeGameFactory")?;
+    let anchor_address = l1_contract(devnet.anchor_state_registry(), "AnchorStateRegistry")?;
 
-    let signer: PrivateKeySigner = DEVNET_SIGNER_KEY.parse()?;
+    // Prefunded on both L1 and L2 in the devnet genesis, so one key covers the L2 withdrawal
+    // initiation and the L1 prove/finalize calls.
+    let signer: PrivateKeySigner = SUPERCHAIN_GUARDIAN_PRIVATE_KEY.parse()?;
     let withdrawal_sender = signer.address();
-    let l1_provider = ProviderBuilder::new()
-        .wallet(EthereumWallet::from(signer.clone()))
-        .connect_http(Url::parse(l1_rpc)?);
-    let l2_provider = ProviderBuilder::new()
-        .wallet(EthereumWallet::from(signer))
-        .connect_http(Url::parse(&devnet.l2_rpc_url())?);
+    let l1_provider = signing_provider(l1_rpc, signer.clone())?;
+    let l2_provider = signing_provider(&devnet.l2_rpc_url(), signer)?;
 
     let portal = OptimismPortal::new(portal_address, l1_provider.clone());
-    let anchor = IAnchorStateRegistry::IAnchorStateRegistryInstance::new(
-        anchor_address,
-        l1_provider.clone(),
-    );
+    let anchor = anchor_at(anchor_address, l1_provider.clone());
     ensure!(
         portal.version().call().await? == "5.6.1",
         "devnet Portal version does not match the pinned compatibility target"
@@ -152,8 +115,9 @@ async fn op_native_wip_1006_portal_withdrawal_and_bond_claim() -> eyre::Result<(
 
     let withdrawal = initiate_withdrawal(l2_provider.clone(), withdrawal_sender).await?;
     let (game_index, game_address, game_l2_block) =
-        wait_for_covering_game(l1_provider.clone(), factory_address, withdrawal.l2_block).await?;
-    let game = IMultiProofGame::IMultiProofGameInstance::new(game_address, l1_provider.clone());
+        wait_for_multi_proof_game(l1_provider.clone(), factory_address, withdrawal.l2_block)
+            .await?;
+    let game = game_at(game_address, l1_provider.clone());
     ensure!(
         game.wasRespectedGameTypeWhenCreated().call().await?,
         "covering WIP-1006 game was not respected when created"
@@ -162,7 +126,7 @@ async fn op_native_wip_1006_portal_withdrawal_and_bond_claim() -> eyre::Result<(
         anchor.isGameProper(game_address).call().await?,
         "covering WIP-1006 game is not proper"
     );
-    wait_for_initial_proof(l1_provider.clone(), game_address).await?;
+    wait_for_proof_lane(&game).await?;
 
     let (output_root_proof, withdrawal_proof) =
         build_withdrawal_proof(l2_provider, game_l2_block, withdrawal.hash).await?;
@@ -198,7 +162,7 @@ async fn op_native_wip_1006_portal_withdrawal_and_bond_claim() -> eyre::Result<(
     )
     .await?;
 
-    wait_for_defender_win(l1_provider.clone(), game_address).await?;
+    wait_for_status(&game, GAME_DEFENDER_WINS).await?;
     let finality_delay: u64 = portal
         .disputeGameFinalityDelaySeconds()
         .call()
@@ -210,7 +174,7 @@ async fn op_native_wip_1006_portal_withdrawal_and_bond_claim() -> eyre::Result<(
         resolved_at.saturating_add(finality_delay).saturating_add(1),
     )
     .await?;
-    wait_for_game_finality(l1_provider.clone(), anchor_address, game_address).await?;
+    wait_for_game_finality(&anchor, game_address).await?;
     ensure!(
         anchor.isGameClaimValid(game_address).call().await?,
         "resolved WIP-1006 game is not a valid Portal claim"
@@ -230,14 +194,13 @@ async fn op_native_wip_1006_portal_withdrawal_and_bond_claim() -> eyre::Result<(
         portal.finalizedWithdrawals(withdrawal.hash).call().await?,
         "Portal did not persist the finalized withdrawal"
     );
-    wait_for_anchor_at_or_beyond(l1_provider.clone(), anchor_address, game_l2_block).await?;
+    wait_for_anchor_at_or_beyond(&anchor, game_l2_block).await?;
 
     let proposer = game.gameCreator().call().await?;
-    let delayed_weth = game.weth().call().await?;
-    let unlock_at =
-        wait_for_bond_unlock(l1_provider.clone(), delayed_weth, game_address, proposer).await?;
+    let weth = weth_at(game.weth().call().await?, l1_provider.clone());
+    let unlock_at = wait_for_bond_unlock(&weth, game_address, proposer).await?;
     advance_to_timestamp(&l1_provider, unlock_at).await?;
-    wait_for_bond_withdrawal(l1_provider.clone(), delayed_weth, game_address, proposer).await?;
+    wait_for_bond_withdrawal(&weth, game_address, proposer).await?;
 
     Ok(())
 }
@@ -285,41 +248,6 @@ where
     })
 }
 
-async fn wait_for_covering_game<P>(
-    provider: P,
-    factory_address: Address,
-    withdrawal_block: u64,
-) -> eyre::Result<(u64, Address, u64)>
-where
-    P: Provider + Clone,
-{
-    let factory =
-        IDisputeGameFactory::IDisputeGameFactoryInstance::new(factory_address, provider.clone());
-    let started = Instant::now();
-
-    loop {
-        let game_count: u64 = factory.gameCount().call().await?.try_into()?;
-        for index in (0..game_count).rev() {
-            let entry = factory.gameAtIndex(U256::from(index)).call().await?;
-            if entry.gameType != MULTI_PROOF_GAME_TYPE {
-                continue;
-            }
-            let game = IMultiProofGame::IMultiProofGameInstance::new(entry.proxy, provider.clone());
-            let l2_block: u64 = game.l2SequenceNumber().call().await?.try_into()?;
-            if l2_block >= withdrawal_block {
-                return Ok((index, entry.proxy, l2_block));
-            }
-        }
-
-        if started.elapsed() >= GAME_WAIT_TIMEOUT {
-            bail!(
-                "timed out waiting for a respected WIP-1006 game covering withdrawal block {withdrawal_block}"
-            );
-        }
-        tokio::time::sleep(Duration::from_secs(2)).await;
-    }
-}
-
 async fn build_withdrawal_proof<P>(
     l2_provider: P,
     game_l2_block: u64,
@@ -355,173 +283,4 @@ where
         },
         storage_proof.proof.clone(),
     ))
-}
-
-async fn wait_for_initial_proof<P>(provider: P, game_address: Address) -> eyre::Result<()>
-where
-    P: Provider,
-{
-    let game = IMultiProofGame::IMultiProofGameInstance::new(game_address, provider);
-    let started = Instant::now();
-
-    loop {
-        if game.proofBitmap().call().await? != 0 {
-            return Ok(());
-        }
-        if game.status().call().await? != GAME_IN_PROGRESS {
-            bail!("game {game_address} resolved before receiving its initial proof");
-        }
-        if started.elapsed() >= GAME_WAIT_TIMEOUT {
-            bail!(
-                "timed out waiting for defender to submit an initial proof to game {game_address}"
-            );
-        }
-        tokio::time::sleep(Duration::from_secs(1)).await;
-    }
-}
-
-async fn wait_for_defender_win<P>(provider: P, game_address: Address) -> eyre::Result<()>
-where
-    P: Provider,
-{
-    let game = IMultiProofGame::IMultiProofGameInstance::new(game_address, provider);
-    let started = Instant::now();
-
-    loop {
-        let status = game.status().call().await?;
-        if status == GAME_DEFENDER_WINS {
-            return Ok(());
-        }
-        if status != GAME_IN_PROGRESS {
-            bail!("game {game_address} resolved with unexpected status {status}");
-        }
-        if started.elapsed() >= GAME_WAIT_TIMEOUT {
-            bail!("timed out waiting for game {game_address} to resolve");
-        }
-        tokio::time::sleep(Duration::from_secs(1)).await;
-    }
-}
-
-async fn wait_for_game_finality<P>(
-    provider: P,
-    anchor_address: Address,
-    game_address: Address,
-) -> eyre::Result<()>
-where
-    P: Provider,
-{
-    let anchor = IAnchorStateRegistry::IAnchorStateRegistryInstance::new(anchor_address, provider);
-    let started = Instant::now();
-    loop {
-        if anchor.isGameFinalized(game_address).call().await? {
-            return Ok(());
-        }
-        if started.elapsed() >= GAME_WAIT_TIMEOUT {
-            bail!("timed out waiting for game {game_address} to pass the ASR finality airgap");
-        }
-        tokio::time::sleep(Duration::from_secs(1)).await;
-    }
-}
-
-async fn wait_for_anchor_at_or_beyond<P>(
-    provider: P,
-    anchor_address: Address,
-    game_l2_block: u64,
-) -> eyre::Result<()>
-where
-    P: Provider,
-{
-    let anchor = IAnchorStateRegistry::IAnchorStateRegistryInstance::new(anchor_address, provider);
-    let started = Instant::now();
-    loop {
-        let anchor_root = anchor.getAnchorRoot().call().await?;
-        if anchor_root.l2SequenceNumber >= U256::from(game_l2_block) {
-            return Ok(());
-        }
-        if started.elapsed() >= GAME_WAIT_TIMEOUT {
-            bail!("timed out waiting for the ASR anchor to reach L2 block {game_l2_block}");
-        }
-        tokio::time::sleep(Duration::from_secs(1)).await;
-    }
-}
-
-async fn wait_for_bond_unlock<P>(
-    provider: P,
-    delayed_weth: Address,
-    game_address: Address,
-    proposer: Address,
-) -> eyre::Result<u64>
-where
-    P: Provider + Clone,
-{
-    let weth = IDelayedWETH::IDelayedWETHInstance::new(delayed_weth, provider);
-    let delay = weth.delay().call().await?;
-    let started = Instant::now();
-    loop {
-        let pending = weth.withdrawals(game_address, proposer).call().await?;
-        if !pending.amount.is_zero() {
-            let unlock_at: u64 = pending
-                .timestamp
-                .checked_add(delay)
-                .ok_or_eyre("DelayedWETH unlock timestamp overflow")?
-                .try_into()?;
-            return Ok(unlock_at);
-        }
-        if started.elapsed() >= GAME_WAIT_TIMEOUT {
-            bail!("timed out waiting for proposer bond credit to unlock");
-        }
-        tokio::time::sleep(Duration::from_secs(1)).await;
-    }
-}
-
-async fn wait_for_bond_withdrawal<P>(
-    provider: P,
-    delayed_weth: Address,
-    game_address: Address,
-    proposer: Address,
-) -> eyre::Result<()>
-where
-    P: Provider,
-{
-    let weth = IDelayedWETH::IDelayedWETHInstance::new(delayed_weth, provider);
-    let started = Instant::now();
-    loop {
-        if weth
-            .withdrawals(game_address, proposer)
-            .call()
-            .await?
-            .amount
-            .is_zero()
-        {
-            return Ok(());
-        }
-        if started.elapsed() >= GAME_WAIT_TIMEOUT {
-            bail!("timed out waiting for proposer bond withdrawal");
-        }
-        tokio::time::sleep(Duration::from_secs(1)).await;
-    }
-}
-
-async fn latest_timestamp<P>(provider: &P) -> eyre::Result<u64>
-where
-    P: Provider,
-{
-    Ok(provider
-        .get_block_by_number(BlockNumberOrTag::Latest)
-        .await?
-        .ok_or_eyre("latest L1 block missing")?
-        .header
-        .timestamp())
-}
-
-async fn advance_to_timestamp<P>(provider: &P, target: u64) -> eyre::Result<()>
-where
-    P: Provider,
-{
-    let current = latest_timestamp(provider).await?;
-    if target > current {
-        provider.anvil_increase_time(target - current).await?;
-    }
-    provider.evm_mine(None).await?;
-    Ok(())
 }

--- a/e2e-tests/src/it/devnet_withdrawal.rs
+++ b/e2e-tests/src/it/devnet_withdrawal.rs
@@ -87,8 +87,7 @@ async fn op_native_wip_1006_portal_withdrawal_and_bond_claim() -> eyre::Result<(
     let factory_address = l1_contract(devnet.dispute_game_factory(), "DisputeGameFactory")?;
     let anchor_address = l1_contract(devnet.anchor_state_registry(), "AnchorStateRegistry")?;
 
-    // Prefunded on both L1 and L2 in the devnet genesis, so one key covers the L2 withdrawal
-    // initiation and the L1 prove/finalize calls.
+    // Prefunded on both chains, so one key covers the L2 initiation and the L1 prove/finalize.
     let signer: PrivateKeySigner = SUPERCHAIN_GUARDIAN_PRIVATE_KEY.parse()?;
     let withdrawal_sender = signer.address();
     let l1_provider = signing_provider(l1_rpc, signer.clone())?;

--- a/e2e-tests/src/it/mod.rs
+++ b/e2e-tests/src/it/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(test)]
 mod acceptance_tests;
 mod admin_tracing;
+mod devnet_challenge;
+mod devnet_proof_invariants;
 mod devnet_smoke;
 mod devnet_withdrawal;
 mod testsuite;
+pub mod utils;

--- a/e2e-tests/src/it/utils/devnet.rs
+++ b/e2e-tests/src/it/utils/devnet.rs
@@ -1,0 +1,457 @@
+//! Shared fixtures for the devnet E2E tests that drive the WIP-1006 proof system.
+//!
+//! [`devnet_challenge`](crate::it::devnet_challenge),
+//! [`devnet_proof_invariants`](crate::it::devnet_proof_invariants) and
+//! [`devnet_withdrawal`](crate::it::devnet_withdrawal) all stand up the same HA-sequencer full
+//! stack, talk to the same `MultiProofGame` instances, and poll the same on-chain state while the
+//! real in-process proposer/challenger/defender services race them. Everything they hold in common
+//! lives here; each test keeps only the setup and assertions specific to the property it exercises.
+
+use std::{
+    future::Future,
+    time::{Duration, Instant},
+};
+
+use alloy_consensus::BlockHeader;
+use alloy_eips::BlockNumberOrTag;
+use alloy_network::EthereumWallet;
+use alloy_primitives::{Address, U256};
+use alloy_provider::{Provider, ProviderBuilder, WalletProvider, ext::AnvilApi};
+use alloy_signer_local::PrivateKeySigner;
+use eyre::eyre::{OptionExt, bail, ensure, eyre};
+use url::Url;
+use world_chain_devnet::{
+    HaSequencerConfig, ObservabilityConfig, WorldDevnet, WorldDevnetBuilder, WorldDevnetPreset,
+    is_docker_unavailable,
+};
+use world_chain_proof_protocol::{
+    DEFAULT_L1_TX_RECEIPT_TIMEOUT_SECONDS, IAnchorStateRegistry, IDelayedWETH, IDisputeGameFactory,
+    IMultiProofGame, MULTI_PROOF_GAME_TYPE,
+};
+use world_chain_proposer::AlloyProofSystemClient;
+
+/// How long any single wait on devnet-driven on-chain state may take before the test fails.
+pub(in crate::it) const GAME_WAIT_TIMEOUT: Duration = Duration::from_secs(300);
+pub(in crate::it) const GAME_IN_PROGRESS: u8 = 0;
+pub(in crate::it) const GAME_CHALLENGER_WINS: u8 = 1;
+pub(in crate::it) const GAME_DEFENDER_WINS: u8 = 2;
+/// `LibProof.InvalidationReason` ordinals (`pkg/contracts/src/dispute/lib/LibProof.sol`).
+pub(in crate::it) const INVALIDATION_REASON_PROOF_TIMEOUT: u8 = 1;
+pub(in crate::it) const INVALIDATION_REASON_INVALID_PARENT: u8 = 2;
+
+/// Funds a throwaway Anvil account well above any bond the factory could demand (100 ETH).
+const THROWAWAY_ACCOUNT_BALANCE_WEI: u128 = 100_000_000_000_000_000_000;
+const GAME_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Builds the HA-sequencer full stack every proof-system test runs against.
+///
+/// Returns `Ok(None)` — after printing `skip_label` — when Docker is unavailable, so a developer
+/// without a container runtime sees a skip rather than a failure.
+pub(in crate::it) async fn try_build_ha_devnet(
+    skip_label: &str,
+) -> eyre::Result<Option<WorldDevnet>> {
+    let ha_config = HaSequencerConfig::default()
+        .with_sequencer_count(2)
+        .with_observability(ObservabilityConfig::default());
+
+    match WorldDevnetBuilder::new()
+        .preset(WorldDevnetPreset::HaSequencer)
+        .ha_sequencer(ha_config)
+        .block_time(Duration::from_secs(1))
+        .build()
+        .await
+    {
+        Ok(devnet) => Ok(Some(devnet)),
+        Err(err) if is_docker_unavailable(&err) => {
+            eprintln!("skipping {skip_label} because Docker is unavailable: {err:#}");
+            Ok(None)
+        }
+        Err(err) => Err(err),
+    }
+}
+
+/// L1 RPC URL of a full-stack devnet.
+pub(in crate::it) fn l1_rpc_url(devnet: &WorldDevnet) -> eyre::Result<&str> {
+    devnet
+        .l1_rpc_url()
+        .ok_or_eyre("full-stack devnet missing L1 RPC")
+}
+
+/// Parses one of the devnet's optional L1 contract addresses, naming it if absent.
+pub(in crate::it) fn l1_contract(address: Option<&str>, what: &str) -> eyre::Result<Address> {
+    Ok(address
+        .ok_or_else(|| eyre!("full-stack devnet missing {what}"))?
+        .parse()?)
+}
+
+/// Builds an HTTP provider that signs with `signer`.
+///
+/// The wallet stays un-erased (no [`alloy_provider::DynProvider`]) because
+/// [`AlloyProofSystemClient`]'s proposer traits require [`WalletProvider`], which erasure drops.
+pub(in crate::it) fn signing_provider(
+    rpc: &str,
+    signer: PrivateKeySigner,
+) -> eyre::Result<impl Provider + WalletProvider + Clone + use<>> {
+    Ok(ProviderBuilder::new()
+        .wallet(EthereumWallet::from(signer))
+        .connect_http(Url::parse(rpc)?))
+}
+
+/// Funds a fresh random account through Anvil's `anvil_setBalance` cheat and returns its address
+/// alongside a provider that signs with it.
+///
+/// Cheating balance in rather than adding the key to the devnet's L1 genesis keeps the shared
+/// devnet fixture unchanged for every other test.
+pub(in crate::it) async fn funded_throwaway_provider(
+    l1_rpc: &str,
+) -> eyre::Result<(Address, impl Provider + WalletProvider + Clone + use<>)> {
+    let signer = PrivateKeySigner::random();
+    let address = signer.address();
+    ProviderBuilder::new()
+        .connect_http(Url::parse(l1_rpc)?)
+        .anvil_set_balance(address, U256::from(THROWAWAY_ACCOUNT_BALANCE_WEI))
+        .await?;
+
+    Ok((address, signing_provider(l1_rpc, signer)?))
+}
+
+/// Connects a proposer-side proof-system client to the devnet's factory.
+pub(in crate::it) async fn proof_system_client<P>(
+    provider: P,
+    factory_address: Address,
+) -> eyre::Result<AlloyProofSystemClient<P>>
+where
+    P: Provider + Clone,
+{
+    Ok(AlloyProofSystemClient::new(
+        provider,
+        factory_address,
+        1,
+        Duration::from_secs(DEFAULT_L1_TX_RECEIPT_TIMEOUT_SECONDS),
+    )
+    .await?)
+}
+
+/// Binds the `MultiProofGame` at `address`.
+pub(in crate::it) fn game_at<P>(
+    address: Address,
+    provider: P,
+) -> IMultiProofGame::IMultiProofGameInstance<P>
+where
+    P: Provider,
+{
+    IMultiProofGame::IMultiProofGameInstance::new(address, provider)
+}
+
+/// Binds the `AnchorStateRegistry` at `address`.
+pub(in crate::it) fn anchor_at<P>(
+    address: Address,
+    provider: P,
+) -> IAnchorStateRegistry::IAnchorStateRegistryInstance<P>
+where
+    P: Provider,
+{
+    IAnchorStateRegistry::IAnchorStateRegistryInstance::new(address, provider)
+}
+
+/// Binds the `DelayedWETH` at `address`.
+pub(in crate::it) fn weth_at<P>(
+    address: Address,
+    provider: P,
+) -> IDelayedWETH::IDelayedWETHInstance<P>
+where
+    P: Provider,
+{
+    IDelayedWETH::IDelayedWETHInstance::new(address, provider)
+}
+
+/// Polls `probe` until it yields a value, giving up after [`GAME_WAIT_TIMEOUT`].
+///
+/// `Ok(None)` means "not yet, keep waiting". An `Err` aborts immediately, which is how callers
+/// surface terminal states — a game that resolved before it could be challenged is a failure worth
+/// reporting now, not after spinning out the full timeout. `what` completes the sentence
+/// "timed out after 300s waiting for …".
+async fn poll_until<F, Fut, T>(what: &str, mut probe: F) -> eyre::Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = eyre::Result<Option<T>>>,
+{
+    let started = Instant::now();
+    loop {
+        if let Some(value) = probe().await? {
+            return Ok(value);
+        }
+        if started.elapsed() >= GAME_WAIT_TIMEOUT {
+            bail!("timed out after {GAME_WAIT_TIMEOUT:?} waiting for {what}");
+        }
+        tokio::time::sleep(GAME_POLL_INTERVAL).await;
+    }
+}
+
+pub(in crate::it) async fn latest_timestamp<P>(provider: &P) -> eyre::Result<u64>
+where
+    P: Provider,
+{
+    Ok(provider
+        .get_block_by_number(BlockNumberOrTag::Latest)
+        .await?
+        .ok_or_eyre("latest L1 block missing")?
+        .header
+        .timestamp())
+}
+
+/// Warps Anvil's clock to `target` (if it is in the future) and mines a block so the new timestamp
+/// is observable on-chain.
+pub(in crate::it) async fn advance_to_timestamp<P>(provider: &P, target: u64) -> eyre::Result<()>
+where
+    P: Provider,
+{
+    let current = latest_timestamp(provider).await?;
+    if target > current {
+        provider.anvil_increase_time(target - current).await?;
+    }
+    provider.evm_mine(None).await?;
+    Ok(())
+}
+
+/// Waits for the newest WIP-1006 game whose L2 sequence number is at or beyond `min_l2_block`,
+/// returning its factory index, address, and L2 sequence number.
+///
+/// Pass `0` to wait for any WIP-1006 game at all.
+pub(in crate::it) async fn wait_for_multi_proof_game<P>(
+    provider: P,
+    factory_address: Address,
+    min_l2_block: u64,
+) -> eyre::Result<(u64, Address, u64)>
+where
+    P: Provider + Clone,
+{
+    let factory =
+        IDisputeGameFactory::IDisputeGameFactoryInstance::new(factory_address, provider.clone());
+    let started = Instant::now();
+
+    loop {
+        let game_count: u64 = factory.gameCount().call().await?.try_into()?;
+        for index in (0..game_count).rev() {
+            let entry = factory.gameAtIndex(U256::from(index)).call().await?;
+            if entry.gameType != MULTI_PROOF_GAME_TYPE {
+                continue;
+            }
+            let game = game_at(entry.proxy, provider.clone());
+            let l2_block: u64 = game.l2SequenceNumber().call().await?.try_into()?;
+            if l2_block >= min_l2_block {
+                return Ok((index, entry.proxy, l2_block));
+            }
+        }
+
+        if started.elapsed() >= GAME_WAIT_TIMEOUT {
+            bail!(
+                "timed out waiting for a respected WIP-1006 game at or beyond L2 block {min_l2_block}"
+            );
+        }
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+}
+
+/// Waits for `game` to be challenged, returning the challenger's address.
+pub(in crate::it) async fn wait_for_challenge<P>(
+    game: &IMultiProofGame::IMultiProofGameInstance<P>,
+) -> eyre::Result<Address>
+where
+    P: Provider,
+{
+    let address = *game.address();
+    poll_until(&format!("game {address} to be challenged"), || async {
+        let challenger = game.challenger().call().await?;
+        if challenger != Address::ZERO {
+            return Ok(Some(challenger));
+        }
+        ensure!(
+            game.status().call().await? == GAME_IN_PROGRESS,
+            "game {address} resolved before it was ever challenged"
+        );
+        Ok(None)
+    })
+    .await
+}
+
+/// Waits for at least one proof lane to land on `game`.
+pub(in crate::it) async fn wait_for_proof_lane<P>(
+    game: &IMultiProofGame::IMultiProofGameInstance<P>,
+) -> eyre::Result<()>
+where
+    P: Provider,
+{
+    let address = *game.address();
+    poll_until(&format!("a proof lane on game {address}"), || async {
+        if game.proofBitmap().call().await? != 0 {
+            return Ok(Some(()));
+        }
+        ensure!(
+            game.status().call().await? == GAME_IN_PROGRESS,
+            "game {address} resolved before receiving any proof lane"
+        );
+        Ok(None)
+    })
+    .await
+}
+
+/// Waits for `game` to resolve to `expected`, failing fast if it resolves to anything else.
+pub(in crate::it) async fn wait_for_status<P>(
+    game: &IMultiProofGame::IMultiProofGameInstance<P>,
+    expected: u8,
+) -> eyre::Result<()>
+where
+    P: Provider,
+{
+    let address = *game.address();
+    poll_until(
+        &format!("game {address} to resolve to status {expected}"),
+        || async {
+            let status = game.status().call().await?;
+            if status == expected {
+                return Ok(Some(()));
+            }
+            ensure!(
+                status == GAME_IN_PROGRESS,
+                "game {address} resolved with status {status}, expected {expected}"
+            );
+            Ok(None)
+        },
+    )
+    .await
+}
+
+/// Like [`wait_for_status`], but resolves the game itself if nothing else has by the timeout.
+///
+/// Necessary where no in-process service is guaranteed to be watching the game — a proposal the
+/// real challenger never discovers as challengeable will sit `InProgress` forever unless the test
+/// drives resolution. Either way, the resolved status must still be `expected`.
+pub(in crate::it) async fn wait_for_status_or_resolve<P>(
+    game: &IMultiProofGame::IMultiProofGameInstance<P>,
+    expected: u8,
+) -> eyre::Result<()>
+where
+    P: Provider,
+{
+    let address = *game.address();
+    let started = Instant::now();
+    let status = loop {
+        let status = game.status().call().await?;
+        if status != GAME_IN_PROGRESS {
+            break status;
+        }
+        if started.elapsed() >= GAME_WAIT_TIMEOUT {
+            resolve_if_still_in_progress(game).await?;
+            break game.status().call().await?;
+        }
+        tokio::time::sleep(GAME_POLL_INTERVAL).await;
+    };
+
+    ensure!(
+        status == expected,
+        "game {address} resolved with status {status}, expected {expected}"
+    );
+    Ok(())
+}
+
+/// Calls `resolve()` unless another actor (e.g. the real challenger's resolution manager) already
+/// resolved the game first; either way is fine, these tests only care about the final outcome.
+pub(in crate::it) async fn resolve_if_still_in_progress<P>(
+    game: &IMultiProofGame::IMultiProofGameInstance<P>,
+) -> eyre::Result<()>
+where
+    P: Provider,
+{
+    if game.status().call().await? == GAME_IN_PROGRESS {
+        let receipt = game.resolve().send().await?.get_receipt().await?;
+        ensure!(receipt.status(), "resolve() transaction reverted");
+    }
+    Ok(())
+}
+
+/// Waits for `game_address` to clear the `AnchorStateRegistry`'s finality airgap.
+pub(in crate::it) async fn wait_for_game_finality<P>(
+    anchor: &IAnchorStateRegistry::IAnchorStateRegistryInstance<P>,
+    game_address: Address,
+) -> eyre::Result<()>
+where
+    P: Provider,
+{
+    poll_until(
+        &format!("game {game_address} to pass the ASR finality airgap"),
+        || async {
+            Ok(anchor
+                .isGameFinalized(game_address)
+                .call()
+                .await?
+                .then_some(()))
+        },
+    )
+    .await
+}
+
+/// Waits for the `AnchorStateRegistry` anchor to advance to at least `game_l2_block`.
+pub(in crate::it) async fn wait_for_anchor_at_or_beyond<P>(
+    anchor: &IAnchorStateRegistry::IAnchorStateRegistryInstance<P>,
+    game_l2_block: u64,
+) -> eyre::Result<()>
+where
+    P: Provider,
+{
+    poll_until(
+        &format!("the ASR anchor to reach L2 block {game_l2_block}"),
+        || async {
+            let anchor_root = anchor.getAnchorRoot().call().await?;
+            Ok((anchor_root.l2SequenceNumber >= U256::from(game_l2_block)).then_some(()))
+        },
+    )
+    .await
+}
+
+/// Waits for `proposer`'s bond on `game_address` to be credited in `DelayedWETH`, returning the
+/// timestamp at which the withdrawal delay expires.
+pub(in crate::it) async fn wait_for_bond_unlock<P>(
+    weth: &IDelayedWETH::IDelayedWETHInstance<P>,
+    game_address: Address,
+    proposer: Address,
+) -> eyre::Result<u64>
+where
+    P: Provider,
+{
+    let delay = weth.delay().call().await?;
+    poll_until("proposer bond credit to unlock", || async {
+        let pending = weth.withdrawals(game_address, proposer).call().await?;
+        if pending.amount.is_zero() {
+            return Ok(None);
+        }
+        let unlock_at: u64 = pending
+            .timestamp
+            .checked_add(delay)
+            .ok_or_eyre("DelayedWETH unlock timestamp overflow")?
+            .try_into()?;
+        Ok(Some(unlock_at))
+    })
+    .await
+}
+
+/// Waits for `proposer`'s bond on `game_address` to be fully withdrawn from `DelayedWETH`.
+pub(in crate::it) async fn wait_for_bond_withdrawal<P>(
+    weth: &IDelayedWETH::IDelayedWETHInstance<P>,
+    game_address: Address,
+    proposer: Address,
+) -> eyre::Result<()>
+where
+    P: Provider,
+{
+    poll_until("proposer bond withdrawal", || async {
+        Ok(weth
+            .withdrawals(game_address, proposer)
+            .call()
+            .await?
+            .amount
+            .is_zero()
+            .then_some(()))
+    })
+    .await
+}

--- a/e2e-tests/src/it/utils/devnet.rs
+++ b/e2e-tests/src/it/utils/devnet.rs
@@ -1,11 +1,7 @@
 //! Shared fixtures for the devnet E2E tests that drive the WIP-1006 proof system.
 //!
-//! [`devnet_challenge`](crate::it::devnet_challenge),
-//! [`devnet_proof_invariants`](crate::it::devnet_proof_invariants) and
-//! [`devnet_withdrawal`](crate::it::devnet_withdrawal) all stand up the same HA-sequencer full
-//! stack, talk to the same `MultiProofGame` instances, and poll the same on-chain state while the
-//! real in-process proposer/challenger/defender services race them. Everything they hold in common
-//! lives here; each test keeps only the setup and assertions specific to the property it exercises.
+//! These tests all stand up the same HA-sequencer stack and poll the same on-chain state while the
+//! real proposer/challenger/defender services race them.
 
 use std::{
     future::Future,
@@ -45,8 +41,7 @@ const GAME_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Builds the HA-sequencer full stack every proof-system test runs against.
 ///
-/// Returns `Ok(None)` — after printing `skip_label` — when Docker is unavailable, so a developer
-/// without a container runtime sees a skip rather than a failure.
+/// `Ok(None)` means Docker is unavailable — the caller should skip, not fail.
 pub(in crate::it) async fn try_build_ha_devnet(
     skip_label: &str,
 ) -> eyre::Result<Option<WorldDevnet>> {
@@ -70,7 +65,6 @@ pub(in crate::it) async fn try_build_ha_devnet(
     }
 }
 
-/// L1 RPC URL of a full-stack devnet.
 pub(in crate::it) fn l1_rpc_url(devnet: &WorldDevnet) -> eyre::Result<&str> {
     devnet
         .l1_rpc_url()
@@ -86,8 +80,8 @@ pub(in crate::it) fn l1_contract(address: Option<&str>, what: &str) -> eyre::Res
 
 /// Builds an HTTP provider that signs with `signer`.
 ///
-/// The wallet stays un-erased (no [`alloy_provider::DynProvider`]) because
-/// [`AlloyProofSystemClient`]'s proposer traits require [`WalletProvider`], which erasure drops.
+/// Not erased to `DynProvider`: [`AlloyProofSystemClient`]'s proposer traits need
+/// [`WalletProvider`], which erasure drops.
 pub(in crate::it) fn signing_provider(
     rpc: &str,
     signer: PrivateKeySigner,
@@ -97,11 +91,9 @@ pub(in crate::it) fn signing_provider(
         .connect_http(Url::parse(rpc)?))
 }
 
-/// Funds a fresh random account through Anvil's `anvil_setBalance` cheat and returns its address
-/// alongside a provider that signs with it.
+/// Funds a fresh random account via `anvil_setBalance` and returns it with a signing provider.
 ///
-/// Cheating balance in rather than adding the key to the devnet's L1 genesis keeps the shared
-/// devnet fixture unchanged for every other test.
+/// Cheating balance in leaves the shared devnet genesis untouched for every other test.
 pub(in crate::it) async fn funded_throwaway_provider(
     l1_rpc: &str,
 ) -> eyre::Result<(Address, impl Provider + WalletProvider + Clone + use<>)> {
@@ -115,7 +107,6 @@ pub(in crate::it) async fn funded_throwaway_provider(
     Ok((address, signing_provider(l1_rpc, signer)?))
 }
 
-/// Connects a proposer-side proof-system client to the devnet's factory.
 pub(in crate::it) async fn proof_system_client<P>(
     provider: P,
     factory_address: Address,
@@ -132,7 +123,6 @@ where
     .await?)
 }
 
-/// Binds the `MultiProofGame` at `address`.
 pub(in crate::it) fn game_at<P>(
     address: Address,
     provider: P,
@@ -143,7 +133,6 @@ where
     IMultiProofGame::IMultiProofGameInstance::new(address, provider)
 }
 
-/// Binds the `AnchorStateRegistry` at `address`.
 pub(in crate::it) fn anchor_at<P>(
     address: Address,
     provider: P,
@@ -154,7 +143,6 @@ where
     IAnchorStateRegistry::IAnchorStateRegistryInstance::new(address, provider)
 }
 
-/// Binds the `DelayedWETH` at `address`.
 pub(in crate::it) fn weth_at<P>(
     address: Address,
     provider: P,
@@ -167,10 +155,8 @@ where
 
 /// Polls `probe` until it yields a value, giving up after [`GAME_WAIT_TIMEOUT`].
 ///
-/// `Ok(None)` means "not yet, keep waiting". An `Err` aborts immediately, which is how callers
-/// surface terminal states — a game that resolved before it could be challenged is a failure worth
-/// reporting now, not after spinning out the full timeout. `what` completes the sentence
-/// "timed out after 300s waiting for …".
+/// `Ok(None)` means keep waiting; an `Err` aborts immediately, which is how callers fail fast on
+/// terminal states. `what` completes "timed out after 300s waiting for …".
 async fn poll_until<F, Fut, T>(what: &str, mut probe: F) -> eyre::Result<T>
 where
     F: FnMut() -> Fut,
@@ -200,8 +186,7 @@ where
         .timestamp())
 }
 
-/// Warps Anvil's clock to `target` (if it is in the future) and mines a block so the new timestamp
-/// is observable on-chain.
+/// Warps Anvil's clock forward to `target` and mines a block so it is observable on-chain.
 pub(in crate::it) async fn advance_to_timestamp<P>(provider: &P, target: u64) -> eyre::Result<()>
 where
     P: Provider,
@@ -214,10 +199,8 @@ where
     Ok(())
 }
 
-/// Waits for the newest WIP-1006 game whose L2 sequence number is at or beyond `min_l2_block`,
-/// returning its factory index, address, and L2 sequence number.
-///
-/// Pass `0` to wait for any WIP-1006 game at all.
+/// Waits for the newest WIP-1006 game at or beyond `min_l2_block`, returning its factory index,
+/// address, and L2 sequence number. Pass `0` for any game at all.
 pub(in crate::it) async fn wait_for_multi_proof_game<P>(
     provider: P,
     factory_address: Address,
@@ -324,9 +307,8 @@ where
 
 /// Like [`wait_for_status`], but resolves the game itself if nothing else has by the timeout.
 ///
-/// Necessary where no in-process service is guaranteed to be watching the game — a proposal the
-/// real challenger never discovers as challengeable will sit `InProgress` forever unless the test
-/// drives resolution. Either way, the resolved status must still be `expected`.
+/// Needed where no service is watching the game; it would sit `InProgress` forever otherwise. The
+/// final status must still be `expected`.
 pub(in crate::it) async fn wait_for_status_or_resolve<P>(
     game: &IMultiProofGame::IMultiProofGameInstance<P>,
     expected: u8,
@@ -355,8 +337,7 @@ where
     Ok(())
 }
 
-/// Calls `resolve()` unless another actor (e.g. the real challenger's resolution manager) already
-/// resolved the game first; either way is fine, these tests only care about the final outcome.
+/// Calls `resolve()` unless another actor already did; only the final outcome matters.
 pub(in crate::it) async fn resolve_if_still_in_progress<P>(
     game: &IMultiProofGame::IMultiProofGameInstance<P>,
 ) -> eyre::Result<()>

--- a/e2e-tests/src/it/utils/mod.rs
+++ b/e2e-tests/src/it/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod devnet;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches devnet Docker topology and L1 proof-system activation (guardian-gated), which affects all full-stack devnet and withdrawal E2E paths; test-only surface area limits production blast radius.
> 
> **Overview**
> Adds **full-stack devnet E2E coverage** for WIP-1006 dispute games and pulls shared setup into `it::utils::devnet` so smoke, withdrawal, and new tests reuse the same HA devnet builder and on-chain wait helpers.
> 
> **New tests** drive the real in-process proposer/challenger/defender: bad-root challenge → `ChallengerWins`, proof-timeout and invalid-parent cascades, and honest claims surviving a griefing challenge (validity lane mocked where SP1/beacon wiring is missing).
> 
> **Devnet stack** changes put OP containers on a per-instance Docker network with stable names so op-node, op-conductor, batcher, proposer, and challenger talk over container DNS instead of `host.docker.internal` (fixes flaky Raft/consensus). After `DeployProofSystem`, a separate **`ActivateProofSystem`** forge step sets the ASR respected game type to WIP-1006 (moved out of deploy env). `SUPERCHAIN_GUARDIAN_PRIVATE_KEY` is exported for funded cross-chain E2E signers.
> 
> **CI/local runs**: nextest `devnet-stack` group limits one Docker devnet at a time and extends slow timeouts for `it::devnet_*` tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8de385a819adeb85cf10cbdfc8a698e4c18dd71b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



  ## New E2E test scenarios

  Four new devnet-level tests covering the WIP-1006 proof system's fault paths. They run the
  *real* in-process World Chain proposer / challenger / defender against a full local OP Stack,
  rather than mocking the services — so they exercise the same code that runs in production.

  These mirror the properties Optimism validates in `op-e2e/faultproofs`, adapted to WIP-1006's
  non-interactive, multi-lane-proof-or-timeout design. There is no bisection game, no Cannon FPVM,
  and no preimage oracle here, so those specific mechanics have no analog.

  ### `devnet_challenge.rs`

  **`bad_root_proposal_is_challenged_and_invalidated`** — the fault-injection counterpart to the
  existing `devnet_withdrawal` happy path. That test proves an honest root survives to finalization;
  this one proves a dishonest root does not survive challenge.

  A throwaway signer races the honest proposer to the first proposal window and posts a root that
  disagrees with consensus. Asserts:
  - the real challenger detects and contests it,
  - the real defender submits **no** proof lane for it — an honest defender must not accidentally
    rescue an invalid proposal (this is the key invariant),
  - the game resolves `ChallengerWins`,
  - the dishonest proposer's bond is not creditable back to them.

  ### `devnet_proof_invariants.rs`

  | Test | Property | op-e2e analog |
  |---|---|---|
  | `unproven_proposal_times_out_to_challenger_wins` | A proposal that never accumulates a valid proof cannot win merely by going unchallenged. Resolves `ChallengerWins` with `PROOF_TIMEOUT`. |
  `TestInvalidateUnsafeProposal` / `TestInvalidateProposalForFutureBlock` |
  | `invalid_parent_cascades_to_challenger_wins` | A game built on an already-invalidated parent resolves `ChallengerWins` via `INVALID_PARENT`, regardless of its own root claim or proof state. | *none — untested
  anywhere else in this repo* |
  | `valid_proposal_survives_adversarial_challenge` | A genuinely honest claim resolves `DefenderWins` even when maliciously challenged, once the proof threshold is reached. | `AttackWithCorrectTrace` /
  `DefendWithCorrectTrace` |

  Two notes on what these demonstrate:

  - **`unproven_proposal_times_out…`** shows WIP-1006 needs *less* machinery than Optimism here.
    `MultiProofGame.resolve()` treats `Unchallenged` and `Challenged` identically once the deadline
    passes with `proofBitmap == 0`, so a proofless proposal always loses whether or not anyone
    formally challenged it. Optimism needs a special-cased honest-actor strategy for this case.
  - **`invalid_parent_cascades…`** targets the dynamic check inside `resolve()`, not the creation-time
    `_isValidParent` check. The child is deliberately created while the parent still looks healthy,
    then the parent is invalidated — the realistic ordering a chain would actually see.

  ### Known limitation

  `valid_proposal_survives_adversarial_challenge` does **not** route through the in-process SP1
  worker. That worker's `OnlineHostConfig` unconditionally requires a real beacon-API endpoint
  (kona's `OnlineBlobProvider` calls `/eth/v1/config/spec` at startup) even though this devnet's
  batcher runs `--data-availability-type calldata` and never touches blobs. Anvil has no
  consensus-layer component to serve that endpoint, so the worker panics before it can produce a
  validity proof. **This is a real gap in how the worker is wired up**, tracked separately.

  The test instead submits the validity-proof lane directly on the game contract. This is still a
  faithful exercise of the invariant: `submitProofLane()` builds `TransitionPublicValues` from the
  game's own on-chain state, and the devnet only ever deploys `MockRootIdVerifier(acceptAny=true)`
  for every lane — the same mechanism `DevnetNitroBackend::handle_claimed_job` already relies on.
  The real defender still supplies the TEE lane; the test supplies the validity lane, so together
  they reach `PROOF_THRESHOLD` without real or mock SP1 proving.