### PR TITLE
proofs: split SP1 ranges earlier

### DIFF
--- a/docs/proof/sp1-worker.md
+++ b/docs/proof/sp1-worker.md
@@ -84,7 +84,7 @@ unexecutable is bisected at its block midpoint and re-proved.
 
 | Variable | Flag | Default |
 |---|---|---:|
-| `SP1_CYCLES_PER_GAS` | `--sp1-cycles-per-gas` | `25` (assumed worst case, unmeasured) |
+| `SP1_CYCLES_PER_GAS` | `--sp1-cycles-per-gas` | `300` (calibrated from HandleOps load) |
 | `SP1_MAX_BLOCKS_PER_RANGE` | `--sp1-max-blocks-per-range` | `1000` |
 | `SP1_MAX_RANGE_SPLITS` | `--sp1-max-range-splits` | `2` |
 

--- a/proofs/workers/sp1/src/cmd/run.rs
+++ b/proofs/workers/sp1/src/cmd/run.rs
@@ -739,7 +739,7 @@ mod tests {
         // The derived gas target tracks the configured cycle ceiling.
         assert_eq!(
             target_gas_per_range(cli.sp1_range_cycle_limit, cli.sp1_cycles_per_gas),
-            30_000_000_000
+            2_500_000_000
         );
     }
 

--- a/proofs/workers/sp1/src/planner.rs
+++ b/proofs/workers/sp1/src/planner.rs
@@ -21,10 +21,10 @@ const GAS_FETCH_MAX_CONCURRENCY: usize = 8;
 
 /// Default SP1 range-proof cycle ceiling; the planning gas target derives from it.
 pub const DEFAULT_RANGE_CYCLE_LIMIT: u64 = 1_500_000_000_000;
-/// Conservative worst-case zkVM cycles per L2 gas (keccak/precompile-heavy blocks); typical
-/// blocks measure ~5-15. Unmeasured on World Chain — replace once `prover-sp1 execute`
-/// numbers exist.
-pub const DEFAULT_CYCLES_PER_GAS: u64 = 25;
+/// Conservative zkVM cycles per L2 gas, calibrated from World Chain HandleOps load.
+/// A 1,000-block Alphanet range used 4,553,216,450 L2 gas and 1,265,948,452,006 cycles
+/// (~278 cycles per L2 gas); round up to retain planning headroom.
+pub const DEFAULT_CYCLES_PER_GAS: u64 = 300;
 /// Caps witness size and build time per range regardless of how empty the blocks are.
 pub const DEFAULT_MAX_BLOCKS_PER_RANGE: u64 = 1_000;
 /// Two bisections shrink a mis-estimated range to a quarter of its planned gas.
@@ -345,10 +345,10 @@ mod tests {
 
     #[test]
     fn gas_target_derives_from_the_cycle_ceiling() {
-        // 1.5T cycles / 25 cycles-per-gas / 2 headroom = 30B gas.
+        // 1.5T cycles / 300 cycles-per-gas / 2 headroom = 2.5B gas.
         assert_eq!(
             target_gas_per_range(DEFAULT_RANGE_CYCLE_LIMIT, DEFAULT_CYCLES_PER_GAS),
-            30_000_000_000
+            2_500_000_000
         );
         assert_eq!(target_gas_per_range(1_000, 25), 20);
         // Never zero, even when the ceiling is smaller than one gas worth of cycles.


### PR DESCRIPTION
## Summary

- calibrate SP1 range planning from the measured Alphanet HandleOps execution
- raise the default cycles-per-L2-gas estimate from 25 to 300
- reduce the derived default cumulative L2 gas target from 30B to 2.5B while retaining the independent 1,000-block cap

## Evidence

The failed 1,000-block range used 4,553,216,450 L2 gas and simulated at 1,265,948,452,006 cycles (~278 cycles/L2 gas). Rounding to 300 and retaining the existing 2x headroom gives a 2.5B L2 gas target.

## Validation

- `cargo fmt --check`
- `cargo test -p world-chain-proof-sp1-worker planner --lib` (9 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default range-splitting behavior for all SP1 workers using defaults, which affects proof job count and network load but is grounded in measured execution data.
> 
> **Overview**
> **SP1 range planning** now uses a **measured** cycles-per-L2-gas ratio instead of an uncalibrated worst-case guess, so proof intervals are **split into smaller ranges earlier** and stay under the network cycle ceiling.
> 
> The default **`SP1_CYCLES_PER_GAS`** rises from **25** to **300**, based on a failed 1,000-block Alphanet range (~278 cycles/L2 gas under HandleOps load, rounded up). With the unchanged **1.5T** cycle limit and **2×** headroom, the derived cumulative L2 gas target per range drops from **30B** to **2.5B**. The **1,000-block** cap per range is unchanged.
> 
> Docs (`sp1-worker.md`) and unit tests in **`planner.rs`** / **`run.rs`** are updated to match the new default and derived target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6c84a9f532297d4ef4631fafcc882d0061f8a09. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->