### PR TITLE
feat(proofs): log local SP1 limit estimation progress

### DIFF
--- a/proofs/backends/sp1/host/src/network_prover.rs
+++ b/proofs/backends/sp1/host/src/network_prover.rs
@@ -1,7 +1,7 @@
 //! Range proofs are produced in `Compressed` mode so the aggregation guest can recursively
 //! verify them; the aggregation proof mode is configurable (Groth16 for on-chain verification).
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::{SuccinctProverError, WorldSuccinctProver};
 use alloy_primitives::{B256, U256};
@@ -16,8 +16,11 @@ use sp1_sdk::{
         signer::NetworkSigner,
     },
 };
+use tokio::time::MissedTickBehavior;
 use world_chain_proof_core::types::AggregationInputs;
 use world_chain_proof_sp1_types::{AggregationProofRequest, RangeProofRequest, Sp1ProofRequest};
+
+const LOCAL_LIMIT_ESTIMATION_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15 * 60);
 
 /// [`WorldSuccinctProver`] network implementation over the sp1-sdk network prover.
 pub struct NetworkSuccinctProver {
@@ -204,6 +207,7 @@ impl NetworkSuccinctProver {
     }
 
     async fn request_range_proof(&self, request: RangeProofRequest) -> anyhow::Result<String> {
+        let witness_bytes = request.witness_rkyv.len();
         let mut stdin = SP1Stdin::new();
         stdin.write_vec(request.witness_rkyv);
 
@@ -221,10 +225,41 @@ impl NetworkSuccinctProver {
             proof_request = proof_request.timeout(proof_timeout);
         }
 
-        let backend_session_id = proof_request
-            .request()
-            .await
-            .context("request range proving failed")?;
+        let (backend_session_id, limit_estimation_elapsed) = if self.limits.is_none() {
+            tracing::info!(
+                witness_bytes,
+                heartbeat_interval_seconds = LOCAL_LIMIT_ESTIMATION_HEARTBEAT_INTERVAL.as_secs(),
+                "starting local SP1 range limit simulation"
+            );
+            let started_at = Instant::now();
+            let request_future = proof_request.request();
+            tokio::pin!(request_future);
+            let mut heartbeat = tokio::time::interval(LOCAL_LIMIT_ESTIMATION_HEARTBEAT_INTERVAL);
+            heartbeat.set_missed_tick_behavior(MissedTickBehavior::Delay);
+            heartbeat.tick().await;
+
+            let result = loop {
+                tokio::select! {
+                    result = &mut request_future => break result,
+                    _ = heartbeat.tick() => tracing::info!(
+                        witness_bytes,
+                        elapsed_seconds = started_at.elapsed().as_secs(),
+                        "local SP1 range limit simulation still running"
+                    ),
+                }
+            };
+            (result, Some(started_at.elapsed()))
+        } else {
+            (proof_request.request().await, None)
+        };
+        let backend_session_id = backend_session_id.context("request range proving failed")?;
+        if let Some(elapsed) = limit_estimation_elapsed {
+            tracing::info!(
+                witness_bytes,
+                elapsed_seconds = elapsed.as_secs(),
+                "local SP1 range limit-estimation request completed"
+            );
+        }
 
         Ok(backend_session_id.to_string())
     }
@@ -233,6 +268,7 @@ impl NetworkSuccinctProver {
         &self,
         request: AggregationProofRequest,
     ) -> anyhow::Result<String> {
+        let range_count = request.inputs.transition_public_values.len();
         let mut stdin = SP1Stdin::new();
         let range_vk = self.range_pk.verifying_key().vk.clone();
         for proof_bytes in &request.range_proofs {
@@ -263,10 +299,41 @@ impl NetworkSuccinctProver {
             proof_request = proof_request.timeout(proof_timeout);
         }
 
-        let backend_session_id = proof_request
-            .request()
-            .await
-            .context("aggregation proving failed")?;
+        let (backend_session_id, limit_estimation_elapsed) = if self.limits.is_none() {
+            tracing::info!(
+                range_count,
+                heartbeat_interval_seconds = LOCAL_LIMIT_ESTIMATION_HEARTBEAT_INTERVAL.as_secs(),
+                "starting local SP1 aggregation limit simulation"
+            );
+            let started_at = Instant::now();
+            let request_future = proof_request.request();
+            tokio::pin!(request_future);
+            let mut heartbeat = tokio::time::interval(LOCAL_LIMIT_ESTIMATION_HEARTBEAT_INTERVAL);
+            heartbeat.set_missed_tick_behavior(MissedTickBehavior::Delay);
+            heartbeat.tick().await;
+
+            let result = loop {
+                tokio::select! {
+                    result = &mut request_future => break result,
+                    _ = heartbeat.tick() => tracing::info!(
+                        range_count,
+                        elapsed_seconds = started_at.elapsed().as_secs(),
+                        "local SP1 aggregation limit simulation still running"
+                    ),
+                }
+            };
+            (result, Some(started_at.elapsed()))
+        } else {
+            (proof_request.request().await, None)
+        };
+        let backend_session_id = backend_session_id.context("aggregation proving failed")?;
+        if let Some(elapsed) = limit_estimation_elapsed {
+            tracing::info!(
+                range_count,
+                elapsed_seconds = elapsed.as_secs(),
+                "local SP1 aggregation limit-estimation request completed"
+            );
+        }
 
         Ok(backend_session_id.to_string())
     }

--- a/proofs/metrics/src/lib.rs
+++ b/proofs/metrics/src/lib.rs
@@ -48,6 +48,8 @@ pub const METRICS_PROOF_JOB_DURATION_SECONDS: &str = "proof_job.duration_seconds
 pub const METRICS_WITNESS_COLLECTIONS_COMPLETED: &str = "witness_collection.completed";
 /// Witness-collection duration.
 pub const METRICS_WITNESS_COLLECTION_DURATION_SECONDS: &str = "witness_collection.duration_seconds";
+/// Duration of a proof-worker phase.
+pub const METRICS_PROOF_PHASE_DURATION_SECONDS: &str = "proof_phase.duration_seconds";
 /// Whether this worker's enclave signing key is registered on-chain.
 pub const METRICS_ENCLAVE_KEY_REGISTERED: &str = "enclave_key.registered";
 /// Enclave key registration attempts, by outcome.
@@ -130,6 +132,11 @@ pub fn describe_metrics() {
         METRICS_WITNESS_COLLECTION_DURATION_SECONDS,
         metrics::Unit::Seconds,
         "Kona witness-collection duration by backend and outcome."
+    );
+    metrics::describe_histogram!(
+        METRICS_PROOF_PHASE_DURATION_SECONDS,
+        metrics::Unit::Seconds,
+        "Proof-worker phase duration by backend, phase, and outcome."
     );
     metrics::describe_gauge!(
         METRICS_ENCLAVE_KEY_REGISTERED,
@@ -286,6 +293,25 @@ pub fn record_witness_collection(backend: &'static str, outcome: &'static str, d
     metrics::histogram!(
         METRICS_WITNESS_COLLECTION_DURATION_SECONDS,
         "backend" => backend,
+        "outcome" => outcome,
+    )
+    .record(duration.as_secs_f64());
+}
+
+/// Records one proof-worker phase.
+///
+/// Labels are intentionally low-cardinality: backend, phase, and outcome only. Query-specific
+/// identifiers and range bounds remain in structured logs.
+pub fn record_proof_phase_duration(
+    backend: &'static str,
+    phase: &'static str,
+    outcome: &'static str,
+    duration: Duration,
+) {
+    metrics::histogram!(
+        METRICS_PROOF_PHASE_DURATION_SECONDS,
+        "backend" => backend,
+        "phase" => phase,
         "outcome" => outcome,
     )
     .record(duration.as_secs_f64());

--- a/proofs/workers/nitro/src/lib.rs
+++ b/proofs/workers/nitro/src/lib.rs
@@ -22,6 +22,8 @@
 
 #![cfg(target_os = "linux")]
 
+use std::time::Instant;
+
 use alloy_primitives::{B256, Bytes, keccak256};
 use alloy_sol_types::SolValue;
 use anyhow::{Context, bail};
@@ -109,13 +111,12 @@ where
         let prover = NitroProver::new(endpoint, self.config.expected_pcrs);
 
         info!(
+            proof_id = %request.id(),
             start_block,
             end_block = request.l2_block_number,
-            l1_rpc = %self.config.online.l1_rpc,
-            l2_rpc = %self.config.online.l2_rpc,
             "collecting witness data for range"
         );
-        let witness_collection_started_at = std::time::Instant::now();
+        let witness_collection_started_at = Instant::now();
         let input = match build_range_input(
             &self.config.online,
             RangeWitnessRequest {
@@ -154,6 +155,7 @@ where
             .context("witness serialize")?;
 
         info!(
+            proof_id = %request.id(),
             start_block,
             end_block = request.l2_block_number,
             duration_secs = witness_collection_started_at.elapsed().as_secs_f64(),
@@ -161,10 +163,50 @@ where
             "witness data collection complete"
         );
 
-        let artifact = prover
-            .prove_range(nitro_request)
-            .await
-            .context("nitro enclave proving failed")?;
+        info!(
+            proof_id = %request.id(),
+            start_block,
+            end_block = request.l2_block_number,
+            "requesting Nitro enclave range proof"
+        );
+        let enclave_proving_started_at = Instant::now();
+        let artifact = match prover.prove_range(nitro_request).await {
+            Ok(artifact) => {
+                let duration = enclave_proving_started_at.elapsed();
+                world_chain_proof_metrics::record_proof_phase_duration(
+                    "nitro",
+                    "enclave_proving",
+                    "success",
+                    duration,
+                );
+                tracing::info!(
+                    proof_id = %request.id(),
+                    start_block,
+                    end_block = request.l2_block_number,
+                    duration_secs = duration.as_secs_f64(),
+                    "Nitro enclave range proof complete"
+                );
+                artifact
+            }
+            Err(error) => {
+                let duration = enclave_proving_started_at.elapsed();
+                world_chain_proof_metrics::record_proof_phase_duration(
+                    "nitro",
+                    "enclave_proving",
+                    "error",
+                    duration,
+                );
+                tracing::error!(
+                    proof_id = %request.id(),
+                    start_block,
+                    end_block = request.l2_block_number,
+                    duration_secs = duration.as_secs_f64(),
+                    error = %error,
+                    "Nitro enclave range proof failed"
+                );
+                return Err(error).context("nitro enclave proving failed");
+            }
+        };
 
         if artifact.transition_public_values.l2PostRoot != request.root_claim {
             bail!(

--- a/proofs/workers/sp1/src/backend.rs
+++ b/proofs/workers/sp1/src/backend.rs
@@ -310,9 +310,6 @@ impl<P: WorldSuccinctProver + Send + Sync, G: ProofGameProvider> Sp1Backend<P, G
                 {
                     Ok(range_request) => {
                         let duration = witness_started_at.elapsed();
-                        world_chain_proof_metrics::record_witness_collection(
-                            "sp1", "success", duration,
-                        );
                         tracing::info!(
                             proof_id = %request.id(),
                             start_block = range_start,
@@ -326,14 +323,6 @@ impl<P: WorldSuccinctProver + Send + Sync, G: ProofGameProvider> Sp1Backend<P, G
                     }
                     Err(error) => {
                         let duration = witness_started_at.elapsed();
-                        let outcome = if is_witness_generation_timeout(&error) {
-                            "timeout"
-                        } else {
-                            "error"
-                        };
-                        world_chain_proof_metrics::record_witness_collection(
-                            "sp1", outcome, duration,
-                        );
                         tracing::error!(
                             proof_id = %request.id(),
                             start_block = range_start,

--- a/proofs/workers/sp1/src/backend.rs
+++ b/proofs/workers/sp1/src/backend.rs
@@ -1,6 +1,9 @@
 //! SP1 validity-proof backend for the defender's [`ProofWorker`].
 
-use std::{collections::HashMap, time::Duration};
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
 
 use alloy_primitives::B256;
 use alloy_sol_types::SolValue;
@@ -225,9 +228,16 @@ impl<P: WorldSuccinctProver + Send + Sync, G: ProofGameProvider> Sp1Backend<P, G
         if let Some(stark_session) = self.get_session(job, SessionType::Stark).await? {
             let plan = RangePlan::decode(&stark_session.backend_session_id, start_block, end_block);
             if plan.covers(start_block, end_block) {
-                tracing::debug!(
+                let submitted_ranges = plan
+                    .ranges
+                    .iter()
+                    .filter(|range| range.session_id.is_some())
+                    .count();
+                tracing::info!(
                     proof_id = %request.id(),
                     ranges = plan.ranges.len(),
+                    submitted_ranges,
+                    pending_ranges = plan.ranges.len() - submitted_ranges,
                     "resuming recorded SP1 range plan"
                 );
                 return Ok(plan);
@@ -283,17 +293,111 @@ impl<P: WorldSuccinctProver + Send + Sync, G: ProofGameProvider> Sp1Backend<P, G
                 if plan.ranges[index].session_id.is_some() {
                     continue;
                 }
-                let (range_start, range_end) =
-                    (plan.ranges[index].start_block, plan.ranges[index].end_block);
-                let range_request = self
+                let range = &plan.ranges[index];
+                let (range_start, range_end) = (range.start_block, range.end_block);
+                let splits = range.splits;
+                tracing::info!(
+                    proof_id = %request.id(),
+                    start_block = range_start,
+                    end_block = range_end,
+                    splits,
+                    "building SP1 range witness"
+                );
+                let witness_started_at = Instant::now();
+                let range_request = match self
                     .build_range_request(range_start, range_end, request)
                     .await
-                    .context("failed to build range proof request")?;
-                let session_id = self
+                {
+                    Ok(range_request) => {
+                        let duration = witness_started_at.elapsed();
+                        world_chain_proof_metrics::record_witness_collection(
+                            "sp1", "success", duration,
+                        );
+                        tracing::info!(
+                            proof_id = %request.id(),
+                            start_block = range_start,
+                            end_block = range_end,
+                            splits,
+                            witness_bytes = range_request.witness_rkyv.len(),
+                            duration_secs = duration.as_secs_f64(),
+                            "SP1 range witness complete"
+                        );
+                        range_request
+                    }
+                    Err(error) => {
+                        let duration = witness_started_at.elapsed();
+                        let outcome = if is_witness_generation_timeout(&error) {
+                            "timeout"
+                        } else {
+                            "error"
+                        };
+                        world_chain_proof_metrics::record_witness_collection(
+                            "sp1", outcome, duration,
+                        );
+                        tracing::error!(
+                            proof_id = %request.id(),
+                            start_block = range_start,
+                            end_block = range_end,
+                            splits,
+                            duration_secs = duration.as_secs_f64(),
+                            error = %error,
+                            "SP1 range witness failed"
+                        );
+                        return Err(error).context("failed to build range proof request");
+                    }
+                };
+                tracing::info!(
+                    proof_id = %request.id(),
+                    start_block = range_start,
+                    end_block = range_end,
+                    splits,
+                    "submitting SP1 range proof request"
+                );
+                let submission_started_at = Instant::now();
+                let session_id = match self
                     .prover
                     .submit(Sp1ProofRequest::Range(range_request))
                     .await
-                    .context("failed to submit range proof")?;
+                {
+                    Ok(session_id) => {
+                        let duration = submission_started_at.elapsed();
+                        world_chain_proof_metrics::record_proof_phase_duration(
+                            "sp1",
+                            "range_submission",
+                            "success",
+                            duration,
+                        );
+                        tracing::info!(
+                            proof_id = %request.id(),
+                            start_block = range_start,
+                            end_block = range_end,
+                            splits,
+                            backend_session_id = %session_id,
+                            duration_secs = duration.as_secs_f64(),
+                            "SP1 range proof request submitted"
+                        );
+                        session_id
+                    }
+                    Err(error) => {
+                        let duration = submission_started_at.elapsed();
+                        world_chain_proof_metrics::record_proof_phase_duration(
+                            "sp1",
+                            "range_submission",
+                            "error",
+                            duration,
+                        );
+                        tracing::error!(
+                            proof_id = %request.id(),
+                            start_block = range_start,
+                            end_block = range_end,
+                            splits,
+                            duration_secs = duration.as_secs_f64(),
+                            error = %error,
+                            "SP1 range proof request failed"
+                        );
+                        return Err(error).context("failed to submit range proof");
+                    }
+                };
                 plan.ranges[index].session_id = Some(session_id);
                 self.persist_plan(job, plan, BackendSessionStatus::Running, None)
                     .await?;
@@ -314,12 +418,56 @@ impl<P: WorldSuccinctProver + Send + Sync, G: ProofGameProvider> Sp1Backend<P, G
                 .clone()
                 .context("planned range lost its session id before waiting")?;
 
+            tracing::info!(
+                proof_id = %request.id(),
+                start_block = range.start_block,
+                end_block = range.end_block,
+                splits = range.splits,
+                backend_session_id = %session_id,
+                "waiting for SP1 range proof"
+            );
+            let wait_started_at = Instant::now();
             let error = match self.prover.wait(&session_id).await {
                 Ok(proof) => {
+                    let duration = wait_started_at.elapsed();
+                    world_chain_proof_metrics::record_proof_phase_duration(
+                        "sp1",
+                        "range_wait",
+                        "success",
+                        duration,
+                    );
+                    tracing::info!(
+                        proof_id = %request.id(),
+                        start_block = range.start_block,
+                        end_block = range.end_block,
+                        splits = range.splits,
+                        backend_session_id = %session_id,
+                        duration_secs = duration.as_secs_f64(),
+                        "SP1 range proof fulfilled"
+                    );
                     artifacts.insert(key, range_artifact_from_sp1_proof(&proof)?);
                     continue;
                 }
-                Err(error) => error,
+                Err(error) => {
+                    let duration = wait_started_at.elapsed();
+                    world_chain_proof_metrics::record_proof_phase_duration(
+                        "sp1",
+                        "range_wait",
+                        "error",
+                        duration,
+                    );
+                    tracing::warn!(
+                        proof_id = %request.id(),
+                        start_block = range.start_block,
+                        end_block = range.end_block,
+                        splits = range.splits,
+                        backend_session_id = %session_id,
+                        duration_secs = duration.as_secs_f64(),
+                        error = %error,
+                        "SP1 range proof wait failed"
+                    );
+                    error
+                }
             };
             match error.downcast_ref::<SuccinctProverError>() {
                 Some(session_error) if session_error.should_resubmit() => {
@@ -432,8 +580,27 @@ impl<P: WorldSuccinctProver + Send + Sync, G: ProofGameProvider> Sp1Backend<P, G
         session_id: String,
     ) -> anyhow::Result<Option<AggregationProofArtifact>> {
         let session_type = SessionType::Snark;
+        tracing::info!(
+            proof_id = %job.request.id(),
+            backend_session_id = %session_id,
+            "waiting for SP1 aggregation proof"
+        );
+        let wait_started_at = Instant::now();
         match self.prover.wait(&session_id).await {
             Ok(proof) => {
+                let duration = wait_started_at.elapsed();
+                world_chain_proof_metrics::record_proof_phase_duration(
+                    "sp1",
+                    "aggregation_wait",
+                    "success",
+                    duration,
+                );
+                tracing::info!(
+                    proof_id = %job.request.id(),
+                    backend_session_id = %session_id,
+                    duration_secs = duration.as_secs_f64(),
+                    "SP1 aggregation proof fulfilled"
+                );
                 let artifact = aggregation_artifact_from_sp1_proof(&proof)?;
                 self.record_session(
                     job,
@@ -446,6 +613,20 @@ impl<P: WorldSuccinctProver + Send + Sync, G: ProofGameProvider> Sp1Backend<P, G
                 Ok(Some(artifact))
             }
             Err(error) => {
+                let duration = wait_started_at.elapsed();
+                world_chain_proof_metrics::record_proof_phase_duration(
+                    "sp1",
+                    "aggregation_wait",
+                    "error",
+                    duration,
+                );
+                tracing::warn!(
+                    proof_id = %job.request.id(),
+                    backend_session_id = %session_id,
+                    duration_secs = duration.as_secs_f64(),
+                    error = %error,
+                    "SP1 aggregation proof wait failed"
+                );
                 self.handle_wait_error(job, session_type, &session_id, error)
                     .await?;
                 Ok(None)
@@ -502,13 +683,58 @@ impl<P: WorldSuccinctProver + Send + Sync, G: ProofGameProvider> Sp1Backend<P, G
                 self.wait_before_resubmission(SessionType::Snark, resubmission, delay)
                     .await;
             }
-            let session_id = self
+            tracing::info!(
+                proof_id = %job.request.id(),
+                ranges = request.range_proofs.len(),
+                resubmission,
+                "submitting SP1 aggregation proof request"
+            );
+            let submission_started_at = Instant::now();
+            let session_id = match self
                 .submit_session(
                     job,
                     SessionType::Snark,
                     Sp1ProofRequest::Aggregation(request.clone()),
                 )
-                .await?;
+                .await
+            {
+                Ok(session_id) => {
+                    let duration = submission_started_at.elapsed();
+                    world_chain_proof_metrics::record_proof_phase_duration(
+                        "sp1",
+                        "aggregation_submission",
+                        "success",
+                        duration,
+                    );
+                    tracing::info!(
+                        proof_id = %job.request.id(),
+                        ranges = request.range_proofs.len(),
+                        resubmission,
+                        backend_session_id = %session_id,
+                        duration_secs = duration.as_secs_f64(),
+                        "SP1 aggregation proof request submitted"
+                    );
+                    session_id
+                }
+                Err(error) => {
+                    let duration = submission_started_at.elapsed();
+                    world_chain_proof_metrics::record_proof_phase_duration(
+                        "sp1",
+                        "aggregation_submission",
+                        "error",
+                        duration,
+                    );
+                    tracing::error!(
+                        proof_id = %job.request.id(),
+                        ranges = request.range_proofs.len(),
+                        resubmission,
+                        duration_secs = duration.as_secs_f64(),
+                        error = %error,
+                        "SP1 aggregation proof request failed"
+                    );
+                    return Err(error);
+                }
+            };
             if let Some(artifact) = self.wait_for_aggregation(job, session_id).await? {
                 return Ok(artifact);
             }


### PR DESCRIPTION
## Summary
- add 15-minute liveness updates while the SP1 SDK performs local limit estimation
- log and measure SP1 range and aggregation witness, submission, wait, and resume phases
- log and measure Nitro enclave proving duration; remove raw L1/L2 RPC URLs from logs

All changes are host-only; guest ELFs and vkeys are unchanged.

## Validation
- `cargo fmt --check`
- `cargo check -p world-chain-proof-sp1-worker`
- `cargo check -p world-chain-proof-metrics`
- `cargo check -p world-chain-proof-nitro-worker`

`cargo test -p world-chain-proof-sp1-worker --lib` was started but stopped during dependency compilation to avoid consuming the local machine; no test result is claimed.