### PR TITLE
fix(proofs): allow optimistic retries for timed-out games

### DIFF
--- a/pkg/contracts/src/dispute/MultiProofGame.sol
+++ b/pkg/contracts/src/dispute/MultiProofGame.sol
@@ -370,25 +370,28 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
         }
 
         // Retries: attempt N is only proposable when attempt N-1 for the identical transition
-        // timed out on proofs or was created before WIP-1006 became respected. The latter
-        // prevents a pre-cutover game from permanently occupying the factory UUID. Inherited
-        // invalidations rebase onto a replacement parent and therefore restart at attempt zero.
-        // Duplicate attempts are impossible: the factory UUID covers (gameType, rootClaim,
-        // extraData).
+        // timed out on proofs (already settled, or locally doomed per `resolutionStatus`) or was
+        // created before WIP-1006 became respected. The latter prevents a pre-cutover game from
+        // permanently occupying the factory UUID. Inherited invalidations rebase onto a
+        // replacement parent and therefore restart at attempt zero. Duplicate attempts are
+        // impossible: the factory UUID covers (gameType, rootClaim, extraData).
         if (attempt_ > 0) {
             bytes memory previousExtraData = abi.encode(domainHash, l2SequenceNumber_, parentRef_, attempt_ - 1);
+            bytes32 previousUuid = keccak256(abi.encode(GameTypes.MULTI_PROOF_GAME_TYPE, rootClaim_, previousExtraData));
             (IDisputeGame previous,) =
                 disputeGameFactory.games(GameTypes.MULTI_PROOF_GAME_TYPE, rootClaim_, previousExtraData);
+            if (address(previous) == address(0)) revert GameNotRetryable(previousUuid);
+
+            // Unrespected pre-cutover games may always be replaced. Respected ones only after a
+            // proof-timeout outcome (settled or parent-gated local doom).
+            (, GameStatus previousOutcome, InvalidationReason previousReason) =
+                IMultiProofGame(address(previous)).resolutionStatus();
             if (
-                address(previous) == address(0)
-                    || (previous.wasRespectedGameTypeWhenCreated()
-                        && (previous.status() != GameStatus.CHALLENGER_WINS
-                            || IMultiProofGame(address(previous)).invalidationReason()
-                                != InvalidationReason.PROOF_TIMEOUT))
+                previous.wasRespectedGameTypeWhenCreated()
+                    && (previousOutcome != GameStatus.CHALLENGER_WINS
+                        || previousReason != InvalidationReason.PROOF_TIMEOUT)
             ) {
-                revert GameNotRetryable(keccak256(
-                        abi.encode(GameTypes.MULTI_PROOF_GAME_TYPE, rootClaim_, previousExtraData)
-                    ));
+                revert GameNotRetryable(previousUuid);
             }
         }
 
@@ -626,7 +629,10 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
     }
 
     /// @inheritdoc IMultiProofGame
-    /// @dev View twin of `resolve()`: reports what a resolve call would do right now.
+    /// @dev Reports the eventual outcome. `resolvable` is true only when `resolve()`
+    ///      would succeed. A locally doomed, unproven game surfaces `CHALLENGER_WINS` /
+    ///      `PROOF_TIMEOUT` even while its parent is still open, so keepers can stop building
+    ///      on it. Settlement still waits for the parent so bond credits stay correct.
     function resolutionStatus() external view returns (bool resolvable, GameStatus outcome, InvalidationReason reason) {
         if (status != GameStatus.IN_PROGRESS) {
             return (false, status, claimData.invalidationReason);
@@ -634,17 +640,32 @@ contract MultiProofGame is Clone, ISemver, IMultiProofGame {
 
         (GameStatus parentStatus, bool parentBlacklisted) = _parentResolution();
         if (parentBlacklisted || parentStatus == GameStatus.CHALLENGER_WINS) {
+            // Parent game is invalid, return `CHALLENGER_WINS` with `INVALID_PARENT`.
             return (true, GameStatus.CHALLENGER_WINS, InvalidationReason.INVALID_PARENT);
         }
-        if (parentStatus == GameStatus.IN_PROGRESS || !gameOver()) {
-            return (false, GameStatus.IN_PROGRESS, InvalidationReason.NONE);
-        }
 
+        bool parentResolved = parentStatus != GameStatus.IN_PROGRESS;
         bool proven = claimData.status == ProposalStatus.UnchallengedAndValidProofProvided
             || claimData.status == ProposalStatus.ChallengedAndValidProofProvided;
-        return proven
-            ? (true, GameStatus.DEFENDER_WINS, InvalidationReason.NONE)
-            : (true, GameStatus.CHALLENGER_WINS, InvalidationReason.PROOF_TIMEOUT);
+
+        if (!gameOver()) {
+            // This game is not over yet, return `IN_PROGRESS`.
+            return (false, GameStatus.IN_PROGRESS, InvalidationReason.NONE);
+        }
+        // This game is over.
+        if (!proven) {
+            // This game is over but it doesn't have enough proofs.
+            // Return `CHALLENGER_WINS` as outcome. The `resolvable` instead depends on the
+            // parent game: you cannot resolve this game if parent is not resolved yet.
+            return (parentResolved, GameStatus.CHALLENGER_WINS, InvalidationReason.PROOF_TIMEOUT);
+        }
+        // This game is over and has enough proofs.
+        if (!parentResolved) {
+            // Parent game is not resolved yet, therefore return `IN_PROGRESS`.
+            return (false, GameStatus.IN_PROGRESS, InvalidationReason.NONE);
+        }
+        // This game is over, it has enough proofs and the parent is already resolved.
+        return (true, GameStatus.DEFENDER_WINS, InvalidationReason.NONE);
     }
 
     /// @inheritdoc IMultiProofGame

--- a/pkg/contracts/src/dispute/interfaces/IMultiProofGame.sol
+++ b/pkg/contracts/src/dispute/interfaces/IMultiProofGame.sol
@@ -174,7 +174,8 @@ interface IMultiProofGame is IDisputeGame {
     function proposalDomainHash() external view returns (bytes32);
 
     /// @notice Retry nonce for this transition. Attempt N requires attempt N-1 to have timed
-    ///         out on proofs or to have been created before this game type became respected.
+    ///         out on proofs (settled or locally doomed) or to have been created before this
+    ///         game type became respected.
     function attempt() external view returns (uint256);
 
     /// @notice Parent game, or the anchor registry when no compatible anchor game exists.
@@ -230,8 +231,10 @@ interface IMultiProofGame is IDisputeGame {
     ///         passed or the proof threshold has been reached.
     function gameOver() external view returns (bool);
 
-    /// @notice Returns whether this game can resolve now and the outcome a resolve call would
-    ///         produce; `outcome` is `IN_PROGRESS` while the game cannot resolve.
+    /// @notice Returns whether this game can resolve now and its eventual outcome.
+    /// @dev `resolvable` is true only when `resolve()` would succeed. `outcome` may already be
+    ///      terminal (e.g. a locally doomed unproven game) while `resolvable` is still false
+    ///      because the parent has not resolved yet.
     function resolutionStatus() external view returns (bool resolvable, GameStatus outcome, InvalidationReason reason);
 
     ////////////////////////////////////////////////////////////////

--- a/pkg/contracts/test/dispute/MultiProofGame.t.sol
+++ b/pkg/contracts/test/dispute/MultiProofGame.t.sol
@@ -585,6 +585,23 @@ contract MultiProofGameTest is OPStackFixtures {
         dgf.create(WC_GAME_TYPE, claim, retryExtraData);
     }
 
+    function test_Retry_AllowsLocalProofTimeoutWhilePreviousStillInProgress() public {
+        MultiProofGame parent = _proposeAtAnchor();
+        MultiProofGame child = _proposeChild(0);
+
+        vm.warp(child.challengeDeadline().raw());
+        (bool resolvable, GameStatus outcome, InvalidationReason reason) = child.resolutionStatus();
+        assertFalse(resolvable);
+        assertEq(uint8(outcome), uint8(GameStatus.CHALLENGER_WINS));
+        assertEq(uint8(reason), uint8(InvalidationReason.PROOF_TIMEOUT));
+        assertEq(uint8(child.status()), uint8(GameStatus.IN_PROGRESS));
+        assertEq(uint8(parent.status()), uint8(GameStatus.IN_PROGRESS));
+
+        MultiProofGame retry = _propose(0, Claim.unwrap(child.rootClaim()), child.l2SequenceNumber(), 1);
+        assertEq(retry.attempt(), 1);
+        assertEq(uint8(child.status()), uint8(GameStatus.IN_PROGRESS));
+    }
+
     function test_ChildWaitsForParentResolutionNotFinality() public {
         MultiProofGame parent = _proposeAtAnchor();
         MultiProofGame child = _proposeChild(0);
@@ -604,6 +621,24 @@ contract MultiProofGameTest is OPStackFixtures {
 
         child.resolve();
         assertEq(uint8(child.status()), uint8(GameStatus.DEFENDER_WINS));
+    }
+
+    function test_ResolutionStatus_SurfacesLocalProofTimeoutWhileParentInProgress() public {
+        MultiProofGame parent = _proposeAtAnchor();
+        MultiProofGame child = _proposeChild(0);
+
+        vm.warp(child.challengeDeadline().raw());
+        assertTrue(child.gameOver());
+        assertEq(uint8(parent.status()), uint8(GameStatus.IN_PROGRESS));
+
+        (bool resolvable, GameStatus outcome, InvalidationReason reason) = child.resolutionStatus();
+        assertFalse(resolvable);
+        assertEq(uint8(outcome), uint8(GameStatus.CHALLENGER_WINS));
+        assertEq(uint8(reason), uint8(InvalidationReason.PROOF_TIMEOUT));
+
+        vm.expectRevert(ParentGameNotResolved.selector);
+        child.resolve();
+        assertEq(uint8(child.status()), uint8(GameStatus.IN_PROGRESS));
     }
 
     function test_ParentBlacklistedDuringFinalityAirgap_InvalidatesChild() public {

--- a/proofs/it/src/lib.rs
+++ b/proofs/it/src/lib.rs
@@ -373,13 +373,30 @@ impl LineageProvider for FakeExecution {
         let outcome = record.state.outcome();
         if record.state == GameLifecycle::Finalized {
             return Ok(ResolutionStatus {
+                status: outcome,
                 resolvable: false,
                 outcome,
                 invalidation_reason: InvalidationReason::None,
             });
         }
+        let local_timeout = match record.state {
+            GameLifecycle::Proposed => record.challenge_deadline == 0 && record.proof_bitmap == 0,
+            GameLifecycle::Challenged => {
+                record.proof_deadline == 0 && !has_threshold(record.proof_bitmap)
+            }
+            _ => false,
+        };
+        if local_timeout {
+            return Ok(ResolutionStatus {
+                status: outcome,
+                resolvable: !parent_is_unresolved(&state, record),
+                outcome: GameStatus::ChallengerWins,
+                invalidation_reason: InvalidationReason::ProofTimeout,
+            });
+        }
         if parent_is_unresolved(&state, record) {
             return Ok(ResolutionStatus {
+                status: outcome,
                 resolvable: false,
                 outcome,
                 invalidation_reason: InvalidationReason::None,
@@ -391,35 +408,23 @@ impl LineageProvider for FakeExecution {
         ) && has_threshold(record.proof_bitmap)
         {
             return Ok(ResolutionStatus {
+                status: outcome,
                 resolvable: true,
                 outcome: GameStatus::DefenderWins,
                 invalidation_reason: InvalidationReason::None,
             });
         }
-        if record.state == GameLifecycle::Challenged && record.proof_deadline == 0 {
-            return Ok(ResolutionStatus {
-                resolvable: true,
-                outcome: GameStatus::ChallengerWins,
-                invalidation_reason: InvalidationReason::ProofTimeout,
-            });
-        }
         if record.state == GameLifecycle::Proposed && record.challenge_deadline == 0 {
             return Ok(ResolutionStatus {
+                status: outcome,
                 resolvable: true,
-                outcome: if record.proof_bitmap == 0 {
-                    GameStatus::ChallengerWins
-                } else {
-                    GameStatus::DefenderWins
-                },
-                invalidation_reason: if record.proof_bitmap == 0 {
-                    InvalidationReason::ProofTimeout
-                } else {
-                    InvalidationReason::None
-                },
+                outcome: GameStatus::DefenderWins,
+                invalidation_reason: InvalidationReason::None,
             });
         }
 
         Ok(ResolutionStatus {
+            status: outcome,
             resolvable: false,
             outcome,
             invalidation_reason: InvalidationReason::None,

--- a/proofs/protocol/src/lib.rs
+++ b/proofs/protocol/src/lib.rs
@@ -23,8 +23,8 @@ pub use consensus_provider::{
 pub use lineage::{
     LineageAnchor, LineageError, LineageGame, LineageProvider, LineageStop, LineageTransition,
     RegisteredLineageConfig, SelectedLineage, SelectedLineageGame, read_game_for_transition,
-    read_lineage_anchor, read_lineage_resolution_status, read_registered_bond_vault,
-    read_registered_lineage_config, select_lineage,
+    read_game_has_retry, read_lineage_anchor, read_lineage_resolution_status,
+    read_registered_bond_vault, read_registered_lineage_config, select_lineage,
 };
 pub use proof_game::{
     AlloyProofGameProvider, ProofGameContext, ProofGameContextError, ProofGameProvider,

--- a/proofs/protocol/src/lineage.rs
+++ b/proofs/protocol/src/lineage.rs
@@ -3,8 +3,9 @@ use crate::{
     IDisputeGameFactory, IMultiProofGame, InvalidationReasonError, MAX_ATTEMPT_SCAN,
     MULTI_PROOF_GAME_TYPE, ProposalCommitment, ResolutionStatus,
 };
-use alloy_primitives::{Address, B256};
+use alloy_primitives::{Address, B256, U256};
 use alloy_provider::Provider;
+use alloy_sol_types::SolValue;
 use async_trait::async_trait;
 use thiserror::Error;
 
@@ -357,20 +358,69 @@ where
     Ok(latest)
 }
 
-/// Reads and decodes a game's current resolution evaluation.
+/// Returns whether the factory contains the next attempt for this exact transition.
+/// Attempts are sequential, so finding the immediate successor establishes supersession.
+pub async fn read_game_has_retry<P>(
+    factory: &IDisputeGameFactory::IDisputeGameFactoryInstance<P>,
+    game: &IMultiProofGame::IMultiProofGameInstance<P>,
+) -> Result<bool, LineageError>
+where
+    P: Provider + Clone,
+{
+    let (domain, block_number, parent, attempt, root) = game
+        .provider()
+        .multicall()
+        .add(game.proposalDomainHash())
+        .add(game.l2SequenceNumber())
+        .add(game.parentRef())
+        .add(game.attempt())
+        .add(game.rootClaim())
+        .aggregate()
+        .await
+        .map_err(|error| {
+            LineageError::Contract(format!(
+                "read retry context for {}: {error}",
+                game.address()
+            ))
+        })?;
+    let Some(next_attempt) = attempt.checked_add(U256::from(1)) else {
+        return Ok(false);
+    };
+    let extra_data = (domain, block_number, parent, next_attempt).abi_encode();
+    let entry = factory
+        .games(MULTI_PROOF_GAME_TYPE, root, extra_data.into())
+        .call()
+        .await
+        .map_err(|error| {
+            LineageError::Contract(format!("look up retry for {}: {error}", game.address()))
+        })?;
+    Ok(entry.proxy != Address::ZERO)
+}
+
+/// Reads the stored status and resolution evaluation atomically so resolution between
+/// separate RPC calls cannot produce an inconsistent snapshot.
 pub async fn read_lineage_resolution_status<P>(
     game: &IMultiProofGame::IMultiProofGameInstance<P>,
 ) -> Result<ResolutionStatus, LineageError>
 where
     P: Provider + Clone,
 {
-    let result = game
-        .resolutionStatus()
-        .call()
+    let (status, result) = game
+        .provider()
+        .multicall()
+        .add(game.status())
+        .add(game.resolutionStatus())
+        .aggregate()
         .await
-        .map_err(|error| LineageError::Contract(error.to_string()))?;
+        .map_err(|error| {
+            LineageError::Contract(format!(
+                "read resolution status for {}: {error}",
+                game.address()
+            ))
+        })?;
 
     Ok(ResolutionStatus {
+        status: status.try_into()?,
         resolvable: result.resolvable,
         outcome: result.outcome.try_into()?,
         invalidation_reason: result.reason.try_into()?,

--- a/proofs/protocol/src/types.rs
+++ b/proofs/protocol/src/types.rs
@@ -318,12 +318,17 @@ impl TryFrom<u8> for InvalidationReason {
     }
 }
 
-/// Decoded `MultiProofGame.resolutionStatus()`: what a resolve call would do right now.
+/// A game's stored status and its current resolution evaluation, read at the same block.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ResolutionStatus {
+    /// Actual on-chain `status()`, which only becomes terminal after `resolve()` succeeds.
+    pub status: GameStatus,
+    /// Whether `resolve()` can succeed now.
     pub resolvable: bool,
-    /// The outcome a resolve call would produce, or the outcome already reached.
+    /// Predicted or resolved outcome. A local proof timeout can be terminal while the
+    /// stored status is still `InProgress` and resolution is waiting for the parent.
     pub outcome: GameStatus,
+    /// Current invalidation reason; a local timeout may later become `InvalidParent`.
     pub invalidation_reason: InvalidationReason,
 }
 
@@ -342,10 +347,9 @@ impl ResolutionStatus {
 
     /// Returns whether the game has already reached a terminal state.
     ///
-    /// `outcome` describes the expected result while a game is still resolvable, so a terminal
-    /// outcome only means resolved once `resolvable` is false.
+    /// Neither the predicted outcome nor `resolvable` establishes actual resolution.
     pub fn is_resolved(&self) -> bool {
-        !self.resolvable && self.outcome != GameStatus::InProgress
+        self.status != GameStatus::InProgress
     }
 }
 
@@ -419,6 +423,7 @@ mod tests {
     #[test]
     fn resolution_status_reads_outcomes_not_proposal_states() {
         let finalized = ResolutionStatus {
+            status: GameStatus::InProgress,
             resolvable: true,
             outcome: GameStatus::DefenderWins,
             invalidation_reason: InvalidationReason::None,
@@ -427,6 +432,7 @@ mod tests {
         assert!(!finalized.is_resolved());
 
         let live = ResolutionStatus {
+            status: GameStatus::InProgress,
             resolvable: false,
             outcome: GameStatus::InProgress,
             invalidation_reason: InvalidationReason::None,
@@ -435,11 +441,43 @@ mod tests {
         assert!(!live.is_resolved());
 
         let bad_parent = ResolutionStatus {
+            status: GameStatus::InProgress,
             resolvable: true,
             outcome: GameStatus::ChallengerWins,
             invalidation_reason: InvalidationReason::InvalidParent,
         };
         assert!(bad_parent.invalid_parent_resolvable());
+    }
+
+    #[test]
+    fn local_timeout_is_not_resolved_until_the_stored_status_changes() {
+        let waiting = ResolutionStatus {
+            status: GameStatus::InProgress,
+            resolvable: false,
+            outcome: GameStatus::ChallengerWins,
+            invalidation_reason: InvalidationReason::ProofTimeout,
+        };
+        assert!(!waiting.is_resolved());
+        assert!(!waiting.positive_resolvable());
+        assert!(!waiting.invalid_parent_resolvable());
+
+        let ready = ResolutionStatus {
+            resolvable: true,
+            ..waiting
+        };
+        assert!(!ready.is_resolved());
+        let resolved = ResolutionStatus {
+            status: GameStatus::ChallengerWins,
+            ..waiting
+        };
+        assert!(resolved.is_resolved());
+        let defender_wins = ResolutionStatus {
+            status: GameStatus::DefenderWins,
+            outcome: GameStatus::DefenderWins,
+            invalidation_reason: InvalidationReason::None,
+            ..waiting
+        };
+        assert!(defender_wins.is_resolved());
     }
 
     #[test]

--- a/proofs/services/challenger/src/alloy.rs
+++ b/proofs/services/challenger/src/alloy.rs
@@ -12,8 +12,8 @@ use tokio::sync::Semaphore;
 use tracing::warn;
 use world_chain_proof_protocol::{
     IAnchorStateRegistry, IDisputeGameFactory, IERC20StakingVault, IMultiProofGame,
-    MULTI_PROOF_GAME_TYPE, ProposalStatus, ResolutionStatus, read_registered_bond_vault,
-    read_registered_lineage_config,
+    MULTI_PROOF_GAME_TYPE, ProposalStatus, ResolutionStatus, read_lineage_resolution_status,
+    read_registered_bond_vault, read_registered_lineage_config,
 };
 
 /// Alloy-backed implementation of the challenger contract clients.
@@ -131,12 +131,9 @@ where
         &self,
         address: Address,
     ) -> Result<ResolutionStatus, ChallengerError> {
-        let result = self.game(address).resolutionStatus().call().await?;
-        Ok(ResolutionStatus {
-            resolvable: result.resolvable,
-            outcome: result.outcome.try_into()?,
-            invalidation_reason: result.reason.try_into()?,
-        })
+        read_lineage_resolution_status(&self.game(address))
+            .await
+            .map_err(Into::into)
     }
 }
 

--- a/proofs/services/challenger/src/tests.rs
+++ b/proofs/services/challenger/src/tests.rs
@@ -191,6 +191,11 @@ impl ResolutionManagerClient for MockClient {
             .copied()
             .ok_or_else(|| ChallengerError::message(format!("unknown game {game}")))?;
         Ok(ResolutionStatus {
+            status: if record.proposal_status == ProposalStatus::Resolved {
+                record.resolution_outcome
+            } else {
+                GameStatus::InProgress
+            },
             resolvable: record.resolvable,
             outcome: record.resolution_outcome,
             invalidation_reason: InvalidationReason::try_from(record.resolution_reason)?,

--- a/proofs/services/defender/src/tests.rs
+++ b/proofs/services/defender/src/tests.rs
@@ -237,6 +237,7 @@ impl LineageProvider for MockClient {
             state => state,
         };
         Ok(ResolutionStatus {
+            status: record.state.outcome(),
             resolvable: lifecycle != record.state,
             outcome: lifecycle.outcome(),
             invalidation_reason: record.invalidation_reason,

--- a/proofs/services/proposer/src/alloy.rs
+++ b/proofs/services/proposer/src/alloy.rs
@@ -7,8 +7,9 @@ use tracing::warn;
 use world_chain_proof_protocol::{
     IAnchorStateRegistry, IDisputeGameFactory, IERC20StakingVault, IMultiProofGame, LineageAnchor,
     LineageError, LineageGame, LineageProvider, LineageTransition, MULTI_PROOF_GAME_TYPE,
-    RegisteredLineageConfig, ResolutionStatus, read_game_for_transition, read_lineage_anchor,
-    read_lineage_resolution_status, read_registered_bond_vault, read_registered_lineage_config,
+    RegisteredLineageConfig, ResolutionStatus, read_game_for_transition, read_game_has_retry,
+    read_lineage_anchor, read_lineage_resolution_status, read_registered_bond_vault,
+    read_registered_lineage_config,
 };
 
 use crate::{
@@ -233,6 +234,12 @@ where
 
     async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError> {
         self.read_resolution_status(game).await
+    }
+
+    async fn has_retry(&self, game: Address) -> Result<bool, ProposerError> {
+        read_game_has_retry(&self.factory, &self.game(game))
+            .await
+            .map_err(Into::into)
     }
 
     async fn resolve_game(&self, game: Address) -> Result<ResolveSubmission, ProposerError> {

--- a/proofs/services/proposer/src/bond_manager.rs
+++ b/proofs/services/proposer/src/bond_manager.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 
 use alloy_primitives::Address;
 use tracing::{info, warn};
+use world_chain_proof_protocol::{GameStatus, InvalidationReason};
 
 use crate::{BondManagerClient, BondManagerConfig, ProposerError};
 
@@ -12,6 +13,8 @@ pub struct BondManager<E> {
     execution_provider: E,
     proposed_games: HashSet<Address>,
     next_game_index: Option<u64>,
+    /// Rotates cleanup work so a failing resolution cannot starve other superseded attempts.
+    last_retry_resolution: Option<Address>,
 }
 
 impl<E> BondManager<E> {
@@ -22,6 +25,7 @@ impl<E> BondManager<E> {
             execution_provider,
             proposed_games: HashSet::default(),
             next_game_index: None,
+            last_retry_resolution: None,
         }
     }
 
@@ -84,8 +88,14 @@ where
 
     /// Resolves abandoned games, settles finalized games, and prunes settled games.
     pub async fn settle_games(&mut self) -> Result<(), ProposerError> {
-        let proposed_games: Vec<_> = self.proposed_games.iter().copied().collect();
+        let mut proposed_games: Vec<_> = self.proposed_games.iter().copied().collect();
+        proposed_games.sort_unstable();
+        if let Some(last) = self.last_retry_resolution {
+            let start = proposed_games.partition_point(|game| *game <= last);
+            proposed_games.rotate_left(start);
+        }
         let active_domain_hash = self.execution_provider.active_domain_hash();
+        let mut retry_resolutions_attempted = 0;
 
         for game in proposed_games {
             let result: Result<bool, ProposerError> = async {
@@ -98,14 +108,30 @@ where
                 }
                 let resolution_status = self.execution_provider.resolution_status(game).await?;
                 if !resolution_status.is_resolved() {
-                    // Resolve games abandoned by retries or domain upgrades; active-domain direct
-                    // outcomes stay with the proposer to avoid racing retry creation.
+                    // The lineage proposer only visits the highest attempt. Once a retry exists,
+                    // we own cleanup of the old attempt as well as its invalidated descendants.
                     let obsolete_domain_resolvable = if resolution_status.resolvable {
                         self.execution_provider.game_domain_hash(game).await? != active_domain_hash
                     } else {
                         false
                     };
-                    if resolution_status.invalid_parent_resolvable() || obsolete_domain_resolvable {
+                    let superseded_retry = resolution_status.resolvable
+                        && resolution_status.outcome == GameStatus::ChallengerWins
+                        && resolution_status.invalidation_reason
+                            == InvalidationReason::ProofTimeout
+                        && !obsolete_domain_resolvable
+                        && retry_resolutions_attempted < self.config.max_retry_resolutions_per_tick
+                        && self.execution_provider.has_retry(game).await?;
+                    if resolution_status.invalid_parent_resolvable()
+                        || obsolete_domain_resolvable
+                        || superseded_retry
+                    {
+                        if superseded_retry {
+                            // Charge failed submissions against the budget too. The next pass
+                            // starts after this game so a persistent failure cannot monopolize it.
+                            retry_resolutions_attempted += 1;
+                            self.last_retry_resolution = Some(game);
+                        }
                         let submission = self.execution_provider.resolve_game(game).await?;
                         info!(
                             lifecycle_event = "game_resolved",

--- a/proofs/services/proposer/src/config.rs
+++ b/proofs/services/proposer/src/config.rs
@@ -15,6 +15,9 @@ pub struct BondManagerConfig {
     pub poll_interval: Duration,
     /// Number of most recently created games scanned on startup.
     pub initial_scan_limit: u64,
+    /// Maximum superseded proof-timeout resolution attempts per settlement pass.
+    /// Zero disables this cleanup without disabling existing settlement behavior.
+    pub max_retry_resolutions_per_tick: usize,
 }
 
 impl BondManagerConfig {
@@ -38,6 +41,7 @@ impl Default for BondManagerConfig {
         Self {
             poll_interval: DEFAULT_BOND_MANAGER_POLL_INTERVAL,
             initial_scan_limit: DEFAULT_BOND_MANAGER_INITIAL_SCAN_LIMIT,
+            max_retry_resolutions_per_tick: 1,
         }
     }
 }

--- a/proofs/services/proposer/src/main.rs
+++ b/proofs/services/proposer/src/main.rs
@@ -74,6 +74,14 @@ struct Cli {
     #[arg(long, env = "BOND_MANAGER_INITIAL_SCAN_LIMIT", default_value_t = 1_000)]
     bond_manager_initial_scan_limit: u64,
 
+    /// Maximum superseded proof-timeout resolution attempts per bond-manager pass; zero disables them.
+    #[arg(
+        long,
+        env = "BOND_MANAGER_MAX_RETRY_RESOLUTIONS_PER_TICK",
+        default_value_t = 1
+    )]
+    bond_manager_max_retry_resolutions_per_tick: usize,
+
     /// Number of confirmations to require after sending a tx onchain.
     #[arg(long, env = "CONFIRMATIONS", default_value_t = 5)]
     confirmations: u64,
@@ -141,6 +149,7 @@ async fn main() -> Result<()> {
     let bond_manager_config = BondManagerConfig {
         poll_interval: Duration::from_secs(cli.bond_manager_poll_interval_seconds),
         initial_scan_limit: cli.bond_manager_initial_scan_limit,
+        max_retry_resolutions_per_tick: cli.bond_manager_max_retry_resolutions_per_tick,
     };
     let mut bond_manager = BondManager::new(bond_manager_config, contracts.clone());
     let output_roots = VerifyingConsensusProvider::new(

--- a/proofs/services/proposer/src/tests.rs
+++ b/proofs/services/proposer/src/tests.rs
@@ -82,6 +82,7 @@ impl LineageProvider for MockContracts {
             .expect("not poisoned")
             .remove(&game)
             .unwrap_or(ResolutionStatus {
+                status: GameStatus::InProgress,
                 resolvable: false,
                 outcome: GameStatus::InProgress,
                 invalidation_reason: InvalidationReason::None,
@@ -160,6 +161,11 @@ struct MockBondClient {
     closes: Arc<Mutex<Vec<Address>>>,
     fail_game_at_once: Arc<Mutex<Option<u64>>>,
     fail_close_once: Arc<Mutex<HashSet<Address>>>,
+    retried_games: Arc<Mutex<HashSet<Address>>>,
+    fail_retry_lookup_once: Arc<Mutex<HashSet<Address>>>,
+    fail_resolve_once: Arc<Mutex<HashSet<Address>>>,
+    resolution_attempts: Arc<Mutex<Vec<Address>>>,
+    parents: Arc<Mutex<HashMap<Address, Address>>>,
 }
 
 impl MockBondClient {
@@ -188,6 +194,11 @@ impl MockBondClient {
             closes: Arc::default(),
             fail_game_at_once: Arc::default(),
             fail_close_once: Arc::default(),
+            retried_games: Arc::default(),
+            fail_retry_lookup_once: Arc::default(),
+            fail_resolve_once: Arc::default(),
+            resolution_attempts: Arc::default(),
+            parents: Arc::default(),
         }
     }
 }
@@ -244,14 +255,29 @@ impl BondManagerClient for MockBondClient {
     }
 
     async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError> {
-        if let Some(status) = self
-            .resolution_statuses
-            .lock()
-            .expect("not poisoned")
-            .get(&game)
-            .copied()
         {
-            return Ok(status);
+            let statuses = self.resolution_statuses.lock().expect("not poisoned");
+            if let Some(mut status) = statuses.get(&game).copied() {
+                if !status.is_resolved()
+                    && let Some(parent) = self.parents.lock().expect("not poisoned").get(&game)
+                {
+                    match statuses.get(parent).expect("parent status exists").status {
+                        GameStatus::ChallengerWins => {
+                            status.resolvable = true;
+                            status.outcome = GameStatus::ChallengerWins;
+                            status.invalidation_reason = InvalidationReason::InvalidParent;
+                        }
+                        GameStatus::InProgress => {
+                            status.resolvable = false;
+                            if status.outcome == GameStatus::DefenderWins {
+                                status.outcome = GameStatus::InProgress;
+                            }
+                        }
+                        GameStatus::DefenderWins => {}
+                    }
+                }
+                return Ok(status);
+            }
         }
         let resolved = self
             .resolved_games
@@ -259,6 +285,11 @@ impl BondManagerClient for MockBondClient {
             .expect("not poisoned")
             .contains(&game);
         Ok(ResolutionStatus {
+            status: if resolved {
+                GameStatus::DefenderWins
+            } else {
+                GameStatus::InProgress
+            },
             resolvable: false,
             outcome: if resolved {
                 GameStatus::DefenderWins
@@ -270,16 +301,30 @@ impl BondManagerClient for MockBondClient {
     }
 
     async fn resolve_game(&self, game: Address) -> Result<ResolveSubmission, ProposerError> {
-        let mut statuses = self.resolution_statuses.lock().expect("not poisoned");
-        let status = statuses
-            .get_mut(&game)
-            .ok_or_else(|| ProposerError::message(format!("game {game} is not resolvable")))?;
+        self.resolution_attempts
+            .lock()
+            .expect("not poisoned")
+            .push(game);
+        if self
+            .fail_resolve_once
+            .lock()
+            .expect("not poisoned")
+            .remove(&game)
+        {
+            return Err(ProposerError::message("injected resolve failure"));
+        }
+        let mut status = self.resolution_status(game).await?;
         if !status.resolvable {
             return Err(ProposerError::message(format!(
                 "game {game} is not resolvable"
             )));
         }
         status.resolvable = false;
+        status.status = status.outcome;
+        self.resolution_statuses
+            .lock()
+            .expect("not poisoned")
+            .insert(game, status);
         self.resolutions.lock().expect("not poisoned").push(game);
         Ok(ResolveSubmission {
             tx_hash: B256::repeat_byte(0xbb),
@@ -287,8 +332,27 @@ impl BondManagerClient for MockBondClient {
     }
 
     async fn is_game_finalized(&self, game: Address) -> Result<bool, ProposerError> {
+        if !self.resolution_status(game).await?.is_resolved() {
+            return Ok(false);
+        }
         Ok(!self
             .unfinalized_games
+            .lock()
+            .expect("not poisoned")
+            .contains(&game))
+    }
+
+    async fn has_retry(&self, game: Address) -> Result<bool, ProposerError> {
+        if self
+            .fail_retry_lookup_once
+            .lock()
+            .expect("not poisoned")
+            .remove(&game)
+        {
+            return Err(ProposerError::message("injected retry lookup failure"));
+        }
+        Ok(self
+            .retried_games
             .lock()
             .expect("not poisoned")
             .contains(&game))
@@ -358,6 +422,7 @@ async fn advance_proposal(
 
 fn positive_ready_status() -> ResolutionStatus {
     ResolutionStatus {
+        status: GameStatus::InProgress,
         resolvable: true,
         outcome: GameStatus::DefenderWins,
         invalidation_reason: InvalidationReason::None,
@@ -380,6 +445,7 @@ fn anchor_advanced_onto(anchor_game: Address, l2_block_number: u64) -> LineageAn
 
 fn timed_out_status() -> ResolutionStatus {
     ResolutionStatus {
+        status: GameStatus::ChallengerWins,
         resolvable: false,
         outcome: GameStatus::ChallengerWins,
         invalidation_reason: InvalidationReason::ProofTimeout,
@@ -388,6 +454,7 @@ fn timed_out_status() -> ResolutionStatus {
 
 fn negatively_resolvable_timeout() -> ResolutionStatus {
     ResolutionStatus {
+        status: GameStatus::InProgress,
         resolvable: true,
         outcome: GameStatus::ChallengerWins,
         invalidation_reason: InvalidationReason::ProofTimeout,
@@ -428,6 +495,7 @@ fn bond_manager_config(initial_scan_limit: u64) -> BondManagerConfig {
     BondManagerConfig {
         poll_interval: Duration::from_secs(1),
         initial_scan_limit,
+        ..BondManagerConfig::default()
     }
 }
 
@@ -656,6 +724,7 @@ async fn resolve_games_caps_submissions_and_keeps_scanning_resolved_games() {
             (
                 game_3,
                 ResolutionStatus {
+                    status: GameStatus::DefenderWins,
                     resolvable: false,
                     outcome: GameStatus::DefenderWins,
                     invalidation_reason: InvalidationReason::None,
@@ -708,6 +777,7 @@ async fn advance_anchor_skips_newer_game_that_is_not_yet_valid() {
             (
                 GAME_1,
                 ResolutionStatus {
+                    status: GameStatus::DefenderWins,
                     resolvable: false,
                     outcome: GameStatus::DefenderWins,
                     invalidation_reason: InvalidationReason::None,
@@ -716,6 +786,7 @@ async fn advance_anchor_skips_newer_game_that_is_not_yet_valid() {
             (
                 game_2,
                 ResolutionStatus {
+                    status: GameStatus::DefenderWins,
                     resolvable: false,
                     outcome: GameStatus::DefenderWins,
                     invalidation_reason: InvalidationReason::None,
@@ -724,6 +795,7 @@ async fn advance_anchor_skips_newer_game_that_is_not_yet_valid() {
             (
                 game_3,
                 ResolutionStatus {
+                    status: GameStatus::DefenderWins,
                     resolvable: false,
                     outcome: GameStatus::DefenderWins,
                     invalidation_reason: InvalidationReason::None,
@@ -768,6 +840,7 @@ async fn resolved_games_do_not_consume_resolution_budget() {
             (
                 GAME_1,
                 ResolutionStatus {
+                    status: GameStatus::DefenderWins,
                     resolvable: false,
                     outcome: GameStatus::DefenderWins,
                     invalidation_reason: InvalidationReason::None,
@@ -984,6 +1057,7 @@ async fn bond_manager_resolves_invalid_parent_before_settlement() {
         .insert(
             game,
             ResolutionStatus {
+                status: GameStatus::InProgress,
                 resolvable: true,
                 outcome: GameStatus::ChallengerWins,
                 invalidation_reason: InvalidationReason::InvalidParent,
@@ -1017,6 +1091,7 @@ async fn bond_manager_leaves_direct_proof_timeout_to_lineage_proposer() {
         .insert(
             game,
             ResolutionStatus {
+                status: GameStatus::InProgress,
                 resolvable: true,
                 outcome: GameStatus::ChallengerWins,
                 invalidation_reason: InvalidationReason::ProofTimeout,
@@ -1029,6 +1104,160 @@ async fn bond_manager_leaves_direct_proof_timeout_to_lineage_proposer() {
 
     assert!(client.resolutions.lock().expect("not poisoned").is_empty());
     assert!(manager.tracks_game(game));
+}
+
+#[tokio::test]
+async fn bond_manager_recovers_superseded_timeout_and_its_descendants() {
+    let owner = Address::repeat_byte(0xa1);
+    let parent = game_address(10);
+    let old_attempt = game_address(11);
+    let child = game_address(12);
+    let grandchild = game_address(13);
+    let client = MockBondClient::new(
+        owner,
+        vec![(old_attempt, owner), (child, owner), (grandchild, owner)],
+    );
+    client.parents.lock().unwrap().extend([
+        (old_attempt, parent),
+        (child, old_attempt),
+        (grandchild, child),
+    ]);
+    client.retried_games.lock().unwrap().insert(old_attempt);
+    client.resolution_statuses.lock().unwrap().extend([
+        (parent, positive_ready_status()),
+        (old_attempt, negatively_resolvable_timeout()),
+        (child, positive_ready_status()),
+        (grandchild, positive_ready_status()),
+    ]);
+    client
+        .unfinalized_games
+        .lock()
+        .unwrap()
+        .extend([old_attempt, child, grandchild]);
+
+    // Discover the superseded attempt from the factory, including after a process restart.
+    let mut manager = BondManager::new(bond_manager_config(100), client.clone());
+    manager.scan_games().await.unwrap();
+    manager.settle_games().await.unwrap();
+    let waiting = client.resolution_status(old_attempt).await.unwrap();
+    assert_eq!(waiting.outcome, GameStatus::ChallengerWins);
+    assert!(!waiting.is_resolved());
+    assert!(client.resolution_attempts.lock().unwrap().is_empty());
+    assert!(client.closes.lock().unwrap().is_empty());
+
+    // The selected branch resolves the parent; cleanup must resolve the skipped attempt.
+    client
+        .resolution_statuses
+        .lock()
+        .unwrap()
+        .get_mut(&parent)
+        .unwrap()
+        .status = GameStatus::DefenderWins;
+    manager.settle_games().await.unwrap();
+    assert_eq!(
+        *client.resolutions.lock().unwrap(),
+        vec![old_attempt, child, grandchild]
+    );
+    for game in [child, grandchild] {
+        let status = client.resolution_status(game).await.unwrap();
+        assert!(status.is_resolved());
+        assert_eq!(
+            status.invalidation_reason,
+            InvalidationReason::InvalidParent
+        );
+    }
+    manager.settle_games().await.unwrap();
+    assert!(
+        client.closes.lock().unwrap().is_empty(),
+        "respect the finality airgap"
+    );
+
+    client.unfinalized_games.lock().unwrap().clear();
+    manager.settle_games().await.unwrap();
+    assert_eq!(client.closes.lock().unwrap().len(), 3);
+    for game in [old_attempt, child, grandchild] {
+        assert!(!manager.tracks_game(game));
+    }
+}
+
+#[tokio::test]
+async fn bond_manager_bounds_retry_resolutions_and_rotates_after_failure() {
+    let owner = Address::repeat_byte(0xa1);
+    let first = game_address(1);
+    let second = game_address(2);
+    let client = MockBondClient::new(owner, vec![(first, owner), (second, owner)]);
+    client.retried_games.lock().unwrap().extend([first, second]);
+    client.resolution_statuses.lock().unwrap().extend([
+        (first, negatively_resolvable_timeout()),
+        (second, negatively_resolvable_timeout()),
+    ]);
+    client.fail_resolve_once.lock().unwrap().insert(first);
+    let mut manager = BondManager::new(bond_manager_config(100), client.clone());
+    manager.scan_games().await.unwrap();
+
+    manager.settle_games().await.unwrap();
+    assert_eq!(*client.resolution_attempts.lock().unwrap(), vec![first]);
+    assert!(client.resolutions.lock().unwrap().is_empty());
+
+    manager.settle_games().await.unwrap();
+    assert_eq!(
+        *client.resolution_attempts.lock().unwrap(),
+        vec![first, second]
+    );
+    assert!(manager.tracks_game(first));
+
+    manager.settle_games().await.unwrap();
+    assert_eq!(
+        *client.resolution_attempts.lock().unwrap(),
+        vec![first, second, first]
+    );
+    assert!(!manager.tracks_game(second));
+    manager.settle_games().await.unwrap();
+    assert!(!manager.tracks_game(first));
+}
+
+#[tokio::test]
+async fn bond_manager_retries_failed_successor_lookup_without_stalling_other_games() {
+    let owner = Address::repeat_byte(0xa1);
+    let first = game_address(1);
+    let second = game_address(2);
+    let client = MockBondClient::new(owner, vec![(first, owner), (second, owner)]);
+    client.retried_games.lock().unwrap().extend([first, second]);
+    client.resolution_statuses.lock().unwrap().extend([
+        (first, negatively_resolvable_timeout()),
+        (second, negatively_resolvable_timeout()),
+    ]);
+    client.fail_retry_lookup_once.lock().unwrap().insert(first);
+    let mut manager = BondManager::new(bond_manager_config(100), client.clone());
+    manager.scan_games().await.unwrap();
+    manager.settle_games().await.unwrap();
+    assert_eq!(*client.resolutions.lock().unwrap(), vec![second]);
+    assert!(manager.tracks_game(first));
+    manager.settle_games().await.unwrap();
+    assert_eq!(*client.resolutions.lock().unwrap(), vec![second, first]);
+}
+
+#[tokio::test]
+async fn bond_manager_can_disable_retry_cleanup_without_disabling_settlement() {
+    let owner = Address::repeat_byte(0xa1);
+    let old_attempt = game_address(1);
+    let finalized = game_address(2);
+    let client = MockBondClient::new(owner, vec![(old_attempt, owner), (finalized, owner)]);
+    client.retried_games.lock().unwrap().insert(old_attempt);
+    client
+        .resolution_statuses
+        .lock()
+        .unwrap()
+        .insert(old_attempt, negatively_resolvable_timeout());
+    client.resolved_games.lock().unwrap().insert(finalized);
+    let mut config = bond_manager_config(100);
+    config.max_retry_resolutions_per_tick = 0;
+    let mut manager = BondManager::new(config, client.clone());
+    manager.scan_games().await.unwrap();
+    manager.settle_games().await.unwrap();
+    assert!(client.resolution_attempts.lock().unwrap().is_empty());
+    assert!(manager.tracks_game(old_attempt));
+    assert_eq!(*client.closes.lock().unwrap(), vec![finalized]);
 }
 
 #[tokio::test]
@@ -1126,6 +1355,71 @@ async fn bond_manager_prunes_an_already_settled_game_without_closing_again() {
     manager.settle_games().await.unwrap();
     assert!(!manager.tracks_game(game));
     assert!(client.closes.lock().expect("not poisoned").is_empty());
+}
+
+#[tokio::test]
+async fn proposer_retries_parent_gated_timeout_and_skips_old_descendants() {
+    let parent = game_address(90);
+    let old_attempt = game_address(91);
+    let descendant = game_address(92);
+    let root_10 = B256::repeat_byte(0x10);
+    let root_20 = B256::repeat_byte(0x20);
+    let root_30 = B256::repeat_byte(0x30);
+    let contracts = MockContracts {
+        anchor: anchor_at(0),
+        games: Arc::new(Mutex::new(HashMap::from([
+            (game_uuid(ANCHOR, root_10, 10, 0), parent),
+            (game_uuid(parent, root_20, 20, 0), old_attempt),
+            (game_uuid(old_attempt, root_30, 30, 0), descendant),
+        ]))),
+        submissions: Arc::default(),
+        resolution_statuses: Arc::new(Mutex::new(HashMap::from([(
+            old_attempt,
+            ResolutionStatus {
+                status: GameStatus::InProgress,
+                ..timed_out_status()
+            },
+        )]))),
+        resolutions: Arc::default(),
+        closures: Arc::default(),
+        submission_failures: Arc::default(),
+        unfinalized_games: Arc::default(),
+    };
+    let proposer = WorldChainProposer::new(
+        config(),
+        contracts.clone(),
+        MockOutputRoots {
+            roots: HashMap::from([(10, root_10), (20, root_20), (30, root_30)]),
+            finalized_l2_block: 30,
+        },
+    );
+    let scan = proposer.scan_selected_lineage().await.unwrap();
+    assert_eq!(scan.lineage().games().len(), 1);
+    assert_eq!(
+        scan.next_action(),
+        &NextProposalAction::RetryTimedOut {
+            proposal: Proposal {
+                parent_ref: parent,
+                root_claim: root_20,
+                l2_block_number: 20,
+                attempt: 1
+            },
+            invalidated_game: old_attempt,
+        }
+    );
+    proposer.submit_next_proposal(&scan).await.unwrap();
+    let next_scan = proposer.scan_selected_lineage().await.unwrap();
+    assert_eq!(next_scan.lineage().games().len(), 2);
+    assert_eq!(next_scan.lineage().games()[1].game.attempt, 1);
+    assert!(
+        next_scan
+            .lineage()
+            .games()
+            .iter()
+            .all(|selected| selected.game.address != old_attempt
+                && selected.game.address != descendant)
+    );
+    assert!(contracts.resolutions.lock().unwrap().is_empty());
 }
 
 #[tokio::test]

--- a/proofs/services/proposer/src/traits.rs
+++ b/proofs/services/proposer/src/traits.rs
@@ -30,6 +30,9 @@ pub trait BondManagerClient: Send + Sync {
     /// Returns the proposal domain embedded in the provided game.
     async fn game_domain_hash(&self, game: Address) -> Result<B256, ProposerError>;
 
+    /// Returns whether a newer attempt exists for the game's exact transition and domain.
+    async fn has_retry(&self, game: Address) -> Result<bool, ProposerError>;
+
     /// Returns the resolution status of the provided game.
     async fn resolution_status(&self, game: Address) -> Result<ResolutionStatus, ProposerError>;
 


### PR DESCRIPTION
### Problem

An unchallenged game that receives no proof is guaranteed to lose once its challenge period expires. However, while its parent remained unresolved, `resolutionStatus()` reported `IN_PROGRESS` and retries were blocked. The proposer therefore continued extending a doomed lineage whose descendants would eventually be invalidated.

### Solution

Return `CHALLENGER_WINS` / `PROOF_TIMEOUT` for expired games with insufficient proofs, even before their parents resolve, and allow optimistic retries. Actual resolution still waits for the parent to preserve correct bond distribution.

Update Rust clients to distinguish predicted outcomes from stored on-chain status. Extend the bond manager to resolve superseded attempts and recover abandoned descendants, with bounded cleanup and failure isolation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dispute-game resolution semantics and retry eligibility in `MultiProofGame`, affecting lineage selection and bond settlement; off-chain behavior is aligned via multicall reads but incorrect keeper logic could still race with retries.
> 
> **Overview**
> **`MultiProofGame.resolutionStatus()`** now separates *eventual outcome* from *resolvable now*: proofless games past their deadline report **`CHALLENGER_WINS` / `PROOF_TIMEOUT`** while **`status()`** may still be **`IN_PROGRESS`** if the parent has not resolved. **`resolve()`** behavior is unchanged (still requires a resolved parent). **Retry initialization** treats the prior attempt as retryable when **`resolutionStatus()`** shows that local doom, not only after on-chain settlement.
> 
> **Rust clients** add **`ResolutionStatus.status`** (atomic multicall with **`resolutionStatus()`**), **`read_game_has_retry`**, and **`is_resolved()`** keyed on stored **`status()`** so keepers do not treat predicted timeouts as finalized.
> 
> The **proposer bond manager** can **`resolve()`** superseded attempts once a factory retry exists, with **per-tick caps** and **rotation** so one stuck game does not block cleanup of descendants; config **`max_retry_resolutions_per_tick`** (CLI/env) can disable this path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c29956b5baff3896b08733cd9beb65e363a9f5a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->