### PR TITLE
chore(proofs): prepare v1.0.0-rc.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18568,7 +18568,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-challenger"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-contract",
@@ -18652,7 +18652,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-defender"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "alloy-contract",
  "alloy-network 2.1.1",
@@ -18998,7 +18998,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-core"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -19021,7 +19021,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-it"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -19042,7 +19042,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-kona-client"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -19072,7 +19072,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-kona-host"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -19100,7 +19100,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-metrics"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "alloy-json-rpc 2.1.1",
  "alloy-primitives",
@@ -19116,7 +19116,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-nitro-enclave"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -19149,7 +19149,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-nitro-register"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -19170,7 +19170,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-nitro-worker"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -19196,7 +19196,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-protocol"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -19217,7 +19217,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-sp1-elfs"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "sp1-build",
  "sp1-sdk",
@@ -19225,7 +19225,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-sp1-guest-builder"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "anyhow",
  "sp1-build",
@@ -19233,7 +19233,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-sp1-host"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -19259,7 +19259,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-sp1-types"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "alloy-primitives",
  "rkyv",
@@ -19269,7 +19269,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-sp1-worker"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "alloy-contract",
  "alloy-network 2.1.1",
@@ -19309,7 +19309,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-tx-signer"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "alloy-network 2.1.1",
  "alloy-primitives",
@@ -19326,7 +19326,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-worker"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -19341,7 +19341,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proposer"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-contract",
@@ -19370,7 +19370,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-prover"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -19388,7 +19388,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-prover-cli"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -19406,7 +19406,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-prover-nitro"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -19422,7 +19422,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-prover-service"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -19447,7 +19447,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-prover-sp1"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "alloy-primitives",
  "anyhow",

--- a/proofs/backends/nitro/register/Cargo.toml
+++ b/proofs/backends/nitro/register/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "world-chain-proof-nitro-register"
 description = "Host-side on-chain registration of a Nitro enclave's ephemeral signing key"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/proofs/backends/sp1/elfs/Cargo.toml
+++ b/proofs/backends/sp1/elfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-chain-proof-sp1-elfs"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/proofs/backends/sp1/guest-builder/Cargo.toml
+++ b/proofs/backends/sp1/guest-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-chain-proof-sp1-guest-builder"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/proofs/backends/sp1/host/Cargo.toml
+++ b/proofs/backends/sp1/host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-chain-proof-sp1-host"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/proofs/backends/sp1/types/Cargo.toml
+++ b/proofs/backends/sp1/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-chain-proof-sp1-types"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/proofs/debug/bin/prover-cli/Cargo.toml
+++ b/proofs/debug/bin/prover-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-chain-prover-cli"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/proofs/debug/bin/prover-nitro/Cargo.toml
+++ b/proofs/debug/bin/prover-nitro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-chain-prover-nitro"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/proofs/debug/bin/prover-sp1/Cargo.toml
+++ b/proofs/debug/bin/prover-sp1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-chain-prover-sp1"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/proofs/debug/prover/Cargo.toml
+++ b/proofs/debug/prover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-chain-prover"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/proofs/it/Cargo.toml
+++ b/proofs/it/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-chain-proof-it"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/proofs/kona-host/Cargo.toml
+++ b/proofs/kona-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-chain-proof-kona-host"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/proofs/measured/core/Cargo.toml
+++ b/proofs/measured/core/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "3"
 members = ["."]
 
 [workspace.package]
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 edition = "2024"
 rust-version = "1.95.0"
 license = "MIT"

--- a/proofs/measured/kona-client/Cargo.toml
+++ b/proofs/measured/kona-client/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 members = ["."]
 
 [workspace.package]
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 edition = "2024"
 rust-version = "1.95.0"
 license = "MIT"

--- a/proofs/measured/nitro-enclave/Cargo.lock
+++ b/proofs/measured/nitro-enclave/Cargo.lock
@@ -5076,7 +5076,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "world-chain-proof-core"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5099,7 +5099,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-kona-client"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5129,7 +5129,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-nitro-enclave"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/proofs/measured/nitro-enclave/Cargo.toml
+++ b/proofs/measured/nitro-enclave/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "3"
 members = ["."]
 
 [workspace.package]
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 edition = "2024"
 rust-version = "1.95.0"
 license = "MIT"

--- a/proofs/measured/sp1-programs/Cargo.lock
+++ b/proofs/measured/sp1-programs/Cargo.lock
@@ -4385,7 +4385,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-core"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4408,7 +4408,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-kona-client"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4438,7 +4438,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-succinct-aggregation"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -4453,7 +4453,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-succinct-range-ethereum"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "kona-proof",
  "rkyv",
@@ -4465,7 +4465,7 @@ dependencies = [
 
 [[package]]
 name = "world-chain-proof-succinct-range-utils"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "anyhow",
  "kona-proof",

--- a/proofs/measured/sp1-programs/Cargo.toml
+++ b/proofs/measured/sp1-programs/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 edition = "2024"
 license = "MIT"
 homepage = "https://world.org/world-chain"

--- a/proofs/measurements.json
+++ b/proofs/measurements.json
@@ -1,19 +1,19 @@
 {
   "nitro": {
-    "pcr0": "0x1047a9abb6fdfc70f1e4df56faf857fba33b7c2643833e0845060d21133a1812d31c113af3ff4582dfcb5ee5af3a5477",
+    "pcr0": "0xa1fdfb876e6c749dfc011052a0b91181bb2c3bd19847eae15269398a7336d8ef62efb8adfbf6cd5da277cb198489acd5",
     "pcr1": "0xab92a79f22cbca162b415c97f3406327ab858f9a73ffd4f7720710529eee87f085d21c3dd2819ef63263b0dad0b4a9d6",
-    "pcr2": "0x94bc876bd0dfc0f5c8d8f1c34cbdbc0c4e6f2521428805901b660c85391afca77b435b1b1cace64aba01313ae91d2c3b"
+    "pcr2": "0x3013b543832eb35aa4859711df6ba2ea24c00065c5f282a4409ce6199ad7e3f8ceb893e0ae75627d934c8aa13054bcb4"
   },
   "sp1": {
-    "aggregation_vkey": "0x00e9ee2c9771b4a3596809af947148b803be6c9989bc98dded1c185ebffe18c9",
+    "aggregation_vkey": "0x00c4d8da0e477d108681a7e525ee841934b467243e899bdeff739200ebf8e1a9",
     "elfs": {
       "world-chain-aggregation": {
-        "sha256": "0147dc683e64a75b9ecb869042bb3db3c946a258be3b8f66fa9f5ae497210c0c"
+        "sha256": "8eaa39a8734ad0ef5af5fd217ae7b80befa06796f4768a7fa4540d2f9fa97ea2"
       },
       "world-chain-range-ethereum": {
-        "sha256": "ca68d1f513e81bff7b0977f5425152f445b6e0c14733acec1b03ecceeef4ddb0"
+        "sha256": "c2e50b1dd336b8630d57e1d265cfe308d550137c4095be61642b6952a6399342"
       }
     },
-    "range_vkey_commitment": "0x729e953b5968b34c75ab76a94e819fdb4000c24422f695181a1e29e522d13fa0"
+    "range_vkey_commitment": "0x4469cac34891b0fd3e18ecb551df1075407d0eea696bf57426deed190269c4fc"
   }
 }

--- a/proofs/metrics/Cargo.toml
+++ b/proofs/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-chain-proof-metrics"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/proofs/protocol/Cargo.toml
+++ b/proofs/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-chain-proof-protocol"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/proofs/services/challenger/Cargo.toml
+++ b/proofs/services/challenger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-chain-challenger"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/proofs/services/defender/Cargo.toml
+++ b/proofs/services/defender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-chain-defender"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/proofs/services/proposer/Cargo.toml
+++ b/proofs/services/proposer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-chain-proposer"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/proofs/services/prover-service/Cargo.toml
+++ b/proofs/services/prover-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-chain-prover-service"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/proofs/services/tx-signer/Cargo.toml
+++ b/proofs/services/tx-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-chain-proof-tx-signer"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/proofs/workers/core/Cargo.toml
+++ b/proofs/workers/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-chain-proof-worker"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/proofs/workers/nitro/Cargo.toml
+++ b/proofs/workers/nitro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-chain-proof-nitro-worker"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/proofs/workers/sp1/Cargo.toml
+++ b/proofs/workers/sp1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-chain-proof-sp1-worker"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mechanical version-only release prep with no logic or dependency graph changes in this diff.
> 
> **Overview**
> This PR advances the **proofs release train** from `1.0.0-rc.1` to **`1.0.0-rc.2`** across the `world-chain-proof-*` / prover crates that share `[package.metadata.release] shared-version = "proofs"`.
> 
> The bump is applied in the root **`Cargo.lock`**, host-side **`Cargo.toml`** manifests (services, workers, SP1/Nitro backends, debug binaries, protocol/metrics, etc.), and the **measured** standalone workspaces under `proofs/measured/` (including their nested lockfiles). There are **no Rust source or dependency changes** in the diff—only crate version metadata and lockfile entries reflecting those versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7cc644709cb5a6f8591754a67249cb938ffd1be. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->