### PR TITLE
chore: bump v2.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18475,7 +18475,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "world-chain"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "clap",
  "color-eyre",
@@ -18495,7 +18495,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-builder"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -18546,7 +18546,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-chainspec"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.1.1",
@@ -18599,7 +18599,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-cli"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "alloy-chains",
  "alloy-genesis",
@@ -18634,7 +18634,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-commands"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "clap",
  "color-eyre",
@@ -18680,7 +18680,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-devnet"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-genesis",
@@ -18737,7 +18737,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-evm"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -18777,7 +18777,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-node"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -18842,7 +18842,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-p2p"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -18880,7 +18880,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-payload"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -18909,7 +18909,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-pbh"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -18926,7 +18926,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-pool"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -18963,7 +18963,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-primitives"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -19464,7 +19464,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-rpc"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "alloy",
  "alloy-consensus 2.1.1",
@@ -19523,7 +19523,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-test-utils"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-contract",
@@ -19607,7 +19607,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-tests"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-contract",
@@ -19673,7 +19673,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-validator"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -19789,7 +19789,7 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xtask"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-contract",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "2.4.2"
+version = "2.4.3"
 edition = "2024"
 rust-version = "1.95.0"
 license = "MIT"
@@ -250,8 +250,14 @@ alloy-trie = { version = "0.9.4", default-features = false, features = [
 ] }
 
 # aws
-aws-config = { version = "1", default-features = false, features = ["rt-tokio", "rustls"] }
-aws-sdk-kms = { version = "1", default-features = false, features = ["rt-tokio", "rustls"] }
+aws-config = { version = "1", default-features = false, features = [
+    "rt-tokio",
+    "rustls",
+] }
+aws-sdk-kms = { version = "1", default-features = false, features = [
+    "rt-tokio",
+    "rustls",
+] }
 
 # revm
 revm = { version = "41.0.0", default-features = false }
@@ -325,7 +331,14 @@ test-case = "3"
 serde_json = "1"
 rand = { version = "0.9", features = ["small_rng"] }
 reqwest = { version = "0.12", default-features = false }
-sqlx = { version = "0.9.0", default-features = false, features = ["runtime-tokio", "postgres", "migrate", "macros", "uuid", "chrono"] }
+sqlx = { version = "0.9.0", default-features = false, features = [
+    "runtime-tokio",
+    "postgres",
+    "migrate",
+    "macros",
+    "uuid",
+    "chrono",
+] }
 bon = "3.3.0"
 rayon = "1.12.0"
 auto_impl = "1"
@@ -334,7 +347,10 @@ dashmap = { version = "6.2.1", features = ["rayon"] }
 spin = "0.10"
 rkyv = { version = "0.8", features = ["hashbrown-0_15", "std"] }
 tower = "0.5.0"
-backon = { version = "1", default-features = false, features = ["std", "tokio-sleep"] }
+backon = { version = "1", default-features = false, features = [
+    "std",
+    "tokio-sleep",
+] }
 arbitrary = { version = "=1.4.2", features = ["derive"] }
 blake3 = "1.8.4"
 ed25519-dalek = { version = "2", features = ["serde"] }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version metadata and lockfile alignment only; no runtime or dependency behavior changes.
> 
> **Overview**
> **Release bump** from **2.4.2** to **2.4.3** via `[workspace.package].version` in `Cargo.toml`, with `Cargo.lock` updated so every in-workspace `world-chain-*` crate (and `xtask`) reports **2.4.3**.
> 
> The only other `Cargo.toml` edits are **formatting**: `aws-config`, `aws-sdk-kms`, `sqlx`, and `backon` feature lists are split across multiple lines. **No dependency versions or feature sets change.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 121baee7821d952b75c886dab6a1e32c4b8585b1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->