### PR TITLE
test(proof-system): add e2e devnet tests for challenger

### DIFF
--- a/e2e-tests/src/it/devnet_challenge.rs
+++ b/e2e-tests/src/it/devnet_challenge.rs
@@ -119,7 +119,7 @@ async fn already_expired_game_is_ignored() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
     let Some(devnet) = try_build_ha_devnet_with_custom_block_time(
-        "unkown game type is ignored",
+        "already expired game is ignored",
         Duration::from_millis(200), // 200ms block time
     )
     .await?

--- a/e2e-tests/src/it/devnet_challenge.rs
+++ b/e2e-tests/src/it/devnet_challenge.rs
@@ -1,12 +1,17 @@
-use alloy_primitives::B256;
-use eyre::eyre::ensure;
-use world_chain_proof_protocol::LineageProvider;
+use std::time::Duration;
+
+use alloy_primitives::{B256, U256, utils::parse_ether};
+use eyre::eyre::{ensure, eyre};
+use world_chain_proof_protocol::{IDisputeGameFactory, LineageProvider};
 use world_chain_proposer::{Proposal, ProposerClient};
 
-use crate::it::utils::devnet::{
-    GAME_CHALLENGER_WINS, advance_to_timestamp, funded_throwaway_provider, game_at, l1_contract,
-    l1_rpc_url, proof_system_client, try_build_ha_devnet, vault_at, wait_for_challenge,
-    wait_for_status,
+use crate::it::utils::{
+    bindings::IFaultDisputeGame::{GameStatus, IFaultDisputeGameInstance},
+    devnet::{
+        GAME_CHALLENGER_WINS, advance_to_timestamp, fund_address, funded_throwaway_provider,
+        game_at, l1_contract, l1_rpc_url, proof_system_client, try_build_ha_devnet,
+        try_build_ha_devnet_with_custom_block_time, vault_at, wait_for_challenge, wait_for_status,
+    },
 };
 
 /// End-to-end fault path: a dishonest proposer posts a root that disagrees with consensus, the
@@ -97,5 +102,125 @@ async fn bad_root_proposal_is_challenged_and_invalidated() -> eyre::Result<()> {
 
     println!("devnet challenge: bad root at game {game_address} correctly resolved ChallengerWins");
 
+    Ok(())
+}
+
+/// The challenger completely ignores games that are already expired.
+#[ignore = "requires Docker, Foundry, and the full local OP Stack"]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn already_expired_game_is_ignored() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let Some(devnet) = try_build_ha_devnet_with_custom_block_time(
+        "unkown game type is ignored",
+        Duration::from_millis(200), // 200ms block time
+    )
+    .await?
+    else {
+        return Ok(());
+    };
+
+    let l1_rpc = l1_rpc_url(&devnet)?;
+    let factory_address = l1_contract(devnet.dispute_game_factory(), "DisputeGameFactory")?;
+
+    let (address, provider) = funded_throwaway_provider(l1_rpc, factory_address).await?;
+    let contracts = proof_system_client(provider.clone(), factory_address).await?;
+
+    // Wins the first proposal window: the honest proposer can't submit until `block_interval` L2
+    // blocks are safe, several seconds out at devnet block time.
+    let anchor = contracts.lineage_anchor().await?;
+    let registered = contracts.registered_lineage_config();
+    let bad_root = B256::repeat_byte(0xba);
+    let bad_proposal = Proposal {
+        parent_ref: anchor.address,
+        root_claim: bad_root,
+        l2_block_number: anchor
+            .l2_block_number
+            .saturating_add(registered.block_interval),
+        attempt: 0,
+    };
+
+    let submission = contracts.submit_proposal(&bad_proposal).await?;
+    let game_address = submission.game_address;
+    println!(
+        "devnet challenge: malicious proposer {address} posted bad root {bad_root} for l2 block {} at game {game_address}",
+        bad_proposal.l2_block_number
+    );
+    let game = game_at(game_address, provider.clone());
+    let proof_deadline = game.proofDeadline().call().await?;
+    advance_to_timestamp(&provider, proof_deadline.saturating_add(1)).await?;
+    // Sleep for ~30 secs so that the block that contains that game becomes finalized.
+    // Our challenger only looks at games contained in finalized blocks.
+    tokio::time::sleep(Duration::from_secs(30)).await;
+    let game_status = game.status().call().await?;
+    // The challenger doesn't challenge this game even if it contains an invalid root_claim
+    // because proof_deadline has already elapsed, therefore this game won't ever be considered
+    // valid anymore.
+    let expected_game_status = 0; // IN_PROGRESS
+    assert_eq!(game_status, expected_game_status);
+    Ok(())
+}
+
+/// The challenger completely ignores games that are not WIP1006 type.
+#[ignore = "requires Docker, Foundry, and the full local OP Stack"]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn unknown_game_type_is_ignored() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+    // The type must be already set in the `DisputeGameFactory` contract, otherwise the creation
+    // of a game fails with `NoImplementation` error.
+    const PERMISSIONED_CANNON: u32 = 1;
+    const OP_PROPOSER_PRIVATE_KEY: &str =
+        "0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97";
+
+    let Some(devnet) = try_build_ha_devnet_with_custom_block_time(
+        "unkown game type is ignored",
+        Duration::from_millis(200), // 200ms block time
+    )
+    .await?
+    else {
+        return Ok(());
+    };
+    let l1_rpc = l1_rpc_url(&devnet)?;
+    let factory_address = l1_contract(devnet.dispute_game_factory(), "DisputeGameFactory")?;
+
+    let provider = fund_address(l1_rpc, OP_PROPOSER_PRIVATE_KEY).await?;
+    let factory =
+        IDisputeGameFactory::IDisputeGameFactoryInstance::new(factory_address, provider.clone());
+
+    let dummy_root_claim = B256::ZERO;
+    // Extra data must be 32 bytes long in the permissioned cannon game.
+    // It represents the l2 block number.
+    let dummy_extra_data = U256::from(1).to_be_bytes::<32>().into();
+    // Set 0.08 ether as the bond value for the game creation
+    let init_bond = parse_ether("0.08")?;
+    let pending_create_tx = factory
+        .create(PERMISSIONED_CANNON, dummy_root_claim, dummy_extra_data)
+        .value(init_bond)
+        .send()
+        .await?;
+    let receipt = pending_create_tx.get_receipt().await?;
+    assert!(receipt.status());
+    let game_address = receipt
+        .logs()
+        .iter()
+        .filter(|log| log.address() == factory_address)
+        .find_map(|log| {
+            log.log_decode_validate::<IDisputeGameFactory::DisputeGameCreated>()
+                .ok()
+                .map(|decoded| decoded.inner.data)
+        })
+        .filter(|event| {
+            event.gameType == PERMISSIONED_CANNON && event.rootClaim == dummy_root_claim
+        })
+        .map(|event| event.disputeProxy)
+        .ok_or_else(|| eyre!("no game created"))?;
+    // Sleep for ~30 secs so that the block that contains that game becomes finalized.
+    // Our challenger only looks at games contained in finalized blocks.
+    tokio::time::sleep(Duration::from_secs(30)).await;
+    // Ensure that the game is still `IN_PROGRESS` because our challenger isn't triggered
+    // by an unknown game type that differs from WIP1006.
+    let fault_dispute_game = IFaultDisputeGameInstance::new(game_address, provider);
+    let status = fault_dispute_game.status().call().await?;
+    assert_eq!(status, GameStatus::IN_PROGRESS);
     Ok(())
 }

--- a/e2e-tests/src/it/devnet_challenge.rs
+++ b/e2e-tests/src/it/devnet_challenge.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
-use alloy_primitives::{B256, U256, utils::parse_ether};
+use alloy_primitives::{Address, B256, U256, address, utils::parse_ether};
+use alloy_provider::Provider;
 use eyre::eyre::{ensure, eyre};
 use world_chain_proof_protocol::{IDisputeGameFactory, LineageProvider};
 use world_chain_proposer::{Proposal, ProposerClient};
@@ -13,6 +14,12 @@ use crate::it::utils::{
         try_build_ha_devnet_with_custom_block_time, vault_at, wait_for_challenge, wait_for_status,
     },
 };
+
+/// In-process World Chain challenger (`WORLD_CHALLENGER_PRIVATE_KEY` in
+/// `crates/devnet/src/full_stack.rs`).
+const WORLD_CHALLENGER_ADDRESS: Address = address!("0x743dAA55063C608894C125Cf8eC82Afe83B2d5c5");
+/// Long enough for several challenger poll ticks after the game is L1-finalized.
+const CHALLENGER_IDLE_OBSERVATION: Duration = Duration::from_secs(20);
 
 /// End-to-end fault path: a dishonest proposer posts a root that disagrees with consensus, the
 /// real challenger detects and challenges it, the real defender declines to defend it, and the
@@ -158,6 +165,75 @@ async fn already_expired_game_is_ignored() -> eyre::Result<()> {
     // valid anymore.
     let expected_game_status = 0; // IN_PROGRESS
     assert_eq!(game_status, expected_game_status);
+    Ok(())
+}
+
+/// The challenger completely ignores already challenged games.
+///
+/// Game state alone cannot prove this: a second `challenge()` reverts with
+/// `ClaimAlreadyChallenged` and leaves `challenger()` unchanged. We instead
+/// assert the world challenger's L1 nonce does not move after it has had time
+/// to see the finalized game. A mined (even reverted) challenge would bump it.
+#[ignore = "requires Docker, Foundry, and the full local OP Stack"]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn already_challenged_game_is_ignored() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let Some(devnet) = try_build_ha_devnet_with_custom_block_time(
+        "already challenged game is ignored",
+        Duration::from_millis(200), // 200ms block time
+    )
+    .await?
+    else {
+        return Ok(());
+    };
+
+    let l1_rpc = l1_rpc_url(&devnet)?;
+    let factory_address = l1_contract(devnet.dispute_game_factory(), "DisputeGameFactory")?;
+
+    let (address, provider) = funded_throwaway_provider(l1_rpc, factory_address).await?;
+    let contracts = proof_system_client(provider.clone(), factory_address).await?;
+
+    // Wins the first proposal window: the honest proposer can't submit until `block_interval` L2
+    // blocks are safe, several seconds out at devnet block time.
+    let anchor = contracts.lineage_anchor().await?;
+    let registered = contracts.registered_lineage_config();
+    let bad_root = B256::repeat_byte(0xba);
+    let bad_proposal = Proposal {
+        parent_ref: anchor.address,
+        root_claim: bad_root,
+        l2_block_number: anchor
+            .l2_block_number
+            .saturating_add(registered.block_interval),
+        attempt: 0,
+    };
+
+    let submission = contracts.submit_proposal(&bad_proposal).await?;
+    let game_address = submission.game_address;
+    println!(
+        "devnet challenge: malicious proposer {address} posted bad root {bad_root} for l2 block {} at game {game_address}",
+        bad_proposal.l2_block_number
+    );
+    let game = game_at(game_address, provider.clone());
+    // Challenge before L1 finalization so the real challenger first sees an already-challenged game.
+    let receipt = game.challenge().send().await?.get_receipt().await?;
+    assert!(receipt.status());
+    assert_eq!(game.challenger().call().await?, address);
+
+    // Sleep for ~30 secs so that the block that contains that game becomes finalized.
+    // Our challenger only looks at games contained in finalized blocks.
+    tokio::time::sleep(Duration::from_secs(30)).await;
+
+    let nonce_before = provider
+        .get_transaction_count(WORLD_CHALLENGER_ADDRESS)
+        .await?;
+    tokio::time::sleep(CHALLENGER_IDLE_OBSERVATION).await;
+    let nonce_after = provider
+        .get_transaction_count(WORLD_CHALLENGER_ADDRESS)
+        .await?;
+
+    assert_eq!(nonce_after, nonce_before,);
+    assert_eq!(game.challenger().call().await?, address);
     Ok(())
 }
 

--- a/e2e-tests/src/it/utils/bindings.rs
+++ b/e2e-tests/src/it/utils/bindings.rs
@@ -1,0 +1,19 @@
+use alloy_sol_types::sol;
+
+sol! {
+    #[sol(rpc)]
+    interface IFaultDisputeGame {
+        /// @notice The current status of the dispute game.
+        #[derive(Debug, PartialEq)]
+        enum GameStatus {
+            // The game is currently in progress, and has not been resolved.
+            IN_PROGRESS,
+            // The game has concluded, and the `rootClaim` was challenged successfully.
+            CHALLENGER_WINS,
+            // The game has concluded, and the `rootClaim` could not be contested.
+            DEFENDER_WINS
+        }
+
+        function status() external view returns (GameStatus);
+    }
+}

--- a/e2e-tests/src/it/utils/devnet.rs
+++ b/e2e-tests/src/it/utils/devnet.rs
@@ -5,6 +5,7 @@
 
 use std::{
     future::Future,
+    str::FromStr,
     time::{Duration, Instant},
 };
 
@@ -51,11 +52,9 @@ sol! {
     }
 }
 
-/// Builds the HA-sequencer full stack every proof-system test runs against.
-///
-/// `Ok(None)` means Docker is unavailable — the caller should skip, not fail.
-pub(in crate::it) async fn try_build_ha_devnet(
+pub async fn try_build_ha_devnet_with_custom_block_time(
     skip_label: &str,
+    block_time: Duration,
 ) -> eyre::Result<Option<WorldDevnet>> {
     let ha_config = HaSequencerConfig::default()
         .with_sequencer_count(2)
@@ -64,7 +63,7 @@ pub(in crate::it) async fn try_build_ha_devnet(
     match WorldDevnetBuilder::new()
         .preset(WorldDevnetPreset::HaSequencer)
         .ha_sequencer(ha_config)
-        .block_time(Duration::from_secs(1))
+        .block_time(block_time)
         .build()
         .await
     {
@@ -75,6 +74,13 @@ pub(in crate::it) async fn try_build_ha_devnet(
         }
         Err(err) => Err(err),
     }
+}
+
+/// Builds the HA-sequencer full stack every proof-system test runs against.
+///
+/// `Ok(None)` means Docker is unavailable — the caller should skip, not fail.
+pub async fn try_build_ha_devnet(skip_label: &str) -> eyre::Result<Option<WorldDevnet>> {
+    try_build_ha_devnet_with_custom_block_time(skip_label, Duration::from_secs(1)).await
 }
 
 pub(in crate::it) fn l1_rpc_url(devnet: &WorldDevnet) -> eyre::Result<&str> {
@@ -101,6 +107,22 @@ pub(in crate::it) fn signing_provider(
     Ok(ProviderBuilder::new()
         .wallet(EthereumWallet::from(signer))
         .connect_http(Url::parse(rpc)?))
+}
+
+/// Funds the address originated from the provided private key with ETH and returns the related provider.
+pub async fn fund_address(
+    l1_rpc: &str,
+    private_key: &str,
+) -> eyre::Result<impl Provider + WalletProvider + Clone + use<>> {
+    let signer = PrivateKeySigner::from_str(private_key)?;
+    let address = signer.address();
+    ProviderBuilder::new()
+        .connect_http(Url::parse(l1_rpc)?)
+        .anvil_set_balance(address, U256::from(THROWAWAY_ACCOUNT_BALANCE_WEI))
+        .await?;
+
+    let provider = signing_provider(l1_rpc, signer)?;
+    Ok(provider)
 }
 
 /// Funds a fresh random account with L1 gas and mock tokens deposited into the active bond vault.

--- a/e2e-tests/src/it/utils/mod.rs
+++ b/e2e-tests/src/it/utils/mod.rs
@@ -1,1 +1,2 @@
+pub mod bindings;
 pub mod devnet;

--- a/pkg/contracts/src/pbh/PBHEntryPointImplV1.sol
+++ b/pkg/contracts/src/pbh/PBHEntryPointImplV1.sol
@@ -280,7 +280,8 @@ contract PBHEntryPointImplV1 is IPBHEntryPoint, Base, ReentrancyGuardTransient {
                 // We now generate the signal hash from the sender, nonce, and calldata
                 uint256 signalHash = abi.encodePacked(
                         sender, opsPerAggregator[i].userOps[j].nonce, opsPerAggregator[i].userOps[j].callData
-                    ).hashToField();
+                    )
+                    .hashToField();
 
                 _verifyPbh(signalHash, pbhPayloads[j]);
                 bytes32 userOpHash = getUserOpHash(opsPerAggregator[i].userOps[j]);

--- a/pkg/contracts/src/pbh/PBHEntryPointImplV1.sol
+++ b/pkg/contracts/src/pbh/PBHEntryPointImplV1.sol
@@ -280,8 +280,7 @@ contract PBHEntryPointImplV1 is IPBHEntryPoint, Base, ReentrancyGuardTransient {
                 // We now generate the signal hash from the sender, nonce, and calldata
                 uint256 signalHash = abi.encodePacked(
                         sender, opsPerAggregator[i].userOps[j].nonce, opsPerAggregator[i].userOps[j].callData
-                    )
-                    .hashToField();
+                    ).hashToField();
 
                 _verifyPbh(signalHash, pbhPayloads[j]);
                 bytes32 userOpHash = getUserOpHash(opsPerAggregator[i].userOps[j]);


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-5047/local-devnet-add-tests-in-devnet-challenge-file

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to e2e fixtures and bindings; no production challenger or contract logic is modified.
> 
> **Overview**
> Adds **three ignored Docker devnet E2E tests** in `devnet_challenge.rs` that assert the in-process World Chain challenger does **not** act on games that are past the proof deadline, already challenged, or of a non-WIP1006 type (permissioned cannon via `DisputeGameFactory.create`).
> 
> Test support changes: **`try_build_ha_devnet_with_custom_block_time`** (200ms blocks for faster finalization waits) with **`try_build_ha_devnet`** delegating to the 1s default; new **`fund_address`** for a known devnet signer; a small **`IFaultDisputeGame`** binding for `GameStatus`; and **`WORLD_CHALLENGER_ADDRESS` / nonce idle checks** for the already-challenged case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cdeae14fda85810d006e819fdbcf482e4497e72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->