### PR TITLE
feat(proofs): use ERC-20 vault for game bonds

### DIFF
--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -2901,7 +2901,9 @@ async fn start_world_chain_challenger(
         factory_address,
         DEFAULT_L1_TX_CONFIRMATIONS,
         Duration::from_secs(world_chain_proof_protocol::DEFAULT_L1_TX_RECEIPT_TIMEOUT_SECONDS),
-    );
+    )
+    .await
+    .wrap_err("failed to bind the World Chain proof system")?;
     let output_roots = OptimismConsensusClient::new(output_root_rpc_url.to_string());
     let config = ChallengerConfig {
         poll_interval: WORLD_CHALLENGER_POLL_INTERVAL,

--- a/proofs/metrics/src/lib.rs
+++ b/proofs/metrics/src/lib.rs
@@ -6,10 +6,7 @@ use std::{
 };
 
 use alloy_json_rpc::{RequestPacket, ResponsePacket};
-use alloy_primitives::{
-    Address,
-    utils::{format_ether, format_units},
-};
+use alloy_primitives::{Address, utils::format_ether};
 use alloy_provider::Provider;
 use alloy_rpc_client::{ClientBuilder, RpcClient};
 use alloy_transport::{BoxFuture, TransportError};
@@ -31,10 +28,10 @@ pub const METRICS_L2_FINALIZED_BLOCK_NUMBER: &str = "l2.finalized_block_number";
 pub const METRICS_RPC_CLIENT_REQUESTS: &str = "rpc.client.requests";
 /// Confirmed challenge transactions.
 pub const METRICS_CHALLENGES_SUBMITTED: &str = "challenges.submitted";
-/// WLD locked by proposer and challenger transactions.
-pub const METRICS_BONDS_LOCKED_WLD: &str = "bonds.locked_wld";
-/// WLD immediately reusable by a proof-system participant.
-pub const METRICS_VAULT_AVAILABLE_BALANCE_WLD: &str = "vault.available_balance_wld";
+/// Bond-token base units locked by proposer and challenger transactions.
+pub const METRICS_BONDS_LOCKED_BASE_UNITS: &str = "bonds.locked_base_units";
+/// Bond-token base units immediately reusable by a proof-system participant.
+pub const METRICS_VAULT_AVAILABLE_BALANCE_BASE_UNITS: &str = "vault.available_balance_base_units";
 /// Games processed by a bond settlement manager.
 pub const METRICS_GAMES_CLOSED: &str = "games.closed";
 /// Confirmed on-chain proof-lane submissions.
@@ -81,14 +78,14 @@ pub fn describe_metrics() {
         "Number of challenge transactions successfully confirmed on L1."
     );
     metrics::describe_histogram!(
-        METRICS_BONDS_LOCKED_WLD,
+        METRICS_BONDS_LOCKED_BASE_UNITS,
         metrics::Unit::Count,
-        "WLD locked by successfully confirmed proposer and challenger transactions."
+        "Bond-token base units locked by successfully confirmed proposer and challenger transactions."
     );
     metrics::describe_gauge!(
-        METRICS_VAULT_AVAILABLE_BALANCE_WLD,
+        METRICS_VAULT_AVAILABLE_BALANCE_BASE_UNITS,
         metrics::Unit::Count,
-        "WLD immediately reusable by the participant in the proof-system staking vault."
+        "Bond-token base units immediately reusable by the participant in the proof-system staking vault."
     );
     metrics::describe_counter!(
         METRICS_GAMES_CLOSED,
@@ -188,16 +185,14 @@ pub fn increment_challenges_submitted() {
     metrics::counter!(METRICS_CHALLENGES_SUBMITTED).increment(1);
 }
 
-/// Records WLD locked by a successfully confirmed bond transaction.
+/// Records bond-token base units locked by a successfully confirmed bond transaction.
 pub fn record_bond_locked(role: &'static str, amount: alloy_primitives::U256) {
-    match format_units(amount, 18) {
-        Ok(formatted) => match formatted.parse::<f64>() {
-            Ok(amount_wld) => {
-                metrics::histogram!(METRICS_BONDS_LOCKED_WLD, "role" => role).record(amount_wld);
-            }
-            Err(error) => warn!(%error, %role, ?amount, "failed to convert bond amount to WLD"),
-        },
-        Err(error) => warn!(%error, %role, ?amount, "failed to format bond amount as WLD"),
+    match amount.to_string().parse::<f64>() {
+        Ok(amount_base_units) => {
+            metrics::histogram!(METRICS_BONDS_LOCKED_BASE_UNITS, "role" => role)
+                .record(amount_base_units);
+        }
+        Err(error) => warn!(%error, %role, ?amount, "failed to convert bond-token base units"),
     }
 }
 
@@ -206,7 +201,7 @@ pub fn increment_games_closed(role: &'static str, result: &'static str) {
     metrics::counter!(METRICS_GAMES_CLOSED, "role" => role, "result" => result).increment(1);
 }
 
-/// Records and logs an account's immediately reusable WLD vault balance.
+/// Records and logs an account's immediately reusable bond-token balance in base units.
 pub fn record_vault_balance(
     vault_address: Address,
     account: Address,
@@ -214,21 +209,18 @@ pub fn record_vault_balance(
     balance: alloy_primitives::U256,
 ) {
     let gauge = metrics::gauge!(
-        METRICS_VAULT_AVAILABLE_BALANCE_WLD,
+        METRICS_VAULT_AVAILABLE_BALANCE_BASE_UNITS,
         "role" => role,
         "address" => account.to_string(),
     );
-    match format_units(balance, 18) {
-        Ok(formatted) => match formatted.parse::<f64>() {
-            Ok(balance_wld) => {
-                gauge.set(balance_wld);
-                info!(%role, %account, %vault_address, %balance, balance_wld, "refreshed available WLD vault balance");
-            }
-            Err(error) => {
-                warn!(%account, %error, ?balance, "failed to convert vault balance to WLD")
-            }
-        },
-        Err(error) => warn!(%account, %error, ?balance, "failed to format vault balance as WLD"),
+    match balance.to_string().parse::<f64>() {
+        Ok(balance_base_units) => {
+            gauge.set(balance_base_units);
+            info!(%role, %account, %vault_address, %balance, balance_base_units, "refreshed available ERC-20 vault balance");
+        }
+        Err(error) => {
+            warn!(%account, %error, ?balance, "failed to convert vault balance base units")
+        }
     }
 }
 

--- a/proofs/metrics/src/lib.rs
+++ b/proofs/metrics/src/lib.rs
@@ -6,13 +6,16 @@ use std::{
 };
 
 use alloy_json_rpc::{RequestPacket, ResponsePacket};
-use alloy_primitives::{Address, utils::format_ether};
+use alloy_primitives::{
+    Address,
+    utils::{format_ether, format_units},
+};
 use alloy_provider::Provider;
 use alloy_rpc_client::{ClientBuilder, RpcClient};
 use alloy_transport::{BoxFuture, TransportError};
 use telemetry_batteries::reexports::metrics;
 use tower::{Layer, Service};
-use tracing::warn;
+use tracing::{info, warn};
 use url::Url;
 
 /// Ethereum L1 execution RPC target label.
@@ -28,10 +31,12 @@ pub const METRICS_L2_FINALIZED_BLOCK_NUMBER: &str = "l2.finalized_block_number";
 pub const METRICS_RPC_CLIENT_REQUESTS: &str = "rpc.client.requests";
 /// Confirmed challenge transactions.
 pub const METRICS_CHALLENGES_SUBMITTED: &str = "challenges.submitted";
-/// ETH bonded by proposer and challenger transactions.
-pub const METRICS_BONDS_POSTED_ETH: &str = "bonds.posted_eth";
-/// ETH transferred back to proposer and challenger wallets after bond settlement.
-pub const METRICS_BONDS_WITHDRAWN_ETH: &str = "bonds.withdrawn_eth";
+/// WLD locked by proposer and challenger transactions.
+pub const METRICS_BONDS_LOCKED_WLD: &str = "bonds.locked_wld";
+/// WLD immediately reusable by a proof-system participant.
+pub const METRICS_VAULT_AVAILABLE_BALANCE_WLD: &str = "vault.available_balance_wld";
+/// Games processed by a bond settlement manager.
+pub const METRICS_GAMES_CLOSED: &str = "games.closed";
 /// Confirmed on-chain proof-lane submissions.
 pub const METRICS_PROOF_LANES_SUBMITTED: &str = "proof_lanes.submitted";
 /// Newly created durable proof requests.
@@ -76,14 +81,19 @@ pub fn describe_metrics() {
         "Number of challenge transactions successfully confirmed on L1."
     );
     metrics::describe_histogram!(
-        METRICS_BONDS_POSTED_ETH,
+        METRICS_BONDS_LOCKED_WLD,
         metrics::Unit::Count,
-        "ETH bonded by successfully confirmed proposer and challenger transactions."
+        "WLD locked by successfully confirmed proposer and challenger transactions."
     );
-    metrics::describe_histogram!(
-        METRICS_BONDS_WITHDRAWN_ETH,
+    metrics::describe_gauge!(
+        METRICS_VAULT_AVAILABLE_BALANCE_WLD,
         metrics::Unit::Count,
-        "ETH transferred after successfully confirmed proposer and challenger bond withdrawals."
+        "WLD immediately reusable by the participant in the proof-system staking vault."
+    );
+    metrics::describe_counter!(
+        METRICS_GAMES_CLOSED,
+        metrics::Unit::Count,
+        "Games submitted for settlement or observed as already settled."
     );
     metrics::describe_counter!(
         METRICS_PROOF_LANES_SUBMITTED,
@@ -178,20 +188,47 @@ pub fn increment_challenges_submitted() {
     metrics::counter!(METRICS_CHALLENGES_SUBMITTED).increment(1);
 }
 
-/// Records ETH posted by a successfully confirmed bond transaction.
-pub fn record_bond_posted(role: &'static str, amount: alloy_primitives::U256) {
-    record_bond_amount(METRICS_BONDS_POSTED_ETH, role, amount);
+/// Records WLD locked by a successfully confirmed bond transaction.
+pub fn record_bond_locked(role: &'static str, amount: alloy_primitives::U256) {
+    match format_units(amount, 18) {
+        Ok(formatted) => match formatted.parse::<f64>() {
+            Ok(amount_wld) => {
+                metrics::histogram!(METRICS_BONDS_LOCKED_WLD, "role" => role).record(amount_wld);
+            }
+            Err(error) => warn!(%error, %role, ?amount, "failed to convert bond amount to WLD"),
+        },
+        Err(error) => warn!(%error, %role, ?amount, "failed to format bond amount as WLD"),
+    }
 }
 
-/// Records ETH transferred by a successfully confirmed bond withdrawal.
-pub fn record_bond_withdrawn(role: &'static str, amount: alloy_primitives::U256) {
-    record_bond_amount(METRICS_BONDS_WITHDRAWN_ETH, role, amount);
+/// Records a game handled by a bond settlement manager.
+pub fn increment_games_closed(role: &'static str, result: &'static str) {
+    metrics::counter!(METRICS_GAMES_CLOSED, "role" => role, "result" => result).increment(1);
 }
 
-fn record_bond_amount(metric: &'static str, role: &'static str, amount: alloy_primitives::U256) {
-    match format_ether(amount).parse::<f64>() {
-        Ok(amount_eth) => metrics::histogram!(metric, "role" => role).record(amount_eth),
-        Err(error) => warn!(%error, %role, ?amount, "failed to convert bond amount to ETH"),
+/// Records and logs an account's immediately reusable WLD vault balance.
+pub fn record_vault_balance(
+    vault_address: Address,
+    account: Address,
+    role: &'static str,
+    balance: alloy_primitives::U256,
+) {
+    let gauge = metrics::gauge!(
+        METRICS_VAULT_AVAILABLE_BALANCE_WLD,
+        "role" => role,
+        "address" => account.to_string(),
+    );
+    match format_units(balance, 18) {
+        Ok(formatted) => match formatted.parse::<f64>() {
+            Ok(balance_wld) => {
+                gauge.set(balance_wld);
+                info!(%role, %account, %vault_address, %balance, balance_wld, "refreshed available WLD vault balance");
+            }
+            Err(error) => {
+                warn!(%account, %error, ?balance, "failed to convert vault balance to WLD")
+            }
+        },
+        Err(error) => warn!(%account, %error, ?balance, "failed to format vault balance as WLD"),
     }
 }
 

--- a/proofs/protocol/src/bindings.rs
+++ b/proofs/protocol/src/bindings.rs
@@ -118,9 +118,9 @@ sol! {
         function credit(address recipient) external view returns (uint256);
     }
 
-    /// Singleton WLD vault that locks and settles WIP-1006 proposal and challenge bonds.
+    /// Singleton ERC-20 vault that locks and settles WIP-1006 proposal and challenge bonds.
     #[sol(rpc)]
-    interface IWLDStakingVault {
+    interface IERC20StakingVault {
         event ProposerBondLocked(address indexed game, address indexed proposer, uint256 amount);
         function disputeGameFactory() external view returns (address);
         function availableBalance(address account) external view returns (uint256 amount);

--- a/proofs/protocol/src/bindings.rs
+++ b/proofs/protocol/src/bindings.rs
@@ -63,6 +63,7 @@ sol! {
         function protocolFeeRecipient() external view returns (address);
         function disputeGameFactory() external view returns (address);
         function anchorStateRegistry() external view returns (address);
+        function bondVault() external view returns (address);
         function weth() external view returns (address);
 
         // Proposal context.
@@ -102,7 +103,7 @@ sol! {
             returns (bool resolvable, uint8 outcome, uint8 reason);
 
         // Mutating entry points.
-        function challenge() external payable returns (uint8 proposalStatus);
+        function challenge() external returns (uint8 proposalStatus);
         /// `proof` is the compact payload built by `encode_compact_proof`.
         function submitProofLane(bytes calldata proof) external returns (uint8 proposalStatus);
         function resolve() external returns (uint8 status);
@@ -115,6 +116,18 @@ sol! {
         function normalModeCredit(address recipient) external view returns (uint256);
         function refundModeCredit(address recipient) external view returns (uint256);
         function credit(address recipient) external view returns (uint256);
+    }
+
+    /// Singleton WLD vault that locks and settles WIP-1006 proposal and challenge bonds.
+    #[sol(rpc)]
+    interface IWLDStakingVault {
+        event ProposerBondLocked(address indexed game, address indexed proposer, uint256 amount);
+        function disputeGameFactory() external view returns (address);
+        function availableBalance(address account) external view returns (uint256 amount);
+        function gameBonds(address game)
+            external
+            view
+            returns (uint256 proposerBond, uint256 challengerBond, bool settled);
     }
 
     /// Stock OP Stack `AnchorStateRegistry`.
@@ -134,7 +147,7 @@ sol! {
         function paused() external view returns (bool);
     }
 
-    /// Stock OP Stack `DelayedWETH`, the bond custody contract behind every game.
+    /// Legacy E2E-only binding retained until the stacked devnet migration removes WETH flows.
     #[sol(rpc)]
     interface IDelayedWETH {
         function delay() external view returns (uint256);

--- a/proofs/protocol/src/lib.rs
+++ b/proofs/protocol/src/lib.rs
@@ -14,15 +14,17 @@ mod proof_game;
 mod types;
 
 // re-exports
-pub use bindings::{IAnchorStateRegistry, IDelayedWETH, IDisputeGameFactory, IMultiProofGame};
+pub use bindings::{
+    IAnchorStateRegistry, IDelayedWETH, IDisputeGameFactory, IMultiProofGame, IWLDStakingVault,
+};
 pub use consensus_provider::{
     ConsensusError, ConsensusProvider, OptimismConsensusClient, VerifyingConsensusProvider,
 };
 pub use lineage::{
     LineageAnchor, LineageError, LineageGame, LineageProvider, LineageStop, LineageTransition,
     RegisteredLineageConfig, SelectedLineage, SelectedLineageGame, read_game_for_transition,
-    read_lineage_anchor, read_lineage_resolution_status, read_registered_lineage_config,
-    select_lineage,
+    read_lineage_anchor, read_lineage_resolution_status, read_registered_bond_vault,
+    read_registered_lineage_config, select_lineage,
 };
 pub use proof_game::{
     AlloyProofGameProvider, ProofGameContext, ProofGameContextError, ProofGameProvider,

--- a/proofs/protocol/src/lib.rs
+++ b/proofs/protocol/src/lib.rs
@@ -15,7 +15,7 @@ mod types;
 
 // re-exports
 pub use bindings::{
-    IAnchorStateRegistry, IDelayedWETH, IDisputeGameFactory, IMultiProofGame, IWLDStakingVault,
+    IAnchorStateRegistry, IDelayedWETH, IDisputeGameFactory, IERC20StakingVault, IMultiProofGame,
 };
 pub use consensus_provider::{
     ConsensusError, ConsensusProvider, OptimismConsensusClient, VerifyingConsensusProvider,

--- a/proofs/protocol/src/lineage.rs
+++ b/proofs/protocol/src/lineage.rs
@@ -246,20 +246,7 @@ pub async fn read_registered_lineage_config<P>(
 where
     P: Provider + Clone,
 {
-    let implementation_address = factory
-        .gameImpls(MULTI_PROOF_GAME_TYPE)
-        .call()
-        .await
-        .map_err(|error| LineageError::Contract(error.to_string()))?;
-    if implementation_address == Address::ZERO {
-        return Err(LineageError::Contract(format!(
-            "dispute-game factory {} has no implementation for game type {MULTI_PROOF_GAME_TYPE}",
-            factory.address()
-        )));
-    }
-
-    let implementation =
-        IMultiProofGame::IMultiProofGameInstance::new(implementation_address, provider.clone());
+    let implementation = read_registered_game_implementation(provider, factory).await?;
     let (domain_hash, anchor_registry, block_interval) = provider
         .multicall()
         .add(implementation.domainHash())
@@ -285,6 +272,52 @@ where
         block_interval,
         anchor_registry,
     })
+}
+
+/// Discovers the singleton bond vault from the factory's registered WIP-1006 implementation.
+pub async fn read_registered_bond_vault<P>(
+    provider: &P,
+    factory: &IDisputeGameFactory::IDisputeGameFactoryInstance<P>,
+) -> Result<Address, LineageError>
+where
+    P: Provider + Clone,
+{
+    let implementation = read_registered_game_implementation(provider, factory).await?;
+    let bond_vault = implementation
+        .bondVault()
+        .call()
+        .await
+        .map_err(|error| LineageError::Contract(error.to_string()))?;
+    if bond_vault == Address::ZERO {
+        return Err(LineageError::Contract(
+            "registered game implementation has no bond vault".into(),
+        ));
+    }
+    Ok(bond_vault)
+}
+
+async fn read_registered_game_implementation<P>(
+    provider: &P,
+    factory: &IDisputeGameFactory::IDisputeGameFactoryInstance<P>,
+) -> Result<IMultiProofGame::IMultiProofGameInstance<P>, LineageError>
+where
+    P: Provider + Clone,
+{
+    let implementation_address = factory
+        .gameImpls(MULTI_PROOF_GAME_TYPE)
+        .call()
+        .await
+        .map_err(|error| LineageError::Contract(error.to_string()))?;
+    if implementation_address == Address::ZERO {
+        return Err(LineageError::Contract(format!(
+            "dispute-game factory {} has no implementation for game type {MULTI_PROOF_GAME_TYPE}",
+            factory.address()
+        )));
+    }
+    Ok(IMultiProofGame::IMultiProofGameInstance::new(
+        implementation_address,
+        provider.clone(),
+    ))
 }
 
 /// Looks up the highest sequential retry attempt for a transition.

--- a/proofs/services/challenger/src/alloy.rs
+++ b/proofs/services/challenger/src/alloy.rs
@@ -1,21 +1,19 @@
 use crate::{
     error::ChallengerError,
     traits::{BondManagerClient, ChallengerClient, ResolutionManagerClient},
-    types::{
-        ChallengeSubmission, ClaimSubmission, GameMetadata, PendingWithdrawal, ResolveSubmission,
-    },
+    types::{ChallengeSubmission, CloseGameSubmission, GameMetadata, ResolveSubmission},
 };
-use alloy_consensus::BlockHeader;
-use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{Address, U256};
 use alloy_provider::{Provider, WalletProvider};
 use alloy_rpc_types_eth::BlockId;
 use async_trait::async_trait;
 use std::{sync::Arc, time::Duration};
 use tokio::sync::Semaphore;
+use tracing::warn;
 use world_chain_proof_protocol::{
-    IAnchorStateRegistry, IDelayedWETH, IDisputeGameFactory, IMultiProofGame,
-    MULTI_PROOF_GAME_TYPE, ProposalStatus, ResolutionStatus,
+    IAnchorStateRegistry, IDisputeGameFactory, IMultiProofGame, IWLDStakingVault,
+    MULTI_PROOF_GAME_TYPE, ProposalStatus, ResolutionStatus, read_registered_bond_vault,
+    read_registered_lineage_config,
 };
 
 /// Alloy-backed implementation of the challenger contract clients.
@@ -25,6 +23,7 @@ use world_chain_proof_protocol::{
 #[derive(Debug, Clone)]
 pub struct AlloyChallengerClient<P> {
     factory: IDisputeGameFactory::IDisputeGameFactoryInstance<P>,
+    bond_vault: IWLDStakingVault::IWLDStakingVaultInstance<P>,
     confirmations: u64,
     receipt_timeout: Duration,
     semaphore: Arc<Semaphore>,
@@ -36,28 +35,71 @@ where
     P: Provider + Clone,
 {
     /// Creates an Alloy-backed contract client.
-    pub fn new(
+    pub async fn new(
         provider: P,
         factory_address: Address,
         confirmations: u64,
         receipt_timeout: Duration,
-    ) -> Self {
+    ) -> Result<Self, ChallengerError> {
         let factory = IDisputeGameFactory::IDisputeGameFactoryInstance::new(
             factory_address,
             provider.clone(),
         );
+        read_registered_lineage_config(&provider, &factory).await?;
+        let bond_vault = read_registered_bond_vault(&provider, &factory).await?;
+        let init_bond = factory.initBonds(MULTI_PROOF_GAME_TYPE).call().await?;
+        if !init_bond.is_zero() {
+            return Err(ChallengerError::NonZeroFactoryBond(init_bond));
+        }
+        let vault = IWLDStakingVault::IWLDStakingVaultInstance::new(bond_vault, provider.clone());
+        let configured_factory = vault.disputeGameFactory().call().await?;
+        if configured_factory != factory_address {
+            return Err(ChallengerError::VaultFactoryMismatch {
+                vault: bond_vault,
+                expected: factory_address,
+                actual: configured_factory,
+            });
+        }
         let semaphore = Arc::new(Semaphore::new(1));
-        Self {
+        Ok(Self {
             factory,
+            bond_vault: vault,
             confirmations,
             receipt_timeout,
             semaphore,
             provider,
-        }
+        })
     }
 
     fn game(&self, address: Address) -> IMultiProofGame::IMultiProofGameInstance<P> {
         IMultiProofGame::IMultiProofGameInstance::new(address, self.provider.clone())
+    }
+
+    /// Refreshes the managed challenger's reusable WLD balance metric.
+    pub async fn refresh_vault_balance(&self)
+    where
+        P: WalletProvider,
+    {
+        self.refresh_vault_balance_for(self.provider.default_signer_address())
+            .await;
+    }
+
+    /// Returns the singleton WLD vault discovered from the active implementation.
+    #[must_use]
+    pub fn bond_vault_address(&self) -> Address {
+        *self.bond_vault.address()
+    }
+
+    async fn refresh_vault_balance_for(&self, account: Address) {
+        match self.bond_vault.availableBalance(account).call().await {
+            Ok(balance) => world_chain_proof_metrics::record_vault_balance(
+                self.bond_vault_address(),
+                account,
+                "challenger",
+                balance,
+            ),
+            Err(error) => warn!(%error, %account, "failed to fetch challenger WLD vault balance"),
+        }
     }
 
     async fn read_game_count(&self) -> Result<u64, ChallengerError> {
@@ -91,41 +133,6 @@ where
             resolvable: result.resolvable,
             outcome: result.outcome.try_into()?,
             invalidation_reason: result.reason.try_into()?,
-        })
-    }
-
-    async fn read_credit(
-        &self,
-        address: Address,
-        recipient: Address,
-    ) -> Result<U256, ChallengerError> {
-        Ok(self.game(address).credit(recipient).call().await?)
-    }
-
-    async fn read_pending_withdrawal(
-        &self,
-        address: Address,
-        recipient: Address,
-    ) -> Result<PendingWithdrawal, ChallengerError> {
-        let weth_address = self.game(address).weth().call().await?;
-        let weth = IDelayedWETH::IDelayedWETHInstance::new(weth_address, self.provider.clone());
-
-        let (pending, delay) = tokio::try_join!(
-            async { weth.withdrawals(address, recipient).call().await },
-            async { weth.delay().call().await },
-        )?;
-
-        if pending.amount.is_zero() {
-            return Ok(PendingWithdrawal::default());
-        }
-        let unlock_at = pending
-            .timestamp
-            .checked_add(delay)
-            .ok_or(ChallengerError::Overflow)?;
-
-        Ok(PendingWithdrawal {
-            amount: pending.amount,
-            unlock_at: u256_to_u64(unlock_at)?,
         })
     }
 }
@@ -171,13 +178,11 @@ where
         address: Address,
     ) -> Result<ChallengeSubmission, ChallengerError> {
         let _permit = self.semaphore.acquire().await?;
-        // The bond is an immutable of whichever implementation this clone was created from, so
-        // it is read per game: a re-registered implementation would otherwise make every
-        // challenge revert with `IncorrectBondAmount`.
+        // Read the game-pinned amount so the submission and telemetry report the actual lock.
         let game = self.game(address);
         let challenger_bond = game.challengerBond().call().await?;
 
-        let pending = game.challenge().value(challenger_bond).send().await?;
+        let pending = game.challenge().send().await?;
         let tx_hash = *pending.tx_hash();
         let receipt = pending
             .with_required_confirmations(self.confirmations)
@@ -188,7 +193,8 @@ where
         if !receipt.status() {
             return Err(ChallengerError::Revert(tx_hash));
         }
-        world_chain_proof_metrics::record_bond_posted("challenger", challenger_bond);
+        world_chain_proof_metrics::record_bond_locked("challenger", challenger_bond);
+        self.refresh_vault_balance_for(receipt.from).await;
         Ok(ChallengeSubmission {
             tx_hash,
             bond: challenger_bond,
@@ -253,39 +259,13 @@ where
         Ok(anchor.isGameFinalized(address).call().await?)
     }
 
-    async fn credit(&self, address: Address) -> Result<U256, ChallengerError> {
-        self.read_credit(address, self.challenger_address()).await
+    async fn is_game_settled(&self, address: Address) -> Result<bool, ChallengerError> {
+        Ok(self.bond_vault.gameBonds(address).call().await?.settled)
     }
 
-    async fn pending_withdrawal(
-        &self,
-        address: Address,
-    ) -> Result<PendingWithdrawal, ChallengerError> {
-        self.read_pending_withdrawal(address, self.challenger_address())
-            .await
-    }
-
-    async fn latest_l1_timestamp(&self) -> Result<u64, ChallengerError> {
-        self.provider
-            .get_block_by_number(BlockNumberOrTag::Latest)
-            .await?
-            .map(|block| block.header.timestamp())
-            .ok_or(ChallengerError::UnavailableLatestL1Block)
-    }
-
-    async fn claim_credit(&self, address: Address) -> Result<ClaimSubmission, ChallengerError> {
+    async fn close_game(&self, address: Address) -> Result<CloseGameSubmission, ChallengerError> {
         let _permit = self.semaphore.acquire().await?;
-        let recipient = self.challenger_address();
-        // Read both phases up front so the submission can report what the call moved; the
-        // receipt carries no amount of its own.
-        let credit = self.read_credit(address, recipient).await?;
-        let pending = if credit.is_zero() {
-            self.read_pending_withdrawal(address, recipient).await?
-        } else {
-            PendingWithdrawal::default()
-        };
-
-        let pending_tx = self.game(address).claimCredit(recipient).send().await?;
+        let pending_tx = self.game(address).closeGame().send().await?;
         let tx_hash = *pending_tx.tx_hash();
         let receipt = pending_tx
             .with_required_confirmations(self.confirmations)
@@ -298,20 +278,9 @@ where
             return Err(ChallengerError::Revert(tx_hash));
         }
 
-        Ok(if credit.is_zero() {
-            world_chain_proof_metrics::record_bond_withdrawn("challenger", pending.amount);
-            ClaimSubmission {
-                tx_hash,
-                amount: pending.amount,
-                withdrawn: true,
-            }
-        } else {
-            ClaimSubmission {
-                tx_hash,
-                amount: credit,
-                withdrawn: false,
-            }
-        })
+        self.refresh_vault_balance_for(receipt.from).await;
+
+        Ok(CloseGameSubmission { tx_hash })
     }
 }
 

--- a/proofs/services/challenger/src/alloy.rs
+++ b/proofs/services/challenger/src/alloy.rs
@@ -11,7 +11,7 @@ use std::{sync::Arc, time::Duration};
 use tokio::sync::Semaphore;
 use tracing::warn;
 use world_chain_proof_protocol::{
-    IAnchorStateRegistry, IDisputeGameFactory, IMultiProofGame, IWLDStakingVault,
+    IAnchorStateRegistry, IDisputeGameFactory, IERC20StakingVault, IMultiProofGame,
     MULTI_PROOF_GAME_TYPE, ProposalStatus, ResolutionStatus, read_registered_bond_vault,
     read_registered_lineage_config,
 };
@@ -23,7 +23,7 @@ use world_chain_proof_protocol::{
 #[derive(Debug, Clone)]
 pub struct AlloyChallengerClient<P> {
     factory: IDisputeGameFactory::IDisputeGameFactoryInstance<P>,
-    bond_vault: IWLDStakingVault::IWLDStakingVaultInstance<P>,
+    bond_vault: IERC20StakingVault::IERC20StakingVaultInstance<P>,
     confirmations: u64,
     receipt_timeout: Duration,
     semaphore: Arc<Semaphore>,
@@ -51,7 +51,8 @@ where
         if !init_bond.is_zero() {
             return Err(ChallengerError::NonZeroFactoryBond(init_bond));
         }
-        let vault = IWLDStakingVault::IWLDStakingVaultInstance::new(bond_vault, provider.clone());
+        let vault =
+            IERC20StakingVault::IERC20StakingVaultInstance::new(bond_vault, provider.clone());
         let configured_factory = vault.disputeGameFactory().call().await?;
         if configured_factory != factory_address {
             return Err(ChallengerError::VaultFactoryMismatch {
@@ -75,7 +76,7 @@ where
         IMultiProofGame::IMultiProofGameInstance::new(address, self.provider.clone())
     }
 
-    /// Refreshes the managed challenger's reusable WLD balance metric.
+    /// Refreshes the managed challenger's reusable bond-token balance metric.
     pub async fn refresh_vault_balance(&self)
     where
         P: WalletProvider,
@@ -84,7 +85,7 @@ where
             .await;
     }
 
-    /// Returns the singleton WLD vault discovered from the active implementation.
+    /// Returns the singleton ERC-20 vault discovered from the active implementation.
     #[must_use]
     pub fn bond_vault_address(&self) -> Address {
         *self.bond_vault.address()
@@ -98,7 +99,9 @@ where
                 "challenger",
                 balance,
             ),
-            Err(error) => warn!(%error, %account, "failed to fetch challenger WLD vault balance"),
+            Err(error) => {
+                warn!(%error, %account, "failed to fetch challenger ERC-20 vault balance")
+            }
         }
     }
 

--- a/proofs/services/challenger/src/bond_manager.rs
+++ b/proofs/services/challenger/src/bond_manager.rs
@@ -1,9 +1,8 @@
-use alloy_primitives::U256;
 use tracing::{info, warn};
 
 use crate::{BondManagerClient, BondManagerConfig, ChallengerError, OwnedGames};
 
-/// Discovers challenger-owned games and withdraws their resolved bond credits.
+/// Discovers challenger-owned games and settles their resolved bond pots.
 #[derive(Debug)]
 pub struct BondManager<E> {
     config: BondManagerConfig,
@@ -13,7 +12,7 @@ pub struct BondManager<E> {
 }
 
 impl<E> BondManager<E> {
-    /// Creates an empty bond manager. Its bounded recovery window is scanned on the first pass.
+    /// Creates an empty bond manager. Its bounded lookback window is scanned on the first pass.
     pub const fn new(
         config: BondManagerConfig,
         execution_provider: E,
@@ -75,55 +74,33 @@ where
         Ok(())
     }
 
-    /// Advances the two-phase bond claim on owned games and prunes fully settled ones.
-    ///
-    /// `MultiProofGame.claimCredit` first unlocks the credit in `DelayedWETH` and only
-    /// transfers it on a second call after the WETH delay, so a game stays owned until its
-    /// pending withdrawal is drained. Dropping it after the unlock would strand the bond.
-    pub async fn withdraw_credits(&self) -> Result<(), ChallengerError> {
+    /// Settles finalized owned games and prunes games whose complete pot is settled.
+    pub async fn settle_games(&self) -> Result<(), ChallengerError> {
         let games = self.owned_games.snapshot();
-        let now = self.execution_provider.latest_l1_timestamp().await?;
 
         for game in games {
             let result: Result<bool, ChallengerError> = async {
+                if self.execution_provider.is_game_settled(game).await? {
+                    world_chain_proof_metrics::increment_games_closed(
+                        "challenger",
+                        "already_settled",
+                    );
+                    return Ok(true);
+                }
                 let status = self.execution_provider.resolution_status(game).await?;
                 if !status.is_resolved() {
                     return Ok(false);
                 }
-                // `claimCredit` calls `closeGame`, which reverts until the registry's finality
-                // airgap has elapsed.
                 if !self.execution_provider.is_game_finalized(game).await? {
                     return Ok(false);
                 }
 
-                let credit = self.execution_provider.credit(game).await?;
-                if credit > U256::ZERO {
-                    let submission = self.execution_provider.claim_credit(game).await?;
-                    info!(
-                        game_address = %game,
-                        tx_hash = ?submission.tx_hash,
-                        amount = ?submission.amount,
-                        "unlocked challenger bond credits in DelayedWETH"
-                    );
-                    // Keep tracking: the unlocked amount still needs the second claim.
-                    return Ok(false);
-                }
-
-                let pending = self.execution_provider.pending_withdrawal(game).await?;
-                if pending.amount.is_zero() {
-                    // Nothing owed on this game; stop tracking it.
-                    return Ok(true);
-                }
-                if now < pending.unlock_at {
-                    return Ok(false);
-                }
-
-                let submission = self.execution_provider.claim_credit(game).await?;
+                let submission = self.execution_provider.close_game(game).await?;
+                world_chain_proof_metrics::increment_games_closed("challenger", "submitted");
                 info!(
                     game_address = %game,
                     tx_hash = ?submission.tx_hash,
-                    amount = ?submission.amount,
-                    "withdrew challenger bond credits"
+                    "settled challenger-owned game into reusable vault balances"
                 );
                 Ok(true)
             }
@@ -133,7 +110,7 @@ where
                 Ok(true) => self.owned_games.remove(game),
                 Ok(false) => {}
                 Err(error) => {
-                    warn!(%error, game_address = %game, "failed to process challenger bond credits");
+                    warn!(%error, game_address = %game, "failed to process challenger bond settlement");
                 }
             }
         }
@@ -141,7 +118,7 @@ where
         Ok(())
     }
 
-    /// Runs recent-game discovery and withdrawals forever.
+    /// Runs recent-game discovery and settlement forever.
     pub async fn run_forever(&mut self) -> Result<(), ChallengerError> {
         self.config.validate()?;
 
@@ -151,8 +128,8 @@ where
             if let Err(error) = self.scan_games().await {
                 warn!(%error, "bond-manager game scan failed; retrying on next tick");
             }
-            if let Err(error) = self.withdraw_credits().await {
-                warn!(%error, "bond-manager withdrawal pass failed; retrying on next tick");
+            if let Err(error) = self.settle_games().await {
+                warn!(%error, "bond-manager settlement pass failed; retrying on next tick");
             }
         }
     }

--- a/proofs/services/challenger/src/config.rs
+++ b/proofs/services/challenger/src/config.rs
@@ -13,7 +13,7 @@ pub const DEFAULT_GAME_SCAN_LOOKBACK: u64 = 100;
 pub const DEFAULT_RESOLUTION_POLL_INTERVAL: Duration = Duration::from_secs(30);
 /// Default maximum number of resolution transactions submitted per pass.
 pub const DEFAULT_MAX_RESOLUTIONS_PER_TICK: usize = 1;
-/// Default delay between challenger-bond discovery and withdrawal passes.
+/// Default delay between challenger-bond discovery and settlement passes.
 pub const DEFAULT_BOND_MANAGER_POLL_INTERVAL: Duration = Duration::from_secs(5 * 60);
 /// Default number of recent factory games inspected for challenger ownership.
 pub const DEFAULT_BOND_MANAGER_INITIAL_SCAN_LIMIT: u64 = 1_000;
@@ -104,7 +104,7 @@ impl Default for ResolutionManagerConfig {
 /// Configuration for asynchronous challenger-bond management.
 #[derive(Debug, Clone)]
 pub struct BondManagerConfig {
-    /// Delay between factory scans and withdrawal attempts.
+    /// Delay between factory scans and settlement attempts.
     pub poll_interval: Duration,
     /// Number of most recently created games scanned on startup.
     pub initial_scan_limit: u64,

--- a/proofs/services/challenger/src/error.rs
+++ b/proofs/services/challenger/src/error.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{Address, TxHash};
+use alloy_primitives::{Address, TxHash, U256};
 use alloy_provider::{PendingTransactionError, transport::RpcError};
 use alloy_transport::TransportErrorKind;
 use thiserror::Error;
@@ -13,6 +13,14 @@ pub enum ChallengerError {
     /// Invalid challenger configuration.
     #[error("invalid challenger config: {0}")]
     InvalidConfig(&'static str),
+    #[error("WIP-1006 factory init bond must be zero, got {0}")]
+    NonZeroFactoryBond(U256),
+    #[error("vault {vault} is wired to factory {actual}, expected {expected}")]
+    VaultFactoryMismatch {
+        vault: Address,
+        expected: Address,
+        actual: Address,
+    },
     /// Adding `block_interval` overflowed `u64`.
     #[error("l2 block number overflow: parent {parent_block} + interval {block_interval}")]
     BlockNumberOverflow {
@@ -36,8 +44,6 @@ pub enum ChallengerError {
     NotExistingInvalidReason(#[from] InvalidationReasonError),
     #[error(transparent)]
     PendingTransaction(#[from] PendingTransactionError),
-    #[error("Latest L1 block is unavailable.")]
-    UnavailableLatestL1Block,
     #[error("Overflow error.")]
     Overflow,
     #[error(transparent)]
@@ -57,6 +63,8 @@ pub enum ChallengerError {
     },
     #[error(transparent)]
     Permit(#[from] AcquireError),
+    #[error(transparent)]
+    Lineage(#[from] world_chain_proof_protocol::LineageError),
 }
 
 impl From<alloy_contract::Error> for ChallengerError {

--- a/proofs/services/challenger/src/lib.rs
+++ b/proofs/services/challenger/src/lib.rs
@@ -23,8 +23,7 @@ pub use error::ChallengerError;
 pub use resolution_manager::ResolutionManager;
 pub use traits::{BondManagerClient, ChallengerClient, ResolutionManagerClient};
 pub use types::{
-    ChallengeSubmission, ClaimSubmission, GameMetadata, OwnedGames, PendingWithdrawal,
-    ResolveSubmission,
+    ChallengeSubmission, CloseGameSubmission, GameMetadata, OwnedGames, ResolveSubmission,
 };
 
 #[cfg(test)]

--- a/proofs/services/challenger/src/main.rs
+++ b/proofs/services/challenger/src/main.rs
@@ -106,7 +106,7 @@ struct Cli {
     #[arg(long, env = "MAX_RESOLUTIONS_PER_TICK", default_value_t = 1)]
     max_resolutions_per_tick: usize,
 
-    /// Seconds between challenger-bond discovery and withdrawal passes.
+    /// Seconds between challenger-bond discovery and settlement passes.
     #[arg(
         long,
         env = "BOND_MANAGER_POLL_INTERVAL_SECONDS",
@@ -165,7 +165,10 @@ async fn main() -> Result<()> {
         cli.factory_address,
         cli.l1_tx_confirmations,
         Duration::from_secs(cli.l1_tx_receipt_timeout_seconds),
-    );
+    )
+    .await
+    .context("failed to bind the World Chain proof system")?;
+    client.refresh_vault_balance().await;
 
     // Preflight the factory index before entering the scan loop. Crash instead of reporting the
     // process alive while every scan tick fails.
@@ -200,6 +203,7 @@ async fn main() -> Result<()> {
         poll_interval: Duration::from_secs(cli.bond_manager_poll_interval_seconds),
         initial_scan_limit: cli.bond_manager_initial_scan_limit,
     };
+    let bond_vault = client.bond_vault_address();
     let owned_games = OwnedGames::default();
     let mut challenger = WorldChainChallenger::with_owned_games(
         config,
@@ -216,6 +220,7 @@ async fn main() -> Result<()> {
         output_root_rpc_url = world_chain_proof_metrics::redact_endpoint(&cli.output_root_rpc),
         verifying_output_root_rpc_configured = cli.verifying_output_root_rpc.is_some(),
         dispute_game_factory = %cli.factory_address,
+        bond_vault = %bond_vault,
         factory_game_count = game_count,
         challenger = %challenger_address,
         max_games_per_tick = cli.max_games_per_tick,

--- a/proofs/services/challenger/src/tests.rs
+++ b/proofs/services/challenger/src/tests.rs
@@ -1,8 +1,8 @@
 use crate::{
     BondManager, BondManagerClient, BondManagerConfig, ChallengeSubmission, ChallengerClient,
-    ChallengerConfig, ChallengerError, ClaimSubmission, GameMetadata, OwnedGames,
-    PendingWithdrawal, ResolutionManager, ResolutionManagerClient, ResolutionManagerConfig,
-    ResolveSubmission, challenger::WorldChainChallenger,
+    ChallengerConfig, ChallengerError, CloseGameSubmission, GameMetadata, OwnedGames,
+    ResolutionManager, ResolutionManagerClient, ResolutionManagerConfig, ResolveSubmission,
+    challenger::WorldChainChallenger,
 };
 use alloy_primitives::{Address, B256, BlockNumber, U256, address};
 use async_trait::async_trait;
@@ -37,8 +37,7 @@ struct MockGame {
     resolvable: bool,
     resolution_outcome: GameStatus,
     resolution_reason: u8,
-    credit: U256,
-    pending: PendingWithdrawal,
+    settled: bool,
     /// Whether the registry's finality airgap has elapsed for this game.
     finalized: bool,
 }
@@ -57,11 +56,7 @@ impl MockGame {
             resolvable: false,
             resolution_outcome: GameStatus::InProgress,
             resolution_reason: REASON_NONE,
-            credit: U256::ZERO,
-            pending: PendingWithdrawal {
-                amount: U256::ZERO,
-                unlock_at: 0,
-            },
+            settled: false,
             finalized: true,
         }
     }
@@ -74,10 +69,8 @@ struct MockState {
     requested_indices: Vec<u64>,
     challenges: Vec<Address>,
     resolutions: Vec<Address>,
-    unlocks: Vec<Address>,
-    withdrawals: Vec<Address>,
-    fail_claim_once: HashSet<Address>,
-    latest_l1_timestamp: u64,
+    closes: Vec<Address>,
+    fail_close_once: HashSet<Address>,
     /// Factory indices holding a game of a different type.
     foreign_indices: HashSet<u64>,
 }
@@ -111,8 +104,8 @@ impl MockClient {
         self.state.lock().expect("not poisoned").resolutions.clone()
     }
 
-    fn withdrawals(&self) -> Vec<Address> {
-        self.state.lock().expect("not poisoned").withdrawals.clone()
+    fn closes(&self) -> Vec<Address> {
+        self.state.lock().expect("not poisoned").closes.clone()
     }
 }
 
@@ -253,67 +246,29 @@ impl BondManagerClient for MockClient {
             .ok_or_else(|| ChallengerError::message(format!("unknown game {game}")))
     }
 
-    async fn credit(&self, game: Address) -> Result<U256, ChallengerError> {
+    async fn is_game_settled(&self, game: Address) -> Result<bool, ChallengerError> {
         self.state
             .lock()
             .expect("not poisoned")
             .games
             .get(&game)
-            .map(|game| game.credit)
+            .map(|game| game.settled)
             .ok_or_else(|| ChallengerError::message(format!("unknown game {game}")))
     }
 
-    async fn pending_withdrawal(
-        &self,
-        game: Address,
-    ) -> Result<PendingWithdrawal, ChallengerError> {
-        self.state
-            .lock()
-            .expect("not poisoned")
-            .games
-            .get(&game)
-            .map(|game| game.pending)
-            .ok_or_else(|| ChallengerError::message(format!("unknown game {game}")))
-    }
-
-    async fn latest_l1_timestamp(&self) -> Result<u64, ChallengerError> {
-        Ok(self.state.lock().expect("not poisoned").latest_l1_timestamp)
-    }
-
-    /// Mirrors `MultiProofGame.claimCredit`: the first call unlocks credit into a pending
-    /// `DelayedWETH` withdrawal, the second drains it.
-    async fn claim_credit(&self, game: Address) -> Result<ClaimSubmission, ChallengerError> {
+    async fn close_game(&self, game: Address) -> Result<CloseGameSubmission, ChallengerError> {
         let mut state = self.state.lock().expect("not poisoned");
-        if state.fail_claim_once.remove(&game) {
-            return Err(ChallengerError::message("injected claim failure"));
+        if state.fail_close_once.remove(&game) {
+            return Err(ChallengerError::message("injected close failure"));
         }
         let record = state
             .games
             .get_mut(&game)
             .ok_or_else(|| ChallengerError::message(format!("unknown game {game}")))?;
-
-        if record.credit > U256::ZERO {
-            let amount = record.credit;
-            record.credit = U256::ZERO;
-            record.pending = PendingWithdrawal {
-                amount,
-                unlock_at: 0,
-            };
-            state.unlocks.push(game);
-            return Ok(ClaimSubmission {
-                tx_hash: B256::with_last_byte(state.unlocks.len() as u8),
-                amount,
-                withdrawn: false,
-            });
-        }
-
-        let amount = record.pending.amount;
-        record.pending = PendingWithdrawal::default();
-        state.withdrawals.push(game);
-        Ok(ClaimSubmission {
-            tx_hash: B256::with_last_byte(state.withdrawals.len() as u8),
-            amount,
-            withdrawn: true,
+        record.settled = true;
+        state.closes.push(game);
+        Ok(CloseGameSubmission {
+            tx_hash: B256::with_last_byte(state.closes.len() as u8),
         })
     }
 }
@@ -591,22 +546,21 @@ async fn bond_manager_scans_games_appended_after_recovery() {
 }
 
 #[tokio::test]
-async fn bond_manager_completes_two_phase_claim_and_prunes_terminal_games() {
-    let mut claimable = MockGame::proposed(GAME_1, B256::ZERO, L2_BLOCK);
-    claimable.proposal_status = ProposalStatus::Resolved;
-    claimable.resolution_outcome = GameStatus::ChallengerWins;
-    claimable.resolution_reason = REASON_PROOF_TIMEOUT;
-    claimable.credit = U256::from(10);
-    let mut zero_credit = MockGame::proposed(GAME_2, B256::ZERO, L2_BLOCK);
-    zero_credit.proposal_status = ProposalStatus::Resolved;
-    zero_credit.resolution_outcome = GameStatus::DefenderWins;
+async fn bond_manager_settles_finalized_games_and_prunes_terminal_games() {
+    let mut closable = MockGame::proposed(GAME_1, B256::ZERO, L2_BLOCK);
+    closable.proposal_status = ProposalStatus::Resolved;
+    closable.resolution_outcome = GameStatus::ChallengerWins;
+    closable.resolution_reason = REASON_PROOF_TIMEOUT;
+    let mut already_settled = MockGame::proposed(GAME_2, B256::ZERO, L2_BLOCK);
+    already_settled.proposal_status = ProposalStatus::Resolved;
+    already_settled.resolution_outcome = GameStatus::DefenderWins;
+    already_settled.settled = true;
     // Resolved but still inside the registry's finality airgap: `closeGame` would revert.
     let mut awaiting_airgap = MockGame::proposed(GAME_3, B256::ZERO, L2_BLOCK);
     awaiting_airgap.proposal_status = ProposalStatus::Resolved;
     awaiting_airgap.resolution_outcome = GameStatus::DefenderWins;
-    awaiting_airgap.credit = U256::from(5);
     awaiting_airgap.finalized = false;
-    let client = MockClient::new(vec![claimable, zero_credit, awaiting_airgap]);
+    let client = MockClient::new(vec![closable, already_settled, awaiting_airgap]);
     let owned_games = OwnedGames::default();
     owned_games.insert(GAME_1);
     owned_games.insert(GAME_2);
@@ -617,40 +571,29 @@ async fn bond_manager_completes_two_phase_claim_and_prunes_terminal_games() {
         owned_games.clone(),
     );
 
-    // Pass 1 unlocks the credit in DelayedWETH; the bond is not paid out yet.
-    manager.withdraw_credits().await.unwrap();
+    manager.settle_games().await.unwrap();
 
-    assert!(client.withdrawals().is_empty());
-    assert!(
-        owned_games.contains(GAME_1),
-        "an unlocked bond must stay owned until it is withdrawn"
-    );
+    assert_eq!(client.closes(), vec![GAME_1]);
+    assert!(!owned_games.contains(GAME_1));
     assert!(!owned_games.contains(GAME_2));
     assert!(
         owned_games.contains(GAME_3),
         "a game inside the finality airgap must stay owned"
     );
-
-    // Pass 2 drains the pending withdrawal and drops the game.
-    manager.withdraw_credits().await.unwrap();
-
-    assert_eq!(client.withdrawals(), vec![GAME_1]);
-    assert!(!owned_games.contains(GAME_1));
 }
 
 #[tokio::test]
-async fn bond_manager_retries_failed_claim() {
+async fn bond_manager_retries_failed_close() {
     let mut game = MockGame::proposed(GAME_1, B256::ZERO, L2_BLOCK);
     game.proposal_status = ProposalStatus::Resolved;
     game.resolution_outcome = GameStatus::ChallengerWins;
     game.resolution_reason = REASON_PROOF_TIMEOUT;
-    game.credit = U256::from(10);
     let client = MockClient::new(vec![game]);
     client
         .state
         .lock()
         .expect("not poisoned")
-        .fail_claim_once
+        .fail_close_once
         .insert(GAME_1);
     let owned_games = OwnedGames::default();
     owned_games.insert(GAME_1);
@@ -660,32 +603,21 @@ async fn bond_manager_retries_failed_claim() {
         owned_games.clone(),
     );
 
-    // Injected failure on the unlock, then unlock, then withdraw.
-    for _ in 0..2 {
-        manager.withdraw_credits().await.unwrap();
-        assert!(owned_games.contains(GAME_1));
-    }
+    manager.settle_games().await.unwrap();
+    assert!(owned_games.contains(GAME_1));
 
-    manager.withdraw_credits().await.unwrap();
+    manager.settle_games().await.unwrap();
     assert!(!owned_games.contains(GAME_1));
-    assert_eq!(client.withdrawals(), vec![GAME_1]);
+    assert_eq!(client.closes(), vec![GAME_1]);
 }
 
 #[tokio::test]
-async fn bond_manager_uses_l1_timestamp_for_delayed_withdrawal() {
+async fn bond_manager_prunes_already_settled_game_without_closing_again() {
     let mut game = MockGame::proposed(GAME_1, B256::ZERO, L2_BLOCK);
     game.proposal_status = ProposalStatus::Resolved;
     game.resolution_outcome = GameStatus::DefenderWins;
-    game.pending = PendingWithdrawal {
-        amount: U256::from(10),
-        unlock_at: 100,
-    };
+    game.settled = true;
     let client = MockClient::new(vec![game]);
-    client
-        .state
-        .lock()
-        .expect("not poisoned")
-        .latest_l1_timestamp = 99;
     let owned_games = OwnedGames::default();
     owned_games.insert(GAME_1);
     let manager = BondManager::new(
@@ -694,18 +626,9 @@ async fn bond_manager_uses_l1_timestamp_for_delayed_withdrawal() {
         owned_games.clone(),
     );
 
-    manager.withdraw_credits().await.unwrap();
-    assert!(owned_games.contains(GAME_1));
-    assert!(client.withdrawals().is_empty());
-
-    client
-        .state
-        .lock()
-        .expect("not poisoned")
-        .latest_l1_timestamp = 100;
-    manager.withdraw_credits().await.unwrap();
+    manager.settle_games().await.unwrap();
     assert!(!owned_games.contains(GAME_1));
-    assert_eq!(client.withdrawals(), vec![GAME_1]);
+    assert!(client.closes().is_empty());
 }
 
 #[tokio::test]

--- a/proofs/services/challenger/src/traits.rs
+++ b/proofs/services/challenger/src/traits.rs
@@ -1,10 +1,8 @@
 use crate::{
     ChallengerError,
-    types::{
-        ChallengeSubmission, ClaimSubmission, GameMetadata, PendingWithdrawal, ResolveSubmission,
-    },
+    types::{ChallengeSubmission, CloseGameSubmission, GameMetadata, ResolveSubmission},
 };
-use alloy_primitives::{Address, U256};
+use alloy_primitives::Address;
 use async_trait::async_trait;
 use world_chain_proof_protocol::{ProposalStatus, ResolutionStatus};
 
@@ -52,16 +50,9 @@ pub trait BondManagerClient: ResolutionManagerClient {
     /// Returns the challenger recorded by the provided game.
     async fn game_challenger(&self, game: Address) -> Result<Address, ChallengerError>;
     /// Returns whether the registry's finality airgap has elapsed for the provided game.
-    ///
-    /// `claimCredit` calls `closeGame`, which reverts until this holds.
     async fn is_game_finalized(&self, game: Address) -> Result<bool, ChallengerError>;
-    /// Returns the credit the managed challenger can unlock from the provided game.
-    async fn credit(&self, game: Address) -> Result<U256, ChallengerError>;
-    /// Returns the managed challenger's pending `DelayedWETH` withdrawal for the game.
-    async fn pending_withdrawal(&self, game: Address)
-    -> Result<PendingWithdrawal, ChallengerError>;
-    /// Returns the latest L1 block timestamp used by `DelayedWETH`.
-    async fn latest_l1_timestamp(&self) -> Result<u64, ChallengerError>;
-    /// Advances the managed challenger's two-phase bond claim on the provided game.
-    async fn claim_credit(&self, game: Address) -> Result<ClaimSubmission, ChallengerError>;
+    /// Returns whether the game's complete bond pot has already been settled.
+    async fn is_game_settled(&self, game: Address) -> Result<bool, ChallengerError>;
+    /// Settles the game's complete bond pot into reusable vault balances.
+    async fn close_game(&self, game: Address) -> Result<CloseGameSubmission, ChallengerError>;
 }

--- a/proofs/services/challenger/src/types.rs
+++ b/proofs/services/challenger/src/types.rs
@@ -18,7 +18,7 @@ pub struct GameMetadata {
 pub struct ChallengeSubmission {
     /// Transaction hash for the challenge submission.
     pub tx_hash: TxHash,
-    /// Bond posted with the challenge, read from the game itself.
+    /// WLD bond locked by the challenge, read from the game itself.
     pub bond: U256,
 }
 
@@ -29,27 +29,11 @@ pub struct ResolveSubmission {
     pub tx_hash: TxHash,
 }
 
-/// Result of a `claimCredit` transaction.
-///
-/// Bond payout is two-phase: the first call unlocks the credit in `DelayedWETH`, the second
-/// (after the WETH delay) withdraws and transfers it.
+/// Result of a closeGame transaction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ClaimSubmission {
-    /// Transaction hash for the claim.
+pub struct CloseGameSubmission {
+    /// Transaction hash for the closeGame submission.
     pub tx_hash: TxHash,
-    /// Amount moved by this phase.
-    pub amount: U256,
-    /// Whether this call finalized the withdrawal and transferred funds.
-    pub withdrawn: bool,
-}
-
-/// A pending `DelayedWETH` withdrawal opened by the first `claimCredit` call.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub struct PendingWithdrawal {
-    /// Amount unlocked in `DelayedWETH` and awaiting the withdrawal delay.
-    pub amount: U256,
-    /// Unix timestamp at which the unlocked amount becomes withdrawable.
-    pub unlock_at: u64,
 }
 
 /// Challenger-owned games shared by scanning, resolution, and bond-management loops.

--- a/proofs/services/challenger/src/types.rs
+++ b/proofs/services/challenger/src/types.rs
@@ -18,7 +18,7 @@ pub struct GameMetadata {
 pub struct ChallengeSubmission {
     /// Transaction hash for the challenge submission.
     pub tx_hash: TxHash,
-    /// WLD bond locked by the challenge, read from the game itself.
+    /// ERC-20 bond locked by the challenge, read from the game itself.
     pub bond: U256,
 }
 

--- a/proofs/services/defender/src/main.rs
+++ b/proofs/services/defender/src/main.rs
@@ -18,7 +18,7 @@ use world_chain_defender::{
     AlloyDefenderClient, DEFAULT_L1_TX_CONFIRMATIONS, DefenderConfig, WorldChainDefender,
 };
 use world_chain_proof_protocol::{
-    IDisputeGameFactory, IWLDStakingVault, OptimismConsensusClient, VerifyingConsensusProvider,
+    IDisputeGameFactory, IERC20StakingVault, OptimismConsensusClient, VerifyingConsensusProvider,
     read_registered_bond_vault,
 };
 use world_chain_proof_tx_signer::build_transaction_signer;
@@ -141,7 +141,7 @@ async fn main() -> Result<()> {
     match read_registered_bond_vault(&provider, &factory).await {
         Ok(bond_vault) => {
             let vault =
-                IWLDStakingVault::IWLDStakingVaultInstance::new(bond_vault, provider.clone());
+                IERC20StakingVault::IERC20StakingVaultInstance::new(bond_vault, provider.clone());
             match vault.availableBalance(reward_recipient).call().await {
                 Ok(balance) => world_chain_proof_metrics::record_vault_balance(
                     bond_vault,
@@ -150,11 +150,11 @@ async fn main() -> Result<()> {
                     balance,
                 ),
                 Err(error) => {
-                    warn!(%error, "failed to fetch defender reward-recipient WLD vault balance")
+                    warn!(%error, "failed to fetch defender reward-recipient ERC-20 vault balance")
                 }
             }
         }
-        Err(error) => warn!(%error, "failed to discover WLD vault for defender telemetry"),
+        Err(error) => warn!(%error, "failed to discover ERC-20 vault for defender telemetry"),
     }
 
     let client = AlloyDefenderClient::new(

--- a/proofs/services/defender/src/main.rs
+++ b/proofs/services/defender/src/main.rs
@@ -12,12 +12,15 @@ use alloy_provider::ProviderBuilder;
 use alloy_signer_local::PrivateKeySigner;
 use anyhow::{Context, Result};
 use clap::{ArgGroup, Parser};
-use tracing::info;
+use tracing::{info, warn};
 use url::Url;
 use world_chain_defender::{
     AlloyDefenderClient, DEFAULT_L1_TX_CONFIRMATIONS, DefenderConfig, WorldChainDefender,
 };
-use world_chain_proof_protocol::{OptimismConsensusClient, VerifyingConsensusProvider};
+use world_chain_proof_protocol::{
+    IDisputeGameFactory, IWLDStakingVault, OptimismConsensusClient, VerifyingConsensusProvider,
+    read_registered_bond_vault,
+};
 use world_chain_proof_tx_signer::build_transaction_signer;
 use world_chain_prover_service::RpcProverServiceClient;
 
@@ -131,6 +134,28 @@ async fn main() -> Result<()> {
         .wallet(wallet)
         .connect_client(l1_rpc_client);
     world_chain_proof_metrics::refresh_wallet_balance(&provider, defender_address).await;
+    let factory = IDisputeGameFactory::IDisputeGameFactoryInstance::new(
+        cli.factory_address,
+        provider.clone(),
+    );
+    match read_registered_bond_vault(&provider, &factory).await {
+        Ok(bond_vault) => {
+            let vault =
+                IWLDStakingVault::IWLDStakingVaultInstance::new(bond_vault, provider.clone());
+            match vault.availableBalance(reward_recipient).call().await {
+                Ok(balance) => world_chain_proof_metrics::record_vault_balance(
+                    bond_vault,
+                    reward_recipient,
+                    "defender",
+                    balance,
+                ),
+                Err(error) => {
+                    warn!(%error, "failed to fetch defender reward-recipient WLD vault balance")
+                }
+            }
+        }
+        Err(error) => warn!(%error, "failed to discover WLD vault for defender telemetry"),
+    }
 
     let client = AlloyDefenderClient::new(
         provider,

--- a/proofs/services/proposer/README.md
+++ b/proofs/services/proposer/README.md
@@ -48,7 +48,7 @@ claim is valid according to the registry, allowing it to skip a newer game still
 The automated services assume proof-timeout retries are exceptional. The proposer creates the next
 attempt and the defender follows that replacement. Games descending from the abandoned attempt
 become resolvable as `INVALID_PARENT`; the bond manager keeps proposer-owned games tracked, resolves
-those descendants as their parents settle, and claims the refunded bonds. Retry creation remains
+those descendants as their parents settle, and closes them to release their bonds. Retry creation remains
 logged at warn level for operator visibility.
 
 ### `root_claim`
@@ -61,11 +61,11 @@ logged at warn level for operator visibility.
 
 ## Bond settlement
 
-Bonds are custodied in `DelayedWETH` and paid out in two phases. The first `claimCredit(recipient)`
-call unlocks the credit; the second, after the WETH delay, withdraws and transfers it. Both are
-gated on `AnchorStateRegistry.isGameFinalized`, since `claimCredit` calls `closeGame`, which reverts
-until the registry's finality airgap has elapsed. The bond manager keeps every discovered
-proposer-owned game tracked until it is resolved and its pending withdrawal is drained. For games
+Bonds are locked from the proposer's available balance in the singleton WLD staking vault.
+After a game resolves and passes the registry's finality airgap, its permissionless `closeGame()`
+call settles the complete bond pot into immediately reusable vault balances. The service never
+requests an external WLD withdrawal. The bond manager keeps every discovered proposer-owned game
+tracked until it is resolved and settled. For games
 whose embedded proposal domain differs from the currently registered domain, it also submits any
 available positive or negative resolution because those games are no longer visible to the selected
 lineage proposer. Same-domain outcomes remain with the proposer to avoid racing retry creation.

--- a/proofs/services/proposer/README.md
+++ b/proofs/services/proposer/README.md
@@ -61,11 +61,11 @@ logged at warn level for operator visibility.
 
 ## Bond settlement
 
-Bonds are locked from the proposer's available balance in the singleton WLD staking vault.
+Bonds are locked from the proposer's available balance in the singleton ERC-20 staking vault.
 After a game resolves and passes the registry's finality airgap, its permissionless `closeGame()`
 call settles the complete bond pot into immediately reusable vault balances. The service never
-requests an external WLD withdrawal. The bond manager keeps every discovered proposer-owned game
-tracked until it is resolved and settled. For games
+requests an external bond-token withdrawal. The bond manager keeps every discovered proposer-owned
+game tracked until it is resolved and settled. For games
 whose embedded proposal domain differs from the currently registered domain, it also submits any
 available positive or negative resolution because those games are no longer visible to the selected
 lineage proposer. Same-domain outcomes remain with the proposer to avoid racing retry creation.

--- a/proofs/services/proposer/src/alloy.rs
+++ b/proofs/services/proposer/src/alloy.rs
@@ -1,20 +1,19 @@
-use alloy_consensus::BlockHeader;
-use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{Address, B256, U256};
 use alloy_provider::{Provider, WalletProvider};
 use async_trait::async_trait;
 use std::{sync::Arc, time::Duration};
 use tokio::sync::Semaphore;
+use tracing::warn;
 use world_chain_proof_protocol::{
-    IAnchorStateRegistry, IDelayedWETH, IDisputeGameFactory, IMultiProofGame, LineageAnchor,
+    IAnchorStateRegistry, IDisputeGameFactory, IMultiProofGame, IWLDStakingVault, LineageAnchor,
     LineageError, LineageGame, LineageProvider, LineageTransition, MULTI_PROOF_GAME_TYPE,
     RegisteredLineageConfig, ResolutionStatus, read_game_for_transition, read_lineage_anchor,
-    read_lineage_resolution_status, read_registered_lineage_config,
+    read_lineage_resolution_status, read_registered_bond_vault, read_registered_lineage_config,
 };
 
 use crate::{
     BondManagerClient, Proposal, ProposalSubmission, ProposerClient, ProposerError,
-    types::{ClaimSubmission, CloseGameSubmission, PendingWithdrawal, ResolveSubmission},
+    types::{CloseGameSubmission, ResolveSubmission},
 };
 
 /// Alloy-backed implementation of the proposer contract clients.
@@ -26,6 +25,7 @@ use crate::{
 pub struct AlloyProofSystemClient<P> {
     factory: IDisputeGameFactory::IDisputeGameFactoryInstance<P>,
     anchor: IAnchorStateRegistry::IAnchorStateRegistryInstance<P>,
+    vault: IWLDStakingVault::IWLDStakingVaultInstance<P>,
     registered: RegisteredLineageConfig,
     /// Number of confirmations to require after sending a tx onchain.
     confirmations: u64,
@@ -54,6 +54,20 @@ where
             provider.clone(),
         );
         let registered = read_registered_lineage_config(&provider, &factory).await?;
+        let bond_vault = read_registered_bond_vault(&provider, &factory).await?;
+        let init_bond = factory.initBonds(MULTI_PROOF_GAME_TYPE).call().await?;
+        if !init_bond.is_zero() {
+            return Err(ProposerError::NonZeroFactoryBond(init_bond));
+        }
+        let vault = IWLDStakingVault::IWLDStakingVaultInstance::new(bond_vault, provider.clone());
+        let configured_factory = vault.disputeGameFactory().call().await?;
+        if configured_factory != factory_address {
+            return Err(ProposerError::VaultFactoryMismatch {
+                vault: bond_vault,
+                expected: factory_address,
+                actual: configured_factory,
+            });
+        }
         let anchor = IAnchorStateRegistry::IAnchorStateRegistryInstance::new(
             registered.anchor_registry,
             provider.clone(),
@@ -63,6 +77,7 @@ where
         Ok(Self {
             factory,
             anchor,
+            vault,
             registered,
             confirmations,
             receipt_timeout,
@@ -75,6 +90,33 @@ where
     #[must_use]
     pub const fn registered_lineage_config(&self) -> RegisteredLineageConfig {
         self.registered
+    }
+
+    /// Returns the singleton WLD vault discovered from the active implementation.
+    #[must_use]
+    pub fn bond_vault_address(&self) -> Address {
+        *self.vault.address()
+    }
+
+    /// Refreshes the managed proposer's reusable WLD balance metric.
+    pub async fn refresh_vault_balance(&self)
+    where
+        P: WalletProvider,
+    {
+        self.refresh_vault_balance_for(self.provider.default_signer_address())
+            .await;
+    }
+
+    async fn refresh_vault_balance_for(&self, account: Address) {
+        match self.vault.availableBalance(account).call().await {
+            Ok(balance) => world_chain_proof_metrics::record_vault_balance(
+                self.bond_vault_address(),
+                account,
+                "proposer",
+                balance,
+            ),
+            Err(error) => warn!(%error, %account, "failed to fetch proposer WLD vault balance"),
+        }
     }
 
     fn game(&self, address: Address) -> IMultiProofGame::IMultiProofGameInstance<P> {
@@ -131,63 +173,9 @@ where
         Ok(ResolveSubmission { tx_hash })
     }
 
-    /// Reads the credit `recipient` can unlock from `game`.
-    async fn read_credit(&self, game: Address, recipient: Address) -> Result<U256, ProposerError> {
-        self.game(game)
-            .credit(recipient)
-            .call()
-            .await
-            .map_err(Into::into)
-    }
-
-    /// Reads `recipient`'s pending `DelayedWETH` withdrawal for `game`.
-    async fn read_pending_withdrawal(
-        &self,
-        game: Address,
-        recipient: Address,
-    ) -> Result<PendingWithdrawal, ProposerError> {
-        let weth_address = self.game(game).weth().call().await?;
-        let weth = IDelayedWETH::IDelayedWETHInstance::new(weth_address, self.provider.clone());
-
-        let (pending, delay) = self
-            .provider
-            .multicall()
-            .add(weth.withdrawals(game, recipient))
-            .add(weth.delay())
-            .aggregate()
-            .await?;
-
-        if pending.amount.is_zero() {
-            return Ok(PendingWithdrawal::default());
-        }
-        let unlock_at = pending
-            .timestamp
-            .checked_add(delay)
-            .ok_or(ProposerError::Overflow)?;
-
-        Ok(PendingWithdrawal {
-            amount: pending.amount,
-            unlock_at: u256_to_u64(unlock_at)?,
-        })
-    }
-
-    /// Sends `claimCredit(recipient)` and reports which phase of the two-phase flow ran.
-    async fn send_claim_credit(
-        &self,
-        game: Address,
-        recipient: Address,
-    ) -> Result<ClaimSubmission, ProposerError> {
+    async fn send_close_game(&self, game: Address) -> Result<CloseGameSubmission, ProposerError> {
         let _permit = self.semaphore.acquire().await?;
-        // Read both phases up front so the submission can report what the call moved; the
-        // receipt carries no amount of its own.
-        let credit = self.read_credit(game, recipient).await?;
-        let pending = if credit.is_zero() {
-            self.read_pending_withdrawal(game, recipient).await?
-        } else {
-            PendingWithdrawal::default()
-        };
-
-        let pending_tx = self.game(game).claimCredit(recipient).send().await?;
+        let pending_tx = self.game(game).closeGame().send().await?;
         let tx_hash = *pending_tx.tx_hash();
         let receipt = pending_tx
             .with_required_confirmations(self.confirmations)
@@ -198,21 +186,9 @@ where
         if !receipt.status() {
             return Err(ProposerError::Revert(tx_hash));
         }
+        self.refresh_vault_balance_for(receipt.from).await;
 
-        Ok(if credit.is_zero() {
-            world_chain_proof_metrics::record_bond_withdrawn("proposer", pending.amount);
-            ClaimSubmission {
-                tx_hash,
-                amount: pending.amount,
-                withdrawn: true,
-            }
-        } else {
-            ClaimSubmission {
-                tx_hash,
-                amount: credit,
-                withdrawn: false,
-            }
-        })
+        Ok(CloseGameSubmission { tx_hash })
     }
 }
 
@@ -266,25 +242,12 @@ where
         self.read_is_game_finalized(game).await
     }
 
-    async fn credit(&self, game: Address) -> Result<U256, ProposerError> {
-        self.read_credit(game, self.proposer_address()).await
+    async fn is_game_settled(&self, game: Address) -> Result<bool, ProposerError> {
+        Ok(self.vault.gameBonds(game).call().await?.settled)
     }
 
-    async fn pending_withdrawal(&self, game: Address) -> Result<PendingWithdrawal, ProposerError> {
-        self.read_pending_withdrawal(game, self.proposer_address())
-            .await
-    }
-
-    async fn latest_l1_timestamp(&self) -> Result<u64, ProposerError> {
-        self.provider
-            .get_block_by_number(BlockNumberOrTag::Latest)
-            .await?
-            .map(|block| block.header.timestamp())
-            .ok_or(ProposerError::UnavailableLatestL1Block)
-    }
-
-    async fn claim_credit(&self, game: Address) -> Result<ClaimSubmission, ProposerError> {
-        self.send_claim_credit(game, self.proposer_address()).await
+    async fn close_game(&self, game: Address) -> Result<CloseGameSubmission, ProposerError> {
+        self.send_close_game(game).await
     }
 }
 
@@ -330,21 +293,7 @@ where
     }
 
     async fn close_game(&self, game: Address) -> Result<CloseGameSubmission, ProposerError> {
-        let _permit = self.semaphore.acquire().await?;
-        let pending = self.game(game).closeGame().send().await?;
-
-        let tx_hash = *pending.tx_hash();
-        let receipt = pending
-            .with_required_confirmations(self.confirmations)
-            .with_timeout(Some(self.receipt_timeout))
-            .get_receipt()
-            .await?;
-        world_chain_proof_metrics::refresh_wallet_balance(&self.provider, receipt.from).await;
-        if !receipt.status() {
-            return Err(ProposerError::Revert(tx_hash));
-        }
-
-        Ok(CloseGameSubmission { tx_hash })
+        self.send_close_game(game).await
     }
 
     async fn submit_proposal(
@@ -352,17 +301,12 @@ where
         proposal: &Proposal,
     ) -> Result<ProposalSubmission, ProposerError> {
         let _permit = self.semaphore.acquire().await?;
-        // `DisputeGameFactory.create` reverts unless `msg.value` matches the configured init
-        // bond exactly, so it is read per submission rather than cached in configuration.
-        let init_bond = self.factory.initBonds(MULTI_PROOF_GAME_TYPE).call().await?;
-
         let extra_data = proposal
             .commitment()
             .extra_data(self.registered.domain_hash);
         let pending = self
             .factory
             .create(MULTI_PROOF_GAME_TYPE, proposal.root_claim, extra_data)
-            .value(init_bond)
             .send()
             .await?;
 
@@ -376,7 +320,19 @@ where
         if !receipt.status() {
             return Err(ProposerError::Revert(tx_hash));
         }
-        world_chain_proof_metrics::record_bond_posted("proposer", init_bond);
+        let locked = receipt
+            .logs()
+            .iter()
+            .filter(|log| log.address() == *self.vault.address())
+            .find_map(|log| {
+                log.log_decode_validate::<IWLDStakingVault::ProposerBondLocked>()
+                    .ok()
+                    .map(|decoded| decoded.inner.data.amount)
+            })
+            .ok_or(ProposerError::MissingProposerBondLockedEvent(tx_hash))?;
+        world_chain_proof_metrics::record_bond_locked("proposer", locked);
+        self.refresh_vault_balance_for(self.proposer_address())
+            .await;
 
         let game_address = receipt
             .logs()

--- a/proofs/services/proposer/src/alloy.rs
+++ b/proofs/services/proposer/src/alloy.rs
@@ -5,7 +5,7 @@ use std::{sync::Arc, time::Duration};
 use tokio::sync::Semaphore;
 use tracing::warn;
 use world_chain_proof_protocol::{
-    IAnchorStateRegistry, IDisputeGameFactory, IMultiProofGame, IWLDStakingVault, LineageAnchor,
+    IAnchorStateRegistry, IDisputeGameFactory, IERC20StakingVault, IMultiProofGame, LineageAnchor,
     LineageError, LineageGame, LineageProvider, LineageTransition, MULTI_PROOF_GAME_TYPE,
     RegisteredLineageConfig, ResolutionStatus, read_game_for_transition, read_lineage_anchor,
     read_lineage_resolution_status, read_registered_bond_vault, read_registered_lineage_config,
@@ -25,7 +25,7 @@ use crate::{
 pub struct AlloyProofSystemClient<P> {
     factory: IDisputeGameFactory::IDisputeGameFactoryInstance<P>,
     anchor: IAnchorStateRegistry::IAnchorStateRegistryInstance<P>,
-    vault: IWLDStakingVault::IWLDStakingVaultInstance<P>,
+    vault: IERC20StakingVault::IERC20StakingVaultInstance<P>,
     registered: RegisteredLineageConfig,
     /// Number of confirmations to require after sending a tx onchain.
     confirmations: u64,
@@ -59,7 +59,8 @@ where
         if !init_bond.is_zero() {
             return Err(ProposerError::NonZeroFactoryBond(init_bond));
         }
-        let vault = IWLDStakingVault::IWLDStakingVaultInstance::new(bond_vault, provider.clone());
+        let vault =
+            IERC20StakingVault::IERC20StakingVaultInstance::new(bond_vault, provider.clone());
         let configured_factory = vault.disputeGameFactory().call().await?;
         if configured_factory != factory_address {
             return Err(ProposerError::VaultFactoryMismatch {
@@ -92,13 +93,13 @@ where
         self.registered
     }
 
-    /// Returns the singleton WLD vault discovered from the active implementation.
+    /// Returns the singleton ERC-20 vault discovered from the active implementation.
     #[must_use]
     pub fn bond_vault_address(&self) -> Address {
         *self.vault.address()
     }
 
-    /// Refreshes the managed proposer's reusable WLD balance metric.
+    /// Refreshes the managed proposer's reusable bond-token balance metric.
     pub async fn refresh_vault_balance(&self)
     where
         P: WalletProvider,
@@ -115,7 +116,7 @@ where
                 "proposer",
                 balance,
             ),
-            Err(error) => warn!(%error, %account, "failed to fetch proposer WLD vault balance"),
+            Err(error) => warn!(%error, %account, "failed to fetch proposer ERC-20 vault balance"),
         }
     }
 
@@ -325,7 +326,7 @@ where
             .iter()
             .filter(|log| log.address() == *self.vault.address())
             .find_map(|log| {
-                log.log_decode_validate::<IWLDStakingVault::ProposerBondLocked>()
+                log.log_decode_validate::<IERC20StakingVault::ProposerBondLocked>()
                     .ok()
                     .map(|decoded| decoded.inner.data.amount)
             })

--- a/proofs/services/proposer/src/bond_manager.rs
+++ b/proofs/services/proposer/src/bond_manager.rs
@@ -1,11 +1,11 @@
 use std::collections::HashSet;
 
-use alloy_primitives::{Address, U256};
+use alloy_primitives::Address;
 use tracing::{info, warn};
 
 use crate::{BondManagerClient, BondManagerConfig, ProposerError};
 
-/// Discovers proposer-owned games, resolves abandoned games, and recovers bond credits.
+/// Discovers proposer-owned games, resolves abandoned games, and settles their bond pots.
 #[derive(Debug)]
 pub struct BondManager<E> {
     config: BondManagerConfig,
@@ -37,7 +37,7 @@ impl<E> BondManager<E> {
         self.next_game_index
     }
 
-    /// Returns whether a game is currently awaiting resolution or withdrawal.
+    /// Returns whether a game is currently awaiting resolution or settlement.
     #[must_use]
     pub fn tracks_game(&self, game: Address) -> bool {
         self.proposed_games.contains(&game)
@@ -82,18 +82,20 @@ where
         Ok(())
     }
 
-    /// Resolves abandoned games, advances bond claims, and prunes fully settled games.
-    ///
-    /// `MultiProofGame.claimCredit` first unlocks the credit in `DelayedWETH` and only
-    /// transfers it on a second call after the WETH delay, so a game stays tracked until its
-    /// pending withdrawal is drained. Dropping it after the unlock would strand the bond.
+    /// Resolves abandoned games, settles finalized games, and prunes settled games.
     pub async fn settle_games(&mut self) -> Result<(), ProposerError> {
         let proposed_games: Vec<_> = self.proposed_games.iter().copied().collect();
-        let now = self.execution_provider.latest_l1_timestamp().await?;
         let active_domain_hash = self.execution_provider.active_domain_hash();
 
         for game in proposed_games {
             let result: Result<bool, ProposerError> = async {
+                if self.execution_provider.is_game_settled(game).await? {
+                    world_chain_proof_metrics::increment_games_closed(
+                        "proposer",
+                        "already_settled",
+                    );
+                    return Ok(true);
+                }
                 let resolution_status = self.execution_provider.resolution_status(game).await?;
                 if !resolution_status.is_resolved() {
                     // Resolve games abandoned by retries or domain upgrades; active-domain direct
@@ -117,40 +119,16 @@ where
                     }
                     return Ok(false);
                 }
-                // `claimCredit` calls `closeGame`, which reverts until the registry's finality
-                // airgap has elapsed.
                 if !self.execution_provider.is_game_finalized(game).await? {
                     return Ok(false);
                 }
 
-                let credit = self.execution_provider.credit(game).await?;
-                if credit > U256::ZERO {
-                    let submission = self.execution_provider.claim_credit(game).await?;
-                    info!(
-                        tx_hash = ?submission.tx_hash,
-                        amount = ?submission.amount,
-                        game_address = %game,
-                        "unlocked proposer bond credits in DelayedWETH"
-                    );
-                    // Keep tracking: the unlocked amount still needs the second claim.
-                    return Ok(false);
-                }
-
-                let pending = self.execution_provider.pending_withdrawal(game).await?;
-                if pending.amount.is_zero() {
-                    // Nothing owed on this game; stop tracking it.
-                    return Ok(true);
-                }
-                if now < pending.unlock_at {
-                    return Ok(false);
-                }
-
-                let submission = self.execution_provider.claim_credit(game).await?;
+                let submission = self.execution_provider.close_game(game).await?;
+                world_chain_proof_metrics::increment_games_closed("proposer", "submitted");
                 info!(
                     tx_hash = ?submission.tx_hash,
-                    amount = ?submission.amount,
                     game_address = %game,
-                    "withdrew proposer bond credits"
+                    "settled proposer-owned game into reusable vault balances"
                 );
                 Ok(true)
             }
@@ -165,7 +143,7 @@ where
                     warn!(
                         %error,
                         game_address = %game,
-                        "failed to process proposer credits"
+                        "failed to process proposer bond settlement"
                     );
                 }
             }

--- a/proofs/services/proposer/src/config.rs
+++ b/proofs/services/proposer/src/config.rs
@@ -11,7 +11,7 @@ pub const DEFAULT_BOND_MANAGER_INITIAL_SCAN_LIMIT: u64 = 1_000;
 /// Configuration for asynchronous proposer-bond management.
 #[derive(Debug, Clone)]
 pub struct BondManagerConfig {
-    /// Delay between factory scans and withdrawal attempts.
+    /// Delay between factory scans and settlement attempts.
     pub poll_interval: Duration,
     /// Number of most recently created games scanned on startup.
     pub initial_scan_limit: u64,
@@ -44,9 +44,8 @@ impl Default for BondManagerConfig {
 
 /// Configuration for the proposer loop.
 ///
-/// The proposal bond is deliberately absent: `DisputeGameFactory.create` reverts unless
-/// `msg.value` matches `initBonds(gameType)` exactly, so it is read per submission rather than
-/// captured at startup where an owner update would silently break every proposal.
+/// The proposal bond is deliberately absent: the vault reads it from the active implementation
+/// when creating a game and locking its proposer bond.
 #[derive(Debug, Clone)]
 pub struct ProposerConfig {
     /// Delay between periodic proposal attempts.

--- a/proofs/services/proposer/src/error.rs
+++ b/proofs/services/proposer/src/error.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::TxHash;
+use alloy_primitives::{Address, TxHash, U256};
 use alloy_provider::{MulticallError, PendingTransactionError, transport::RpcError};
 use alloy_transport::TransportErrorKind;
 use thiserror::Error;
@@ -11,6 +11,14 @@ pub enum ProposerError {
     /// Invalid proposer configuration.
     #[error("invalid proposer config: {0}")]
     InvalidConfig(&'static str),
+    #[error("WIP-1006 factory init bond must be zero, got {0}")]
+    NonZeroFactoryBond(U256),
+    #[error("vault {vault} is wired to factory {actual}, expected {expected}")]
+    VaultFactoryMismatch {
+        vault: Address,
+        expected: Address,
+        actual: Address,
+    },
     /// Contract call or transaction failure.
     #[error(transparent)]
     Contract(#[from] alloy_contract::Error),
@@ -29,10 +37,10 @@ pub enum ProposerError {
     Revert(TxHash),
     #[error("Overflow error.")]
     Overflow,
-    #[error("Latest L1 block is unavailable.")]
-    UnavailableLatestL1Block,
     #[error("DisputeGameCreated event missing from proposal transaction {0}")]
     MissingProposalEvent(TxHash),
+    #[error("ProposerBondLocked event missing from proposal transaction {0}")]
+    MissingProposerBondLockedEvent(TxHash),
     #[error(transparent)]
     Permit(#[from] AcquireError),
 }

--- a/proofs/services/proposer/src/lib.rs
+++ b/proofs/services/proposer/src/lib.rs
@@ -23,8 +23,8 @@ pub use error::ProposerError;
 pub use proposer::WorldChainProposer;
 pub use traits::{BondManagerClient, ProposerClient};
 pub use types::{
-    ClaimSubmission, CloseGameSubmission, NextProposalAction, PendingWithdrawal, Proposal,
-    ProposalSubmission, ProposerScan, ResolveSubmission,
+    CloseGameSubmission, NextProposalAction, Proposal, ProposalSubmission, ProposerScan,
+    ResolveSubmission,
 };
 
 #[cfg(test)]

--- a/proofs/services/proposer/src/main.rs
+++ b/proofs/services/proposer/src/main.rs
@@ -62,7 +62,7 @@ struct Cli {
     #[arg(long, env = "MAX_RESOLUTIONS_PER_TICK", default_value_t = 1)]
     max_resolutions_per_tick: usize,
 
-    /// Seconds between proposer-bond discovery and withdrawal passes.
+    /// Seconds between proposer-bond discovery and settlement passes.
     #[arg(
         long,
         env = "BOND_MANAGER_POLL_INTERVAL_SECONDS",
@@ -137,6 +137,7 @@ async fn main() -> Result<()> {
     )
     .await
     .context("failed to bind the World Chain proof system")?;
+    contracts.refresh_vault_balance().await;
     let bond_manager_config = BondManagerConfig {
         poll_interval: Duration::from_secs(cli.bond_manager_poll_interval_seconds),
         initial_scan_limit: cli.bond_manager_initial_scan_limit,
@@ -149,6 +150,7 @@ async fn main() -> Result<()> {
             .map(OptimismConsensusClient::new),
     );
     let registered = contracts.registered_lineage_config();
+    let bond_vault = contracts.bond_vault_address();
     let config = ProposerConfig {
         poll_interval: Duration::from_secs(cli.poll_interval_seconds),
         max_resolutions_per_tick: cli.max_resolutions_per_tick,
@@ -161,6 +163,7 @@ async fn main() -> Result<()> {
         verifying_output_root_rpc_configured = cli.verifying_output_root_rpc.is_some(),
         dispute_game_factory = %cli.factory_address,
         anchor = %registered.anchor_registry,
+        bond_vault = %bond_vault,
         proposer = %proposer_address,
         domain_hash = %registered.domain_hash,
         block_interval = registered.block_interval,

--- a/proofs/services/proposer/src/tests.rs
+++ b/proofs/services/proposer/src/tests.rs
@@ -1,13 +1,10 @@
 use std::{
     collections::{HashMap, HashSet},
-    sync::{
-        Arc, Mutex,
-        atomic::{AtomicU64, Ordering},
-    },
+    sync::{Arc, Mutex},
     time::Duration,
 };
 
-use alloy_primitives::{Address, B256, BlockNumber, U256, address, b256};
+use alloy_primitives::{Address, B256, BlockNumber, address, b256};
 use async_trait::async_trait;
 use world_chain_proof_protocol::{
     ConsensusError, ConsensusProvider, GameStatus, InvalidationReason, LineageAnchor, LineageError,
@@ -18,10 +15,7 @@ use world_chain_proof_protocol::{
 use crate::{
     BondManager, BondManagerClient, BondManagerConfig, Proposal, ProposalSubmission,
     ProposerClient, ProposerConfig, ProposerError, ProposerScan, WorldChainProposer,
-    types::{
-        ClaimSubmission, CloseGameSubmission, NextProposalAction, PendingWithdrawal,
-        ResolveSubmission,
-    },
+    types::{CloseGameSubmission, NextProposalAction, ResolveSubmission},
 };
 
 const DOMAIN_HASH: B256 = b256!("1111111111111111111111111111111111111111111111111111111111111111");
@@ -150,8 +144,6 @@ impl ProposerClient for MockContracts {
     }
 }
 
-/// Two-phase bond client mirroring `MultiProofGame.claimCredit`: the first claim moves credit
-/// into a pending `DelayedWETH` withdrawal, the second drains it.
 #[derive(Debug, Clone)]
 struct MockBondClient {
     proposer: Address,
@@ -164,13 +156,10 @@ struct MockBondClient {
     resolution_statuses: Arc<Mutex<HashMap<Address, ResolutionStatus>>>,
     resolutions: Arc<Mutex<Vec<Address>>>,
     unfinalized_games: Arc<Mutex<HashSet<Address>>>,
-    credit: Arc<Mutex<HashMap<Address, U256>>>,
-    pending: Arc<Mutex<HashMap<Address, PendingWithdrawal>>>,
-    latest_l1_timestamp: Arc<AtomicU64>,
-    unlocks: Arc<Mutex<Vec<Address>>>,
-    withdrawals: Arc<Mutex<Vec<Address>>>,
+    settled_games: Arc<Mutex<HashSet<Address>>>,
+    closes: Arc<Mutex<Vec<Address>>>,
     fail_game_at_once: Arc<Mutex<Option<u64>>>,
-    fail_claim_once: Arc<Mutex<HashSet<Address>>>,
+    fail_close_once: Arc<Mutex<HashSet<Address>>>,
 }
 
 impl MockBondClient {
@@ -195,13 +184,10 @@ impl MockBondClient {
             resolution_statuses: Arc::default(),
             resolutions: Arc::default(),
             unfinalized_games: Arc::default(),
-            credit: Arc::default(),
-            pending: Arc::default(),
-            latest_l1_timestamp: Arc::default(),
-            unlocks: Arc::default(),
-            withdrawals: Arc::default(),
+            settled_games: Arc::default(),
+            closes: Arc::default(),
             fail_game_at_once: Arc::default(),
-            fail_claim_once: Arc::default(),
+            fail_close_once: Arc::default(),
         }
     }
 }
@@ -308,75 +294,30 @@ impl BondManagerClient for MockBondClient {
             .contains(&game))
     }
 
-    async fn credit(&self, game: Address) -> Result<U256, ProposerError> {
+    async fn is_game_settled(&self, game: Address) -> Result<bool, ProposerError> {
         Ok(self
-            .credit
+            .settled_games
             .lock()
             .expect("not poisoned")
-            .get(&game)
-            .copied()
-            .unwrap_or_default())
+            .contains(&game))
     }
 
-    async fn pending_withdrawal(&self, game: Address) -> Result<PendingWithdrawal, ProposerError> {
-        Ok(self
-            .pending
-            .lock()
-            .expect("not poisoned")
-            .get(&game)
-            .copied()
-            .unwrap_or_default())
-    }
-
-    async fn latest_l1_timestamp(&self) -> Result<u64, ProposerError> {
-        Ok(self.latest_l1_timestamp.load(Ordering::SeqCst))
-    }
-
-    async fn claim_credit(&self, game: Address) -> Result<ClaimSubmission, ProposerError> {
+    async fn close_game(&self, game: Address) -> Result<CloseGameSubmission, ProposerError> {
         if self
-            .fail_claim_once
+            .fail_close_once
             .lock()
             .expect("not poisoned")
             .remove(&game)
         {
-            return Err(ProposerError::message("injected claim failure"));
+            return Err(ProposerError::message("injected close failure"));
         }
-
-        let credit = self
-            .credit
+        self.settled_games
             .lock()
             .expect("not poisoned")
-            .remove(&game)
-            .unwrap_or_default();
-        if credit > U256::ZERO {
-            // Phase 1: unlock in DelayedWETH, immediately withdrawable in tests.
-            self.pending.lock().expect("not poisoned").insert(
-                game,
-                PendingWithdrawal {
-                    amount: credit,
-                    unlock_at: 0,
-                },
-            );
-            self.unlocks.lock().expect("not poisoned").push(game);
-            return Ok(ClaimSubmission {
-                tx_hash: B256::repeat_byte(0xdd),
-                amount: credit,
-                withdrawn: false,
-            });
-        }
-
-        // Phase 2: drain the pending withdrawal.
-        let pending = self
-            .pending
-            .lock()
-            .expect("not poisoned")
-            .remove(&game)
-            .unwrap_or_default();
-        self.withdrawals.lock().expect("not poisoned").push(game);
-        Ok(ClaimSubmission {
+            .insert(game);
+        self.closes.lock().expect("not poisoned").push(game);
+        Ok(CloseGameSubmission {
             tx_hash: B256::repeat_byte(0xde),
-            amount: pending.amount,
-            withdrawn: true,
         })
     }
 }
@@ -972,25 +913,25 @@ async fn bond_manager_retries_complete_range_after_partial_scan_failure() {
 }
 
 #[tokio::test]
-async fn bond_manager_prunes_resolved_games_and_retries_failed_claims() {
+async fn bond_manager_settles_finalized_games_and_retries_failed_closes() {
     let proposer = Address::repeat_byte(0xa1);
     let unresolved = game_address(1);
-    let zero_credit = game_address(2);
-    let claimable = game_address(3);
-    let retry_claim = game_address(4);
+    let already_settled = game_address(2);
+    let closable = game_address(3);
+    let retry_close = game_address(4);
     let awaiting_airgap = game_address(5);
     let games = vec![
         (unresolved, proposer),
-        (zero_credit, proposer),
-        (claimable, proposer),
-        (retry_claim, proposer),
+        (already_settled, proposer),
+        (closable, proposer),
+        (retry_close, proposer),
         (awaiting_airgap, proposer),
     ];
     let client = MockBondClient::new(proposer, games);
     client.resolved_games.lock().expect("not poisoned").extend([
-        zero_credit,
-        claimable,
-        retry_claim,
+        already_settled,
+        closable,
+        retry_close,
         awaiting_airgap,
     ]);
     client
@@ -998,60 +939,41 @@ async fn bond_manager_prunes_resolved_games_and_retries_failed_claims() {
         .lock()
         .expect("not poisoned")
         .insert(awaiting_airgap);
-    client.credit.lock().expect("not poisoned").extend([
-        (claimable, U256::from(10)),
-        (retry_claim, U256::from(20)),
-        (awaiting_airgap, U256::from(30)),
-    ]);
     client
-        .fail_claim_once
+        .settled_games
         .lock()
         .expect("not poisoned")
-        .insert(retry_claim);
+        .insert(already_settled);
+    client
+        .fail_close_once
+        .lock()
+        .expect("not poisoned")
+        .insert(retry_close);
     let mut manager = BondManager::new(bond_manager_config(100), client.clone());
     manager.scan_games().await.unwrap();
 
-    // Pass 1: only `claimable` advances, and only through the DelayedWETH unlock.
     manager.settle_games().await.unwrap();
 
     assert!(manager.tracks_game(unresolved));
-    assert!(!manager.tracks_game(zero_credit));
-    assert!(
-        manager.tracks_game(claimable),
-        "unlocked bond must stay tracked"
-    );
-    assert!(manager.tracks_game(retry_claim));
+    assert!(!manager.tracks_game(already_settled));
+    assert!(!manager.tracks_game(closable));
+    assert!(manager.tracks_game(retry_close));
     assert!(
         manager.tracks_game(awaiting_airgap),
         "a game inside the finality airgap must stay tracked"
     );
-    assert_eq!(
-        *client.unlocks.lock().expect("not poisoned"),
-        vec![claimable]
-    );
-    assert!(client.withdrawals.lock().expect("not poisoned").is_empty());
+    assert_eq!(*client.closes.lock().expect("not poisoned"), vec![closable]);
 
-    // Pass 2: `claimable` withdraws and is dropped; the failed claim is retried and unlocks.
     manager.settle_games().await.unwrap();
 
-    assert!(!manager.tracks_game(claimable));
-    assert!(manager.tracks_game(retry_claim));
-    assert_eq!(
-        *client.withdrawals.lock().expect("not poisoned"),
-        vec![claimable]
-    );
-
-    // Pass 3: the retried claim withdraws and is dropped.
-    manager.settle_games().await.unwrap();
-
-    assert!(!manager.tracks_game(retry_claim));
-    let withdrawals = client.withdrawals.lock().expect("not poisoned");
-    assert!(withdrawals.contains(&claimable));
-    assert!(withdrawals.contains(&retry_claim));
+    assert!(!manager.tracks_game(retry_close));
+    let closes = client.closes.lock().expect("not poisoned");
+    assert!(closes.contains(&closable));
+    assert!(closes.contains(&retry_close));
 }
 
 #[tokio::test]
-async fn bond_manager_resolves_invalid_parent_before_claiming_refund() {
+async fn bond_manager_resolves_invalid_parent_before_settlement() {
     let proposer = Address::repeat_byte(0xa1);
     let game = game_address(1);
     let client = MockBondClient::new(proposer, vec![(game, proposer)]);
@@ -1067,11 +989,6 @@ async fn bond_manager_resolves_invalid_parent_before_claiming_refund() {
                 invalidation_reason: InvalidationReason::InvalidParent,
             },
         );
-    client
-        .credit
-        .lock()
-        .expect("not poisoned")
-        .insert(game, U256::from(10));
     let mut manager = BondManager::new(bond_manager_config(100), client.clone());
     manager.scan_games().await.unwrap();
 
@@ -1080,18 +997,11 @@ async fn bond_manager_resolves_invalid_parent_before_claiming_refund() {
         *client.resolutions.lock().expect("not poisoned"),
         vec![game]
     );
-    assert!(client.unlocks.lock().expect("not poisoned").is_empty());
+    assert!(client.closes.lock().expect("not poisoned").is_empty());
     assert!(manager.tracks_game(game));
 
     manager.settle_games().await.unwrap();
-    assert_eq!(*client.unlocks.lock().expect("not poisoned"), vec![game]);
-    assert!(manager.tracks_game(game));
-
-    manager.settle_games().await.unwrap();
-    assert_eq!(
-        *client.withdrawals.lock().expect("not poisoned"),
-        vec![game]
-    );
+    assert_eq!(*client.closes.lock().expect("not poisoned"), vec![game]);
     assert!(!manager.tracks_game(game));
 }
 
@@ -1163,11 +1073,6 @@ async fn bond_manager_resolves_positive_game_from_obsolete_domain() {
         .lock()
         .expect("not poisoned")
         .insert(game, positive_ready_status());
-    client
-        .credit
-        .lock()
-        .expect("not poisoned")
-        .insert(game, U256::from(10));
     let mut manager = BondManager::new(bond_manager_config(100), client.clone());
     manager.scan_games().await.unwrap();
 
@@ -1180,14 +1085,7 @@ async fn bond_manager_resolves_positive_game_from_obsolete_domain() {
     assert!(manager.tracks_game(game));
 
     manager.settle_games().await.unwrap();
-    assert_eq!(*client.unlocks.lock().expect("not poisoned"), vec![game]);
-    assert!(manager.tracks_game(game));
-
-    manager.settle_games().await.unwrap();
-    assert_eq!(
-        *client.withdrawals.lock().expect("not poisoned"),
-        vec![game]
-    );
+    assert_eq!(*client.closes.lock().expect("not poisoned"), vec![game]);
     assert!(!manager.tracks_game(game));
 }
 
@@ -1208,7 +1106,7 @@ async fn bond_manager_skips_foreign_game_types() {
 }
 
 #[tokio::test]
-async fn bond_manager_uses_l1_timestamp_for_delayed_withdrawal() {
+async fn bond_manager_prunes_an_already_settled_game_without_closing_again() {
     let proposer = Address::repeat_byte(0xa1);
     let game = game_address(1);
     let client = MockBondClient::new(proposer, vec![(game, proposer)]);
@@ -1217,28 +1115,17 @@ async fn bond_manager_uses_l1_timestamp_for_delayed_withdrawal() {
         .lock()
         .expect("not poisoned")
         .insert(game);
-    client.pending.lock().expect("not poisoned").insert(
-        game,
-        PendingWithdrawal {
-            amount: U256::from(10),
-            unlock_at: 100,
-        },
-    );
-    client.latest_l1_timestamp.store(99, Ordering::SeqCst);
+    client
+        .settled_games
+        .lock()
+        .expect("not poisoned")
+        .insert(game);
 
     let mut manager = BondManager::new(bond_manager_config(100), client.clone());
     manager.scan_games().await.unwrap();
     manager.settle_games().await.unwrap();
-    assert!(manager.tracks_game(game));
-    assert!(client.withdrawals.lock().expect("not poisoned").is_empty());
-
-    client.latest_l1_timestamp.store(100, Ordering::SeqCst);
-    manager.settle_games().await.unwrap();
     assert!(!manager.tracks_game(game));
-    assert_eq!(
-        *client.withdrawals.lock().expect("not poisoned"),
-        vec![game]
-    );
+    assert!(client.closes.lock().expect("not poisoned").is_empty());
 }
 
 #[tokio::test]

--- a/proofs/services/proposer/src/traits.rs
+++ b/proofs/services/proposer/src/traits.rs
@@ -1,16 +1,16 @@
-use alloy_primitives::{Address, B256, U256};
+use alloy_primitives::{Address, B256};
 use async_trait::async_trait;
 use world_chain_proof_protocol::{LineageProvider, ResolutionStatus};
 
 use crate::{
     Proposal, ProposalSubmission, ProposerError,
-    types::{ClaimSubmission, CloseGameSubmission, PendingWithdrawal, ResolveSubmission},
+    types::{CloseGameSubmission, ResolveSubmission},
 };
 
 /// Contract surface needed by the asynchronous bond manager.
 #[async_trait]
 pub trait BondManagerClient: Send + Sync {
-    /// Returns the address whose proposal credits are managed.
+    /// Returns the proposer whose games are managed for bond settlement.
     fn proposer_address(&self) -> Address;
 
     /// Returns the proposal domain currently registered for WIP-1006.
@@ -24,7 +24,7 @@ pub trait BondManagerClient: Send + Sync {
     /// holds a game of a different type.
     async fn game_at(&self, index: u64) -> Result<Option<Address>, ProposerError>;
 
-    /// Returns the account that created the provided game.
+    /// Returns the account that created and bonded the provided game.
     async fn game_creator(&self, game: Address) -> Result<Address, ProposerError>;
 
     /// Returns the proposal domain embedded in the provided game.
@@ -37,21 +37,11 @@ pub trait BondManagerClient: Send + Sync {
     async fn resolve_game(&self, game: Address) -> Result<ResolveSubmission, ProposerError>;
 
     /// Returns whether the registry's finality airgap has elapsed for the provided game.
-    ///
-    /// `claimCredit` calls `closeGame`, which reverts until this holds.
     async fn is_game_finalized(&self, game: Address) -> Result<bool, ProposerError>;
-
-    /// Returns the credit the managed proposer can unlock from the provided game.
-    async fn credit(&self, game: Address) -> Result<U256, ProposerError>;
-
-    /// Returns the managed proposer's pending `DelayedWETH` withdrawal for the provided game.
-    async fn pending_withdrawal(&self, game: Address) -> Result<PendingWithdrawal, ProposerError>;
-
-    /// Returns the latest L1 block timestamp used by `DelayedWETH`.
-    async fn latest_l1_timestamp(&self) -> Result<u64, ProposerError>;
-
-    /// Advances the managed proposer's two-phase bond claim on the provided game.
-    async fn claim_credit(&self, game: Address) -> Result<ClaimSubmission, ProposerError>;
+    /// Returns whether the game's complete bond pot has already been settled.
+    async fn is_game_settled(&self, game: Address) -> Result<bool, ProposerError>;
+    /// Settles the game's complete bond pot into reusable vault balances.
+    async fn close_game(&self, game: Address) -> Result<CloseGameSubmission, ProposerError>;
 }
 
 /// Minimal contract surface needed by the proposer.

--- a/proofs/services/proposer/src/types.rs
+++ b/proofs/services/proposer/src/types.rs
@@ -1,14 +1,5 @@
-use alloy_primitives::{Address, B256, TxHash, U256};
+use alloy_primitives::{Address, B256, TxHash};
 use world_chain_proof_protocol::{InvalidationReason, ProposalCommitment, SelectedLineage};
-
-/// A pending `DelayedWETH` withdrawal opened by the first `claimCredit` call.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub struct PendingWithdrawal {
-    /// Amount unlocked in `DelayedWETH` and awaiting the withdrawal delay.
-    pub amount: U256,
-    /// Unix timestamp at which the unlocked amount becomes withdrawable.
-    pub unlock_at: u64,
-}
 
 /// The selected lineage discovered by the proposer and the action available at its tip.
 #[derive(Debug)]
@@ -120,18 +111,4 @@ pub struct ResolveSubmission {
 pub struct CloseGameSubmission {
     /// Transaction hash for the closeGame submission.
     pub tx_hash: TxHash,
-}
-
-/// Result of a `claimCredit` transaction.
-///
-/// Bond payout is two-phase: the first call unlocks the credit in `DelayedWETH`, the second
-/// (after the WETH delay) withdraws and transfers it.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ClaimSubmission {
-    /// Transaction hash for the claim.
-    pub tx_hash: TxHash,
-    /// Amount moved by this phase.
-    pub amount: U256,
-    /// Whether this call finalized the withdrawal and transferred funds.
-    pub withdrawn: bool,
 }


### PR DESCRIPTION
- Route proposal and challenge bonds through the singleton deposit-backed ERC-20 vault without sending ETH.
- Create games through the stock Dispute Game Factory; the vault locks the proposer bond from `gameCreator` available balance during initialization.
- Close finalized recent games into immediately reusable vault balances and expose token-generic available-balance, locked-bond, and settlement telemetry.
