### PR TITLE
feat(e2e-withdrawal): add step command to e2e-withdrawal

### DIFF
--- a/e2e-tests/e2e-withdrawal/src/args.rs
+++ b/e2e-tests/e2e-withdrawal/src/args.rs
@@ -1,6 +1,17 @@
 use alloy_primitives::{Address, U256, utils::parse_ether};
 use clap::Args;
 
+/// Arguments for the L1.
+#[derive(Debug, Args, Clone)]
+pub struct L1Args {
+    /// L1 rpc endpoint url.
+    #[arg(long, env = "L1_RPC_ENDPOINT")]
+    pub l1_rpc_endpoint: String,
+    /// L1 private key.
+    #[arg(long, env = "L1_PRIVATE_KEY")]
+    pub l1_private_key: String,
+}
+
 /// Arguments for the `init` command.
 #[derive(Debug, Args)]
 pub struct InitArgs {
@@ -25,12 +36,9 @@ pub struct InitArgs {
 /// Arguments for the `prove` command.
 #[derive(Debug, Args)]
 pub struct ProveArgs {
-    /// L1 rpc endpoint url.
-    #[arg(long, env = "L1_RPC_ENDPOINT")]
-    pub l1_rpc_endpoint: String,
-    /// L1 private key.
-    #[arg(long, env = "L1_PRIVATE_KEY")]
-    pub l1_private_key: String,
+    /// L1 args.
+    #[command(flatten)]
+    pub l1_args: L1Args,
     /// L2 rpc endpoint url.
     #[arg(long, env = "L2_RPC_ENDPOINT")]
     pub l2_rpc_endpoint: String,
@@ -59,12 +67,9 @@ pub struct ProveArgs {
 /// Arguments for the `finalize` command.
 #[derive(Debug, Args)]
 pub struct FinalizeArgs {
-    /// L1 rpc endpoint url.
-    #[arg(long, env = "L1_RPC_ENDPOINT")]
-    pub l1_rpc_endpoint: String,
-    /// L1 private key.
-    #[arg(long, env = "L1_PRIVATE_KEY")]
-    pub l1_private_key: String,
+    /// L1 args.
+    #[command(flatten)]
+    pub l1_args: L1Args,
     /// AnchorStateRegistry contract address.
     #[arg(long, env = "ANCHOR_STATE_REGISTRY")]
     pub anchor_state_registry: Address,
@@ -78,4 +83,70 @@ pub struct FinalizeArgs {
         default_value = "prove_withdrawal.json"
     )]
     pub input: String,
+}
+
+/// Arguments for the `step` command.
+#[derive(Debug, Args)]
+pub struct StepArgs {
+    /// L1 args.
+    #[command(flatten)]
+    pub l1_args: L1Args,
+    /// L2 rpc endpoint url.
+    #[arg(long, env = "L2_RPC_ENDPOINT")]
+    pub l2_rpc_endpoint: String,
+    /// L2 private key.
+    #[arg(long, env = "L2_PRIVATE_KEY")]
+    pub l2_private_key: String,
+    /// The amount of ETH you want to withdraw.
+    #[arg(long, env = "ETH_VALUE", value_parser = parse_ether, default_value_t = U256::ZERO)]
+    pub value: U256,
+    /// DisputeGameFactory contract address.
+    #[arg(long, env = "DISPUTE_GAME_FACTORY")]
+    pub dispute_game_factory: Address,
+    /// OptimismPortal contract address.
+    #[arg(long, env = "OPTIMISM_PORTAL")]
+    pub optimism_portal: Address,
+    /// AnchorStateRegistry contract address.
+    #[arg(long, env = "ANCHOR_STATE_REGISTRY")]
+    pub anchor_state_registry: Address,
+    /// Durable location for the initiated-withdrawal JSON.
+    #[arg(long, env = "WITHDRAWAL_INITIATED", default_value = "initiated_withdrawal.json")]
+    pub initiated: String,
+    /// Durable location for the proven-withdrawal JSON.
+    #[arg(long, env = "WITHDRAWAL_PROVEN", default_value = "prove_withdrawal.json")]
+    pub proven: String,
+}
+
+impl StepArgs {
+    /// Convert into `InitArgs`
+    pub fn to_init(&self) -> InitArgs {
+        InitArgs {
+            l2_rpc_endpoint: self.l2_rpc_endpoint.clone(),
+            l2_private_key: self.l2_private_key.clone(),
+            value: self.value,
+            output: self.initiated.clone(),
+        }
+    }
+
+    /// Convert into `ProveArgs`
+    pub fn to_prove(&self) -> ProveArgs {
+        ProveArgs {
+            l1_args: self.l1_args.clone(),
+            l2_rpc_endpoint: self.l2_rpc_endpoint.clone(),
+            dispute_game_factory: self.dispute_game_factory,
+            optimism_portal: self.optimism_portal,
+            input: self.initiated.clone(),
+            output: self.proven.clone(),
+        }
+    }
+
+    /// Convert into `FinalizeArgs`
+    pub fn to_finalize(&self) -> FinalizeArgs {
+        FinalizeArgs {
+            l1_args: self.l1_args.clone(),
+            anchor_state_registry: self.anchor_state_registry,
+            optimism_portal: self.optimism_portal,
+            input: self.proven.clone(),
+        }
+    }
 }

--- a/e2e-tests/e2e-withdrawal/src/args.rs
+++ b/e2e-tests/e2e-withdrawal/src/args.rs
@@ -110,10 +110,18 @@ pub struct StepArgs {
     #[arg(long, env = "ANCHOR_STATE_REGISTRY")]
     pub anchor_state_registry: Address,
     /// Durable location for the initiated-withdrawal JSON.
-    #[arg(long, env = "WITHDRAWAL_INITIATED", default_value = "initiated_withdrawal.json")]
+    #[arg(
+        long,
+        env = "WITHDRAWAL_INITIATED",
+        default_value = "initiated_withdrawal.json"
+    )]
     pub initiated: String,
     /// Durable location for the proven-withdrawal JSON.
-    #[arg(long, env = "WITHDRAWAL_PROVEN", default_value = "prove_withdrawal.json")]
+    #[arg(
+        long,
+        env = "WITHDRAWAL_PROVEN",
+        default_value = "prove_withdrawal.json"
+    )]
     pub proven: String,
 }
 

--- a/e2e-tests/e2e-withdrawal/src/args.rs
+++ b/e2e-tests/e2e-withdrawal/src/args.rs
@@ -24,13 +24,13 @@ pub struct InitArgs {
     /// The amount of ETH you want to withdraw.
     #[arg(long, env = "ETH_VALUE", value_parser = parse_ether, default_value_t = U256::ZERO)]
     pub value: U256,
-    /// Output location for the initiated withdrawal JSON (local path or `s3://bucket/key`).
+    /// Location for the initiated withdrawal JSON (local path or `s3://bucket/key`).
     #[arg(
         long,
-        env = "WITHDRAWAL_OUTPUT",
+        env = "WITHDRAWAL_INITIATED",
         default_value = "initiated_withdrawal.json"
     )]
-    pub output: String,
+    pub initiated: String,
 }
 
 /// Arguments for the `prove` command.
@@ -48,20 +48,20 @@ pub struct ProveArgs {
     /// OptimismPortal contract address.
     #[arg(long, env = "OPTIMISM_PORTAL")]
     pub optimism_portal: Address,
-    /// Input location for the initiated withdrawal JSON (local path or `s3://bucket/key`).
+    /// Location for the initiated withdrawal JSON (local path or `s3://bucket/key`).
     #[arg(
         long,
-        env = "WITHDRAWAL_INPUT",
+        env = "WITHDRAWAL_INITIATED",
         default_value = "initiated_withdrawal.json"
     )]
-    pub input: String,
-    /// Output location for the proven withdrawal JSON (local path or `s3://bucket/key`).
+    pub initiated: String,
+    /// Location for the proven withdrawal JSON (local path or `s3://bucket/key`).
     #[arg(
         long,
-        env = "WITHDRAWAL_OUTPUT",
+        env = "WITHDRAWAL_PROVEN",
         default_value = "prove_withdrawal.json"
     )]
-    pub output: String,
+    pub proven: String,
 }
 
 /// Arguments for the `finalize` command.
@@ -76,13 +76,13 @@ pub struct FinalizeArgs {
     /// OptimismPortal contract address.
     #[arg(long, env = "OPTIMISM_PORTAL")]
     pub optimism_portal: Address,
-    /// Input location for the proven withdrawal JSON (local path or `s3://bucket/key`).
+    /// Location for the proven withdrawal JSON (local path or `s3://bucket/key`).
     #[arg(
         long,
-        env = "WITHDRAWAL_INPUT",
+        env = "WITHDRAWAL_PROVEN",
         default_value = "prove_withdrawal.json"
     )]
-    pub input: String,
+    pub proven: String,
 }
 
 /// Arguments for the `step` command.
@@ -132,7 +132,7 @@ impl StepArgs {
             l2_rpc_endpoint: self.l2_rpc_endpoint.clone(),
             l2_private_key: self.l2_private_key.clone(),
             value: self.value,
-            output: self.initiated.clone(),
+            initiated: self.initiated.clone(),
         }
     }
 
@@ -143,8 +143,8 @@ impl StepArgs {
             l2_rpc_endpoint: self.l2_rpc_endpoint.clone(),
             dispute_game_factory: self.dispute_game_factory,
             optimism_portal: self.optimism_portal,
-            input: self.initiated.clone(),
-            output: self.proven.clone(),
+            initiated: self.initiated.clone(),
+            proven: self.proven.clone(),
         }
     }
 
@@ -154,7 +154,7 @@ impl StepArgs {
             l1_args: self.l1_args.clone(),
             anchor_state_registry: self.anchor_state_registry,
             optimism_portal: self.optimism_portal,
-            input: self.proven.clone(),
+            proven: self.proven.clone(),
         }
     }
 }

--- a/e2e-tests/e2e-withdrawal/src/cmd/finalize.rs
+++ b/e2e-tests/e2e-withdrawal/src/cmd/finalize.rs
@@ -17,10 +17,10 @@ use std::str::FromStr;
 /// Run the `finalize` command.
 pub async fn run(args: &FinalizeArgs) -> eyre::Result<()> {
     // create L1 signer provider
-    let local_signer = PrivateKeySigner::from_str(&args.l1_private_key)?;
+    let local_signer = PrivateKeySigner::from_str(&args.l1_args.l1_private_key)?;
     let l1_provider = ProviderBuilder::new()
         .wallet(EthereumWallet::from(local_signer))
-        .connect(&args.l1_rpc_endpoint)
+        .connect(&args.l1_args.l1_rpc_endpoint)
         .await?;
     // read ProveWithdrawal data (local path or s3://bucket/key)
     let prove_withdrawal: ProveWithdrawal = storage::read_json(&args.input).await?;

--- a/e2e-tests/e2e-withdrawal/src/cmd/finalize.rs
+++ b/e2e-tests/e2e-withdrawal/src/cmd/finalize.rs
@@ -24,9 +24,17 @@ pub async fn run(args: &FinalizeArgs) -> eyre::Result<()> {
         .await?;
     // read ProveWithdrawal data (local path or s3://bucket/key)
     let prove_withdrawal: ProveWithdrawal = storage::read_json(&args.proven).await?;
+    // already finalized on-chain, treat as success so step can retry handoff cleanup.
+    let optimism_portal = OptimismPortalInstance::new(args.optimism_portal, &l1_provider);
+    if optimism_portal
+        .finalizedWithdrawals(prove_withdrawal.hash)
+        .call()
+        .await?
+    {
+        return Ok(());
+    }
     // check whether the withdrawal is finalizable:
     // 1. now - proven.timestamp > OptimismPortal::proofMaturityDelaySeconds()
-    let optimism_portal = OptimismPortalInstance::new(args.optimism_portal, &l1_provider);
     let latest_block = l1_provider
         .get_block(BlockId::latest())
         .await?

--- a/e2e-tests/e2e-withdrawal/src/cmd/finalize.rs
+++ b/e2e-tests/e2e-withdrawal/src/cmd/finalize.rs
@@ -23,7 +23,7 @@ pub async fn run(args: &FinalizeArgs) -> eyre::Result<()> {
         .connect(&args.l1_args.l1_rpc_endpoint)
         .await?;
     // read ProveWithdrawal data (local path or s3://bucket/key)
-    let prove_withdrawal: ProveWithdrawal = storage::read_json(&args.input).await?;
+    let prove_withdrawal: ProveWithdrawal = storage::read_json(&args.proven).await?;
     // check whether the withdrawal is finalizable:
     // 1. now - proven.timestamp > OptimismPortal::proofMaturityDelaySeconds()
     let optimism_portal = OptimismPortalInstance::new(args.optimism_portal, &l1_provider);

--- a/e2e-tests/e2e-withdrawal/src/cmd/init.rs
+++ b/e2e-tests/e2e-withdrawal/src/cmd/init.rs
@@ -27,7 +27,7 @@ pub async fn run(args: &InitArgs) -> eyre::Result<()> {
     // sends the initiate_withdrawal transaction to the L2ToL1MessagePasser contract
     let initiated_withdrawal = initiate_withdrawal(l2_provider, target_addr, args.value).await?;
     // save the InitiatedWithdrawal data (local path or s3://bucket/key)
-    storage::write_json(&args.output, &initiated_withdrawal).await?;
+    storage::write_json(&args.initiated, &initiated_withdrawal).await?;
     Ok(())
 }
 

--- a/e2e-tests/e2e-withdrawal/src/cmd/mod.rs
+++ b/e2e-tests/e2e-withdrawal/src/cmd/mod.rs
@@ -1,9 +1,10 @@
-use crate::args::{FinalizeArgs, InitArgs, ProveArgs};
+use crate::args::{FinalizeArgs, InitArgs, ProveArgs, StepArgs};
 use clap::Subcommand;
 
 mod finalize;
 mod init;
 mod prove;
+mod step;
 
 /// Commands for an end-to-end L2->L1 withdrawal flow.
 ///
@@ -25,6 +26,8 @@ pub enum Command {
     Prove(ProveArgs),
     /// Finalize the withdrawal.
     Finalize(FinalizeArgs),
+    /// Run the next stage of the withdrawal workflow based on stored state.
+    Step(StepArgs)
 }
 
 impl Command {
@@ -34,6 +37,7 @@ impl Command {
             Self::Init(args) => init::run(args).await,
             Self::Prove(args) => prove::run(args).await,
             Self::Finalize(args) => finalize::run(args).await,
+            Self::Step(args) => step::run(args).await,
         }
     }
 }

--- a/e2e-tests/e2e-withdrawal/src/cmd/mod.rs
+++ b/e2e-tests/e2e-withdrawal/src/cmd/mod.rs
@@ -27,7 +27,7 @@ pub enum Command {
     /// Finalize the withdrawal.
     Finalize(FinalizeArgs),
     /// Run the next stage of the withdrawal workflow based on stored state.
-    Step(StepArgs)
+    Step(StepArgs),
 }
 
 impl Command {

--- a/e2e-tests/e2e-withdrawal/src/cmd/prove.rs
+++ b/e2e-tests/e2e-withdrawal/src/cmd/prove.rs
@@ -35,7 +35,7 @@ pub async fn run(args: &ProveArgs) -> eyre::Result<()> {
         .connect(&args.l2_rpc_endpoint)
         .await?;
     // read InitiatedWithdrawal data (local path or s3://bucket/key)
-    let initiated_withdrawal: InitiatedWithdrawal = storage::read_json(&args.input).await?;
+    let initiated_withdrawal: InitiatedWithdrawal = storage::read_json(&args.initiated).await?;
     // wait for a covering WIP1006 game with l2SequenceNumber >= initiated_withdrawal.l2_block
     let (game_index, game_addr, game_l2_block) = check_multi_proof_game(
         &l1_provider,
@@ -81,7 +81,7 @@ pub async fn run(args: &ProveArgs) -> eyre::Result<()> {
         game_addr,
         proven_at: l1_timestamp,
     };
-    storage::write_json(&args.output, &prove_withdrawal).await?;
+    storage::write_json(&args.proven, &prove_withdrawal).await?;
     Ok(())
 }
 

--- a/e2e-tests/e2e-withdrawal/src/cmd/prove.rs
+++ b/e2e-tests/e2e-withdrawal/src/cmd/prove.rs
@@ -25,10 +25,10 @@ const L2_TO_L1_MESSAGE_PASSER: Address = address!("42000000000000000000000000000
 /// Run the `prove` command.
 pub async fn run(args: &ProveArgs) -> eyre::Result<()> {
     // create L1 signer provider
-    let local_signer = PrivateKeySigner::from_str(&args.l1_private_key)?;
+    let local_signer = PrivateKeySigner::from_str(&args.l1_args.l1_private_key)?;
     let l1_provider = ProviderBuilder::new()
         .wallet(EthereumWallet::from(local_signer))
-        .connect(&args.l1_rpc_endpoint)
+        .connect(&args.l1_args.l1_rpc_endpoint)
         .await?;
     // create L2 provider
     let l2_provider = ProviderBuilder::new()

--- a/e2e-tests/e2e-withdrawal/src/cmd/step.rs
+++ b/e2e-tests/e2e-withdrawal/src/cmd/step.rs
@@ -27,17 +27,16 @@ pub async fn run(args: &StepArgs) -> eyre::Result<()> {
     }
 }
 
-/// Delete both handoffs, attempting each even if the other fails.
+/// Delete handoffs in order: initiated first, then proven.
+///
+/// If initiated delete fails, keep proven so the next tick still sees both
+/// handoffs and retries finalize (idempotent) + cleanup instead of re-proving.
 async fn delete_handoffs(args: &StepArgs) -> eyre::Result<()> {
-    let initiated = storage::delete(&args.initiated)
+    storage::delete(&args.initiated)
         .await
-        .wrap_err_with(|| format!("failed to delete initiated handoff at `{}`", args.initiated));
-    let proven = storage::delete(&args.proven)
+        .wrap_err_with(|| format!("failed to delete initiated handoff at `{}`", args.initiated))?;
+    storage::delete(&args.proven)
         .await
-        .wrap_err_with(|| format!("failed to delete proven handoff at `{}`", args.proven));
-    match (initiated, proven) {
-        (Ok(()), Ok(())) => Ok(()),
-        (Err(e), Ok(())) | (Ok(()), Err(e)) => Err(e),
-        (Err(e1), Err(e2)) => Err(e1.wrap_err(e2)),
-    }
+        .wrap_err_with(|| format!("failed to delete proven handoff at `{}`", args.proven))?;
+    Ok(())
 }

--- a/e2e-tests/e2e-withdrawal/src/cmd/step.rs
+++ b/e2e-tests/e2e-withdrawal/src/cmd/step.rs
@@ -3,14 +3,14 @@ use crate::{
     cmd::{finalize, init, prove},
     storage,
 };
-use eyre::eyre::bail;
+use eyre::eyre::WrapErr;
 
 /// Run the `step` command.
 ///
 /// Dispatches to the next withdrawal stage based on durable handoff presence:
 /// - no initiated -> `init`
 /// - initiated, no proven -> `prove`
-/// - proven -> `finalize`, then delete both handoffs
+/// - proven -> `finalize` (idempotent if already on-chain), then delete handoffs
 pub async fn run(args: &StepArgs) -> eyre::Result<()> {
     let initiated_exists = storage::exists(&args.initiated).await?;
     let proven_exists = storage::exists(&args.proven).await?;
@@ -18,19 +18,26 @@ pub async fn run(args: &StepArgs) -> eyre::Result<()> {
     match (initiated_exists, proven_exists) {
         (false, false) => init::run(&args.to_init()).await,
         (true, false) => prove::run(&args.to_prove()).await,
-        (true, true) => {
+        // Both present, or only proven left after a partial cleanup: finalize is
+        // idempotent, then retry handoff deletion.
+        (true, true) | (false, true) => {
             finalize::run(&args.to_finalize()).await?;
-            storage::delete(&args.initiated).await?;
-            storage::delete(&args.proven).await?;
-            Ok(())
+            delete_handoffs(args).await
         }
-        (false, true) => {
-            bail!(
-                "inconsistent withdrawal state: proven handoff exists at `{}` \
-                 but initiated handoff is missing at `{}`",
-                args.proven,
-                args.initiated
-            )
-        }
+    }
+}
+
+/// Delete both handoffs, attempting each even if the other fails.
+async fn delete_handoffs(args: &StepArgs) -> eyre::Result<()> {
+    let initiated = storage::delete(&args.initiated)
+        .await
+        .wrap_err_with(|| format!("failed to delete initiated handoff at `{}`", args.initiated));
+    let proven = storage::delete(&args.proven)
+        .await
+        .wrap_err_with(|| format!("failed to delete proven handoff at `{}`", args.proven));
+    match (initiated, proven) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(e), Ok(())) | (Ok(()), Err(e)) => Err(e),
+        (Err(e1), Err(e2)) => Err(e1.wrap_err(e2)),
     }
 }

--- a/e2e-tests/e2e-withdrawal/src/cmd/step.rs
+++ b/e2e-tests/e2e-withdrawal/src/cmd/step.rs
@@ -1,0 +1,7 @@
+use crate::{args::StepArgs, cmd::prove};
+
+/// Run the `step` command.
+pub async fn run(args: &StepArgs) -> eyre::Result<()> {
+    let prove_args = args.to_prove();
+    prove::run(&prove_args).await
+}

--- a/e2e-tests/e2e-withdrawal/src/cmd/step.rs
+++ b/e2e-tests/e2e-withdrawal/src/cmd/step.rs
@@ -1,7 +1,36 @@
-use crate::{args::StepArgs, cmd::prove};
+use crate::{
+    args::StepArgs,
+    cmd::{finalize, init, prove},
+    storage,
+};
+use eyre::eyre::bail;
 
 /// Run the `step` command.
+///
+/// Dispatches to the next withdrawal stage based on durable handoff presence:
+/// - no initiated -> `init`
+/// - initiated, no proven -> `prove`
+/// - proven -> `finalize`, then delete both handoffs
 pub async fn run(args: &StepArgs) -> eyre::Result<()> {
-    let prove_args = args.to_prove();
-    prove::run(&prove_args).await
+    let initiated_exists = storage::exists(&args.initiated).await?;
+    let proven_exists = storage::exists(&args.proven).await?;
+
+    match (initiated_exists, proven_exists) {
+        (false, false) => init::run(&args.to_init()).await,
+        (true, false) => prove::run(&args.to_prove()).await,
+        (true, true) => {
+            finalize::run(&args.to_finalize()).await?;
+            storage::delete(&args.initiated).await?;
+            storage::delete(&args.proven).await?;
+            Ok(())
+        }
+        (false, true) => {
+            bail!(
+                "inconsistent withdrawal state: proven handoff exists at `{}` \
+                 but initiated handoff is missing at `{}`",
+                args.proven,
+                args.initiated
+            )
+        }
+    }
 }

--- a/e2e-tests/e2e-withdrawal/src/storage.rs
+++ b/e2e-tests/e2e-withdrawal/src/storage.rs
@@ -6,8 +6,14 @@ use serde::{Serialize, de::DeserializeOwned};
 /// Byte-oriented blob store used for withdrawal handoff JSON.
 #[async_trait]
 pub trait BlobStore: Send + Sync {
+    /// Read the blob at `key`.
     async fn get(&self, key: &str) -> eyre::Result<Vec<u8>>;
+    /// Write `bytes` to `key`.
     async fn put(&self, key: &str, bytes: &[u8]) -> eyre::Result<()>;
+    /// Return whether `key` exists.
+    async fn exists(&self, key: &str) -> eyre::Result<bool>;
+    /// Delete `key`. Missing keys are ignored.
+    async fn delete(&self, key: &str) -> eyre::Result<()>;
 }
 
 /// Filesystem-backed store. The key is treated as a filesystem path.
@@ -21,6 +27,18 @@ impl BlobStore for LocalStore {
 
     async fn put(&self, key: &str, bytes: &[u8]) -> eyre::Result<()> {
         Ok(std::fs::write(key, bytes)?)
+    }
+
+    async fn exists(&self, key: &str) -> eyre::Result<bool> {
+        Ok(std::path::Path::new(key).exists())
+    }
+
+    async fn delete(&self, key: &str) -> eyre::Result<()> {
+        match std::fs::remove_file(key) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(err.into()),
+        }
     }
 }
 
@@ -61,6 +79,38 @@ impl BlobStore for S3Store {
             .send()
             .await
             .wrap_err_with(|| format!("failed to put s3://{}/{}", self.bucket, key))?;
+        Ok(())
+    }
+
+    async fn exists(&self, key: &str) -> eyre::Result<bool> {
+        match self
+            .client
+            .head_object()
+            .bucket(&self.bucket)
+            .key(key)
+            .send()
+            .await
+        {
+            Ok(_) => Ok(true),
+            Err(err) => {
+                if err.as_service_error().is_some_and(|e| e.is_not_found()) {
+                    Ok(false)
+                } else {
+                    Err(err)
+                        .wrap_err_with(|| format!("failed to head s3://{}/{}", self.bucket, key))
+                }
+            }
+        }
+    }
+
+    async fn delete(&self, key: &str) -> eyre::Result<()> {
+        self.client
+            .delete_object()
+            .bucket(&self.bucket)
+            .key(key)
+            .send()
+            .await
+            .wrap_err_with(|| format!("failed to delete s3://{}/{}", self.bucket, key))?;
         Ok(())
     }
 }
@@ -118,4 +168,16 @@ pub async fn read_json<T: DeserializeOwned>(location: &str) -> eyre::Result<T> {
 pub async fn write_json<T: Serialize>(location: &str, value: &T) -> eyre::Result<()> {
     let (store, key) = open(location).await?;
     store.put(&key, &serde_json::to_vec_pretty(value)?).await
+}
+
+/// Return whether a local path or `s3://bucket/key` exists.
+pub async fn exists(location: &str) -> eyre::Result<bool> {
+    let (store, key) = open(location).await?;
+    store.exists(&key).await
+}
+
+/// Delete a local path or `s3://bucket/key`. Missing objects are ignored.
+pub async fn delete(location: &str) -> eyre::Result<()> {
+    let (store, key) = open(location).await?;
+    store.delete(&key).await
 }


### PR DESCRIPTION
Closes https://linear.app/worldcoin/issue/PROTO-5081/add-step-command-to-e2e-withdrawal-binary

### Problem

The e2e withdrawal binary requires callers to pick `init`, `prove`, or `finalize` and pass stage-specific input/output locations. That does not work well as a Kubernetes CronJob, where each tick should use the same command and durable handoff state (local or S3).

### Solution

Add a `step` command that inspects fixed `WITHDRAWAL_INITIATED` / `WITHDRAWAL_PROVEN` locations, runs the next stage, and clears both handoffs after a successful finalize.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> E2e withdrawal tooling and CLI/env renames only; no production chain logic beyond an idempotent finalize check in the test binary.
> 
> **Overview**
> Adds a **`step`** subcommand so CronJob-style runners can invoke one fixed command each tick instead of choosing `init` / `prove` / `finalize` manually. **`step`** checks durable handoff JSON at `WITHDRAWAL_INITIATED` and `WITHDRAWAL_PROVEN` (local or S3), runs the next stage (`init` → `prove` → `finalize`), then deletes both handoffs after a successful finalize—with ordered cleanup so a failed delete does not cause re-proving on the next tick.
> 
> CLI cleanup: shared **`L1Args`** (flattened into prove/finalize/step), and handoff fields/env renamed from generic input/output to **`initiated`** / **`proven`**. Storage gains **`exists`** and **`delete`** on the blob layer (filesystem + S3). **`finalize`** returns success early when the withdrawal is already finalized on-chain so **`step`** can safely retry cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12871531001ea6ccaacc7c0b48965fe29e72e06d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->