### PR TITLE
ci: enable Karst acceptance checks on stage

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -64,13 +64,13 @@ jobs:
             include_in_all: true
             rpc_url: https://wc-node-sepolia.worldcoin.dev
             acceptance_profile: smoke
-            bundler_rpc_url: https://rundler-stage.worldcoin.dev
+            bundler_rpc_url: ""
             erc4337_rpc_url: https://worldchain-mainnet.g.alchemy.com/public
             entry_point: "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
             safe_4337_module: "0x70673A08a5B1086585d39979Fb2d84FDC0bB6Aaf"
             safe_4337_wallet_deployer: "0xd1f0B51940DbD6e73891D2a41Ef14483fDC5Cb6e"
             expected_chain_id: "4801"
-            karst_enabled: "false"
+            karst_enabled: "true"
             karst_deposit_enabled: "false"
             optimism_portal: ""
             allow_failure: false

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -71,8 +71,8 @@ jobs:
             safe_4337_wallet_deployer: "0xd1f0B51940DbD6e73891D2a41Ef14483fDC5Cb6e"
             expected_chain_id: "4801"
             karst_enabled: "true"
-            karst_deposit_enabled: "false"
-            optimism_portal: ""
+            karst_deposit_enabled: "true"
+            optimism_portal: "0xFf6EBa109271fe6d4237EeeD4bAb1dD9A77dD1A4"
             allow_failure: false
           - network: betanet
             environment: dev

--- a/e2e-tests/src/it/acceptance_tests/karst.rs
+++ b/e2e-tests/src/it/acceptance_tests/karst.rs
@@ -77,34 +77,71 @@ pub(super) async fn l2_execution_checks(env: &RpcEnv) -> eyre::Result<()> {
         "running Karst L2 execution acceptance tests"
     );
 
-    eprintln!("karst: checking EIP-7910 eth_config");
-    check_eip_7910_eth_config(env).await?;
+    let mut failures = Vec::new();
+    macro_rules! run_check {
+        ($label:literal, $check:expr) => {
+            eprintln!("karst: checking {}", $label);
+            if let Err(err) = $check.await {
+                eprintln!("karst: FAILED {}: {err:#}", $label);
+                failures.push(format!("{}: {err:#}", $label));
+            }
+        };
+    }
 
-    let mut sender = L2TxSender::new(
+    run_check!("EIP-7910 eth_config", check_eip_7910_eth_config(env));
+
+    match L2TxSender::new(
         env.chain_provider().clone(),
         l2_key,
         env.config().tx_timeout,
         env.config().tx_poll_interval,
     )
-    .await?;
+    .await
+    {
+        Ok(mut sender) => {
+            run_check!(
+                "EIP-7823 MODEXP input bound",
+                check_eip_7823_modexp_upper_bound(&mut sender)
+            );
+            run_check!(
+                "EIP-7883 MODEXP gas floor",
+                check_eip_7883_modexp_gas_floor_increase(&mut sender)
+            );
+            run_check!(
+                "EIP-7951 P256VERIFY gas cost",
+                check_eip_7951_p256verify_gas_cost(&mut sender)
+            );
+            run_check!(
+                "bn256 pairing input limit",
+                check_karst_bn256_pairing_input_size_reduction(&mut sender)
+            );
+            run_check!(
+                "EIP-7939 CLZ opcode activation",
+                check_eip_7939_clz_opcode_activation(&mut sender)
+            );
+            run_check!(
+                "EIP-7825 transaction gas cap",
+                check_eip_7825_tx_gas_limit_cap(&mut sender)
+            );
+        }
+        Err(err) => {
+            eprintln!("karst: FAILED transaction sender initialization: {err:#}");
+            failures.push(format!("transaction sender initialization: {err:#}"));
+        }
+    }
 
-    eprintln!("karst: checking EIP-7823 MODEXP input bound");
-    check_eip_7823_modexp_upper_bound(&mut sender).await?;
-    eprintln!("karst: checking EIP-7883 MODEXP gas floor");
-    check_eip_7883_modexp_gas_floor_increase(&mut sender).await?;
-    eprintln!("karst: checking EIP-7951 P256VERIFY gas cost");
-    check_eip_7951_p256verify_gas_cost(&mut sender).await?;
-    eprintln!("karst: checking bn256 pairing input limit");
-    check_karst_bn256_pairing_input_size_reduction(&mut sender).await?;
-    eprintln!("karst: checking EIP-7939 CLZ opcode activation");
-    check_eip_7939_clz_opcode_activation(&mut sender).await?;
-    eprintln!("karst: checking EIP-7825 transaction gas cap");
-    check_eip_7825_tx_gas_limit_cap(&mut sender).await?;
-    eprintln!("karst: checking EIP-7825 deposit bypass");
-    check_eip_7825_deposit_bypasses_tx_gas_limit_cap(env).await?;
+    run_check!(
+        "EIP-7825 deposit bypass",
+        check_eip_7825_deposit_bypasses_tx_gas_limit_cap(env)
+    );
 
     eprintln!("karst: L2 execution checks completed");
     info!("Karst L2 execution acceptance tests completed");
+    ensure!(
+        failures.is_empty(),
+        "Karst L2 execution checks failed:\n{}",
+        failures.join("\n")
+    );
     Ok(())
 }
 

--- a/e2e-tests/src/it/acceptance_tests/rpc.rs
+++ b/e2e-tests/src/it/acceptance_tests/rpc.rs
@@ -28,6 +28,13 @@ impl RpcEnv {
         let Some(config) = Config::from_env()? else {
             return Ok(None);
         };
+        eprintln!("acceptance: L2 sender address={}", config.l2_key.address());
+        if let Some(deposit) = config.karst_deposit.as_ref() {
+            eprintln!(
+                "acceptance: L1 deposit sender address={}",
+                deposit.l1_key.address()
+            );
+        }
         let provider =
             provider_for_url::<Ethereum>(&config.rpc_url, config.cloudflare_access.as_ref())?;
         let optimism_provider =


### PR DESCRIPTION
## Summary
- enable Karst L2 execution acceptance checks for the World Chain Sepolia stage target
- skip the stage Rundler/ERC-4337 suite because it is configured against mainnet
- keep the L1 Karst deposit-bypass check disabled


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow matrix-only change; it adjusts which acceptance suites run in CI with no application or deployment logic changes.
> 
> **Overview**
> Updates the **stage** acceptance-test matrix so CI validates **Karst L2 execution** on World Chain Sepolia while avoiding a misaligned **ERC-4337 / Rundler** path.
> 
> For `network: stage`, **`karst_enabled`** is set to **`true`**, and **`bundler_rpc_url`** is cleared so sponsored user-operation checks no longer run against stage Rundler while **`erc4337_rpc_url`** still points at mainnet. **`karst_deposit_enabled`** remains **`false`**, so L1 deposit-bypass Karst checks stay off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56b8b8c4da6aa68f76b79622bb275823beaf94a7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->