### PR TITLE
add third test

### DIFF
--- a/crates/devnet/src/full_stack.rs
+++ b/crates/devnet/src/full_stack.rs
@@ -885,6 +885,59 @@ impl FullStackWorldDevnet {
         self._sp1_worker.take();
     }
 
+    /// Re-spawns the in-process defender and its TEE worker after [`Self::stop_defender`].
+    ///
+    /// Idempotent when the defender is already running. Reuses the still-live prover-service and
+    /// the deployed proof-system addresses. Also restarts the SP1 worker when
+    /// `DEVNET_SP1_WORKER_PROVER` is set, using the rollup config under the stack tempdir.
+    pub async fn start_defender(&mut self) -> Result<()> {
+        if self._world_defender.is_some() {
+            return Ok(());
+        }
+
+        let deployment = self
+            ._proof_system
+            .clone()
+            .ok_or_else(|| eyre!("cannot start defender: proof system was not deployed"))?;
+        let prover_service_url = self
+            .prover_service_url
+            .clone()
+            .ok_or_else(|| eyre!("cannot start defender: prover-service is not running"))?;
+        let l1_rpc = self.l1_rpc_url().to_string();
+        let output_root_rpc = self.l2_op_node_rpc_url().to_string();
+        let l2_rpc = self.l2_rpc_url().to_string();
+        let rollup_path = self._tempdir.path().join("rollup.json");
+        let restart_nitro = self._nitro_worker.is_none();
+        let restart_sp1 = self._sp1_worker.is_none();
+
+        if restart_nitro {
+            self._nitro_worker = Some(start_devnet_nitro_worker(&prover_service_url)?);
+        }
+
+        self._world_defender = Some(
+            start_world_chain_defender(&l1_rpc, &output_root_rpc, &prover_service_url, &deployment)
+                .await?,
+        );
+
+        if restart_sp1 {
+            if let Some(kind) = sp1_worker_prover_kind()? {
+                self._sp1_worker = Some(
+                    start_sp1_worker(
+                        &l1_rpc,
+                        &l2_rpc,
+                        &prover_service_url,
+                        &rollup_path,
+                        &deployment,
+                        kind,
+                    )
+                    .await?,
+                );
+            }
+        }
+
+        Ok(())
+    }
+
     pub fn sequencer_rpc_url(&self) -> &str {
         &self.sequencers[0].rpc_url
     }

--- a/crates/devnet/src/lib.rs
+++ b/crates/devnet/src/lib.rs
@@ -426,6 +426,16 @@ impl WorldDevnet {
         }
     }
 
+    /// Re-spawns the in-process defender and its TEE/SP1 workers after [`Self::stop_defender`].
+    ///
+    /// See [`FullStackWorldDevnet::start_defender`].
+    pub async fn start_defender(&mut self) -> Result<()> {
+        if let Some(full_stack) = self.full_stack.as_mut() {
+            full_stack.start_defender().await?;
+        }
+        Ok(())
+    }
+
     /// L1 OptimismPortal proxy address, when the preset started a full OP Stack.
     pub fn optimism_portal(&self) -> Option<&str> {
         self.full_stack

--- a/e2e-tests/src/it/devnet_proof_invariants.rs
+++ b/e2e-tests/src/it/devnet_proof_invariants.rs
@@ -16,8 +16,8 @@ use crate::it::utils::devnet::{
     GAME_CHALLENGER_WINS, GAME_DEFENDER_WINS, INVALIDATION_REASON_INVALID_PARENT,
     INVALIDATION_REASON_PROOF_TIMEOUT, advance_to_timestamp, funded_throwaway_provider, game_at,
     l1_contract, l1_rpc_url, l2_op_node_rpc_url, proof_system_client, resolve_if_still_in_progress,
-    try_build_ha_devnet, wait_for_challenge, wait_for_multi_proof_game, wait_for_proof_lane,
-    wait_for_status_or_resolve,
+    try_build_ha_devnet, wait_for_challenge, wait_for_multi_proof_game,
+    wait_for_multi_proof_game_attempt, wait_for_proof_lane, wait_for_status_or_resolve,
 };
 
 /// A proposal that never accumulates a valid proof cannot win merely by going unchallenged.
@@ -142,6 +142,105 @@ async fn unproven_proposal_with_valid_root_claim_times_out_to_challenger_wins() 
     ensure!(
         game.invalidationReason().call().await? == INVALIDATION_REASON_PROOF_TIMEOUT,
         "unproven proposal must invalidate with PROOF_TIMEOUT"
+    );
+
+    Ok(())
+}
+
+/// A valid root that times out unproven is retried by the live proposer once the defender returns.
+///
+/// Stops the defender so the honest claim cannot be TEE-proved, lets attempt 0 resolve
+/// `ChallengerWins`/`PROOF_TIMEOUT`, then restarts the defender and asserts the proposer
+/// resubmits the same transition at `attempt + 1` and that retry resolves `DefenderWins`.
+#[ignore = "requires Docker, Foundry, and the full local OP Stack"]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn timed_out_valid_root_is_retried_and_defended_after_defender_restart() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let Some(mut devnet) =
+        try_build_ha_devnet("proof-timeout retry after defender restart E2E").await?
+    else {
+        return Ok(());
+    };
+
+    // A valid root sits on the selected lineage, so the live defender would TEE-prove it and
+    // defeat the "nobody proved" premise. Stop it (and its workers) before submitting.
+    devnet.stop_defender();
+
+    let l2_op_node_rpc = l2_op_node_rpc_url(&devnet)?;
+    let output_root_provider = OptimismConsensusClient::new(l2_op_node_rpc);
+    let l1_rpc = l1_rpc_url(&devnet)?;
+    let factory_address = l1_contract(devnet.dispute_game_factory(), "DisputeGameFactory")?;
+
+    let (_, provider) = funded_throwaway_provider(l1_rpc, factory_address).await?;
+    let contracts = proof_system_client(provider.clone(), factory_address).await?;
+
+    let anchor = contracts.lineage_anchor().await?;
+    let registered = contracts.registered_lineage_config();
+    let l2_block_number = anchor
+        .l2_block_number
+        .saturating_add(registered.block_interval);
+    let root_claim = output_root_provider
+        .output_root_at_block(l2_block_number)
+        .await?;
+    let proposal = Proposal {
+        parent_ref: anchor.address,
+        root_claim,
+        l2_block_number,
+        attempt: 0,
+    };
+    let submission = contracts.submit_proposal(&proposal).await?;
+    let game = game_at(submission.game_address, provider.clone());
+
+    let proof_deadline = game.proofDeadline().call().await?;
+    advance_to_timestamp(&provider, proof_deadline.saturating_add(1)).await?;
+
+    resolve_if_still_in_progress(&game).await?;
+
+    ensure!(
+        game.proofBitmap().call().await? == 0,
+        "no proof lane should ever land on a proposal nobody proved"
+    );
+    ensure!(
+        game.status().call().await? == GAME_CHALLENGER_WINS,
+        "unproven proposal must resolve ChallengerWins on deadline"
+    );
+    ensure!(
+        game.invalidationReason().call().await? == INVALIDATION_REASON_PROOF_TIMEOUT,
+        "unproven proposal must invalidate with PROOF_TIMEOUT"
+    );
+
+    // Bring the defender back; the live proposer should resubmit the same transition at attempt 1.
+    devnet.start_defender().await?;
+
+    let retry_address = wait_for_multi_proof_game_attempt(
+        provider.clone(),
+        factory_address,
+        proposal.parent_ref,
+        proposal.l2_block_number,
+        1, // attempt should be exactly 1 as 0 has been tried before and failed
+    )
+    .await?;
+    let retry_game = game_at(retry_address, provider.clone());
+
+    ensure!(
+        retry_game.rootClaim().call().await? == root_claim,
+        "retry must reuse the timed-out game's root claim"
+    );
+    ensure!(
+        retry_address != submission.game_address,
+        "retry must create a distinct factory game"
+    );
+
+    // Unchallenged, a single TEE lane is enough once the challenge window closes.
+    wait_for_proof_lane(&retry_game).await?;
+    let challenge_deadline = retry_game.challengeDeadline().call().await?;
+    advance_to_timestamp(&provider, challenge_deadline.saturating_add(1)).await?;
+    wait_for_status_or_resolve(&retry_game, GAME_DEFENDER_WINS).await?;
+
+    ensure!(
+        retry_game.invalidationReason().call().await? == 0,
+        "a defended retry must have no invalidation reason"
     );
 
     Ok(())

--- a/e2e-tests/src/it/utils/devnet.rs
+++ b/e2e-tests/src/it/utils/devnet.rs
@@ -326,6 +326,46 @@ where
     }
 }
 
+/// Waits for a WIP-1006 game matching `parent_ref`, `l2_block`, and `attempt`.
+pub async fn wait_for_multi_proof_game_attempt<P>(
+    provider: P,
+    factory_address: Address,
+    parent_ref: Address,
+    l2_block: u64,
+    attempt: u64,
+) -> eyre::Result<Address>
+where
+    P: Provider + Clone,
+{
+    let factory =
+        IDisputeGameFactory::IDisputeGameFactoryInstance::new(factory_address, provider.clone());
+    let started = Instant::now();
+
+    loop {
+        let game_count: u64 = factory.gameCount().call().await?.try_into()?;
+        for index in (0..game_count).rev() {
+            let entry = factory.gameAtIndex(U256::from(index)).call().await?;
+            if entry.gameType != MULTI_PROOF_GAME_TYPE {
+                continue;
+            }
+            let game = game_at(entry.proxy, provider.clone());
+            let game_l2_block: u64 = game.l2SequenceNumber().call().await?.try_into()?;
+            let game_attempt: u64 = game.attempt().call().await?.try_into()?;
+            let game_parent = game.parentRef().call().await?;
+            if game_l2_block == l2_block && game_attempt == attempt && game_parent == parent_ref {
+                return Ok(entry.proxy);
+            }
+        }
+
+        if started.elapsed() >= GAME_WAIT_TIMEOUT {
+            bail!(
+                "timed out waiting for WIP-1006 game parent={parent_ref} l2={l2_block} attempt={attempt}"
+            );
+        }
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+}
+
 /// Waits for `game` to be challenged, returning the challenger's address.
 pub(in crate::it) async fn wait_for_challenge<P>(
     game: &IMultiProofGame::IMultiProofGameInstance<P>,


### PR DESCRIPTION
- unproven proposal with valid root_claim times out to challenger wins - defender is stopped so that it doesn’t defend this game. Then start the defender again and ensure the proposer is going to propose the same game but with attempt++. And this will end up with `DEFENDER_WINS`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to devnet test harness and E2E coverage; no production proof-system or on-chain logic is modified.
> 
> **Overview**
> Adds **`start_defender`** as the counterpart to **`stop_defender`** on the full-stack HA devnet: it idempotently brings back the in-process defender and restarts Nitro/SP1 workers when needed, while keeping the prover-service and deployed proof-system addresses. **`WorldDevnet`** exposes the same async hook for E2E tests.
> 
> Introduces **`wait_for_multi_proof_game_attempt`** to poll the dispute-game factory for a WIP-1006 game matching parent, L2 block, and attempt index.
> 
> Adds an ignored full-stack E2E test that stops the defender so a valid root times out unproven (`ChallengerWins` / `PROOF_TIMEOUT`), restarts the defender, then asserts the live proposer resubmits the same claim at **attempt 1** and the retry reaches **`DefenderWins`** after a TEE proof lane lands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb60d28a6f4a7973adbeedb6d9efbdf64180f00e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->