### PR TITLE
ci(contracts): pin Foundry 1.7.1

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1
+        with:
+          version: v1.7.1
 
       - name: Show Forge version
         run: forge --version

--- a/pkg/contracts/src/pbh/PBHEntryPointImplV1.sol
+++ b/pkg/contracts/src/pbh/PBHEntryPointImplV1.sol
@@ -280,7 +280,8 @@ contract PBHEntryPointImplV1 is IPBHEntryPoint, Base, ReentrancyGuardTransient {
                 // We now generate the signal hash from the sender, nonce, and calldata
                 uint256 signalHash = abi.encodePacked(
                         sender, opsPerAggregator[i].userOps[j].nonce, opsPerAggregator[i].userOps[j].callData
-                    ).hashToField();
+                    )
+                    .hashToField();
 
                 _verifyPbh(signalHash, pbhPayloads[j]);
                 bytes32 userOpHash = getUserOpHash(opsPerAggregator[i].userOps[j]);

--- a/pkg/contracts/src/pbh/PBHEntryPointImplV1.sol
+++ b/pkg/contracts/src/pbh/PBHEntryPointImplV1.sol
@@ -280,8 +280,7 @@ contract PBHEntryPointImplV1 is IPBHEntryPoint, Base, ReentrancyGuardTransient {
                 // We now generate the signal hash from the sender, nonce, and calldata
                 uint256 signalHash = abi.encodePacked(
                         sender, opsPerAggregator[i].userOps[j].nonce, opsPerAggregator[i].userOps[j].callData
-                    )
-                    .hashToField();
+                    ).hashToField();
 
                 _verifyPbh(signalHash, pbhPayloads[j]);
                 bytes32 userOpHash = getUserOpHash(opsPerAggregator[i].userOps[j]);


### PR DESCRIPTION
## Summary

- pin the Foundry toolchain to v1.7.1 instead of floating on the latest stable release
- prevent Forge 1.8.0 formatter drift and its incompatible `anvil_nodeInfo` probe from breaking unchanged fork tests

## Evidence

- the last green `main` Foundry job used Forge 1.7.1 (`4072e48705af9d93e3c0f6e29e93b5e9a40caed8`)

## Validation

- `forge fmt --check` with Forge 1.7.1