### PR TITLE
test(proof-system): add e2e devnet tests for proof invariants

### DIFF
--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -919,20 +919,18 @@ impl FullStackWorldDevnet {
                 .await?,
         );
 
-        if restart_sp1 {
-            if let Some(kind) = sp1_worker_prover_kind()? {
-                self._sp1_worker = Some(
-                    start_sp1_worker(
-                        &l1_rpc,
-                        &l2_rpc,
-                        &prover_service_url,
-                        &rollup_path,
-                        &deployment,
-                        kind,
-                    )
-                    .await?,
-                );
-            }
+        if restart_sp1 && let Some(kind) = sp1_worker_prover_kind()? {
+            self._sp1_worker = Some(
+                start_sp1_worker(
+                    &l1_rpc,
+                    &l2_rpc,
+                    &prover_service_url,
+                    &rollup_path,
+                    &deployment,
+                    kind,
+                )
+                .await?,
+            );
         }
 
         Ok(())

--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -865,6 +865,10 @@ impl FullStackWorldDevnet {
         &self.sequencers[0].rpc_url
     }
 
+    pub fn l2_op_node_rpc_url(&self) -> &str {
+        &self._op_nodes[0].rpc_url
+    }
+
     /// JSON-RPC URL of the in-process defender prover-service, when enabled.
     #[allow(dead_code)]
     pub fn prover_service_url(&self) -> Option<&str> {

--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -885,6 +885,59 @@ impl FullStackWorldDevnet {
         self._sp1_worker.take();
     }
 
+    /// Re-spawns the in-process defender and its TEE worker after [`Self::stop_defender`].
+    ///
+    /// Idempotent when the defender is already running. Reuses the still-live prover-service and
+    /// the deployed proof-system addresses. Also restarts the SP1 worker when
+    /// `DEVNET_SP1_WORKER_PROVER` is set, using the rollup config under the stack tempdir.
+    pub async fn start_defender(&mut self) -> Result<()> {
+        if self._world_defender.is_some() {
+            return Ok(());
+        }
+
+        let deployment = self
+            ._proof_system
+            .clone()
+            .ok_or_else(|| eyre!("cannot start defender: proof system was not deployed"))?;
+        let prover_service_url = self
+            .prover_service_url
+            .clone()
+            .ok_or_else(|| eyre!("cannot start defender: prover-service is not running"))?;
+        let l1_rpc = self.l1_rpc_url().to_string();
+        let output_root_rpc = self.l2_op_node_rpc_url().to_string();
+        let l2_rpc = self.l2_rpc_url().to_string();
+        let rollup_path = self._tempdir.path().join("rollup.json");
+        let restart_nitro = self._nitro_worker.is_none();
+        let restart_sp1 = self._sp1_worker.is_none();
+
+        if restart_nitro {
+            self._nitro_worker = Some(start_devnet_nitro_worker(&prover_service_url)?);
+        }
+
+        self._world_defender = Some(
+            start_world_chain_defender(&l1_rpc, &output_root_rpc, &prover_service_url, &deployment)
+                .await?,
+        );
+
+        if restart_sp1 {
+            if let Some(kind) = sp1_worker_prover_kind()? {
+                self._sp1_worker = Some(
+                    start_sp1_worker(
+                        &l1_rpc,
+                        &l2_rpc,
+                        &prover_service_url,
+                        &rollup_path,
+                        &deployment,
+                        kind,
+                    )
+                    .await?,
+                );
+            }
+        }
+
+        Ok(())
+    }
+
     pub fn sequencer_rpc_url(&self) -> &str {
         &self.sequencers[0].rpc_url
     }

--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -875,6 +875,16 @@ impl FullStackWorldDevnet {
         self.prover_service_url.as_deref()
     }
 
+    /// Aborts the in-process defender and its TEE/SP1 workers so no proof lanes can land.
+    ///
+    /// Idempotent. Leaves the prover-service RPC up (harmless without requesters) so tests that
+    /// assert an unproven game's timeout outcome can keep the rest of the stack running.
+    pub fn stop_defender(&mut self) {
+        self._world_defender.take();
+        self._nitro_worker.take();
+        self._sp1_worker.take();
+    }
+
     pub fn sequencer_rpc_url(&self) -> &str {
         &self.sequencers[0].rpc_url
     }

--- a/crates/devnet/src/lib.rs
+++ b/crates/devnet/src/lib.rs
@@ -426,6 +426,16 @@ impl WorldDevnet {
         }
     }
 
+    /// Re-spawns the in-process defender and its TEE/SP1 workers after [`Self::stop_defender`].
+    ///
+    /// See [`FullStackWorldDevnet::start_defender`].
+    pub async fn start_defender(&mut self) -> Result<()> {
+        if let Some(full_stack) = self.full_stack.as_mut() {
+            full_stack.start_defender().await?;
+        }
+        Ok(())
+    }
+
     /// L1 OptimismPortal proxy address, when the preset started a full OP Stack.
     pub fn optimism_portal(&self) -> Option<&str> {
         self.full_stack

--- a/crates/devnet/src/lib.rs
+++ b/crates/devnet/src/lib.rs
@@ -417,6 +417,15 @@ impl WorldDevnet {
             .map(FullStackWorldDevnet::l2_op_node_rpc_url)
     }
 
+    /// Aborts the in-process defender and its TEE/SP1 workers, when the full stack is running.
+    ///
+    /// See [`FullStackWorldDevnet::stop_defender`].
+    pub fn stop_defender(&mut self) {
+        if let Some(full_stack) = self.full_stack.as_mut() {
+            full_stack.stop_defender();
+        }
+    }
+
     /// L1 OptimismPortal proxy address, when the preset started a full OP Stack.
     pub fn optimism_portal(&self) -> Option<&str> {
         self.full_stack

--- a/crates/devnet/src/lib.rs
+++ b/crates/devnet/src/lib.rs
@@ -410,6 +410,13 @@ impl WorldDevnet {
             .or_else(|| self.l1.as_ref().map(L1DevChain::rpc_url))
     }
 
+    /// L2 op-node RPC URL.
+    pub fn l2_op_node_rpc_url(&self) -> Option<&str> {
+        self.full_stack
+            .as_ref()
+            .map(FullStackWorldDevnet::l2_op_node_rpc_url)
+    }
+
     /// L1 OptimismPortal proxy address, when the preset started a full OP Stack.
     pub fn optimism_portal(&self) -> Option<&str> {
         self.full_stack

--- a/e2e-tests/src/it/devnet_proof_invariants.rs
+++ b/e2e-tests/src/it/devnet_proof_invariants.rs
@@ -80,15 +80,24 @@ async fn unproven_proposal_with_invalid_root_claim_times_out_to_challenger_wins(
     Ok(())
 }
 
+/// A game that contains a valid root_claim but without any proof will still end up as `CHALLENGER_WINS`.
+/// 
+/// This test is the same as the previous one, but this game contains a valid root_claim, instead of the
+/// invalid root_claim in the other test.
 #[ignore = "requires Docker, Foundry, and the full local OP Stack"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn unproven_proposal_with_valid_root_claim_times_out_to_challenger_wins() -> eyre::Result<()>
 {
     reth_tracing::init_test_tracing();
 
-    let Some(devnet) = try_build_ha_devnet("proof-timeout with valid root claim E2E").await? else {
+    let Some(mut devnet) = try_build_ha_devnet("proof-timeout with valid root claim E2E").await?
+    else {
         return Ok(());
     };
+
+    // A valid root sits on the selected lineage, so the live defender would TEE-prove it and
+    // defeat the "nobody proved" premise. Stop it (and its workers) before submitting.
+    devnet.stop_defender();
 
     let l2_op_node_rpc = l2_op_node_rpc_url(&devnet)?;
     let output_root_provider = OptimismConsensusClient::new(l2_op_node_rpc);

--- a/e2e-tests/src/it/devnet_proof_invariants.rs
+++ b/e2e-tests/src/it/devnet_proof_invariants.rs
@@ -16,8 +16,8 @@ use crate::it::utils::devnet::{
     GAME_CHALLENGER_WINS, GAME_DEFENDER_WINS, INVALIDATION_REASON_INVALID_PARENT,
     INVALIDATION_REASON_PROOF_TIMEOUT, advance_to_timestamp, funded_throwaway_provider, game_at,
     l1_contract, l1_rpc_url, l2_op_node_rpc_url, proof_system_client, resolve_if_still_in_progress,
-    try_build_ha_devnet, wait_for_challenge, wait_for_multi_proof_game, wait_for_proof_lane,
-    wait_for_status_or_resolve,
+    try_build_ha_devnet, wait_for_challenge, wait_for_multi_proof_game,
+    wait_for_multi_proof_game_attempt, wait_for_proof_lane, wait_for_status_or_resolve,
 };
 
 /// A proposal that never accumulates a valid proof cannot win merely by going unchallenged.
@@ -142,6 +142,105 @@ async fn unproven_proposal_with_valid_root_claim_times_out_to_challenger_wins() 
     ensure!(
         game.invalidationReason().call().await? == INVALIDATION_REASON_PROOF_TIMEOUT,
         "unproven proposal must invalidate with PROOF_TIMEOUT"
+    );
+
+    Ok(())
+}
+
+/// A valid root that times out unproven is retried by the live proposer once the defender returns.
+///
+/// Stops the defender so the honest claim cannot be TEE-proved, lets attempt 0 resolve
+/// `ChallengerWins`/`PROOF_TIMEOUT`, then restarts the defender and asserts the proposer
+/// resubmits the same transition at `attempt + 1` and that retry resolves `DefenderWins`.
+#[ignore = "requires Docker, Foundry, and the full local OP Stack"]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn timed_out_valid_root_is_retried_and_defended_after_defender_restart() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let Some(mut devnet) =
+        try_build_ha_devnet("proof-timeout retry after defender restart E2E").await?
+    else {
+        return Ok(());
+    };
+
+    // A valid root sits on the selected lineage, so the live defender would TEE-prove it and
+    // defeat the "nobody proved" premise. Stop it (and its workers) before submitting.
+    devnet.stop_defender();
+
+    let l2_op_node_rpc = l2_op_node_rpc_url(&devnet)?;
+    let output_root_provider = OptimismConsensusClient::new(l2_op_node_rpc);
+    let l1_rpc = l1_rpc_url(&devnet)?;
+    let factory_address = l1_contract(devnet.dispute_game_factory(), "DisputeGameFactory")?;
+
+    let (_, provider) = funded_throwaway_provider(l1_rpc, factory_address).await?;
+    let contracts = proof_system_client(provider.clone(), factory_address).await?;
+
+    let anchor = contracts.lineage_anchor().await?;
+    let registered = contracts.registered_lineage_config();
+    let l2_block_number = anchor
+        .l2_block_number
+        .saturating_add(registered.block_interval);
+    let root_claim = output_root_provider
+        .output_root_at_block(l2_block_number)
+        .await?;
+    let proposal = Proposal {
+        parent_ref: anchor.address,
+        root_claim,
+        l2_block_number,
+        attempt: 0,
+    };
+    let submission = contracts.submit_proposal(&proposal).await?;
+    let game = game_at(submission.game_address, provider.clone());
+
+    let proof_deadline = game.proofDeadline().call().await?;
+    advance_to_timestamp(&provider, proof_deadline.saturating_add(1)).await?;
+
+    resolve_if_still_in_progress(&game).await?;
+
+    ensure!(
+        game.proofBitmap().call().await? == 0,
+        "no proof lane should ever land on a proposal nobody proved"
+    );
+    ensure!(
+        game.status().call().await? == GAME_CHALLENGER_WINS,
+        "unproven proposal must resolve ChallengerWins on deadline"
+    );
+    ensure!(
+        game.invalidationReason().call().await? == INVALIDATION_REASON_PROOF_TIMEOUT,
+        "unproven proposal must invalidate with PROOF_TIMEOUT"
+    );
+
+    // Bring the defender back; the live proposer should resubmit the same transition at attempt 1.
+    devnet.start_defender().await?;
+
+    let retry_address = wait_for_multi_proof_game_attempt(
+        provider.clone(),
+        factory_address,
+        proposal.parent_ref,
+        proposal.l2_block_number,
+        1, // attempt should be exactly 1 as 0 has been tried before and failed
+    )
+    .await?;
+    let retry_game = game_at(retry_address, provider.clone());
+
+    ensure!(
+        retry_game.rootClaim().call().await? == root_claim,
+        "retry must reuse the timed-out game's root claim"
+    );
+    ensure!(
+        retry_address != submission.game_address,
+        "retry must create a distinct factory game"
+    );
+
+    // Unchallenged, a single TEE lane is enough once the challenge window closes.
+    wait_for_proof_lane(&retry_game).await?;
+    let challenge_deadline = retry_game.challengeDeadline().call().await?;
+    advance_to_timestamp(&provider, challenge_deadline.saturating_add(1)).await?;
+    wait_for_status_or_resolve(&retry_game, GAME_DEFENDER_WINS).await?;
+
+    ensure!(
+        retry_game.invalidationReason().call().await? == 0,
+        "a defended retry must have no invalidation reason"
     );
 
     Ok(())

--- a/e2e-tests/src/it/devnet_proof_invariants.rs
+++ b/e2e-tests/src/it/devnet_proof_invariants.rs
@@ -81,7 +81,7 @@ async fn unproven_proposal_with_invalid_root_claim_times_out_to_challenger_wins(
 }
 
 /// A game that contains a valid root_claim but without any proof will still end up as `CHALLENGER_WINS`.
-/// 
+///
 /// This test is the same as the previous one, but this game contains a valid root_claim, instead of the
 /// invalid root_claim in the other test.
 #[ignore = "requires Docker, Foundry, and the full local OP Stack"]
@@ -159,10 +159,11 @@ async fn unproven_proposal_with_valid_root_claim_times_out_to_challenger_wins() 
 /// challenger contesting the parent.
 #[ignore = "requires Docker, Foundry, and the full local OP Stack"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn invalid_parent_cascades_to_challenger_wins() -> eyre::Result<()> {
+async fn invalid_game_with_invalid_parent_cascades_to_challenger_wins() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    let Some(devnet) = try_build_ha_devnet("invalid-parent cascade E2E").await? else {
+    let Some(devnet) = try_build_ha_devnet("invalid game with invalid-parent cascade E2E").await?
+    else {
         return Ok(());
     };
 
@@ -195,6 +196,85 @@ async fn invalid_parent_cascades_to_challenger_wins() -> eyre::Result<()> {
         parent_ref: parent_submission.game_address,
         root_claim: B256::repeat_byte(0xcd),
         l2_block_number: parent_l2_block_number.saturating_add(registered.block_interval),
+        attempt: 0,
+    };
+    let child_submission = contracts.submit_proposal(&child_proposal).await?;
+    let child_game = game_at(child_submission.game_address, provider.clone());
+
+    // Wait for the real World Chain challenger to contest the bad parent.
+    wait_for_challenge(&parent_game).await?;
+
+    // Skip past the parent's proof deadline so its challenge can resolve.
+    let parent_proof_deadline = parent_game.proofDeadline().call().await?;
+    advance_to_timestamp(&provider, parent_proof_deadline.saturating_add(1)).await?;
+
+    // Resolved by the real challenger's resolution manager, or by us as a fallback.
+    wait_for_status_or_resolve(&parent_game, GAME_CHALLENGER_WINS).await?;
+
+    // Its l2 block is far beyond the finalized head, so the real challenger never picks it up.
+    resolve_if_still_in_progress(&child_game).await?;
+
+    ensure!(
+        child_game.status().call().await? == GAME_CHALLENGER_WINS,
+        "child of an invalidated parent must resolve ChallengerWins regardless of its own root claim"
+    );
+    ensure!(
+        child_game.invalidationReason().call().await? == INVALIDATION_REASON_INVALID_PARENT,
+        "child of an invalidated parent must invalidate with INVALID_PARENT, not PROOF_TIMEOUT"
+    );
+
+    Ok(())
+}
+
+/// A game that contains a valid root_claim but with an invalid parent will end up to `CHALLENGER_WINS`.
+///
+/// This test is the same as the previous one, but this child game contains a valid root_claim,
+/// instead of the invalid root_claim in the other test.
+#[ignore = "requires Docker, Foundry, and the full local OP Stack"]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn valid_game_with_invalid_parent_cascades_to_challenger_wins() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let Some(devnet) = try_build_ha_devnet("valid game with invalid-parent cascade E2E").await?
+    else {
+        return Ok(());
+    };
+
+    let l2_op_node_rpc = l2_op_node_rpc_url(&devnet)?;
+    let output_root_provider = OptimismConsensusClient::new(l2_op_node_rpc);
+    let l1_rpc = l1_rpc_url(&devnet)?;
+    let factory_address = l1_contract(devnet.dispute_game_factory(), "DisputeGameFactory")?;
+
+    let (_, provider) = funded_throwaway_provider(l1_rpc, factory_address).await?;
+    let contracts = proof_system_client(provider.clone(), factory_address).await?;
+
+    let anchor = contracts.lineage_anchor().await?;
+    let registered = contracts.registered_lineage_config();
+
+    // Parent: a bad root that the real challenger will contest.
+    let parent_l2_block_number = anchor
+        .l2_block_number
+        .saturating_add(registered.block_interval);
+    let parent_proposal = Proposal {
+        parent_ref: anchor.address,
+        root_claim: B256::repeat_byte(0xba),
+        l2_block_number: parent_l2_block_number,
+        attempt: 0,
+    };
+    let parent_submission = contracts.submit_proposal(&parent_proposal).await?;
+    let parent_game = game_at(parent_submission.game_address, provider.clone());
+
+    // Child must be created *before* the parent resolves: `_isValidParent`
+    // (MultiProofGame.sol:421-424) rejects parents already known invalid. The cascade under test is
+    // enforced dynamically in `resolve()`, so this ordering is the realistic case.
+    let l2_block_number = parent_l2_block_number.saturating_add(registered.block_interval);
+    let root_claim = output_root_provider
+        .output_root_at_block(l2_block_number)
+        .await?;
+    let child_proposal = Proposal {
+        parent_ref: parent_submission.game_address,
+        root_claim,
+        l2_block_number,
         attempt: 0,
     };
     let child_submission = contracts.submit_proposal(&child_proposal).await?;

--- a/e2e-tests/src/it/devnet_proof_invariants.rs
+++ b/e2e-tests/src/it/devnet_proof_invariants.rs
@@ -7,13 +7,15 @@
 
 use alloy_primitives::{Address, B256};
 use eyre::eyre::ensure;
-use world_chain_proof_protocol::{LineageProvider, ProofLane, encode_compact_proof};
+use world_chain_proof_protocol::{
+    ConsensusProvider, LineageProvider, OptimismConsensusClient, ProofLane, encode_compact_proof,
+};
 use world_chain_proposer::{Proposal, ProposerClient};
 
 use crate::it::utils::devnet::{
     GAME_CHALLENGER_WINS, GAME_DEFENDER_WINS, INVALIDATION_REASON_INVALID_PARENT,
     INVALIDATION_REASON_PROOF_TIMEOUT, advance_to_timestamp, funded_throwaway_provider, game_at,
-    l1_contract, l1_rpc_url, proof_system_client, resolve_if_still_in_progress,
+    l1_contract, l1_rpc_url, l2_op_node_rpc_url, proof_system_client, resolve_if_still_in_progress,
     try_build_ha_devnet, wait_for_challenge, wait_for_multi_proof_game, wait_for_proof_lane,
     wait_for_status_or_resolve,
 };
@@ -27,10 +29,12 @@ use crate::it::utils::devnet::{
 /// `ChallengerWins`/`PROOF_TIMEOUT` outcome, whether or not the real challenger races in first.
 #[ignore = "requires Docker, Foundry, and the full local OP Stack"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn unproven_proposal_times_out_to_challenger_wins() -> eyre::Result<()> {
+async fn unproven_proposal_with_invalid_root_claim_times_out_to_challenger_wins() -> eyre::Result<()>
+{
     reth_tracing::init_test_tracing();
 
-    let Some(devnet) = try_build_ha_devnet("proof-timeout E2E").await? else {
+    let Some(devnet) = try_build_ha_devnet("proof-timeout with invalid root claim E2E").await?
+    else {
         return Ok(());
     };
 
@@ -48,6 +52,64 @@ async fn unproven_proposal_times_out_to_challenger_wins() -> eyre::Result<()> {
         l2_block_number: anchor
             .l2_block_number
             .saturating_add(registered.block_interval),
+        attempt: 0,
+    };
+    let submission = contracts.submit_proposal(&proposal).await?;
+    let game = game_at(submission.game_address, provider.clone());
+
+    // `proofDeadline()` is always the later deadline (`proofPeriod > challengePeriod`), so
+    // `gameOver()` holds whether or not the real challenger challenged this first.
+    let proof_deadline = game.proofDeadline().call().await?;
+    advance_to_timestamp(&provider, proof_deadline.saturating_add(1)).await?;
+
+    resolve_if_still_in_progress(&game).await?;
+
+    ensure!(
+        game.proofBitmap().call().await? == 0,
+        "no proof lane should ever land on a proposal nobody proved"
+    );
+    ensure!(
+        game.status().call().await? == GAME_CHALLENGER_WINS,
+        "unproven proposal must resolve ChallengerWins on deadline, whether or not it was formally challenged"
+    );
+    ensure!(
+        game.invalidationReason().call().await? == INVALIDATION_REASON_PROOF_TIMEOUT,
+        "unproven proposal must invalidate with PROOF_TIMEOUT"
+    );
+
+    Ok(())
+}
+
+#[ignore = "requires Docker, Foundry, and the full local OP Stack"]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn unproven_proposal_with_valid_root_claim_times_out_to_challenger_wins() -> eyre::Result<()>
+{
+    reth_tracing::init_test_tracing();
+
+    let Some(devnet) = try_build_ha_devnet("proof-timeout with valid root claim E2E").await? else {
+        return Ok(());
+    };
+
+    let l2_op_node_rpc = l2_op_node_rpc_url(&devnet)?;
+    let output_root_provider = OptimismConsensusClient::new(l2_op_node_rpc);
+    let l1_rpc = l1_rpc_url(&devnet)?;
+    let factory_address = l1_contract(devnet.dispute_game_factory(), "DisputeGameFactory")?;
+
+    let (_, provider) = funded_throwaway_provider(l1_rpc, factory_address).await?;
+    let contracts = proof_system_client(provider.clone(), factory_address).await?;
+
+    let anchor = contracts.lineage_anchor().await?;
+    let registered = contracts.registered_lineage_config();
+    let l2_block_number = anchor
+        .l2_block_number
+        .saturating_add(registered.block_interval);
+    let root_claim = output_root_provider
+        .output_root_at_block(l2_block_number)
+        .await?;
+    let proposal = Proposal {
+        parent_ref: anchor.address,
+        root_claim,
+        l2_block_number,
         attempt: 0,
     };
     let submission = contracts.submit_proposal(&proposal).await?;

--- a/e2e-tests/src/it/utils/devnet.rs
+++ b/e2e-tests/src/it/utils/devnet.rs
@@ -89,6 +89,12 @@ pub(in crate::it) fn l1_rpc_url(devnet: &WorldDevnet) -> eyre::Result<&str> {
         .ok_or_eyre("full-stack devnet missing L1 RPC")
 }
 
+pub fn l2_op_node_rpc_url(devnet: &WorldDevnet) -> eyre::Result<&str> {
+    devnet
+        .l2_op_node_rpc_url()
+        .ok_or_eyre("full-stack devnet missing L2 op-node RPC")
+}
+
 /// Parses one of the devnet's optional L1 contract addresses, naming it if absent.
 pub(in crate::it) fn l1_contract(address: Option<&str>, what: &str) -> eyre::Result<Address> {
     Ok(address

--- a/e2e-tests/src/it/utils/devnet.rs
+++ b/e2e-tests/src/it/utils/devnet.rs
@@ -326,6 +326,46 @@ where
     }
 }
 
+/// Waits for a WIP-1006 game matching `parent_ref`, `l2_block`, and `attempt`.
+pub async fn wait_for_multi_proof_game_attempt<P>(
+    provider: P,
+    factory_address: Address,
+    parent_ref: Address,
+    l2_block: u64,
+    attempt: u64,
+) -> eyre::Result<Address>
+where
+    P: Provider + Clone,
+{
+    let factory =
+        IDisputeGameFactory::IDisputeGameFactoryInstance::new(factory_address, provider.clone());
+    let started = Instant::now();
+
+    loop {
+        let game_count: u64 = factory.gameCount().call().await?.try_into()?;
+        for index in (0..game_count).rev() {
+            let entry = factory.gameAtIndex(U256::from(index)).call().await?;
+            if entry.gameType != MULTI_PROOF_GAME_TYPE {
+                continue;
+            }
+            let game = game_at(entry.proxy, provider.clone());
+            let game_l2_block: u64 = game.l2SequenceNumber().call().await?.try_into()?;
+            let game_attempt: u64 = game.attempt().call().await?.try_into()?;
+            let game_parent = game.parentRef().call().await?;
+            if game_l2_block == l2_block && game_attempt == attempt && game_parent == parent_ref {
+                return Ok(entry.proxy);
+            }
+        }
+
+        if started.elapsed() >= GAME_WAIT_TIMEOUT {
+            bail!(
+                "timed out waiting for WIP-1006 game parent={parent_ref} l2={l2_block} attempt={attempt}"
+            );
+        }
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+}
+
 /// Waits for `game` to be challenged, returning the challenger's address.
 pub(in crate::it) async fn wait_for_challenge<P>(
     game: &IMultiProofGame::IMultiProofGameInstance<P>,


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-5048/local-devnet-add-tests-in-devnet-proof-invariants-file

- unproven proposal with valid root_claim times out to challenger wins (no matter the validity of the root_claim)
- child game with valid root_claim of an invalid game becomes invalid with `INVALID_PARENT` as invalidation reason
- unproven proposal with valid root_claim times out to challenger wins - defender is stopped so that it doesn’t defend this game. Then start the defender again and ensure the proposer is going to propose the same game but with attempt++. And this will end up with `DEFENDER_WINS`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to devnet lifecycle APIs and ignored Docker e2e tests; no production proof-system or on-chain logic changes.
> 
> **Overview**
> Adds **devnet test hooks** so full-stack e2e can simulate “nobody proved this game” without the live defender auto-TEE-proving honest claims: `l2_op_node_rpc_url`, idempotent **`stop_defender`** / **`start_defender`** on `FullStackWorldDevnet` and `WorldDevnet` (drops or respawns defender + Nitro/SP1 workers while keeping prover-service up).
> 
> Expands **`devnet_proof_invariants`** with scenarios that mirror Optimism fault-proof properties on the real stack: proof timeout with **invalid vs valid** `root_claim`, **invalid-parent cascade** with invalid vs valid child claims (valid roots from op-node via `OptimismConsensusClient`), and **proposer retry** after timeout (`attempt + 1` → `DefenderWins` once defender restarts). E2e helpers add `l2_op_node_rpc_url` and **`wait_for_multi_proof_game_attempt`**; existing tests are renamed for clarity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bce63b7d96b6978b8f5414ee825d22879c6aec7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->