### PR TITLE
Add SP1 max price per PGU option

### DIFF
--- a/docs/proof/sp1-worker.md
+++ b/docs/proof/sp1-worker.md
@@ -48,10 +48,17 @@ the range and aggregation guests:
 | `SP1_RANGE_GAS_LIMIT` | `--sp1-range-gas-limit` | `1300000000000` PGUs |
 | `SP1_AGGREGATION_CYCLE_LIMIT` | `--sp1-aggregation-cycle-limit` | `7000000` |
 | `SP1_AGGREGATION_GAS_LIMIT` | `--sp1-aggregation-gas-limit` | `6500000` PGUs |
+| `SP1_MAX_PRICE_PER_PGU` | `--sp1-max-price-per-pgu` | SP1 Network default |
 
-These are safety ceilings, not requested billing amounts. To execute each guest locally and let the
-SP1 SDK estimate both limits instead, set `SP1_ESTIMATE_LIMITS=true` or pass
-`--sp1-estimate-limits`. Local estimation conflicts with explicitly configured limit flags.
+These are execution safety ceilings, not the final auction charge. The gas limit still affects the
+request's worst-case authorization and balance check because the network multiplies it by the
+maximum price per PGU. To execute each guest locally and let the SP1 SDK estimate both limits
+instead, set `SP1_ESTIMATE_LIMITS=true` or pass `--sp1-estimate-limits`. Local estimation conflicts
+with explicitly configured limit flags.
+
+`SP1_MAX_PRICE_PER_PGU` caps the auction price encoded in each range and aggregation request. The
+value uses PROVE base units (18 decimals) per PGU. For example, `50000000` is `0.05 PROVE/bPGU`.
+When omitted, the SP1 SDK uses the maximum price returned by the Succinct Network RPC.
 
 ## Deposit PROVE
 

--- a/proofs/backends/sp1/host/src/network_prover.rs
+++ b/proofs/backends/sp1/host/src/network_prover.rs
@@ -142,17 +142,7 @@ impl NetworkSuccinctProver {
         agg_mode: SP1ProofMode,
         connection: NetworkConnection,
     ) -> anyhow::Result<Self> {
-        Self::from_connection_with_limits(agg_mode, connection, None).await
-    }
-
-    /// Creates the prover with optional explicit execution limits. Supplying limits skips SP1's
-    /// local guest execution before each network request.
-    pub async fn from_connection_with_limits(
-        agg_mode: SP1ProofMode,
-        connection: NetworkConnection,
-        limits: Option<NetworkProverLimits>,
-    ) -> anyhow::Result<Self> {
-        Self::from_connection_with_request_config(agg_mode, connection, limits, None).await
+        Self::from_connection_with_request_config(agg_mode, connection, None, None).await
     }
 
     /// Creates the prover with optional execution limits and auction price ceiling.

--- a/proofs/backends/sp1/host/src/network_prover.rs
+++ b/proofs/backends/sp1/host/src/network_prover.rs
@@ -28,6 +28,7 @@ pub struct NetworkSuccinctProver {
     multi_block_vkey: [u32; 8],
     agg_mode: SP1ProofMode,
     limits: Option<NetworkProverLimits>,
+    max_price_per_pgu: Option<u64>,
 }
 
 /// Upper bounds supplied to SP1 Network instead of estimating them by executing guests locally.
@@ -151,6 +152,16 @@ impl NetworkSuccinctProver {
         connection: NetworkConnection,
         limits: Option<NetworkProverLimits>,
     ) -> anyhow::Result<Self> {
+        Self::from_connection_with_request_config(agg_mode, connection, limits, None).await
+    }
+
+    /// Creates the prover with optional execution limits and auction price ceiling.
+    pub async fn from_connection_with_request_config(
+        agg_mode: SP1ProofMode,
+        connection: NetworkConnection,
+        limits: Option<NetworkProverLimits>,
+        max_price_per_pgu: Option<u64>,
+    ) -> anyhow::Result<Self> {
         let range_elf = world_chain_proof_sp1_elfs::range_elf();
         let agg_elf = world_chain_proof_sp1_elfs::aggregation_elf();
         let client =
@@ -172,6 +183,7 @@ impl NetworkSuccinctProver {
             multi_block_vkey,
             agg_mode,
             limits,
+            max_price_per_pgu,
         })
     }
 
@@ -185,6 +197,9 @@ impl NetworkSuccinctProver {
                 .cycle_limit(limits.range.cycle_limit)
                 .gas_limit(limits.range.gas_limit)
                 .skip_simulation(true);
+        }
+        if let Some(max_price_per_pgu) = self.max_price_per_pgu {
+            proof_request = proof_request.max_price_per_pgu(max_price_per_pgu);
         }
 
         let backend_session_id = proof_request
@@ -218,6 +233,9 @@ impl NetworkSuccinctProver {
                 .cycle_limit(limits.aggregation.cycle_limit)
                 .gas_limit(limits.aggregation.gas_limit)
                 .skip_simulation(true);
+        }
+        if let Some(max_price_per_pgu) = self.max_price_per_pgu {
+            proof_request = proof_request.max_price_per_pgu(max_price_per_pgu);
         }
 
         let backend_session_id = proof_request

--- a/proofs/workers/sp1/src/cmd/run.rs
+++ b/proofs/workers/sp1/src/cmd/run.rs
@@ -186,6 +186,14 @@ pub struct WorkerArgs {
     )]
     sp1_aggregation_gas_limit: u64,
 
+    /// Maximum auction price in PROVE base units per PGU. Uses the SP1 Network default if omitted.
+    #[arg(
+        long,
+        env = "SP1_MAX_PRICE_PER_PGU",
+        value_parser = clap::value_parser!(u64).range(1..)
+    )]
+    sp1_max_price_per_pgu: Option<u64>,
+
     /// Maximum number of jobs proved concurrently. One suits a local CPU prover; raise it for
     /// the Succinct proving network.
     #[arg(long, default_value_t = 1)]
@@ -312,10 +320,11 @@ pub async fn run(cli: WorkerArgs) -> Result<()> {
             run_worker(
                 &cli,
                 host,
-                NetworkSuccinctProver::from_connection_with_limits(
+                NetworkSuccinctProver::from_connection_with_request_config(
                     SP1ProofMode::Groth16,
                     connection,
                     limits,
+                    cli.sp1_max_price_per_pgu,
                 )
                 .await?,
             )
@@ -464,6 +473,7 @@ where
         sp1_range_gas_limit = cli.sp1_range_gas_limit,
         sp1_aggregation_cycle_limit = cli.sp1_aggregation_cycle_limit,
         sp1_aggregation_gas_limit = cli.sp1_aggregation_gas_limit,
+        sp1_max_price_per_pgu = ?cli.sp1_max_price_per_pgu,
         submit_proof_retry_max_retries = cli.submit_proof_retry_max_retries,
         submit_proof_retry_initial_delay_ms = cli.submit_proof_retry_initial_delay_ms,
         submit_proof_retry_max_delay_ms = cli.submit_proof_retry_max_delay_ms,
@@ -519,6 +529,7 @@ mod tests {
             cli.sp1_aggregation_gas_limit,
             DEFAULT_SP1_AGGREGATION_GAS_LIMIT
         );
+        assert_eq!(cli.sp1_max_price_per_pgu, None);
     }
 
     #[test]
@@ -540,6 +551,27 @@ mod tests {
         let cli = WorkerArgs::parse_from(args);
 
         assert!(cli.sp1_estimate_limits);
+    }
+
+    #[test]
+    fn parses_sp1_max_price_per_pgu() {
+        let mut args = base_args();
+        args.extend(["--sp1-max-price-per-pgu", "50000000"]);
+
+        let cli = WorkerArgs::parse_from(args);
+
+        assert_eq!(cli.sp1_max_price_per_pgu, Some(50_000_000));
+    }
+
+    #[test]
+    fn rejects_zero_sp1_max_price_per_pgu() {
+        let mut args = base_args();
+        args.extend(["--sp1-max-price-per-pgu", "0"]);
+
+        let error = WorkerArgs::try_parse_from(args)
+            .expect_err("zero max price per PGU should be rejected");
+
+        assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- add `--sp1-max-price-per-pgu` / `SP1_MAX_PRICE_PER_PGU`
- apply the configured ceiling to both range and aggregation network requests
- retain the SP1 Network-provided maximum when the option is omitted
- document the price units and authorization behavior

## Why

Fixed gas ceilings are multiplied by the request's maximum price per PGU for the network authorization and balance check. An explicit price ceiling keeps that authorization bounded without reducing the execution limits needed for load testing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, opt-in configuration on network proof submission and CLI parsing; no auth or on-chain verification changes.
> 
> **Overview**
> Adds **`--sp1-max-price-per-pgu` / `SP1_MAX_PRICE_PER_PGU`** so operators can cap the auction price on SP1 Network range and aggregation requests without lowering cycle/gas ceilings.
> 
> The network prover stores an optional ceiling and calls the SP1 SDK’s **`max_price_per_pgu`** on both proof paths when set; omitting it keeps the Succinct Network RPC default. Worker startup wires the flag through **`from_connection_with_request_config`** (with **`from_connection_with_limits`** delegating to it).
> 
> Docs clarify that **gas limits × max price per PGU** drive worst-case authorization/balance checks, and document PROVE base units per PGU (e.g. `50000000` → 0.05 PROVE/bPGU).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a36e2d9e9f013e0f580af4905ac41109b81873b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->