### PR TITLE
fix(proposer): settle obsolete-domain games

### DIFF
--- a/pkg/contracts/scripts/devnet/DeployProofSystem.s.sol
+++ b/pkg/contracts/scripts/devnet/DeployProofSystem.s.sol
@@ -28,6 +28,10 @@ import {ISystemConfig} from "@optimism-bedrock/interfaces/L1/ISystemConfig.sol";
 /// ready. This script never changes the respected game type or retirement timestamp.
 /// `setImplementation(WC_GAME_TYPE, address(0))` is the kill switch: it stops new game
 /// creation without touching in-flight games.
+/// When replacing type 1006, stop the proposer while implementation and bond registration are
+/// updated. If the new implementation changes `domainHash`, restart the proposer so its selected
+/// lineage uses the new domain; its bond manager will resolve ready proposer-owned games left in
+/// the superseded domain. Same-domain games remain on the selected lineage and settle normally.
 ///
 /// The three proof-lane verifiers are **inputs**, not outputs: this script never deploys them.
 /// Every one is a required env address and must already hold code.

--- a/proofs/services/proposer/README.md
+++ b/proofs/services/proposer/README.md
@@ -62,4 +62,7 @@ Bonds are custodied in `DelayedWETH` and paid out in two phases. The first `clai
 call unlocks the credit; the second, after the WETH delay, withdraws and transfers it. Both are
 gated on `AnchorStateRegistry.isGameFinalized`, since `claimCredit` calls `closeGame`, which reverts
 until the registry's finality airgap has elapsed. The bond manager keeps every discovered
-proposer-owned game tracked until it is resolved and its pending withdrawal is drained.
+proposer-owned game tracked until it is resolved and its pending withdrawal is drained. For games
+whose embedded proposal domain differs from the currently registered domain, it also submits any
+available positive or negative resolution because those games are no longer visible to the selected
+lineage proposer. Same-domain outcomes remain with the proposer to avoid racing retry creation.

--- a/proofs/services/proposer/src/alloy.rs
+++ b/proofs/services/proposer/src/alloy.rs
@@ -1,6 +1,6 @@
 use alloy_consensus::BlockHeader;
 use alloy_eips::BlockNumberOrTag;
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{Address, B256, U256};
 use alloy_provider::{Provider, WalletProvider};
 use async_trait::async_trait;
 use std::{sync::Arc, time::Duration};
@@ -217,6 +217,10 @@ where
         self.provider.default_signer_address()
     }
 
+    fn active_domain_hash(&self) -> B256 {
+        self.registered.domain_hash
+    }
+
     async fn game_count(&self) -> Result<u64, ProposerError> {
         let count = self.factory.gameCount().call().await?;
         u256_to_u64(count)
@@ -229,6 +233,14 @@ where
     async fn game_creator(&self, game: Address) -> Result<Address, ProposerError> {
         self.game(game)
             .gameCreator()
+            .call()
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn game_domain_hash(&self, game: Address) -> Result<B256, ProposerError> {
+        self.game(game)
+            .proposalDomainHash()
             .call()
             .await
             .map_err(Into::into)

--- a/proofs/services/proposer/src/bond_manager.rs
+++ b/proofs/services/proposer/src/bond_manager.rs
@@ -5,7 +5,7 @@ use tracing::{info, warn};
 
 use crate::{BondManagerClient, BondManagerConfig, ProposerError};
 
-/// Discovers proposer-owned games, resolves invalid-parent descendants, and recovers bond credits.
+/// Discovers proposer-owned games, resolves abandoned games, and recovers bond credits.
 #[derive(Debug)]
 pub struct BondManager<E> {
     config: BondManagerConfig,
@@ -82,7 +82,7 @@ where
         Ok(())
     }
 
-    /// Resolves invalid-parent games, advances bond claims, and prunes fully settled games.
+    /// Resolves abandoned games, advances bond claims, and prunes fully settled games.
     ///
     /// `MultiProofGame.claimCredit` first unlocks the credit in `DelayedWETH` and only
     /// transfers it on a second call after the WETH delay, so a game stays tracked until its
@@ -90,22 +90,29 @@ where
     pub async fn settle_games(&mut self) -> Result<(), ProposerError> {
         let proposed_games: Vec<_> = self.proposed_games.iter().copied().collect();
         let now = self.execution_provider.latest_l1_timestamp().await?;
+        let active_domain_hash = self.execution_provider.active_domain_hash();
 
         for game in proposed_games {
             let result: Result<bool, ProposerError> = async {
                 let resolution_status = self.execution_provider.resolution_status(game).await?;
                 if !resolution_status.is_resolved() {
-                    // Retried lineages no longer expose their stale descendants to the canonical
-                    // proposer loop, so the bond manager resolves those descendants for recovery.
-                    // Leave direct proof timeouts to the proposer to avoid racing retry creation.
-                    if resolution_status.invalid_parent_resolvable() {
+                    // Resolve games abandoned by retries or domain upgrades; active-domain direct
+                    // outcomes stay with the proposer to avoid racing retry creation.
+                    let obsolete_domain_resolvable = if resolution_status.resolvable {
+                        self.execution_provider.game_domain_hash(game).await? != active_domain_hash
+                    } else {
+                        false
+                    };
+                    if resolution_status.invalid_parent_resolvable() || obsolete_domain_resolvable {
                         let submission = self.execution_provider.resolve_game(game).await?;
                         info!(
                             lifecycle_event = "game_resolved",
-                            outcome = "negative_invalid_parent",
+                            outcome = ?resolution_status.outcome,
+                            invalidation_reason = ?resolution_status.invalidation_reason,
+                            obsolete_domain = obsolete_domain_resolvable,
                             tx_hash = ?submission.tx_hash,
                             game_address = %game,
-                            "resolved proposer-owned game invalidated by its parent"
+                            "resolved abandoned proposer-owned game"
                         );
                     }
                     return Ok(false);

--- a/proofs/services/proposer/src/tests.rs
+++ b/proofs/services/proposer/src/tests.rs
@@ -25,6 +25,8 @@ use crate::{
 };
 
 const DOMAIN_HASH: B256 = b256!("1111111111111111111111111111111111111111111111111111111111111111");
+const OLD_DOMAIN_HASH: B256 =
+    b256!("2222222222222222222222222222222222222222222222222222222222222222");
 const ANCHOR: Address = address!("0000000000000000000000000000000000001006");
 const GAME_1: Address = address!("0000000000000000000000000000000000000001");
 
@@ -153,8 +155,10 @@ impl ProposerClient for MockContracts {
 #[derive(Debug, Clone)]
 struct MockBondClient {
     proposer: Address,
+    active_domain_hash: B256,
     /// `(game, creator)` pairs in factory index order. `None` marks a foreign game type.
     games: Arc<Mutex<Vec<(Option<Address>, Address)>>>,
+    game_domain_hashes: Arc<Mutex<HashMap<Address, B256>>>,
     requested_indices: Arc<Mutex<Vec<u64>>>,
     resolved_games: Arc<Mutex<HashSet<Address>>>,
     resolution_statuses: Arc<Mutex<HashMap<Address, ResolutionStatus>>>,
@@ -183,7 +187,9 @@ impl MockBondClient {
     fn with_indexed_games(proposer: Address, games: Vec<(Option<Address>, Address)>) -> Self {
         Self {
             proposer,
+            active_domain_hash: DOMAIN_HASH,
             games: Arc::new(Mutex::new(games)),
+            game_domain_hashes: Arc::default(),
             requested_indices: Arc::default(),
             resolved_games: Arc::default(),
             resolution_statuses: Arc::default(),
@@ -204,6 +210,10 @@ impl MockBondClient {
 impl BondManagerClient for MockBondClient {
     fn proposer_address(&self) -> Address {
         self.proposer
+    }
+
+    fn active_domain_hash(&self) -> B256 {
+        self.active_domain_hash
     }
 
     async fn game_count(&self) -> Result<u64, ProposerError> {
@@ -235,6 +245,16 @@ impl BondManagerClient for MockBondClient {
             .iter()
             .find_map(|(candidate, creator)| (*candidate == Some(game)).then_some(*creator))
             .ok_or_else(|| ProposerError::message(format!("unknown game {game}")))
+    }
+
+    async fn game_domain_hash(&self, game: Address) -> Result<B256, ProposerError> {
+        Ok(self
+            .game_domain_hashes
+            .lock()
+            .expect("not poisoned")
+            .get(&game)
+            .copied()
+            .unwrap_or(self.active_domain_hash))
     }
 
     async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError> {
@@ -1039,6 +1059,76 @@ async fn bond_manager_leaves_direct_proof_timeout_to_lineage_proposer() {
 
     assert!(client.resolutions.lock().expect("not poisoned").is_empty());
     assert!(manager.tracks_game(game));
+}
+
+#[tokio::test]
+async fn bond_manager_resolves_proof_timeout_from_obsolete_domain() {
+    let proposer = Address::repeat_byte(0xa1);
+    let game = game_address(1);
+    let client = MockBondClient::new(proposer, vec![(game, proposer)]);
+    client
+        .game_domain_hashes
+        .lock()
+        .expect("not poisoned")
+        .insert(game, OLD_DOMAIN_HASH);
+    client
+        .resolution_statuses
+        .lock()
+        .expect("not poisoned")
+        .insert(game, negatively_resolvable_timeout());
+    let mut manager = BondManager::new(bond_manager_config(100), client.clone());
+    manager.scan_games().await.unwrap();
+
+    manager.settle_games().await.unwrap();
+
+    assert_eq!(
+        *client.resolutions.lock().expect("not poisoned"),
+        vec![game]
+    );
+    assert!(manager.tracks_game(game));
+}
+
+#[tokio::test]
+async fn bond_manager_resolves_positive_game_from_obsolete_domain() {
+    let proposer = Address::repeat_byte(0xa1);
+    let game = game_address(1);
+    let client = MockBondClient::new(proposer, vec![(game, proposer)]);
+    client
+        .game_domain_hashes
+        .lock()
+        .expect("not poisoned")
+        .insert(game, OLD_DOMAIN_HASH);
+    client
+        .resolution_statuses
+        .lock()
+        .expect("not poisoned")
+        .insert(game, positive_ready_status());
+    client
+        .credit
+        .lock()
+        .expect("not poisoned")
+        .insert(game, U256::from(10));
+    let mut manager = BondManager::new(bond_manager_config(100), client.clone());
+    manager.scan_games().await.unwrap();
+
+    manager.settle_games().await.unwrap();
+
+    assert_eq!(
+        *client.resolutions.lock().expect("not poisoned"),
+        vec![game]
+    );
+    assert!(manager.tracks_game(game));
+
+    manager.settle_games().await.unwrap();
+    assert_eq!(*client.unlocks.lock().expect("not poisoned"), vec![game]);
+    assert!(manager.tracks_game(game));
+
+    manager.settle_games().await.unwrap();
+    assert_eq!(
+        *client.withdrawals.lock().expect("not poisoned"),
+        vec![game]
+    );
+    assert!(!manager.tracks_game(game));
 }
 
 #[tokio::test]

--- a/proofs/services/proposer/src/traits.rs
+++ b/proofs/services/proposer/src/traits.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{Address, B256, U256};
 use async_trait::async_trait;
 use world_chain_proof_protocol::{LineageProvider, ResolutionStatus};
 
@@ -13,6 +13,9 @@ pub trait BondManagerClient: Send + Sync {
     /// Returns the address whose proposal credits are managed.
     fn proposer_address(&self) -> Address;
 
+    /// Returns the proposal domain currently registered for WIP-1006.
+    fn active_domain_hash(&self) -> B256;
+
     /// Returns the total number of games indexed by the dispute-game factory, across all
     /// game types.
     async fn game_count(&self) -> Result<u64, ProposerError>;
@@ -24,10 +27,13 @@ pub trait BondManagerClient: Send + Sync {
     /// Returns the account that created the provided game.
     async fn game_creator(&self, game: Address) -> Result<Address, ProposerError>;
 
+    /// Returns the proposal domain embedded in the provided game.
+    async fn game_domain_hash(&self, game: Address) -> Result<B256, ProposerError>;
+
     /// Returns the resolution status of the provided game.
     async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError>;
 
-    /// Resolves a proposer-owned game invalidated by its parent.
+    /// Resolves a proposer-owned game that is ready for a terminal outcome.
     async fn resolve_game(&self, game: Address) -> Result<ResolveSubmission, ProposerError>;
 
     /// Returns whether the registry's finality airgap has elapsed for the provided game.


### PR DESCRIPTION
makes the bond manager "upgrade-safe" in the sense that it would even resolve and collect bonds from games which were, but are no longer in the current lineage due to a change in e.g. domain hash / a fork

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7ec4713b7cde62908472bccf6d239532c3aa4c98. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->