### PR TITLE
test(proof-system): add L2->L1 withdrawal test against alphanet

### DIFF
--- a/e2e-tests/src/it/alphanet/mod.rs
+++ b/e2e-tests/src/it/alphanet/mod.rs
@@ -1,0 +1,1 @@
+mod withdrawal;

--- a/e2e-tests/src/it/alphanet/withdrawal.rs
+++ b/e2e-tests/src/it/alphanet/withdrawal.rs
@@ -1,5 +1,5 @@
 use crate::it::utils::{
-    devnet::wait_for_multi_proof_game,
+    devnet::wait_for_multi_proof_game_with_timeout,
     withdrawals::{
         AnchorStateRegistry::AnchorStateRegistryInstance, InitiatedWithdrawal,
         OptimismPortal::OptimismPortalInstance, ProveWithdrawal, build_withdrawal_proof,
@@ -11,7 +11,7 @@ use alloy_network::{EthereumWallet, ReceiptResponse};
 use alloy_provider::{Provider, ProviderBuilder};
 use alloy_signer_local::PrivateKeySigner;
 use revm_primitives::{Address, U256};
-use std::str::FromStr;
+use std::{str::FromStr, time::Duration};
 
 #[tokio::test]
 #[ignore]
@@ -66,10 +66,12 @@ async fn prove_withdrawal() {
     let initiated_withdrawal: InitiatedWithdrawal =
         serde_json::from_slice(&std::fs::read("initiated_withdrawal.json").unwrap()).unwrap();
     // wait for a covering WIP1006 game with l2SequenceNumber >= initiated_withdrawal.l2_block
-    let (game_index, game_addr, game_l2_block) = wait_for_multi_proof_game(
+    let timeout = Duration::from_secs(10);
+    let (game_index, game_addr, game_l2_block) = wait_for_multi_proof_game_with_timeout(
         &l1_provider,
         dispute_game_facatory_addr,
         initiated_withdrawal.l2_block,
+        timeout,
     )
     .await
     .unwrap();

--- a/e2e-tests/src/it/alphanet/withdrawal.rs
+++ b/e2e-tests/src/it/alphanet/withdrawal.rs
@@ -1,0 +1,37 @@
+use crate::it::utils::withdrawals::initiate_withdrawal;
+use alloy_network::EthereumWallet;
+use alloy_provider::ProviderBuilder;
+use alloy_signer_local::PrivateKeySigner;
+use std::str::FromStr;
+
+#[tokio::test]
+#[ignore]
+async fn init_withdrawal() {
+    // fetch env vars
+    let l2_private_key_str = std::env::var("L2_PRIVATE_KEY").unwrap();
+    let l2_rpc_endpoint = std::env::var("L2_RPC_ENDPOINT").unwrap();
+    // create L2 signer provider
+    let local_signer = PrivateKeySigner::from_str(&l2_private_key_str).unwrap();
+    let local_signer_addr = local_signer.address();
+    let l2_provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(local_signer))
+        .connect(&l2_rpc_endpoint)
+        .await
+        .unwrap();
+    // target address of the L2 -> L1 withdrawal is the same address that sends the tx on L2
+    let target_addr = local_signer_addr;
+    // sends the initiate_withdrawal transaction to the L2ToL1MessagePasser contract
+    let initiate_withdrawal = initiate_withdrawal(l2_provider, target_addr).await.unwrap();
+    // save the InitiatedWithdrawal data to a .json file
+    std::fs::write(
+        "initiate_withdrawal.json",
+        serde_json::to_string_pretty(&initiate_withdrawal).unwrap(),
+    )
+    .unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn prove_withdrawal() {
+    // 
+}

--- a/e2e-tests/src/it/alphanet/withdrawal.rs
+++ b/e2e-tests/src/it/alphanet/withdrawal.rs
@@ -30,11 +30,11 @@ async fn init_withdrawal() {
     // target address of the L2 -> L1 withdrawal is the same address that sends the tx on L2
     let target_addr = local_signer_addr;
     // sends the initiate_withdrawal transaction to the L2ToL1MessagePasser contract
-    let initiate_withdrawal = initiate_withdrawal(l2_provider, target_addr).await.unwrap();
+    let initiated_withdrawal = initiate_withdrawal(l2_provider, target_addr).await.unwrap();
     // save the InitiatedWithdrawal data to a .json file
     std::fs::write(
-        "initiate_withdrawal.json",
-        serde_json::to_string_pretty(&initiate_withdrawal).unwrap(),
+        "initiated_withdrawal.json",
+        serde_json::to_string_pretty(&initiated_withdrawal).unwrap(),
     )
     .unwrap();
 }
@@ -103,6 +103,7 @@ async fn prove_withdrawal() {
     // save useful data into a .json file
     let prove_withdrawal = ProveWithdrawal {
         transaction: initiated_withdrawal.transaction,
+        hash: initiated_withdrawal.hash,
         game_index,
         game_l2_block,
         game_addr,
@@ -170,4 +171,12 @@ async fn finalize_withdrawal() {
         .unwrap();
     let receipt = pending_tx.get_receipt().await.unwrap();
     assert!(receipt.status());
+    assert!(
+        optimism_portal
+            .finalizedWithdrawals(prove_withdrawal.hash)
+            .call()
+            .await
+            .unwrap(),
+        "Portal did not persist the finalized withdrawal"
+    );
 }

--- a/e2e-tests/src/it/alphanet/withdrawal.rs
+++ b/e2e-tests/src/it/alphanet/withdrawal.rs
@@ -1,7 +1,14 @@
-use crate::it::utils::withdrawals::initiate_withdrawal;
+use crate::it::utils::{
+    devnet::wait_for_multi_proof_game,
+    withdrawals::{
+        InitiatedWithdrawal, OptimismPortal::OptimismPortalInstance, ProveWithdrawal,
+        build_withdrawal_proof, initiate_withdrawal,
+    },
+};
 use alloy_network::EthereumWallet;
 use alloy_provider::ProviderBuilder;
 use alloy_signer_local::PrivateKeySigner;
+use revm_primitives::{Address, U256};
 use std::str::FromStr;
 
 #[tokio::test]
@@ -33,5 +40,66 @@ async fn init_withdrawal() {
 #[tokio::test]
 #[ignore]
 async fn prove_withdrawal() {
-    // 
+    // fetch env vars
+    let l1_private_key_str = std::env::var("L1_PRIVATE_KEY").unwrap();
+    let l1_rpc_endpoint = std::env::var("L1_RPC_ENDPOINT").unwrap();
+    let dispute_game_factory_str = std::env::var("DISPUTE_GAME_FACTORY").unwrap();
+    let dispute_game_facatory_addr = Address::from_str(&dispute_game_factory_str).unwrap();
+    let l2_rpc_endpoint = std::env::var("L2_RPC_ENDPOINT").unwrap();
+    let optimism_portal_str = std::env::var("OPTIMISM_PORTAL").unwrap();
+    let optimism_portal_addr = Address::from_str(&optimism_portal_str).unwrap();
+    // create L1 signer provider
+    let local_signer = PrivateKeySigner::from_str(&l1_private_key_str).unwrap();
+    let l1_provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(local_signer))
+        .connect(&l1_rpc_endpoint)
+        .await
+        .unwrap();
+    // create L2 provider
+    let l2_provider = ProviderBuilder::new()
+        .connect(&l2_rpc_endpoint)
+        .await
+        .unwrap();
+    // fetch InitiatedWithdrawl data from .json file
+    let initiated_withdrawal: InitiatedWithdrawal =
+        serde_json::from_slice(&std::fs::read("initiated_withdrawal.json").unwrap()).unwrap();
+    // wait for a covering WIP1006 game with l2SequenceNumber >= initiated_withdrawal.l2_block
+    let (game_index, game_addr, game_l2_block) = wait_for_multi_proof_game(
+        &l1_provider,
+        dispute_game_facatory_addr,
+        initiated_withdrawal.l2_block,
+    )
+    .await
+    .unwrap();
+    // get the output root proof and the withdrawal proof
+    let (output_root_proof, withdrawal_proof) =
+        build_withdrawal_proof(l2_provider, game_l2_block, initiated_withdrawal.hash)
+            .await
+            .unwrap();
+    // send the OptimismPortal::proveWithdrawalTransaction
+    let optimism_portal = OptimismPortalInstance::new(optimism_portal_addr, &l1_provider);
+    let pending_tx = optimism_portal
+        .proveWithdrawalTransaction(
+            initiated_withdrawal.transaction.clone(),
+            U256::from(game_index),
+            output_root_proof,
+            withdrawal_proof,
+        )
+        .send()
+        .await
+        .unwrap();
+    let receipt = pending_tx.get_receipt().await.unwrap();
+    assert!(receipt.status());
+    // save useful data into a .json file
+    let prove_withdrawal = ProveWithdrawal {
+        transaction: initiated_withdrawal.transaction,
+        game_index,
+        game_l2_block,
+        game_addr,
+    };
+    std::fs::write(
+        "prove_withdrawal.json",
+        serde_json::to_string_pretty(&prove_withdrawal).unwrap(),
+    )
+    .unwrap();
 }

--- a/e2e-tests/src/it/alphanet/withdrawal.rs
+++ b/e2e-tests/src/it/alphanet/withdrawal.rs
@@ -1,12 +1,14 @@
 use crate::it::utils::{
     devnet::wait_for_multi_proof_game,
     withdrawals::{
-        InitiatedWithdrawal, OptimismPortal::OptimismPortalInstance, ProveWithdrawal,
-        build_withdrawal_proof, initiate_withdrawal,
+        AnchorStateRegistry::AnchorStateRegistryInstance, InitiatedWithdrawal,
+        OptimismPortal::OptimismPortalInstance, ProveWithdrawal, build_withdrawal_proof,
+        initiate_withdrawal,
     },
 };
-use alloy_network::EthereumWallet;
-use alloy_provider::ProviderBuilder;
+use alloy_eips::BlockId;
+use alloy_network::{EthereumWallet, ReceiptResponse};
+use alloy_provider::{Provider, ProviderBuilder};
 use alloy_signer_local::PrivateKeySigner;
 use revm_primitives::{Address, U256};
 use std::str::FromStr;
@@ -60,7 +62,7 @@ async fn prove_withdrawal() {
         .connect(&l2_rpc_endpoint)
         .await
         .unwrap();
-    // fetch InitiatedWithdrawl data from .json file
+    // read InitiatedWithdrawl data from .json file
     let initiated_withdrawal: InitiatedWithdrawal =
         serde_json::from_slice(&std::fs::read("initiated_withdrawal.json").unwrap()).unwrap();
     // wait for a covering WIP1006 game with l2SequenceNumber >= initiated_withdrawal.l2_block
@@ -90,16 +92,82 @@ async fn prove_withdrawal() {
         .unwrap();
     let receipt = pending_tx.get_receipt().await.unwrap();
     assert!(receipt.status());
+    // get the L1 timestamp of the block that includes this proveWithdrawal
+    let block_number = receipt.block_number().unwrap();
+    let block = l1_provider
+        .get_block(BlockId::number(block_number))
+        .await
+        .unwrap()
+        .unwrap();
+    let l1_timestamp = block.header.timestamp;
     // save useful data into a .json file
     let prove_withdrawal = ProveWithdrawal {
         transaction: initiated_withdrawal.transaction,
         game_index,
         game_l2_block,
         game_addr,
+        proven_at: l1_timestamp,
     };
     std::fs::write(
         "prove_withdrawal.json",
         serde_json::to_string_pretty(&prove_withdrawal).unwrap(),
     )
     .unwrap();
+}
+
+#[tokio::test]
+#[ignore]
+async fn finalize_withdrawal() {
+    // fetch env vars
+    let l1_private_key_str = std::env::var("L1_PRIVATE_KEY").unwrap();
+    let l1_rpc_endpoint = std::env::var("L1_RPC_ENDPOINT").unwrap();
+    let anchor_state_registry_str = std::env::var("ANCHOR_STATE_REGISTRY").unwrap();
+    let anchor_state_registry_addr = Address::from_str(&anchor_state_registry_str).unwrap();
+    let optimism_portal_str = std::env::var("OPTIMISM_PORTAL").unwrap();
+    let optimism_portal_addr = Address::from_str(&optimism_portal_str).unwrap();
+    // create L1 signer provider
+    let local_signer = PrivateKeySigner::from_str(&l1_private_key_str).unwrap();
+    let l1_provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(local_signer))
+        .connect(&l1_rpc_endpoint)
+        .await
+        .unwrap();
+    // read ProveWithdrawl data from .json file
+    let prove_withdrawal: ProveWithdrawal =
+        serde_json::from_slice(&std::fs::read("prove_withdrawal.json").unwrap()).unwrap();
+    // check whether the withdrawal is finalizable:
+    // 1. now - proven.timestamp > OptimismPortal::proofMaturityDelaySeconds()
+    let optimism_portal = OptimismPortalInstance::new(optimism_portal_addr, &l1_provider);
+    let latest_block = l1_provider
+        .get_block(BlockId::latest())
+        .await
+        .unwrap()
+        .unwrap();
+    let now = latest_block.header.timestamp;
+    let proof_maturity_delay_seconds = optimism_portal
+        .proofMaturityDelaySeconds()
+        .call()
+        .await
+        .unwrap();
+    assert!(
+        U256::from(now - prove_withdrawal.proven_at) > proof_maturity_delay_seconds,
+        "proof maturity is not elapsed yet"
+    );
+    // 2. ASR.isGameClaimValid must return true
+    let anchor_state_registry =
+        AnchorStateRegistryInstance::new(anchor_state_registry_addr, &l1_provider);
+    let is_game_claim_valid = anchor_state_registry
+        .isGameClaimValid(prove_withdrawal.game_addr)
+        .call()
+        .await
+        .unwrap();
+    assert!(is_game_claim_valid, "game claim is not valid");
+    // send the OptimismPortal::finalizeWithdrawal
+    let pending_tx = optimism_portal
+        .finalizeWithdrawalTransaction(prove_withdrawal.transaction)
+        .send()
+        .await
+        .unwrap();
+    let receipt = pending_tx.get_receipt().await.unwrap();
+    assert!(receipt.status());
 }

--- a/e2e-tests/src/it/devnet_withdrawal.rs
+++ b/e2e-tests/src/it/devnet_withdrawal.rs
@@ -1,77 +1,18 @@
-use alloy_consensus::BlockHeader;
-use alloy_eips::{BlockId, BlockNumberOrTag};
-use alloy_primitives::{Address, B256, Bytes, U256, address, keccak256};
-use alloy_provider::Provider;
+use alloy_primitives::U256;
 use alloy_signer_local::PrivateKeySigner;
-use alloy_sol_types::{SolValue, sol};
 use eyre::eyre::{OptionExt, ensure};
 use world_chain_devnet::SUPERCHAIN_GUARDIAN_PRIVATE_KEY;
 use world_chain_proof_protocol::MULTI_PROOF_GAME_TYPE;
 
-use crate::it::utils::devnet::{
-    GAME_DEFENDER_WINS, advance_to_timestamp, anchor_at, game_at, l1_contract, l1_rpc_url,
-    latest_timestamp, signing_provider, try_build_ha_devnet, vault_at,
-    wait_for_anchor_at_or_beyond, wait_for_game_finality, wait_for_game_settlement,
-    wait_for_multi_proof_game, wait_for_proof_lane, wait_for_status,
+use crate::it::utils::{
+    devnet::{
+        GAME_DEFENDER_WINS, advance_to_timestamp, anchor_at, game_at, l1_contract, l1_rpc_url,
+        latest_timestamp, signing_provider, try_build_ha_devnet, vault_at,
+        wait_for_anchor_at_or_beyond, wait_for_game_finality, wait_for_game_settlement,
+        wait_for_multi_proof_game, wait_for_proof_lane, wait_for_status,
+    },
+    withdrawals::{OptimismPortal, build_withdrawal_proof, initiate_withdrawal},
 };
-
-const L2_TO_L1_MESSAGE_PASSER: Address = address!("4200000000000000000000000000000000000016");
-
-sol! {
-    struct WithdrawalTransaction {
-        uint256 nonce;
-        address sender;
-        address target;
-        uint256 value;
-        uint256 gasLimit;
-        bytes data;
-    }
-
-    struct OutputRootProof {
-        bytes32 version;
-        bytes32 stateRoot;
-        bytes32 messagePasserStorageRoot;
-        bytes32 latestBlockhash;
-    }
-
-    #[sol(rpc)]
-    interface L2ToL1MessagePasser {
-        event MessagePassed(
-            uint256 indexed nonce,
-            address indexed sender,
-            address indexed target,
-            uint256 value,
-            uint256 gasLimit,
-            bytes data,
-            bytes32 withdrawalHash
-        );
-
-        function initiateWithdrawal(address target, uint256 gasLimit, bytes data) external payable;
-    }
-
-    #[sol(rpc)]
-    interface OptimismPortal {
-        function anchorStateRegistry() external view returns (address);
-        function disputeGameFactory() external view returns (address);
-        function disputeGameFinalityDelaySeconds() external view returns (uint256);
-        function proofMaturityDelaySeconds() external view returns (uint256);
-        function version() external view returns (string);
-        function proveWithdrawalTransaction(
-            WithdrawalTransaction tx_,
-            uint256 disputeGameIndex,
-            OutputRootProof outputRootProof,
-            bytes[] withdrawalProof
-        ) external;
-        function finalizeWithdrawalTransaction(WithdrawalTransaction tx_) external;
-        function finalizedWithdrawals(bytes32 withdrawalHash) external view returns (bool);
-    }
-}
-
-struct InitiatedWithdrawal {
-    transaction: WithdrawalTransaction,
-    hash: B256,
-    l2_block: u64,
-}
 
 #[ignore = "requires Docker, Foundry, and the full local OP Stack"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -213,84 +154,4 @@ async fn op_native_wip_1006_portal_withdrawal_and_bond_settlement() -> eyre::Res
     );
 
     Ok(())
-}
-
-async fn initiate_withdrawal<P>(
-    provider: P,
-    withdrawal_sender: Address,
-) -> eyre::Result<InitiatedWithdrawal>
-where
-    P: Provider,
-{
-    let receipt = L2ToL1MessagePasser::new(L2_TO_L1_MESSAGE_PASSER, provider)
-        .initiateWithdrawal(withdrawal_sender, U256::from(100_000), Bytes::new())
-        .gas(250_000)
-        .send()
-        .await?
-        .get_receipt()
-        .await?;
-    ensure!(receipt.status(), "L2 withdrawal initiation reverted");
-
-    let l2_block = receipt
-        .block_number
-        .ok_or_eyre("withdrawal receipt missing L2 block number")?;
-    let message = receipt
-        .logs()
-        .iter()
-        .find_map(|log| {
-            log.log_decode_validate::<L2ToL1MessagePasser::MessagePassed>()
-                .ok()
-        })
-        .ok_or_eyre("withdrawal receipt missing MessagePassed event")?;
-    let message = message.data();
-
-    Ok(InitiatedWithdrawal {
-        transaction: WithdrawalTransaction {
-            nonce: message.nonce,
-            sender: message.sender,
-            target: message.target,
-            value: message.value,
-            gasLimit: message.gasLimit,
-            data: message.data.clone(),
-        },
-        hash: message.withdrawalHash,
-        l2_block,
-    })
-}
-
-async fn build_withdrawal_proof<P>(
-    l2_provider: P,
-    game_l2_block: u64,
-    withdrawal_hash: B256,
-) -> eyre::Result<(OutputRootProof, Vec<Bytes>)>
-where
-    P: Provider,
-{
-    let block = l2_provider
-        .get_block_by_number(BlockNumberOrTag::Number(game_l2_block))
-        .await?
-        .ok_or_eyre("WIP-1006 output block missing from L2")?;
-    let storage_key = keccak256((withdrawal_hash, U256::ZERO).abi_encode_params());
-    let account_proof = l2_provider
-        .get_proof(L2_TO_L1_MESSAGE_PASSER, vec![storage_key])
-        .block_id(BlockId::Number(BlockNumberOrTag::Number(game_l2_block)))
-        .await?;
-    let storage_proof = account_proof
-        .storage_proof
-        .first()
-        .ok_or_eyre("eth_getProof returned no withdrawal storage proof")?;
-    ensure!(
-        storage_proof.value == U256::from(1),
-        "withdrawal is absent from the message passer"
-    );
-
-    Ok((
-        OutputRootProof {
-            version: B256::ZERO,
-            stateRoot: block.header.state_root(),
-            messagePasserStorageRoot: account_proof.storage_hash,
-            latestBlockhash: block.header.hash,
-        },
-        storage_proof.proof.clone(),
-    ))
 }

--- a/e2e-tests/src/it/mod.rs
+++ b/e2e-tests/src/it/mod.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod acceptance_tests;
 mod admin_tracing;
+mod alphanet;
 mod devnet_challenge;
 mod devnet_proof_invariants;
 mod devnet_smoke;

--- a/e2e-tests/src/it/utils/devnet.rs
+++ b/e2e-tests/src/it/utils/devnet.rs
@@ -29,13 +29,13 @@ use world_chain_proof_protocol::{
 use world_chain_proposer::AlloyProofSystemClient;
 
 /// How long any single wait on devnet-driven on-chain state may take before the test fails.
-pub(in crate::it) const GAME_WAIT_TIMEOUT: Duration = Duration::from_secs(300);
-pub(in crate::it) const GAME_IN_PROGRESS: u8 = 0;
-pub(in crate::it) const GAME_CHALLENGER_WINS: u8 = 1;
-pub(in crate::it) const GAME_DEFENDER_WINS: u8 = 2;
+pub const GAME_WAIT_TIMEOUT: Duration = Duration::from_secs(300);
+pub const GAME_IN_PROGRESS: u8 = 0;
+pub const GAME_CHALLENGER_WINS: u8 = 1;
+pub const GAME_DEFENDER_WINS: u8 = 2;
 /// `LibProof.InvalidationReason` ordinals (`pkg/contracts/src/dispute/lib/LibProof.sol`).
-pub(in crate::it) const INVALIDATION_REASON_PROOF_TIMEOUT: u8 = 1;
-pub(in crate::it) const INVALIDATION_REASON_INVALID_PARENT: u8 = 2;
+pub const INVALIDATION_REASON_PROOF_TIMEOUT: u8 = 1;
+pub const INVALIDATION_REASON_INVALID_PARENT: u8 = 2;
 
 /// Funds a throwaway Anvil account well above any bond the factory could demand (100 ETH).
 const THROWAWAY_ACCOUNT_BALANCE_WEI: u128 = 100_000_000_000_000_000_000;
@@ -83,7 +83,7 @@ pub async fn try_build_ha_devnet(skip_label: &str) -> eyre::Result<Option<WorldD
     try_build_ha_devnet_with_custom_block_time(skip_label, Duration::from_secs(1)).await
 }
 
-pub(in crate::it) fn l1_rpc_url(devnet: &WorldDevnet) -> eyre::Result<&str> {
+pub fn l1_rpc_url(devnet: &WorldDevnet) -> eyre::Result<&str> {
     devnet
         .l1_rpc_url()
         .ok_or_eyre("full-stack devnet missing L1 RPC")
@@ -96,7 +96,7 @@ pub fn l2_op_node_rpc_url(devnet: &WorldDevnet) -> eyre::Result<&str> {
 }
 
 /// Parses one of the devnet's optional L1 contract addresses, naming it if absent.
-pub(in crate::it) fn l1_contract(address: Option<&str>, what: &str) -> eyre::Result<Address> {
+pub fn l1_contract(address: Option<&str>, what: &str) -> eyre::Result<Address> {
     Ok(address
         .ok_or_else(|| eyre!("full-stack devnet missing {what}"))?
         .parse()?)
@@ -106,7 +106,7 @@ pub(in crate::it) fn l1_contract(address: Option<&str>, what: &str) -> eyre::Res
 ///
 /// Not erased to `DynProvider`: [`AlloyProofSystemClient`]'s proposer traits need
 /// [`WalletProvider`], which erasure drops.
-pub(in crate::it) fn signing_provider(
+pub fn signing_provider(
     rpc: &str,
     signer: PrivateKeySigner,
 ) -> eyre::Result<impl Provider + WalletProvider + Clone + use<>> {
@@ -134,7 +134,7 @@ pub async fn fund_address(
 /// Funds a fresh random account with L1 gas and mock tokens deposited into the active bond vault.
 ///
 /// Cheating balance in leaves the shared devnet genesis untouched for every other test.
-pub(in crate::it) async fn funded_throwaway_provider(
+pub async fn funded_throwaway_provider(
     l1_rpc: &str,
     factory_address: Address,
 ) -> eyre::Result<(Address, impl Provider + WalletProvider + Clone + use<>)> {
@@ -197,7 +197,7 @@ pub(in crate::it) async fn funded_throwaway_provider(
     Ok((address, provider))
 }
 
-pub(in crate::it) async fn proof_system_client<P>(
+pub async fn proof_system_client<P>(
     provider: P,
     factory_address: Address,
 ) -> eyre::Result<AlloyProofSystemClient<P>>
@@ -213,17 +213,14 @@ where
     .await?)
 }
 
-pub(in crate::it) fn game_at<P>(
-    address: Address,
-    provider: P,
-) -> IMultiProofGame::IMultiProofGameInstance<P>
+pub fn game_at<P>(address: Address, provider: P) -> IMultiProofGame::IMultiProofGameInstance<P>
 where
     P: Provider,
 {
     IMultiProofGame::IMultiProofGameInstance::new(address, provider)
 }
 
-pub(in crate::it) fn anchor_at<P>(
+pub fn anchor_at<P>(
     address: Address,
     provider: P,
 ) -> IAnchorStateRegistry::IAnchorStateRegistryInstance<P>
@@ -233,7 +230,7 @@ where
     IAnchorStateRegistry::IAnchorStateRegistryInstance::new(address, provider)
 }
 
-pub(in crate::it) fn vault_at<P>(
+pub fn vault_at<P>(
     address: Address,
     provider: P,
 ) -> IERC20StakingVault::IERC20StakingVaultInstance<P>
@@ -264,7 +261,7 @@ where
     }
 }
 
-pub(in crate::it) async fn latest_timestamp<P>(provider: &P) -> eyre::Result<u64>
+pub async fn latest_timestamp<P>(provider: &P) -> eyre::Result<u64>
 where
     P: Provider,
 {
@@ -277,7 +274,7 @@ where
 }
 
 /// Warps Anvil's clock forward to `target` and mines a block so it is observable on-chain.
-pub(in crate::it) async fn advance_to_timestamp<P>(provider: &P, target: u64) -> eyre::Result<()>
+pub async fn advance_to_timestamp<P>(provider: &P, target: u64) -> eyre::Result<()>
 where
     P: Provider,
 {
@@ -291,7 +288,7 @@ where
 
 /// Waits for the newest WIP-1006 game at or beyond `min_l2_block`, returning its factory index,
 /// address, and L2 sequence number. Pass `0` for any game at all.
-pub(in crate::it) async fn wait_for_multi_proof_game<P>(
+pub async fn wait_for_multi_proof_game<P>(
     provider: P,
     factory_address: Address,
     min_l2_block: u64,
@@ -367,7 +364,7 @@ where
 }
 
 /// Waits for `game` to be challenged, returning the challenger's address.
-pub(in crate::it) async fn wait_for_challenge<P>(
+pub async fn wait_for_challenge<P>(
     game: &IMultiProofGame::IMultiProofGameInstance<P>,
 ) -> eyre::Result<Address>
 where
@@ -389,7 +386,7 @@ where
 }
 
 /// Waits for at least one proof lane to land on `game`.
-pub(in crate::it) async fn wait_for_proof_lane<P>(
+pub async fn wait_for_proof_lane<P>(
     game: &IMultiProofGame::IMultiProofGameInstance<P>,
 ) -> eyre::Result<()>
 where
@@ -410,7 +407,7 @@ where
 }
 
 /// Waits for `game` to resolve to `expected`, failing fast if it resolves to anything else.
-pub(in crate::it) async fn wait_for_status<P>(
+pub async fn wait_for_status<P>(
     game: &IMultiProofGame::IMultiProofGameInstance<P>,
     expected: u8,
 ) -> eyre::Result<()>
@@ -439,7 +436,7 @@ where
 ///
 /// Needed where no service is watching the game; it would sit `InProgress` forever otherwise. The
 /// final status must still be `expected`.
-pub(in crate::it) async fn wait_for_status_or_resolve<P>(
+pub async fn wait_for_status_or_resolve<P>(
     game: &IMultiProofGame::IMultiProofGameInstance<P>,
     expected: u8,
 ) -> eyre::Result<()>
@@ -468,7 +465,7 @@ where
 }
 
 /// Calls `resolve()` unless another actor already did; only the final outcome matters.
-pub(in crate::it) async fn resolve_if_still_in_progress<P>(
+pub async fn resolve_if_still_in_progress<P>(
     game: &IMultiProofGame::IMultiProofGameInstance<P>,
 ) -> eyre::Result<()>
 where
@@ -482,7 +479,7 @@ where
 }
 
 /// Waits for `game_address` to clear the `AnchorStateRegistry`'s finality airgap.
-pub(in crate::it) async fn wait_for_game_finality<P>(
+pub async fn wait_for_game_finality<P>(
     anchor: &IAnchorStateRegistry::IAnchorStateRegistryInstance<P>,
     game_address: Address,
 ) -> eyre::Result<()>
@@ -503,7 +500,7 @@ where
 }
 
 /// Waits for the `AnchorStateRegistry` anchor to advance to at least `game_l2_block`.
-pub(in crate::it) async fn wait_for_anchor_at_or_beyond<P>(
+pub async fn wait_for_anchor_at_or_beyond<P>(
     anchor: &IAnchorStateRegistry::IAnchorStateRegistryInstance<P>,
     game_l2_block: u64,
 ) -> eyre::Result<()>
@@ -521,7 +518,7 @@ where
 }
 
 /// Waits for the complete bond pot of `game_address` to be settled into reusable vault balances.
-pub(in crate::it) async fn wait_for_game_settlement<P>(
+pub async fn wait_for_game_settlement<P>(
     vault: &IERC20StakingVault::IERC20StakingVaultInstance<P>,
     game_address: Address,
 ) -> eyre::Result<()>

--- a/e2e-tests/src/it/utils/devnet.rs
+++ b/e2e-tests/src/it/utils/devnet.rs
@@ -286,12 +286,11 @@ where
     Ok(())
 }
 
-/// Waits for the newest WIP-1006 game at or beyond `min_l2_block`, returning its factory index,
-/// address, and L2 sequence number. Pass `0` for any game at all.
-pub async fn wait_for_multi_proof_game<P>(
+pub async fn wait_for_multi_proof_game_with_timeout<P>(
     provider: P,
     factory_address: Address,
     min_l2_block: u64,
+    timeout: Duration,
 ) -> eyre::Result<(u64, Address, u64)>
 where
     P: Provider + Clone,
@@ -314,13 +313,32 @@ where
             }
         }
 
-        if started.elapsed() >= GAME_WAIT_TIMEOUT {
+        if started.elapsed() >= timeout {
             bail!(
                 "timed out waiting for a respected WIP-1006 game at or beyond L2 block {min_l2_block}"
             );
         }
         tokio::time::sleep(Duration::from_secs(2)).await;
     }
+}
+
+/// Waits for the newest WIP-1006 game at or beyond `min_l2_block`, returning its factory index,
+/// address, and L2 sequence number. Pass `0` for any game at all.
+pub async fn wait_for_multi_proof_game<P>(
+    provider: P,
+    factory_address: Address,
+    min_l2_block: u64,
+) -> eyre::Result<(u64, Address, u64)>
+where
+    P: Provider + Clone,
+{
+    wait_for_multi_proof_game_with_timeout(
+        provider,
+        factory_address,
+        min_l2_block,
+        GAME_WAIT_TIMEOUT,
+    )
+    .await
 }
 
 /// Waits for a WIP-1006 game matching `parent_ref`, `l2_block`, and `attempt`.

--- a/e2e-tests/src/it/utils/mod.rs
+++ b/e2e-tests/src/it/utils/mod.rs
@@ -1,2 +1,3 @@
 pub mod bindings;
 pub mod devnet;
+pub mod withdrawals;

--- a/e2e-tests/src/it/utils/withdrawals.rs
+++ b/e2e-tests/src/it/utils/withdrawals.rs
@@ -57,6 +57,13 @@ sol! {
         function finalizeWithdrawalTransaction(WithdrawalTransaction tx_) external;
         function finalizedWithdrawals(bytes32 withdrawalHash) external view returns (bool);
     }
+
+    interface IDisputeGame {}
+
+    #[sol(rpc)]
+    interface AnchorStateRegistry {
+        function isGameClaimValid(IDisputeGame _game) public view returns (bool);
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -72,6 +79,7 @@ pub struct ProveWithdrawal {
     pub game_index: u64,
     pub game_l2_block: u64,
     pub game_addr: Address,
+    pub proven_at: u64,
 }
 
 pub async fn initiate_withdrawal<P>(

--- a/e2e-tests/src/it/utils/withdrawals.rs
+++ b/e2e-tests/src/it/utils/withdrawals.rs
@@ -66,6 +66,14 @@ pub struct InitiatedWithdrawal {
     pub l2_block: u64,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ProveWithdrawal {
+    pub transaction: WithdrawalTransaction,
+    pub game_index: u64,
+    pub game_l2_block: u64,
+    pub game_addr: Address,
+}
+
 pub async fn initiate_withdrawal<P>(
     provider: P,
     target_addr: Address,

--- a/e2e-tests/src/it/utils/withdrawals.rs
+++ b/e2e-tests/src/it/utils/withdrawals.rs
@@ -76,6 +76,7 @@ pub struct InitiatedWithdrawal {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ProveWithdrawal {
     pub transaction: WithdrawalTransaction,
+    pub hash: B256,
     pub game_index: u64,
     pub game_l2_block: u64,
     pub game_addr: Address,

--- a/e2e-tests/src/it/utils/withdrawals.rs
+++ b/e2e-tests/src/it/utils/withdrawals.rs
@@ -1,0 +1,147 @@
+use alloy_consensus::BlockHeader;
+use alloy_eips::{BlockId, BlockNumberOrTag};
+use alloy_primitives::{Address, B256, Bytes, U256, address, keccak256};
+use alloy_provider::Provider;
+use alloy_sol_types::{SolValue, sol};
+use eyre::eyre::{OptionExt, ensure};
+use serde::{Deserialize, Serialize};
+
+const L2_TO_L1_MESSAGE_PASSER: Address = address!("4200000000000000000000000000000000000016");
+
+sol! {
+    #[derive(Debug, Serialize, Deserialize)]
+    struct WithdrawalTransaction {
+        uint256 nonce;
+        address sender;
+        address target;
+        uint256 value;
+        uint256 gasLimit;
+        bytes data;
+    }
+
+    struct OutputRootProof {
+        bytes32 version;
+        bytes32 stateRoot;
+        bytes32 messagePasserStorageRoot;
+        bytes32 latestBlockhash;
+    }
+
+    #[sol(rpc)]
+    interface L2ToL1MessagePasser {
+        event MessagePassed(
+            uint256 indexed nonce,
+            address indexed sender,
+            address indexed target,
+            uint256 value,
+            uint256 gasLimit,
+            bytes data,
+            bytes32 withdrawalHash
+        );
+
+        function initiateWithdrawal(address target, uint256 gasLimit, bytes data) external payable;
+    }
+
+    #[sol(rpc)]
+    interface OptimismPortal {
+        function anchorStateRegistry() external view returns (address);
+        function disputeGameFactory() external view returns (address);
+        function disputeGameFinalityDelaySeconds() external view returns (uint256);
+        function proofMaturityDelaySeconds() external view returns (uint256);
+        function version() external view returns (string);
+        function proveWithdrawalTransaction(
+            WithdrawalTransaction tx_,
+            uint256 disputeGameIndex,
+            OutputRootProof outputRootProof,
+            bytes[] withdrawalProof
+        ) external;
+        function finalizeWithdrawalTransaction(WithdrawalTransaction tx_) external;
+        function finalizedWithdrawals(bytes32 withdrawalHash) external view returns (bool);
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct InitiatedWithdrawal {
+    pub transaction: WithdrawalTransaction,
+    pub hash: B256,
+    pub l2_block: u64,
+}
+
+pub async fn initiate_withdrawal<P>(
+    provider: P,
+    target_addr: Address,
+) -> eyre::Result<InitiatedWithdrawal>
+where
+    P: Provider,
+{
+    let receipt = L2ToL1MessagePasser::new(L2_TO_L1_MESSAGE_PASSER, provider)
+        .initiateWithdrawal(target_addr, U256::from(100_000), Bytes::new())
+        .gas(250_000)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    ensure!(receipt.status(), "L2 withdrawal initiation reverted");
+
+    let l2_block = receipt
+        .block_number
+        .ok_or_eyre("withdrawal receipt missing L2 block number")?;
+    let message = receipt
+        .logs()
+        .iter()
+        .find_map(|log| {
+            log.log_decode_validate::<L2ToL1MessagePasser::MessagePassed>()
+                .ok()
+        })
+        .ok_or_eyre("withdrawal receipt missing MessagePassed event")?;
+    let message = message.data();
+
+    Ok(InitiatedWithdrawal {
+        transaction: WithdrawalTransaction {
+            nonce: message.nonce,
+            sender: message.sender,
+            target: message.target,
+            value: message.value,
+            gasLimit: message.gasLimit,
+            data: message.data.clone(),
+        },
+        hash: message.withdrawalHash,
+        l2_block,
+    })
+}
+
+pub async fn build_withdrawal_proof<P>(
+    l2_provider: P,
+    game_l2_block: u64,
+    withdrawal_hash: B256,
+) -> eyre::Result<(OutputRootProof, Vec<Bytes>)>
+where
+    P: Provider,
+{
+    let block = l2_provider
+        .get_block_by_number(BlockNumberOrTag::Number(game_l2_block))
+        .await?
+        .ok_or_eyre("WIP-1006 output block missing from L2")?;
+    let storage_key = keccak256((withdrawal_hash, U256::ZERO).abi_encode_params());
+    let account_proof = l2_provider
+        .get_proof(L2_TO_L1_MESSAGE_PASSER, vec![storage_key])
+        .block_id(BlockId::Number(BlockNumberOrTag::Number(game_l2_block)))
+        .await?;
+    let storage_proof = account_proof
+        .storage_proof
+        .first()
+        .ok_or_eyre("eth_getProof returned no withdrawal storage proof")?;
+    ensure!(
+        storage_proof.value == U256::from(1),
+        "withdrawal is absent from the message passer"
+    );
+
+    Ok((
+        OutputRootProof {
+            version: B256::ZERO,
+            stateRoot: block.header.state_root(),
+            messagePasserStorageRoot: account_proof.storage_hash,
+            latestBlockhash: block.header.hash,
+        },
+        storage_proof.proof.clone(),
+    ))
+}


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-5050/e2e-withdrawal-test

### Notes

These tests perform a full L2 -> L1 withdrawal path against alphanet.

- You need to run them one after the other in the correct order:
    - init
    - prove
    - finalize

### Next Step

- similar tests for the `world-chain-challenger` specifically
- similar tests to assert several proof invariants

### Future Iterations

The long term idea for these kinds of tests is to containerized them (so I need to transform them into binaries) and schedule them as cronjobs into the alphent cluster periodically so that we can always ensure the system is working as expected.

See https://linear.app/worldcoin/issue/PROTO-5075/transform-e2e-cargo-tests-against-alphanet-into-binaries

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes: shared helpers and new ignored alphanet tests; no production withdrawal or portal logic is modified.
> 
> **Overview**
> Adds **ignored, env-driven alphanet E2E tests** for the full Optimism Portal withdrawal path: initiate on L2, prove on L1 against a covering WIP-1006 game, then finalize after maturity and valid ASR claim checks. Steps are **split into three tests** (`init_withdrawal`, `prove_withdrawal`, `finalize_withdrawal`) that pass state through **`initiated_withdrawal.json` / `prove_withdrawal.json`**, so they must be run in order against live RPC endpoints and contract addresses.
> 
> **Refactors** L2→L1 withdrawal plumbing out of `devnet_withdrawal.rs` into a new **`utils/withdrawals`** module (contract bindings, `InitiatedWithdrawal` / `ProveWithdrawal`, `initiate_withdrawal`, `build_withdrawal_proof` with serde). The existing Docker devnet withdrawal test now imports those helpers unchanged in behavior.
> 
> **Opens up devnet test utilities** (`pub` instead of `pub(in crate::it)`) and adds **`wait_for_multi_proof_game_with_timeout`** so alphanet can poll for games with a short timeout while devnet keeps the 300s default via a thin wrapper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 958fa81357311037d9cb9e8b150cd9db72935e68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->