### PR TITLE
Publish witness benchmark images

### DIFF
--- a/.github/workflows/docker-proof.yml
+++ b/.github/workflows/docker-proof.yml
@@ -144,6 +144,8 @@ jobs:
       matrix:
         service:
           - { suffix: -sp1-worker, package: world-chain-proof-sp1-worker, bin: world-chain-proof-sp1-worker, prefix: digests-sp1-worker, target: sp1-worker }
+          - { suffix: -prover-sp1, package: world-chain-prover-sp1, bin: world-chain-prover-sp1, prefix: digests-prover-sp1, target: final }
+          - { suffix: -prover-nitro, package: world-chain-prover-nitro, bin: world-chain-prover-nitro, prefix: digests-prover-nitro, target: final }
           - { suffix: -proposer, package: world-chain-proposer, bin: world-chain-proposer, prefix: digests-proposer, target: final }
           - { suffix: -challenger, package: world-chain-challenger, bin: world-chain-challenger, prefix: digests-challenger, target: final }
           - { suffix: -defender, package: world-chain-defender, bin: world-chain-defender, prefix: digests-defender, target: final }
@@ -188,6 +190,8 @@ jobs:
       matrix:
         service:
           - { suffix: -sp1-worker, prefix: digests-sp1-worker }
+          - { suffix: -prover-sp1, prefix: digests-prover-sp1 }
+          - { suffix: -prover-nitro, prefix: digests-prover-nitro }
           - { suffix: -proposer, prefix: digests-proposer }
           - { suffix: -challenger, prefix: digests-challenger }
           - { suffix: -defender, prefix: digests-defender }


### PR DESCRIPTION
## Summary
- publish the existing SP1 and Nitro witness CLI binaries as OCI images
- keep the images independent from production worker images

These images expose the `witness` command for in-cluster benchmark Jobs.

## Validation
- `yq . .github/workflows/docker-proof.yml`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only matrix additions that publish additional container images; no application or security logic changes in this diff.
> 
> **Overview**
> Extends the **docker-proof** workflow so **GHCR** also builds and merges multi-arch manifests for **`world-chain-prover-sp1`** and **`world-chain-prover-nitro`**, using the same service-image pipeline as proposer/challenger (`Dockerfile.prover` **`final`** target with per-service `PROVER_PACKAGE` / `PROVER_BIN`).
> 
> New image names are **`…-prover-sp1`** and **`…-prover-nitro`**, tagged like other service images (`nightly` / `sha-<short>`), separate from the production **sp1-worker** and **nitro-worker** images—intended for in-cluster benchmark Jobs that run the **`witness`** CLI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fcab245e3e44e8561e99e5909d2d3adbb9c3ef0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->