### PR TITLE
ci: serialize fork-backed RPC tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -8,9 +8,18 @@ slow-timeout = { period = "120s", terminate-after = 3 }
 [test-groups.devnet-stack]
 max-threads = 1
 
+# Fork-backed RPC tests share one rate-limited archive endpoint in CI. Running them concurrently
+# causes provider-level `-32005 rate limit exceeded` failures before assertions are reached.
+[test-groups.worldchain-rpc-fork]
+max-threads = 1
+
 [[profile.default.overrides]]
 filter = 'package(world-chain-tests)'
 threads-required = 4
+
+[[profile.default.overrides]]
+filter = 'package(world-chain-rpc) & binary(fork_simulate)'
+test-group = "worldchain-rpc-fork"
 
 # The excluded test builds `without_l1()` in-process and needs no Docker.
 [[profile.default.overrides]]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-runner configuration only; no production RPC or application logic changes.
> 
> **Overview**
> CI was hitting **`-32005 rate limit exceeded`** when multiple `fork_simulate` integration tests hit the same shared archive RPC at once.
> 
> This adds a **`worldchain-rpc-fork`** nextest group with **`max-threads = 1`** (same idea as **`devnet-stack`** for Docker) and routes **`package(world-chain-rpc) & binary(fork_simulate)`** into it so those tests run one at a time instead of in parallel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34af9c44bf735147127239e3d675a750e13adfa3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->