### PR TITLE
feat(contracts): simplify WLD staking

### DIFF
--- a/pkg/contracts/README.md
+++ b/pkg/contracts/README.md
@@ -10,11 +10,11 @@ This repository contains smart contracts for World Chain, including PBH (Priorit
 
 ## Proof System Bond Claims
 
-WIP-1006 proposal and challenge bonds use WLD held one-to-one in the upgradeable `WLDStakingVault`. The stock `DisputeGameFactory` remains unchanged and its type-1006 ETH initialization bond is zero. A proposer keeps a standing WLD approval to the vault and calls the stock factory directly; during `initialize` the vault authenticates the clone against the factory's deterministic deployment address and pulls the bond from `gameCreator`.
+WIP-1006 proposal and challenge bonds use WLD held one-to-one in the upgradeable `WLDStakingVault`. Participants deposit WLD once, without leaving a standing allowance. The stock `DisputeGameFactory` remains unchanged and its type-1006 ETH initialization bond is zero. A proposer calls the stock factory directly; during `initialize` the vault authenticates the clone against the factory's deterministic deployment address and locks the bond from `gameCreator`'s available balance.
 
 `MultiProofGame.resolve()` records the outcome and payout credits without moving funds. After ASR finality, `closeGame()` selects normal or refund mode and atomically credits the complete game pot to recipients' reusable vault balances. Each account may later request a WLD withdrawal and transfer it after the vault delay; new requests reset the delay for the full pending amount.
 
-The vault is WIP-1006-only, keeps exact liabilities, and supports old registered game implementations after upgrades. Its ProxyAdmin owner has DelayedWETH-equivalent break-glass `hold` and `recover` authority; `recover` can intentionally make the vault insolvent and therefore remains a production trust assumption. The DisputeGameFactory owner and vault ProxyAdmin owner must remain the same governance authority; bond pulls fail closed if they diverge.
+The vault is WIP-1006-only, keeps exact liabilities, and supports old registered game implementations after upgrades. Its ProxyAdmin owner has DelayedWETH-equivalent break-glass `hold` and `recover` authority; `recover` can intentionally make the vault insolvent and therefore remains a production trust assumption. The DisputeGameFactory owner and vault ProxyAdmin owner must remain the same governance authority; new bond locks fail closed if they diverge.
 
 ## OP Stack Withdrawal Boundary
 

--- a/pkg/contracts/README.md
+++ b/pkg/contracts/README.md
@@ -10,11 +10,11 @@ This repository contains smart contracts for World Chain, including PBH (Priorit
 
 ## Proof System Bond Claims
 
-WIP-1006 proposal and challenge bonds use WLD held one-to-one in the upgradeable `WLDStakingVault`. The stock `DisputeGameFactory` remains unchanged and its type-1006 ETH initialization bond is zero. A proposer first reserves WLD for the deterministic factory UUID; the proposer or any keeper may then call the stock factory, and the game records the reserving account as `bondProposer` independently of `gameCreator`.
+WIP-1006 proposal and challenge bonds use WLD held one-to-one in the upgradeable `WLDStakingVault`. The stock `DisputeGameFactory` remains unchanged and its type-1006 ETH initialization bond is zero. A proposer keeps a standing WLD approval to the vault and calls the stock factory directly; during `initialize` the vault authenticates the clone against the factory's deterministic deployment address and pulls the bond from `gameCreator`.
 
 `MultiProofGame.resolve()` records the outcome and payout credits without moving funds. After ASR finality, `closeGame()` selects normal or refund mode and atomically credits the complete game pot to recipients' reusable vault balances. Each account may later request a WLD withdrawal and transfer it after the vault delay; new requests reset the delay for the full pending amount.
 
-The vault is WIP-1006-only, keeps exact liabilities, supports old registered game implementations after upgrades, and permits stale uncreated reservations to be invalidated and refunded. Its ProxyAdmin owner has DelayedWETH-equivalent break-glass `hold` and `recover` authority; `recover` can intentionally make the vault insolvent and therefore remains a production trust assumption. The DisputeGameFactory owner and vault ProxyAdmin owner must remain the same governance authority; challenge reservation fails closed if they diverge.
+The vault is WIP-1006-only, keeps exact liabilities, and supports old registered game implementations after upgrades. Its ProxyAdmin owner has DelayedWETH-equivalent break-glass `hold` and `recover` authority; `recover` can intentionally make the vault insolvent and therefore remains a production trust assumption. The DisputeGameFactory owner and vault ProxyAdmin owner must remain the same governance authority; bond pulls fail closed if they diverge.
 
 ## OP Stack Withdrawal Boundary
 

--- a/pkg/contracts/src/dispute/MultiProofGame.sol
+++ b/pkg/contracts/src/dispute/MultiProofGame.sol
@@ -177,9 +177,6 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
     /// @notice The total bonds deposited into the game.
     uint256 public totalBonds;
 
-    /// @notice Account that reserved and funded the proposer bond.
-    address public bondProposer;
-
     /// @notice Reward recipient recorded for each accepted proof lane, indexed by `ProofLane`.
     mapping(uint8 laneId => address recipient) public laneRecipient;
 
@@ -409,8 +406,10 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
         // Set the game as initialized.
         initialized = true;
 
-        bondProposer = bondVault.consumeProposal();
-        _depositBond(bondProposer, proposerBond);
+        // Pull the proposer bond from the creator's WLD allowance; the vault authenticates this
+        // clone against the factory's deterministic deployment address.
+        bondVault.pullProposerBond();
+        _depositBond(gameCreator(), proposerBond);
 
         // Set the game's starting timestamp.
         createdAt = Timestamp.wrap(uint64(block.timestamp));
@@ -465,7 +464,7 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
         // at the challenge, so late challenges cannot extend the game.
         claimData.deadline = proofDeadline();
 
-        bondVault.reserveChallenge();
+        bondVault.pullChallengerBond();
         _depositBond(msg.sender, challengerBond);
 
         emit Challenged(msg.sender, claimData.deadline.raw());
@@ -557,7 +556,7 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
             // An invalid parent invalidates this game regardless of its own proof state.
             status = GameStatus.CHALLENGER_WINS;
             claimData.invalidationReason = InvalidationReason.INVALID_PARENT;
-            normalModeCredit[bondProposer] += proposerBond;
+            normalModeCredit[gameCreator()] += proposerBond;
             if (claimData.challenger != address(0)) {
                 normalModeCredit[claimData.challenger] += challengerBond;
             }
@@ -621,7 +620,7 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
             }
         }
 
-        normalModeCredit[bondProposer] += totalBonds - distributed;
+        normalModeCredit[gameCreator()] += totalBonds - distributed;
     }
 
     /// @inheritdoc IMultiProofGame
@@ -684,7 +683,7 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
     function _settlementCandidates() internal view returns (address[] memory candidates) {
         // Possible recipients are the proposer, challenger, protocol, and one recipient per proof lane.
         candidates = new address[](3 + LibProof.PROOF_LANE_COUNT);
-        candidates[0] = bondProposer;
+        candidates[0] = gameCreator();
         candidates[1] = claimData.challenger;
         candidates[2] = protocolFeeRecipient;
         for (uint8 laneId; laneId < LibProof.PROOF_LANE_COUNT; laneId++) {

--- a/pkg/contracts/src/dispute/MultiProofGame.sol
+++ b/pkg/contracts/src/dispute/MultiProofGame.sol
@@ -406,9 +406,9 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
         // Set the game as initialized.
         initialized = true;
 
-        // Pull the proposer bond from the creator's WLD allowance; the vault authenticates this
+        // Lock the proposer bond from the creator's vault balance; the vault authenticates this
         // clone against the factory's deterministic deployment address.
-        bondVault.pullProposerBond();
+        bondVault.lockProposerBond();
         _depositBond(gameCreator(), proposerBond);
 
         // Set the game's starting timestamp.
@@ -464,7 +464,7 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
         // at the challenge, so late challenges cannot extend the game.
         claimData.deadline = proofDeadline();
 
-        bondVault.pullChallengerBond();
+        bondVault.lockChallengerBond();
         _depositBond(msg.sender, challengerBond);
 
         emit Challenged(msg.sender, claimData.deadline.raw());

--- a/pkg/contracts/src/dispute/MultiProofGame.sol
+++ b/pkg/contracts/src/dispute/MultiProofGame.sol
@@ -187,7 +187,8 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
     constructor(GameConfig memory config) {
         if (
             config.blockInterval == 0 || config.challengePeriod == 0 || config.proofPeriod <= config.challengePeriod
-                || config.proposerBond == 0 || config.challengerBond == 0 || config.proofThreshold < 2
+                || config.proposerBond == 0 || config.proposerBond > type(uint256).max / CHALLENGER_REWARD_BPS
+                || config.challengerBond == 0 || config.proofThreshold < 2
                 || config.proofThreshold > LibProof.PROOF_LANE_COUNT || config.protocolFeeRecipient == address(0)
                 || config.aggregationVKey == bytes32(0) || config.rangeVKeyCommitment == bytes32(0)
                 || config.teeImageId == bytes32(0) || address(config.anchorStateRegistry) == address(0)
@@ -398,7 +399,7 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
         claimData = ClaimData({
             status: ProposalStatus.Unchallenged,
             challenger: address(0),
-            deadline: Timestamp.wrap(uint64(block.timestamp + challengePeriod.raw())),
+            deadline: _toTimestamp(block.timestamp + challengePeriod.raw()),
             proofBitmap: Bitmap.wrap(0),
             invalidationReason: InvalidationReason.NONE
         });
@@ -412,7 +413,7 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
         _depositBond(gameCreator(), proposerBond);
 
         // Set the game's starting timestamp.
-        createdAt = Timestamp.wrap(uint64(block.timestamp));
+        createdAt = _toTimestamp(block.timestamp);
 
         // Set whether the game type was respected when the game was created.
         wasRespectedGameTypeWhenCreated =
@@ -597,7 +598,7 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
 
         // Mark the game as resolved.
         claimData.status = ProposalStatus.Resolved;
-        resolvedAt = Timestamp.wrap(uint64(block.timestamp));
+        resolvedAt = _toTimestamp(block.timestamp);
 
         emit Resolved(status);
 
@@ -725,8 +726,7 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
     /// @notice Determines if the game is finished.
     /// @return gameOver_ True if the active deadline has passed or the threshold is reached.
     function gameOver() public view returns (bool gameOver_) {
-        gameOver_ =
-            claimData.deadline.raw() <= uint64(block.timestamp) || claimData.proofBitmap.hasThreshold(PROOF_THRESHOLD);
+        gameOver_ = claimData.deadline.raw() <= block.timestamp || claimData.proofBitmap.hasThreshold(PROOF_THRESHOLD);
     }
 
     /// @inheritdoc IMultiProofGame
@@ -785,12 +785,19 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
 
     /// @inheritdoc IMultiProofGame
     function challengeDeadline() public view returns (Timestamp) {
-        return Timestamp.wrap(createdAt.raw() + challengePeriod.raw());
+        return _toTimestamp(uint256(createdAt.raw()) + challengePeriod.raw());
     }
 
     /// @inheritdoc IMultiProofGame
     function proofDeadline() public view returns (Timestamp) {
-        return Timestamp.wrap(createdAt.raw() + proofPeriod.raw());
+        return _toTimestamp(uint256(createdAt.raw()) + proofPeriod.raw());
+    }
+
+    function _toTimestamp(uint256 value) internal pure returns (Timestamp) {
+        if (value > type(uint64).max) revert TimestampOutOfBounds(value);
+        // The bound above proves this narrowing conversion is lossless.
+        // forge-lint: disable-next-line(unsafe-typecast)
+        return Timestamp.wrap(uint64(value));
     }
 
     /// @dev Selects the verifier and game-pinned statement for `lane`. The generic public-values

--- a/pkg/contracts/src/dispute/WLDStakingVault.sol
+++ b/pkg/contracts/src/dispute/WLDStakingVault.sol
@@ -34,7 +34,6 @@ contract WLDStakingVault is Initializable, IWLDStakingVault {
 
     mapping(address account => uint256 amount) public availableBalance;
     mapping(address account => WithdrawalRequest request) public withdrawals;
-    mapping(Hash uuid => ProposalReservation reservation) public proposalReservations;
     mapping(address game => GameBond bond) public gameBonds;
 
     constructor(uint256 delaySeconds) {
@@ -83,22 +82,11 @@ contract WLDStakingVault is Initializable, IWLDStakingVault {
     }
 
     /// @inheritdoc IWLDStakingVault
-    function deposit(uint256 amount) external {
-        if (amount == 0) revert InvalidAmount();
-        uint256 balanceBefore = wld.balanceOf(address(this));
-        wld.safeTransferFrom(msg.sender, address(this), amount);
-        uint256 received = wld.balanceOf(address(this)) - balanceBefore;
-        if (received != amount) revert ExactTransferRequired(amount, received);
-
-        availableBalance[msg.sender] += amount;
-        totalLiabilities += amount;
-        emit Deposited(msg.sender, amount);
-    }
-
-    /// @inheritdoc IWLDStakingVault
     function requestWithdrawal(uint256 amount) external {
         if (amount == 0) revert InvalidWithdrawal();
-        _debitAvailable(msg.sender, amount);
+        uint256 available = availableBalance[msg.sender];
+        if (available < amount) revert InsufficientBalance(msg.sender, available, amount);
+        availableBalance[msg.sender] = available - amount;
 
         WithdrawalRequest storage request = withdrawals[msg.sender];
         request.amount += amount;
@@ -123,84 +111,10 @@ contract WLDStakingVault is Initializable, IWLDStakingVault {
         emit Withdrawn(msg.sender, amount);
     }
 
-    // Derive the UUID from the canonical creation data onchain; accepting a precomputed UUID
-    // would make its correctness an offchain responsibility.
     /// @inheritdoc IWLDStakingVault
-    function reserveProposal(Claim rootClaim, bytes calldata extraData) external returns (Hash uuid) {
-        return _reserveProposal(msg.sender, rootClaim, extraData);
-    }
+    function pullProposerBond() external {
+        _assertAlignedOwners();
 
-    /// @inheritdoc IWLDStakingVault
-    function reserveAndCreate(Claim rootClaim, bytes calldata extraData) external returns (IDisputeGame game) {
-        _reserveProposal(msg.sender, rootClaim, extraData);
-        game = disputeGameFactory.create(GameTypes.MULTI_PROOF_GAME_TYPE, rootClaim, extraData);
-    }
-
-    function _reserveProposal(address proposer, Claim rootClaim, bytes calldata extraData)
-        internal
-        returns (Hash uuid)
-    {
-        uint256 factoryBond = disputeGameFactory.initBonds(GameTypes.MULTI_PROOF_GAME_TYPE);
-        if (factoryBond != 0) revert FactoryBondMustBeZero(factoryBond);
-
-        IDisputeGame implementation = disputeGameFactory.gameImpls(GameTypes.MULTI_PROOF_GAME_TYPE);
-        if (address(implementation) == address(0)) revert NoGameImplementation();
-
-        IMultiProofGame gameImplementation_ = IMultiProofGame(address(implementation));
-        if (
-            address(gameImplementation_.bondVault()) != address(this)
-                || address(gameImplementation_.disputeGameFactory()) != address(disputeGameFactory)
-        ) {
-            revert InvalidVaultConfiguration();
-        }
-
-        uuid = disputeGameFactory.getGameUUID(GameTypes.MULTI_PROOF_GAME_TYPE, rootClaim, extraData);
-        (IDisputeGame existing,) = disputeGameFactory.games(GameTypes.MULTI_PROOF_GAME_TYPE, rootClaim, extraData);
-        if (address(existing) != address(0)) revert GameAlreadyCreated(address(existing));
-        if (proposalReservations[uuid].proposer != address(0)) revert AlreadyReserved(uuid);
-
-        uint256 amount = gameImplementation_.proposerBond();
-        _debitAvailable(proposer, amount);
-        proposalReservations[uuid] =
-            ProposalReservation({proposer: proposer, implementation: address(implementation), amount: amount});
-        emit ProposalReserved(uuid, proposer, address(implementation), rootClaim, extraData, amount);
-    }
-
-    /// @inheritdoc IWLDStakingVault
-    function cancelProposal(Claim rootClaim, bytes calldata extraData) external {
-        Hash uuid = disputeGameFactory.getGameUUID(GameTypes.MULTI_PROOF_GAME_TYPE, rootClaim, extraData);
-        ProposalReservation memory reservation = proposalReservations[uuid];
-        if (reservation.proposer == address(0)) revert InvalidReservation(uuid);
-        if (msg.sender != reservation.proposer) revert NotReservedProposer(msg.sender, reservation.proposer);
-        _releaseUncreatedReservation(uuid, rootClaim, extraData, reservation);
-    }
-
-    /// @inheritdoc IWLDStakingVault
-    function invalidateStaleProposal(Claim rootClaim, bytes calldata extraData) external {
-        Hash uuid = disputeGameFactory.getGameUUID(GameTypes.MULTI_PROOF_GAME_TYPE, rootClaim, extraData);
-        ProposalReservation memory reservation = proposalReservations[uuid];
-        if (reservation.proposer == address(0)) revert InvalidReservation(uuid);
-        if (address(disputeGameFactory.gameImpls(GameTypes.MULTI_PROOF_GAME_TYPE)) == reservation.implementation) {
-            revert ReservationNotStale(uuid);
-        }
-        _releaseUncreatedReservation(uuid, rootClaim, extraData, reservation);
-    }
-
-    function _releaseUncreatedReservation(
-        Hash uuid,
-        Claim rootClaim,
-        bytes calldata extraData,
-        ProposalReservation memory reservation
-    ) internal {
-        (IDisputeGame existing,) = disputeGameFactory.games(GameTypes.MULTI_PROOF_GAME_TYPE, rootClaim, extraData);
-        if (address(existing) != address(0)) revert GameAlreadyCreated(address(existing));
-        delete proposalReservations[uuid];
-        availableBalance[reservation.proposer] += reservation.amount;
-        emit ProposalReservationReleased(uuid, reservation.proposer, reservation.amount);
-    }
-
-    /// @inheritdoc IWLDStakingVault
-    function consumeProposal() external returns (address proposer) {
         IMultiProofGame game = IMultiProofGame(msg.sender);
         if (
             GameType.unwrap(game.gameType()) != GameType.unwrap(GameTypes.MULTI_PROOF_GAME_TYPE)
@@ -210,17 +124,15 @@ contract WLDStakingVault is Initializable, IWLDStakingVault {
             revert GameNotRegistered(msg.sender);
         }
 
+        // The factory registers a game only after `initialize` returns, so the factory mapping
+        // cannot authenticate this call yet. Instead recompute the deterministic clone address
+        // the factory derives for the current implementation and the caller's creation data;
+        // only a clone the factory itself deployed can occupy it.
         (GameType gameType_, Claim rootClaim_, bytes memory extraData_) = game.gameData();
         Hash uuid = disputeGameFactory.getGameUUID(gameType_, rootClaim_, extraData_);
-        ProposalReservation memory reservation = proposalReservations[uuid];
-        if (reservation.proposer == address(0) || reservation.amount != game.proposerBond()) {
-            revert InvalidReservation(uuid);
-        }
-        if (reservation.implementation != address(disputeGameFactory.gameImpls(GameTypes.MULTI_PROOF_GAME_TYPE))) {
-            revert StaleReservation(uuid);
-        }
+        address implementation = address(disputeGameFactory.gameImpls(GameTypes.MULTI_PROOF_GAME_TYPE));
         address expectedGame = LibClone.predictDeterministicAddress(
-            reservation.implementation,
+            implementation,
             abi.encodePacked(game.gameCreator(), rootClaim_, game.l1Head(), extraData_),
             Hash.unwrap(uuid),
             address(disputeGameFactory)
@@ -228,29 +140,29 @@ contract WLDStakingVault is Initializable, IWLDStakingVault {
         if (expectedGame != msg.sender) revert UnexpectedGameAddress(expectedGame, msg.sender);
         if (gameBonds[msg.sender].proposerBond != 0) revert GameBondAlreadyInitialized(msg.sender);
 
-        delete proposalReservations[uuid];
-        gameBonds[msg.sender] = GameBond({proposerBond: reservation.amount, challengerBond: 0, settled: false});
-        emit ProposalBondAssigned(uuid, msg.sender, reservation.proposer, reservation.amount);
-        return reservation.proposer;
+        address proposer = game.gameCreator();
+        uint256 amount = game.proposerBond();
+        if (amount == 0) revert InvalidVaultConfiguration();
+        _pullExact(proposer, amount);
+        gameBonds[msg.sender] = GameBond({proposerBond: amount, challengerBond: 0, settled: false});
+        emit ProposerBondPulled(msg.sender, proposer, amount);
     }
 
     /// @inheritdoc IWLDStakingVault
-    function reserveChallenge() external {
-        address factoryOwner = disputeGameFactory.owner();
-        address vaultOwner = proxyAdminOwner();
-        if (factoryOwner != vaultOwner) revert OwnerMismatch(factoryOwner, vaultOwner);
+    function pullChallengerBond() external {
+        _assertAlignedOwners();
 
         IMultiProofGame game = _registeredGame(msg.sender);
         GameBond storage bond = gameBonds[msg.sender];
         if (bond.proposerBond == 0) revert GameNotRegistered(msg.sender);
-        if (bond.challengerBond != 0 || bond.settled) revert ChallengeBondAlreadyReserved(msg.sender);
+        if (bond.challengerBond != 0 || bond.settled) revert ChallengerBondAlreadyPulled(msg.sender);
 
         address challenger = game.challenger();
         uint256 amount = game.challengerBond();
         if (challenger == address(0) || amount == 0) revert InvalidVaultConfiguration();
-        _debitAvailable(challenger, amount);
+        _pullExact(challenger, amount);
         bond.challengerBond = amount;
-        emit ChallengeBondReserved(msg.sender, challenger, amount);
+        emit ChallengerBondPulled(msg.sender, challenger, amount);
     }
 
     /// @inheritdoc IWLDStakingVault
@@ -282,7 +194,7 @@ contract WLDStakingVault is Initializable, IWLDStakingVault {
 
     // TODO(security): Reassess unrestricted `hold` and `recover` authority before production
     // deployment. These functions intentionally mirror DelayedWETH's break-glass custody model,
-    // but this singleton also holds participants' uncommitted WLD balances and therefore has a
+    // but this singleton also holds participants' settled WLD credits and therefore has a
     // larger blast radius.
     /// @inheritdoc IWLDStakingVault
     function hold(address account, uint256 amount) public {
@@ -307,10 +219,18 @@ contract WLDStakingVault is Initializable, IWLDStakingVault {
         address recipient = _assertProxyAdminOwner();
         uint256 balance = wld.balanceOf(address(this));
         uint256 recovered = amount < balance ? amount : balance;
-        // Liabilities intentionally remain unchanged: recovery may seize backing for pending
-        // reservations or active games without blocking their later internal settlement.
+        // Liabilities intentionally remain unchanged: recovery may seize backing for active
+        // games without blocking their later internal settlement.
         wld.safeTransfer(recipient, recovered);
         emit Recovered(recipient, recovered);
+    }
+
+    function _pullExact(address from, uint256 amount) internal {
+        uint256 balanceBefore = wld.balanceOf(address(this));
+        wld.safeTransferFrom(from, address(this), amount);
+        uint256 received = wld.balanceOf(address(this)) - balanceBefore;
+        if (received != amount) revert ExactTransferRequired(amount, received);
+        totalLiabilities += amount;
     }
 
     function _registeredGame(address gameAddress) internal view returns (IMultiProofGame game) {
@@ -325,10 +245,12 @@ contract WLDStakingVault is Initializable, IWLDStakingVault {
         }
     }
 
-    function _debitAvailable(address account, uint256 amount) internal {
-        uint256 available = availableBalance[account];
-        if (available < amount) revert InsufficientBalance(account, available, amount);
-        availableBalance[account] = available - amount;
+    // Bond pulls spend participant allowances on the word of factory-registered game code, so
+    // the factory owner must be the same governance authority that controls this vault.
+    function _assertAlignedOwners() internal view {
+        address factoryOwner = disputeGameFactory.owner();
+        address vaultOwner = proxyAdminOwner();
+        if (factoryOwner != vaultOwner) revert OwnerMismatch(factoryOwner, vaultOwner);
     }
 
     function _assertProxyAdminOrOwner() internal view {

--- a/pkg/contracts/src/dispute/WLDStakingVault.sol
+++ b/pkg/contracts/src/dispute/WLDStakingVault.sol
@@ -82,6 +82,16 @@ contract WLDStakingVault is Initializable, IWLDStakingVault {
     }
 
     /// @inheritdoc IWLDStakingVault
+    function deposit(uint256 amount) external {
+        _depositFor(msg.sender, amount);
+    }
+
+    /// @inheritdoc IWLDStakingVault
+    function depositFor(address account, uint256 amount) external {
+        _depositFor(account, amount);
+    }
+
+    /// @inheritdoc IWLDStakingVault
     function requestWithdrawal(uint256 amount) external {
         if (amount == 0) revert InvalidWithdrawal();
         uint256 available = availableBalance[msg.sender];
@@ -112,7 +122,7 @@ contract WLDStakingVault is Initializable, IWLDStakingVault {
     }
 
     /// @inheritdoc IWLDStakingVault
-    function pullProposerBond() external {
+    function lockProposerBond() external {
         _assertAlignedOwners();
 
         IMultiProofGame game = IMultiProofGame(msg.sender);
@@ -143,26 +153,26 @@ contract WLDStakingVault is Initializable, IWLDStakingVault {
         address proposer = game.gameCreator();
         uint256 amount = game.proposerBond();
         if (amount == 0) revert InvalidVaultConfiguration();
-        _pullExact(proposer, amount);
+        _debitAvailable(proposer, amount);
         gameBonds[msg.sender] = GameBond({proposerBond: amount, challengerBond: 0, settled: false});
-        emit ProposerBondPulled(msg.sender, proposer, amount);
+        emit ProposerBondLocked(msg.sender, proposer, amount);
     }
 
     /// @inheritdoc IWLDStakingVault
-    function pullChallengerBond() external {
+    function lockChallengerBond() external {
         _assertAlignedOwners();
 
         IMultiProofGame game = _registeredGame(msg.sender);
         GameBond storage bond = gameBonds[msg.sender];
         if (bond.proposerBond == 0) revert GameNotRegistered(msg.sender);
-        if (bond.challengerBond != 0 || bond.settled) revert ChallengerBondAlreadyPulled(msg.sender);
+        if (bond.challengerBond != 0 || bond.settled) revert ChallengerBondAlreadyLocked(msg.sender);
 
         address challenger = game.challenger();
         uint256 amount = game.challengerBond();
         if (challenger == address(0) || amount == 0) revert InvalidVaultConfiguration();
-        _pullExact(challenger, amount);
+        _debitAvailable(challenger, amount);
         bond.challengerBond = amount;
-        emit ChallengerBondPulled(msg.sender, challenger, amount);
+        emit ChallengerBondLocked(msg.sender, challenger, amount);
     }
 
     /// @inheritdoc IWLDStakingVault
@@ -225,12 +235,18 @@ contract WLDStakingVault is Initializable, IWLDStakingVault {
         emit Recovered(recipient, recovered);
     }
 
-    function _pullExact(address from, uint256 amount) internal {
+    function _depositFor(address account, uint256 amount) internal {
+        if (account == address(0)) revert InvalidAccount();
+        if (amount == 0) revert InvalidAmount();
+
         uint256 balanceBefore = wld.balanceOf(address(this));
-        wld.safeTransferFrom(from, address(this), amount);
+        wld.safeTransferFrom(msg.sender, address(this), amount);
         uint256 received = wld.balanceOf(address(this)) - balanceBefore;
         if (received != amount) revert ExactTransferRequired(amount, received);
+
+        availableBalance[account] += amount;
         totalLiabilities += amount;
+        emit Deposited(msg.sender, account, amount);
     }
 
     function _registeredGame(address gameAddress) internal view returns (IMultiProofGame game) {
@@ -245,8 +261,8 @@ contract WLDStakingVault is Initializable, IWLDStakingVault {
         }
     }
 
-    // Bond pulls spend participant allowances on the word of factory-registered game code, so
-    // the factory owner must be the same governance authority that controls this vault.
+    // Bond locking lets factory-selected game code allocate participant balances, so the factory
+    // owner must be the same governance authority that controls this vault.
     function _assertAlignedOwners() internal view {
         address factoryOwner = disputeGameFactory.owner();
         address vaultOwner = proxyAdminOwner();
@@ -256,6 +272,12 @@ contract WLDStakingVault is Initializable, IWLDStakingVault {
     function _assertProxyAdminOrOwner() internal view {
         IProxyAdmin admin = proxyAdmin();
         if (msg.sender != address(admin) && msg.sender != admin.owner()) revert NotProxyAdminOwner(msg.sender);
+    }
+
+    function _debitAvailable(address account, uint256 amount) internal {
+        uint256 available = availableBalance[account];
+        if (available < amount) revert InsufficientBalance(account, available, amount);
+        availableBalance[account] = available - amount;
     }
 
     function _assertProxyAdminOwner() internal view returns (address owner) {

--- a/pkg/contracts/src/dispute/interfaces/IMultiProofGame.sol
+++ b/pkg/contracts/src/dispute/interfaces/IMultiProofGame.sol
@@ -191,9 +191,6 @@ interface IMultiProofGame is IDisputeGame {
     /// @notice L1 block number of `l1Head`.
     function l1OriginNumber() external view returns (uint256);
 
-    /// @notice Account that reserved and funded the proposer bond.
-    function bondProposer() external view returns (address);
-
     ////////////////////////////////////////////////////////////////
     //                       Game progress                        //
     ////////////////////////////////////////////////////////////////
@@ -240,7 +237,8 @@ interface IMultiProofGame is IDisputeGame {
     //                    Challenge and proofs                    //
     ////////////////////////////////////////////////////////////////
 
-    /// @notice Disputes a proposal and reserves `challengerBond` WLD from the caller's vault balance.
+    /// @notice Disputes a proposal, pulling `challengerBond` WLD from the caller's allowance to
+    ///         the bond vault.
     function challenge() external returns (ProposalStatus);
 
     /// @notice Submits a compact proof payload. Before a challenge, any accepted lane satisfies

--- a/pkg/contracts/src/dispute/interfaces/IMultiProofGame.sol
+++ b/pkg/contracts/src/dispute/interfaces/IMultiProofGame.sol
@@ -79,6 +79,7 @@ interface IMultiProofGame is IDisputeGame {
     error InvalidProof(ProofLane lane, bytes32 rootId);
     error InvalidDomainHash(bytes32 expected, bytes32 actual);
     error InconsistentSystemConfiguration();
+    error TimestampOutOfBounds(uint256 value);
 
     /// @notice Thrown when a lane that already counts toward the threshold is resubmitted.
     error DuplicateProofLane(ProofLane lane, bytes32 rootId, Bitmap proofBitmap);

--- a/pkg/contracts/src/dispute/interfaces/IMultiProofGame.sol
+++ b/pkg/contracts/src/dispute/interfaces/IMultiProofGame.sol
@@ -237,8 +237,7 @@ interface IMultiProofGame is IDisputeGame {
     //                    Challenge and proofs                    //
     ////////////////////////////////////////////////////////////////
 
-    /// @notice Disputes a proposal, pulling `challengerBond` WLD from the caller's allowance to
-    ///         the bond vault.
+    /// @notice Disputes a proposal, locking `challengerBond` from the caller's available vault balance.
     function challenge() external returns (ProposalStatus);
 
     /// @notice Submits a compact proof payload. Before a challenge, any accepted lane satisfies

--- a/pkg/contracts/src/dispute/interfaces/IWLDStakingVault.sol
+++ b/pkg/contracts/src/dispute/interfaces/IWLDStakingVault.sol
@@ -25,13 +25,15 @@ interface IWLDStakingVault {
         uint256 amount;
     }
 
-    error ChallengerBondAlreadyPulled(address game);
+    error ChallengerBondAlreadyLocked(address game);
     error ExactTransferRequired(uint256 expected, uint256 actual);
     error GameAlreadySettled(address game);
     error GameBondAlreadyInitialized(address game);
     error GameNotRegistered(address game);
     error InsufficientBalance(address account, uint256 available, uint256 required);
     error InvalidPayoutTotal(uint256 expected, uint256 actual);
+    error InvalidAccount();
+    error InvalidAmount();
     error InvalidVaultConfiguration();
     error InvalidWithdrawal();
     error NotProxyAdminOwner(address caller);
@@ -40,8 +42,9 @@ interface IWLDStakingVault {
     error WithdrawalDelayNotMet(uint256 availableAt);
     error WithdrawalPaused();
 
-    event ProposerBondPulled(address indexed game, address indexed proposer, uint256 amount);
-    event ChallengerBondPulled(address indexed game, address indexed challenger, uint256 amount);
+    event Deposited(address indexed depositor, address indexed account, uint256 amount);
+    event ProposerBondLocked(address indexed game, address indexed proposer, uint256 amount);
+    event ChallengerBondLocked(address indexed game, address indexed challenger, uint256 amount);
     event GameSettled(address indexed game, uint256 amount);
     event WithdrawalRequested(address indexed account, uint256 amount, uint256 availableAt);
     event Withdrawn(address indexed account, uint256 amount);
@@ -66,7 +69,7 @@ interface IWLDStakingVault {
     /// @notice Total WLD owed across available, pending, and active-game balances.
     function totalLiabilities() external view returns (uint256);
 
-    /// @notice Settled WLD credit available to request for withdrawal.
+    /// @notice Deposited or settled WLD available to fund bonds or request for withdrawal.
     function availableBalance(address account) external view returns (uint256);
 
     /// @notice Pending external withdrawal amount and the timestamp of its latest request.
@@ -84,20 +87,26 @@ interface IWLDStakingVault {
     /// @notice Owner of the vault's ProxyAdmin and break-glass custody authority.
     function proxyAdminOwner() external view returns (address);
 
+    /// @notice Deposits WLD into the caller's available balance.
+    function deposit(uint256 amount) external;
+
+    /// @notice Deposits the caller's WLD into another account's available balance.
+    function depositFor(address account, uint256 amount) external;
+
     /// @notice Moves available WLD into a pending withdrawal and resets its full delay.
     function requestWithdrawal(uint256 amount) external;
 
     /// @notice Transfers matured pending WLD to the caller while the system is unpaused.
     function withdraw(uint256 amount) external;
 
-    /// @notice Pulls the calling game's proposer bond from its creator's WLD allowance.
+    /// @notice Locks the calling game's proposer bond from its creator's available balance.
     /// @dev Called during `initialize`, before the factory registers the game, so the caller is
     ///      authenticated as the deterministic clone the factory deploys for its creation data.
-    function pullProposerBond() external;
+    function lockProposerBond() external;
 
-    /// @notice Pulls the calling registered game's single challenger bond from the challenger's
-    ///         WLD allowance.
-    function pullChallengerBond() external;
+    /// @notice Locks the calling registered game's single challenger bond from the challenger's
+    ///         available balance.
+    function lockChallengerBond() external;
 
     /// @notice Credits a registered game's complete finalized pot exactly once.
     function settle(Payout[] calldata payouts) external;

--- a/pkg/contracts/src/dispute/interfaces/IWLDStakingVault.sol
+++ b/pkg/contracts/src/dispute/interfaces/IWLDStakingVault.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {Claim, Hash} from "@optimism-bedrock/src/dispute/lib/Types.sol";
-import {IDisputeGame} from "@optimism-bedrock/interfaces/dispute/IDisputeGame.sol";
 import {IDisputeGameFactory} from "@optimism-bedrock/interfaces/dispute/IDisputeGameFactory.sol";
 import {ISystemConfig} from "@optimism-bedrock/interfaces/L1/ISystemConfig.sol";
 import {IProxyAdmin} from "@optimism-bedrock/interfaces/universal/IProxyAdmin.sol";
@@ -11,12 +9,6 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 /// @title IWLDStakingVault
 /// @notice Custodies WLD used by WIP-1006 proposers, challengers, and reward recipients.
 interface IWLDStakingVault {
-    struct ProposalReservation {
-        address proposer;
-        address implementation;
-        uint256 amount;
-    }
-
     struct GameBond {
         uint256 proposerBond;
         uint256 challengerBond;
@@ -33,42 +25,23 @@ interface IWLDStakingVault {
         uint256 amount;
     }
 
-    error AlreadyReserved(Hash uuid);
+    error ChallengerBondAlreadyPulled(address game);
     error ExactTransferRequired(uint256 expected, uint256 actual);
-    error FactoryBondMustBeZero(uint256 bond);
-    error GameAlreadyCreated(address game);
     error GameAlreadySettled(address game);
     error GameBondAlreadyInitialized(address game);
-    error ChallengeBondAlreadyReserved(address game);
     error GameNotRegistered(address game);
     error InsufficientBalance(address account, uint256 available, uint256 required);
-    error InvalidVaultConfiguration();
-    error OwnerMismatch(address disputeGameFactoryOwner, address proxyAdminOwner);
-    error InvalidAmount();
     error InvalidPayoutTotal(uint256 expected, uint256 actual);
-    error InvalidReservation(Hash uuid);
+    error InvalidVaultConfiguration();
     error InvalidWithdrawal();
-    error NoGameImplementation();
     error NotProxyAdminOwner(address caller);
-    error NotReservedProposer(address caller, address proposer);
-    error ReservationNotStale(Hash uuid);
-    error StaleReservation(Hash uuid);
+    error OwnerMismatch(address disputeGameFactoryOwner, address proxyAdminOwner);
     error UnexpectedGameAddress(address expected, address actual);
     error WithdrawalDelayNotMet(uint256 availableAt);
     error WithdrawalPaused();
 
-    event Deposited(address indexed account, uint256 amount);
-    event ProposalReserved(
-        Hash indexed uuid,
-        address indexed proposer,
-        address indexed implementation,
-        Claim rootClaim,
-        bytes extraData,
-        uint256 amount
-    );
-    event ProposalReservationReleased(Hash indexed uuid, address indexed proposer, uint256 amount);
-    event ProposalBondAssigned(Hash indexed uuid, address indexed game, address indexed proposer, uint256 amount);
-    event ChallengeBondReserved(address indexed game, address indexed challenger, uint256 amount);
+    event ProposerBondPulled(address indexed game, address indexed proposer, uint256 amount);
+    event ChallengerBondPulled(address indexed game, address indexed challenger, uint256 amount);
     event GameSettled(address indexed game, uint256 amount);
     event WithdrawalRequested(address indexed account, uint256 amount, uint256 availableAt);
     event Withdrawn(address indexed account, uint256 amount);
@@ -90,20 +63,14 @@ interface IWLDStakingVault {
     /// @notice Delay between requesting and executing an external WLD withdrawal.
     function delay() external view returns (uint256);
 
-    /// @notice Total WLD owed across available, pending, reserved, and active-game balances.
+    /// @notice Total WLD owed across available, pending, and active-game balances.
     function totalLiabilities() external view returns (uint256);
 
-    /// @notice WLD immediately reusable or available to request for withdrawal.
+    /// @notice Settled WLD credit available to request for withdrawal.
     function availableBalance(address account) external view returns (uint256);
 
     /// @notice Pending external withdrawal amount and the timestamp of its latest request.
     function withdrawals(address account) external view returns (uint256 amount, uint256 timestamp);
-
-    /// @notice Reservation bound to a deterministic factory game UUID.
-    function proposalReservations(Hash uuid)
-        external
-        view
-        returns (address proposer, address implementation, uint256 amount);
 
     /// @notice Bond amounts assigned to a game and whether its complete pot was settled.
     function gameBonds(address game) external view returns (uint256 proposerBond, uint256 challengerBond, bool settled);
@@ -117,32 +84,20 @@ interface IWLDStakingVault {
     /// @notice Owner of the vault's ProxyAdmin and break-glass custody authority.
     function proxyAdminOwner() external view returns (address);
 
-    /// @notice Deposits exact-transfer WLD into the caller's available balance.
-    function deposit(uint256 amount) external;
-
     /// @notice Moves available WLD into a pending withdrawal and resets its full delay.
     function requestWithdrawal(uint256 amount) external;
 
     /// @notice Transfers matured pending WLD to the caller while the system is unpaused.
     function withdraw(uint256 amount) external;
 
-    /// @notice Reserves the current implementation's proposer bond for a factory UUID.
-    function reserveProposal(Claim rootClaim, bytes calldata extraData) external returns (Hash uuid);
+    /// @notice Pulls the calling game's proposer bond from its creator's WLD allowance.
+    /// @dev Called during `initialize`, before the factory registers the game, so the caller is
+    ///      authenticated as the deterministic clone the factory deploys for its creation data.
+    function pullProposerBond() external;
 
-    /// @notice Reserves a proposal and creates its game atomically through the stock factory.
-    function reserveAndCreate(Claim rootClaim, bytes calldata extraData) external returns (IDisputeGame game);
-
-    /// @notice Releases the caller's reservation if its game has not been created.
-    function cancelProposal(Claim rootClaim, bytes calldata extraData) external;
-
-    /// @notice Permissionlessly releases an uncreated reservation after its implementation is replaced.
-    function invalidateStaleProposal(Claim rootClaim, bytes calldata extraData) external;
-
-    /// @notice Assigns a reservation to the authenticated deterministic clone during initialization.
-    function consumeProposal() external returns (address proposer);
-
-    /// @notice Reserves the calling registered game's single challenger bond.
-    function reserveChallenge() external;
+    /// @notice Pulls the calling registered game's single challenger bond from the challenger's
+    ///         WLD allowance.
+    function pullChallengerBond() external;
 
     /// @notice Credits a registered game's complete finalized pot exactly once.
     function settle(Payout[] calldata payouts) external;

--- a/pkg/contracts/test/dispute/MultiProofGame.t.sol
+++ b/pkg/contracts/test/dispute/MultiProofGame.t.sol
@@ -321,14 +321,14 @@ contract MultiProofGameTest is OPStackFixtures {
         address keeper = makeAddr("keeper");
         vm.prank(keeper);
         game.closeGame();
-        assertEq(bondVault.availableBalance(proposer), PROPOSER_BOND);
+        assertEq(bondVault.availableBalance(proposer), 100 * WLD_UNIT);
 
         (Hash anchorRoot, uint256 anchorBlock) = asr.getAnchorRoot();
         assertEq(Hash.unwrap(anchorRoot), Claim.unwrap(game.rootClaim()));
         assertEq(anchorBlock, game.l2SequenceNumber());
         assertEq(uint8(game.bondDistributionMode()), uint8(BondDistributionMode.NORMAL));
 
-        assertEq(wld.balanceOf(proposer), 100 * WLD_UNIT - PROPOSER_BOND);
+        assertEq(wld.balanceOf(proposer), 0);
         assertEq(wld.balanceOf(keeper), 0);
     }
 
@@ -380,7 +380,7 @@ contract MultiProofGameTest is OPStackFixtures {
         game.challenge();
 
         assertEq(game.challenger(), address(0));
-        assertEq(wld.balanceOf(challengerAccount), 100 * WLD_UNIT);
+        assertEq(bondVault.availableBalance(challengerAccount), 100 * WLD_UNIT);
     }
 
     function test_Challenge_DoesNotExtendProofDeadline() public {
@@ -763,7 +763,7 @@ contract MultiProofGameTest is OPStackFixtures {
 
         _passAirgap(game);
         game.closeGame();
-        assertEq(bondVault.availableBalance(proposer), PROPOSER_BOND + CHALLENGER_BOND);
+        assertEq(bondVault.availableBalance(proposer), 100 * WLD_UNIT + CHALLENGER_BOND);
     }
 
     /// @dev Each lane recipient is independently credited in the shared vault.

--- a/pkg/contracts/test/dispute/MultiProofGame.t.sol
+++ b/pkg/contracts/test/dispute/MultiProofGame.t.sol
@@ -185,6 +185,11 @@ contract MultiProofGameTest is OPStackFixtures {
         new MultiProofGame(config);
 
         config = _gameConfig();
+        config.proposerBond = type(uint256).max / gameImpl.CHALLENGER_REWARD_BPS() + 1;
+        vm.expectRevert(IMultiProofGame.InvalidActivationParameters.selector);
+        new MultiProofGame(config);
+
+        config = _gameConfig();
         config.aggregationVKey = bytes32(0);
         vm.expectRevert(IMultiProofGame.InvalidActivationParameters.selector);
         new MultiProofGame(config);
@@ -205,6 +210,21 @@ contract MultiProofGameTest is OPStackFixtures {
         vm.expectRevert(IMultiProofGame.InconsistentSystemConfiguration.selector);
         new MultiProofGame(config);
         vm.clearMockedCalls();
+    }
+
+    function test_Create_RejectsTimestampBeyondUint64() public {
+        (, uint256 anchorBlock) = asr.getAnchorRoot();
+        uint256 target = anchorBlock + BLOCK_INTERVAL;
+        bytes memory extraData = _extraDataForParent(target, address(asr), 0);
+
+        vm.warp(type(uint64).max);
+        vm.prank(proposer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IMultiProofGame.TimestampOutOfBounds.selector, uint256(type(uint64).max) + uint256(CHALLENGE_PERIOD)
+            )
+        );
+        dgf.create(WC_GAME_TYPE, Claim.wrap(_rootClaimFor(target)), extraData);
     }
 
     function test_Constructor_AllowsIndependentBondAmounts() public {

--- a/pkg/contracts/test/dispute/MultiProofGame.t.sol
+++ b/pkg/contracts/test/dispute/MultiProofGame.t.sol
@@ -34,8 +34,7 @@ contract MultiProofGameTest is OPStackFixtures {
         MultiProofGame game = _proposeAtAnchor();
         uint256 target = STARTING_ANCHOR_BLOCK + BLOCK_INTERVAL;
 
-        assertEq(game.gameCreator(), creationKeeper);
-        assertEq(game.bondProposer(), proposer);
+        assertEq(game.gameCreator(), proposer);
         assertEq(Claim.unwrap(game.rootClaim()), _rootClaimFor(target));
         assertEq(game.l2SequenceNumber(), target);
         assertEq(game.parentRef(), address(asr));
@@ -61,15 +60,13 @@ contract MultiProofGameTest is OPStackFixtures {
         Claim claim = Claim.wrap(_rootClaimFor(target));
         bytes memory shortExtraData = abi.encode(target, address(asr));
 
-        _reserve(proposer, claim, shortExtraData);
-        vm.prank(creationKeeper);
+        vm.prank(proposer);
         vm.expectRevert(BadExtraData.selector);
         dgf.create(WC_GAME_TYPE, claim, shortExtraData);
 
         uint256 malformedParent = uint256(uint160(address(asr))) | (uint256(1) << 160);
         bytes memory extraData = abi.encode(_domainHash(), target, malformedParent, uint256(0));
-        _reserve(proposer, claim, extraData);
-        vm.prank(creationKeeper);
+        vm.prank(proposer);
         vm.expectRevert(BadExtraData.selector);
         dgf.create(WC_GAME_TYPE, claim, extraData);
     }
@@ -80,8 +77,7 @@ contract MultiProofGameTest is OPStackFixtures {
 
         Claim claim = Claim.wrap(_rootClaimFor(target));
         bytes memory wrongDomainExtraData = abi.encode(wrongDomain, target, address(asr), uint256(0));
-        _reserve(proposer, claim, wrongDomainExtraData);
-        vm.prank(creationKeeper);
+        vm.prank(proposer);
         vm.expectRevert(
             abi.encodeWithSelector(IMultiProofGame.InvalidDomainHash.selector, gameImpl.domainHash(), wrongDomain)
         );
@@ -92,8 +88,7 @@ contract MultiProofGameTest is OPStackFixtures {
         for (uint256 i = 0; i < wrongTargets.length; i++) {
             Claim wrongClaim = Claim.wrap(_rootClaimFor(wrongTargets[i]));
             bytes memory wrongExtraData = _extraData(wrongTargets[i], type(uint256).max, 0);
-            _reserve(proposer, wrongClaim, wrongExtraData);
-            vm.prank(creationKeeper);
+            vm.prank(proposer);
             vm.expectRevert(
                 abi.encodeWithSelector(IMultiProofGame.InvalidL2BlockNumber.selector, target, wrongTargets[i])
             );
@@ -105,8 +100,7 @@ contract MultiProofGameTest is OPStackFixtures {
         uint256 target = STARTING_ANCHOR_BLOCK + BLOCK_INTERVAL;
         Claim claim = Claim.wrap(_rootClaimFor(target));
         bytes memory unknownParentExtraData = _extraDataForParent(target, makeAddr("unknown-parent"), 0);
-        _reserve(proposer, claim, unknownParentExtraData);
-        vm.prank(creationKeeper);
+        vm.prank(proposer);
         vm.expectRevert();
         dgf.create(WC_GAME_TYPE, claim, unknownParentExtraData);
 
@@ -117,8 +111,7 @@ contract MultiProofGameTest is OPStackFixtures {
         uint256 childTarget = parent.l2SequenceNumber() + BLOCK_INTERVAL;
         bytes memory childExtraData = _extraData(childTarget, 0, 0);
         Claim childClaim = Claim.wrap(_rootClaimFor(childTarget));
-        _reserve(proposer, childClaim, childExtraData);
-        vm.prank(creationKeeper);
+        vm.prank(proposer);
         vm.expectRevert(InvalidParentGame.selector);
         dgf.create(WC_GAME_TYPE, childClaim, childExtraData);
     }
@@ -132,8 +125,7 @@ contract MultiProofGameTest is OPStackFixtures {
         uint256 target = parent.l2SequenceNumber() + BLOCK_INTERVAL;
         bytes memory previousAnchorParentExtraData = _extraData(target, 0, 0);
         Claim claim = Claim.wrap(_rootClaimFor(target));
-        _reserve(proposer, claim, previousAnchorParentExtraData);
-        vm.prank(creationKeeper);
+        vm.prank(proposer);
         MultiProofGame previousAnchorChild =
             MultiProofGame(address(dgf.create(WC_GAME_TYPE, claim, previousAnchorParentExtraData)));
         assertEq(previousAnchorChild.parentRef(), address(parent));
@@ -151,8 +143,7 @@ contract MultiProofGameTest is OPStackFixtures {
         uint256 target = STARTING_ANCHOR_BLOCK + BLOCK_INTERVAL;
         Claim claim = Claim.wrap(keccak256("late-bootstrap-root"));
         bytes memory extraData = _extraData(target, type(uint256).max, 0);
-        _reserve(proposer, claim, extraData);
-        vm.prank(creationKeeper);
+        vm.prank(proposer);
         vm.expectRevert(InvalidParentGame.selector);
         dgf.create(WC_GAME_TYPE, claim, extraData);
     }
@@ -330,14 +321,14 @@ contract MultiProofGameTest is OPStackFixtures {
         address keeper = makeAddr("keeper");
         vm.prank(keeper);
         game.closeGame();
-        assertEq(bondVault.availableBalance(proposer), 100 * WLD_UNIT);
+        assertEq(bondVault.availableBalance(proposer), PROPOSER_BOND);
 
         (Hash anchorRoot, uint256 anchorBlock) = asr.getAnchorRoot();
         assertEq(Hash.unwrap(anchorRoot), Claim.unwrap(game.rootClaim()));
         assertEq(anchorBlock, game.l2SequenceNumber());
         assertEq(uint8(game.bondDistributionMode()), uint8(BondDistributionMode.NORMAL));
 
-        assertEq(wld.balanceOf(proposer), 0);
+        assertEq(wld.balanceOf(proposer), 100 * WLD_UNIT - PROPOSER_BOND);
         assertEq(wld.balanceOf(keeper), 0);
     }
 
@@ -346,14 +337,11 @@ contract MultiProofGameTest is OPStackFixtures {
         uint256 target = STARTING_ANCHOR_BLOCK + BLOCK_INTERVAL;
         Claim claim = Claim.wrap(_rootClaimFor(target));
         bytes memory extraData = _extraData(target, type(uint256).max, 0);
-        _reserve(proposer, claim, extraData);
-        vm.prank(creationKeeper);
+        vm.prank(proposer);
         vm.expectRevert(GamePaused.selector);
         dgf.create(WC_GAME_TYPE, claim, extraData);
 
         systemConfig.setPaused(false);
-        vm.prank(proposer);
-        bondVault.cancelProposal(claim, extraData);
         MultiProofGame game = _proposeAtAnchor();
         _resolveUnchallenged(game);
         _passAirgap(game);
@@ -392,7 +380,7 @@ contract MultiProofGameTest is OPStackFixtures {
         game.challenge();
 
         assertEq(game.challenger(), address(0));
-        assertEq(bondVault.availableBalance(challengerAccount), 100 * WLD_UNIT);
+        assertEq(wld.balanceOf(challengerAccount), 100 * WLD_UNIT);
     }
 
     function test_Challenge_DoesNotExtendProofDeadline() public {
@@ -572,8 +560,7 @@ contract MultiProofGameTest is OPStackFixtures {
         Claim claim = first.rootClaim();
         uint256 l2BlockNumber = first.l2SequenceNumber();
         bytes memory retryExtraData = _extraData(l2BlockNumber, type(uint256).max, 1);
-        _reserve(proposer, claim, retryExtraData);
-        vm.prank(creationKeeper);
+        vm.prank(proposer);
         vm.expectRevert();
         dgf.create(WC_GAME_TYPE, claim, retryExtraData);
     }
@@ -712,7 +699,7 @@ contract MultiProofGameTest is OPStackFixtures {
     /// @dev A proposer cannot recover a forfeited bond by challenging from a second address.
     function test_SelfChallenge_IsAlwaysLossMaking() public {
         address sybil = makeAddr("proposer-sybil");
-        _depositWLD(sybil, 10 * WLD_UNIT);
+        _fundWLD(sybil, 10 * WLD_UNIT);
 
         // Challenging a proofless proposal still burns part of the proposer's bond.
         MultiProofGame proofless = _proposeAtAnchor();
@@ -776,7 +763,7 @@ contract MultiProofGameTest is OPStackFixtures {
 
         _passAirgap(game);
         game.closeGame();
-        assertEq(bondVault.availableBalance(proposer), 100 * WLD_UNIT + CHALLENGER_BOND);
+        assertEq(bondVault.availableBalance(proposer), PROPOSER_BOND + CHALLENGER_BOND);
     }
 
     /// @dev Each lane recipient is independently credited in the shared vault.

--- a/pkg/contracts/test/dispute/OPStackFixtures.sol
+++ b/pkg/contracts/test/dispute/OPStackFixtures.sol
@@ -49,7 +49,6 @@ abstract contract OPStackFixtures is Test {
     address internal guardian = makeAddr("guardian");
     address internal proposer = makeAddr("proposer");
     address internal challengerAccount = makeAddr("challenger");
-    address internal creationKeeper = makeAddr("creation-keeper");
     address internal protocolFeeRecipient = makeAddr("protocol-fee-recipient");
 
     MockSystemConfig internal systemConfig;
@@ -115,8 +114,8 @@ abstract contract OPStackFixtures is Test {
         // The registry retires every game created at or before its initialization timestamp.
         vm.warp(block.timestamp + 1);
 
-        _depositWLD(proposer, 100 * WLD_UNIT);
-        _depositWLD(challengerAccount, 100 * WLD_UNIT);
+        _fundWLD(proposer, 100 * WLD_UNIT);
+        _fundWLD(challengerAccount, 100 * WLD_UNIT);
     }
 
     /// @dev Address of the implementation most recently deployed by `_proxied`.
@@ -179,29 +178,22 @@ abstract contract OPStackFixtures is Test {
         return keccak256(abi.encode("output-root", l2BlockNumber));
     }
 
-    function _depositWLD(address account, uint256 amount) internal {
+    /// @dev Mints WLD to `account` and approves the vault to pull bonds from it.
+    function _fundWLD(address account, uint256 amount) internal {
         wld.mint(account, amount);
-        vm.startPrank(account);
-        wld.approve(address(bondVault), amount);
-        bondVault.deposit(amount);
-        vm.stopPrank();
-    }
-
-    function _reserve(address account, Claim rootClaim, bytes memory extraData) internal {
         vm.prank(account);
-        bondVault.reserveProposal(rootClaim, extraData);
+        wld.approve(address(bondVault), type(uint256).max);
     }
 
-    /// @dev Reserves as `proposer`, then creates through the stock factory as a keeper.
+    /// @dev Creates through the stock factory as `proposer`; the vault pulls the bond from
+    ///      the creator's allowance during `initialize`.
     function _propose(uint256 parentIndex, bytes32 rootClaim, uint256 l2BlockNumber, uint256 attempt)
         internal
         returns (MultiProofGame)
     {
         bytes memory extraData = _extraData(l2BlockNumber, parentIndex, attempt);
-        Claim claim = Claim.wrap(rootClaim);
-        _reserve(proposer, claim, extraData);
-        vm.prank(creationKeeper);
-        IDisputeGame proxy = dgf.create(WC_GAME_TYPE, claim, extraData);
+        vm.prank(proposer);
+        IDisputeGame proxy = dgf.create(WC_GAME_TYPE, Claim.wrap(rootClaim), extraData);
         return MultiProofGame(address(proxy));
     }
 
@@ -212,10 +204,8 @@ abstract contract OPStackFixtures is Test {
         IDisputeGame anchorGame = asr.anchorGame();
         address parent = address(anchorGame) == address(0) ? address(asr) : address(anchorGame);
         bytes memory extraData = _extraDataForParent(target, parent, 0);
-        Claim claim = Claim.wrap(_rootClaimFor(target));
-        _reserve(proposer, claim, extraData);
-        vm.prank(creationKeeper);
-        IDisputeGame proxy = dgf.create(WC_GAME_TYPE, claim, extraData);
+        vm.prank(proposer);
+        IDisputeGame proxy = dgf.create(WC_GAME_TYPE, Claim.wrap(_rootClaimFor(target)), extraData);
         return MultiProofGame(address(proxy));
     }
 

--- a/pkg/contracts/test/dispute/OPStackFixtures.sol
+++ b/pkg/contracts/test/dispute/OPStackFixtures.sol
@@ -178,15 +178,17 @@ abstract contract OPStackFixtures is Test {
         return keccak256(abi.encode("output-root", l2BlockNumber));
     }
 
-    /// @dev Mints WLD to `account` and approves the vault to pull bonds from it.
+    /// @dev Mints WLD to `account` and deposits it into the vault with no remaining allowance.
     function _fundWLD(address account, uint256 amount) internal {
         wld.mint(account, amount);
         vm.prank(account);
-        wld.approve(address(bondVault), type(uint256).max);
+        wld.approve(address(bondVault), amount);
+        vm.prank(account);
+        bondVault.deposit(amount);
     }
 
-    /// @dev Creates through the stock factory as `proposer`; the vault pulls the bond from
-    ///      the creator's allowance during `initialize`.
+    /// @dev Creates through the stock factory as `proposer`; the vault locks the bond from
+    ///      the creator's available balance during `initialize`.
     function _propose(uint256 parentIndex, bytes32 rootClaim, uint256 l2BlockNumber, uint256 attempt)
         internal
         returns (MultiProofGame)

--- a/pkg/contracts/test/dispute/WLDStakingVault.t.sol
+++ b/pkg/contracts/test/dispute/WLDStakingVault.t.sol
@@ -60,8 +60,8 @@ contract ImpersonatingGameHarness {
         return 1e18;
     }
 
-    function pull() external {
-        VAULT.pullProposerBond();
+    function lock() external {
+        VAULT.lockProposerBond();
     }
 }
 
@@ -83,13 +83,67 @@ contract WLDStakingVaultAccountingTest is OPStackFixtures {
         vault.initialize(wld, ISystemConfig(address(systemConfig)), dgf);
     }
 
-    function test_Create_PullsProposerBondFromCreatorAllowance() public {
+    function test_DepositAndDepositForCreditAvailableBalances() public {
+        address funder = makeAddr("funder");
+        address beneficiary = makeAddr("beneficiary");
+        uint256 amount = 3 * WLD_UNIT;
+        wld.mint(funder, amount);
+
+        vm.prank(funder);
+        wld.approve(address(bondVault), amount);
+        vm.prank(funder);
+        bondVault.deposit(WLD_UNIT);
+        vm.prank(funder);
+        bondVault.depositFor(beneficiary, 2 * WLD_UNIT);
+
+        assertEq(bondVault.availableBalance(funder), WLD_UNIT);
+        assertEq(bondVault.availableBalance(beneficiary), 2 * WLD_UNIT);
+        assertEq(wld.allowance(funder, address(bondVault)), 0);
+        assertEq(wld.balanceOf(funder), 0);
+        assertEq(wld.balanceOf(address(bondVault)), 203 * WLD_UNIT);
+        assertEq(bondVault.totalLiabilities(), 203 * WLD_UNIT);
+    }
+
+    function test_DepositForRejectsZeroAccount() public {
+        vm.prank(proposer);
+        vm.expectRevert(IWLDStakingVault.InvalidAccount.selector);
+        bondVault.depositFor(address(0), WLD_UNIT);
+    }
+
+    function test_DepositRejectsZeroAmount() public {
+        vm.prank(proposer);
+        vm.expectRevert(IWLDStakingVault.InvalidAmount.selector);
+        bondVault.deposit(0);
+    }
+
+    function test_PauseAllowsDepositsAndWithdrawalRequests() public {
+        address funder = makeAddr("paused-funder");
+        address beneficiary = makeAddr("paused-beneficiary");
+        wld.mint(funder, WLD_UNIT);
+        vm.prank(funder);
+        wld.approve(address(bondVault), WLD_UNIT);
+        systemConfig.setPaused(true);
+
+        vm.prank(funder);
+        bondVault.depositFor(beneficiary, WLD_UNIT);
+        vm.prank(proposer);
+        bondVault.requestWithdrawal(WLD_UNIT);
+
+        assertEq(bondVault.availableBalance(beneficiary), WLD_UNIT);
+        assertEq(bondVault.availableBalance(proposer), 99 * WLD_UNIT);
+        (uint256 pending,) = bondVault.withdrawals(proposer);
+        assertEq(pending, WLD_UNIT);
+    }
+
+    function test_Create_LocksProposerBondFromAvailableBalance() public {
         MultiProofGame game = _proposeAtAnchor();
 
         assertEq(game.gameCreator(), proposer);
-        assertEq(wld.balanceOf(proposer), 100 * WLD_UNIT - PROPOSER_BOND);
-        assertEq(wld.balanceOf(address(bondVault)), PROPOSER_BOND);
-        assertEq(bondVault.totalLiabilities(), PROPOSER_BOND);
+        assertEq(bondVault.availableBalance(proposer), 99 * WLD_UNIT);
+        assertEq(wld.balanceOf(proposer), 0);
+        assertEq(wld.allowance(proposer, address(bondVault)), 0);
+        assertEq(wld.balanceOf(address(bondVault)), 200 * WLD_UNIT);
+        assertEq(bondVault.totalLiabilities(), 200 * WLD_UNIT);
         assertTrue(bondVault.isSolvent());
 
         (uint256 proposerBond_, uint256 challengerBond_, bool settled_) = bondVault.gameBonds(address(game));
@@ -98,16 +152,20 @@ contract WLDStakingVaultAccountingTest is OPStackFixtures {
         assertFalse(settled_);
     }
 
-    function test_Create_RevertsWithoutAllowance() public {
-        address unapproved = makeAddr("unapproved-proposer");
-        wld.mint(unapproved, PROPOSER_BOND);
+    function test_Create_RevertsWithoutAvailableBalance() public {
+        address unfunded = makeAddr("unfunded-proposer");
+        wld.mint(unfunded, PROPOSER_BOND);
+        vm.prank(unfunded);
+        wld.approve(address(bondVault), PROPOSER_BOND);
 
         uint256 target = STARTING_ANCHOR_BLOCK + BLOCK_INTERVAL;
         Claim claim = Claim.wrap(_rootClaimFor(target));
         bytes memory extraData = _extraData(target, type(uint256).max, 0);
 
-        vm.prank(unapproved);
-        vm.expectRevert();
+        vm.prank(unfunded);
+        vm.expectRevert(
+            abi.encodeWithSelector(IWLDStakingVault.InsufficientBalance.selector, unfunded, 0, PROPOSER_BOND)
+        );
         dgf.create(WC_GAME_TYPE, claim, extraData);
     }
 
@@ -136,21 +194,21 @@ contract WLDStakingVaultAccountingTest is OPStackFixtures {
         dgf.create(WC_GAME_TYPE, claim, extraData);
     }
 
-    function test_PullProposerBond_RejectsNonFactoryClone() public {
+    function test_LockProposerBond_RejectsNonFactoryClone() public {
         ImpersonatingGameHarness impersonator = new ImpersonatingGameHarness(dgf, bondVault, proposer);
 
         vm.expectRevert();
-        impersonator.pull();
-        assertEq(wld.balanceOf(proposer), 100 * WLD_UNIT);
-        assertEq(bondVault.totalLiabilities(), 0);
+        impersonator.lock();
+        assertEq(bondVault.availableBalance(proposer), 100 * WLD_UNIT);
+        assertEq(bondVault.totalLiabilities(), 200 * WLD_UNIT);
     }
 
-    function test_PullChallengerBond_RejectsUnregisteredGame() public {
+    function test_LockChallengerBond_RejectsUnregisteredGame() public {
         UnregisteredGameHarness game = new UnregisteredGameHarness();
 
         vm.prank(address(game));
         vm.expectRevert(abi.encodeWithSelector(IWLDStakingVault.GameNotRegistered.selector, address(game)));
-        bondVault.pullChallengerBond();
+        bondVault.lockChallengerBond();
     }
 
     function test_Settlement_DelayedWithdrawalKeepsExactLiabilities() public {
@@ -159,21 +217,22 @@ contract WLDStakingVaultAccountingTest is OPStackFixtures {
         _passAirgap(game);
         game.closeGame();
 
-        assertEq(bondVault.availableBalance(proposer), PROPOSER_BOND);
-        assertEq(bondVault.totalLiabilities(), PROPOSER_BOND);
+        assertEq(bondVault.availableBalance(proposer), 100 * WLD_UNIT);
+        assertEq(bondVault.totalLiabilities(), 200 * WLD_UNIT);
         assertTrue(bondVault.isSolvent());
 
         vm.prank(proposer);
         bondVault.requestWithdrawal(PROPOSER_BOND);
-        assertEq(bondVault.availableBalance(proposer), 0);
-        assertEq(bondVault.totalLiabilities(), PROPOSER_BOND);
+        assertEq(bondVault.availableBalance(proposer), 99 * WLD_UNIT);
+        assertEq(bondVault.totalLiabilities(), 200 * WLD_UNIT);
 
         vm.warp(block.timestamp + WLD_WITHDRAWAL_DELAY_SECONDS);
         vm.prank(proposer);
         bondVault.withdraw(PROPOSER_BOND);
 
-        assertEq(wld.balanceOf(proposer), 100 * WLD_UNIT);
-        assertEq(bondVault.totalLiabilities(), 0);
+        assertEq(wld.balanceOf(proposer), PROPOSER_BOND);
+        assertEq(bondVault.availableBalance(proposer), 99 * WLD_UNIT);
+        assertEq(bondVault.totalLiabilities(), 199 * WLD_UNIT);
         assertTrue(bondVault.isSolvent());
     }
 
@@ -223,7 +282,23 @@ contract WLDStakingVaultAccountingTest is OPStackFixtures {
 
         (,, bool settled) = bondVault.gameBonds(address(game));
         assertTrue(settled);
-        assertEq(bondVault.availableBalance(proposer), PROPOSER_BOND);
+        assertEq(bondVault.availableBalance(proposer), 100 * WLD_UNIT);
+    }
+
+    function test_SettledBondIsImmediatelyReusableForNextProposal() public {
+        MultiProofGame first = _proposeAtAnchor();
+        _resolveUnchallenged(first);
+        _passAirgap(first);
+        first.closeGame();
+
+        MultiProofGame second = _proposeChild(0);
+
+        assertEq(bondVault.availableBalance(proposer), 99 * WLD_UNIT);
+        assertEq(wld.balanceOf(proposer), 0);
+        assertEq(wld.allowance(proposer, address(bondVault)), 0);
+        (uint256 proposerBond_,,) = bondVault.gameBonds(address(second));
+        assertEq(proposerBond_, PROPOSER_BOND);
+        assertEq(bondVault.totalLiabilities(), 200 * WLD_UNIT);
     }
 
     function test_BreakGlassHoldAndRecoverMirrorDelayedWETHTrust() public {
@@ -233,13 +308,13 @@ contract WLDStakingVaultAccountingTest is OPStackFixtures {
         game.closeGame();
 
         bondVault.hold(proposer, PROPOSER_BOND);
-        assertEq(bondVault.availableBalance(proposer), 0);
+        assertEq(bondVault.availableBalance(proposer), 99 * WLD_UNIT);
         assertEq(bondVault.availableBalance(address(this)), PROPOSER_BOND);
         assertTrue(bondVault.isSolvent());
 
         bondVault.recover(PROPOSER_BOND);
         assertFalse(bondVault.isSolvent());
-        assertEq(bondVault.totalLiabilities(), PROPOSER_BOND);
+        assertEq(bondVault.totalLiabilities(), 200 * WLD_UNIT);
     }
 
     function test_BreakGlassHoldAndRecoverRejectUnauthorizedCaller() public {
@@ -257,8 +332,8 @@ contract WLDStakingVaultAccountingTest is OPStackFixtures {
     function test_DirectDonationCreatesSurplusWithoutChangingLiabilities() public {
         wld.mint(address(bondVault), 5 * WLD_UNIT);
 
-        assertEq(wld.balanceOf(address(bondVault)), 5 * WLD_UNIT);
-        assertEq(bondVault.totalLiabilities(), 0);
+        assertEq(wld.balanceOf(address(bondVault)), 205 * WLD_UNIT);
+        assertEq(bondVault.totalLiabilities(), 200 * WLD_UNIT);
         assertTrue(bondVault.isSolvent());
     }
 
@@ -273,10 +348,10 @@ contract WLDStakingVaultAccountingTest is OPStackFixtures {
 
         _passAirgap(game);
         game.closeGame();
-        assertEq(bondVault.totalLiabilities(), PROPOSER_BOND + CHALLENGER_BOND);
+        assertEq(bondVault.totalLiabilities(), 200 * WLD_UNIT);
 
         MultiProofGame next = _proposeChild(0);
-        assertEq(bondVault.totalLiabilities(), 2 * PROPOSER_BOND + CHALLENGER_BOND);
+        assertEq(bondVault.totalLiabilities(), 200 * WLD_UNIT);
         (uint256 proposerBond_,,) = bondVault.gameBonds(address(next));
         assertEq(proposerBond_, PROPOSER_BOND);
     }
@@ -293,8 +368,8 @@ contract WLDStakingVaultAccountingTest is OPStackFixtures {
         _passAirgap(game);
         game.closeGame();
 
-        assertEq(bondVault.availableBalance(proposer), PROPOSER_BOND + CHALLENGER_BOND);
-        assertEq(bondVault.totalLiabilities(), PROPOSER_BOND + CHALLENGER_BOND);
+        assertEq(bondVault.availableBalance(proposer), 100 * WLD_UNIT);
+        assertEq(bondVault.totalLiabilities(), 200 * WLD_UNIT);
     }
 
     function test_Settle_RejectsUnregisteredGame() public {

--- a/pkg/contracts/test/dispute/WLDStakingVault.t.sol
+++ b/pkg/contracts/test/dispute/WLDStakingVault.t.sol
@@ -5,15 +5,63 @@ import {OPStackFixtures} from "./OPStackFixtures.sol";
 import {MultiProofGame} from "../../src/dispute/MultiProofGame.sol";
 import {WLDStakingVault} from "../../src/dispute/WLDStakingVault.sol";
 import {IWLDStakingVault} from "../../src/dispute/interfaces/IWLDStakingVault.sol";
+import {IDisputeGameFactory} from "@optimism-bedrock/interfaces/dispute/IDisputeGameFactory.sol";
 import {GameTypes} from "../../src/dispute/lib/GameTypes.sol";
 
 import {Claim, GameType, Hash} from "@optimism-bedrock/src/dispute/lib/Types.sol";
+import {IncorrectBondAmount} from "@optimism-bedrock/src/dispute/lib/Errors.sol";
 import {IDisputeGame} from "@optimism-bedrock/interfaces/dispute/IDisputeGame.sol";
 import {ISystemConfig} from "@optimism-bedrock/interfaces/L1/ISystemConfig.sol";
 
 contract UnregisteredGameHarness {
     function gameData() external pure returns (GameType, Claim, bytes memory) {
         return (GameTypes.MULTI_PROOF_GAME_TYPE, Claim.wrap(bytes32(uint256(1))), hex"");
+    }
+}
+
+/// @dev Mimics a mid-creation game's surface but was not deployed by the factory, so it cannot
+///      occupy the deterministic clone address the vault recomputes.
+contract ImpersonatingGameHarness {
+    IDisputeGameFactory internal immutable FACTORY;
+    IWLDStakingVault internal immutable VAULT;
+    address internal immutable VICTIM;
+
+    constructor(IDisputeGameFactory factory, IWLDStakingVault vault, address victim) {
+        FACTORY = factory;
+        VAULT = vault;
+        VICTIM = victim;
+    }
+
+    function gameType() external pure returns (GameType) {
+        return GameTypes.MULTI_PROOF_GAME_TYPE;
+    }
+
+    function disputeGameFactory() external view returns (IDisputeGameFactory) {
+        return FACTORY;
+    }
+
+    function bondVault() external view returns (IWLDStakingVault) {
+        return VAULT;
+    }
+
+    function gameData() external pure returns (GameType, Claim, bytes memory) {
+        return (GameTypes.MULTI_PROOF_GAME_TYPE, Claim.wrap(bytes32(uint256(1))), hex"");
+    }
+
+    function gameCreator() external view returns (address) {
+        return VICTIM;
+    }
+
+    function l1Head() external pure returns (Hash) {
+        return Hash.wrap(bytes32(0));
+    }
+
+    function proposerBond() external pure returns (uint256) {
+        return 1e18;
+    }
+
+    function pull() external {
+        VAULT.pullProposerBond();
     }
 }
 
@@ -35,92 +83,133 @@ contract WLDStakingVaultAccountingTest is OPStackFixtures {
         vault.initialize(wld, ISystemConfig(address(systemConfig)), dgf);
     }
 
-    function test_DepositAndDelayedWithdrawalKeepExactLiabilities() public {
-        vm.prank(proposer);
-        bondVault.requestWithdrawal(40 * WLD_UNIT);
+    function test_Create_PullsProposerBondFromCreatorAllowance() public {
+        MultiProofGame game = _proposeAtAnchor();
 
-        assertEq(bondVault.availableBalance(proposer), 60 * WLD_UNIT);
-        assertEq(bondVault.totalLiabilities(), 200 * WLD_UNIT);
+        assertEq(game.gameCreator(), proposer);
+        assertEq(wld.balanceOf(proposer), 100 * WLD_UNIT - PROPOSER_BOND);
+        assertEq(wld.balanceOf(address(bondVault)), PROPOSER_BOND);
+        assertEq(bondVault.totalLiabilities(), PROPOSER_BOND);
         assertTrue(bondVault.isSolvent());
+
+        (uint256 proposerBond_, uint256 challengerBond_, bool settled_) = bondVault.gameBonds(address(game));
+        assertEq(proposerBond_, PROPOSER_BOND);
+        assertEq(challengerBond_, 0);
+        assertFalse(settled_);
+    }
+
+    function test_Create_RevertsWithoutAllowance() public {
+        address unapproved = makeAddr("unapproved-proposer");
+        wld.mint(unapproved, PROPOSER_BOND);
+
+        uint256 target = STARTING_ANCHOR_BLOCK + BLOCK_INTERVAL;
+        Claim claim = Claim.wrap(_rootClaimFor(target));
+        bytes memory extraData = _extraData(target, type(uint256).max, 0);
+
+        vm.prank(unapproved);
+        vm.expectRevert();
+        dgf.create(WC_GAME_TYPE, claim, extraData);
+    }
+
+    function test_Create_RejectsNonzeroFactoryEthBond() public {
+        dgf.setInitBond(WC_GAME_TYPE, 1);
+        uint256 target = STARTING_ANCHOR_BLOCK + BLOCK_INTERVAL;
+        Claim claim = Claim.wrap(_rootClaimFor(target));
+        bytes memory extraData = _extraData(target, type(uint256).max, 0);
+
+        vm.deal(proposer, 1);
+        vm.prank(proposer);
+        vm.expectRevert(IncorrectBondAmount.selector);
+        dgf.create{value: 1}(WC_GAME_TYPE, claim, extraData);
+    }
+
+    function test_Create_RejectsDivergedFactoryAndVaultOwners() public {
+        address newFactoryOwner = makeAddr("new-factory-owner");
+        dgf.transferOwnership(newFactoryOwner);
+
+        uint256 target = STARTING_ANCHOR_BLOCK + BLOCK_INTERVAL;
+        Claim claim = Claim.wrap(_rootClaimFor(target));
+        bytes memory extraData = _extraData(target, type(uint256).max, 0);
+
+        vm.prank(proposer);
+        vm.expectRevert(abi.encodeWithSelector(IWLDStakingVault.OwnerMismatch.selector, newFactoryOwner, address(this)));
+        dgf.create(WC_GAME_TYPE, claim, extraData);
+    }
+
+    function test_PullProposerBond_RejectsNonFactoryClone() public {
+        ImpersonatingGameHarness impersonator = new ImpersonatingGameHarness(dgf, bondVault, proposer);
+
+        vm.expectRevert();
+        impersonator.pull();
+        assertEq(wld.balanceOf(proposer), 100 * WLD_UNIT);
+        assertEq(bondVault.totalLiabilities(), 0);
+    }
+
+    function test_PullChallengerBond_RejectsUnregisteredGame() public {
+        UnregisteredGameHarness game = new UnregisteredGameHarness();
+
+        vm.prank(address(game));
+        vm.expectRevert(abi.encodeWithSelector(IWLDStakingVault.GameNotRegistered.selector, address(game)));
+        bondVault.pullChallengerBond();
+    }
+
+    function test_Settlement_DelayedWithdrawalKeepsExactLiabilities() public {
+        MultiProofGame game = _proposeAtAnchor();
+        _resolveUnchallenged(game);
+        _passAirgap(game);
+        game.closeGame();
+
+        assertEq(bondVault.availableBalance(proposer), PROPOSER_BOND);
+        assertEq(bondVault.totalLiabilities(), PROPOSER_BOND);
+        assertTrue(bondVault.isSolvent());
+
+        vm.prank(proposer);
+        bondVault.requestWithdrawal(PROPOSER_BOND);
+        assertEq(bondVault.availableBalance(proposer), 0);
+        assertEq(bondVault.totalLiabilities(), PROPOSER_BOND);
 
         vm.warp(block.timestamp + WLD_WITHDRAWAL_DELAY_SECONDS);
         vm.prank(proposer);
-        bondVault.withdraw(40 * WLD_UNIT);
+        bondVault.withdraw(PROPOSER_BOND);
 
-        assertEq(wld.balanceOf(proposer), 40 * WLD_UNIT);
-        assertEq(bondVault.totalLiabilities(), 160 * WLD_UNIT);
+        assertEq(wld.balanceOf(proposer), 100 * WLD_UNIT);
+        assertEq(bondVault.totalLiabilities(), 0);
         assertTrue(bondVault.isSolvent());
     }
 
-    function test_ReserveAndCreate_BindsBondProposerRatherThanFactoryCaller() public {
-        uint256 target = STARTING_ANCHOR_BLOCK + BLOCK_INTERVAL;
-        Claim claim = Claim.wrap(_rootClaimFor(target));
-        bytes memory extraData = _extraData(target, type(uint256).max, 0);
+    function test_WithdrawalRequestResetsDelayAndPauseOnlyBlocksTransfer() public {
+        MultiProofGame game = _proposeAtAnchor();
+        _resolveUnchallenged(game);
+        _passAirgap(game);
+        game.closeGame();
 
         vm.prank(proposer);
-        MultiProofGame game = MultiProofGame(address(bondVault.reserveAndCreate(claim, extraData)));
-
-        assertEq(game.gameCreator(), address(bondVault));
-        assertEq(game.bondProposer(), proposer);
-        assertEq(bondVault.availableBalance(proposer), 100 * WLD_UNIT - PROPOSER_BOND);
-    }
-
-    function test_Reservation_CanBeCreatedByPermissionlessKeeper() public {
-        uint256 target = STARTING_ANCHOR_BLOCK + BLOCK_INTERVAL;
-        Claim claim = Claim.wrap(_rootClaimFor(target));
-        bytes memory extraData = _extraData(target, type(uint256).max, 0);
-        _reserve(proposer, claim, extraData);
-
-        address keeper = makeAddr("permissionless-keeper");
-        vm.prank(keeper);
-        MultiProofGame game = MultiProofGame(address(dgf.create(WC_GAME_TYPE, claim, extraData)));
-
-        assertEq(game.gameCreator(), keeper);
-        assertEq(game.bondProposer(), proposer);
-    }
-
-    function test_Reservation_RequiresZeroFactoryEthBond() public {
-        dgf.setInitBond(WC_GAME_TYPE, 1);
-        uint256 target = STARTING_ANCHOR_BLOCK + BLOCK_INTERVAL;
+        bondVault.requestWithdrawal(PROPOSER_BOND / 2);
+        vm.warp(block.timestamp + WLD_WITHDRAWAL_DELAY_SECONDS - 1);
 
         vm.prank(proposer);
-        vm.expectRevert(abi.encodeWithSelector(IWLDStakingVault.FactoryBondMustBeZero.selector, 1));
-        bondVault.reserveProposal(Claim.wrap(_rootClaimFor(target)), _extraData(target, type(uint256).max, 0));
-    }
-
-    function test_Reservation_CancelRefundsOnlyBeforeCreation() public {
-        uint256 target = STARTING_ANCHOR_BLOCK + BLOCK_INTERVAL;
-        Claim claim = Claim.wrap(_rootClaimFor(target));
-        bytes memory extraData = _extraData(target, type(uint256).max, 0);
-        _reserve(proposer, claim, extraData);
-
-        vm.prank(challengerAccount);
+        bondVault.requestWithdrawal(PROPOSER_BOND / 4);
+        (, uint256 resetAt) = bondVault.withdrawals(proposer);
+        vm.warp(block.timestamp + 1);
+        vm.prank(proposer);
         vm.expectRevert(
-            abi.encodeWithSelector(IWLDStakingVault.NotReservedProposer.selector, challengerAccount, proposer)
+            abi.encodeWithSelector(
+                IWLDStakingVault.WithdrawalDelayNotMet.selector, resetAt + WLD_WITHDRAWAL_DELAY_SECONDS
+            )
         );
-        bondVault.cancelProposal(claim, extraData);
+        bondVault.withdraw(PROPOSER_BOND / 4);
 
+        vm.warp(block.timestamp + WLD_WITHDRAWAL_DELAY_SECONDS - 1);
+        systemConfig.setPaused(true);
         vm.prank(proposer);
-        bondVault.cancelProposal(claim, extraData);
-        assertEq(bondVault.availableBalance(proposer), 100 * WLD_UNIT);
-    }
+        vm.expectRevert(IWLDStakingVault.WithdrawalPaused.selector);
+        bondVault.withdraw(PROPOSER_BOND / 4);
 
-    function test_Reservation_ImplReplacementMakesReservationStaleAndRefundable() public {
-        uint256 target = STARTING_ANCHOR_BLOCK + BLOCK_INTERVAL;
-        Claim claim = Claim.wrap(_rootClaimFor(target));
-        bytes memory extraData = _extraData(target, type(uint256).max, 0);
-        Hash uuid = dgf.getGameUUID(WC_GAME_TYPE, claim, extraData);
-        _reserve(proposer, claim, extraData);
-
-        MultiProofGame replacement = new MultiProofGame(_gameConfig());
-        dgf.setImplementation(WC_GAME_TYPE, IDisputeGame(address(replacement)), hex"");
-
-        vm.prank(creationKeeper);
-        vm.expectRevert(abi.encodeWithSelector(IWLDStakingVault.StaleReservation.selector, uuid));
-        dgf.create(WC_GAME_TYPE, claim, extraData);
-
-        bondVault.invalidateStaleProposal(claim, extraData);
-        assertEq(bondVault.availableBalance(proposer), 100 * WLD_UNIT);
+        systemConfig.setPaused(false);
+        vm.prank(proposer);
+        bondVault.withdraw(PROPOSER_BOND / 4);
+        (uint256 pending,) = bondVault.withdrawals(proposer);
+        assertEq(pending, PROPOSER_BOND / 2);
     }
 
     function test_RegisteredOldImplementationCanSettleAfterReplacement() public {
@@ -134,48 +223,23 @@ contract WLDStakingVaultAccountingTest is OPStackFixtures {
 
         (,, bool settled) = bondVault.gameBonds(address(game));
         assertTrue(settled);
-        assertEq(bondVault.availableBalance(proposer), 100 * WLD_UNIT);
-    }
-
-    function test_WithdrawalRequestResetsDelayAndPauseOnlyBlocksTransfer() public {
-        vm.prank(proposer);
-        bondVault.requestWithdrawal(10 * WLD_UNIT);
-        vm.warp(block.timestamp + WLD_WITHDRAWAL_DELAY_SECONDS - 1);
-
-        vm.prank(proposer);
-        bondVault.requestWithdrawal(5 * WLD_UNIT);
-        (, uint256 resetAt) = bondVault.withdrawals(proposer);
-        vm.warp(block.timestamp + 1);
-        vm.prank(proposer);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IWLDStakingVault.WithdrawalDelayNotMet.selector, resetAt + WLD_WITHDRAWAL_DELAY_SECONDS
-            )
-        );
-        bondVault.withdraw(WLD_UNIT);
-
-        vm.warp(block.timestamp + WLD_WITHDRAWAL_DELAY_SECONDS - 1);
-        systemConfig.setPaused(true);
-        vm.prank(proposer);
-        vm.expectRevert(IWLDStakingVault.WithdrawalPaused.selector);
-        bondVault.withdraw(WLD_UNIT);
-
-        systemConfig.setPaused(false);
-        vm.prank(proposer);
-        bondVault.withdraw(WLD_UNIT);
-        (uint256 pending,) = bondVault.withdrawals(proposer);
-        assertEq(pending, 14 * WLD_UNIT);
+        assertEq(bondVault.availableBalance(proposer), PROPOSER_BOND);
     }
 
     function test_BreakGlassHoldAndRecoverMirrorDelayedWETHTrust() public {
-        bondVault.hold(proposer, 25 * WLD_UNIT);
-        assertEq(bondVault.availableBalance(proposer), 75 * WLD_UNIT);
-        assertEq(bondVault.availableBalance(address(this)), 25 * WLD_UNIT);
+        MultiProofGame game = _proposeAtAnchor();
+        _resolveUnchallenged(game);
+        _passAirgap(game);
+        game.closeGame();
+
+        bondVault.hold(proposer, PROPOSER_BOND);
+        assertEq(bondVault.availableBalance(proposer), 0);
+        assertEq(bondVault.availableBalance(address(this)), PROPOSER_BOND);
         assertTrue(bondVault.isSolvent());
 
-        bondVault.recover(WLD_UNIT);
+        bondVault.recover(PROPOSER_BOND);
         assertFalse(bondVault.isSolvent());
-        assertEq(bondVault.totalLiabilities(), 200 * WLD_UNIT);
+        assertEq(bondVault.totalLiabilities(), PROPOSER_BOND);
     }
 
     function test_BreakGlassHoldAndRecoverRejectUnauthorizedCaller() public {
@@ -193,12 +257,12 @@ contract WLDStakingVaultAccountingTest is OPStackFixtures {
     function test_DirectDonationCreatesSurplusWithoutChangingLiabilities() public {
         wld.mint(address(bondVault), 5 * WLD_UNIT);
 
-        assertEq(wld.balanceOf(address(bondVault)), 205 * WLD_UNIT);
-        assertEq(bondVault.totalLiabilities(), 200 * WLD_UNIT);
+        assertEq(wld.balanceOf(address(bondVault)), 5 * WLD_UNIT);
+        assertEq(bondVault.totalLiabilities(), 0);
         assertTrue(bondVault.isSolvent());
     }
 
-    function test_InsolvencyDoesNotBlockInternalSettlementOrReservation() public {
+    function test_InsolvencyDoesNotBlockInternalSettlementOrCreation() public {
         MultiProofGame game = _proposeAtAnchor();
         _challenge(game);
         _submitLanes(game, PROOF_THRESHOLD);
@@ -209,12 +273,12 @@ contract WLDStakingVaultAccountingTest is OPStackFixtures {
 
         _passAirgap(game);
         game.closeGame();
-        assertEq(bondVault.totalLiabilities(), 200 * WLD_UNIT);
+        assertEq(bondVault.totalLiabilities(), PROPOSER_BOND + CHALLENGER_BOND);
 
-        (, uint256 anchorBlock) = asr.getAnchorRoot();
-        uint256 target = anchorBlock + BLOCK_INTERVAL;
-        _reserve(proposer, Claim.wrap(_rootClaimFor(target)), _extraDataForParent(target, address(game), 0));
-        assertEq(bondVault.totalLiabilities(), 200 * WLD_UNIT);
+        MultiProofGame next = _proposeChild(0);
+        assertEq(bondVault.totalLiabilities(), 2 * PROPOSER_BOND + CHALLENGER_BOND);
+        (uint256 proposerBond_,,) = bondVault.gameBonds(address(next));
+        assertEq(proposerBond_, PROPOSER_BOND);
     }
 
     function test_OverlappingParticipantRolesSettleOnceAndConserveLiabilities() public {
@@ -229,8 +293,8 @@ contract WLDStakingVaultAccountingTest is OPStackFixtures {
         _passAirgap(game);
         game.closeGame();
 
-        assertEq(bondVault.availableBalance(proposer), 100 * WLD_UNIT);
-        assertEq(bondVault.totalLiabilities(), 200 * WLD_UNIT);
+        assertEq(bondVault.availableBalance(proposer), PROPOSER_BOND + CHALLENGER_BOND);
+        assertEq(bondVault.totalLiabilities(), PROPOSER_BOND + CHALLENGER_BOND);
     }
 
     function test_Settle_RejectsUnregisteredGame() public {

--- a/wips/wip-1006.md
+++ b/wips/wip-1006.md
@@ -52,8 +52,8 @@ requires activating a new game implementation; existing games retain their origi
 | `BLOCK_INTERVAL` | TBD | Exact distance each proposal MUST advance from its parent. |
 | `CHALLENGE_PERIOD` | `1 day` | Duration after proposal creation during which any participant MAY challenge a root and any party MAY submit the initial proof. Per-proposal `challengeDeadline = createdAt + CHALLENGE_PERIOD`. |
 | `PROOF_PERIOD` | `7 days` | Duration after proposal creation during which the proposer MAY defend a challenged root by accumulating lane submissions toward `PROOF_THRESHOLD`. Per-proposal `proofDeadline = createdAt + PROOF_PERIOD`. `PROOF_PERIOD` MUST be greater than `CHALLENGE_PERIOD`. A challenged root that the proposer has not defended to `PROOF_THRESHOLD` by `proofDeadline` MUST be invalidated. |
-| `PROPOSER_BOND` | TBD | WLD reserved in `WLDStakingVault` before factory creation. Paid to the proposer after `DEFENDER_WINS`, split between the challenger and protocol after a challenged proof timeout, paid to the protocol after an unchallenged proof timeout, or refunded if the registry invalidates the game. |
-| `CHALLENGER_BOND` | TBD | WLD reserved from the challenger's available vault balance. Split between the proposer and accepted proof-lane recipients after a successful defense, returned to the challenger after proof timeout, or refunded if the registry invalidates the game. |
+| `PROPOSER_BOND` | TBD | WLD pulled into `WLDStakingVault` from the creator's allowance during factory creation. Paid to the proposer after `DEFENDER_WINS`, split between the challenger and protocol after a challenged proof timeout, paid to the protocol after an unchallenged proof timeout, or refunded if the registry invalidates the game. |
+| `CHALLENGER_BOND` | TBD | WLD pulled into `WLDStakingVault` from the challenger's allowance at challenge time. Split between the proposer and accepted proof-lane recipients after a successful defense, returned to the challenger after proof timeout, or refunded if the registry invalidates the game. |
 | `PROTOCOL_FEE_RECIPIENT` | TBD | Nonzero protocol-controlled recipient credited with the proposer bond after an unchallenged proof timeout and with the portion not paid to the challenger after a challenged proof timeout. |
 
 ### Proof Lanes
@@ -84,7 +84,7 @@ The factory UUID identifies a game, while each proof lane authenticates a statem
 | `l1OriginHash` | Factory | Previous L1 block hash captured at proposal creation. The proposer does not pass it as calldata. |
 | `l1OriginNumber` | Game | L1 block number paired with the factory-captured `l1OriginHash`. |
 
-The proposer reserves the deterministic proposal in `WLDStakingVault`, after which the proposer or any keeper calls `DisputeGameFactory.create(gameType, rootClaim, extraData)`, where:
+The proposer approves `WLDStakingVault` to transfer WLD and calls `DisputeGameFactory.create(gameType, rootClaim, extraData)`, where:
 
 ```text
 extraData = abi.encode(domainHash, l2BlockNumber, parentRef, attempt)
@@ -185,17 +185,15 @@ stateDiagram-v2
 
 A root enters the system in the `PROPOSED` state.
 
-1. The proposer deposits WLD and calls `reserveProposal(rootClaim, extraData)` or `reserveAndCreate`. The vault reserves `PROPOSER_BOND` against the stock factory UUID and binds it to the currently registered WIP-1006 implementation.
-2. The proposer or any keeper calls the stock `DisputeGameFactory.create` with zero ETH. The factory creates a clone, captures its caller as `gameCreator` and the L1 head, and calls `initialize`.
-3. The game validates the domain, parent registration and eligibility, exact L2 block interval, retry predecessor, and reservation. The vault authenticates the deterministic factory clone and assigns the reserved bond to it atomically.
-4. The game snapshots the reserving account as `bondProposer`, independently of the factory caller, and records `createdAt = block.timestamp`, `challengeDeadline = createdAt + CHALLENGE_PERIOD`, and `proofDeadline = createdAt + PROOF_PERIOD`.
+1. The proposer, holding a standing WLD approval to the vault, calls the stock `DisputeGameFactory.create` with zero ETH. The factory creates a clone, captures its caller as `gameCreator` and the L1 head, and calls `initialize`.
+2. The game validates the domain, parent registration and eligibility, exact L2 block interval, and retry predecessor, then asks the vault to pull `PROPOSER_BOND`.
+3. The factory registers a game only after `initialize` returns, so the vault authenticates the caller as the deterministic clone the factory deploys for the current implementation and the caller's creation data, then transfers `PROPOSER_BOND` from `gameCreator`. Any failure reverts the entire creation.
+4. The game records `createdAt = block.timestamp`, `challengeDeadline = createdAt + CHALLENGE_PERIOD`, and `proofDeadline = createdAt + PROOF_PERIOD`.
 5. The root remains open to challenge until `challengeDeadline`.
 
-As a convenience, `reserveAndCreate(rootClaim, extraData)` performs the reservation and stock factory creation atomically. In this path the vault is the factory caller recorded as `gameCreator`, while the account calling `reserveAndCreate` remains the economically relevant `bondProposer`.
+The account calling `create` is both `gameCreator` and the bonded proposer. Once a game is registered, it remains authorized to settle through the same singleton vault even if the factory later registers a newer implementation. Game-implementation rotations MUST reuse that vault so settled balances remain available across versions.
 
-Only one live reservation may exist per UUID. The proposer MAY cancel an uncreated reservation. If the factory implementation changes before creation, anyone MAY invalidate the stale reservation and refund the original proposer; a reservation bound to an old implementation MUST NOT fund a clone of the replacement implementation. Once a game is registered, it remains authorized to settle through the same singleton vault even if the factory later registers a newer implementation. Game-implementation rotations MUST reuse that vault so settled balances remain available across versions.
-
-The DisputeGameFactory owner and vault ProxyAdmin owner MUST remain the same governance authority. This is required because the factory owner selects implementations that may reserve challenger balances, while the ProxyAdmin owner controls the vault implementation and break-glass custody. Challenge reservation MUST fail closed if those owners diverge, and deployment and activation tooling MUST validate the invariant.
+The DisputeGameFactory owner and vault ProxyAdmin owner MUST remain the same governance authority. This is required because the factory owner selects the implementations on whose word the vault pulls participant allowances, while the ProxyAdmin owner controls the vault implementation and break-glass custody. Bond pulls MUST fail closed if those owners diverge, and deployment and activation tooling MUST validate the invariant.
 
 Proof material MUST NOT be part of factory creation or `extraData`. After the game exists, any party MAY submit a valid configured proof lane before `challengeDeadline`. Offchain services MAY choose a preferred operational lane, but the onchain protocol MUST NOT privilege one lane for the initial proof.
 
@@ -208,7 +206,7 @@ Any participant MAY challenge a proposed root before `challengeDeadline`, regard
 The challenge transaction:
 
 - MUST NOT require the caller to submit proof material.
-- MUST atomically reserve `CHALLENGER_BOND` from the caller's available WLD vault balance;
+- MUST atomically pull `CHALLENGER_BOND` from the caller's WLD allowance into the vault;
 - MUST mark the root as `CHALLENGED`.
 - MUST NOT change the `proofDeadline` derived from proposal creation.
 
@@ -297,9 +295,9 @@ Resolution assigns normal-mode credits without releasing WLD. After the stock di
 - `NORMAL` when `AnchorStateRegistry.isGameProper(game)` is true;
 - `REFUND` when the game has been blacklisted, retired, or otherwise made improper.
 
-Closing SHOULD attempt to advance the anchor but MUST treat an ineligible or stale anchor update as non-fatal. It MUST atomically settle the full game pot into the selected recipients' available vault balances, reject duplicate settlement, and preserve exact payout conservation. A recipient may reuse credited WLD immediately for another bond. External withdrawal is account-controlled and two-phase: the account requests an amount, waits the configured delay, and withdraws WLD. A new request resets the delay for the full pending amount.
+Closing SHOULD attempt to advance the anchor but MUST treat an ineligible or stale anchor update as non-fatal. It MUST atomically settle the full game pot into the selected recipients' available vault balances, reject duplicate settlement, and preserve exact payout conservation. External withdrawal is account-controlled and two-phase: the account requests an amount, waits the configured delay, and withdraws WLD. A new request resets the delay for the full pending amount.
 
-The vault MUST maintain one-to-one WLD-denominated liabilities and MUST NOT issue transferable shares or apply an exchange rate. Direct token donations MAY make assets exceed liabilities. Insolvency MUST NOT prevent internal game settlement, but an external transfer may fail until the vault is recapitalized. System pause blocks external withdrawal and does not block deposits, reservations, or withdrawal requests; game creation and closing retain their existing ASR pause checks.
+The vault MUST maintain one-to-one WLD-denominated liabilities and MUST NOT issue transferable shares or apply an exchange rate. Direct token donations MAY make assets exceed liabilities. Insolvency MUST NOT prevent internal game settlement, but an external transfer may fail until the vault is recapitalized. System pause blocks external withdrawal and does not block withdrawal requests; game creation and closing retain their existing ASR pause checks.
 
 For challenged `DEFENDER_WINS`, `CHALLENGER_BOND` MUST be split equally between the proposer and every accepted proof-lane recipient, with any integer-division remainder credited to the proposer. For challenged `PROOF_TIMEOUT`, the challenger receives its bond plus `CHALLENGER_REWARD_BPS` of `PROPOSER_BOND`; `PROTOCOL_FEE_RECIPIENT` receives the rest of `PROPOSER_BOND`. `REFUND` mode returns the full deposited bonds to their depositors instead of applying normal-mode rewards.
 
@@ -316,7 +314,7 @@ WIP-1006 is implemented as a new game type on the stock OP Stack dispute infrast
 | `IDisputeGameFactory` | Stock OP factory; registers the WIP-1006 implementation, creates clones, indexes games by UUID and list index, and captures `l1Head`. | [`DisputeGameFactory`][base-factory] |
 | `IDisputeGame` / `IMultiProofGame` | Per-proposal game; exposes the Portal-facing lifecycle and World Chain proof-lane extensions. | [`AggregateVerifier`][base-aggregate] |
 | `IAnchorStateRegistry` | Stock OP registry; evaluates registration, respect, blacklist, retirement, finality, claim validity, and the current anchor. | [`AnchorStateRegistry`][base-anchor] |
-| `IWLDStakingVault` | Reserves WIP-1006 proposal and challenge bonds, settles finalized game payouts, and enforces delayed WLD withdrawal. | [`IWLDStakingVault`](../pkg/contracts/src/dispute/interfaces/IWLDStakingVault.sol) |
+| `IWLDStakingVault` | Pulls WIP-1006 proposal and challenge bonds from participant allowances, settles finalized game payouts, and enforces delayed WLD withdrawal. | [`IWLDStakingVault`](../pkg/contracts/src/dispute/interfaces/IWLDStakingVault.sol) |
 | `IWorldChainProofVerifier` | Common interface for verifying lane proofs against a game-supplied verifier identity and game-derived public values. | [`IWorldChainProofVerifier`](../pkg/contracts/src/dispute/interfaces/IWorldChainProofVerifier.sol) |
 | `NitroEnclaveKeyRegistry` | Maintains TEE signer identities admitted through Nitro attestation. | [`NitroEnclaveKeyRegistry`](../pkg/contracts/src/dispute/nitro/NitroEnclaveKeyRegistry.sol) |
 | `SecurityCouncilVerifier` | Verifies the council Safe's ERC-1271 attestation over `rootId`. | [`SecurityCouncilVerifier`](../pkg/contracts/src/dispute/council/SecurityCouncilVerifier.sol) |
@@ -338,15 +336,15 @@ The proposal data remains aligned with the OP Stack:
 - factory identity uses the canonical `(gameType, rootClaim, extraData)` UUID;
 - `domainHash`, `l2BlockNumber`, `parentRef`, and `attempt` are encoded in `extraData`.
 
-Offchain services MUST use the vault reservation API before the stock factory creation API; `reserveAndCreate` MAY combine both calls. They do not require a custom factory or anchor registry. Proposers and defenders MAY reconstruct a selected lineage by looking up the expected transition from the current anchor; challengers use the factory index to inspect all games. A deployment MAY have its defender submit the TEE lane as the initial operational policy, but challenged games MUST still be escalated with an independent lane.
+Offchain services only need a standing WLD approval to the vault before using the stock factory creation API. They do not require a custom factory or anchor registry. Proposers and defenders MAY reconstruct a selected lineage by looking up the expected transition from the current anchor; challengers use the factory index to inspect all games. A deployment MAY have its defender submit the TEE lane as the initial operational policy, but challenged games MUST still be escalated with an independent lane.
 
 ## Test Cases
 
 Before this WIP can move beyond Draft, implementations SHOULD cover at least:
 
 - a newly created game has no proof support and a factory UUID independent of later proof bytes;
-- a proposal reservation can be created by its proposer and consumed by any permissionless factory keeper without changing `bondProposer`;
-- a stale uncreated reservation cannot fund a replacement implementation and can be permissionlessly invalidated and refunded;
+- the proposer bond is pulled from `gameCreator` atomically with factory creation, and creation reverts without allowance or balance;
+- the vault rejects a bond pull from any caller that is not the deterministic clone the canonical factory deploys;
 - an already registered game can settle after the factory implementation is replaced;
 - an unchallenged root with any one valid configured lane finalizes after exactly `CHALLENGE_PERIOD`;
 - an unchallenged root with `PROOF_THRESHOLD` distinct lanes finalizes before `CHALLENGE_PERIOD`;
@@ -369,7 +367,7 @@ Before this WIP can move beyond Draft, implementations SHOULD cover at least:
 - parent invalidation cascades and refunds both descendant participants;
 - retry attempts reject an ineligible predecessor and accept each specified recovery case;
 - close atomically settles normal mode for proper games and refund mode for blacklisted or retired games;
-- vault liabilities remain exact across deposits, reservations, settlement, delayed withdrawals, and participant-address overlap;
+- vault liabilities remain exact across bond pulls, settlement, delayed withdrawals, and participant-address overlap;
 - Portal withdrawal proof and finalization accept a claim-valid WIP-1006 game and reject blacklisted, retired, unrespected, challenger-winning, or insufficiently mature games.
 
 ## Security Considerations
@@ -392,7 +390,7 @@ Before this WIP can move beyond Draft, implementations SHOULD cover at least:
 
 **The vault ProxyAdmin is a custody trust assumption.** For parity with `DelayedWETH`, the ProxyAdmin owner can move participant balances with `hold`, remove backing WLD with `recover`, and upgrade the singleton vault. These powers apply to uncommitted balances as well as backing for active games, so compromise has a larger blast radius than a per-implementation bond contract. Production deployment MUST protect this role accordingly and SHOULD reassess whether narrower optimistic recovery is sufficient.
 
-**Reservation authentication is part of factory integrity.** A reservation MUST bind to the exact current implementation and may only be consumed by the deterministic clone deployed by the canonical factory. The economic proposer is the account recorded by the reservation; the factory's `gameCreator` is only the creation caller and MAY be an unrelated keeper.
+**Bond-pull authentication is part of factory integrity.** The factory registers a game only after `initialize` returns, so the vault MUST authenticate a proposer bond pull by recomputing the deterministic clone address the canonical factory deploys for the current implementation and the caller's creation data. Because pulls spend allowances on the word of factory-selected code, they MUST fail closed unless the factory owner and the vault ProxyAdmin owner are the same authority.
 
 **Bond calibration is security-critical.** If `CHALLENGER_BOND` is too cheap, attackers can force valid roots into the slow path or create repeated proof work. If it is too expensive, honest watchers may fail to challenge invalid roots. `PROPOSER_BOND` must make invalid proposals expensive while keeping proposal participation viable. Exact economic parameters are out of scope for this WIP but MUST be tuned before mainnet deployment.
 

--- a/wips/wip-1006.md
+++ b/wips/wip-1006.md
@@ -52,8 +52,8 @@ requires activating a new game implementation; existing games retain their origi
 | `BLOCK_INTERVAL` | TBD | Exact distance each proposal MUST advance from its parent. |
 | `CHALLENGE_PERIOD` | `1 day` | Duration after proposal creation during which any participant MAY challenge a root and any party MAY submit the initial proof. Per-proposal `challengeDeadline = createdAt + CHALLENGE_PERIOD`. |
 | `PROOF_PERIOD` | `7 days` | Duration after proposal creation during which the proposer MAY defend a challenged root by accumulating lane submissions toward `PROOF_THRESHOLD`. Per-proposal `proofDeadline = createdAt + PROOF_PERIOD`. `PROOF_PERIOD` MUST be greater than `CHALLENGE_PERIOD`. A challenged root that the proposer has not defended to `PROOF_THRESHOLD` by `proofDeadline` MUST be invalidated. |
-| `PROPOSER_BOND` | TBD | WLD pulled into `WLDStakingVault` from the creator's allowance during factory creation. Paid to the proposer after `DEFENDER_WINS`, split between the challenger and protocol after a challenged proof timeout, paid to the protocol after an unchallenged proof timeout, or refunded if the registry invalidates the game. |
-| `CHALLENGER_BOND` | TBD | WLD pulled into `WLDStakingVault` from the challenger's allowance at challenge time. Split between the proposer and accepted proof-lane recipients after a successful defense, returned to the challenger after proof timeout, or refunded if the registry invalidates the game. |
+| `PROPOSER_BOND` | TBD | WLD locked from the creator's available vault balance during factory creation. Paid to the proposer after `DEFENDER_WINS`, split between the challenger and protocol after a challenged proof timeout, paid to the protocol after an unchallenged proof timeout, or refunded if the registry invalidates the game. |
+| `CHALLENGER_BOND` | TBD | WLD locked from the challenger's available vault balance at challenge time. Split between the proposer and accepted proof-lane recipients after a successful defense, returned to the challenger after proof timeout, or refunded if the registry invalidates the game. |
 | `PROTOCOL_FEE_RECIPIENT` | TBD | Nonzero protocol-controlled recipient credited with the proposer bond after an unchallenged proof timeout and with the portion not paid to the challenger after a challenged proof timeout. |
 
 ### Proof Lanes
@@ -84,7 +84,7 @@ The factory UUID identifies a game, while each proof lane authenticates a statem
 | `l1OriginHash` | Factory | Previous L1 block hash captured at proposal creation. The proposer does not pass it as calldata. |
 | `l1OriginNumber` | Game | L1 block number paired with the factory-captured `l1OriginHash`. |
 
-The proposer approves `WLDStakingVault` to transfer WLD and calls `DisputeGameFactory.create(gameType, rootClaim, extraData)`, where:
+The proposer deposits WLD into `WLDStakingVault` and calls `DisputeGameFactory.create(gameType, rootClaim, extraData)`, where:
 
 ```text
 extraData = abi.encode(domainHash, l2BlockNumber, parentRef, attempt)
@@ -185,15 +185,15 @@ stateDiagram-v2
 
 A root enters the system in the `PROPOSED` state.
 
-1. The proposer, holding a standing WLD approval to the vault, calls the stock `DisputeGameFactory.create` with zero ETH. The factory creates a clone, captures its caller as `gameCreator` and the L1 head, and calls `initialize`.
-2. The game validates the domain, parent registration and eligibility, exact L2 block interval, and retry predecessor, then asks the vault to pull `PROPOSER_BOND`.
-3. The factory registers a game only after `initialize` returns, so the vault authenticates the caller as the deterministic clone the factory deploys for the current implementation and the caller's creation data, then transfers `PROPOSER_BOND` from `gameCreator`. Any failure reverts the entire creation.
+1. The proposer deposits WLD into its available vault balance, then calls the stock `DisputeGameFactory.create` with zero ETH. The factory creates a clone, captures its caller as `gameCreator` and the L1 head, and calls `initialize`.
+2. The game validates the domain, parent registration and eligibility, exact L2 block interval, and retry predecessor, then asks the vault to lock `PROPOSER_BOND`.
+3. The factory registers a game only after `initialize` returns, so the vault authenticates the caller as the deterministic clone the factory deploys for the current implementation and the caller's creation data, then debits `PROPOSER_BOND` from `gameCreator`'s available balance. Any failure reverts the entire creation.
 4. The game records `createdAt = block.timestamp`, `challengeDeadline = createdAt + CHALLENGE_PERIOD`, and `proofDeadline = createdAt + PROOF_PERIOD`.
 5. The root remains open to challenge until `challengeDeadline`.
 
 The account calling `create` is both `gameCreator` and the bonded proposer. Once a game is registered, it remains authorized to settle through the same singleton vault even if the factory later registers a newer implementation. Game-implementation rotations MUST reuse that vault so settled balances remain available across versions.
 
-The DisputeGameFactory owner and vault ProxyAdmin owner MUST remain the same governance authority. This is required because the factory owner selects the implementations on whose word the vault pulls participant allowances, while the ProxyAdmin owner controls the vault implementation and break-glass custody. Bond pulls MUST fail closed if those owners diverge, and deployment and activation tooling MUST validate the invariant.
+The DisputeGameFactory owner and vault ProxyAdmin owner MUST remain the same governance authority. This is required because the factory owner selects the implementations on whose word the vault allocates participant balances, while the ProxyAdmin owner controls the vault implementation and break-glass custody. New bond locks MUST fail closed if those owners diverge, and deployment and activation tooling MUST validate the invariant.
 
 Proof material MUST NOT be part of factory creation or `extraData`. After the game exists, any party MAY submit a valid configured proof lane before `challengeDeadline`. Offchain services MAY choose a preferred operational lane, but the onchain protocol MUST NOT privilege one lane for the initial proof.
 
@@ -206,7 +206,7 @@ Any participant MAY challenge a proposed root before `challengeDeadline`, regard
 The challenge transaction:
 
 - MUST NOT require the caller to submit proof material.
-- MUST atomically pull `CHALLENGER_BOND` from the caller's WLD allowance into the vault;
+- MUST atomically lock `CHALLENGER_BOND` from the caller's available vault balance;
 - MUST mark the root as `CHALLENGED`.
 - MUST NOT change the `proofDeadline` derived from proposal creation.
 
@@ -295,9 +295,9 @@ Resolution assigns normal-mode credits without releasing WLD. After the stock di
 - `NORMAL` when `AnchorStateRegistry.isGameProper(game)` is true;
 - `REFUND` when the game has been blacklisted, retired, or otherwise made improper.
 
-Closing SHOULD attempt to advance the anchor but MUST treat an ineligible or stale anchor update as non-fatal. It MUST atomically settle the full game pot into the selected recipients' available vault balances, reject duplicate settlement, and preserve exact payout conservation. External withdrawal is account-controlled and two-phase: the account requests an amount, waits the configured delay, and withdraws WLD. A new request resets the delay for the full pending amount.
+Closing SHOULD attempt to advance the anchor but MUST treat an ineligible or stale anchor update as non-fatal. It MUST atomically settle the full game pot into the selected recipients' available vault balances, making those balances immediately reusable for new bonds, reject duplicate settlement, and preserve exact payout conservation. External withdrawal is account-controlled and two-phase: the account requests an amount, waits the configured delay, and withdraws WLD. A new request resets the delay for the full pending amount.
 
-The vault MUST maintain one-to-one WLD-denominated liabilities and MUST NOT issue transferable shares or apply an exchange rate. Direct token donations MAY make assets exceed liabilities. Insolvency MUST NOT prevent internal game settlement, but an external transfer may fail until the vault is recapitalized. System pause blocks external withdrawal and does not block withdrawal requests; game creation and closing retain their existing ASR pause checks.
+The vault MUST maintain one-to-one WLD-denominated liabilities and MUST NOT issue transferable shares or apply an exchange rate. Direct token donations MAY make assets exceed liabilities. Insolvency MUST NOT prevent internal game settlement, but an external transfer may fail until the vault is recapitalized. System pause blocks external withdrawal but does not block deposits, withdrawal requests, or challenges to existing games; game creation and closing retain their existing ASR pause checks.
 
 For challenged `DEFENDER_WINS`, `CHALLENGER_BOND` MUST be split equally between the proposer and every accepted proof-lane recipient, with any integer-division remainder credited to the proposer. For challenged `PROOF_TIMEOUT`, the challenger receives its bond plus `CHALLENGER_REWARD_BPS` of `PROPOSER_BOND`; `PROTOCOL_FEE_RECIPIENT` receives the rest of `PROPOSER_BOND`. `REFUND` mode returns the full deposited bonds to their depositors instead of applying normal-mode rewards.
 
@@ -314,7 +314,7 @@ WIP-1006 is implemented as a new game type on the stock OP Stack dispute infrast
 | `IDisputeGameFactory` | Stock OP factory; registers the WIP-1006 implementation, creates clones, indexes games by UUID and list index, and captures `l1Head`. | [`DisputeGameFactory`][base-factory] |
 | `IDisputeGame` / `IMultiProofGame` | Per-proposal game; exposes the Portal-facing lifecycle and World Chain proof-lane extensions. | [`AggregateVerifier`][base-aggregate] |
 | `IAnchorStateRegistry` | Stock OP registry; evaluates registration, respect, blacklist, retirement, finality, claim validity, and the current anchor. | [`AnchorStateRegistry`][base-anchor] |
-| `IWLDStakingVault` | Pulls WIP-1006 proposal and challenge bonds from participant allowances, settles finalized game payouts, and enforces delayed WLD withdrawal. | [`IWLDStakingVault`](../pkg/contracts/src/dispute/interfaces/IWLDStakingVault.sol) |
+| `IWLDStakingVault` | Accepts participant deposits, locks WIP-1006 proposal and challenge bonds from available balances, settles finalized game payouts, and enforces delayed WLD withdrawal. | [`IWLDStakingVault`](../pkg/contracts/src/dispute/interfaces/IWLDStakingVault.sol) |
 | `IWorldChainProofVerifier` | Common interface for verifying lane proofs against a game-supplied verifier identity and game-derived public values. | [`IWorldChainProofVerifier`](../pkg/contracts/src/dispute/interfaces/IWorldChainProofVerifier.sol) |
 | `NitroEnclaveKeyRegistry` | Maintains TEE signer identities admitted through Nitro attestation. | [`NitroEnclaveKeyRegistry`](../pkg/contracts/src/dispute/nitro/NitroEnclaveKeyRegistry.sol) |
 | `SecurityCouncilVerifier` | Verifies the council Safe's ERC-1271 attestation over `rootId`. | [`SecurityCouncilVerifier`](../pkg/contracts/src/dispute/council/SecurityCouncilVerifier.sol) |
@@ -336,15 +336,15 @@ The proposal data remains aligned with the OP Stack:
 - factory identity uses the canonical `(gameType, rootClaim, extraData)` UUID;
 - `domainHash`, `l2BlockNumber`, `parentRef`, and `attempt` are encoded in `extraData`.
 
-Offchain services only need a standing WLD approval to the vault before using the stock factory creation API. They do not require a custom factory or anchor registry. Proposers and defenders MAY reconstruct a selected lineage by looking up the expected transition from the current anchor; challengers use the factory index to inspect all games. A deployment MAY have its defender submit the TEE lane as the initial operational policy, but challenged games MUST still be escalated with an independent lane.
+Proposers and challengers deposit enough WLD into their available vault balances before using the stock factory and game APIs. Deposits may be credited by another account through `depositFor`, and no standing allowance is required after a deposit. Offchain services do not require a custom factory or anchor registry. Proposers and defenders MAY reconstruct a selected lineage by looking up the expected transition from the current anchor; challengers use the factory index to inspect all games. A deployment MAY have its defender submit the TEE lane as the initial operational policy, but challenged games MUST still be escalated with an independent lane.
 
 ## Test Cases
 
 Before this WIP can move beyond Draft, implementations SHOULD cover at least:
 
 - a newly created game has no proof support and a factory UUID independent of later proof bytes;
-- the proposer bond is pulled from `gameCreator` atomically with factory creation, and creation reverts without allowance or balance;
-- the vault rejects a bond pull from any caller that is not the deterministic clone the canonical factory deploys;
+- the proposer bond is locked from `gameCreator` atomically with factory creation, and creation reverts without sufficient available balance;
+- the vault rejects a proposer-bond lock from any caller that is not the deterministic clone the canonical factory deploys;
 - an already registered game can settle after the factory implementation is replaced;
 - an unchallenged root with any one valid configured lane finalizes after exactly `CHALLENGE_PERIOD`;
 - an unchallenged root with `PROOF_THRESHOLD` distinct lanes finalizes before `CHALLENGE_PERIOD`;
@@ -367,7 +367,7 @@ Before this WIP can move beyond Draft, implementations SHOULD cover at least:
 - parent invalidation cascades and refunds both descendant participants;
 - retry attempts reject an ineligible predecessor and accept each specified recovery case;
 - close atomically settles normal mode for proper games and refund mode for blacklisted or retired games;
-- vault liabilities remain exact across bond pulls, settlement, delayed withdrawals, and participant-address overlap;
+- vault liabilities remain exact across deposits, bond locks, settlement, delayed withdrawals, and participant-address overlap;
 - Portal withdrawal proof and finalization accept a claim-valid WIP-1006 game and reject blacklisted, retired, unrespected, challenger-winning, or insufficiently mature games.
 
 ## Security Considerations
@@ -390,7 +390,7 @@ Before this WIP can move beyond Draft, implementations SHOULD cover at least:
 
 **The vault ProxyAdmin is a custody trust assumption.** For parity with `DelayedWETH`, the ProxyAdmin owner can move participant balances with `hold`, remove backing WLD with `recover`, and upgrade the singleton vault. These powers apply to uncommitted balances as well as backing for active games, so compromise has a larger blast radius than a per-implementation bond contract. Production deployment MUST protect this role accordingly and SHOULD reassess whether narrower optimistic recovery is sufficient.
 
-**Bond-pull authentication is part of factory integrity.** The factory registers a game only after `initialize` returns, so the vault MUST authenticate a proposer bond pull by recomputing the deterministic clone address the canonical factory deploys for the current implementation and the caller's creation data. Because pulls spend allowances on the word of factory-selected code, they MUST fail closed unless the factory owner and the vault ProxyAdmin owner are the same authority.
+**Bond-lock authentication is part of factory integrity.** The factory registers a game only after `initialize` returns, so the vault MUST authenticate a proposer bond lock by recomputing the deterministic clone address the canonical factory deploys for the current implementation and the caller's creation data. Because locks allocate deposited balances on the word of factory-selected code, they MUST fail closed unless the factory owner and the vault ProxyAdmin owner are the same authority. Participant exposure is bounded by the WLD deliberately deposited into the vault.
 
 **Bond calibration is security-critical.** If `CHALLENGER_BOND` is too cheap, attackers can force valid roots into the slow path or create repeated proof work. If it is too expensive, honest watchers may fail to challenge invalid roots. `PROPOSER_BOND` must make invalid proposals expensive while keeping proposal participation viable. Exact economic parameters are out of scope for this WIP but MUST be tuned before mainnet deployment.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> This changes dispute-game bond custody, allowance-based pulls, factory registration order, and governance invariants (DGF owner must match vault ProxyAdmin owner)—all security- and funds-critical paths before audit.
> 
> **Overview**
> **Replaces ETH/`DelayedWETH` bond custody with a singleton `WLDStakingVault` for WIP-1006.** Proposer and challenger bonds are pulled from WLD allowances (factory `create` must send **zero ETH**); `closeGame()` settles the full pot into vault balances instead of in-game `claimCredit` / two-phase WETH withdrawal.
> 
> **Adds `WLDStakingVault`** (proxy-deployed, reusable across game rotations): deterministic-clone auth for proposer pulls at `initialize`, registered-game checks for challenger pulls and `settle`, delayed external withdrawals, and ProxyAdmin `hold`/`recover` break-glass. **`MultiProofGame`** wires `bondVault` instead of `weth`; `challenge()` is no longer payable.
> 
> **Splits deploy vs activate:** `DeployProofSystem` deploys the vault (or reuses an existing one) and a new `MultiProofGame` implementation only—no DGF registration. **`ActivateProofSystem`** validates vault/factory/owner alignment, registers the implementation, sets type-1006 **init bond to 0**, and optionally switches the respected game type (guardian only when needed). **`just proof-*`** recipes and deployment JSON gain `WLD_TOKEN`, vault reuse, and `DGF_OWNER_KEY` for activation.
> 
> Docs (**README**, **WIP-1006**) and tests are updated accordingly; new **`WLDStakingVault`** test suite and **`MockWLD`** for fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27a1d644b647866aea0ea8da18c08224b8677a22. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->