### PR TITLE
feat(proofs): instrument witness collection

### DIFF
--- a/proofs/kona-host/src/online.rs
+++ b/proofs/kona-host/src/online.rs
@@ -215,6 +215,18 @@ pub struct RangeProofInput {
     pub witness: WorldRangeWitnessData,
 }
 
+/// Returns whether a failed witness build exhausted its collection deadline.
+///
+/// The public builder returns `anyhow::Error` so callers can keep their existing error context;
+/// this centralizes the timeout classification used for low-cardinality worker metrics.
+pub fn is_witness_generation_timeout(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .to_string()
+            .starts_with("Kona witness generation timed out after ")
+    })
+}
+
 /// Context captured while building a range witness.
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/proofs/metrics/src/lib.rs
+++ b/proofs/metrics/src/lib.rs
@@ -44,6 +44,10 @@ pub const METRICS_PROOF_JOBS_CLAIMED: &str = "proof_jobs.claimed";
 pub const METRICS_PROOF_JOBS_COMPLETED: &str = "proof_jobs.completed";
 /// End-to-end worker proof-job attempt duration.
 pub const METRICS_PROOF_JOB_DURATION_SECONDS: &str = "proof_job.duration_seconds";
+/// Completed witness-collection attempts.
+pub const METRICS_WITNESS_COLLECTIONS_COMPLETED: &str = "witness_collection.completed";
+/// Witness-collection duration.
+pub const METRICS_WITNESS_COLLECTION_DURATION_SECONDS: &str = "witness_collection.duration_seconds";
 /// Whether this worker's enclave signing key is registered on-chain.
 pub const METRICS_ENCLAVE_KEY_REGISTERED: &str = "enclave_key.registered";
 /// Enclave key registration attempts, by outcome.
@@ -116,6 +120,16 @@ pub fn describe_metrics() {
         METRICS_PROOF_JOB_DURATION_SECONDS,
         metrics::Unit::Seconds,
         "End-to-end worker proof-job attempt duration by backend and outcome."
+    );
+    metrics::describe_counter!(
+        METRICS_WITNESS_COLLECTIONS_COMPLETED,
+        metrics::Unit::Count,
+        "Completed Kona witness-collection attempts by backend and outcome."
+    );
+    metrics::describe_histogram!(
+        METRICS_WITNESS_COLLECTION_DURATION_SECONDS,
+        metrics::Unit::Seconds,
+        "Kona witness-collection duration by backend and outcome."
     );
     metrics::describe_gauge!(
         METRICS_ENCLAVE_KEY_REGISTERED,
@@ -253,6 +267,24 @@ pub fn record_proof_job_completed(
     .increment(1);
     metrics::histogram!(
         METRICS_PROOF_JOB_DURATION_SECONDS,
+        "backend" => backend,
+        "outcome" => outcome,
+    )
+    .record(duration.as_secs_f64());
+}
+
+/// Records one Kona witness-collection attempt.
+///
+/// `outcome` is limited to `success`, `timeout`, or `error`.
+pub fn record_witness_collection(backend: &'static str, outcome: &'static str, duration: Duration) {
+    metrics::counter!(
+        METRICS_WITNESS_COLLECTIONS_COMPLETED,
+        "backend" => backend,
+        "outcome" => outcome,
+    )
+    .increment(1);
+    metrics::histogram!(
+        METRICS_WITNESS_COLLECTION_DURATION_SECONDS,
         "backend" => backend,
         "outcome" => outcome,
     )

--- a/proofs/workers/nitro/src/lib.rs
+++ b/proofs/workers/nitro/src/lib.rs
@@ -27,7 +27,7 @@ use alloy_sol_types::SolValue;
 use anyhow::{Context, bail};
 use tracing::{debug, info};
 use world_chain_proof_kona_host::online::{
-    OnlineHostConfig, RangeWitnessRequest, build_range_input,
+    OnlineHostConfig, RangeWitnessRequest, build_range_input, is_witness_generation_timeout,
 };
 use world_chain_proof_nitro_enclave::{
     ExpectedPcrs, NitroRangeProofRequest,
@@ -116,7 +116,7 @@ where
             "collecting witness data for range"
         );
         let witness_collection_started_at = std::time::Instant::now();
-        let input = build_range_input(
+        let input = match build_range_input(
             &self.config.online,
             RangeWitnessRequest {
                 start_block,
@@ -126,7 +126,29 @@ where
             },
         )
         .await
-        .context("witness generation failed")?;
+        {
+            Ok(input) => {
+                world_chain_proof_metrics::record_witness_collection(
+                    "nitro",
+                    "success",
+                    witness_collection_started_at.elapsed(),
+                );
+                input
+            }
+            Err(error) => {
+                let outcome = if is_witness_generation_timeout(&error) {
+                    "timeout"
+                } else {
+                    "error"
+                };
+                world_chain_proof_metrics::record_witness_collection(
+                    "nitro",
+                    outcome,
+                    witness_collection_started_at.elapsed(),
+                );
+                return Err(error).context("witness generation failed");
+            }
+        };
 
         let nitro_request = NitroRangeProofRequest::from_witness_data(&input.witness, None)
             .context("witness serialize")?;

--- a/proofs/workers/sp1/src/backend.rs
+++ b/proofs/workers/sp1/src/backend.rs
@@ -8,6 +8,7 @@ use anyhow::Context;
 use world_chain_proof_core::artifacts::{AggregationProofArtifact, RangeProofArtifact};
 use world_chain_proof_kona_host::online::{
     OnlineHostConfig, RangeWitnessRequest, build_range_input, fetch_l1_header_by_hash,
+    is_witness_generation_timeout,
 };
 use world_chain_proof_protocol::ProofGameProvider;
 use world_chain_proof_sp1_host::{
@@ -563,7 +564,8 @@ impl<P: WorldSuccinctProver + Send + Sync, G: ProofGameProvider> Sp1Backend<P, G
         end_block: u64,
         request: &ProofRequest,
     ) -> anyhow::Result<RangeProofRequest> {
-        let input = build_range_input(
+        let witness_collection_started_at = std::time::Instant::now();
+        let input = match build_range_input(
             &self.host,
             RangeWitnessRequest {
                 start_block,
@@ -573,7 +575,29 @@ impl<P: WorldSuccinctProver + Send + Sync, G: ProofGameProvider> Sp1Backend<P, G
             },
         )
         .await
-        .context("failed to build SP1 range witness")?;
+        {
+            Ok(input) => {
+                world_chain_proof_metrics::record_witness_collection(
+                    "sp1",
+                    "success",
+                    witness_collection_started_at.elapsed(),
+                );
+                input
+            }
+            Err(error) => {
+                let outcome = if is_witness_generation_timeout(&error) {
+                    "timeout"
+                } else {
+                    "error"
+                };
+                world_chain_proof_metrics::record_witness_collection(
+                    "sp1",
+                    outcome,
+                    witness_collection_started_at.elapsed(),
+                );
+                return Err(error).context("failed to build SP1 range witness");
+            }
+        };
 
         let range_request = RangeProofRequest::from_witness_data(&input.witness)
             .context("failed to serialize SP1 range witness")?;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metrics-only instrumentation around existing witness build paths; proof behavior and error handling are unchanged aside from recording counters and histograms.
> 
> **Overview**
> Adds **observability for Kona witness collection** on the Nitro and SP1 proof workers, separate from end-to-end proof-job metrics.
> 
> New shared metrics **`witness_collection.completed`** and **`witness_collection.duration_seconds`** are recorded via `record_witness_collection`, labeled by **`backend`** (`nitro` / `sp1`) and **`outcome`** (`success`, `timeout`, or `error`). Both workers time `build_range_input` and emit metrics on every attempt before propagating failures unchanged.
> 
> **`is_witness_generation_timeout`** in `kona-host` centralizes detection of the existing `"Kona witness generation timed out after …"` error so timeouts get a low-cardinality outcome label instead of lumping into generic errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8130de5359f699c77c5984d5544aba224751c9a5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->