### PR TITLE
feat(devnet): deploy mock bond token independently

### DIFF
--- a/justfiles/proof.just
+++ b/justfiles/proof.just
@@ -19,7 +19,8 @@
 # Workflow phases owned by this repo:
 #   Phase 0a  proof-rollup-config-hash   – Compute rollup config hash from an L2 RPC
 #   Phase 1   proof-deploy-nitro         – Deploy Nitro attestation contracts
-#   Phase 1b  proof-deploy-mocks         – Deploy proof-lane test doubles (devnet only)
+#   Phase 1b  proof-deploy-mock-bond-token – Deploy a mintable bond token (devnet only)
+#   Phase 1c  proof-deploy-mocks         – Deploy proof-lane test doubles (devnet only)
 #   Phase 2   proof-deploy-system        – Deploy proof system implementation and vault
 #   Phase 2b  proof-fund-mock-bonds      – Fund persistent devnet bond accounts (devnet only)
 #   Phase 3a  proof-certmanager-prewarm  – Pre-warm CertManager with CA certs
@@ -151,6 +152,27 @@ proof-deploy-nitro env="alphanet":
     fi
     echo "Deploying Nitro contracts (deployment → $NITRO_DEPLOYMENT_OUT)$([ -n "$BROADCAST_FLAG" ] || echo ' [DRY RUN]')…"
     cd pkg/contracts && mkdir -p deployments && forge script scripts/devnet/DeployNitro.s.sol:DeployNitro \
+        --rpc-url "$L1_RPC_URL" --private-key "$PRIVATE_KEY" $BROADCAST_FLAG --slow
+
+# Phase 1b (devnet only) – Deploy only the mintable token for a real-verifier devnet.
+[doc("Phase 1b (devnet only) - Deploy a mintable ERC-20 proof bond token.")]
+[group('proof')]
+proof-deploy-mock-bond-token env="alphanet":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    : "${PRIVATE_KEY:?PRIVATE_KEY is required}"
+    : "${L1_RPC_URL:?L1_RPC_URL is required}"
+    BROADCAST_FLAG=""
+    if [ "{{dry_run}}" = "false" ]; then
+        BROADCAST_FLAG="--broadcast"
+    fi
+    if [ -n "$BROADCAST_FLAG" ]; then
+        export MOCK_BOND_TOKEN_DEPLOYMENT_OUT="deployments/{{env}}-mock-bond-token.json"
+    else
+        export MOCK_BOND_TOKEN_DEPLOYMENT_OUT="deployments/{{env}}-mock-bond-token.dryrun.json"
+    fi
+    echo "WARNING: deploying an unrestricted mintable mock bond token for '{{env}}'." >&2
+    cd pkg/contracts && mkdir -p deployments && forge script scripts/devnet/DeployMockBondToken.s.sol:DeployMockBondToken \
         --rpc-url "$L1_RPC_URL" --private-key "$PRIVATE_KEY" $BROADCAST_FLAG --slow
 
 # Writes deployments/<env>-proof-mocks.json for proof-deploy-system to consume.

--- a/pkg/contracts/scripts/devnet/DeployMockBondToken.s.sol
+++ b/pkg/contracts/scripts/devnet/DeployMockBondToken.s.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Script} from "forge-std/Script.sol";
+
+import {MockBondToken} from "../../test/mocks/MockBondToken.sol";
+
+/// @notice Deploys the mintable ERC-20 bond token used by a devnet with real proof verifiers.
+/// @dev Devnet only. This is separate from DeployProofMocks so deployments do not create
+///      accept-any verifier contracts when only a mock bond token is needed.
+contract DeployMockBondToken is Script {
+    function run() external returns (MockBondToken bondToken) {
+        uint256 privateKey = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(privateKey);
+        bondToken = new MockBondToken();
+        vm.stopBroadcast();
+
+        string memory out = vm.envOr("MOCK_BOND_TOKEN_DEPLOYMENT_OUT", string(""));
+        if (bytes(out).length != 0) {
+            string memory json = vm.serializeAddress("mockBondToken", "bondToken", address(bondToken));
+            vm.writeJson(json, out);
+        }
+    }
+}


### PR DESCRIPTION
small one for devnetworks, need to deploy a mock token but using real verifiers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Devnet-only tooling and an explicit stderr warning; no production verifier or proof-path changes.
> 
> **Overview**
> Adds a **devnet-only** deployment path for a mintable mock bond token without pulling in accept-any proof verifiers.
> 
> A new `just proof-deploy-mock-bond-token` recipe (proof workflow **Phase 1b**) runs `DeployMockBondToken.s.sol`, writes `deployments/<env>-mock-bond-token.json` (or `.dryrun.json`), and mirrors the existing dry-run / broadcast pattern. The proof workflow header renumbers full mock deployment to **Phase 1c** (`proof-deploy-mocks`).
> 
> This supports devnets that use **real** verifiers but still need a test `BOND_TOKEN` for `proof-deploy-system`, instead of running `proof-deploy-mocks` and deploying `MockRootIdVerifier` contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd69f4de46ab24df0dfaff8a2a85c08054971a11. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->