### PR TITLE
feat(chainspec): set Karst upgrade timestamps

### DIFF
--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -7,5 +7,6 @@ mod spec;
 pub use builder::WorldChainSpecBuilder;
 pub use hardfork::{WorldChainHardfork, WorldChainHardforks};
 pub use spec::{
-    JOVIAN_UPGRADE_TIMESTAMP_MAINNET, JOVIAN_UPGRADE_TIMESTAMP_SEPOLIA, WorldChainSpec,
+    JOVIAN_UPGRADE_TIMESTAMP_MAINNET, JOVIAN_UPGRADE_TIMESTAMP_SEPOLIA,
+    KARST_UPGRADE_TIMESTAMP_MAINNET, KARST_UPGRADE_TIMESTAMP_SEPOLIA, WorldChainSpec,
 };

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -93,20 +93,14 @@ impl WorldChainSpec {
                     WorldChainHardfork::Jovian,
                     JOVIAN_UPGRADE_TIMESTAMP_MAINNET,
                 );
-                self.set_missing_world_fork(
-                    WorldChainHardfork::Karst,
-                    KARST_UPGRADE_TIMESTAMP_MAINNET,
-                );
+                self.set_missing_karst_forks(KARST_UPGRADE_TIMESTAMP_MAINNET);
             }
             Some(NamedChain::WorldSepolia) => {
                 self.set_missing_world_fork(
                     WorldChainHardfork::Jovian,
                     JOVIAN_UPGRADE_TIMESTAMP_SEPOLIA,
                 );
-                self.set_missing_world_fork(
-                    WorldChainHardfork::Karst,
-                    KARST_UPGRADE_TIMESTAMP_SEPOLIA,
-                );
+                self.set_missing_karst_forks(KARST_UPGRADE_TIMESTAMP_SEPOLIA);
             }
             _ => {}
         }
@@ -115,6 +109,18 @@ impl WorldChainSpec {
     fn set_missing_world_fork(&mut self, fork: WorldChainHardfork, timestamp: u64) {
         if matches!(self.inner.fork(fork), ForkCondition::Never) {
             self.set_fork(fork, ForkCondition::Timestamp(timestamp));
+        }
+    }
+
+    fn set_missing_karst_forks(&mut self, default_timestamp: u64) {
+        self.set_missing_world_fork(WorldChainHardfork::Karst, default_timestamp);
+
+        if matches!(
+            self.inner.fork(EthereumHardfork::Osaka),
+            ForkCondition::Never
+        ) && let Some(timestamp) = self.inner.fork(WorldChainHardfork::Karst).as_timestamp()
+        {
+            self.set_fork(EthereumHardfork::Osaka, ForkCondition::Timestamp(timestamp));
         }
     }
 }
@@ -590,6 +596,10 @@ mod tests {
             spec.fork(WorldChainHardfork::Karst),
             ForkCondition::Timestamp(KARST_UPGRADE_TIMESTAMP_MAINNET)
         );
+        assert_eq!(
+            spec.fork(EthereumHardfork::Osaka),
+            ForkCondition::Timestamp(KARST_UPGRADE_TIMESTAMP_MAINNET)
+        );
     }
 
     #[test]
@@ -601,6 +611,10 @@ mod tests {
         );
         assert_eq!(
             spec.fork(WorldChainHardfork::Karst),
+            ForkCondition::Timestamp(KARST_UPGRADE_TIMESTAMP_SEPOLIA)
+        );
+        assert_eq!(
+            spec.fork(EthereumHardfork::Osaka),
             ForkCondition::Timestamp(KARST_UPGRADE_TIMESTAMP_SEPOLIA)
         );
     }

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -28,6 +28,12 @@ pub const JOVIAN_UPGRADE_TIMESTAMP_SEPOLIA: u64 = 1_777_161_600;
 /// World Chain Jovian activation timestamp on mainnet.
 pub const JOVIAN_UPGRADE_TIMESTAMP_MAINNET: u64 = 1_777_593_600;
 
+/// World Chain Karst activation timestamp on Sepolia.
+pub const KARST_UPGRADE_TIMESTAMP_SEPOLIA: u64 = 1_788_868_800;
+
+/// World Chain Karst activation timestamp on mainnet.
+pub const KARST_UPGRADE_TIMESTAMP_MAINNET: u64 = 1_789_992_000;
+
 /// World Chain spec type.
 ///
 /// This wraps reth's generic [`ChainSpec`] the same way the OP stack spec does, while using World
@@ -78,25 +84,37 @@ impl WorldChainSpec {
     }
 
     /// Applies World Chain defaults that are not yet represented in the upstream OP stack chain
-    /// specs. Only fills in forks that have no explicit activation; an operator-supplied
-    /// timestamp (e.g. `jovianTime` in genesis) is preserved.
+    /// specs. Only fills in forks that have no explicit activation; operator-supplied timestamps
+    /// (e.g. `jovianTime` and `karstTime` in genesis) are preserved.
     pub fn apply_world_chain_defaults(&mut self) {
-        if !matches!(
-            self.inner.fork(WorldChainHardfork::Jovian),
-            ForkCondition::Never
-        ) {
-            return;
-        }
         match self.chain().named() {
-            Some(NamedChain::World) => self.set_fork(
-                WorldChainHardfork::Jovian,
-                ForkCondition::Timestamp(JOVIAN_UPGRADE_TIMESTAMP_MAINNET),
-            ),
-            Some(NamedChain::WorldSepolia) => self.set_fork(
-                WorldChainHardfork::Jovian,
-                ForkCondition::Timestamp(JOVIAN_UPGRADE_TIMESTAMP_SEPOLIA),
-            ),
+            Some(NamedChain::World) => {
+                self.set_missing_world_fork(
+                    WorldChainHardfork::Jovian,
+                    JOVIAN_UPGRADE_TIMESTAMP_MAINNET,
+                );
+                self.set_missing_world_fork(
+                    WorldChainHardfork::Karst,
+                    KARST_UPGRADE_TIMESTAMP_MAINNET,
+                );
+            }
+            Some(NamedChain::WorldSepolia) => {
+                self.set_missing_world_fork(
+                    WorldChainHardfork::Jovian,
+                    JOVIAN_UPGRADE_TIMESTAMP_SEPOLIA,
+                );
+                self.set_missing_world_fork(
+                    WorldChainHardfork::Karst,
+                    KARST_UPGRADE_TIMESTAMP_SEPOLIA,
+                );
+            }
             _ => {}
+        }
+    }
+
+    fn set_missing_world_fork(&mut self, fork: WorldChainHardfork, timestamp: u64) {
+        if matches!(self.inner.fork(fork), ForkCondition::Never) {
+            self.set_fork(fork, ForkCondition::Timestamp(timestamp));
         }
     }
 }
@@ -562,13 +580,29 @@ mod tests {
     use super::*;
 
     #[test]
-    fn world_mainnet_defaults_to_jovian() {
+    fn world_mainnet_defaults_to_jovian_and_karst() {
         let spec = WorldChainSpec::mainnet();
         assert_eq!(
             spec.fork(WorldChainHardfork::Jovian),
             ForkCondition::Timestamp(JOVIAN_UPGRADE_TIMESTAMP_MAINNET)
         );
-        assert_eq!(spec.fork(WorldChainHardfork::Karst), ForkCondition::Never);
+        assert_eq!(
+            spec.fork(WorldChainHardfork::Karst),
+            ForkCondition::Timestamp(KARST_UPGRADE_TIMESTAMP_MAINNET)
+        );
+    }
+
+    #[test]
+    fn world_sepolia_defaults_to_jovian_and_karst() {
+        let spec = WorldChainSpec::sepolia();
+        assert_eq!(
+            spec.fork(WorldChainHardfork::Jovian),
+            ForkCondition::Timestamp(JOVIAN_UPGRADE_TIMESTAMP_SEPOLIA)
+        );
+        assert_eq!(
+            spec.fork(WorldChainHardfork::Karst),
+            ForkCondition::Timestamp(KARST_UPGRADE_TIMESTAMP_SEPOLIA)
+        );
     }
 
     #[test]

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -13,7 +13,8 @@ use reth_rpc_server_types::{
 use std::{str::FromStr, sync::Arc};
 use tracing::{debug, info, warn};
 use world_chain_chainspec::{
-    JOVIAN_UPGRADE_TIMESTAMP_MAINNET, JOVIAN_UPGRADE_TIMESTAMP_SEPOLIA, WorldChainHardfork,
+    JOVIAN_UPGRADE_TIMESTAMP_MAINNET, JOVIAN_UPGRADE_TIMESTAMP_SEPOLIA,
+    KARST_UPGRADE_TIMESTAMP_MAINNET, KARST_UPGRADE_TIMESTAMP_SEPOLIA, WorldChainHardfork,
     WorldChainSpec,
 };
 
@@ -163,10 +164,19 @@ impl WorldChainArgs {
                     WorldChainHardfork::Jovian,
                     ForkCondition::Timestamp(JOVIAN_UPGRADE_TIMESTAMP_MAINNET),
                 );
+                chain_spec.set_fork(
+                    WorldChainHardfork::Karst,
+                    ForkCondition::Timestamp(KARST_UPGRADE_TIMESTAMP_MAINNET),
+                );
                 info!(
                     target: "reth::cli",
                     timestamp = JOVIAN_UPGRADE_TIMESTAMP_MAINNET,
                     "Overriding Jovian activation timestamp for World mainnet"
+                );
+                info!(
+                    target: "reth::cli",
+                    timestamp = KARST_UPGRADE_TIMESTAMP_MAINNET,
+                    "Overriding Karst activation timestamp for World mainnet"
                 );
             }
             Some(NamedChain::WorldSepolia) => {
@@ -211,10 +221,19 @@ impl WorldChainArgs {
                     WorldChainHardfork::Jovian,
                     ForkCondition::Timestamp(JOVIAN_UPGRADE_TIMESTAMP_SEPOLIA),
                 );
+                chain_spec.set_fork(
+                    WorldChainHardfork::Karst,
+                    ForkCondition::Timestamp(KARST_UPGRADE_TIMESTAMP_SEPOLIA),
+                );
                 info!(
                     target: "reth::cli",
                     timestamp = JOVIAN_UPGRADE_TIMESTAMP_SEPOLIA,
                     "Overriding Jovian activation timestamp for World Sepolia"
+                );
+                info!(
+                    target: "reth::cli",
+                    timestamp = KARST_UPGRADE_TIMESTAMP_SEPOLIA,
+                    "Overriding Karst activation timestamp for World Sepolia"
                 );
             }
             _ => {

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -2,7 +2,7 @@ use crate::config::{FlashblocksPayloadBuilderConfig, FlashblocksStoreConfig};
 use ::eyre::eyre::bail;
 use alloy_chains::NamedChain;
 use alloy_primitives::{Address, address};
-use reth_chainspec::{EthChainSpec, ForkCondition};
+use reth_chainspec::{EthChainSpec, EthereumHardfork, ForkCondition};
 use reth_network_peers::{PeerId, TrustedPeer};
 use reth_node_builder::NodeConfig;
 use reth_optimism_node::args::RollupArgs;
@@ -168,6 +168,10 @@ impl WorldChainArgs {
                     WorldChainHardfork::Karst,
                     ForkCondition::Timestamp(KARST_UPGRADE_TIMESTAMP_MAINNET),
                 );
+                chain_spec.set_fork(
+                    EthereumHardfork::Osaka,
+                    ForkCondition::Timestamp(KARST_UPGRADE_TIMESTAMP_MAINNET),
+                );
                 info!(
                     target: "reth::cli",
                     timestamp = JOVIAN_UPGRADE_TIMESTAMP_MAINNET,
@@ -223,6 +227,10 @@ impl WorldChainArgs {
                 );
                 chain_spec.set_fork(
                     WorldChainHardfork::Karst,
+                    ForkCondition::Timestamp(KARST_UPGRADE_TIMESTAMP_SEPOLIA),
+                );
+                chain_spec.set_fork(
+                    EthereumHardfork::Osaka,
                     ForkCondition::Timestamp(KARST_UPGRADE_TIMESTAMP_SEPOLIA),
                 );
                 info!(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Hardfork activation times are consensus-critical; wrong timestamps can fork the network. Custom genesis and operator-supplied times remain respected except for the CLI override on named World chains.
> 
> **Overview**
> Schedules the **Karst** hardfork on World mainnet and Sepolia with default activation timestamps (`KARST_UPGRADE_TIMESTAMP_*`), matching how Jovian is already configured.
> 
> `apply_world_chain_defaults` now fills in both Jovian and Karst when a fork has no explicit activation, via `set_missing_world_fork`, so genesis `karstTime` is still preserved. CLI startup for World/WorldSepolia also **overrides** Karst (and continues to override Jovian) to those timestamps.
> 
> Custom genesis still leaves Karst inactive unless specified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca0e9611fc2bb4e7f069d44e700ecdf710483c22. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->