### PR TITLE
feat(proofs): configure witness timeout from environment

### DIFF
--- a/proofs/workers/nitro/src/cmd/run.rs
+++ b/proofs/workers/nitro/src/cmd/run.rs
@@ -185,7 +185,7 @@ pub struct WorkerArgs {
     poll_interval_seconds: u64,
 
     /// Maximum seconds to spend generating one Kona witness.
-    #[arg(long, default_value_t = 900)]
+    #[arg(long, env = "WITNESS_TIMEOUT_SECONDS", default_value_t = 900)]
     witness_timeout_seconds: u64,
 
     /// Maximum number of jobs proved concurrently. TEE attestation is cheaper than ZK

--- a/proofs/workers/sp1/src/cmd/run.rs
+++ b/proofs/workers/sp1/src/cmd/run.rs
@@ -121,7 +121,7 @@ pub struct WorkerArgs {
     allow_unfinalized: bool,
 
     /// Maximum seconds to spend generating one Kona witness.
-    #[arg(long, default_value_t = 900)]
+    #[arg(long, env = "WITNESS_TIMEOUT_SECONDS", default_value_t = 900)]
     witness_timeout_seconds: u64,
 
     /// Prover backend.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds env-based configuration only; default timeout and behavior are unchanged unless operators set the variable.
> 
> **Overview**
> Both the **Nitro** and **SP1** proving workers can now set the Kona witness generation ceiling via the **`WITNESS_TIMEOUT_SECONDS`** environment variable (still overridable with `--witness-timeout-seconds`). The default remains **900** seconds.
> 
> This matches how other worker flags are configured (e.g. `POLL_INTERVAL_SECONDS`, RPC URLs) so operators can tune witness timeouts in Kubernetes or other deployments without changing CLI args.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72e9981e4270f77d7988bfa4fcb81fec2292f5e6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->