### PR TITLE
feat (proofs): automatic cancel + retries on auction timeout of SP1 proofs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15271,9 +15271,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "6.1.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7321136acefff985b0fb201b84359d609451bbd0a63203d4b601eaabe28da14f"
+checksum = "b86f0b3b6f39976825b472e2967e212b4e36f6dc395c74076b25b2ed52c605dd"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -15764,9 +15764,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "6.1.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349ca86c7a88456c9f0fa1c8869e0d35bb63d6c811dc9ad8337c90909ce532ec"
+checksum = "ac474619d83bd48d3bec8ffea7e620c6f490223a399f3ff8ad4826c146c25bef"
 dependencies = [
  "alloy-primitives",
  "alloy-signer 1.8.3",

--- a/Dockerfile.prover
+++ b/Dockerfile.prover
@@ -29,7 +29,7 @@ ENV CARGO_HOME=/usr/local/cargo \
 # Canonical SP1 guest builder. This is the same linux/amd64 image and `/root/program`
 # workspace layout used by sp1-build's reproducible Docker mode. The digest is the
 # governance boundary: changing it intentionally rotates the ELF hashes and vkeys.
-FROM --platform=${SP1_GUEST_PLATFORM} ghcr.io/succinctlabs/sp1:v6.1.0@sha256:c90d0a816ca40357346e8ad5b53178bc8f4b3fc2b8dd6bfc061f60d92cb61953 AS sp1-guests
+FROM --platform=${SP1_GUEST_PLATFORM} ghcr.io/succinctlabs/sp1:v6.3.1@sha256:7c1c8201de6f63e3f1fb9075bd9a67a4c5fc8c2d546d11a5ff71587bb51e6eb3 AS sp1-guests
 WORKDIR /root/program
 
 COPY . .

--- a/Justfile
+++ b/Justfile
@@ -110,7 +110,7 @@ proof-vkeys *args='':
     cargo run --release -p world-chain-prover-sp1 -- vkeys $@
 
 # Recompute vkeys from the embedded ELFs and update proofs/backends/sp1/elfs/vkeys.json.
-# Requires Docker and the SP1 toolchain (sp1up v6.1.0) for reproducible ELF builds.
+# Requires Docker and the SP1 toolchain (sp1up v6.3.1) for reproducible ELF builds.
 update-proof-vkeys:
     cargo run -p world-chain-prover-sp1 -- vkeys --output /tmp/vkeys-update.json
     jq -S . /tmp/vkeys-update.json > proofs/backends/sp1/elfs/vkeys.json

--- a/docs/proof/elf-management.md
+++ b/docs/proof/elf-management.md
@@ -35,7 +35,7 @@ embedded bytes (`just proof-vkeys`), which is pinned in the `MultiProofGame` imp
 
 ## Reproducibility
 
-`sp1_build::build_program_with_args` uses Docker by default with the SP1 v6.1.0 linux/amd64
+`sp1_build::build_program_with_args` uses Docker by default with the SP1 v6.3.1 linux/amd64
 image pinned by digest. A `cargo build -p world-chain-prover-sp1` from a clean checkout therefore
 produces bit-for-bit identical ELFs and vkeys regardless of host toolchain.
 
@@ -62,15 +62,15 @@ cargo build -p world-chain-proof-sp1-worker   # likewise
 just proof-vkeys                         # prints the on-chain vkey commitments
 ```
 
-The first build runs each guest build inside the digest-pinned SP1 v6.1.0 image (a few minutes).
+The first build runs each guest build inside the digest-pinned SP1 v6.3.1 image (a few minutes).
 Subsequent builds reuse the cached ELFs unless the guest source or SP1 image reference changes —
 `sp1-build` calls `cargo:rerun-if-changed` on every dependency of the program
 crate, so any meaningful source edit invalidates the cache.
 
 Requirements:
 
-- Docker (default reproducibility mode pulls the digest-pinned `succinctlabs/sp1:v6.1.0`), or
-- The SP1 toolchain on `PATH` (`curl -L https://sp1.succinct.xyz | bash && sp1up --version v6.1.0`)
+- Docker (default reproducibility mode pulls the digest-pinned `succinctlabs/sp1:v6.3.1`), or
+- The SP1 toolchain on `PATH` (`curl -L https://sp1.succinct.xyz | bash && sp1up --version v6.3.1`)
   with `SP1_BUILD_DOCKER=false` for non-production iteration only.
 
 Build the production worker with its dedicated target:

--- a/docs/proof/sp1-worker.md
+++ b/docs/proof/sp1-worker.md
@@ -60,7 +60,8 @@ with explicitly configured limit flags.
 
 `SP1_MAX_PRICE_PER_PGU` caps the auction price encoded in each range and aggregation request. The
 value uses PROVE base units (18 decimals) per PGU. For example, `50000000` is `0.05 PROVE/bPGU`.
-When omitted, the SP1 SDK uses the maximum price returned by the Succinct Network RPC.
+When omitted, the SP1 SDK applies its default 20% buffer to the market-based maximum price
+returned by the Succinct Network RPC.
 
 The auction timeout limits how long a request may remain unassigned. The proof timeout sets the
 request's overall network deadline and may be longer than four hours when configured explicitly;

--- a/docs/proof/sp1-worker.md
+++ b/docs/proof/sp1-worker.md
@@ -37,7 +37,7 @@ does not interrupt in-flight work.
 `NETWORK_RPC_URL` remains the optional override for the SP1 Network API itself. It is distinct from
 `SP1_NETWORK_L1_RPC_URL`.
 
-### SP1 Network execution limits
+### SP1 Network request configuration
 
 Network requests skip local guest execution by default and submit with separate upper bounds for
 the range and aggregation guests:
@@ -49,6 +49,8 @@ the range and aggregation guests:
 | `SP1_AGGREGATION_CYCLE_LIMIT` | `--sp1-aggregation-cycle-limit` | `7000000` |
 | `SP1_AGGREGATION_GAS_LIMIT` | `--sp1-aggregation-gas-limit` | `6500000` PGUs |
 | `SP1_MAX_PRICE_PER_PGU` | `--sp1-max-price-per-pgu` | SP1 Network default |
+| `SP1_AUCTION_TIMEOUT_SECONDS` | `--sp1-auction-timeout-seconds` | SP1 SDK default (30 seconds) |
+| `SP1_PROOF_TIMEOUT_SECONDS` | `--sp1-proof-timeout-seconds` | SP1 SDK derived deadline |
 
 These are execution safety ceilings, not the final auction charge. The gas limit still affects the
 request's worst-case authorization and balance check because the network multiplies it by the
@@ -59,6 +61,15 @@ with explicitly configured limit flags.
 `SP1_MAX_PRICE_PER_PGU` caps the auction price encoded in each range and aggregation request. The
 value uses PROVE base units (18 decimals) per PGU. For example, `50000000` is `0.05 PROVE/bPGU`.
 When omitted, the SP1 SDK uses the maximum price returned by the Succinct Network RPC.
+
+The auction timeout limits how long a request may remain unassigned. The proof timeout sets the
+request's overall network deadline and may be longer than four hours when configured explicitly;
+when omitted, the SDK derives a deadline from the gas limit and caps it at four hours.
+
+If either phase times out, the worker marks that request failed and resubmits after one, two, and
+five minutes. This three-resubmission budget applies to one worker attempt. The prover service
+separately bounds complete worker attempts, so a restarted or expired lease cannot retry forever.
+Completed range proofs are reused when only aggregation needs to be retried.
 
 ## Deposit PROVE
 

--- a/proofs/backends/sp1/elfs/Cargo.toml
+++ b/proofs/backends/sp1/elfs/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 build = "build.rs"
 
 [build-dependencies]
-sp1-build = "=6.1.0"
+sp1-build = "=6.3.1"
 
 [dependencies]
-sp1-sdk = { version = "=6.1.0", features = ["network"] }
+sp1-sdk = { version = "=6.3.1", features = ["network"] }

--- a/proofs/backends/sp1/elfs/build.rs
+++ b/proofs/backends/sp1/elfs/build.rs
@@ -9,8 +9,8 @@
 //!
 //! Behaviour:
 //! - Uses `docker: true` by default with the pinned SP1 toolchain image
-//!   (matches the `=6.1.0` version of `sp1-sdk` / `sp1-zkvm` the workspace
-//!   pins to) for bit-for-bit reproducible ELFs. This is the ecosystem
+//!   (matches the `=6.3.1` version of `sp1-zkvm` the guest workspace pins to)
+//!   for bit-for-bit reproducible ELFs. This is the ecosystem
 //!   standard used by op-succinct, sp1-helios, and all other SP1 adopters.
 //!   Docker provides reproducibility by fixing the build environment path
 //!   layout inside the container.
@@ -96,7 +96,7 @@ fn main() {
                 // reference for readability, while the digest prevents a mutable tag from
                 // silently rotating the guest ELFs and their on-chain vkeys.
                 tag:
-                    "v6.1.0@sha256:c90d0a816ca40357346e8ad5b53178bc8f4b3fc2b8dd6bfc061f60d92cb61953"
+                    "v6.3.1@sha256:7c1c8201de6f63e3f1fb9075bd9a67a4c5fc8c2d546d11a5ff71587bb51e6eb3"
                         .to_string(),
                 ignore_rust_version: true,
                 locked: true,

--- a/proofs/backends/sp1/elfs/vkeys.json
+++ b/proofs/backends/sp1/elfs/vkeys.json
@@ -1,12 +1,12 @@
 {
-  "aggregation_vkey": "0x0042f631d3c97e500164f9a739196ffe3d8b478aac1e976ffec2980c88e1143c",
+  "aggregation_vkey": "0x004d15ae5aedd4ec4fec8102118493fe024110c82762229a04868700603a5aff",
   "elfs": {
     "world-chain-aggregation": {
-      "sha256": "6226e0dca04c3da08f210f5369a4eae867757f47d073cdb2604611321beef6ff"
+      "sha256": "510206ff7f3700931989355f8e27c1ee8674f3fdc293d77cc404cadfea293512"
     },
     "world-chain-range-ethereum": {
-      "sha256": "ebf8cee5404353f09aed03d456d0d378d965e72b29ef9562af9a083fa1253506"
+      "sha256": "2c0d49fd69a201f761ea3f27813056def37c47afe2d42ea297ac2a55623e15a2"
     }
   },
-  "range_vkey_commitment": "0x47436363223a0b000f27d1062acf07ca769733725adea5292e02aede0c4d0431"
+  "range_vkey_commitment": "0x4082e07347e801d82c3e8fb252fe6f734d48af3a18c6d36b0646caa060291f6e"
 }

--- a/proofs/backends/sp1/guest-builder/Cargo.toml
+++ b/proofs/backends/sp1/guest-builder/Cargo.toml
@@ -10,4 +10,4 @@ publish = false
 
 [dependencies]
 anyhow.workspace = true
-sp1-build = "=6.1.0"
+sp1-build = "=6.3.1"

--- a/proofs/backends/sp1/host/Cargo.toml
+++ b/proofs/backends/sp1/host/Cargo.toml
@@ -36,6 +36,6 @@ alloy-sol-types = { workspace = true, optional = true }
 bincode = { version = "1", optional = true }
 hex = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
-sp1-sdk = { version = "=6.1.0", features = ["network"], optional = true }
+sp1-sdk = { version = "=6.3.1", features = ["network"], optional = true }
 async-trait.workspace = true
 world-chain-prover-service.workspace = true

--- a/proofs/backends/sp1/host/src/cpu_prover.rs
+++ b/proofs/backends/sp1/host/src/cpu_prover.rs
@@ -17,9 +17,7 @@ use std::{
     },
 };
 use world_chain_proof_core::types::AggregationInputs;
-use world_chain_proof_sp1_types::{
-    AggregationProofRequest, RangeProofRequest, Sp1ProofRequest, Sp1SessionStatus,
-};
+use world_chain_proof_sp1_types::{AggregationProofRequest, RangeProofRequest, Sp1ProofRequest};
 
 /// [`WorldSuccinctProver`] CPU-local implementation over the sp1-sdk local prover.
 pub struct CpuSuccinctProver {
@@ -149,20 +147,7 @@ impl WorldSuccinctProver for CpuSuccinctProver {
         Ok(session_id)
     }
 
-    async fn poll(&self, session_id: &str) -> anyhow::Result<Sp1SessionStatus> {
-        let proofs = self
-            .proofs
-            .lock()
-            .map_err(|_| anyhow::anyhow!("mutex lock poisoned"))?;
-        if proofs.contains_key(session_id) {
-            // CPU prover immediately returns completed status if the entry exists in the hashmap.
-            Ok(Sp1SessionStatus::Completed)
-        } else {
-            Ok(Sp1SessionStatus::NotFound)
-        }
-    }
-
-    async fn download(&self, session_id: &str) -> anyhow::Result<SP1ProofWithPublicValues> {
+    async fn wait(&self, session_id: &str) -> anyhow::Result<SP1ProofWithPublicValues> {
         let proofs = self
             .proofs
             .lock()

--- a/proofs/backends/sp1/host/src/cpu_prover.rs
+++ b/proofs/backends/sp1/host/src/cpu_prover.rs
@@ -115,10 +115,6 @@ impl CpuSuccinctProver {
 
 #[async_trait]
 impl WorldSuccinctProver for CpuSuccinctProver {
-    fn supports_persistent_sessions(&self) -> bool {
-        false
-    }
-
     async fn submit(&self, request: Sp1ProofRequest) -> anyhow::Result<String> {
         let (prefix, proof) = match request {
             Sp1ProofRequest::Range(range_request) => {

--- a/proofs/backends/sp1/host/src/lib.rs
+++ b/proofs/backends/sp1/host/src/lib.rs
@@ -8,9 +8,7 @@ use anyhow::Context;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "sp1")]
-use sp1_sdk::SP1Proof;
-#[cfg(feature = "sp1")]
-pub use sp1_sdk::SP1ProofWithPublicValues;
+use sp1_sdk::{SP1Proof, SP1ProofWithPublicValues};
 use strum::EnumString;
 #[cfg(feature = "sp1")]
 use world_chain_proof_core::{

--- a/proofs/backends/sp1/host/src/lib.rs
+++ b/proofs/backends/sp1/host/src/lib.rs
@@ -1,6 +1,6 @@
 //! Host-side helpers for preparing World Chain OP Succinct Lite proof requests.
 
-use std::{fmt, time::Duration};
+use std::fmt;
 
 #[cfg(feature = "sp1")]
 use anyhow::Context;
@@ -85,35 +85,8 @@ pub trait WorldSuccinctProver {
         request: world_chain_proof_sp1_types::Sp1ProofRequest,
     ) -> anyhow::Result<String>;
 
-    async fn poll(
-        &self,
-        session_id: &str,
-    ) -> anyhow::Result<world_chain_proof_sp1_types::Sp1SessionStatus>;
-
-    async fn download(&self, session_id: &str) -> anyhow::Result<SP1ProofWithPublicValues>;
-
     /// Waits for a submitted session and returns its proof.
-    ///
-    /// Network provers override this to use the SDK's auction cancellation and request-deadline
-    /// handling. Local provers use the generic poll-and-download loop.
-    async fn wait(&self, session_id: &str) -> anyhow::Result<SP1ProofWithPublicValues> {
-        loop {
-            match self.poll(session_id).await? {
-                world_chain_proof_sp1_types::Sp1SessionStatus::Running => {
-                    tokio::time::sleep(Duration::from_secs(10)).await;
-                }
-                world_chain_proof_sp1_types::Sp1SessionStatus::Completed => {
-                    return self.download(session_id).await;
-                }
-                world_chain_proof_sp1_types::Sp1SessionStatus::Failed(reason) => {
-                    anyhow::bail!("proof session {session_id} failed: {reason}");
-                }
-                world_chain_proof_sp1_types::Sp1SessionStatus::NotFound => {
-                    anyhow::bail!("proof session {session_id} was not found");
-                }
-            }
-        }
-    }
+    async fn wait(&self, session_id: &str) -> anyhow::Result<SP1ProofWithPublicValues>;
 }
 
 /// Converts a raw compressed SP1 range proof into the artifact consumed by aggregation.

--- a/proofs/backends/sp1/host/src/lib.rs
+++ b/proofs/backends/sp1/host/src/lib.rs
@@ -1,6 +1,6 @@
 //! Host-side helpers for preparing World Chain OP Succinct Lite proof requests.
 
-use std::fmt;
+use std::{fmt, time::Duration};
 
 #[cfg(feature = "sp1")]
 use anyhow::Context;
@@ -8,7 +8,9 @@ use anyhow::Context;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "sp1")]
-use sp1_sdk::{SP1Proof, SP1ProofWithPublicValues};
+use sp1_sdk::SP1Proof;
+#[cfg(feature = "sp1")]
+pub use sp1_sdk::SP1ProofWithPublicValues;
 use strum::EnumString;
 #[cfg(feature = "sp1")]
 use world_chain_proof_core::{
@@ -35,6 +37,43 @@ pub enum SuccinctProverError {
     /// Aggregation requires compressed range proofs for recursive verification.
     #[error("range proof was not in compressed mode")]
     NotCompressed,
+
+    /// The network request expired before a prover accepted it.
+    #[error("SP1 Network request {session_id} timed out during the auction")]
+    RequestAuctionTimedOut { session_id: String },
+
+    /// The network request exceeded its proof-generation deadline.
+    #[error("SP1 Network request {session_id} timed out")]
+    RequestTimedOut { session_id: String },
+
+    /// The network determined that the request cannot be executed.
+    #[error("SP1 Network request {session_id} is unexecutable")]
+    RequestUnexecutable { session_id: String },
+
+    /// The network determined that the request cannot be fulfilled.
+    #[error("SP1 Network request {session_id} is unfulfillable")]
+    RequestUnfulfillable { session_id: String },
+}
+
+impl SuccinctProverError {
+    /// Whether a fresh SP1 Network request may recover from this terminal session failure.
+    pub const fn should_resubmit(&self) -> bool {
+        matches!(
+            self,
+            Self::RequestAuctionTimedOut { .. } | Self::RequestTimedOut { .. }
+        )
+    }
+
+    /// Whether the external proving session has reached a terminal state.
+    pub const fn is_terminal_session(&self) -> bool {
+        matches!(
+            self,
+            Self::RequestAuctionTimedOut { .. }
+                | Self::RequestTimedOut { .. }
+                | Self::RequestUnexecutable { .. }
+                | Self::RequestUnfulfillable { .. }
+        )
+    }
 }
 
 /// Interface expected from a concrete SP1 prover backend.
@@ -54,6 +93,29 @@ pub trait WorldSuccinctProver {
     ) -> anyhow::Result<world_chain_proof_sp1_types::Sp1SessionStatus>;
 
     async fn download(&self, session_id: &str) -> anyhow::Result<SP1ProofWithPublicValues>;
+
+    /// Waits for a submitted session and returns its proof.
+    ///
+    /// Network provers override this to use the SDK's auction cancellation and request-deadline
+    /// handling. Local provers use the generic poll-and-download loop.
+    async fn wait(&self, session_id: &str) -> anyhow::Result<SP1ProofWithPublicValues> {
+        loop {
+            match self.poll(session_id).await? {
+                world_chain_proof_sp1_types::Sp1SessionStatus::Running => {
+                    tokio::time::sleep(Duration::from_secs(10)).await;
+                }
+                world_chain_proof_sp1_types::Sp1SessionStatus::Completed => {
+                    return self.download(session_id).await;
+                }
+                world_chain_proof_sp1_types::Sp1SessionStatus::Failed(reason) => {
+                    anyhow::bail!("proof session {session_id} failed: {reason}");
+                }
+                world_chain_proof_sp1_types::Sp1SessionStatus::NotFound => {
+                    anyhow::bail!("proof session {session_id} was not found");
+                }
+            }
+        }
+    }
 }
 
 /// Converts a raw compressed SP1 range proof into the artifact consumed by aggregation.
@@ -127,5 +189,40 @@ impl Sp1ProverKind {
 impl fmt::Display for Sp1ProverKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
+    }
+}
+
+#[cfg(all(test, feature = "sp1"))]
+mod tests {
+    use super::SuccinctProverError;
+
+    #[test]
+    fn only_network_timeouts_are_resubmitted() {
+        for error in [
+            SuccinctProverError::RequestAuctionTimedOut {
+                session_id: "auction".to_string(),
+            },
+            SuccinctProverError::RequestTimedOut {
+                session_id: "proof".to_string(),
+            },
+        ] {
+            assert!(error.is_terminal_session());
+            assert!(error.should_resubmit());
+        }
+
+        for error in [
+            SuccinctProverError::RequestUnexecutable {
+                session_id: "unexecutable".to_string(),
+            },
+            SuccinctProverError::RequestUnfulfillable {
+                session_id: "unfulfillable".to_string(),
+            },
+        ] {
+            assert!(error.is_terminal_session());
+            assert!(!error.should_resubmit());
+        }
+
+        assert!(!SuccinctProverError::NotCompressed.is_terminal_session());
+        assert!(!SuccinctProverError::NotCompressed.should_resubmit());
     }
 }

--- a/proofs/backends/sp1/host/src/lib.rs
+++ b/proofs/backends/sp1/host/src/lib.rs
@@ -78,7 +78,9 @@ impl SuccinctProverError {
 #[cfg(feature = "sp1")]
 #[async_trait]
 pub trait WorldSuccinctProver {
-    fn supports_persistent_sessions(&self) -> bool;
+    fn supports_persistent_sessions(&self) -> bool {
+        false
+    }
 
     async fn submit(
         &self,

--- a/proofs/backends/sp1/host/src/mock_prover.rs
+++ b/proofs/backends/sp1/host/src/mock_prover.rs
@@ -116,10 +116,6 @@ impl MockSuccinctProver {
 
 #[async_trait]
 impl WorldSuccinctProver for MockSuccinctProver {
-    fn supports_persistent_sessions(&self) -> bool {
-        false
-    }
-
     async fn submit(&self, request: Sp1ProofRequest) -> anyhow::Result<String> {
         let (prefix, proof) = match request {
             Sp1ProofRequest::Range(range_request) => {

--- a/proofs/backends/sp1/host/src/mock_prover.rs
+++ b/proofs/backends/sp1/host/src/mock_prover.rs
@@ -16,9 +16,7 @@ use std::{
     },
 };
 use world_chain_proof_core::types::AggregationInputs;
-use world_chain_proof_sp1_types::{
-    AggregationProofRequest, RangeProofRequest, Sp1ProofRequest, Sp1SessionStatus,
-};
+use world_chain_proof_sp1_types::{AggregationProofRequest, RangeProofRequest, Sp1ProofRequest};
 
 /// [`WorldSuccinctProver`] mock implementation over the sp1-sdk mock prover.
 pub struct MockSuccinctProver {
@@ -150,20 +148,7 @@ impl WorldSuccinctProver for MockSuccinctProver {
         Ok(session_id)
     }
 
-    async fn poll(&self, session_id: &str) -> anyhow::Result<Sp1SessionStatus> {
-        let proofs = self
-            .proofs
-            .lock()
-            .map_err(|_| anyhow::anyhow!("mutex lock poisoned"))?;
-        if proofs.contains_key(session_id) {
-            // Mock prover immediately returns completed status if the entry exists in the hashmap.
-            Ok(Sp1SessionStatus::Completed)
-        } else {
-            Ok(Sp1SessionStatus::NotFound)
-        }
-    }
-
-    async fn download(&self, session_id: &str) -> anyhow::Result<SP1ProofWithPublicValues> {
+    async fn wait(&self, session_id: &str) -> anyhow::Result<SP1ProofWithPublicValues> {
         let proofs = self
             .proofs
             .lock()

--- a/proofs/backends/sp1/host/src/network_prover.rs
+++ b/proofs/backends/sp1/host/src/network_prover.rs
@@ -1,6 +1,8 @@
 //! Range proofs are produced in `Compressed` mode so the aggregation guest can recursively
 //! verify them; the aggregation proof mode is configurable (Groth16 for on-chain verification).
 
+use std::time::Duration;
+
 use crate::{SuccinctProverError, WorldSuccinctProver};
 use alloy_primitives::{B256, U256};
 use anyhow::{Context, bail};
@@ -10,7 +12,7 @@ use sp1_sdk::{
     HashableKey, NetworkProver, ProveRequest, Prover, ProvingKey, SP1Proof,
     SP1ProofWithPublicValues, SP1ProvingKey, SP1Stdin,
     network::{
-        NetworkClient, NetworkMode, get_default_rpc_url_for_mode,
+        Error as NetworkError, NetworkClient, NetworkMode, get_default_rpc_url_for_mode,
         proto::{GetProofRequestStatusResponse, types::FulfillmentStatus},
         signer::NetworkSigner,
     },
@@ -29,6 +31,8 @@ pub struct NetworkSuccinctProver {
     agg_mode: SP1ProofMode,
     limits: Option<NetworkProverLimits>,
     max_price_per_pgu: Option<u64>,
+    auction_timeout: Option<Duration>,
+    proof_timeout: Option<Duration>,
 }
 
 /// Upper bounds supplied to SP1 Network instead of estimating them by executing guests locally.
@@ -47,6 +51,19 @@ pub struct NetworkProverLimits {
     pub range: ProofLimits,
     /// Limits for the aggregation guest.
     pub aggregation: ProofLimits,
+}
+
+/// Optional request settings forwarded to the SP1 Network SDK.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct NetworkProofRequestConfig {
+    /// Guest execution limits. When absent, the SDK estimates them locally.
+    pub limits: Option<NetworkProverLimits>,
+    /// Maximum auction price in PROVE base units per PGU.
+    pub max_price_per_pgu: Option<u64>,
+    /// Maximum time a request may remain unassigned. The SDK default applies when absent.
+    pub auction_timeout: Option<Duration>,
+    /// Overall proof-generation deadline. The SDK-derived default applies when absent.
+    pub proof_timeout: Option<Duration>,
 }
 
 /// Lightweight client for reading an account's SP1 Network credit balance.
@@ -142,16 +159,26 @@ impl NetworkSuccinctProver {
         agg_mode: SP1ProofMode,
         connection: NetworkConnection,
     ) -> anyhow::Result<Self> {
-        Self::from_connection_with_request_config(agg_mode, connection, None, None).await
+        Self::from_connection_with_network_config(
+            agg_mode,
+            connection,
+            NetworkProofRequestConfig::default(),
+        )
+        .await
     }
 
-    /// Creates the prover with optional execution limits and auction price ceiling.
-    pub async fn from_connection_with_request_config(
+    /// Creates the prover with optional SP1 Network request settings.
+    pub async fn from_connection_with_network_config(
         agg_mode: SP1ProofMode,
         connection: NetworkConnection,
-        limits: Option<NetworkProverLimits>,
-        max_price_per_pgu: Option<u64>,
+        request_config: NetworkProofRequestConfig,
     ) -> anyhow::Result<Self> {
+        let NetworkProofRequestConfig {
+            limits,
+            max_price_per_pgu,
+            auction_timeout,
+            proof_timeout,
+        } = request_config;
         let range_elf = world_chain_proof_sp1_elfs::range_elf();
         let agg_elf = world_chain_proof_sp1_elfs::aggregation_elf();
         let client =
@@ -174,6 +201,8 @@ impl NetworkSuccinctProver {
             agg_mode,
             limits,
             max_price_per_pgu,
+            auction_timeout,
+            proof_timeout,
         })
     }
 
@@ -190,6 +219,9 @@ impl NetworkSuccinctProver {
         }
         if let Some(max_price_per_pgu) = self.max_price_per_pgu {
             proof_request = proof_request.max_price_per_pgu(max_price_per_pgu);
+        }
+        if let Some(proof_timeout) = self.proof_timeout {
+            proof_request = proof_request.timeout(proof_timeout);
         }
 
         let backend_session_id = proof_request
@@ -226,6 +258,9 @@ impl NetworkSuccinctProver {
         }
         if let Some(max_price_per_pgu) = self.max_price_per_pgu {
             proof_request = proof_request.max_price_per_pgu(max_price_per_pgu);
+        }
+        if let Some(proof_timeout) = self.proof_timeout {
+            proof_request = proof_request.timeout(proof_timeout);
         }
 
         let backend_session_id = proof_request
@@ -296,6 +331,75 @@ impl WorldSuccinctProver for NetworkSuccinctProver {
             }
         }
     }
+
+    async fn wait(&self, session_id: &str) -> anyhow::Result<SP1ProofWithPublicValues> {
+        let proof_id = parse_proof_id(session_id)?;
+        let result = self
+            .client
+            // The request carries its immutable network deadline. Passing no additional local
+            // timeout keeps restart recovery anchored to that original deadline.
+            .wait_proof(proof_id, None, self.auction_timeout)
+            .await;
+
+        match result {
+            Ok(proof) => Ok(proof),
+            Err(error)
+                if matches!(
+                    error.downcast_ref::<NetworkError>(),
+                    Some(NetworkError::RequestTimedOut { .. })
+                ) =>
+            {
+                // SP1 v6.1.0 checks the deadline before FULFILLED. Re-read once so a proof that
+                // completed near its deadline is not replaced. This was reordered upstream in
+                // https://github.com/succinctlabs/sp1/pull/2737.
+                let (status, proof) = self
+                    .client
+                    .get_proof_status(proof_id)
+                    .await
+                    .context("rechecking SP1 Network request after timeout")?;
+                if matches!(
+                    FulfillmentStatus::try_from(status.fulfillment_status()),
+                    Ok(FulfillmentStatus::Fulfilled)
+                ) {
+                    return proof.ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "network proof {session_id} is fulfilled but no proof was returned"
+                        )
+                    });
+                }
+                Err(map_network_wait_error(error, session_id))
+            }
+            Err(error) => Err(map_network_wait_error(error, session_id)),
+        }
+    }
+}
+
+fn map_network_wait_error(error: anyhow::Error, session_id: &str) -> anyhow::Error {
+    let Some(network_error) = error.downcast_ref::<NetworkError>() else {
+        return error.context(format!("waiting for SP1 Network request {session_id}"));
+    };
+
+    match network_error {
+        NetworkError::RequestAuctionTimedOut { .. } => {
+            SuccinctProverError::RequestAuctionTimedOut {
+                session_id: session_id.to_string(),
+            }
+            .into()
+        }
+        NetworkError::RequestTimedOut { .. } => SuccinctProverError::RequestTimedOut {
+            session_id: session_id.to_string(),
+        }
+        .into(),
+        NetworkError::RequestUnexecutable { .. } => SuccinctProverError::RequestUnexecutable {
+            session_id: session_id.to_string(),
+        }
+        .into(),
+        NetworkError::RequestUnfulfillable { .. } => SuccinctProverError::RequestUnfulfillable {
+            session_id: session_id.to_string(),
+        }
+        .into(),
+        _ => error.context(format!("waiting for SP1 Network request {session_id}")),
+    }
 }
 
 /// Parse a network proof ID from its hex string representation.
@@ -320,5 +424,38 @@ fn sp1_status(status: &GetProofRequestStatusResponse) -> Sp1SessionStatus {
             "unknown network proof fulfillment status: {}",
             status.fulfillment_status()
         )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_sdk_auction_timeout_to_resubmittable_error() {
+        let error = anyhow::Error::new(NetworkError::RequestAuctionTimedOut {
+            request_id: vec![1; 32],
+        });
+
+        let mapped = map_network_wait_error(error, "0x01");
+        let mapped = mapped
+            .downcast_ref::<SuccinctProverError>()
+            .expect("SDK timeout should map to a structured prover error");
+
+        assert!(matches!(
+            mapped,
+            SuccinctProverError::RequestAuctionTimedOut { session_id } if session_id == "0x01"
+        ));
+        assert!(mapped.should_resubmit());
+    }
+
+    #[test]
+    fn preserves_non_terminal_sdk_errors() {
+        let error = anyhow::Error::new(NetworkError::SimulationFailed);
+
+        let mapped = map_network_wait_error(error, "0x02");
+
+        assert!(mapped.downcast_ref::<NetworkError>().is_some());
+        assert!(mapped.downcast_ref::<SuccinctProverError>().is_none());
     }
 }

--- a/proofs/backends/sp1/host/src/network_prover.rs
+++ b/proofs/backends/sp1/host/src/network_prover.rs
@@ -295,8 +295,6 @@ impl WorldSuccinctProver for NetworkSuccinctProver {
 
     async fn wait(&self, session_id: &str) -> anyhow::Result<SP1ProofWithPublicValues> {
         let proof_id = parse_proof_id(session_id)?;
-        // SP1 6.1.0 can misclassify a fulfilled proof polled after its deadline as timed out.
-        // This accepted limitation is fixed by upgrading to SP1 6.2.0 or newer (#2737).
         self.client
             // The request carries its immutable network deadline. Passing no additional local
             // timeout keeps restart recovery anchored to that original deadline.

--- a/proofs/backends/sp1/host/src/network_prover.rs
+++ b/proofs/backends/sp1/host/src/network_prover.rs
@@ -334,43 +334,14 @@ impl WorldSuccinctProver for NetworkSuccinctProver {
 
     async fn wait(&self, session_id: &str) -> anyhow::Result<SP1ProofWithPublicValues> {
         let proof_id = parse_proof_id(session_id)?;
-        let result = self
-            .client
+        // SP1 6.1.0 can misclassify a fulfilled proof polled after its deadline as timed out.
+        // This accepted limitation is fixed by upgrading to SP1 6.2.0 or newer (#2737).
+        self.client
             // The request carries its immutable network deadline. Passing no additional local
             // timeout keeps restart recovery anchored to that original deadline.
             .wait_proof(proof_id, None, self.auction_timeout)
-            .await;
-
-        match result {
-            Ok(proof) => Ok(proof),
-            Err(error)
-                if matches!(
-                    error.downcast_ref::<NetworkError>(),
-                    Some(NetworkError::RequestTimedOut { .. })
-                ) =>
-            {
-                // SP1 v6.1.0 checks the deadline before FULFILLED. Re-read once so a proof that
-                // completed near its deadline is not replaced. This was reordered upstream in
-                // https://github.com/succinctlabs/sp1/pull/2737.
-                let (status, proof) = self
-                    .client
-                    .get_proof_status(proof_id)
-                    .await
-                    .context("rechecking SP1 Network request after timeout")?;
-                if matches!(
-                    FulfillmentStatus::try_from(status.fulfillment_status()),
-                    Ok(FulfillmentStatus::Fulfilled)
-                ) {
-                    return proof.ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "network proof {session_id} is fulfilled but no proof was returned"
-                        )
-                    });
-                }
-                Err(map_network_wait_error(error, session_id))
-            }
-            Err(error) => Err(map_network_wait_error(error, session_id)),
-        }
+            .await
+            .map_err(|error| map_network_wait_error(error, session_id))
     }
 }
 

--- a/proofs/backends/sp1/host/src/network_prover.rs
+++ b/proofs/backends/sp1/host/src/network_prover.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use crate::{SuccinctProverError, WorldSuccinctProver};
 use alloy_primitives::{B256, U256};
-use anyhow::{Context, bail};
+use anyhow::Context;
 use async_trait::async_trait;
 pub use sp1_sdk::SP1ProofMode;
 use sp1_sdk::{
@@ -13,14 +13,11 @@ use sp1_sdk::{
     SP1ProofWithPublicValues, SP1ProvingKey, SP1Stdin,
     network::{
         Error as NetworkError, NetworkClient, NetworkMode, get_default_rpc_url_for_mode,
-        proto::{GetProofRequestStatusResponse, types::FulfillmentStatus},
         signer::NetworkSigner,
     },
 };
 use world_chain_proof_core::types::AggregationInputs;
-use world_chain_proof_sp1_types::{
-    AggregationProofRequest, RangeProofRequest, Sp1ProofRequest, Sp1SessionStatus,
-};
+use world_chain_proof_sp1_types::{AggregationProofRequest, RangeProofRequest, Sp1ProofRequest};
 
 /// [`WorldSuccinctProver`] network implementation over the sp1-sdk network prover.
 pub struct NetworkSuccinctProver {
@@ -270,21 +267,6 @@ impl NetworkSuccinctProver {
 
         Ok(backend_session_id.to_string())
     }
-
-    /// Fetch the network session state and any proof returned by the SP1 Network.
-    pub async fn get_network_proof_status(
-        &self,
-        backend_session_id: &str,
-    ) -> anyhow::Result<(Sp1SessionStatus, Option<SP1ProofWithPublicValues>)> {
-        let proof_id = parse_proof_id(backend_session_id)?;
-        let (status, proof) = self
-            .client
-            .get_proof_status(proof_id)
-            .await
-            .context("failed to get network proof status")?;
-        let sp1_status = sp1_status(&status);
-        Ok((sp1_status, proof))
-    }
 }
 
 #[async_trait]
@@ -307,27 +289,6 @@ impl WorldSuccinctProver for NetworkSuccinctProver {
                     range_proofs: session_request.range_proofs,
                 };
                 self.request_aggregation_proof(agg_request).await
-            }
-        }
-    }
-
-    async fn poll(&self, session_id: &str) -> anyhow::Result<Sp1SessionStatus> {
-        let (sp1_status, _maybe_proof) = self.get_network_proof_status(session_id).await?;
-        Ok(sp1_status)
-    }
-
-    async fn download(&self, session_id: &str) -> anyhow::Result<SP1ProofWithPublicValues> {
-        let (sp1_status, maybe_proof) = self.get_network_proof_status(session_id).await?;
-        match sp1_status {
-            Sp1SessionStatus::Completed => maybe_proof.ok_or_else(|| {
-                anyhow::anyhow!("network proof {session_id} is fulfilled but no proof was returned")
-            }),
-            Sp1SessionStatus::Running => {
-                bail!("network proof {session_id} is not fulfilled yet");
-            }
-            Sp1SessionStatus::Failed(reason) => bail!("{reason}"),
-            Sp1SessionStatus::NotFound => {
-                bail!("network proof {session_id} was not found");
             }
         }
     }
@@ -378,24 +339,6 @@ fn parse_proof_id(proof_id: &str) -> anyhow::Result<B256> {
     proof_id
         .parse::<B256>()
         .map_err(|e| anyhow::anyhow!("invalid network proof ID: {e}"))
-}
-
-/// Map an SP1 Network proof status response to the sp1 session status.
-fn sp1_status(status: &GetProofRequestStatusResponse) -> Sp1SessionStatus {
-    match FulfillmentStatus::try_from(status.fulfillment_status()) {
-        Ok(FulfillmentStatus::Fulfilled) => Sp1SessionStatus::Completed,
-        Ok(FulfillmentStatus::Unfulfillable) => Sp1SessionStatus::Failed(format!(
-            "proof unfulfillable, execution_status={}",
-            status.execution_status()
-        )),
-        Ok(FulfillmentStatus::Assigned)
-        | Ok(FulfillmentStatus::Requested)
-        | Ok(FulfillmentStatus::UnspecifiedFulfillmentStatus) => Sp1SessionStatus::Running,
-        Err(_) => Sp1SessionStatus::Failed(format!(
-            "unknown network proof fulfillment status: {}",
-            status.fulfillment_status()
-        )),
-    }
 }
 
 #[cfg(test)]

--- a/proofs/backends/sp1/host/src/validity.rs
+++ b/proofs/backends/sp1/host/src/validity.rs
@@ -5,7 +5,6 @@ use crate::{
 };
 use alloy_primitives::B256;
 use anyhow::{Context, bail};
-use sp1_sdk::SP1ProofWithPublicValues;
 use world_chain_proof_core::artifacts::{AggregationProofArtifact, RangeProofArtifact};
 use world_chain_proof_kona_host::online::{
     OnlineHostConfig, RangeMetadata, RangeWitnessRequest, build_range_input,
@@ -64,7 +63,7 @@ where
         .submit(Sp1ProofRequest::Range(range_input.request))
         .await
         .context("failed to submit range proof")?;
-    let range = wait_and_download_range(prover, range_session_id)
+    let range = wait_for_range(prover, range_session_id)
         .await
         .context("failed to complete range proof")?;
 
@@ -77,7 +76,7 @@ where
         .submit(Sp1ProofRequest::Aggregation(aggregation_request))
         .await
         .context("failed to submit aggregation proof")?;
-    let aggregation = wait_and_download_aggregation(prover, aggregation_session_id)
+    let aggregation = wait_for_aggregation(prover, aggregation_session_id)
         .await
         .context("failed to complete aggregation proof")?;
 
@@ -130,40 +129,29 @@ async fn build_aggregation_request(
     })
 }
 
-async fn wait_and_download_range<P>(
-    prover: &P,
-    session_id: String,
-) -> anyhow::Result<RangeProofArtifact>
+async fn wait_for_range<P>(prover: &P, session_id: String) -> anyhow::Result<RangeProofArtifact>
 where
     P: WorldSuccinctProver + Sync,
 {
-    let proof = wait_and_download_proof(prover, session_id, "STARK").await?;
+    let proof = prover
+        .wait(&session_id)
+        .await
+        .context("failed to wait for STARK proof")?;
     range_artifact_from_sp1_proof(&proof)
 }
 
-async fn wait_and_download_aggregation<P>(
+async fn wait_for_aggregation<P>(
     prover: &P,
     session_id: String,
 ) -> anyhow::Result<AggregationProofArtifact>
 where
     P: WorldSuccinctProver + Sync,
 {
-    let proof = wait_and_download_proof(prover, session_id, "SNARK").await?;
-    aggregation_artifact_from_sp1_proof(&proof)
-}
-
-async fn wait_and_download_proof<P>(
-    prover: &P,
-    session_id: String,
-    session_label: &'static str,
-) -> anyhow::Result<SP1ProofWithPublicValues>
-where
-    P: WorldSuccinctProver + Sync,
-{
-    prover
+    let proof = prover
         .wait(&session_id)
         .await
-        .with_context(|| format!("failed to wait for {session_label} proof"))
+        .context("failed to wait for SNARK proof")?;
+    aggregation_artifact_from_sp1_proof(&proof)
 }
 
 fn validate_range_artifact(

--- a/proofs/backends/sp1/host/src/validity.rs
+++ b/proofs/backends/sp1/host/src/validity.rs
@@ -1,7 +1,5 @@
 //! End-to-end validity proof helper built on the generic succinct prover session API.
 
-use std::time::Duration;
-
 use crate::{
     WorldSuccinctProver, aggregation_artifact_from_sp1_proof, range_artifact_from_sp1_proof,
 };
@@ -13,9 +11,7 @@ use world_chain_proof_kona_host::online::{
     OnlineHostConfig, RangeMetadata, RangeWitnessRequest, build_range_input,
     fetch_l1_header_by_hash,
 };
-use world_chain_proof_sp1_types::{
-    AggregationSessionRequest, RangeProofRequest, Sp1ProofRequest, Sp1SessionStatus,
-};
+use world_chain_proof_sp1_types::{AggregationSessionRequest, RangeProofRequest, Sp1ProofRequest};
 
 /// Request for proving one contiguous L2 validity range and aggregating it into a final proof.
 #[derive(Clone, Debug)]
@@ -164,23 +160,10 @@ async fn wait_and_download_proof<P>(
 where
     P: WorldSuccinctProver + Sync,
 {
-    loop {
-        match prover.poll(&session_id).await? {
-            Sp1SessionStatus::Running => tokio::time::sleep(Duration::from_secs(10)).await,
-            Sp1SessionStatus::Completed => {
-                return prover
-                    .download(&session_id)
-                    .await
-                    .with_context(|| format!("failed to download {session_label} proof"));
-            }
-            Sp1SessionStatus::Failed(reason) => {
-                bail!("{session_label} proof session {session_id} failed: {reason}");
-            }
-            Sp1SessionStatus::NotFound => {
-                bail!("{session_label} proof session {session_id} not found by prover");
-            }
-        }
-    }
+    prover
+        .wait(&session_id)
+        .await
+        .with_context(|| format!("failed to wait for {session_label} proof"))
 }
 
 fn validate_range_artifact(

--- a/proofs/backends/sp1/programs/Cargo.lock
+++ b/proofs/backends/sp1/programs/Cargo.lock
@@ -290,7 +290,7 @@ dependencies = [
  "rustc-hash",
  "secp256k1 0.31.1",
  "serde",
- "sha3 0.11.0",
+ "sha3",
 ]
 
 [[package]]
@@ -346,7 +346,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -390,7 +390,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "sha3 0.11.0",
+ "sha3",
  "syn 2.0.117",
  "syn-solidity",
 ]
@@ -866,26 +866,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake2"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "blake2b_simd"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
-]
-
-[[package]]
 name = "blake3"
 version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,19 +895,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
-]
-
-[[package]]
-name = "bls12_381"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3c196a77437e7cc2fb515ce413a6401291578b5afc8ecb29a3c7ab957f05941"
-dependencies = [
- "ff 0.12.1",
- "group 0.12.1",
- "pairing 0.22.0",
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -1132,31 +1099,6 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -1379,9 +1321,9 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "digest 0.10.7",
- "ff 0.13.1",
+ "ff",
  "generic-array",
- "group 0.13.0",
+ "group",
  "hkdf",
  "pkcs8",
  "rand_core 0.6.4",
@@ -1465,17 +1407,6 @@ dependencies = [
  "arrayvec",
  "auto_impl",
  "bytes",
-]
-
-[[package]]
-name = "ff"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
-dependencies = [
- "bitvec",
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -1697,23 +1628,11 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "group"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
-dependencies = [
- "ff 0.12.1",
- "memuse",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff 0.13.1",
+ "ff",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -1723,29 +1642,6 @@ name = "half"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
-
-[[package]]
-name = "halo2"
-version = "0.1.0-beta.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a23c779b38253fe1538102da44ad5bd5378495a61d2c4ee18d64eaa61ae5995"
-dependencies = [
- "halo2_proofs",
-]
-
-[[package]]
-name = "halo2_proofs"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e925780549adee8364c7f2b685c753f6f3df23bde520c67416e93bf615933760"
-dependencies = [
- "blake2b_simd",
- "ff 0.12.1",
- "group 0.12.1",
- "pasta_curves 0.4.1",
- "rand_core 0.6.4",
- "rayon",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1942,20 +1838,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jubjub"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a575df5f985fe1cd5b2b05664ff6accfc46559032b954529fd225a2168d27b0f"
-dependencies = [
- "bitvec",
- "bls12_381",
- "ff 0.12.1",
- "group 0.12.1",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1967,15 +1849,6 @@ dependencies = [
  "once_cell",
  "serdect",
  "sha2",
-]
-
-[[package]]
-name = "keccak"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
-dependencies = [
- "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -2251,7 +2124,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee8b4f55c3dedcfaa8668de1dfc8469e7a32d441c28edf225ed1f566fb32977d"
 dependencies = [
- "ff 0.13.1",
+ "ff",
  "hex",
  "rkyv",
  "serde",
@@ -2340,12 +2213,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "memuse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d97bbf43eb4f088f8ca469930cde17fa036207c9a5e02ccc5107c4e8b17c964"
 
 [[package]]
 name = "miniz_oxide"
@@ -2635,11 +2502,11 @@ dependencies = [
 
 [[package]]
 name = "p3-bn254-fr"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577200e3fa7e49e2b21e940a6dc7399dc63acb8581da088558cdf7c455adafc0"
+checksum = "2077757c7cb514202ccb5368f521f23f5709c720599e6545c683c66e0a52d2d8"
 dependencies = [
- "ff 0.13.1",
+ "ff",
  "num-bigint 0.4.6",
  "p3-field",
  "p3-poseidon2",
@@ -2650,9 +2517,9 @@ dependencies = [
 
 [[package]]
 name = "p3-challenger"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75358edd6e2562752c01f5064a66d88144a3e75ace0407166dbdf8a727597f52"
+checksum = "b6a908924d43e4cfb93fb41c8346cac211b70314385a9037e9241f5b7f3eaf77"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -2664,9 +2531,9 @@ dependencies = [
 
 [[package]]
 name = "p3-dft"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761f1e1b014f2b1b69bd0309124e233d64aa3590e6a41ee786000dd849506d51"
+checksum = "be6408b10a2c27eb13a7d5580c546c2179a8dc7dbc10a990657311891f9b41c0"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -2677,9 +2544,9 @@ dependencies = [
 
 [[package]]
 name = "p3-field"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df7cebaa4079b24e0dd7e3aad59eebcbb99a67c1271f79ad884a7c032f5f183"
+checksum = "3dc75969ca3ac847f43e632ab979d59ff7a68f9eac8dbf8edcbba47fc2e1d3aa"
 dependencies = [
  "itertools 0.12.1",
  "num-bigint 0.4.6",
@@ -2691,9 +2558,9 @@ dependencies = [
 
 [[package]]
 name = "p3-koala-bear"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cea0ba3389b034b6088d566aea8b57aa29dd2e180966e0c8056f61331c92b4e"
+checksum = "3a9683cd0ef68100df7c62490533047bcf19c04c4a0fa1efc9d7c1e03e31f6b3"
 dependencies = [
  "cfg-if",
  "num-bigint 0.4.6",
@@ -2708,9 +2575,9 @@ dependencies = [
 
 [[package]]
 name = "p3-matrix"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fae5cc6ce726cc265cc687c1214e3f1ac1f5c6e973442286ba00d1e75da1c3cb"
+checksum = "75c3f150ceb90e09539413bf481e618d05ee19210b4e467d2902eb82d2e15281"
 dependencies = [
  "itertools 0.12.1",
  "p3-field",
@@ -2723,15 +2590,15 @@ dependencies = [
 
 [[package]]
 name = "p3-maybe-rayon"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ac1d2f102cf8c71dba1b449575c99697781fcc028831e83d2245787bd7a650"
+checksum = "e0641952b42da45e1dfa2d4a2a3163e330f944ad9740942f35026c0a71a605f1"
 
 [[package]]
 name = "p3-mds"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f072643e385d65fb9eb089ee6824b320417f78671a0db748566e057e28b250e"
+checksum = "aa4a5f250e174dcfca5cbeac6ad75713924e7e7320e0a335e3c50b8b1f4fe8ec"
 dependencies = [
  "itertools 0.12.1",
  "p3-dft",
@@ -2744,9 +2611,9 @@ dependencies = [
 
 [[package]]
 name = "p3-poseidon2"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00cc4b6e8a439f79541b0910a016da9e6e12a05a24309bbb713e1db0db396952"
+checksum = "522986377b2164c5f94f2dae88e0e0a3d169cc6239202ef4aeb4322d60feffd0"
 dependencies = [
  "gcd",
  "p3-field",
@@ -2758,9 +2625,9 @@ dependencies = [
 
 [[package]]
 name = "p3-symmetric"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eebff7fea7deb08a57ccf731a0ed39df25cc66a0e0c2d92c4472c4dee02ee21"
+checksum = "9047ce85c086a9b3f118e10078f10636f7bfeed5da871a04da0b61400af8793a"
 dependencies = [
  "itertools 0.12.1",
  "p3-field",
@@ -2769,20 +2636,11 @@ dependencies = [
 
 [[package]]
 name = "p3-util"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8164df89bbc92e29938f916cc5f1ccbfe6a36fb5040f21ba93c1f21985b9868"
+checksum = "cff962f8eaa5f36e0447cee7c241f6b4b475fadf3ee61f154327a26bb4e009ba"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "pairing"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
-dependencies = [
- "group 0.12.1",
 ]
 
 [[package]]
@@ -2791,7 +2649,7 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
- "group 0.13.0",
+ "group",
 ]
 
 [[package]]
@@ -2820,36 +2678,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "pasta_curves"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc65faf8e7313b4b1fbaa9f7ca917a0eed499a9663be71477f87993604341d8"
-dependencies = [
- "blake2b_simd",
- "ff 0.12.1",
- "group 0.12.1",
- "lazy_static",
- "rand 0.8.6",
- "static_assertions",
- "subtle",
-]
-
-[[package]]
-name = "pasta_curves"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
-dependencies = [
- "blake2b_simd",
- "ff 0.13.1",
- "group 0.13.0",
- "lazy_static",
- "rand 0.8.6",
- "static_assertions",
- "subtle",
 ]
 
 [[package]]
@@ -3134,26 +2962,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
 dependencies = [
  "rustversion",
-]
-
-[[package]]
-name = "rayon"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -3757,22 +3565,12 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
-dependencies = [
- "digest 0.10.7",
- "keccak 0.1.6",
-]
-
-[[package]]
-name = "sha3"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
  "digest 0.11.3",
- "keccak 0.2.0",
+ "keccak",
 ]
 
 [[package]]
@@ -3824,9 +3622,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-algebra"
-version = "6.2.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2987d60942c83511c5819afdd9ca83a9723fed072c43d5e1144393beebbce49c"
+checksum = "8c112cafd4c5c374d267a48c8976d12fca3b0f2cc2e44e6fb1343808310b4fc6"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -3835,25 +3633,24 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.2.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b3ca8edc31419a3e33a9f4b9e11f072caf5fd6e2b32f2b9fcaa5b0863f3da66"
+checksum = "ea991a652ea2e55f0523649f5c9efbfb32cf9fdcc2bf3b3580b4343a94379503"
 dependencies = [
- "ff 0.13.1",
+ "ff",
  "p3-bn254-fr",
  "serde",
  "slop-algebra",
  "slop-challenger",
  "slop-poseidon2",
  "slop-symmetric",
- "zkhash",
 ]
 
 [[package]]
 name = "slop-challenger"
-version = "6.2.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144e5c2ed52b6499792c98262b8bbeb435c361d005caa6f2a6c9ecb8529915b4"
+checksum = "33b33f1eaadcd4159157758b0edcf1c14f470915f85c648e660e4740ff83e921"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -3864,9 +3661,9 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.2.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ca44a6d3457836c6a1685dcb27b3f64c0b6f555ade06dd2a8fda5003e7594e"
+checksum = "8795ee9a92ecf0a604c0e3ed20e80bbc38772310c0622f94a2e1b66ca2455cb8"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -3879,27 +3676,27 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.2.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3386c5935d822f8621a19f305dffdcae3d9a1956a7b657a7f8893438abf22526"
+checksum = "25561d9ecf4bcf1aa2e800560ac557bff6dad943b9dc5cd0e8427fceca1e8c65"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.2.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d20475296d399080467eb486e6063967e85d3d13200301275e56541c356f96bd"
+checksum = "f6b24ad70b49f40d6acfe7b1ccf042db25820abe305a4c2232f15204f63f0227"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-symmetric"
-version = "6.2.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "580a4f683c60b000b7ac8ca3fcd200a2a70f4caf2e43268f9089323534d15ecc"
+checksum = "94e580d03bb5383aca1c12579a8a24b838afb12eb356439e740cba34904b6864"
 dependencies = [
  "p3-symmetric",
 ]
@@ -3915,9 +3712,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.1.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b96392c1b1c197beaa6b0806099a8d73643a09d5ac0874e26c9c5153a7fcb4c"
+checksum = "629b673d6aa3c666b41e14d699323413fa90195c906365ba8c49d1b8e4531151"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -3927,9 +3724,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.2.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03476134330b0677d5eee5dec288cf2b0f883511c7496e55dcc9c15cf8debb47"
+checksum = "421b4590a89bf7c263f8a64844a4034ee8cb73c351498911ce0acd18da6b5ed2"
 dependencies = [
  "bincode",
  "blake3",
@@ -3951,9 +3748,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.1.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d31a7c3f072f248342284031684c9195e2264422964129c3b8652f9196ecc937"
+checksum = "f18fbc79e5a1cc499d3ae3904771104a854493ea12c317ff1407137d86153c26"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -3976,9 +3773,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23e41cd36168cc2e51e5d3e35ff0c34b204d945769a65591a76286d04b51e43"
 dependencies = [
  "cfg-if",
- "ff 0.13.1",
- "group 0.13.0",
- "pairing 0.23.0",
+ "ff",
+ "group",
+ "pairing",
  "rand_core 0.6.4",
  "sp1-lib",
  "subtle",
@@ -4734,33 +4531,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "zkhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4352d1081da6922701401cdd4cbf29a2723feb4cfabb5771f6fee8e9276da1c7"
-dependencies = [
- "ark-ff 0.4.2",
- "ark-std 0.4.0",
- "bitvec",
- "blake2",
- "bls12_381",
- "byteorder",
- "cfg-if",
- "group 0.12.1",
- "group 0.13.0",
- "halo2",
- "hex",
- "jubjub",
- "lazy_static",
- "pasta_curves 0.5.1",
- "rand 0.8.6",
- "serde",
- "sha2",
- "sha3 0.10.9",
- "subtle",
 ]
 
 [[package]]

--- a/proofs/backends/sp1/programs/Cargo.toml
+++ b/proofs/backends/sp1/programs/Cargo.toml
@@ -24,8 +24,8 @@ rkyv = { version = "0.8", features = ["hashbrown-0_15", "std"] }
 serde = { version = "1", features = ["derive"] }
 serde_cbor = "0.11"
 sha2 = "0.10.9"
-sp1-lib = { version = "=6.1.0", features = ["verify"] }
-sp1-zkvm = { version = "=6.1.0", features = ["verify"] }
+sp1-lib = { version = "=6.3.1", features = ["verify"] }
+sp1-zkvm = { version = "=6.3.1", features = ["verify"] }
 thiserror = "2"
 tracing = { version = "0.1", default-features = false }
 tracing-subscriber = { version = "0.3.18", features = ["fmt"] }

--- a/proofs/backends/sp1/types/src/lib.rs
+++ b/proofs/backends/sp1/types/src/lib.rs
@@ -66,16 +66,3 @@ pub struct AggregationSessionRequest {
     /// Serialized compressed SP1 range proofs, ordered to match `transition_public_values`.
     pub range_proofs: Vec<Vec<u8>>,
 }
-
-/// Current status of a backend proving session.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Sp1SessionStatus {
-    /// The backend session is still running.
-    Running,
-    /// The backend session completed successfully and the proof can be downloaded.
-    Completed,
-    /// The backend session failed with the given reason.
-    Failed(String),
-    /// The backend has no record of the session id.
-    NotFound,
-}

--- a/proofs/debug/bin/prover-sp1/Cargo.toml
+++ b/proofs/debug/bin/prover-sp1/Cargo.toml
@@ -19,7 +19,7 @@ dotenvy.workspace = true
 hex.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
-sp1-sdk = { version = "=6.1.0", features = ["network"] }
+sp1-sdk = { version = "=6.3.1", features = ["network"] }
 tokio.workspace = true
 world-chain-prover.workspace = true
 world-chain-proof-core.workspace = true

--- a/proofs/services/prover-service/src/tests.rs
+++ b/proofs/services/prover-service/src/tests.rs
@@ -468,6 +468,73 @@ async fn record_and_get_proof_session_round_trips() {
         .expect("session recorded");
     assert_eq!(session.backend_session_id, backend_session_id(1));
     assert_eq!(session.status, BackendSessionStatus::Running);
+
+    service
+        .record_proof_session(record_proof_session_request(
+            id,
+            SessionType::Stark,
+            locked.lock_id,
+            backend_session_id(1),
+            BackendSessionStatus::Failed,
+            Some("auction timed out".to_string()),
+        ))
+        .await
+        .unwrap();
+    assert!(
+        service
+            .get_proof_session(get_proof_session_request(id, SessionType::Stark))
+            .await
+            .unwrap()
+            .session
+            .is_none()
+    );
+
+    service
+        .record_proof_session(record_proof_session_request(
+            id,
+            SessionType::Stark,
+            locked.lock_id,
+            backend_session_id(2),
+            BackendSessionStatus::Running,
+            None,
+        ))
+        .await
+        .unwrap();
+    let replacement = service
+        .get_proof_session(get_proof_session_request(id, SessionType::Stark))
+        .await
+        .unwrap()
+        .session
+        .expect("replacement session recorded");
+    assert_eq!(replacement.backend_session_id, backend_session_id(2));
+    assert_eq!(replacement.status, BackendSessionStatus::Running);
+
+    let rows: Vec<(String, String)> = sqlx::query_as(
+        r#"
+        SELECT backend_session_id, status
+        FROM proof_sessions
+        WHERE proof_id = $1 AND session_type = $2
+        ORDER BY id
+        "#,
+    )
+    .bind(id.0.as_slice().to_vec())
+    .bind(SessionType::Stark.as_str())
+    .fetch_all(service.pool())
+    .await
+    .unwrap();
+    assert_eq!(
+        rows,
+        vec![
+            (
+                backend_session_id(1),
+                BackendSessionStatus::Failed.as_str().to_string()
+            ),
+            (
+                backend_session_id(2),
+                BackendSessionStatus::Running.as_str().to_string()
+            ),
+        ]
+    );
 }
 
 #[tokio::test]

--- a/proofs/workers/sp1/src/backend.rs
+++ b/proofs/workers/sp1/src/backend.rs
@@ -311,10 +311,11 @@ impl<P: WorldSuccinctProver + Send + Sync, G: ProofGameProvider> Sp1Backend<P, G
         request: RangeProofRequest,
         retrying_existing: bool,
     ) -> anyhow::Result<RangeProofArtifact> {
-        let mut resubmission = usize::from(retrying_existing);
-        loop {
-            self.wait_before_resubmission(SessionType::Stark, resubmission)
-                .await;
+        for (resubmission, delay) in network_request_attempts(retrying_existing) {
+            if let Some(delay) = delay {
+                self.wait_before_resubmission(SessionType::Stark, resubmission, delay)
+                    .await;
+            }
             let session_id = self
                 .submit_session(
                     job,
@@ -325,8 +326,12 @@ impl<P: WorldSuccinctProver + Send + Sync, G: ProofGameProvider> Sp1Backend<P, G
             if let Some(artifact) = self.wait_for_range(job, session_id).await? {
                 return Ok(artifact);
             }
-            resubmission = next_resubmission(SessionType::Stark, resubmission)?;
         }
+        anyhow::bail!(
+            "{} proof exhausted {} SP1 Network resubmissions",
+            SessionType::Stark.as_str(),
+            NETWORK_REQUEST_RETRY_BACKOFFS.len()
+        );
     }
 
     async fn submit_aggregation_with_retries(
@@ -335,10 +340,11 @@ impl<P: WorldSuccinctProver + Send + Sync, G: ProofGameProvider> Sp1Backend<P, G
         request: AggregationSessionRequest,
         retrying_existing: bool,
     ) -> anyhow::Result<AggregationProofArtifact> {
-        let mut resubmission = usize::from(retrying_existing);
-        loop {
-            self.wait_before_resubmission(SessionType::Snark, resubmission)
-                .await;
+        for (resubmission, delay) in network_request_attempts(retrying_existing) {
+            if let Some(delay) = delay {
+                self.wait_before_resubmission(SessionType::Snark, resubmission, delay)
+                    .await;
+            }
             let session_id = self
                 .submit_session(
                     job,
@@ -349,15 +355,20 @@ impl<P: WorldSuccinctProver + Send + Sync, G: ProofGameProvider> Sp1Backend<P, G
             if let Some(artifact) = self.wait_for_aggregation(job, session_id).await? {
                 return Ok(artifact);
             }
-            resubmission = next_resubmission(SessionType::Snark, resubmission)?;
         }
+        anyhow::bail!(
+            "{} proof exhausted {} SP1 Network resubmissions",
+            SessionType::Snark.as_str(),
+            NETWORK_REQUEST_RETRY_BACKOFFS.len()
+        );
     }
 
-    async fn wait_before_resubmission(&self, session_type: SessionType, resubmission: usize) {
-        if resubmission == 0 {
-            return;
-        }
-        let delay = NETWORK_REQUEST_RETRY_BACKOFFS[resubmission - 1];
+    async fn wait_before_resubmission(
+        &self,
+        session_type: SessionType,
+        resubmission: usize,
+        delay: Duration,
+    ) {
         tracing::warn!(
             session_type = session_type.as_str(),
             resubmission,
@@ -450,15 +461,15 @@ impl<P: WorldSuccinctProver + Send + Sync, G: ProofGameProvider> Sp1Backend<P, G
     }
 }
 
-fn next_resubmission(session_type: SessionType, current: usize) -> anyhow::Result<usize> {
-    if current >= NETWORK_REQUEST_RETRY_BACKOFFS.len() {
-        anyhow::bail!(
-            "{} proof exhausted {} SP1 Network resubmissions",
-            session_type.as_str(),
-            NETWORK_REQUEST_RETRY_BACKOFFS.len()
-        );
-    }
-    Ok(current + 1)
+fn network_request_attempts(
+    retrying_existing: bool,
+) -> impl Iterator<Item = (usize, Option<Duration>)> {
+    let first_resubmission = usize::from(retrying_existing);
+    std::iter::once(None)
+        .chain(NETWORK_REQUEST_RETRY_BACKOFFS.into_iter().map(Some))
+        .skip(first_resubmission)
+        .enumerate()
+        .map(move |(offset, delay)| (first_resubmission + offset, delay))
 }
 
 /// A proof artifact whose committed outputs do not defend the requested root.
@@ -523,14 +534,23 @@ mod tests {
     }
 
     #[test]
-    fn both_session_types_allow_three_resubmissions() {
-        for session_type in [SessionType::Stark, SessionType::Snark] {
-            let mut resubmission = 0;
-            for expected in 1..=NETWORK_REQUEST_RETRY_BACKOFFS.len() {
-                resubmission = next_resubmission(session_type.clone(), resubmission).unwrap();
-                assert_eq!(resubmission, expected);
-            }
-            assert!(next_resubmission(session_type, resubmission).is_err());
-        }
+    fn request_attempts_are_finite_and_skip_completed_initial_attempt() {
+        assert_eq!(
+            network_request_attempts(false).collect::<Vec<_>>(),
+            vec![
+                (0, None),
+                (1, Some(Duration::from_secs(60))),
+                (2, Some(Duration::from_secs(120))),
+                (3, Some(Duration::from_secs(300))),
+            ]
+        );
+        assert_eq!(
+            network_request_attempts(true).collect::<Vec<_>>(),
+            vec![
+                (1, Some(Duration::from_secs(60))),
+                (2, Some(Duration::from_secs(120))),
+                (3, Some(Duration::from_secs(300))),
+            ]
+        );
     }
 }

--- a/proofs/workers/sp1/src/backend.rs
+++ b/proofs/workers/sp1/src/backend.rs
@@ -11,17 +11,20 @@ use world_chain_proof_kona_host::online::{
 };
 use world_chain_proof_protocol::ProofGameProvider;
 use world_chain_proof_sp1_host::{
-    WorldSuccinctProver, aggregation_artifact_from_sp1_proof, range_artifact_from_sp1_proof,
+    SP1ProofWithPublicValues, SuccinctProverError, WorldSuccinctProver,
+    aggregation_artifact_from_sp1_proof, range_artifact_from_sp1_proof,
 };
-use world_chain_proof_sp1_types::{
-    AggregationSessionRequest, RangeProofRequest, Sp1ProofRequest, Sp1SessionStatus,
-};
+use world_chain_proof_sp1_types::{AggregationSessionRequest, RangeProofRequest, Sp1ProofRequest};
 use world_chain_proof_worker::{ClaimedProofJobHandler, ProofJob};
 use world_chain_prover_service::{
     BackendSession, BackendSessionStatus, ProofBackend, ProofData, ProofRequest, SessionType,
 };
 
-const SP1_SESSION_POLL_INTERVAL: Duration = Duration::from_secs(10);
+const NETWORK_REQUEST_RETRY_BACKOFFS: [Duration; 3] = [
+    Duration::from_secs(60),
+    Duration::from_secs(120),
+    Duration::from_secs(300),
+];
 
 /// Configuration for [`Sp1Backend`].
 #[derive(Clone, Copy, Debug)]
@@ -70,37 +73,57 @@ where
         let request = &job.request;
         let start_block = self.start_block(request).await?;
 
-        if let Some(snark_session) = self.get_session(&job, SessionType::Snark).await? {
-            let agg = self
-                .wait_and_download_aggregation(&job, snark_session.backend_session_id)
-                .await
-                .context("failed to resume aggregation proof")?;
-
-            check_artifact(request, &agg)?;
-
-            return Ok(proof_data_from_aggregation(agg));
-        }
+        let retrying_aggregation =
+            if let Some(snark_session) = self.get_session(&job, SessionType::Snark).await? {
+                match self
+                    .wait_for_artifact(
+                        &job,
+                        SessionType::Snark,
+                        snark_session.backend_session_id,
+                        aggregation_artifact_from_sp1_proof,
+                    )
+                    .await
+                    .context("failed to resume aggregation proof")?
+                {
+                    Some(agg) => {
+                        check_artifact(request, &agg)?;
+                        return Ok(proof_data_from_aggregation(agg));
+                    }
+                    None => true,
+                }
+            } else {
+                false
+            };
 
         let range = if let Some(stark_session) = self.get_session(&job, SessionType::Stark).await? {
-            self.wait_and_download_range(&job, stark_session.backend_session_id)
+            match self
+                .wait_for_artifact(
+                    &job,
+                    SessionType::Stark,
+                    stark_session.backend_session_id,
+                    range_artifact_from_sp1_proof,
+                )
                 .await
                 .context("failed to resume range proof")?
+            {
+                Some(range) => range,
+                None => {
+                    let range_request = self
+                        .build_range_request(start_block, request)
+                        .await
+                        .context("failed to rebuild range proof request")?;
+                    self.submit_range_with_retries(&job, range_request, true)
+                        .await
+                        .context("failed to resubmit range proof")?
+                }
+            }
         } else {
             let range_request = self
                 .build_range_request(start_block, request)
                 .await
                 .context("failed to build range proof request")?;
 
-            let session_id = self
-                .submit_session(
-                    &job,
-                    SessionType::Stark,
-                    Sp1ProofRequest::Range(range_request),
-                )
-                .await
-                .context("failed to submit range proof")?;
-
-            self.wait_and_download_range(&job, session_id)
+            self.submit_range_with_retries(&job, range_request, false)
                 .await
                 .context("failed to complete range proof")?
         };
@@ -112,17 +135,8 @@ where
             .await
             .context("failed to build aggregation proof request")?;
 
-        let snark_session_id = self
-            .submit_session(
-                &job,
-                SessionType::Snark,
-                Sp1ProofRequest::Aggregation(aggregation_request),
-            )
-            .await
-            .context("failed to submit aggregation proof")?;
-
         let agg = self
-            .wait_and_download_aggregation(&job, snark_session_id)
+            .submit_aggregation_with_retries(&job, aggregation_request, retrying_aggregation)
             .await
             .context("failed to complete aggregation proof")?;
 
@@ -132,7 +146,7 @@ where
     }
 }
 
-impl<P: WorldSuccinctProver, G: ProofGameProvider> Sp1Backend<P, G> {
+impl<P: WorldSuccinctProver + Send + Sync, G: ProofGameProvider> Sp1Backend<P, G> {
     async fn start_block(&self, request: &ProofRequest) -> anyhow::Result<u64> {
         let context = self
             .game_provider
@@ -210,98 +224,152 @@ impl<P: WorldSuccinctProver, G: ProofGameProvider> Sp1Backend<P, G> {
         Ok(session_id)
     }
 
-    async fn wait_and_download_range(
+    async fn wait_for_artifact<T>(
         &self,
         job: &ProofJob,
+        session_type: SessionType,
         session_id: String,
-    ) -> anyhow::Result<RangeProofArtifact> {
-        let session_type = SessionType::Stark;
-        let session_label = session_type.as_str();
-        loop {
-            match self.prover.poll(&session_id).await? {
-                Sp1SessionStatus::Running => {
-                    tokio::time::sleep(SP1_SESSION_POLL_INTERVAL).await;
-                }
-                Sp1SessionStatus::Completed => {
-                    let proof = self.prover.download(&session_id).await?;
-                    let artifact = range_artifact_from_sp1_proof(&proof)?;
-                    let empty_failure_reason = None;
-
-                    self.record_session(
-                        job,
-                        session_type.clone(),
-                        &session_id,
-                        BackendSessionStatus::Completed,
-                        empty_failure_reason,
-                    )
+        decode: impl FnOnce(&SP1ProofWithPublicValues) -> anyhow::Result<T>,
+    ) -> anyhow::Result<Option<T>> {
+        let result = self
+            .prover
+            .wait(&session_id)
+            .await
+            .and_then(|proof| decode(&proof));
+        match result {
+            Ok(artifact) => {
+                self.record_session(
+                    job,
+                    session_type,
+                    &session_id,
+                    BackendSessionStatus::Completed,
+                    None,
+                )
+                .await?;
+                Ok(Some(artifact))
+            }
+            Err(error) => {
+                self.handle_wait_error(job, session_type, &session_id, error)
                     .await?;
-
-                    return Ok(artifact);
-                }
-                Sp1SessionStatus::Failed(reason) => {
-                    self.record_session(
-                        job,
-                        session_type.clone(),
-                        &session_id,
-                        BackendSessionStatus::Failed,
-                        Some(reason.clone()),
-                    )
-                    .await?;
-
-                    anyhow::bail!("{session_label} proof session {session_id} failed: {reason}");
-                }
-                Sp1SessionStatus::NotFound => {
-                    anyhow::bail!("{session_label} proof session {session_id} not found by prover");
-                }
+                Ok(None)
             }
         }
     }
 
-    async fn wait_and_download_aggregation(
+    async fn handle_wait_error(
         &self,
         job: &ProofJob,
-        session_id: String,
-    ) -> anyhow::Result<AggregationProofArtifact> {
-        let session_type = SessionType::Snark;
-        let session_label = session_type.as_str();
-        loop {
-            match self.prover.poll(&session_id).await? {
-                Sp1SessionStatus::Running => {
-                    tokio::time::sleep(SP1_SESSION_POLL_INTERVAL).await;
-                }
-                Sp1SessionStatus::Completed => {
-                    let proof = self.prover.download(&session_id).await?;
-                    let artifact = aggregation_artifact_from_sp1_proof(&proof)?;
-                    let empty_failure_reason = None;
-
-                    self.record_session(
-                        job,
-                        session_type.clone(),
-                        &session_id,
-                        BackendSessionStatus::Completed,
-                        empty_failure_reason,
-                    )
-                    .await?;
-
-                    return Ok(artifact);
-                }
-                Sp1SessionStatus::Failed(reason) => {
-                    self.record_session(
-                        job,
-                        session_type.clone(),
-                        &session_id,
-                        BackendSessionStatus::Failed,
-                        Some(reason.clone()),
-                    )
-                    .await?;
-
-                    anyhow::bail!("{session_label} proof session {session_id} failed: {reason}");
-                }
-                Sp1SessionStatus::NotFound => {
-                    anyhow::bail!("{session_label} proof session {session_id} not found by prover");
-                }
-            }
+        session_type: SessionType,
+        session_id: &str,
+        error: anyhow::Error,
+    ) -> anyhow::Result<()> {
+        let Some(session_error) = error.downcast_ref::<SuccinctProverError>() else {
+            return Err(error);
+        };
+        if !session_error.is_terminal_session() {
+            return Err(error);
         }
+
+        let should_resubmit = session_error.should_resubmit();
+        let reason = session_error.to_string();
+        self.record_session(
+            job,
+            session_type.clone(),
+            session_id,
+            BackendSessionStatus::Failed,
+            Some(reason.clone()),
+        )
+        .await?;
+
+        if !should_resubmit {
+            return Err(error);
+        }
+
+        tracing::warn!(
+            session_type = session_type.as_str(),
+            backend_session_id = session_id,
+            reason,
+            "SP1 Network request timed out; scheduling a replacement request"
+        );
+        Ok(())
+    }
+
+    async fn submit_range_with_retries(
+        &self,
+        job: &ProofJob,
+        request: RangeProofRequest,
+        retrying_existing: bool,
+    ) -> anyhow::Result<RangeProofArtifact> {
+        let mut resubmission = usize::from(retrying_existing);
+        loop {
+            self.wait_before_resubmission(SessionType::Stark, resubmission)
+                .await;
+            let session_id = self
+                .submit_session(
+                    job,
+                    SessionType::Stark,
+                    Sp1ProofRequest::Range(request.clone()),
+                )
+                .await?;
+            if let Some(artifact) = self
+                .wait_for_artifact(
+                    job,
+                    SessionType::Stark,
+                    session_id,
+                    range_artifact_from_sp1_proof,
+                )
+                .await?
+            {
+                return Ok(artifact);
+            }
+            resubmission = next_resubmission(SessionType::Stark, resubmission)?;
+        }
+    }
+
+    async fn submit_aggregation_with_retries(
+        &self,
+        job: &ProofJob,
+        request: AggregationSessionRequest,
+        retrying_existing: bool,
+    ) -> anyhow::Result<AggregationProofArtifact> {
+        let mut resubmission = usize::from(retrying_existing);
+        loop {
+            self.wait_before_resubmission(SessionType::Snark, resubmission)
+                .await;
+            let session_id = self
+                .submit_session(
+                    job,
+                    SessionType::Snark,
+                    Sp1ProofRequest::Aggregation(request.clone()),
+                )
+                .await?;
+            if let Some(artifact) = self
+                .wait_for_artifact(
+                    job,
+                    SessionType::Snark,
+                    session_id,
+                    aggregation_artifact_from_sp1_proof,
+                )
+                .await?
+            {
+                return Ok(artifact);
+            }
+            resubmission = next_resubmission(SessionType::Snark, resubmission)?;
+        }
+    }
+
+    async fn wait_before_resubmission(&self, session_type: SessionType, resubmission: usize) {
+        if resubmission == 0 {
+            return;
+        }
+        let delay = NETWORK_REQUEST_RETRY_BACKOFFS[resubmission - 1];
+        tracing::warn!(
+            session_type = session_type.as_str(),
+            resubmission,
+            delay_seconds = delay.as_secs(),
+            "waiting before resubmitting SP1 Network request"
+        );
+        tokio::time::sleep(delay).await;
     }
 
     async fn build_aggregation_request(
@@ -387,6 +455,17 @@ impl<P: WorldSuccinctProver, G: ProofGameProvider> Sp1Backend<P, G> {
     }
 }
 
+fn next_resubmission(session_type: SessionType, current: usize) -> anyhow::Result<usize> {
+    if current >= NETWORK_REQUEST_RETRY_BACKOFFS.len() {
+        anyhow::bail!(
+            "{} proof exhausted {} SP1 Network resubmissions",
+            session_type.as_str(),
+            NETWORK_REQUEST_RETRY_BACKOFFS.len()
+        );
+    }
+    Ok(current + 1)
+}
+
 /// A proof artifact whose committed outputs do not defend the requested root.
 #[derive(Debug, PartialEq, Eq, thiserror::Error)]
 enum ArtifactMismatch {
@@ -429,5 +508,34 @@ fn proof_data_from_aggregation(artifact: AggregationProofArtifact) -> ProofData 
     ProofData::Sp1 {
         proof: artifact.proof.into(),
         public_values: artifact.public_values.abi_encode().into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn network_request_resubmissions_use_fixed_conservative_backoff() {
+        assert_eq!(
+            NETWORK_REQUEST_RETRY_BACKOFFS,
+            [
+                Duration::from_secs(60),
+                Duration::from_secs(120),
+                Duration::from_secs(300),
+            ]
+        );
+    }
+
+    #[test]
+    fn both_session_types_allow_three_resubmissions() {
+        for session_type in [SessionType::Stark, SessionType::Snark] {
+            let mut resubmission = 0;
+            for expected in 1..=NETWORK_REQUEST_RETRY_BACKOFFS.len() {
+                resubmission = next_resubmission(session_type.clone(), resubmission).unwrap();
+                assert_eq!(resubmission, expected);
+            }
+            assert!(next_resubmission(session_type, resubmission).is_err());
+        }
     }
 }

--- a/proofs/workers/sp1/src/backend.rs
+++ b/proofs/workers/sp1/src/backend.rs
@@ -11,8 +11,8 @@ use world_chain_proof_kona_host::online::{
 };
 use world_chain_proof_protocol::ProofGameProvider;
 use world_chain_proof_sp1_host::{
-    SP1ProofWithPublicValues, SuccinctProverError, WorldSuccinctProver,
-    aggregation_artifact_from_sp1_proof, range_artifact_from_sp1_proof,
+    SuccinctProverError, WorldSuccinctProver, aggregation_artifact_from_sp1_proof,
+    range_artifact_from_sp1_proof,
 };
 use world_chain_proof_sp1_types::{AggregationSessionRequest, RangeProofRequest, Sp1ProofRequest};
 use world_chain_proof_worker::{ClaimedProofJobHandler, ProofJob};
@@ -76,12 +76,7 @@ where
         let retrying_aggregation =
             if let Some(snark_session) = self.get_session(&job, SessionType::Snark).await? {
                 match self
-                    .wait_for_artifact(
-                        &job,
-                        SessionType::Snark,
-                        snark_session.backend_session_id,
-                        aggregation_artifact_from_sp1_proof,
-                    )
+                    .wait_for_aggregation(&job, snark_session.backend_session_id)
                     .await
                     .context("failed to resume aggregation proof")?
                 {
@@ -97,12 +92,7 @@ where
 
         let range = if let Some(stark_session) = self.get_session(&job, SessionType::Stark).await? {
             match self
-                .wait_for_artifact(
-                    &job,
-                    SessionType::Stark,
-                    stark_session.backend_session_id,
-                    range_artifact_from_sp1_proof,
-                )
+                .wait_for_range(&job, stark_session.backend_session_id)
                 .await
                 .context("failed to resume range proof")?
             {
@@ -224,20 +214,42 @@ impl<P: WorldSuccinctProver + Send + Sync, G: ProofGameProvider> Sp1Backend<P, G
         Ok(session_id)
     }
 
-    async fn wait_for_artifact<T>(
+    async fn wait_for_range(
         &self,
         job: &ProofJob,
-        session_type: SessionType,
         session_id: String,
-        decode: impl FnOnce(&SP1ProofWithPublicValues) -> anyhow::Result<T>,
-    ) -> anyhow::Result<Option<T>> {
-        let result = self
-            .prover
-            .wait(&session_id)
-            .await
-            .and_then(|proof| decode(&proof));
-        match result {
-            Ok(artifact) => {
+    ) -> anyhow::Result<Option<RangeProofArtifact>> {
+        let session_type = SessionType::Stark;
+        match self.prover.wait(&session_id).await {
+            Ok(proof) => {
+                let artifact = range_artifact_from_sp1_proof(&proof)?;
+                self.record_session(
+                    job,
+                    session_type,
+                    &session_id,
+                    BackendSessionStatus::Completed,
+                    None,
+                )
+                .await?;
+                Ok(Some(artifact))
+            }
+            Err(error) => {
+                self.handle_wait_error(job, session_type, &session_id, error)
+                    .await?;
+                Ok(None)
+            }
+        }
+    }
+
+    async fn wait_for_aggregation(
+        &self,
+        job: &ProofJob,
+        session_id: String,
+    ) -> anyhow::Result<Option<AggregationProofArtifact>> {
+        let session_type = SessionType::Snark;
+        match self.prover.wait(&session_id).await {
+            Ok(proof) => {
+                let artifact = aggregation_artifact_from_sp1_proof(&proof)?;
                 self.record_session(
                     job,
                     session_type,
@@ -311,15 +323,7 @@ impl<P: WorldSuccinctProver + Send + Sync, G: ProofGameProvider> Sp1Backend<P, G
                     Sp1ProofRequest::Range(request.clone()),
                 )
                 .await?;
-            if let Some(artifact) = self
-                .wait_for_artifact(
-                    job,
-                    SessionType::Stark,
-                    session_id,
-                    range_artifact_from_sp1_proof,
-                )
-                .await?
-            {
+            if let Some(artifact) = self.wait_for_range(job, session_id).await? {
                 return Ok(artifact);
             }
             resubmission = next_resubmission(SessionType::Stark, resubmission)?;
@@ -343,15 +347,7 @@ impl<P: WorldSuccinctProver + Send + Sync, G: ProofGameProvider> Sp1Backend<P, G
                     Sp1ProofRequest::Aggregation(request.clone()),
                 )
                 .await?;
-            if let Some(artifact) = self
-                .wait_for_artifact(
-                    job,
-                    SessionType::Snark,
-                    session_id,
-                    aggregation_artifact_from_sp1_proof,
-                )
-                .await?
-            {
+            if let Some(artifact) = self.wait_for_aggregation(job, session_id).await? {
                 return Ok(artifact);
             }
             resubmission = next_resubmission(SessionType::Snark, resubmission)?;

--- a/proofs/workers/sp1/src/backend.rs
+++ b/proofs/workers/sp1/src/backend.rs
@@ -200,14 +200,13 @@ impl<P: WorldSuccinctProver + Send + Sync, G: ProofGameProvider> Sp1Backend<P, G
         request: Sp1ProofRequest,
     ) -> anyhow::Result<String> {
         let session_id = self.prover.submit(request).await?;
-        let empty_failure_reason = None;
 
         self.record_session(
             job,
             session_type,
             &session_id,
             BackendSessionStatus::Running,
-            empty_failure_reason,
+            None,
         )
         .await?;
 

--- a/proofs/workers/sp1/src/cmd/run.rs
+++ b/proofs/workers/sp1/src/cmd/run.rs
@@ -14,8 +14,8 @@ use world_chain_proof_sp1_host::{
     cpu_prover::{CpuSuccinctProver, SP1ProofMode},
     mock_prover::MockSuccinctProver,
     network_prover::{
-        NetworkConnection, NetworkCreditClient, NetworkProverLimits, NetworkSuccinctProver,
-        ProofLimits,
+        NetworkConnection, NetworkCreditClient, NetworkProofRequestConfig, NetworkProverLimits,
+        NetworkSuccinctProver, ProofLimits,
     },
 };
 use world_chain_proof_sp1_worker::{
@@ -194,6 +194,23 @@ pub struct WorkerArgs {
     )]
     sp1_max_price_per_pgu: Option<u64>,
 
+    /// Maximum seconds a network request may remain unassigned. Uses the SP1 SDK default if
+    /// omitted.
+    #[arg(
+        long,
+        env = "SP1_AUCTION_TIMEOUT_SECONDS",
+        value_parser = clap::value_parser!(u64).range(1..)
+    )]
+    sp1_auction_timeout_seconds: Option<u64>,
+
+    /// Overall network proof deadline in seconds. Uses the SP1 SDK default if omitted.
+    #[arg(
+        long,
+        env = "SP1_PROOF_TIMEOUT_SECONDS",
+        value_parser = clap::value_parser!(u64).range(1..)
+    )]
+    sp1_proof_timeout_seconds: Option<u64>,
+
     /// Maximum number of jobs proved concurrently. One suits a local CPU prover; raise it for
     /// the Succinct proving network.
     #[arg(long, default_value_t = 1)]
@@ -320,11 +337,15 @@ pub async fn run(cli: WorkerArgs) -> Result<()> {
             run_worker(
                 &cli,
                 host,
-                NetworkSuccinctProver::from_connection_with_request_config(
+                NetworkSuccinctProver::from_connection_with_network_config(
                     SP1ProofMode::Groth16,
                     connection,
-                    limits,
-                    cli.sp1_max_price_per_pgu,
+                    NetworkProofRequestConfig {
+                        limits,
+                        max_price_per_pgu: cli.sp1_max_price_per_pgu,
+                        auction_timeout: cli.sp1_auction_timeout_seconds.map(Duration::from_secs),
+                        proof_timeout: cli.sp1_proof_timeout_seconds.map(Duration::from_secs),
+                    },
                 )
                 .await?,
             )
@@ -474,6 +495,8 @@ where
         sp1_aggregation_cycle_limit = cli.sp1_aggregation_cycle_limit,
         sp1_aggregation_gas_limit = cli.sp1_aggregation_gas_limit,
         sp1_max_price_per_pgu = ?cli.sp1_max_price_per_pgu,
+        sp1_auction_timeout_seconds = ?cli.sp1_auction_timeout_seconds,
+        sp1_proof_timeout_seconds = ?cli.sp1_proof_timeout_seconds,
         submit_proof_retry_max_retries = cli.submit_proof_retry_max_retries,
         submit_proof_retry_initial_delay_ms = cli.submit_proof_retry_initial_delay_ms,
         submit_proof_retry_max_delay_ms = cli.submit_proof_retry_max_delay_ms,
@@ -530,6 +553,8 @@ mod tests {
             DEFAULT_SP1_AGGREGATION_GAS_LIMIT
         );
         assert_eq!(cli.sp1_max_price_per_pgu, None);
+        assert_eq!(cli.sp1_auction_timeout_seconds, None);
+        assert_eq!(cli.sp1_proof_timeout_seconds, None);
     }
 
     #[test]
@@ -572,6 +597,38 @@ mod tests {
             .expect_err("zero max price per PGU should be rejected");
 
         assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
+    }
+
+    #[test]
+    fn parses_sp1_network_timeouts() {
+        let mut args = base_args();
+        args.extend([
+            "--sp1-auction-timeout-seconds",
+            "120",
+            "--sp1-proof-timeout-seconds",
+            "28800",
+        ]);
+
+        let cli = WorkerArgs::parse_from(args);
+
+        assert_eq!(cli.sp1_auction_timeout_seconds, Some(120));
+        assert_eq!(cli.sp1_proof_timeout_seconds, Some(28_800));
+    }
+
+    #[test]
+    fn rejects_zero_sp1_network_timeouts() {
+        for argument in [
+            "--sp1-auction-timeout-seconds",
+            "--sp1-proof-timeout-seconds",
+        ] {
+            let mut args = base_args();
+            args.extend([argument, "0"]);
+
+            let error = WorkerArgs::try_parse_from(args)
+                .expect_err("zero SP1 Network timeout should be rejected");
+
+            assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
+        }
     }
 
     #[test]


### PR DESCRIPTION
- resubmits timed out and auction timed out proofs with back off (1,2,5 mins if provers are unavailable)
- uses wait_proof for polling instead of our own looping around get (which didnt detect proof / auction time out)
- removes poll() and donwload() from `WorldSuccinctProver`

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes affect live SP1 Network job handling and retry semantics for proof generation; misconfigured timeouts or resubmission limits could delay or duplicate network requests, though scope is limited to the SP1 worker path.
> 
> **Overview**
> **SP1 Network proving** now uses the SDK’s `wait_proof` path (with optional auction and proof deadlines) instead of a manual poll loop, and maps auction/proof timeouts and other terminal network failures into `SuccinctProverError` so callers can tell resubmittable timeouts from hard failures.
> 
> The **SP1 worker** records failed sessions, then automatically resubmits range or aggregation requests after **60s / 120s / 300s** delays, up to **three** resubmissions per worker attempt; a finished range proof is kept when only aggregation needs a retry. Worker CLI/env adds `SP1_AUCTION_TIMEOUT_SECONDS` and `SP1_PROOF_TIMEOUT_SECONDS`, folded into `NetworkProofRequestConfig`.
> 
> **Docs** describe the new timeouts and retry behavior; **prover-service** tests cover replacing a failed proof session with a new running one.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d895258626281c3f24667fb8027313271c8228c6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->