### PR TITLE
feat(proofs): proof fillup fixes and kms support for prove refills

### DIFF
--- a/docs/proof/sp1-worker.md
+++ b/docs/proof/sp1-worker.md
@@ -28,10 +28,10 @@ The network prover additionally requires:
 - `SP1_NETWORK_L1_RPC_URL`: Ethereum mainnet RPC used for Succinct settlement reads.
 - `SUCCINCT_VAPP_ADDRESS`: SuccinctVApp proxy address on Ethereum mainnet.
 
-At startup the worker validates that the settlement RPC is Ethereum mainnet, discovers the PROVE
-token, its decimals, and `minDepositAmount()` from the configured VApp, then waits until the account
-has the configured minimum SP1 Network credits. The default minimum is 10 PROVE. Amounts are
-human-readable and converted to base units with the token's on-chain decimals.
+At startup the worker validates that the settlement RPC is Ethereum mainnet and discovers the
+PROVE token and `minDepositAmount()` from the configured VApp, then waits until the account has the
+configured minimum SP1 Network credits. The default minimum is 10 PROVE. Human-readable amounts
+use PROVE's fixed 18 decimals.
 
 | Variable | Flag | Default |
 |---|---|---:|
@@ -97,7 +97,7 @@ store:
 world-chain-proof-sp1-worker deposit --amount 1000
 ```
 
-The amount is human-readable PROVE; token decimals are read on-chain. The command validates the
+The amount is human-readable PROVE using PROVE's fixed 18 decimals. The command validates the
 Ethereum mainnet contracts, the signer's PROVE and ETH balances, waits for a successful transaction
 receipt, prints the transaction hash and Succinct receipt ID, then polls until the SP1 Network
 credit balance increases. If credits have not changed within 30 minutes, it exits with an error

--- a/docs/proof/sp1-worker.md
+++ b/docs/proof/sp1-worker.md
@@ -21,12 +21,14 @@ For every leased job, the worker reads the proof interval and immutable transiti
 the job's `MultiProofGame`. It rejects queued root, block, L1 head, or rollup-config values that do
 not match the game before collecting a witness.
 
-The network prover additionally requires:
+The worker requires exactly one of `SP1_PRIVATE_KEY` or `SP1_KMS_KEY_ID`. The network prover
+additionally requires:
 
-- Exactly one of `SP1_PRIVATE_KEY` or `SP1_KMS_KEY_ID`: signs SP1 proof requests and Ethereum
-  mainnet refill transactions, and identifies the credited account.
 - `SP1_NETWORK_L1_RPC_URL`: Ethereum mainnet RPC used for Succinct settlement reads.
 - `SUCCINCT_VAPP_ADDRESS`: SuccinctVApp proxy address on Ethereum mainnet.
+
+The configured signer signs SP1 proof requests and Ethereum mainnet refill transactions, and
+identifies the credited account.
 
 At startup the worker validates that the settlement RPC is Ethereum mainnet and discovers the
 PROVE token and `minDepositAmount()` from the configured VApp, then waits until the account has the

--- a/docs/proof/sp1-worker.md
+++ b/docs/proof/sp1-worker.md
@@ -23,16 +23,30 @@ not match the game before collecting a witness.
 
 The network prover additionally requires:
 
-- `SP1_PRIVATE_KEY`: signs SP1 proof requests and identifies the credited account.
+- Exactly one of `SP1_PRIVATE_KEY` or `SP1_KMS_KEY_ID`: signs SP1 proof requests and Ethereum
+  mainnet refill transactions, and identifies the credited account.
 - `SP1_NETWORK_L1_RPC_URL`: Ethereum mainnet RPC used for Succinct settlement reads.
 - `SUCCINCT_VAPP_ADDRESS`: SuccinctVApp proxy address on Ethereum mainnet.
 
 At startup the worker validates that the settlement RPC is Ethereum mainnet, discovers the PROVE
-token and `minDepositAmount()` from the configured VApp, then waits until the account has at least
-`10 * minDepositAmount()` in SP1 Network credits. It retries the credit check every 30 seconds and
-does not lease jobs while waiting. Once running, a background check updates
-`sp1_network_prove_balance` and `sp1_network_balance_sufficient`; a later low balance is logged but
-does not interrupt in-flight work.
+token, its decimals, and `minDepositAmount()` from the configured VApp, then waits until the account
+has the configured minimum SP1 Network credits. The default minimum is 10 PROVE. Amounts are
+human-readable and converted to base units with the token's on-chain decimals.
+
+| Variable | Flag | Default |
+|---|---|---:|
+| `SP1_NETWORK_MINIMUM_BALANCE` | `--sp1-network-minimum-balance` | `10` PROVE |
+| `SP1_NETWORK_REFILL_AMOUNT` | `--sp1-network-refill-amount` | `SuccinctVApp.minDepositAmount()` |
+
+When the balance is low, the worker deposits the larger of the configured refill amount or the
+shortfall to the minimum. The signer must hold enough PROVE and ETH on Ethereum mainnet. After a
+deposit confirms, the worker waits for the same Succinct receipt to appear in SP1 Network credits
+instead of submitting another deposit. It retries the balance check every 30 seconds and does not
+lease jobs during the startup wait. Once running, the same check and refill continue in the
+background while updating `sp1_network_prove_balance` and `sp1_network_balance_sufficient`.
+
+Run only one auto-refilling worker for a given signer. Multiple replicas can observe the same low
+balance and submit independent refills before either sees the other's receipt.
 
 `NETWORK_RPC_URL` remains the optional override for the SP1 Network API itself. It is distinct from
 `SP1_NETWORK_L1_RPC_URL`.
@@ -79,7 +93,7 @@ providing the key and settlement configuration through environment variables bac
 store:
 
 ```bash
-# SP1_NETWORK_L1_RPC_URL, SUCCINCT_VAPP_ADDRESS, and SP1_PRIVATE_KEY are injected.
+# Settlement configuration and exactly one of SP1_PRIVATE_KEY or SP1_KMS_KEY_ID are injected.
 world-chain-proof-sp1-worker deposit --amount 1000
 ```
 

--- a/proofs/workers/sp1/src/cmd/deposit.rs
+++ b/proofs/workers/sp1/src/cmd/deposit.rs
@@ -6,7 +6,7 @@ use alloy_signer::{Signer, SignerSync};
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::eip712_domain;
 use anyhow::{Context, Result, bail};
-use clap::Args;
+use clap::{ArgGroup, Args};
 use url::Url;
 use world_chain_proof_sp1_host::network_prover::{NetworkCreditClient, SignerType};
 use world_chain_proof_tx_signer::{TransactionSigner, build_transaction_signer};
@@ -24,6 +24,12 @@ const CREDIT_POLL_INTERVAL: Duration = Duration::from_secs(10);
 const CREDIT_REFLECTION_TIMEOUT: Duration = Duration::from_secs(30 * 60);
 
 #[derive(Debug, Args)]
+#[command(
+    group = ArgGroup::new("sp1_signer")
+        .required(true)
+        .multiple(false)
+        .args(["sp1_private_key", "sp1_kms_key_id"])
+)]
 pub struct DepositArgs {
     /// Human-readable amount of PROVE to deposit (for example `1000` or `12.5`).
     #[arg(long)]
@@ -38,11 +44,20 @@ pub struct DepositArgs {
     succinct_vapp_address: Address,
 
     /// Private key for both the PROVE holder and the corresponding SP1 Network account.
-    #[arg(long, env = "SP1_PRIVATE_KEY")]
+    #[arg(
+        long,
+        env = "SP1_PRIVATE_KEY",
+        value_parser = clap::builder::NonEmptyStringValueParser::new()
+    )]
     sp1_private_key: Option<String>,
 
     /// AWS KMS key ID for both the PROVE holder and the corresponding SP1 Network account.
-    #[arg(long, env = "SP1_KMS_KEY_ID", hide_env_values = true)]
+    #[arg(
+        long,
+        env = "SP1_KMS_KEY_ID",
+        hide_env_values = true,
+        value_parser = clap::builder::NonEmptyStringValueParser::new()
+    )]
     sp1_kms_key_id: Option<String>,
 }
 
@@ -56,7 +71,7 @@ pub async fn deposit(args: DepositArgs) -> Result<()> {
     let (signer_secret, signer_type) = select_network_signer(
         args.sp1_private_key.as_deref(),
         args.sp1_kms_key_id.as_deref(),
-    )?;
+    );
     let credit_client = NetworkCreditClient::new(signer_secret, signer_type).await?;
     let credit_before = credit_client
         .get_balance()

--- a/proofs/workers/sp1/src/cmd/deposit.rs
+++ b/proofs/workers/sp1/src/cmd/deposit.rs
@@ -14,8 +14,8 @@ use world_chain_proof_tx_signer::{TransactionSigner, build_transaction_signer};
 use super::{
     select_network_signer,
     succinct::{
-        ETHEREUM_MAINNET_CHAIN_ID, IProveToken, ISuccinctVApp, Permit, SettlementConfig,
-        format_prove, load_settlement_config,
+        ETHEREUM_MAINNET_CHAIN_ID, IProveToken, ISuccinctVApp, PROVE_DECIMALS, Permit,
+        SettlementConfig, format_prove, load_settlement_config,
     },
 };
 
@@ -52,7 +52,7 @@ pub async fn deposit(args: DepositArgs) -> Result<()> {
             .await
             .context("validating Succinct settlement configuration")?;
 
-    let amount = parse_prove_amount(&args.amount, settlement.prove_decimals)?;
+    let amount = parse_prove_amount(&args.amount)?;
     let (signer_secret, signer_type) = select_network_signer(
         args.sp1_private_key.as_deref(),
         args.sp1_kms_key_id.as_deref(),
@@ -65,7 +65,7 @@ pub async fn deposit(args: DepositArgs) -> Result<()> {
 
     println!(
         "Depositing {} PROVE through SuccinctVApp {}...",
-        format_prove(amount, settlement.prove_decimals),
+        format_prove(amount),
         settlement.vapp_address,
     );
     let receipt = submit_deposit(
@@ -85,7 +85,6 @@ pub async fn deposit(args: DepositArgs) -> Result<()> {
     wait_for_credit_reflection(
         &credit_client,
         credit_before,
-        settlement.prove_decimals,
         receipt.tx_hash,
         receipt.onchain_receipt,
     )
@@ -108,8 +107,8 @@ pub(crate) async fn submit_deposit(
     if amount < settlement.min_deposit_amount {
         bail!(
             "deposit amount {} PROVE is below SuccinctVApp.minDepositAmount() of {} PROVE",
-            format_prove(amount, settlement.prove_decimals),
-            format_prove(settlement.min_deposit_amount, settlement.prove_decimals),
+            format_prove(amount),
+            format_prove(settlement.min_deposit_amount),
         );
     }
     let l1_rpc_url = Url::parse(l1_rpc_url).context("invalid SP1 Network L1 RPC URL")?;
@@ -132,8 +131,8 @@ pub(crate) async fn submit_deposit(
     if token_balance < amount {
         bail!(
             "insufficient PROVE balance for {signer_address}: have {} PROVE, need {} PROVE",
-            format_prove(token_balance, settlement.prove_decimals),
-            format_prove(amount, settlement.prove_decimals),
+            format_prove(token_balance),
+            format_prove(amount),
         );
     }
 
@@ -223,12 +222,12 @@ pub(crate) async fn submit_deposit(
     })
 }
 
-pub(crate) fn parse_prove_amount(input: &str, decimals: u8) -> Result<U256> {
+pub(crate) fn parse_prove_amount(input: &str) -> Result<U256> {
     let input = input.trim();
     if input.is_empty() || input.starts_with('-') {
         bail!("PROVE amount must be positive");
     }
-    let amount: U256 = parse_units(input, decimals)
+    let amount: U256 = parse_units(input, PROVE_DECIMALS)
         .with_context(|| format!("invalid PROVE amount `{input}`"))?
         .into();
     if amount.is_zero() {
@@ -250,7 +249,6 @@ fn permit_deadline() -> Result<U256> {
 async fn wait_for_credit_reflection(
     client: &NetworkCreditClient,
     credit_before: U256,
-    decimals: u8,
     tx_hash: B256,
     onchain_receipt: u64,
 ) -> Result<()> {
@@ -260,15 +258,15 @@ async fn wait_for_credit_reflection(
             Ok(balance) if balance > credit_before => {
                 println!(
                     "Deposit reflected in SP1 Network credits: {} -> {} PROVE",
-                    format_prove(credit_before, decimals),
-                    format_prove(balance, decimals),
+                    format_prove(credit_before),
+                    format_prove(balance),
                 );
                 return Ok(());
             }
             Ok(balance) => {
                 println!(
                     "Waiting for Succinct receipt {onchain_receipt} to be reflected in SP1 Network credits (current: {} PROVE)...",
-                    format_prove(balance, decimals),
+                    format_prove(balance),
                 );
             }
             Err(error) => {
@@ -313,14 +311,14 @@ mod tests {
     #[test]
     fn parses_human_readable_prove_amount() {
         assert_eq!(
-            parse_prove_amount("12.5", 6).unwrap(),
-            U256::from(12_500_000_u64)
+            parse_prove_amount("12.5").unwrap(),
+            U256::from(12_500_000_000_000_000_000_u128)
         );
     }
 
     #[test]
     fn rejects_non_positive_prove_amounts() {
-        assert!(parse_prove_amount("0", 18).is_err());
-        assert!(parse_prove_amount("-1", 18).is_err());
+        assert!(parse_prove_amount("0").is_err());
+        assert!(parse_prove_amount("-1").is_err());
     }
 }

--- a/proofs/workers/sp1/src/cmd/deposit.rs
+++ b/proofs/workers/sp1/src/cmd/deposit.rs
@@ -14,8 +14,8 @@ use world_chain_proof_tx_signer::{TransactionSigner, build_transaction_signer};
 use super::{
     select_network_signer,
     succinct::{
-        ETHEREUM_MAINNET_CHAIN_ID, IProveToken, ISuccinctVApp, Permit, format_prove,
-        load_settlement_config,
+        ETHEREUM_MAINNET_CHAIN_ID, IProveToken, ISuccinctVApp, Permit, SettlementConfig,
+        format_prove, load_settlement_config,
     },
 };
 
@@ -53,6 +53,58 @@ pub async fn deposit(args: DepositArgs) -> Result<()> {
             .context("validating Succinct settlement configuration")?;
 
     let amount = parse_prove_amount(&args.amount, settlement.prove_decimals)?;
+    let (signer_secret, signer_type) = select_network_signer(
+        args.sp1_private_key.as_deref(),
+        args.sp1_kms_key_id.as_deref(),
+    )?;
+    let credit_client = NetworkCreditClient::new(signer_secret, signer_type).await?;
+    let credit_before = credit_client
+        .get_balance()
+        .await
+        .context("reading SP1 Network credit balance before deposit")?;
+
+    println!(
+        "Depositing {} PROVE through SuccinctVApp {}...",
+        format_prove(amount, settlement.prove_decimals),
+        settlement.vapp_address,
+    );
+    let receipt = submit_deposit(
+        &args.sp1_network_l1_rpc_url,
+        settlement,
+        signer_secret,
+        signer_type,
+        amount,
+    )
+    .await?;
+    println!(
+        "Submitted and confirmed deposit transaction {}",
+        receipt.tx_hash
+    );
+    println!("Succinct on-chain receipt ID: {}", receipt.onchain_receipt);
+
+    wait_for_credit_reflection(
+        &credit_client,
+        credit_before,
+        settlement.prove_decimals,
+        receipt.tx_hash,
+        receipt.onchain_receipt,
+    )
+    .await
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct DepositReceipt {
+    pub tx_hash: B256,
+    pub onchain_receipt: u64,
+}
+
+pub(crate) async fn submit_deposit(
+    l1_rpc_url: &str,
+    settlement: SettlementConfig,
+    signer_secret: &str,
+    signer_type: SignerType,
+    amount: U256,
+) -> Result<DepositReceipt> {
     if amount < settlement.min_deposit_amount {
         bail!(
             "deposit amount {} PROVE is below SuccinctVApp.minDepositAmount() of {} PROVE",
@@ -60,22 +112,12 @@ pub async fn deposit(args: DepositArgs) -> Result<()> {
             format_prove(settlement.min_deposit_amount, settlement.prove_decimals),
         );
     }
-    let l1_rpc_url =
-        Url::parse(&args.sp1_network_l1_rpc_url).context("invalid SP1 Network L1 RPC URL")?;
-    let (signer_secret, signer_type) = select_network_signer(
-        args.sp1_private_key.as_deref(),
-        args.sp1_kms_key_id.as_deref(),
-    )?;
+    let l1_rpc_url = Url::parse(l1_rpc_url).context("invalid SP1 Network L1 RPC URL")?;
     let l1_signer = build_l1_signer(signer_secret, signer_type, &l1_rpc_url).await?;
     let signer_address = match &l1_signer {
         TransactionSigner::Local(signer) => signer.address(),
         TransactionSigner::Aws(signer) => signer.address(),
     };
-    let credit_client = NetworkCreditClient::new(signer_secret, signer_type).await?;
-    let credit_before = credit_client
-        .get_balance()
-        .await
-        .context("reading SP1 Network credit balance before deposit")?;
     let provider = ProviderBuilder::new()
         .wallet(l1_signer.wallet())
         .connect_http(l1_rpc_url);
@@ -148,18 +190,12 @@ pub async fn deposit(args: DepositArgs) -> Result<()> {
     let s = B256::from_slice(&signature[32..64]);
     let v = signature[64];
 
-    println!(
-        "Depositing {} PROVE from {signer_address} through SuccinctVApp {}...",
-        format_prove(amount, settlement.prove_decimals),
-        settlement.vapp_address,
-    );
     let pending = vapp
         .permitAndDeposit(signer_address, amount, deadline, v, r, s)
         .send()
         .await
         .context("submitting permitAndDeposit transaction")?;
     let tx_hash = *pending.tx_hash();
-    println!("Submitted deposit transaction {tx_hash}");
 
     let receipt = pending
         .get_receipt()
@@ -181,30 +217,22 @@ pub async fn deposit(args: DepositArgs) -> Result<()> {
         .with_context(|| {
             format!("deposit transaction {tx_hash} succeeded but emitted no TransactionPending")
         })?;
-    println!(
-        "Deposit transaction {tx_hash} confirmed; Succinct on-chain receipt ID: {onchain_receipt}"
-    );
-
-    wait_for_credit_reflection(
-        &credit_client,
-        credit_before,
-        settlement.prove_decimals,
+    Ok(DepositReceipt {
         tx_hash,
         onchain_receipt,
-    )
-    .await
+    })
 }
 
-fn parse_prove_amount(input: &str, decimals: u8) -> Result<U256> {
+pub(crate) fn parse_prove_amount(input: &str, decimals: u8) -> Result<U256> {
     let input = input.trim();
     if input.is_empty() || input.starts_with('-') {
-        bail!("--amount must be a positive PROVE amount");
+        bail!("PROVE amount must be positive");
     }
     let amount: U256 = parse_units(input, decimals)
         .with_context(|| format!("invalid PROVE amount `{input}`"))?
         .into();
     if amount.is_zero() {
-        bail!("--amount must be greater than zero");
+        bail!("PROVE amount must be greater than zero");
     }
     Ok(amount)
 }

--- a/proofs/workers/sp1/src/cmd/mod.rs
+++ b/proofs/workers/sp1/src/cmd/mod.rs
@@ -1,4 +1,3 @@
-use anyhow::{Result, bail};
 use world_chain_proof_sp1_host::network_prover::SignerType;
 
 pub mod deposit;
@@ -9,42 +8,13 @@ pub mod vkeys;
 fn select_network_signer<'a>(
     private_key: Option<&'a str>,
     kms_key_id: Option<&'a str>,
-) -> Result<(&'a str, SignerType)> {
-    let private_key = private_key.filter(|value| !value.trim().is_empty());
-    let kms_key_id = kms_key_id.filter(|value| !value.trim().is_empty());
-
-    match (private_key, kms_key_id) {
-        (Some(private_key), None) => Ok((private_key, SignerType::Local)),
-        (None, Some(key_id)) => Ok((key_id, SignerType::AwsKms)),
-        _ => bail!("configure exactly one SP1 private key or AWS KMS key ID"),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn blank_private_key_does_not_mask_kms_key() {
-        let (secret, signer_type) =
-            select_network_signer(Some("  "), Some("alias/prover")).unwrap();
-
-        assert_eq!(secret, "alias/prover");
-        assert!(matches!(signer_type, SignerType::AwsKms));
-    }
-
-    #[test]
-    fn blank_kms_key_does_not_mask_private_key() {
-        let (secret, signer_type) = select_network_signer(Some("0x1234"), Some("\t")).unwrap();
-
-        assert_eq!(secret, "0x1234");
-        assert!(matches!(signer_type, SignerType::Local));
-    }
-
-    #[test]
-    fn rejects_missing_or_multiple_signers() {
-        assert!(select_network_signer(None, None).is_err());
-        assert!(select_network_signer(Some(" "), Some("\n")).is_err());
-        assert!(select_network_signer(Some("0x1234"), Some("alias/prover")).is_err());
+) -> (&'a str, SignerType) {
+    if let Some(private_key) = private_key {
+        (private_key, SignerType::Local)
+    } else {
+        (
+            kms_key_id.expect("SP1 signer is required by clap"),
+            SignerType::AwsKms,
+        )
     }
 }

--- a/proofs/workers/sp1/src/cmd/run.rs
+++ b/proofs/workers/sp1/src/cmd/run.rs
@@ -323,20 +323,16 @@ pub async fn run(cli: WorkerArgs) -> Result<()> {
             let settlement = load_settlement_config(l1_rpc_url, vapp_address)
                 .await
                 .context("validating Succinct settlement configuration")?;
-            let minimum_balance =
-                parse_prove_amount(&cli.sp1_network_minimum_balance, settlement.prove_decimals)
-                    .context("invalid SP1 Network minimum balance")?;
+            let minimum_balance = parse_prove_amount(&cli.sp1_network_minimum_balance)
+                .context("invalid SP1 Network minimum balance")?;
             let refill_amount = cli
                 .sp1_network_refill_amount
                 .as_deref()
-                .map(|amount| parse_prove_amount(amount, settlement.prove_decimals))
+                .map(parse_prove_amount)
                 .transpose()
                 .context("invalid SP1 Network refill amount")?;
-            let refill_amount = resolve_refill_amount(
-                refill_amount,
-                settlement.min_deposit_amount,
-                settlement.prove_decimals,
-            )?;
+            let refill_amount =
+                resolve_refill_amount(refill_amount, settlement.min_deposit_amount)?;
             let refill = NetworkRefillConfig {
                 l1_rpc_url: l1_rpc_url.clone(),
                 settlement,
@@ -401,7 +397,7 @@ async fn wait_for_sufficient_network_balance(
     loop {
         if maintain_network_balance(client, minimum_balance, refill, &mut pending_deposit).await {
             tracing::info!(
-                minimum_balance = %format_prove(minimum_balance, refill.settlement.prove_decimals),
+                minimum_balance = %format_prove(minimum_balance),
                 "SP1 Network credit balance is sufficient"
             );
             return Ok(true);
@@ -440,7 +436,6 @@ async fn maintain_network_balance(
     refill: &NetworkRefillConfig,
     pending_deposit: &mut Option<DepositReceipt>,
 ) -> bool {
-    let decimals = refill.settlement.prove_decimals;
     let balance = match client.get_balance().await {
         Ok(balance) => balance,
         Err(error) => {
@@ -449,12 +444,12 @@ async fn maintain_network_balance(
             return false;
         }
     };
-    if record_network_balance(balance, minimum_balance, decimals) {
+    if record_network_balance(balance, minimum_balance) {
         if let Some(receipt) = pending_deposit.take() {
             tracing::info!(
                 tx_hash = %receipt.tx_hash,
                 onchain_receipt = receipt.onchain_receipt,
-                balance = %format_prove(balance, decimals),
+                balance = %format_prove(balance),
                 "SP1 Network refill is reflected in credits"
             );
         }
@@ -465,8 +460,8 @@ async fn maintain_network_balance(
         tracing::warn!(
             tx_hash = %receipt.tx_hash,
             onchain_receipt = receipt.onchain_receipt,
-            balance = %format_prove(balance, decimals),
-            minimum_balance = %format_prove(minimum_balance, decimals),
+            balance = %format_prove(balance),
+            minimum_balance = %format_prove(minimum_balance),
             "waiting for confirmed SP1 Network refill to be reflected in credits"
         );
         return false;
@@ -475,9 +470,9 @@ async fn maintain_network_balance(
     let amount = refill_amount_for_balance(balance, minimum_balance, refill.refill_amount)
         .expect("insufficient balance must have a refill amount");
     tracing::warn!(
-        balance = %format_prove(balance, decimals),
-        minimum_balance = %format_prove(minimum_balance, decimals),
-        refill_amount = %format_prove(amount, decimals),
+        balance = %format_prove(balance),
+        minimum_balance = %format_prove(minimum_balance),
+        refill_amount = %format_prove(amount),
         "SP1 Network credit balance is too low; submitting refill"
     );
     match submit_deposit(
@@ -493,7 +488,7 @@ async fn maintain_network_balance(
             tracing::info!(
                 tx_hash = %receipt.tx_hash,
                 onchain_receipt = receipt.onchain_receipt,
-                refill_amount = %format_prove(amount, decimals),
+                refill_amount = %format_prove(amount),
                 "SP1 Network refill confirmed on Ethereum mainnet"
             );
             *pending_deposit = Some(receipt);
@@ -517,25 +512,21 @@ fn refill_amount_for_balance(
     Some(shortfall.max(refill_amount))
 }
 
-fn resolve_refill_amount(
-    configured: Option<U256>,
-    min_deposit_amount: U256,
-    decimals: u8,
-) -> Result<U256> {
+fn resolve_refill_amount(configured: Option<U256>, min_deposit_amount: U256) -> Result<U256> {
     let amount = configured.unwrap_or(min_deposit_amount);
     if amount < min_deposit_amount {
         anyhow::bail!(
             "SP1 Network refill amount {} PROVE is below SuccinctVApp.minDepositAmount() of {} PROVE",
-            format_prove(amount, decimals),
-            format_prove(min_deposit_amount, decimals),
+            format_prove(amount),
+            format_prove(min_deposit_amount),
         );
     }
     Ok(amount)
 }
 
-fn record_network_balance(balance: U256, minimum_balance: U256, decimals: u8) -> bool {
+fn record_network_balance(balance: U256, minimum_balance: U256) -> bool {
     let sufficient = balance >= minimum_balance;
-    match prove_as_f64(balance, decimals) {
+    match prove_as_f64(balance) {
         Ok(balance_prove) => {
             world_chain_proof_metrics::record_sp1_network_balance(balance_prove, sufficient);
         }
@@ -746,13 +737,9 @@ mod tests {
     }
 
     #[test]
-    fn parses_minimum_balance_using_prove_decimals() {
+    fn parses_minimum_balance_as_prove() {
         assert_eq!(
-            parse_prove_amount(DEFAULT_SP1_NETWORK_MINIMUM_BALANCE, 6).unwrap(),
-            U256::from(10_000_000_u64)
-        );
-        assert_eq!(
-            parse_prove_amount(DEFAULT_SP1_NETWORK_MINIMUM_BALANCE, 18).unwrap(),
+            parse_prove_amount(DEFAULT_SP1_NETWORK_MINIMUM_BALANCE).unwrap(),
             U256::from(10_000_000_000_000_000_000_u128)
         );
     }
@@ -778,9 +765,9 @@ mod tests {
         let vapp_minimum = U256::from(10_000_u64);
 
         assert_eq!(
-            resolve_refill_amount(None, vapp_minimum, 6).unwrap(),
+            resolve_refill_amount(None, vapp_minimum).unwrap(),
             vapp_minimum
         );
-        assert!(resolve_refill_amount(Some(U256::from(9_999)), vapp_minimum, 6).is_err());
+        assert!(resolve_refill_amount(Some(U256::from(9_999)), vapp_minimum).is_err());
     }
 }

--- a/proofs/workers/sp1/src/cmd/run.rs
+++ b/proofs/workers/sp1/src/cmd/run.rs
@@ -15,7 +15,7 @@ use world_chain_proof_sp1_host::{
     mock_prover::MockSuccinctProver,
     network_prover::{
         NetworkConnection, NetworkCreditClient, NetworkProofRequestConfig, NetworkProverLimits,
-        NetworkSuccinctProver, ProofLimits,
+        NetworkSuccinctProver, ProofLimits, SignerType,
     },
 };
 use world_chain_proof_sp1_worker::{
@@ -25,8 +25,9 @@ use world_chain_proof_worker::WorkerHeartbeatConfig;
 use world_chain_prover_service::RpcProverServiceClient;
 
 use super::{
+    deposit::{DepositReceipt, parse_prove_amount, submit_deposit},
     select_network_signer,
-    succinct::{format_prove, load_settlement_config, prove_as_f64},
+    succinct::{SettlementConfig, format_prove, load_settlement_config, prove_as_f64},
 };
 
 const DEFAULT_SUBMIT_PROOF_RETRY_MAX_RETRIES: usize = 10;
@@ -35,7 +36,7 @@ const DEFAULT_SUBMIT_PROOF_RETRY_MAX_DELAY_MS: u64 = 10_000;
 const DEFAULT_WORKER_HEARTBEAT_INTERVAL_SEC: u64 = 30;
 const DEFAULT_WORKER_MAX_CONSECUTIVE_HEARTBEAT_FAILURES: u32 = 5;
 const SP1_NETWORK_BALANCE_POLL_INTERVAL: Duration = Duration::from_secs(30);
-const MINIMUM_DEPOSIT_MULTIPLIER: u64 = 10;
+const DEFAULT_SP1_NETWORK_MINIMUM_BALANCE: &str = "10";
 const DEFAULT_SP1_RANGE_CYCLE_LIMIT: u64 = 1_500_000_000_000;
 const DEFAULT_SP1_RANGE_GAS_LIMIT: u64 = 1_300_000_000_000;
 const DEFAULT_SP1_AGGREGATION_CYCLE_LIMIT: u64 = 7_000_000;
@@ -136,6 +137,19 @@ pub struct WorkerArgs {
     /// SuccinctVApp proxy address on Ethereum mainnet. Required when --prover network.
     #[arg(long, env = "SUCCINCT_VAPP_ADDRESS")]
     succinct_vapp_address: Option<Address>,
+
+    /// Minimum SP1 Network credit balance in human-readable PROVE.
+    #[arg(
+        long,
+        env = "SP1_NETWORK_MINIMUM_BALANCE",
+        default_value = DEFAULT_SP1_NETWORK_MINIMUM_BALANCE
+    )]
+    sp1_network_minimum_balance: String,
+
+    /// Minimum amount of PROVE to deposit when refilling SP1 Network credits.
+    /// Defaults to SuccinctVApp.minDepositAmount().
+    #[arg(long, env = "SP1_NETWORK_REFILL_AMOUNT")]
+    sp1_network_refill_amount: Option<String>,
 
     /// Seconds to sleep between job-queue polls when no work is available.
     #[arg(long, default_value_t = 10)]
@@ -309,21 +323,37 @@ pub async fn run(cli: WorkerArgs) -> Result<()> {
             let settlement = load_settlement_config(l1_rpc_url, vapp_address)
                 .await
                 .context("validating Succinct settlement configuration")?;
-            let minimum_balance = minimum_network_balance(settlement.min_deposit_amount)?;
+            let minimum_balance =
+                parse_prove_amount(&cli.sp1_network_minimum_balance, settlement.prove_decimals)
+                    .context("invalid SP1 Network minimum balance")?;
+            let refill_amount = cli
+                .sp1_network_refill_amount
+                .as_deref()
+                .map(|amount| parse_prove_amount(amount, settlement.prove_decimals))
+                .transpose()
+                .context("invalid SP1 Network refill amount")?;
+            let refill_amount = resolve_refill_amount(
+                refill_amount,
+                settlement.min_deposit_amount,
+                settlement.prove_decimals,
+            )?;
+            let refill = NetworkRefillConfig {
+                l1_rpc_url: l1_rpc_url.clone(),
+                settlement,
+                signer_secret: network_secret.to_owned(),
+                signer_type,
+                refill_amount,
+            };
             let connection = NetworkConnection::new(network_secret, signer_type).await?;
             let credit_client = NetworkCreditClient::from_connection(connection.clone());
 
-            if !wait_for_sufficient_network_balance(
-                &credit_client,
-                minimum_balance,
-                settlement.prove_decimals,
-            )
-            .await?
+            if !wait_for_sufficient_network_balance(&credit_client, minimum_balance, &refill)
+                .await?
             {
                 return Ok(());
             }
 
-            monitor_network_balance(credit_client, minimum_balance, settlement.prove_decimals);
+            monitor_network_balance(credit_client, minimum_balance, refill);
             let limits = (!cli.sp1_estimate_limits).then_some(NetworkProverLimits {
                 range: ProofLimits {
                     cycle_limit: cli.sp1_range_cycle_limit,
@@ -354,44 +384,27 @@ pub async fn run(cli: WorkerArgs) -> Result<()> {
     }
 }
 
-fn minimum_network_balance(min_deposit_amount: U256) -> Result<U256> {
-    min_deposit_amount
-        .checked_mul(U256::from(MINIMUM_DEPOSIT_MULTIPLIER))
-        .context("SP1 Network minimum balance overflow")
+struct NetworkRefillConfig {
+    l1_rpc_url: String,
+    settlement: SettlementConfig,
+    signer_secret: String,
+    signer_type: SignerType,
+    refill_amount: U256,
 }
 
 async fn wait_for_sufficient_network_balance(
     client: &NetworkCreditClient,
     minimum_balance: U256,
-    decimals: u8,
+    refill: &NetworkRefillConfig,
 ) -> Result<bool> {
+    let mut pending_deposit = None;
     loop {
-        match client.get_balance().await {
-            Ok(balance) => {
-                let sufficient = record_network_balance(balance, minimum_balance, decimals);
-                if sufficient {
-                    tracing::info!(
-                        balance = %format_prove(balance, decimals),
-                        minimum_balance = %format_prove(minimum_balance, decimals),
-                        "SP1 Network credit balance is sufficient"
-                    );
-                    return Ok(true);
-                }
-                tracing::error!(
-                    balance = %format_prove(balance, decimals),
-                    minimum_balance = %format_prove(minimum_balance, decimals),
-                    retry_seconds = SP1_NETWORK_BALANCE_POLL_INTERVAL.as_secs(),
-                    "SP1 Network credit balance is too low; worker will not lease jobs"
-                );
-            }
-            Err(error) => {
-                world_chain_proof_metrics::record_sp1_network_balance_unavailable();
-                tracing::warn!(
-                    %error,
-                    retry_seconds = SP1_NETWORK_BALANCE_POLL_INTERVAL.as_secs(),
-                    "failed to read SP1 Network credit balance; worker will not lease jobs"
-                );
-            }
+        if maintain_network_balance(client, minimum_balance, refill, &mut pending_deposit).await {
+            tracing::info!(
+                minimum_balance = %format_prove(minimum_balance, refill.settlement.prove_decimals),
+                "SP1 Network credit balance is sufficient"
+            );
+            return Ok(true);
         }
 
         tokio::select! {
@@ -405,29 +418,119 @@ async fn wait_for_sufficient_network_balance(
     }
 }
 
-fn monitor_network_balance(client: NetworkCreditClient, minimum_balance: U256, decimals: u8) {
+fn monitor_network_balance(
+    client: NetworkCreditClient,
+    minimum_balance: U256,
+    refill: NetworkRefillConfig,
+) {
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(SP1_NETWORK_BALANCE_POLL_INTERVAL);
+        let mut pending_deposit = None;
         interval.tick().await;
         loop {
             interval.tick().await;
-            match client.get_balance().await {
-                Ok(balance) => {
-                    if !record_network_balance(balance, minimum_balance, decimals) {
-                        tracing::error!(
-                            balance = %format_prove(balance, decimals),
-                            minimum_balance = %format_prove(minimum_balance, decimals),
-                            "SP1 Network credit balance is below the recommended minimum"
-                        );
-                    }
-                }
-                Err(error) => {
-                    world_chain_proof_metrics::record_sp1_network_balance_unavailable();
-                    tracing::warn!(%error, "failed to refresh SP1 Network credit balance");
-                }
-            }
+            maintain_network_balance(&client, minimum_balance, &refill, &mut pending_deposit).await;
         }
     });
+}
+
+async fn maintain_network_balance(
+    client: &NetworkCreditClient,
+    minimum_balance: U256,
+    refill: &NetworkRefillConfig,
+    pending_deposit: &mut Option<DepositReceipt>,
+) -> bool {
+    let decimals = refill.settlement.prove_decimals;
+    let balance = match client.get_balance().await {
+        Ok(balance) => balance,
+        Err(error) => {
+            world_chain_proof_metrics::record_sp1_network_balance_unavailable();
+            tracing::warn!(%error, "failed to refresh SP1 Network credit balance");
+            return false;
+        }
+    };
+    if record_network_balance(balance, minimum_balance, decimals) {
+        if let Some(receipt) = pending_deposit.take() {
+            tracing::info!(
+                tx_hash = %receipt.tx_hash,
+                onchain_receipt = receipt.onchain_receipt,
+                balance = %format_prove(balance, decimals),
+                "SP1 Network refill is reflected in credits"
+            );
+        }
+        return true;
+    }
+
+    if let Some(receipt) = pending_deposit {
+        tracing::warn!(
+            tx_hash = %receipt.tx_hash,
+            onchain_receipt = receipt.onchain_receipt,
+            balance = %format_prove(balance, decimals),
+            minimum_balance = %format_prove(minimum_balance, decimals),
+            "waiting for confirmed SP1 Network refill to be reflected in credits"
+        );
+        return false;
+    }
+
+    let amount = refill_amount_for_balance(balance, minimum_balance, refill.refill_amount)
+        .expect("insufficient balance must have a refill amount");
+    tracing::warn!(
+        balance = %format_prove(balance, decimals),
+        minimum_balance = %format_prove(minimum_balance, decimals),
+        refill_amount = %format_prove(amount, decimals),
+        "SP1 Network credit balance is too low; submitting refill"
+    );
+    match submit_deposit(
+        &refill.l1_rpc_url,
+        refill.settlement,
+        &refill.signer_secret,
+        refill.signer_type,
+        amount,
+    )
+    .await
+    {
+        Ok(receipt) => {
+            tracing::info!(
+                tx_hash = %receipt.tx_hash,
+                onchain_receipt = receipt.onchain_receipt,
+                refill_amount = %format_prove(amount, decimals),
+                "SP1 Network refill confirmed on Ethereum mainnet"
+            );
+            *pending_deposit = Some(receipt);
+        }
+        Err(error) => {
+            tracing::error!(%error, "failed to refill SP1 Network credits");
+        }
+    }
+    false
+}
+
+fn refill_amount_for_balance(
+    balance: U256,
+    minimum_balance: U256,
+    refill_amount: U256,
+) -> Option<U256> {
+    if balance >= minimum_balance {
+        return None;
+    }
+    let shortfall = minimum_balance.checked_sub(balance)?;
+    Some(shortfall.max(refill_amount))
+}
+
+fn resolve_refill_amount(
+    configured: Option<U256>,
+    min_deposit_amount: U256,
+    decimals: u8,
+) -> Result<U256> {
+    let amount = configured.unwrap_or(min_deposit_amount);
+    if amount < min_deposit_amount {
+        anyhow::bail!(
+            "SP1 Network refill amount {} PROVE is below SuccinctVApp.minDepositAmount() of {} PROVE",
+            format_prove(amount, decimals),
+            format_prove(min_deposit_amount, decimals),
+        );
+    }
+    Ok(amount)
 }
 
 fn record_network_balance(balance: U256, minimum_balance: U256, decimals: u8) -> bool {
@@ -632,10 +735,52 @@ mod tests {
     }
 
     #[test]
-    fn minimum_balance_is_ten_times_vapp_minimum() {
+    fn defaults_to_ten_prove_minimum_balance() {
+        let cli = WorkerArgs::parse_from(base_args());
+
         assert_eq!(
-            minimum_network_balance(U256::from(42)).unwrap(),
-            U256::from(420)
+            cli.sp1_network_minimum_balance,
+            DEFAULT_SP1_NETWORK_MINIMUM_BALANCE
         );
+        assert_eq!(cli.sp1_network_refill_amount, None);
+    }
+
+    #[test]
+    fn parses_minimum_balance_using_prove_decimals() {
+        assert_eq!(
+            parse_prove_amount(DEFAULT_SP1_NETWORK_MINIMUM_BALANCE, 6).unwrap(),
+            U256::from(10_000_000_u64)
+        );
+        assert_eq!(
+            parse_prove_amount(DEFAULT_SP1_NETWORK_MINIMUM_BALANCE, 18).unwrap(),
+            U256::from(10_000_000_000_000_000_000_u128)
+        );
+    }
+
+    #[test]
+    fn refill_covers_the_shortfall_or_configured_chunk() {
+        assert_eq!(
+            refill_amount_for_balance(U256::from(2), U256::from(10), U256::from(3)),
+            Some(U256::from(8))
+        );
+        assert_eq!(
+            refill_amount_for_balance(U256::from(9), U256::from(10), U256::from(3)),
+            Some(U256::from(3))
+        );
+        assert_eq!(
+            refill_amount_for_balance(U256::from(10), U256::from(10), U256::from(3)),
+            None
+        );
+    }
+
+    #[test]
+    fn refill_defaults_to_vapp_minimum_and_rejects_smaller_values() {
+        let vapp_minimum = U256::from(10_000_u64);
+
+        assert_eq!(
+            resolve_refill_amount(None, vapp_minimum, 6).unwrap(),
+            vapp_minimum
+        );
+        assert!(resolve_refill_amount(Some(U256::from(9_999)), vapp_minimum, 6).is_err());
     }
 }

--- a/proofs/workers/sp1/src/cmd/run.rs
+++ b/proofs/workers/sp1/src/cmd/run.rs
@@ -3,7 +3,7 @@ use std::{path::PathBuf, sync::Arc, time::Duration};
 use alloy_primitives::{Address, B256, U256};
 use alloy_provider::ProviderBuilder;
 use anyhow::{Context, Result};
-use clap::Parser;
+use clap::{ArgGroup, Parser};
 use world_chain_chainspec::WorldChainSpec;
 use world_chain_proof_kona_host::online::{
     OnlineHostConfig, build_online_config, hardfork_config_from_chain_spec,
@@ -67,6 +67,12 @@ impl Network {
 }
 
 #[derive(Debug, Parser)]
+#[command(
+    group = ArgGroup::new("sp1_signer")
+        .required(true)
+        .multiple(false)
+        .args(["sp1_private_key", "sp1_kms_key_id"])
+)]
 pub struct WorkerArgs {
     /// prover-service JSON-RPC URL.
     #[arg(long, env = "PROVER_SERVICE_URL")]
@@ -119,14 +125,23 @@ pub struct WorkerArgs {
 
     /// SP1 network private key.
     ///
-    /// Required when --prover network and sp1_kms_key_id is not provided.
-    #[arg(long, env = "SP1_PRIVATE_KEY")]
+    /// Exactly one of this and sp1_kms_key_id must be configured.
+    #[arg(
+        long,
+        env = "SP1_PRIVATE_KEY",
+        value_parser = clap::builder::NonEmptyStringValueParser::new()
+    )]
     sp1_private_key: Option<String>,
 
     /// AWS KMS key ID or alias the sp1 proof worker signs proof requests.
     ///
-    /// Required when --prover network and sp1_private_key is not provided.
-    #[arg(long, env = "SP1_KMS_KEY_ID", hide_env_values = true)]
+    /// Exactly one of this and sp1_private_key must be configured.
+    #[arg(
+        long,
+        env = "SP1_KMS_KEY_ID",
+        hide_env_values = true,
+        value_parser = clap::builder::NonEmptyStringValueParser::new()
+    )]
     sp1_kms_key_id: Option<String>,
 
     /// Ethereum mainnet RPC used to validate the Succinct VApp and its deposit threshold.
@@ -316,7 +331,7 @@ pub async fn run(cli: WorkerArgs) -> Result<()> {
             let (network_secret, signer_type) = select_network_signer(
                 cli.sp1_private_key.as_deref(),
                 cli.sp1_kms_key_id.as_deref(),
-            )?;
+            );
             let vapp_address = cli
                 .succinct_vapp_address
                 .context("SUCCINCT_VAPP_ADDRESS is required when --prover network")?;
@@ -615,7 +630,7 @@ where
 mod tests {
     use super::*;
 
-    fn base_args() -> Vec<&'static str> {
+    fn base_args_without_signer() -> Vec<&'static str> {
         vec![
             "sp1-worker",
             "--prover-service-url",
@@ -629,6 +644,12 @@ mod tests {
             "--worker-id",
             "test",
         ]
+    }
+
+    fn base_args() -> Vec<&'static str> {
+        let mut args = base_args_without_signer();
+        args.extend(["--sp1-kms-key-id", "alias/prover"]);
+        args
     }
 
     #[test]
@@ -670,6 +691,32 @@ mod tests {
         let cli = WorkerArgs::parse_from(args);
 
         assert!(cli.sp1_estimate_limits);
+    }
+
+    #[test]
+    fn worker_requires_exactly_one_signer() {
+        assert_eq!(
+            WorkerArgs::try_parse_from(base_args_without_signer())
+                .unwrap_err()
+                .kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+
+        let mut multiple = base_args();
+        multiple.extend(["--sp1-private-key", "0x1234"]);
+        assert_eq!(
+            WorkerArgs::try_parse_from(multiple).unwrap_err().kind(),
+            clap::error::ErrorKind::ArgumentConflict
+        );
+
+        for signer in [
+            ["--sp1-private-key", "0x1234"],
+            ["--sp1-kms-key-id", "alias/prover"],
+        ] {
+            let mut valid = base_args_without_signer();
+            valid.extend(signer);
+            WorkerArgs::try_parse_from(valid).unwrap();
+        }
     }
 
     #[test]

--- a/proofs/workers/sp1/src/cmd/run.rs
+++ b/proofs/workers/sp1/src/cmd/run.rs
@@ -630,7 +630,7 @@ where
 mod tests {
     use super::*;
 
-    fn base_args_without_signer() -> Vec<&'static str> {
+    fn base_args() -> Vec<&'static str> {
         vec![
             "sp1-worker",
             "--prover-service-url",
@@ -643,13 +643,9 @@ mod tests {
             "http://127.0.0.1:5052",
             "--worker-id",
             "test",
+            "--sp1-kms-key-id",
+            "alias/prover",
         ]
-    }
-
-    fn base_args() -> Vec<&'static str> {
-        let mut args = base_args_without_signer();
-        args.extend(["--sp1-kms-key-id", "alias/prover"]);
-        args
     }
 
     #[test]
@@ -694,29 +690,13 @@ mod tests {
     }
 
     #[test]
-    fn worker_requires_exactly_one_signer() {
-        assert_eq!(
-            WorkerArgs::try_parse_from(base_args_without_signer())
-                .unwrap_err()
-                .kind(),
-            clap::error::ErrorKind::MissingRequiredArgument
-        );
-
+    fn worker_rejects_multiple_signers() {
         let mut multiple = base_args();
         multiple.extend(["--sp1-private-key", "0x1234"]);
         assert_eq!(
             WorkerArgs::try_parse_from(multiple).unwrap_err().kind(),
             clap::error::ErrorKind::ArgumentConflict
         );
-
-        for signer in [
-            ["--sp1-private-key", "0x1234"],
-            ["--sp1-kms-key-id", "alias/prover"],
-        ] {
-            let mut valid = base_args_without_signer();
-            valid.extend(signer);
-            WorkerArgs::try_parse_from(valid).unwrap();
-        }
     }
 
     #[test]

--- a/proofs/workers/sp1/src/cmd/succinct.rs
+++ b/proofs/workers/sp1/src/cmd/succinct.rs
@@ -5,6 +5,7 @@ use anyhow::{Context, Result, bail};
 use url::Url;
 
 pub const ETHEREUM_MAINNET_CHAIN_ID: u64 = 1;
+pub const PROVE_DECIMALS: u8 = 18;
 
 sol! {
     #[sol(rpc)]
@@ -26,7 +27,6 @@ sol! {
     #[sol(rpc)]
     interface IProveToken {
         function balanceOf(address account) external view returns (uint256);
-        function decimals() external view returns (uint8);
         function name() external view returns (string);
         function nonces(address owner) external view returns (uint256);
         function DOMAIN_SEPARATOR() external view returns (bytes32);
@@ -47,7 +47,6 @@ pub struct SettlementConfig {
     pub vapp_address: Address,
     pub prove_token_address: Address,
     pub min_deposit_amount: U256,
-    pub prove_decimals: u8,
 }
 
 /// Validates the settlement endpoint and discovers the VApp's mutable token configuration.
@@ -107,26 +106,19 @@ pub async fn load_settlement_config(
         bail!("SuccinctVApp.minDepositAmount() returned zero");
     }
 
-    let prove_decimals = IProveToken::new(prove_token_address, provider)
-        .decimals()
-        .call()
-        .await
-        .context("reading PROVE token decimals()")?;
-
     Ok(SettlementConfig {
         vapp_address,
         prove_token_address,
         min_deposit_amount,
-        prove_decimals,
     })
 }
 
-pub fn format_prove(amount: U256, decimals: u8) -> String {
-    format_units(amount, decimals).unwrap_or_else(|_| amount.to_string())
+pub fn format_prove(amount: U256) -> String {
+    format_units(amount, PROVE_DECIMALS).unwrap_or_else(|_| amount.to_string())
 }
 
-pub fn prove_as_f64(amount: U256, decimals: u8) -> Result<f64> {
-    format_units(amount, decimals)
+pub fn prove_as_f64(amount: U256) -> Result<f64> {
+    format_units(amount, PROVE_DECIMALS)
         .context("formatting PROVE base units")?
         .parse::<f64>()
         .context("parsing formatted PROVE balance")
@@ -138,6 +130,9 @@ mod tests {
 
     #[test]
     fn formats_prove_base_units() {
-        assert_eq!(format_prove(U256::from(1_250_000_u64), 6), "1.250000");
+        assert_eq!(
+            format_prove(U256::from(1_250_000_000_000_000_000_u128)),
+            "1.250000000000000000"
+        );
     }
 }

--- a/proofs/workers/sp1/src/main.rs
+++ b/proofs/workers/sp1/src/main.rs
@@ -61,6 +61,8 @@ mod tests {
             "http://127.0.0.1:5052",
             "--worker-id",
             "test",
+            "--sp1-kms-key-id",
+            "alias/prover",
         ]);
 
         assert!(matches!(cli.command, Command::Run(_)));
@@ -82,6 +84,39 @@ mod tests {
         ]);
 
         assert!(matches!(cli.command, Command::Deposit(_)));
+    }
+
+    #[test]
+    fn deposit_requires_exactly_one_signer() {
+        let base_args = || {
+            vec![
+                "sp1-worker",
+                "deposit",
+                "--amount",
+                "100",
+                "--sp1-network-l1-rpc-url",
+                "https://ethereum.example",
+                "--succinct-vapp-address",
+                "0x0000000000000000000000000000000000000001",
+            ]
+        };
+
+        assert_eq!(
+            Cli::try_parse_from(base_args()).unwrap_err().kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+
+        let mut multiple = base_args();
+        multiple.extend([
+            "--sp1-private-key",
+            "0x1234",
+            "--sp1-kms-key-id",
+            "alias/prover",
+        ]);
+        assert_eq!(
+            Cli::try_parse_from(multiple).unwrap_err().kind(),
+            clap::error::ErrorKind::ArgumentConflict
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> The worker now signs and submits Ethereum mainnet `permitAndDeposit` transactions whenever credits are low, moving PROVE from the configured signer. Duplicate workers sharing a signer can race and over-deposit.
> 
> **Overview**
> The network SP1 worker no longer just waits on a low credit balance. At startup and in the background it deposits PROVE through SuccinctVApp when credits fall below a configurable minimum (default **10 PROVE**), using the larger of the shortfall or `--sp1-network-refill-amount` (default `minDepositAmount()`). After a deposit confirms it waits for that receipt to show up in credits instead of depositing again.
> 
> PROVE amounts now always use **fixed 18 decimals** instead of reading `decimals()` on-chain. `run` and `deposit` require exactly one of `SP1_PRIVATE_KEY` or `SP1_KMS_KEY_ID` via clap (empty values are rejected). Docs warn to run only one auto-refilling worker per signer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f6bb477574b53e30df9580fa200ebc46b00c10c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->