### PR TITLE
feat(e2e-withdrawal): add aws s3 buckets support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4760,6 +4760,7 @@ dependencies = [
  "alloy-sol-types",
  "async-trait",
  "aws-config",
+ "aws-credential-types",
  "aws-sdk-s3",
  "clap",
  "color-eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,7 +1402,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1413,7 +1413,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2283,6 +2283,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
+ "aws-smithy-eventstream",
  "aws-smithy-http",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -2291,7 +2292,9 @@ dependencies = [
  "bytes",
  "bytes-utils",
  "fastrand",
+ "http 0.2.12",
  "http 1.5.0",
+ "http-body 0.4.6",
  "http-body 1.1.0",
  "percent-encoding",
  "pin-project-lite",
@@ -2323,6 +2326,43 @@ dependencies = [
  "http 1.5.0",
  "regex-lite",
  "tracing",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "1.141.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f9420d3a2467eed22ed3635ca653653162c386a0b0f65c78189f9bd3c1379e"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-checksums",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "hmac 0.13.0",
+ "http 0.2.12",
+ "http 1.5.0",
+ "http-body 1.1.0",
+ "lru 0.16.4",
+ "percent-encoding",
+ "regex-lite",
+ "sha2 0.11.0",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -2411,6 +2451,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "723c2234ad7511ceef63eab016b7ba6ff7c55590fefb96fa8467af014a07309f"
 dependencies = [
  "aws-credential-types",
+ "aws-smithy-eventstream",
  "aws-smithy-http",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -2438,11 +2479,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-checksums"
+version = "0.65.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67ecd999972b58e67cab052f5129906c08c25883bd0788ceefc55ef97d61307"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "bytes",
+ "crc-fast",
+ "hex",
+ "http 1.5.0",
+ "http-body 1.1.0",
+ "http-body-util",
+ "md-5 0.11.0",
+ "pin-project-lite",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9381123ab62d20c13082b151f30f962a3b112b727345394536dfa39a482944"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
 name = "aws-smithy-http"
 version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d"
 dependencies = [
+ "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -2884,7 +2958,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -3894,6 +3968,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
+name = "crc-fast"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
+dependencies = [
+ "digest 0.10.7",
+ "spin 0.10.1",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4311,7 +4395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4674,6 +4758,9 @@ dependencies = [
  "alloy-provider",
  "alloy-signer-local 2.1.1",
  "alloy-sol-types",
+ "async-trait",
+ "aws-config",
+ "aws-sdk-s3",
  "clap",
  "color-eyre",
  "serde",
@@ -4875,7 +4962,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6063,7 +6150,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -8115,7 +8202,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9784,7 +9871,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -9804,7 +9891,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -9817,7 +9904,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -9895,7 +9982,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.43",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -9934,9 +10021,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13956,7 +14043,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14057,7 +14144,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.9",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15437,7 +15524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -16641,7 +16728,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -18198,7 +18285,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -254,7 +254,10 @@ alloy-trie = { version = "0.9.4", default-features = false, features = [
 aws-config = { version = "1", default-features = false, features = [
     "rt-tokio",
     "rustls",
+    "credentials-process",
+    "sso",
 ] }
+aws-credential-types = { version = "1", default-features = false }
 aws-sdk-kms = { version = "1", default-features = false, features = [
     "rt-tokio",
     "rustls",
@@ -262,6 +265,8 @@ aws-sdk-kms = { version = "1", default-features = false, features = [
 aws-sdk-s3 = { version = "1", default-features = false, features = [
     "rt-tokio",
     "rustls",
+    "default-https-client",
+    "http-1x",
 ] }
 
 # revm

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -259,6 +259,10 @@ aws-sdk-kms = { version = "1", default-features = false, features = [
     "rt-tokio",
     "rustls",
 ] }
+aws-sdk-s3 = { version = "1", default-features = false, features = [
+    "rt-tokio",
+    "rustls",
+] }
 
 # revm
 revm = { version = "41.0.0", default-features = false }

--- a/e2e-tests/e2e-withdrawal/Cargo.toml
+++ b/e2e-tests/e2e-withdrawal/Cargo.toml
@@ -21,7 +21,12 @@ alloy-contract.workspace = true
 alloy-eips.workspace = true
 alloy-consensus.workspace = true
 
+# aws
+aws-config.workspace = true
+aws-sdk-s3.workspace = true
+
 # misc
+async-trait.workspace = true
 clap.workspace = true
 eyre.workspace = true
 tokio.workspace = true

--- a/e2e-tests/e2e-withdrawal/Cargo.toml
+++ b/e2e-tests/e2e-withdrawal/Cargo.toml
@@ -23,6 +23,7 @@ alloy-consensus.workspace = true
 
 # aws
 aws-config.workspace = true
+aws-credential-types.workspace = true
 aws-sdk-s3.workspace = true
 
 # misc

--- a/e2e-tests/e2e-withdrawal/src/args.rs
+++ b/e2e-tests/e2e-withdrawal/src/args.rs
@@ -13,6 +13,13 @@ pub struct InitArgs {
     /// The amount of ETH you want to withdraw.
     #[arg(long, env = "ETH_VALUE", value_parser = parse_ether, default_value_t = U256::ZERO)]
     pub value: U256,
+    /// Output location for the initiated withdrawal JSON (local path or `s3://bucket/key`).
+    #[arg(
+        long,
+        env = "WITHDRAWAL_OUTPUT",
+        default_value = "initiated_withdrawal.json"
+    )]
+    pub output: String,
 }
 
 /// Arguments for the `prove` command.
@@ -33,6 +40,20 @@ pub struct ProveArgs {
     /// OptimismPortal contract address.
     #[arg(long, env = "OPTIMISM_PORTAL")]
     pub optimism_portal: Address,
+    /// Input location for the initiated withdrawal JSON (local path or `s3://bucket/key`).
+    #[arg(
+        long,
+        env = "WITHDRAWAL_INPUT",
+        default_value = "initiated_withdrawal.json"
+    )]
+    pub input: String,
+    /// Output location for the proven withdrawal JSON (local path or `s3://bucket/key`).
+    #[arg(
+        long,
+        env = "WITHDRAWAL_OUTPUT",
+        default_value = "prove_withdrawal.json"
+    )]
+    pub output: String,
 }
 
 /// Arguments for the `finalize` command.
@@ -50,4 +71,11 @@ pub struct FinalizeArgs {
     /// OptimismPortal contract address.
     #[arg(long, env = "OPTIMISM_PORTAL")]
     pub optimism_portal: Address,
+    /// Input location for the proven withdrawal JSON (local path or `s3://bucket/key`).
+    #[arg(
+        long,
+        env = "WITHDRAWAL_INPUT",
+        default_value = "prove_withdrawal.json"
+    )]
+    pub input: String,
 }

--- a/e2e-tests/e2e-withdrawal/src/cmd/finalize.rs
+++ b/e2e-tests/e2e-withdrawal/src/cmd/finalize.rs
@@ -4,6 +4,7 @@ use crate::{
         AnchorStateRegistry::AnchorStateRegistryInstance, OptimismPortal::OptimismPortalInstance,
         ProveWithdrawal,
     },
+    storage,
 };
 use alloy_eips::BlockId;
 use alloy_network::EthereumWallet;
@@ -21,9 +22,8 @@ pub async fn run(args: &FinalizeArgs) -> eyre::Result<()> {
         .wallet(EthereumWallet::from(local_signer))
         .connect(&args.l1_rpc_endpoint)
         .await?;
-    // read ProveWithdrawl data from .json file
-    let prove_withdrawal: ProveWithdrawal =
-        serde_json::from_slice(&std::fs::read("prove_withdrawal.json")?)?;
+    // read ProveWithdrawal data (local path or s3://bucket/key)
+    let prove_withdrawal: ProveWithdrawal = storage::read_json(&args.input).await?;
     // check whether the withdrawal is finalizable:
     // 1. now - proven.timestamp > OptimismPortal::proofMaturityDelaySeconds()
     let optimism_portal = OptimismPortalInstance::new(args.optimism_portal, &l1_provider);

--- a/e2e-tests/e2e-withdrawal/src/cmd/init.rs
+++ b/e2e-tests/e2e-withdrawal/src/cmd/init.rs
@@ -1,6 +1,7 @@
 use crate::{
     args::InitArgs,
     bindings::{InitiatedWithdrawal, L2ToL1MessagePasser, WithdrawalTransaction},
+    storage,
 };
 use alloy_network::EthereumWallet;
 use alloy_primitives::{Address, Bytes, U256, address};
@@ -25,11 +26,8 @@ pub async fn run(args: &InitArgs) -> eyre::Result<()> {
     let target_addr = local_signer_addr;
     // sends the initiate_withdrawal transaction to the L2ToL1MessagePasser contract
     let initiated_withdrawal = initiate_withdrawal(l2_provider, target_addr, args.value).await?;
-    // save the InitiatedWithdrawal data to a .json file
-    std::fs::write(
-        "initiated_withdrawal.json",
-        serde_json::to_string_pretty(&initiated_withdrawal)?,
-    )?;
+    // save the InitiatedWithdrawal data (local path or s3://bucket/key)
+    storage::write_json(&args.output, &initiated_withdrawal).await?;
     Ok(())
 }
 

--- a/e2e-tests/e2e-withdrawal/src/cmd/prove.rs
+++ b/e2e-tests/e2e-withdrawal/src/cmd/prove.rs
@@ -5,6 +5,7 @@ use crate::{
         InitiatedWithdrawal, OptimismPortal::OptimismPortalInstance, OutputRootProof,
         ProveWithdrawal,
     },
+    storage,
 };
 use alloy_consensus::BlockHeader;
 use alloy_eips::{BlockId, BlockNumberOrTag};
@@ -33,9 +34,8 @@ pub async fn run(args: &ProveArgs) -> eyre::Result<()> {
     let l2_provider = ProviderBuilder::new()
         .connect(&args.l2_rpc_endpoint)
         .await?;
-    // read InitiatedWithdrawl data from .json file
-    let initiated_withdrawal: InitiatedWithdrawal =
-        serde_json::from_slice(&std::fs::read("initiated_withdrawal.json")?)?;
+    // read InitiatedWithdrawal data (local path or s3://bucket/key)
+    let initiated_withdrawal: InitiatedWithdrawal = storage::read_json(&args.input).await?;
     // wait for a covering WIP1006 game with l2SequenceNumber >= initiated_withdrawal.l2_block
     let (game_index, game_addr, game_l2_block) = check_multi_proof_game(
         &l1_provider,
@@ -81,10 +81,7 @@ pub async fn run(args: &ProveArgs) -> eyre::Result<()> {
         game_addr,
         proven_at: l1_timestamp,
     };
-    std::fs::write(
-        "prove_withdrawal.json",
-        serde_json::to_string_pretty(&prove_withdrawal)?,
-    )?;
+    storage::write_json(&args.output, &prove_withdrawal).await?;
     Ok(())
 }
 

--- a/e2e-tests/e2e-withdrawal/src/lib.rs
+++ b/e2e-tests/e2e-withdrawal/src/lib.rs
@@ -2,3 +2,4 @@ pub mod args;
 pub mod bindings;
 pub mod cli;
 pub mod cmd;
+pub mod storage;

--- a/e2e-tests/e2e-withdrawal/src/storage.rs
+++ b/e2e-tests/e2e-withdrawal/src/storage.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
-use eyre::eyre::{OptionExt, bail, eyre};
+use aws_credential_types::provider::ProvideCredentials;
+use eyre::eyre::{Context, OptionExt, bail};
 use serde::{Serialize, de::DeserializeOwned};
 
 /// Byte-oriented blob store used for withdrawal handoff JSON.
@@ -39,12 +40,12 @@ impl BlobStore for S3Store {
             .key(key)
             .send()
             .await
-            .map_err(|err| eyre!("failed to get s3://{}/{}: {err}", self.bucket, key))?;
+            .wrap_err_with(|| format!("failed to get s3://{}/{}", self.bucket, key))?;
         let bytes = object
             .body
             .collect()
             .await
-            .map_err(|err| eyre!("failed to read s3://{}/{} body: {err}", self.bucket, key))?
+            .wrap_err_with(|| format!("failed to read s3://{}/{} body", self.bucket, key))?
             .into_bytes()
             .to_vec();
         Ok(bytes)
@@ -59,7 +60,7 @@ impl BlobStore for S3Store {
             .body(bytes.to_vec().into())
             .send()
             .await
-            .map_err(|err| eyre!("failed to put s3://{}/{}: {err}", self.bucket, key))?;
+            .wrap_err_with(|| format!("failed to put s3://{}/{}", self.bucket, key))?;
         Ok(())
     }
 }
@@ -82,6 +83,21 @@ pub async fn open(location: &str) -> eyre::Result<(Box<dyn BlobStore>, String)> 
         let config = aws_config::defaults(aws_config::BehaviorVersion::latest())
             .load()
             .await;
+        if config.region().is_none() {
+            bail!(
+                "AWS region not configured; set AWS_REGION or AWS_DEFAULT_REGION \
+                 (needed for s3:// locations)"
+            );
+        }
+        // Resolve credentials early so missing AWS_PROFILE / expired SSO is obvious,
+        // instead of a later opaque "dispatch failure" from IMDS fallback.
+        if let Some(provider) = config.credentials_provider() {
+            provider.provide_credentials().await.wrap_err(
+                "AWS credentials unavailable; set AWS_PROFILE to an SSO profile \
+                 (e.g. tfh-crypto-dev-poweruseraccess) and run \
+                 `aws sso login --profile <profile>`",
+            )?;
+        }
         let store = S3Store {
             client: aws_sdk_s3::Client::new(&config),
             bucket: bucket.to_string(),

--- a/e2e-tests/e2e-withdrawal/src/storage.rs
+++ b/e2e-tests/e2e-withdrawal/src/storage.rs
@@ -1,0 +1,105 @@
+use async_trait::async_trait;
+use eyre::eyre::{OptionExt, bail, eyre};
+use serde::{Serialize, de::DeserializeOwned};
+
+/// Byte-oriented blob store used for withdrawal handoff JSON.
+#[async_trait]
+pub trait BlobStore: Send + Sync {
+    async fn get(&self, key: &str) -> eyre::Result<Vec<u8>>;
+    async fn put(&self, key: &str, bytes: &[u8]) -> eyre::Result<()>;
+}
+
+/// Filesystem-backed store. The key is treated as a filesystem path.
+pub struct LocalStore;
+
+#[async_trait]
+impl BlobStore for LocalStore {
+    async fn get(&self, key: &str) -> eyre::Result<Vec<u8>> {
+        Ok(std::fs::read(key)?)
+    }
+
+    async fn put(&self, key: &str, bytes: &[u8]) -> eyre::Result<()> {
+        Ok(std::fs::write(key, bytes)?)
+    }
+}
+
+/// S3-backed store for a single bucket.
+pub struct S3Store {
+    client: aws_sdk_s3::Client,
+    bucket: String,
+}
+
+#[async_trait]
+impl BlobStore for S3Store {
+    async fn get(&self, key: &str) -> eyre::Result<Vec<u8>> {
+        let object = self
+            .client
+            .get_object()
+            .bucket(&self.bucket)
+            .key(key)
+            .send()
+            .await
+            .map_err(|err| eyre!("failed to get s3://{}/{}: {err}", self.bucket, key))?;
+        let bytes = object
+            .body
+            .collect()
+            .await
+            .map_err(|err| eyre!("failed to read s3://{}/{} body: {err}", self.bucket, key))?
+            .into_bytes()
+            .to_vec();
+        Ok(bytes)
+    }
+
+    async fn put(&self, key: &str, bytes: &[u8]) -> eyre::Result<()> {
+        self.client
+            .put_object()
+            .bucket(&self.bucket)
+            .key(key)
+            .content_type("application/json")
+            .body(bytes.to_vec().into())
+            .send()
+            .await
+            .map_err(|err| eyre!("failed to put s3://{}/{}: {err}", self.bucket, key))?;
+        Ok(())
+    }
+}
+
+/// Open a location URI and return the store plus the key within that store.
+///
+/// - Local path: any string that does not start with `s3://`
+/// - S3: `s3://bucket/key`
+pub async fn open(location: &str) -> eyre::Result<(Box<dyn BlobStore>, String)> {
+    if let Some(rest) = location.strip_prefix("s3://") {
+        let (bucket, key) = rest
+            .split_once('/')
+            .ok_or_eyre("s3 location must be s3://bucket/key")?;
+        if bucket.is_empty() {
+            bail!("s3 location missing bucket: {location}");
+        }
+        if key.is_empty() {
+            bail!("s3 location missing key: {location}");
+        }
+        let config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+            .load()
+            .await;
+        let store = S3Store {
+            client: aws_sdk_s3::Client::new(&config),
+            bucket: bucket.to_string(),
+        };
+        return Ok((Box::new(store), key.to_string()));
+    }
+
+    Ok((Box::new(LocalStore), location.to_string()))
+}
+
+/// Read and deserialize JSON from a local path or `s3://bucket/key`.
+pub async fn read_json<T: DeserializeOwned>(location: &str) -> eyre::Result<T> {
+    let (store, key) = open(location).await?;
+    Ok(serde_json::from_slice(&store.get(&key).await?)?)
+}
+
+/// Serialize and write JSON to a local path or `s3://bucket/key`.
+pub async fn write_json<T: Serialize>(location: &str, value: &T) -> eyre::Result<()> {
+    let (store, key) = open(location).await?;
+    store.put(&key, &serde_json::to_vec_pretty(value)?).await
+}


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-5077/add-s3-support-to-e2e-withdrawal-binary

This PR adds aws s3 buckets support so that you can choose whether to store/read data locally or on aws s3 buckets.

### How to run

This is an example on how to run it:

```bash
AWS_REGION="us-east-1" AWS_PROFILE="tfh-crypto-dev-poweruseraccess" WITHDRAWAL_OUTPUT="s3://world-chain-alphanet-tests/init" L2_RPC_ENDPOINT="localhost:8545" L2_PRIVATE_KEY="<xxx>" cargo run --package e2e-withdrawal --bin e2e-withdrawal -- init
```

You need to first login in aws through `tfh eks login` or `aws sso login`.

### Next Step

- add dockerfile
- try to run it on the cluster

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to e2e test tooling and optional S3 I/O; on-chain init/prove/finalize logic is unchanged aside from where JSON is loaded from.
> 
> **Overview**
> The **e2e-withdrawal** tool no longer hardcodes `initiated_withdrawal.json` / `prove_withdrawal.json` on disk. Withdrawal handoff JSON can be read and written via **configurable locations**: a local path or an **`s3://bucket/key`** URI.
> 
> A new **`storage`** layer adds a `BlobStore` abstraction (`LocalStore` + `S3Store`), `read_json` / `write_json`, and S3 setup that validates region and **prefetches AWS credentials** (SSO-friendly errors). **CLI/env** flags were added: `WITHDRAWAL_OUTPUT` on `init`, `WITHDRAWAL_INPUT` / `WITHDRAWAL_OUTPUT` on `prove`, and `WITHDRAWAL_INPUT` on `finalize` (defaults unchanged for local filenames).
> 
> Workspace deps add **`aws-sdk-s3`**, **`aws-credential-types`**, and extra **`aws-config`** features (`credentials-process`, `sso`); **`Cargo.lock`** picks up the S3 SDK transitive graph.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a499cdc3be81d9a2961d249bb77d33ed0a32623a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->