### PR TITLE
test(proof-system): add challenger tests against alphanet

### DIFF
--- a/e2e-tests/src/it/alphanet/already_challenged_game_is_ignored.rs
+++ b/e2e-tests/src/it/alphanet/already_challenged_game_is_ignored.rs
@@ -32,7 +32,7 @@ async fn submit_bad_proposal() {
     let registered_block_interval = alloy_proof_system_client
         .registered_lineage_config()
         .block_interval;
-    let bad_root_claim = B256::with_last_byte(1);
+    let bad_root_claim = B256::with_last_byte(2);
     let bad_proposal = Proposal {
         parent_ref: anchor.address,
         root_claim: bad_root_claim,

--- a/e2e-tests/src/it/alphanet/already_challenged_game_is_ignored.rs
+++ b/e2e-tests/src/it/alphanet/already_challenged_game_is_ignored.rs
@@ -1,0 +1,83 @@
+use crate::it::utils::devnet::proof_system_client;
+use alloy_network::EthereumWallet;
+use alloy_primitives::Address;
+use alloy_provider::ProviderBuilder;
+use alloy_signer_local::PrivateKeySigner;
+use revm_primitives::B256;
+use std::str::FromStr;
+use world_chain_proof_protocol::{IMultiProofGame::IMultiProofGameInstance, LineageProvider};
+use world_chain_proposer::{Proposal, ProposalSubmission, ProposerClient};
+
+#[tokio::test]
+#[ignore]
+async fn submit_bad_proposal() {
+    // fetch env vars
+    let l1_private_key_str = std::env::var("L1_PRIVATE_KEY").unwrap();
+    let l1_rpc_endpoint = std::env::var("L1_RPC_ENDPOINT").unwrap();
+    let dispute_game_factory_str = std::env::var("DISPUTE_GAME_FACTORY").unwrap();
+    let dispute_game_facatory_addr = Address::from_str(&dispute_game_factory_str).unwrap();
+    // create L1 signer provider
+    let local_signer = PrivateKeySigner::from_str(&l1_private_key_str).unwrap();
+    let l1_provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(local_signer))
+        .connect(&l1_rpc_endpoint)
+        .await
+        .unwrap();
+    // create Alloy proof system client
+    let alloy_proof_system_client = proof_system_client(l1_provider, dispute_game_facatory_addr)
+        .await
+        .unwrap();
+    // create a bad proposal with a bad root claim
+    let anchor = alloy_proof_system_client.lineage_anchor().await.unwrap();
+    let registered_block_interval = alloy_proof_system_client
+        .registered_lineage_config()
+        .block_interval;
+    let bad_root_claim = B256::with_last_byte(1);
+    let bad_proposal = Proposal {
+        parent_ref: anchor.address,
+        root_claim: bad_root_claim,
+        l2_block_number: anchor
+            .l2_block_number
+            .saturating_add(registered_block_interval),
+        attempt: 0,
+    };
+    // submit bad proposal
+    let proposal_submission = alloy_proof_system_client
+        .submit_proposal(&bad_proposal)
+        .await
+        .unwrap();
+    // save ProposalSubmission to a .json file
+    std::fs::write(
+        "submit_bad_proposal.json",
+        serde_json::to_string_pretty(&proposal_submission).unwrap(),
+    )
+    .unwrap()
+}
+
+#[tokio::test]
+#[ignore]
+async fn challenge() {
+    // fetch env vars
+    let l1_private_key_str = std::env::var("L1_PRIVATE_KEY").unwrap();
+    let l1_rpc_endpoint = std::env::var("L1_RPC_ENDPOINT").unwrap();
+    // create L1 signer provider
+    let local_signer = PrivateKeySigner::from_str(&l1_private_key_str).unwrap();
+    let local_signer_addr = local_signer.address();
+    let l1_provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(local_signer))
+        .connect(&l1_rpc_endpoint)
+        .await
+        .unwrap();
+    // read ProposalSubmission from .json file
+    let proposal_submission: ProposalSubmission =
+        serde_json::from_slice(&std::fs::read("submit_bad_proposal.json").unwrap()).unwrap();
+    // challenge the game
+    let game_instance =
+        IMultiProofGameInstance::new(proposal_submission.game_address, &l1_provider);
+    let challenge_pending_tx = game_instance.challenge().send().await.unwrap();
+    let challenge_receipt = challenge_pending_tx.get_receipt().await.unwrap();
+    assert!(challenge_receipt.status());
+    // ensure the challenger is actually local_signer_addr
+    let challenger_addr = game_instance.challenger().call().await.unwrap();
+    assert_eq!(challenger_addr, local_signer_addr);
+}

--- a/e2e-tests/src/it/alphanet/bad_proposal_is_challenged_and_invalidated.rs
+++ b/e2e-tests/src/it/alphanet/bad_proposal_is_challenged_and_invalidated.rs
@@ -1,0 +1,181 @@
+use crate::it::utils::devnet::{
+    GAME_CHALLENGER_WINS, IMockBondToken, proof_system_client, wait_for_challenge_with_timeout,
+};
+use alloy_eips::BlockId;
+use alloy_network::EthereumWallet;
+use alloy_primitives::{Address, U256};
+use alloy_provider::{Provider, ProviderBuilder};
+use alloy_signer_local::PrivateKeySigner;
+use revm_primitives::B256;
+use std::{str::FromStr, time::Duration};
+use world_chain_proof_protocol::{
+    IDisputeGameFactory::IDisputeGameFactoryInstance,
+    IERC20StakingVault::IERC20StakingVaultInstance, IMultiProofGame::IMultiProofGameInstance,
+    LineageProvider, read_registered_bond_vault,
+};
+use world_chain_proposer::{Proposal, ProposalSubmission, ProposerClient};
+
+/// Mock bond tokens deposited for each throwaway proof-system participant (100 tokens).
+const THROWAWAY_ACCOUNT_BOND_TOKEN_BALANCE: u128 = 100_000_000_000_000_000_000;
+
+#[tokio::test]
+#[ignore]
+async fn fund_l1_signer_mock_token() {
+    // fetch env vars
+    let l1_private_key_str = std::env::var("L1_PRIVATE_KEY").unwrap();
+    let l1_rpc_endpoint = std::env::var("L1_RPC_ENDPOINT").unwrap();
+    let dispute_game_factory_str = std::env::var("DISPUTE_GAME_FACTORY").unwrap();
+    let dispute_game_facatory_addr = Address::from_str(&dispute_game_factory_str).unwrap();
+    // create L1 signer provider
+    let local_signer = PrivateKeySigner::from_str(&l1_private_key_str).unwrap();
+    let local_signer_addr = local_signer.address();
+    let l1_provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(local_signer))
+        .connect(&l1_rpc_endpoint)
+        .await
+        .unwrap();
+    // create dispute game factory instance
+    let dispute_game_factory_instance =
+        IDisputeGameFactoryInstance::new(dispute_game_facatory_addr, l1_provider.clone());
+    // read the registered bond vault contract
+    let bond_vault_addr = read_registered_bond_vault(&l1_provider, &dispute_game_factory_instance)
+        .await
+        .unwrap();
+    let bond_vault_instance = IERC20StakingVaultInstance::new(bond_vault_addr, &l1_provider);
+    // get the bond token contract
+    let bond_token_address = bond_vault_instance.token().call().await.unwrap();
+    let mock_bond_token = IMockBondToken::new(bond_token_address, &l1_provider);
+    // mint tokens
+    let amount = U256::from(THROWAWAY_ACCOUNT_BOND_TOKEN_BALANCE);
+    let mint_pending_tx = mock_bond_token
+        .mint(local_signer_addr, amount)
+        .send()
+        .await
+        .unwrap();
+    let mint_receipt = mint_pending_tx.get_receipt().await.unwrap();
+    assert!(mint_receipt.status());
+    // approve mock tokens to be used by the bond vault contract
+    let approve_pending_tx = mock_bond_token
+        .approve(bond_vault_addr, amount)
+        .send()
+        .await
+        .unwrap();
+    let approve_receipt = approve_pending_tx.get_receipt().await.unwrap();
+    assert!(approve_receipt.status());
+    // deposit mock tokens into the bond vault contract
+    let deposit_pending_tx = bond_vault_instance
+        .deposit(local_signer_addr, amount)
+        .send()
+        .await
+        .unwrap();
+    let deposit_receipt = deposit_pending_tx.get_receipt().await.unwrap();
+    assert!(deposit_receipt.status());
+}
+
+#[tokio::test]
+#[ignore]
+async fn submit_bad_proposal() {
+    // fetch env vars
+    let l1_private_key_str = std::env::var("L1_PRIVATE_KEY").unwrap();
+    let l1_rpc_endpoint = std::env::var("L1_RPC_ENDPOINT").unwrap();
+    let dispute_game_factory_str = std::env::var("DISPUTE_GAME_FACTORY").unwrap();
+    let dispute_game_facatory_addr = Address::from_str(&dispute_game_factory_str).unwrap();
+    // create L1 signer provider
+    let local_signer = PrivateKeySigner::from_str(&l1_private_key_str).unwrap();
+    let l1_provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(local_signer))
+        .connect(&l1_rpc_endpoint)
+        .await
+        .unwrap();
+    // create Alloy proof system client
+    let alloy_proof_system_client = proof_system_client(l1_provider, dispute_game_facatory_addr)
+        .await
+        .unwrap();
+    // create a bad proposal with a bad root claim
+    let anchor = alloy_proof_system_client.lineage_anchor().await.unwrap();
+    let registered_block_interval = alloy_proof_system_client
+        .registered_lineage_config()
+        .block_interval;
+    let bad_root_claim = B256::with_last_byte(1);
+    let bad_proposal = Proposal {
+        parent_ref: anchor.address,
+        root_claim: bad_root_claim,
+        l2_block_number: anchor
+            .l2_block_number
+            .saturating_add(registered_block_interval),
+        attempt: 0,
+    };
+    // submit bad proposal
+    let proposal_submission = alloy_proof_system_client
+        .submit_proposal(&bad_proposal)
+        .await
+        .unwrap();
+    // save ProposalSubmission to a .json file
+    std::fs::write(
+        "submit_bad_proposal.json",
+        serde_json::to_string_pretty(&proposal_submission).unwrap(),
+    )
+    .unwrap()
+}
+
+#[tokio::test]
+#[ignore]
+async fn wait_for_challenger() {
+    // fetch env vars
+    let l1_private_key_str = std::env::var("L1_PRIVATE_KEY").unwrap();
+    let l1_rpc_endpoint = std::env::var("L1_RPC_ENDPOINT").unwrap();
+    // create L1 signer provider
+    let local_signer = PrivateKeySigner::from_str(&l1_private_key_str).unwrap();
+    let l1_provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(local_signer))
+        .connect(&l1_rpc_endpoint)
+        .await
+        .unwrap();
+    // read ProposalSubmission from .json file
+    let proposal_submission: ProposalSubmission =
+        serde_json::from_slice(&std::fs::read("submit_bad_proposal.json").unwrap()).unwrap();
+    // wait for the game to be challenged
+    let timeout = Duration::from_secs(10);
+    let game_instance = IMultiProofGameInstance::new(proposal_submission.game_address, l1_provider);
+    let challenger_addr = wait_for_challenge_with_timeout(&game_instance, timeout)
+        .await
+        .unwrap();
+    println!("challenger address: {challenger_addr}");
+    // assert defender is not defending this game
+    let proof_bitmap = game_instance.proofBitmap().call().await.unwrap();
+    assert_eq!(proof_bitmap, 0);
+}
+
+#[tokio::test]
+#[ignore]
+async fn wait_for_challenger_wins() {
+    // fetch env vars
+    let l1_private_key_str = std::env::var("L1_PRIVATE_KEY").unwrap();
+    let l1_rpc_endpoint = std::env::var("L1_RPC_ENDPOINT").unwrap();
+    // create L1 signer provider
+    let local_signer = PrivateKeySigner::from_str(&l1_private_key_str).unwrap();
+    let l1_provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(local_signer))
+        .connect(&l1_rpc_endpoint)
+        .await
+        .unwrap();
+    let proposal_submission: ProposalSubmission =
+        serde_json::from_slice(&std::fs::read("submit_bad_proposal.json").unwrap()).unwrap();
+    // assert proof deadline is elapsed
+    let game_instance =
+        IMultiProofGameInstance::new(proposal_submission.game_address, &l1_provider);
+    let proof_deadline = game_instance.proofDeadline().call().await.unwrap();
+    let latest_block = l1_provider
+        .get_block(BlockId::latest())
+        .await
+        .unwrap()
+        .unwrap();
+    let latest_block_timestamp = latest_block.header.timestamp;
+    assert!(
+        latest_block_timestamp > proof_deadline,
+        "proof deadline has not elapsed yet - latest block timestamp: {latest_block_timestamp}, proof deadline: {proof_deadline}"
+    );
+    // assert that the game has resolved `CHALLENGER_WINS`
+    let status = game_instance.status().call().await.unwrap();
+    assert_eq!(status, GAME_CHALLENGER_WINS);
+}

--- a/e2e-tests/src/it/alphanet/mod.rs
+++ b/e2e-tests/src/it/alphanet/mod.rs
@@ -1,2 +1,3 @@
+mod already_challenged_game_is_ignored;
 mod bad_proposal_is_challenged_and_invalidated;
 mod withdrawal;

--- a/e2e-tests/src/it/alphanet/mod.rs
+++ b/e2e-tests/src/it/alphanet/mod.rs
@@ -1,1 +1,2 @@
+mod bad_proposal_is_challenged_and_invalidated;
 mod withdrawal;

--- a/e2e-tests/src/it/utils/devnet.rs
+++ b/e2e-tests/src/it/utils/devnet.rs
@@ -240,11 +240,15 @@ where
     IERC20StakingVault::IERC20StakingVaultInstance::new(address, provider)
 }
 
-/// Polls `probe` until it yields a value, giving up after [`GAME_WAIT_TIMEOUT`].
+/// Polls `probe` until it yields a value, giving up after `timeout`.
 ///
 /// `Ok(None)` means keep waiting; an `Err` aborts immediately, which is how callers fail fast on
-/// terminal states. `what` completes "timed out after 300s waiting for …".
-async fn poll_until<F, Fut, T>(what: &str, mut probe: F) -> eyre::Result<T>
+/// terminal states.
+async fn poll_until_with_timeout<F, Fut, T>(
+    what: &str,
+    mut probe: F,
+    timeout: Duration,
+) -> eyre::Result<T>
 where
     F: FnMut() -> Fut,
     Fut: Future<Output = eyre::Result<Option<T>>>,
@@ -254,11 +258,19 @@ where
         if let Some(value) = probe().await? {
             return Ok(value);
         }
-        if started.elapsed() >= GAME_WAIT_TIMEOUT {
-            bail!("timed out after {GAME_WAIT_TIMEOUT:?} waiting for {what}");
+        if started.elapsed() >= timeout {
+            bail!("timed out after {timeout:?} waiting for {what}");
         }
         tokio::time::sleep(GAME_POLL_INTERVAL).await;
     }
+}
+
+async fn poll_until<F, Fut, T>(what: &str, probe: F) -> eyre::Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = eyre::Result<Option<T>>>,
+{
+    poll_until_with_timeout(what, probe, GAME_WAIT_TIMEOUT).await
 }
 
 pub async fn latest_timestamp<P>(provider: &P) -> eyre::Result<u64>
@@ -382,25 +394,39 @@ where
 }
 
 /// Waits for `game` to be challenged, returning the challenger's address.
+pub async fn wait_for_challenge_with_timeout<P>(
+    game: &IMultiProofGame::IMultiProofGameInstance<P>,
+    timeout: Duration,
+) -> eyre::Result<Address>
+where
+    P: Provider,
+{
+    let address = *game.address();
+    poll_until_with_timeout(
+        &format!("game {address} to be challenged"),
+        || async {
+            let challenger = game.challenger().call().await?;
+            if challenger != Address::ZERO {
+                return Ok(Some(challenger));
+            }
+            ensure!(
+                game.status().call().await? == GAME_IN_PROGRESS,
+                "game {address} resolved before it was ever challenged"
+            );
+            Ok(None)
+        },
+        timeout,
+    )
+    .await
+}
+
 pub async fn wait_for_challenge<P>(
     game: &IMultiProofGame::IMultiProofGameInstance<P>,
 ) -> eyre::Result<Address>
 where
     P: Provider,
 {
-    let address = *game.address();
-    poll_until(&format!("game {address} to be challenged"), || async {
-        let challenger = game.challenger().call().await?;
-        if challenger != Address::ZERO {
-            return Ok(Some(challenger));
-        }
-        ensure!(
-            game.status().call().await? == GAME_IN_PROGRESS,
-            "game {address} resolved before it was ever challenged"
-        );
-        Ok(None)
-    })
-    .await
+    wait_for_challenge_with_timeout(game, GAME_WAIT_TIMEOUT).await
 }
 
 /// Waits for at least one proof lane to land on `game`.

--- a/proofs/services/proposer/src/types.rs
+++ b/proofs/services/proposer/src/types.rs
@@ -1,4 +1,5 @@
 use alloy_primitives::{Address, B256, TxHash};
+use serde::{Deserialize, Serialize};
 use world_chain_proof_protocol::{InvalidationReason, ProposalCommitment, SelectedLineage};
 
 /// The selected lineage discovered by the proposer and the action available at its tip.
@@ -91,7 +92,7 @@ impl Proposal {
 }
 
 /// Result of a submitted proposal transaction.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProposalSubmission {
     /// Transaction hash for the proposal submission.
     pub tx_hash: TxHash,


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-5052/challenge-tests


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to ignored e2e tests and serde on a small result type; production proposer logic is unchanged.
> 
> **Overview**
> Adds **ignored, env-driven alphanet integration tests** for the proof-system challenge path, complementing the existing local devnet dispute tests.
> 
> Two new modules under `e2e-tests/src/it/alphanet/`: one walks **manual challenge** (submit a bad proposal, persist `ProposalSubmission` to JSON, then call `challenge()` and assert the challenger address); the other covers **automated challenger behavior** (fund mock bond tokens in the vault, submit a bad root claim, poll until challenged with a **10s timeout**, assert no defender proof lanes, then assert the game resolves to **`CHALLENGER_WINS`** after the proof deadline).
> 
> **Test harness tweaks:** `devnet` polling gains `poll_until_with_timeout` and public `wait_for_challenge_with_timeout`, with the original `wait_for_challenge` delegating to the default 300s timeout. **`ProposalSubmission`** in the proposer crate now implements **`Serialize`/`Deserialize`** so multi-step alphanet tests can pass game metadata via `submit_bad_proposal.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ec3dc51c97fef6691528ec9a4aaf2dd8eb89123. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->