### PR TITLE
fix: bal construction with rejected tx

### DIFF
--- a/crates/builder/tests/bal_rejected_transaction.rs
+++ b/crates/builder/tests/bal_rejected_transaction.rs
@@ -108,7 +108,7 @@ fn rejected_transaction_does_not_pollute_flashblock_access_list() -> TestResult<
     .to_signed_tx(0);
 
     let (previous_outcome, _, previous_bundle) =
-        execute_serial_with_provider(state_provider.as_ref(), None, &[transaction.clone()])?;
+        execute_serial_with_provider(state_provider.as_ref(), None, std::slice::from_ref(&transaction))?;
     let previous = (previous_outcome, previous_bundle);
 
     let (clean_outcome, clean_bal) =

--- a/crates/builder/tests/bal_rejected_transaction.rs
+++ b/crates/builder/tests/bal_rejected_transaction.rs
@@ -1,0 +1,130 @@
+use alloy_consensus::BlockHeader;
+use alloy_op_evm::{OpBlockExecutor, OpEvmFactory, OpTx};
+use alloy_primitives::U256;
+use crossbeam_channel::bounded;
+use reth_evm::{
+    EvmFactory,
+    block::{BlockExecutionError, BlockValidationError},
+    execute::{BlockBuilder, BlockBuilderOutcome},
+};
+use reth_optimism_primitives::{OpPrimitives, OpTransactionSigned};
+use reth_primitives_traits::Recovered;
+use reth_revm::{State, database::StateProviderDatabase};
+use revm::database::BundleState;
+use world_chain_builder::payload_builder_metrics::PayloadBuildAttemptMetrics;
+use world_chain_evm::{
+    BlockBuilderExt, OpRethReceiptBuilder, execution::bal::BalBlockBuilder,
+    utils::cache_prestate_from_bundle,
+};
+use world_chain_primitives::access_list::{FlashblockAccessListData, access_list_hash};
+use world_chain_test_utils::builder::{
+    ALICE, BLOCK_EXECUTION_CTX, BOB, CHAIN_SPEC, EVM_ENV, SEALED_HEADER, TestStateProvider, TxOp,
+    create_test_state_provider, execute_serial_with_provider,
+};
+
+type TestResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+fn finish_next_flashblock(
+    state_provider: &TestStateProvider,
+    previous: (BlockBuilderOutcome<OpPrimitives>, BundleState),
+    attempted_transaction: Option<Recovered<OpTransactionSigned>>,
+) -> TestResult<(BlockBuilderOutcome<OpPrimitives>, FlashblockAccessListData)> {
+    let (previous_outcome, bundle) = previous;
+    let previous_transactions = previous_outcome
+        .block
+        .clone_transactions_recovered()
+        .collect();
+    let previous_gas_used = previous_outcome.block.gas_used();
+    let previous_receipts = previous_outcome.execution_result.receipts.clone();
+
+    let db = StateProviderDatabase::new(state_provider);
+    let mut state = State::builder()
+        .with_database(db)
+        .with_cached_prestate(cache_prestate_from_bundle(&bundle))
+        .with_bundle_update()
+        .with_bal_builder()
+        .build();
+
+    let evm = OpEvmFactory::<OpTx>::default().create_evm(&mut state, EVM_ENV.clone());
+    let mut executor = OpBlockExecutor::new(
+        evm,
+        BLOCK_EXECUTION_CTX.clone(),
+        CHAIN_SPEC.clone(),
+        OpRethReceiptBuilder::default(),
+    );
+    executor.gas_used = previous_gas_used;
+    executor.receipts = previous_receipts;
+
+    let (access_list_tx, access_list_rx) = bounded(1);
+    let mut builder = BalBlockBuilder::<OpRethReceiptBuilder, OpPrimitives, _>::new(
+        BLOCK_EXECUTION_CTX.clone(),
+        &SEALED_HEADER,
+        executor,
+        previous_transactions,
+        CHAIN_SPEC.clone(),
+        access_list_tx,
+        bundle,
+    );
+
+    if let Some(transaction) = attempted_transaction {
+        let error = builder
+            .execute_transaction_with_result_closure(transaction, |_| {})
+            .expect_err("the duplicate nonce transaction should be rejected");
+
+        assert!(
+            matches!(
+                &error,
+                BlockExecutionError::Validation(BlockValidationError::InvalidTx {
+                    error,
+                    ..
+                }) if error.is_nonce_too_low()
+            ),
+            "expected a nonce-too-low validation error, got {error:?}"
+        );
+    }
+
+    let (outcome, _) =
+        builder.finish_with_bundle(state_provider, PayloadBuildAttemptMetrics::default())?;
+    let access_list = access_list_rx.recv()?;
+    let access_list_hash = access_list_hash(&access_list);
+
+    Ok((
+        outcome,
+        FlashblockAccessListData {
+            access_list,
+            access_list_hash,
+        },
+    ))
+}
+
+#[test]
+fn rejected_transaction_does_not_pollute_flashblock_access_list() -> TestResult<()> {
+    let state_provider = create_test_state_provider();
+    let transaction = TxOp::Transfer {
+        from: ALICE.clone(),
+        to: BOB.address(),
+        value: U256::from(1),
+    }
+    .to_signed_tx(0);
+
+    let (previous_outcome, _, previous_bundle) =
+        execute_serial_with_provider(state_provider.as_ref(), None, &[transaction.clone()])?;
+    let previous = (previous_outcome, previous_bundle);
+
+    let (clean_outcome, clean_bal) =
+        finish_next_flashblock(state_provider.as_ref(), previous.clone(), None)?;
+    let (rejected_outcome, rejected_bal) =
+        finish_next_flashblock(state_provider.as_ref(), previous, Some(transaction))?;
+
+    assert_eq!(
+        rejected_outcome.block.hash(),
+        clean_outcome.block.hash(),
+        "rejecting a candidate must not change the finished block"
+    );
+    assert_eq!(
+        rejected_bal, clean_bal,
+        "rejecting a candidate must not change the emitted access list"
+    );
+
+    Ok(())
+}

--- a/crates/builder/tests/bal_rejected_transaction.rs
+++ b/crates/builder/tests/bal_rejected_transaction.rs
@@ -107,8 +107,11 @@ fn rejected_transaction_does_not_pollute_flashblock_access_list() -> TestResult<
     }
     .to_signed_tx(0);
 
-    let (previous_outcome, _, previous_bundle) =
-        execute_serial_with_provider(state_provider.as_ref(), None, std::slice::from_ref(&transaction))?;
+    let (previous_outcome, _, previous_bundle) = execute_serial_with_provider(
+        state_provider.as_ref(),
+        None,
+        std::slice::from_ref(&transaction),
+    )?;
     let previous = (previous_outcome, previous_bundle);
 
     let (clean_outcome, clean_bal) =

--- a/crates/evm/src/execution/bal.rs
+++ b/crates/evm/src/execution/bal.rs
@@ -250,13 +250,13 @@ where
         f: impl FnOnce(&<Self::Executor as BlockExecutor>::Result) -> CommitChanges,
     ) -> Result<Option<GasOutput>, BlockExecutionError> {
         let (tx_env, recovered) = tx.into_parts();
-        if !recovered.is_deposit() {
-            record_op_l1_block_bal_reads(self.executor.evm_mut().db_mut())?;
-        }
         if let Some(gas_used) = self
             .executor
             .execute_transaction_with_commit_condition((tx_env, &recovered), f)?
         {
+            if !recovered.is_deposit() {
+                record_op_l1_block_bal_reads(self.executor.evm_mut().db_mut())?;
+            }
             self.transactions.push(recovered);
             // only prepare the database index for the next transaction if this one was committed
             self.prepare_database()?;

--- a/scripts/stress/scenarios/alphanetBlake2F25m.toml
+++ b/scripts/stress/scenarios/alphanetBlake2F25m.toml
@@ -1,0 +1,10 @@
+[[spam]]
+[spam.tx]
+to = "0x56d8b93762b7f90c97e6d3b7cb351fae3438dadb"
+from_pool = "spammers"
+signature = "callPrecompile(string memory method, uint256 iterations)"
+args = [
+    "blake2f_alt",
+    "865"
+]
+gas_limit = 2600000


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes when BAL reads are recorded during block building, which affects flashblock access lists and block hashes; behavior is constrained by a new regression test but touches core execution paths.
> 
> **Overview**
> **Fixes BAL / flashblock construction when a candidate transaction is rejected** (e.g. nonce-too-low): rejected txs no longer affect the finished block or the emitted flashblock access list.
> 
> In `BalBlockBuilder::execute_transaction_with_commit_condition`, **`record_op_l1_block_bal_reads` now runs only after a transaction commits successfully**, instead of before execution. That prevents L1-block BAL reads from being recorded for txs that never land in the block.
> 
> Adds an integration test (`rejected_transaction_does_not_pollute_flashblock_access_list`) that compares a clean next flashblock finish vs. one that attempts the same tx again and asserts identical block hash and access list data.
> 
> Also adds a stress scenario (`alphanetBlake2F25m.toml`) for heavy `blake2f_alt` precompile spam on alphanet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 598c6031b086ea18fce4abbb7ca6972998769317. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->